### PR TITLE
CB-9290 Stack terminate flow chain reorder

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ProperTerminationFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ProperTerminationFlowEventChainFactory.java
@@ -24,8 +24,8 @@ public class ProperTerminationFlowEventChainFactory implements FlowEventChainFac
     public Queue<Selectable> createFlowTriggerEventQueue(TerminationEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new TerminationEvent(ClusterTerminationEvent.PROPER_TERMINATION_EVENT.event(), event.getResourceId(), event.getForced()));
-        flowEventChain.add(new TerminationEvent(StackTerminationEvent.TERMINATION_EVENT.event(), event.getResourceId(), event.getForced()));
-        flowEventChain.add(new TerminationEvent(START_EXTERNAL_DATABASE_TERMINATION_EVENT.event(), event.getResourceId(), event.getForced(), event.accepted()));
+        flowEventChain.add(new TerminationEvent(START_EXTERNAL_DATABASE_TERMINATION_EVENT.event(), event.getResourceId(), event.getForced()));
+        flowEventChain.add(new TerminationEvent(StackTerminationEvent.TERMINATION_EVENT.event(), event.getResourceId(), event.getForced(), event.accepted()));
         return flowEventChain;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/TerminationFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/TerminationFlowEventChainFactory.java
@@ -25,8 +25,8 @@ public class TerminationFlowEventChainFactory implements FlowEventChainFactory<T
     public Queue<Selectable> createFlowTriggerEventQueue(TerminationEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackEvent(ClusterTerminationEvent.TERMINATION_EVENT.event(), event.getResourceId(), event.accepted()));
-        flowEventChain.add(new TerminationEvent(StackTerminationEvent.TERMINATION_EVENT.event(), event.getResourceId(), event.getForced(), event.accepted()));
         flowEventChain.add(new TerminationEvent(START_EXTERNAL_DATABASE_TERMINATION_EVENT.event(), event.getResourceId(), event.getForced(), event.accepted()));
+        flowEventChain.add(new TerminationEvent(StackTerminationEvent.TERMINATION_EVENT.event(), event.getResourceId(), event.getForced(), event.accepted()));
         return flowEventChain;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/handler/TerminateExternalDatabaseHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/handler/TerminateExternalDatabaseHandler.java
@@ -75,8 +75,8 @@ public class TerminateExternalDatabaseHandler implements EventHandler<TerminateE
                 DetailedEnvironmentResponse environment = environmentClientService.getByCrn(stack.getEnvironmentCrn());
                 terminationService.terminateDatabase(stack.getCluster(), externalDatabase, environment, request.isForced());
                 LOGGER.debug("Updating stack {} status from {} to {}",
-                        stack.getName(), stack.getStatus().name(), DetailedStackStatus.DELETE_COMPLETED.name());
-                stackUpdaterService.updateStatus(stack.getId(), DetailedStackStatus.DELETE_COMPLETED,
+                        stack.getName(), stack.getStatus().name(), DetailedStackStatus.AVAILABLE.name());
+                stackUpdaterService.updateStatus(stack.getId(), DetailedStackStatus.AVAILABLE,
                         ResourceEvent.CLUSTER_EXTERNAL_DATABASE_DELETION_FINISHED, "External database deletion finished");
                 result = new TerminateExternalDatabaseResult(stack.getId(), EXTERNAL_DATABASE_WAIT_TERMINATION_SUCCESS_EVENT.event(),
                         stack.getName(), stack.getCluster().getDatabaseServerCrn());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsClientService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsClientService.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.service.rdsconfig;
 
 import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
 
