### PR TITLE
CB-9307 Stopped RDS is not deleted but hanging forever to timeout

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/acceptor/DescribeDbInstanceForModifyFailureAcceptor.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/acceptor/DescribeDbInstanceForModifyFailureAcceptor.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.cloud.aws.scheduler.acceptor;
+
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.waiters.WaiterAcceptor;
+import com.amazonaws.waiters.WaiterState;
+
+@Component
+public class DescribeDbInstanceForModifyFailureAcceptor extends WaiterAcceptor<DescribeDBInstancesResult> {
+
+    @Override
+    public boolean matches(DescribeDBInstancesResult describeDBInstancesResult) {
+        return describeDBInstancesResult.getDBInstances().stream()
+                .anyMatch(instance ->
+                        "failed".equals(instance.getDBInstanceStatus())
+                                || "deleted".equals(instance.getDBInstanceStatus())
+                );
+    }
+
+    @Override
+    public WaiterState getState() {
+        return WaiterState.FAILURE;
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/acceptor/DescribeDbInstanceForModifySuccessAcceptor.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/acceptor/DescribeDbInstanceForModifySuccessAcceptor.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.cloud.aws.scheduler.acceptor;
+
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.waiters.WaiterAcceptor;
+import com.amazonaws.waiters.WaiterState;
+
+@Component
+public class DescribeDbInstanceForModifySuccessAcceptor extends WaiterAcceptor<DescribeDBInstancesResult> {
+
+    @Override
+    public boolean matches(DescribeDBInstancesResult describeDBInstancesResult) {
+        return describeDBInstancesResult.getDBInstances().stream()
+                .allMatch(instance ->
+                        "available".equals(instance.getDBInstanceStatus())
+                                || "stopped".equals(instance.getDBInstanceStatus())
+                );
+    }
+
+    @Override
+    public WaiterState getState() {
+        return WaiterState.SUCCESS;
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/acceptor/DBInstanceStatuses.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/acceptor/DBInstanceStatuses.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.cloudbreak.cloud.aws.scheduler.acceptor;
+
+import java.util.List;
+
+public final class DBInstanceStatuses {
+
+    /**
+     * Taken from <a href="https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Status.html">DB instance status</a>
+     */
+    static final List<String> DB_STATUSES = List.of(
+            "available",
+            "backing-up",
+            "backtracking",
+            "configuring-enhanced-monitoring",
+            "configuring-iam-database-auth",
+            "configuring-log-exports",
+            "converting-to-vpc",
+            "creating",
+            "deleting",
+            "failed",
+            "inaccessible-encryption-credentials",
+            "incompatible-network",
+            "incompatible-option-group",
+            "incompatible-parameters",
+            "incompatible-restore",
+            "maintenance",
+            "modifying",
+            "moving-to-vpc",
+            "rebooting",
+            "renaming",
+            "resetting-master-credentials",
+            "restore-error",
+            "starting",
+            "stopped",
+            "stopping",
+            "storage-full",
+            "storage-optimization",
+            "upgrading"
+    );
+
+    private DBInstanceStatuses() {
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/acceptor/DescribeDbInstanceForModifyFailureAcceptorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/acceptor/DescribeDbInstanceForModifyFailureAcceptorTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.cloud.aws.scheduler.acceptor;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.scheduler.acceptor.DBInstanceStatuses.DB_STATUSES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.waiters.WaiterState;
+
+class DescribeDbInstanceForModifyFailureAcceptorTest {
+
+    private final DescribeDbInstanceForModifyFailureAcceptor underTest = new DescribeDbInstanceForModifyFailureAcceptor();
+
+    @Test
+    void matches() {
+        DB_STATUSES.forEach(status1 -> {
+            DB_STATUSES.forEach(status2 -> {
+                boolean expected = "failed".equals(status1) ||
+                        "failed".equals(status2) ||
+                        "deleted".equals(status1) ||
+                        "deleted".equals(status2);
+                DBInstance dbInstance1 = new DBInstance().withDBInstanceStatus(status1);
+                DBInstance dbInstance2 = new DBInstance().withDBInstanceStatus(status2);
+                DescribeDBInstancesResult describeDBInstanceResult = new DescribeDBInstancesResult().withDBInstances(dbInstance1, dbInstance2);
+                boolean matches = underTest.matches(describeDBInstanceResult);
+                assertThat(matches)
+                        .withFailMessage("matches expected as '%s' but was '%s' for DB instance states '%s' and '%s'",
+                                expected, matches, status1, status2)
+                        .isEqualTo(expected);
+            });
+        });
+    }
+
+    @Test
+    void getState() {
+        assertThat(underTest.getState()).isEqualTo(WaiterState.FAILURE);
+    }
+}

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/acceptor/DescribeDbInstanceForModifySuccessAcceptorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/scheduler/acceptor/DescribeDbInstanceForModifySuccessAcceptorTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.cloud.aws.scheduler.acceptor;
+
+import static com.sequenceiq.cloudbreak.cloud.aws.scheduler.acceptor.DBInstanceStatuses.DB_STATUSES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.amazonaws.services.rds.model.DBInstance;
+import com.amazonaws.services.rds.model.DescribeDBInstancesResult;
+import com.amazonaws.waiters.WaiterState;
+
+class DescribeDbInstanceForModifySuccessAcceptorTest {
+
+    private final DescribeDbInstanceForModifySuccessAcceptor underTest = new DescribeDbInstanceForModifySuccessAcceptor();
+
+    @Test
+    void matches() {
+        DB_STATUSES.forEach(status1 -> {
+            DB_STATUSES.forEach(status2 -> {
+                boolean expected = "available".equals(status1) && "available".equals(status2) ||
+                        "available".equals(status1) && "stopped".equals(status2) ||
+                        "stopped".equals(status1) && "available".equals(status2) ||
+                        "stopped".equals(status1) && "stopped".equals(status2);
+                DBInstance dbInstance1 = new DBInstance().withDBInstanceStatus(status1);
+                DBInstance dbInstance2 = new DBInstance().withDBInstanceStatus(status2);
+                DescribeDBInstancesResult describeDBInstanceResult = new DescribeDBInstancesResult().withDBInstances(dbInstance1, dbInstance2);
+                boolean matches = underTest.matches(describeDBInstanceResult);
+                assertThat(matches)
+                        .withFailMessage("matches expected as '%s' but was '%s' for DB instance states '%s' and '%s'",
+                                expected, matches, status1, status2)
+                        .isEqualTo(expected);
+            });
+        });
+    }
+
+    @Test
+    void getState() {
+        assertThat(underTest.getState()).isEqualTo(WaiterState.SUCCESS);
+    }
+}


### PR DESCRIPTION
Redbeams was waiting forever on setting the termination protection
flag to 'false' in the case of stopped instances because the waiter
condition was not complete.