@@ -47,6 +48,10 @@ public class RedbeamsClientService {
     public DatabaseServerV4Response deleteByCrn(String crn, boolean force) {
         try {
             return ThreadBasedUserCrnProvider.doAsInternalActor(() -> redbeamsServerEndpoint.deleteByCrn(crn, force));
+        } catch (NotFoundException e) {
+            String message = String.format("DatabaseServer with CRN %s was not found by Redbeams service in the deleteByCrn call.", crn);
+            LOGGER.warn(message, e);
+            throw e;
         } catch (WebApplicationException | ProcessingException e) {
             String message = String.format("Failed to delete DatabaseServer with CRN %s", crn);
             LOGGER.error(message, e);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/handler/TerminateExternalDatabaseHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/handler/TerminateExternalDatabaseHandlerTest.java
@@ -98,7 +98,7 @@ class TerminateExternalDatabaseHandlerTest {
         verify(stackUpdaterService).updateStatus(eq(STACK_ID), eq(DetailedStackStatus.EXTERNAL_DATABASE_DELETION_IN_PROGRESS),
                 eq(ResourceEvent.CLUSTER_EXTERNAL_DATABASE_DELETION_STARTED), eq("External database deletion in progress"));
 
-        verify(stackUpdaterService, never()).updateStatus(eq(STACK_ID), eq(DetailedStackStatus.PROVISION_REQUESTED),
+        verify(stackUpdaterService, never()).updateStatus(eq(STACK_ID), eq(DetailedStackStatus.AVAILABLE),
                 eq(ResourceEvent.CLUSTER_EXTERNAL_DATABASE_CREATION_FINISHED), anyString());
 
         verify(eventBus).notify(eq("TerminateExternalDatabaseFailed"), any(Event.class));
@@ -130,7 +130,7 @@ class TerminateExternalDatabaseHandlerTest {
         verify(stackUpdaterService).updateStatus(eq(STACK_ID), eq(DetailedStackStatus.EXTERNAL_DATABASE_DELETION_IN_PROGRESS),
                 eq(ResourceEvent.CLUSTER_EXTERNAL_DATABASE_DELETION_STARTED), eq("External database deletion in progress"));
 
-        verify(stackUpdaterService).updateStatus(eq(STACK_ID), eq(DetailedStackStatus.DELETE_COMPLETED),
+        verify(stackUpdaterService).updateStatus(eq(STACK_ID), eq(DetailedStackStatus.AVAILABLE),
                 eq(ResourceEvent.CLUSTER_EXTERNAL_DATABASE_DELETION_FINISHED), eq("External database deletion finished"));
 
         ArgumentCaptor<Event<TerminateExternalDatabaseResult>> eventCaptor = ArgumentCaptor.forClass(Event.class);
@@ -161,7 +161,7 @@ class TerminateExternalDatabaseHandlerTest {
 
     private Stack buildStack(DatabaseAvailabilityType databaseAvailabilityType) {
         StackStatus status = new StackStatus();
-        status.setStatus(Status.REQUESTED);
+        status.setStatus(Status.AVAILABLE);
         Cluster cluster = new Cluster();
         Stack stack = new Stack();
         stack.setStackStatus(status);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsClientServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsClientServiceTest.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.service.rdsconfig;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.NotFoundException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
+
+@ExtendWith(MockitoExtension.class)
+class RedbeamsClientServiceTest {
+
+    @Mock
+    private DatabaseServerV4Endpoint redbeamsServerEndpoint;
+
+    @InjectMocks
+    private RedbeamsClientService underTest;
+
+    @Test
+    void deleteByCrnNotFoundIsRethrownAsIs() {
+        when(redbeamsServerEndpoint.deleteByCrn(any(), anyBoolean())).thenThrow(new NotFoundException("not found"));
+        assertThatThrownBy(() -> underTest.deleteByCrn("crn", true)).isExactlyInstanceOf(NotFoundException.class);
+    }
+}


### PR DESCRIPTION
Move external database termination before the stack termination
flow. Previously the stack deletion completed state set another
flags (e.g. termination date) in the 'stack' entity which was not
optimal for several reasons.
During the change I found issues with Redbeams calls checking for
NotFound result. As it turned out, this exception is wrapped into
a custom one and that case needs to be handled as well.
Wrote unit tests around them.