### PR TITLE
CB-8789 Configure DB TLS for DL cluster services & DH HMS

### DIFF
--- a/core-model/build.gradle
+++ b/core-model/build.gradle
@@ -22,7 +22,8 @@ dependencies {
     compile group: 'org.apache.commons',                name: 'commons-lang3',          version: apacheCommonsLangVersion
     compile group: 'com.google.code.findbugs',          name: 'annotations',            version: '3.0.1'
     testCompile group: 'junit',                         name: 'junit',                  version: junitVersion
-    testCompile group: 'org.reflections',               name: 'reflections',            version:  '0.9.11'
+    testCompile group: 'org.reflections',               name: 'reflections',            version: '0.9.11'
+    testCompile group: 'org.assertj',                   name: 'assertj-core',           version: assertjVersion
     testCompile project(path: ':common', configuration: 'tests')
 }
 

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/RDSConfig.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/RDSConfig.java
@@ -15,12 +15,13 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.util.DatabaseVendorConverter;
-import com.sequenceiq.cloudbreak.domain.converter.ResourceStatusConverter;
 import org.hibernate.annotations.Where;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.DatabaseVendorConverter;
+import com.sequenceiq.cloudbreak.domain.converter.RdsSslModeConverter;
+import com.sequenceiq.cloudbreak.domain.converter.ResourceStatusConverter;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.service.secret.SecretValue;
 import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
@@ -46,6 +47,9 @@ public class RDSConfig implements ProvisionEntity, WorkspaceAwareResource, Archi
 
     @Column(nullable = false)
     private String connectionURL;
+
+    @Convert(converter = RdsSslModeConverter.class)
+    private RdsSslMode sslMode;
 
     @Column(nullable = false)
     @Convert(converter = DatabaseVendorConverter.class)
@@ -120,6 +124,14 @@ public class RDSConfig implements ProvisionEntity, WorkspaceAwareResource, Archi
 
     public void setConnectionURL(String connectionURL) {
         this.connectionURL = connectionURL;
+    }
+
+    public RdsSslMode getSslMode() {
+        return sslMode;
+    }
+
+    public void setSslMode(RdsSslMode sslMode) {
+        this.sslMode = sslMode;
     }
 
     public DatabaseVendor getDatabaseEngine() {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/RdsSslMode.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/RdsSslMode.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.domain;
+
+public enum RdsSslMode {
+    ENABLED,
+    DISABLED;
+
+    public static boolean isEnabled(RdsSslMode mode) {
+        return ENABLED.equals(mode);
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/RdsSslModeConverter.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/RdsSslModeConverter.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.cloudbreak.domain.converter;
+
+import com.sequenceiq.cloudbreak.converter.DefaultEnumConverter;
+import com.sequenceiq.cloudbreak.domain.RdsSslMode;
+
+public class RdsSslModeConverter extends DefaultEnumConverter<RdsSslMode> {
+
+    @Override
+    public RdsSslMode getDefault() {
+        return RdsSslMode.DISABLED;
+    }
+
+}

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/RdsSslModeTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/RdsSslModeTest.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class RdsSslModeTest {
+
+    static Object[][] sslDataProvider() {
+        return new Object[][]{
+                // testCaseName sslMode resultExpected
+                {"sslMode=null", null, false},
+                {"sslMode=DISABLED", RdsSslMode.DISABLED, false},
+                {"sslMode=ENABLED", RdsSslMode.ENABLED, true},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("sslDataProvider")
+    void isEnabledTest(String testCaseName, RdsSslMode sslMode, boolean resultExpected) {
+        assertThat(RdsSslMode.isEnabled(sslMode)).isEqualTo(resultExpected);
+    }
+
+}

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/converter/RdsSslModeConverterTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/converter/RdsSslModeConverterTest.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.domain.converter;
+
+import javax.persistence.AttributeConverter;
+
+import com.sequenceiq.cloudbreak.converter.DefaultEnumConverterBaseTest;
+import com.sequenceiq.cloudbreak.domain.RdsSslMode;
+
+class RdsSslModeConverterTest extends DefaultEnumConverterBaseTest<RdsSslMode> {
+
+    @Override
+    public RdsSslMode getDefaultValue() {
+        return RdsSslMode.DISABLED;
+    }
+
+    @Override
+    public AttributeConverter<RdsSslMode, String> getVictim() {
+        return new RdsSslModeConverter();
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/RdsConfigToRdsDetailsConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/RdsConfigToRdsDetailsConverter.java
@@ -1,10 +1,13 @@
 package com.sequenceiq.cloudbreak.structuredevent.converter;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
+import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
@@ -21,30 +24,26 @@ public class RdsConfigToRdsDetailsConverter extends AbstractConversionServiceAwa
         RdsDetails rdsDetails = new RdsDetails();
         rdsDetails.setConnectionDriver(source.getConnectionDriver());
         rdsDetails.setConnectionURL(source.getConnectionURL());
+        rdsDetails.setSslMode(Optional.ofNullable(source.getSslMode()).map(Enum::name).orElse(null));
         rdsDetails.setConnectorJarUrl(source.getConnectorJarUrl());
         rdsDetails.setCreationDate(source.getCreationDate());
         rdsDetails.setDatabaseEngine(source.getDatabaseEngine().name());
-        if (DatabaseVendor.EMBEDDED == source.getDatabaseEngine()) {
-            rdsDetails.setExternal(Boolean.FALSE);
-        } else {
-            rdsDetails.setExternal(Boolean.TRUE);
-        }
+        rdsDetails.setExternal(DatabaseVendor.EMBEDDED != source.getDatabaseEngine());
         rdsDetails.setDescription(source.getDescription());
         rdsDetails.setId(source.getId());
         rdsDetails.setName(source.getName());
         rdsDetails.setStackVersion(source.getStackVersion());
         rdsDetails.setStatus(source.getStatus().name());
         rdsDetails.setType(source.getType());
-        if (source.getWorkspace() != null) {
-            rdsDetails.setWorkspaceId(source.getWorkspace().getId());
-        } else {
-            rdsDetails.setWorkspaceId(restRequestThreadLocalService.getRequestedWorkspaceId());
-        }
-        if (restRequestThreadLocalService.getCloudbreakUser() != null) {
-            rdsDetails.setUserName(restRequestThreadLocalService.getCloudbreakUser().getUsername());
-            rdsDetails.setUserId(restRequestThreadLocalService.getCloudbreakUser().getUserId());
-            rdsDetails.setTenantName(restRequestThreadLocalService.getCloudbreakUser().getTenant());
+        rdsDetails.setWorkspaceId(source.getWorkspace() != null ? source.getWorkspace().getId() : restRequestThreadLocalService.getRequestedWorkspaceId());
+
+        CloudbreakUser cloudbreakUser = restRequestThreadLocalService.getCloudbreakUser();
+        if (cloudbreakUser != null) {
+            rdsDetails.setUserName(cloudbreakUser.getUsername());
+            rdsDetails.setUserId(cloudbreakUser.getUserId());
+            rdsDetails.setTenantName(cloudbreakUser.getTenant());
         }
         return rdsDetails;
     }
+
 }

--- a/core/src/main/resources/schema/app/20201020160302_CB-8789_Configure_DB_TLS_for_DL_cluster_services_and_DH_HMS.sql
+++ b/core/src/main/resources/schema/app/20201020160302_CB-8789_Configure_DB_TLS_for_DL_cluster_services_and_DH_HMS.sql
@@ -1,0 +1,11 @@
+-- // CB-8789 Configure DB TLS for DL cluster services and DH HMS
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE rdsconfig
+    ADD COLUMN IF NOT EXISTS sslmode VARCHAR(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE rdsconfig
+    DROP COLUMN IF EXISTS sslmode;

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@ hibernateValidatorVersion=6.1.0.Final
 jasyptVersion=1.9.2
 apacheCommonsLangVersion=3.8.1
 apacheCommonsIoVersion=2.6
+apacheCommonsTextVersion=1.5
 apacheCommonsValidatorVersion=1.6
 mockitoVersion=3.3.3
 powermockVersion=2.0.0-beta.5

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/RdsDetails.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/RdsDetails.java
@@ -17,6 +17,8 @@ public class RdsDetails implements Serializable {
 
     private String connectionURL;
 
+    private String sslMode;
+
     private String databaseEngine;
 
     private String connectionDriver;
@@ -79,6 +81,14 @@ public class RdsDetails implements Serializable {
 
     public void setConnectionURL(String connectionURL) {
         this.connectionURL = connectionURL;
+    }
+
+    public String getSslMode() {
+        return sslMode;
+    }
+
+    public void setSslMode(String sslMode) {
+        this.sslMode = sslMode;
     }
 
     public String getDatabaseEngine() {
@@ -168,4 +178,5 @@ public class RdsDetails implements Serializable {
     public void setExternal(Boolean external) {
         externalDatabase = external;
     }
+
 }

--- a/template-manager-cmtemplate/build.gradle
+++ b/template-manager-cmtemplate/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     transitive = false
   }
   implementation group: "com.github.jknack",             name: "handlebars",                     version: "4.0.6"
+  implementation(group: "org.apache.commons",            name: "commons-text",                   version: apacheCommonsTextVersion) {
+    transitive = false
+  }
 
   testImplementation group: "org.springframework.boot",  name: "spring-boot-starter",            version: springBootVersion
   testImplementation group: "org.springframework.boot",  name: "spring-boot-starter-test",       version: springBootVersion

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigUtils.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ConfigUtils.java
@@ -85,4 +85,9 @@ public class ConfigUtils {
         }
         return DatabaseVendor.POSTGRES.name();
     }
+
+    public static String getCmVersion(TemplatePreparationObject source) {
+        return source.getProductDetailsView().getCm().getVersion();
+    }
+
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProvider.java
@@ -1,13 +1,24 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.getCmVersion;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.getSafetyValveProperty;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.cloudera.api.swagger.model.ApiClusterTemplateService;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
@@ -20,30 +31,73 @@ import com.sequenceiq.cloudbreak.template.views.RdsView;
 @Component
 public class HiveMetastoreConfigProvider extends AbstractRdsRoleConfigProvider {
 
+    @VisibleForTesting
+    static final String HIVE_METASTORE_DATABASE_HOST = "hive_metastore_database_host";
+
+    @VisibleForTesting
+    static final String HIVE_METASTORE_DATABASE_NAME = "hive_metastore_database_name";
+
+    @VisibleForTesting
+    static final String HIVE_METASTORE_DATABASE_PASSWORD = "hive_metastore_database_password";
+
+    @VisibleForTesting
+    static final String HIVE_METASTORE_DATABASE_PORT = "hive_metastore_database_port";
+
+    @VisibleForTesting
+    static final String HIVE_METASTORE_DATABASE_TYPE = "hive_metastore_database_type";
+
+    @VisibleForTesting
+    static final String HIVE_METASTORE_DATABASE_USER = "hive_metastore_database_user";
+
+    @VisibleForTesting
+    static final String HIVE_SERVICE_CONFIG_SAFETY_VALVE = "hive_service_config_safety_valve";
+
+    @VisibleForTesting
+    static final String HIVE_METASTORE_ENABLE_LDAP_AUTH = "hive_metastore_enable_ldap_auth";
+
+    @VisibleForTesting
+    static final String HIVE_METASTORE_LDAP_URI = "hive_metastore_ldap_uri";
+
+    @VisibleForTesting
+    static final String HIVE_METASTORE_LDAP_BASEDN = "hive_metastore_ldap_basedn";
+
+    @VisibleForTesting
+    static final String METASTORE_CANARY_HEALTH_ENABLED = "metastore_canary_health_enabled";
+
+    @VisibleForTesting
+    static final String JDBC_URL_OVERRIDE = "jdbc_url_override";
+
+    private static final Set<String> HIVE_METASTORE_DATABASE_CONFIG_KEYS = Set.of(HIVE_METASTORE_DATABASE_HOST, HIVE_METASTORE_DATABASE_NAME,
+            HIVE_METASTORE_DATABASE_PASSWORD, HIVE_METASTORE_DATABASE_PORT, HIVE_METASTORE_DATABASE_TYPE, HIVE_METASTORE_DATABASE_USER,
+            JDBC_URL_OVERRIDE);
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HiveMetastoreConfigProvider.class);
+
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
-        RdsView hiveView = getRdsView(source);
+        RdsView hiveRdsView = getRdsView(source);
 
         List<ApiClusterTemplateConfig> configs = Lists.newArrayList(
-                config("hive_metastore_database_host", hiveView.getHost()),
-                config("hive_metastore_database_name", hiveView.getDatabaseName()),
-                config("hive_metastore_database_password", hiveView.getConnectionPassword()),
-                config("hive_metastore_database_port", hiveView.getPort()),
-                config("hive_metastore_database_type", hiveView.getSubprotocol()),
-                config("hive_metastore_database_user", hiveView.getConnectionUserName())
+                config(HIVE_METASTORE_DATABASE_HOST, hiveRdsView.getHost()),
+                config(HIVE_METASTORE_DATABASE_NAME, hiveRdsView.getDatabaseName()),
+                config(HIVE_METASTORE_DATABASE_PASSWORD, hiveRdsView.getConnectionPassword()),
+                config(HIVE_METASTORE_DATABASE_PORT, hiveRdsView.getPort()),
+                config(HIVE_METASTORE_DATABASE_TYPE, hiveRdsView.getSubprotocol()),
+                config(HIVE_METASTORE_DATABASE_USER, hiveRdsView.getConnectionUserName())
         );
+        addDbSslConfigsIfNeeded(templateProcessor, hiveRdsView, configs, getCmVersion(source));
 
         Optional<KerberosConfig> kerberosConfigOpt = source.getKerberosConfig();
         if (kerberosConfigOpt.isPresent()) {
-            String safetyValveValue = "<property><name>hive.hook.proto.file.per.event</name><value>true</value></property>";
-            configs.add(config("hive_service_config_safety_valve", safetyValveValue));
+            String safetyValveValue = getSafetyValveProperty("hive.hook.proto.file.per.event", Boolean.TRUE.toString());
+            configs.add(config(HIVE_SERVICE_CONFIG_SAFETY_VALVE, safetyValveValue));
         }
 
         if (source.getStackType() == StackType.DATALAKE) {
             source.getLdapConfig().ifPresent(ldap -> {
-                configs.add(config("hive_metastore_enable_ldap_auth", "true"));
-                configs.add(config("hive_metastore_ldap_uri", ldap.getConnectionURL()));
-                configs.add(config("hive_metastore_ldap_basedn", ldap.getUserSearchBase()));
+                configs.add(config(HIVE_METASTORE_ENABLE_LDAP_AUTH, Boolean.TRUE.toString()));
+                configs.add(config(HIVE_METASTORE_LDAP_URI, ldap.getConnectionURL()));
+                configs.add(config(HIVE_METASTORE_LDAP_BASEDN, ldap.getUserSearchBase()));
             });
         }
         return configs;
@@ -67,8 +121,44 @@ public class HiveMetastoreConfigProvider extends AbstractRdsRoleConfigProvider {
     @Override
     protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
         return List.of(
-                config("metastore_canary_health_enabled", Boolean.FALSE.toString())
+                config(METASTORE_CANARY_HEALTH_ENABLED, Boolean.FALSE.toString())
         );
+    }
+
+    private List<String> getExistingHiveServiceConfigKeys(CmTemplateProcessor templateProcessor) {
+        return templateProcessor
+                .getServiceByType(getServiceType())
+                .map(ApiClusterTemplateService::getServiceConfigs)
+                .map(this::extractValidConfigKeys)
+                .orElse(List.of());
+    }
+
+    private List<String> extractValidConfigKeys(List<ApiClusterTemplateConfig> configs) {
+        return configs.stream()
+                .filter(config -> config.getValue() != null || config.getVariable() != null)
+                .map(ApiClusterTemplateConfig::getName)
+                .collect(Collectors.toList());
+    }
+
+    private void addDbSslConfigsIfNeeded(CmTemplateProcessor templateProcessor, RdsView hiveRdsView, List<ApiClusterTemplateConfig> configList,
+            String cmVersion) {
+        if (hiveRdsView.isUseSsl()) {
+            if (isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_2)) {
+                ArrayList<String> overriddenDbConfigKeys = new ArrayList<>(getExistingHiveServiceConfigKeys(templateProcessor));
+                overriddenDbConfigKeys.retainAll(HIVE_METASTORE_DATABASE_CONFIG_KEYS);
+                if (overriddenDbConfigKeys.isEmpty()) {
+                    LOGGER.info("Injecting Hive Metastore DB SSL configs because the supplied DB requires SSL " +
+                            "and DB settings are not overridden in the cluster template.");
+                    configList.add(config(JDBC_URL_OVERRIDE, hiveRdsView.getConnectionURL()));
+                } else {
+                    // This is currently possible for Data Hub clusters using a custom cluster template
+                    LOGGER.info("The supplied Hive Metastore DB would require SSL, but the following config keys are present in the cluster template: {}. " +
+                            "Skipping Hive Metastore DB SSL configs injection in favor of cluster template settings.", overriddenDbConfigKeys);
+                }
+            } else {
+                LOGGER.warn("The supplied Hive Metastore DB would require SSL, but this setting is not supported for the CM version {} used here.", cmVersion);
+            }
+        }
     }
 
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProvider.java
@@ -2,11 +2,22 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_0_1;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_1;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.getCmVersion;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.getSafetyValveProperty;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.auth.altus.UmsRight;
 import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupRequest;
@@ -16,25 +27,48 @@ import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfi
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
-import java.util.ArrayList;
-import java.util.List;
-import javax.inject.Inject;
-import org.springframework.stereotype.Component;
 
 @Component
 public class RangerRoleConfigProvider extends AbstractRdsRoleConfigProvider {
+
+    @VisibleForTesting
+    static final String RANGER_DATABASE_HOST = "ranger_database_host";
+
+    @VisibleForTesting
+    static final String RANGER_DATABASE_NAME = "ranger_database_name";
+
+    @VisibleForTesting
+    static final String RANGER_DATABASE_TYPE = "ranger_database_type";
+
+    @VisibleForTesting
+    static final String RANGER_DATABASE_USER = "ranger_database_user";
+
+    @VisibleForTesting
+    static final String RANGER_DATABASE_PASSWORD = "ranger_database_password";
+
+    @VisibleForTesting
+    static final String RANGER_ADMIN_SITE_XML_ROLE_SAFETY_VALVE = "conf/ranger-admin-site.xml_role_safety_valve";
+
+    @VisibleForTesting
+    static final String RANGER_DATABASE_PORT = "ranger_database_port";
+
+    @VisibleForTesting
+    static final String RANGER_DEFAULT_POLICY_GROUPS = "ranger.default.policy.groups";
+
+    private static final String RANGER_JPA_JDBC_URL = "ranger.jpa.jdbc.url";
+
     @Inject
     private VirtualGroupService virtualGroupService;
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
-        String cdhVersion = getCdhVersion(source);
+        String cmVersion = getCmVersion(source);
         List<ApiClusterTemplateConfig> configList = new ArrayList<>();
 
-        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_1)) {
+        if (isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_1)) {
             RdsView rangerRdsView = getRdsView(source);
-            addDbConfigs(rangerRdsView, configList, cdhVersion);
-            configList.add(config("ranger_database_port", rangerRdsView.getPort()));
+            addDbConfigs(rangerRdsView, configList, cmVersion);
+            configList.add(config(RANGER_DATABASE_PORT, rangerRdsView.getPort()));
         }
 
         return configList;
@@ -44,19 +78,21 @@ public class RangerRoleConfigProvider extends AbstractRdsRoleConfigProvider {
     protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
         switch (roleType) {
             case RangerRoles.RANGER_ADMIN:
-                String cdhVersion = getCdhVersion(source);
+                String cmVersion = getCmVersion(source);
                 List<ApiClusterTemplateConfig> configList = new ArrayList<>();
 
                 // In CM 7.2.1 and above, the ranger database parameters have moved to the service
                 // config (see above getServiceConfigs).
-                if (!isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_1)) {
-                    addDbConfigs(getRdsView(source), configList, cdhVersion);
+                RdsView rangerRdsView = getRdsView(source);
+                if (!isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_1)) {
+                    addDbConfigs(rangerRdsView, configList, cmVersion);
                 }
+                addDbSslConfigsIfNeeded(rangerRdsView, configList, cmVersion);
 
-                if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_0_1)) {
+                if (isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_0_1)) {
                     VirtualGroupRequest virtualGroupRequest = source.getVirtualGroupRequest();
                     String adminGroup = virtualGroupService.getVirtualGroup(virtualGroupRequest, UmsRight.RANGER_ADMIN.getRight());
-                    configList.add(config("ranger.default.policy.groups", adminGroup));
+                    configList.add(config(RANGER_DEFAULT_POLICY_GROUPS, adminGroup));
                 }
                 return configList;
             default:
@@ -82,29 +118,32 @@ public class RangerRoleConfigProvider extends AbstractRdsRoleConfigProvider {
     // There is a bug in CM (OPSAPS-56992) which makes the db names case-sensitive.
     // To workaround this, we have to send the correctly cased ranger_database_type depending
     // on the version of CM.
-    private String versionCorrectedPostgresString(final String cdhVersion) {
-        return isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_1) ? "postgresql" : "PostgreSQL";
+    private String versionCorrectedPostgresString(final String cmVersion) {
+        return isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_1) ? "postgresql" : "PostgreSQL";
     }
 
-    private String getRangerDbType(RdsView rdsView, String cdhVersion) {
-        switch (rdsView.getDatabaseVendor()) {
+    private String getRangerDbType(RdsView rangerRdsView, String cmVersion) {
+        switch (rangerRdsView.getDatabaseVendor()) {
             case POSTGRES:
-                return versionCorrectedPostgresString(cdhVersion);
+                return versionCorrectedPostgresString(cmVersion);
             default:
-                throw new CloudbreakServiceException("Unsupported Ranger database type: " + rdsView.getDatabaseVendor().displayName());
+                throw new CloudbreakServiceException("Unsupported Ranger database type: " + rangerRdsView.getDatabaseVendor().displayName());
         }
     }
 
-    private String getCdhVersion(TemplatePreparationObject source) {
-        return source.getBlueprintView().getProcessor().getStackVersion() == null ?
-            "" : source.getBlueprintView().getProcessor().getStackVersion();
+    private void addDbConfigs(RdsView rangerRdsView, List<ApiClusterTemplateConfig> configList, final String cmVersion) {
+        configList.add(config(RANGER_DATABASE_HOST, rangerRdsView.getHost()));
+        configList.add(config(RANGER_DATABASE_NAME, rangerRdsView.getDatabaseName()));
+        configList.add(config(RANGER_DATABASE_TYPE, getRangerDbType(rangerRdsView, cmVersion)));
+        configList.add(config(RANGER_DATABASE_USER, rangerRdsView.getConnectionUserName()));
+        configList.add(config(RANGER_DATABASE_PASSWORD, rangerRdsView.getConnectionPassword()));
     }
 
-    private void addDbConfigs(RdsView rangerRdsView, List<ApiClusterTemplateConfig> configList, final String cdhVersion) {
-        configList.add(config("ranger_database_host", rangerRdsView.getHost()));
-        configList.add(config("ranger_database_name", rangerRdsView.getDatabaseName()));
-        configList.add(config("ranger_database_type", getRangerDbType(rangerRdsView, cdhVersion)));
-        configList.add(config("ranger_database_user", rangerRdsView.getConnectionUserName()));
-        configList.add(config("ranger_database_password", rangerRdsView.getConnectionPassword()));
+    private void addDbSslConfigsIfNeeded(RdsView rangerRdsView, List<ApiClusterTemplateConfig> configList, String cmVersion) {
+        if (isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_2) && rangerRdsView.isUseSsl()) {
+            String escapedConnectionURL = StringEscapeUtils.escapeXml10(rangerRdsView.getConnectionURL());
+            configList.add(config(RANGER_ADMIN_SITE_XML_ROLE_SAFETY_VALVE, getSafetyValveProperty(RANGER_JPA_JDBC_URL, escapedConnectionURL)));
+        }
     }
+
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
@@ -52,6 +52,7 @@ import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.GatewayView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.cloudbreak.template.views.ProductDetailsView;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.common.api.filesystem.S3FileSystem;
 import com.sequenceiq.common.api.type.InstanceGroupType;
@@ -125,10 +126,13 @@ public class CentralCmTemplateUpdaterTest {
         S3FileSystemConfigurationsView fileSystemConfigurationsView =
                 new S3FileSystemConfigurationsView(new S3FileSystem(), locations, false);
         when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(Optional.of(fileSystemConfigurationsView));
+
         when(generalClusterConfigs.getClusterName()).thenReturn("testcluster");
         when(generalClusterConfigs.getPassword()).thenReturn("Admin123!");
         clouderaManagerRepo = new ClouderaManagerRepo();
         clouderaManagerRepo.setVersion("6.1.0");
+        ProductDetailsView productDetailsView = new ProductDetailsView(clouderaManagerRepo, List.of());
+        when(templatePreparationObject.getProductDetailsView()).thenReturn(productDetailsView);
         ReflectionTestUtils.setField(cmTemplateComponentConfigProviderProcessor, "providers", cmTemplateComponentConfigProviders);
         ReflectionTestUtils.setField(cmTemplateConfigInjectorProcessor, "injectors", List.of());
         ReflectionTestUtils.setField(cmHostGroupRoleConfigProviderProcessor, "providers", List.of());

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProviderTest.java
@@ -1,0 +1,296 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive;
+
+import static com.sequenceiq.cloudbreak.TestUtil.kerberosConfigFreeipa;
+import static com.sequenceiq.cloudbreak.TestUtil.ldapConfig;
+import static com.sequenceiq.cloudbreak.TestUtil.rdsConfig;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigTestUtil.getConfigNameToValueMap;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigTestUtil.getConfigNameToVariableNameMap;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.HIVE_METASTORE_DATABASE_HOST;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.HIVE_METASTORE_DATABASE_NAME;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.HIVE_METASTORE_DATABASE_PASSWORD;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.HIVE_METASTORE_DATABASE_PORT;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.HIVE_METASTORE_DATABASE_TYPE;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.HIVE_METASTORE_DATABASE_USER;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.HIVE_METASTORE_ENABLE_LDAP_AUTH;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.HIVE_METASTORE_LDAP_BASEDN;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.HIVE_METASTORE_LDAP_URI;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.HIVE_SERVICE_CONFIG_SAFETY_VALVE;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.JDBC_URL_OVERRIDE;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider.METASTORE_CANARY_HEALTH_ENABLED;
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.cloudera.api.swagger.model.ApiClusterTemplateService;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.common.type.Versioned;
+import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.domain.RdsSslMode;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+@ExtendWith(MockitoExtension.class)
+class HiveMetastoreConfigProviderTest {
+
+    @Mock
+    private CmTemplateProcessor templateProcessor;
+
+    @InjectMocks
+    private HiveMetastoreConfigProvider underTest;
+
+    @Test
+    void getServiceTypeTest() {
+        assertThat(underTest.getServiceType()).isEqualTo(HiveRoles.HIVE);
+    }
+
+    @Test
+    void getRoleTypesTest() {
+        assertThat(underTest.getRoleTypes()).containsOnly(HiveRoles.HIVEMETASTORE);
+    }
+
+    @Test
+    void dbTypeTest() {
+        assertThat(underTest.dbType()).isEqualTo(DatabaseType.HIVE);
+    }
+
+    @Test
+    void getRoleConfigsTest() {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(HiveRoles.HIVEMETASTORE, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                entry(METASTORE_CANARY_HEALTH_ENABLED, Boolean.FALSE.toString())
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    static Object[][] cmVersionMinimalDataProvider() {
+        return new Object[][]{
+                // testCaseName cmVersion
+                {"CM 7.2.0", CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0},
+                {"CM 7.2.1", CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_1},
+                {"CM 7.2.2", CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("cmVersionMinimalDataProvider")
+    void getServiceConfigsTestDbOnlyAndNoSsl(String testCaseName, Versioned cmVersion) {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withRdsConfigs(Set.of(createRdsConfig(null)))
+                .withProductDetails(generateCmRepo(cmVersion), null)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(templateProcessor, tpo);
+
+        verifyDbOnlyMinimalResult(result);
+    }
+
+    private void verifyDbOnlyMinimalResult(List<ApiClusterTemplateConfig> result) {
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                entry(HIVE_METASTORE_DATABASE_HOST, "10.1.1.1"),
+                entry(HIVE_METASTORE_DATABASE_NAME, "hive"),
+                entry(HIVE_METASTORE_DATABASE_PASSWORD, "iamsoosecure"),
+                entry(HIVE_METASTORE_DATABASE_PORT, "5432"),
+                entry(HIVE_METASTORE_DATABASE_TYPE, "postgresql"),
+                entry(HIVE_METASTORE_DATABASE_USER, "heyitsme")
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    void getServiceConfigsTestDbOnlyWithSsl() {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withRdsConfigs(Set.of(createRdsConfig(RdsSslMode.ENABLED)))
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(templateProcessor, tpo);
+
+        verifyDbOnlySslResult(result);
+    }
+
+    private void verifyDbOnlySslResult(List<ApiClusterTemplateConfig> result) {
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                entry(HIVE_METASTORE_DATABASE_HOST, "10.1.1.1"),
+                entry(HIVE_METASTORE_DATABASE_NAME, "hive"),
+                entry(HIVE_METASTORE_DATABASE_PASSWORD, "iamsoosecure"),
+                entry(HIVE_METASTORE_DATABASE_PORT, "5432"),
+                entry(HIVE_METASTORE_DATABASE_TYPE, "postgresql"),
+                entry(HIVE_METASTORE_DATABASE_USER, "heyitsme"),
+                entry(JDBC_URL_OVERRIDE, "jdbc:postgresql://10.1.1.1:5432/hive?sslmode=verify-full&sslrootcert=/hadoopfs/fs1/database-cacerts/certs.pem")
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    static Object[][] cmVersionNoSslSupportDataProvider() {
+        return new Object[][]{
+                // testCaseName cmVersion
+                {"CM 7.2.0", CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0},
+                {"CM 7.2.1", CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_1},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("cmVersionNoSslSupportDataProvider")
+    void getServiceConfigsTestDbOnlyWithSslButWrongCmVersion(String testCaseName, Versioned cmVersion) {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withRdsConfigs(Set.of(createRdsConfig(RdsSslMode.ENABLED)))
+                .withProductDetails(generateCmRepo(cmVersion), null)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(templateProcessor, tpo);
+
+        verifyDbOnlyMinimalResult(result);
+    }
+
+    @Test
+    void getServiceConfigsTestDbOnlyWithSslAndTemplateWithHarmlessHmsServiceConfigs() {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withRdsConfigs(Set.of(createRdsConfig(RdsSslMode.ENABLED)))
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .build();
+        initHmsServiceConfigs(List.of(config("foo", "bar")));
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(templateProcessor, tpo);
+
+        verifyDbOnlySslResult(result);
+    }
+
+    private void initHmsServiceConfigs(List<ApiClusterTemplateConfig> serviceConfigs) {
+        ApiClusterTemplateService service = new ApiClusterTemplateService();
+        service.setServiceConfigs(serviceConfigs);
+        when(templateProcessor.getServiceByType(HiveRoles.HIVE)).thenReturn(Optional.of(service));
+    }
+
+    @Test
+    void getServiceConfigsTestDbOnlyWithSslAndTemplateWithHarmlessHmsServiceConfigsAndDummyCustomHmsDbKeys() {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withRdsConfigs(Set.of(createRdsConfig(RdsSslMode.ENABLED)))
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .build();
+        initHmsServiceConfigs(List.of(config("foo", "bar"), config(HIVE_METASTORE_DATABASE_HOST, null)));
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(templateProcessor, tpo);
+
+        verifyDbOnlySslResult(result);
+    }
+
+    @Test
+    void getServiceConfigsTestDbOnlyWithSslAndTemplateWithHarmlessHmsServiceConfigsAndCustomHmsDbOverride() {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withRdsConfigs(Set.of(createRdsConfig(RdsSslMode.ENABLED)))
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .build();
+        initHmsServiceConfigs(List.of(config("foo", "bar"), config(HIVE_METASTORE_DATABASE_HOST, "customhms.mydomain.com")));
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(templateProcessor, tpo);
+
+        verifyDbOnlyMinimalResult(result);
+    }
+
+    @Test
+    void getServiceConfigsTestDbAndKerberos() {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withRdsConfigs(Set.of(createRdsConfig(null)))
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .withKerberosConfig(kerberosConfigFreeipa())
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(templateProcessor, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                entry(HIVE_METASTORE_DATABASE_HOST, "10.1.1.1"),
+                entry(HIVE_METASTORE_DATABASE_NAME, "hive"),
+                entry(HIVE_METASTORE_DATABASE_PASSWORD, "iamsoosecure"),
+                entry(HIVE_METASTORE_DATABASE_PORT, "5432"),
+                entry(HIVE_METASTORE_DATABASE_TYPE, "postgresql"),
+                entry(HIVE_METASTORE_DATABASE_USER, "heyitsme"),
+                entry(HIVE_SERVICE_CONFIG_SAFETY_VALVE, "<property><name>hive.hook.proto.file.per.event</name><value>true</value></property>")
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    @Test
+    void getServiceConfigsTestDatalakeAndNoLdap() {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withRdsConfigs(Set.of(createRdsConfig(null)))
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .withStackType(StackType.DATALAKE)
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(templateProcessor, tpo);
+
+        verifyDbOnlyMinimalResult(result);
+    }
+
+    @Test
+    void getServiceConfigsTestDatalakeWithLdap() {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withRdsConfigs(Set.of(createRdsConfig(null)))
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .withStackType(StackType.DATALAKE)
+                .withLdapConfig(ldapConfig())
+                .build();
+
+        List<ApiClusterTemplateConfig> result = underTest.getServiceConfigs(templateProcessor, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                entry(HIVE_METASTORE_DATABASE_HOST, "10.1.1.1"),
+                entry(HIVE_METASTORE_DATABASE_NAME, "hive"),
+                entry(HIVE_METASTORE_DATABASE_PASSWORD, "iamsoosecure"),
+                entry(HIVE_METASTORE_DATABASE_PORT, "5432"),
+                entry(HIVE_METASTORE_DATABASE_TYPE, "postgresql"),
+                entry(HIVE_METASTORE_DATABASE_USER, "heyitsme"),
+                entry(HIVE_METASTORE_ENABLE_LDAP_AUTH, Boolean.TRUE.toString()),
+                entry(HIVE_METASTORE_LDAP_URI, "ldap://localhost:389"),
+                entry(HIVE_METASTORE_LDAP_BASEDN, "cn=users,dc=example,dc=org")
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
+    }
+
+    private RDSConfig createRdsConfig(RdsSslMode sslMode) {
+        RDSConfig rdsConfig = rdsConfig(DatabaseType.HIVE);
+        rdsConfig.setSslMode(sslMode);
+        return rdsConfig;
+    }
+
+    private ClouderaManagerRepo generateCmRepo(Versioned version) {
+        return new ClouderaManagerRepo()
+                .withBaseUrl("baseurl")
+                .withGpgKeyUrl("gpgurl")
+                .withPredefined(true)
+                .withVersion(version.getVersion());
+    }
+
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProviderTest.java
@@ -1,48 +1,62 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger;
 
-import static com.sequenceiq.cloudbreak.TestUtil.ldapConfigBuilder;
 import static com.sequenceiq.cloudbreak.TestUtil.rdsConfig;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigTestUtil.getConfigNameToValueMap;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigTestUtil.getConfigNameToVariableNameMap;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger.RangerRoleConfigProvider.RANGER_DATABASE_HOST;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger.RangerRoleConfigProvider.RANGER_DATABASE_NAME;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger.RangerRoleConfigProvider.RANGER_DATABASE_PASSWORD;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger.RangerRoleConfigProvider.RANGER_DATABASE_PORT;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger.RangerRoleConfigProvider.RANGER_DATABASE_TYPE;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger.RangerRoleConfigProvider.RANGER_DATABASE_USER;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger.RangerRoleConfigProvider.RANGER_DEFAULT_POLICY_GROUPS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ranger.RangerRoleConfigProvider.RANGER_ADMIN_SITE_XML_ROLE_SAFETY_VALVE;
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.when;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.ldaps.DirectoryType;
 import com.sequenceiq.cloudbreak.auth.altus.UmsRight;
+import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupRequest;
 import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupService;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
-import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
-import com.sequenceiq.cloudbreak.dto.LdapView;
+import com.sequenceiq.cloudbreak.common.type.Versioned;
+import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.domain.RdsSslMode;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
-import com.sequenceiq.cloudbreak.auth.altus.VirtualGroupRequest;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
-import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.util.TestConstants;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RangerRoleConfigProviderTest {
+
+    private static final String ADMIN_GROUP = "cdh_test";
+
     @Mock
     private VirtualGroupService virtualGroupService;
 
     @InjectMocks
-    private final RangerRoleConfigProvider underTest = new RangerRoleConfigProvider();
+    private RangerRoleConfigProvider underTest;
 
     @Test
     public void testGetRoleConfigsWithoutRanger() {
@@ -56,30 +70,34 @@ public class RangerRoleConfigProviderTest {
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
 
         //Since the blueprint does not contain Ranger
-        assertEquals(0, roleConfigs.size());
+        assertThat(roleConfigs.size()).isEqualTo(0);
 
         List<ApiClusterTemplateConfig> masterRangerAdmin = roleConfigs.get("ranger-RANGER_ADMIN-BASE");
 
-        assertNull(masterRangerAdmin);
+        assertThat(masterRangerAdmin).isNull();
     }
 
-    @Test
-    public void testGetRangerAdminDefaultPolicyGroups() {
-        validateGetRangerAdminDefaultPolicyGroups("6.9.0", 5, 0);
-        validateGetRangerAdminDefaultPolicyGroups("6.x.0", 5, 0);
-        validateGetRangerAdminDefaultPolicyGroups("7.0.0", 5, 0);
-        validateGetRangerAdminDefaultPolicyGroups("", 5, 0);
+    public static Object[][] defaultPolicyGroupsDataProvider() {
+        return new Object[][]{
+                // testCaseName cdhVersion expectedRoleConfigCount expectedSvcConfigCount
+                {"cdhVersion=6.9.0", "6.9.0", 5, 0},
+                {"cdhVersion=6.x.0", "6.x.0", 5, 0},
+                {"cdhVersion=7.0.0", "7.0.0", 5, 0},
+                {"cdhVersion=", "", 5, 0},
 
-        validateGetRangerAdminDefaultPolicyGroups("7.0.1", 6, 0);
-        validateGetRangerAdminDefaultPolicyGroups("7.1.0", 6, 0);
-        validateGetRangerAdminDefaultPolicyGroups("7.1.x", 6, 0);
-        validateGetRangerAdminDefaultPolicyGroups("7.2.0", 6, 0);
-        validateGetRangerAdminDefaultPolicyGroups("7.2.1", 1, 6);
-        validateGetRangerAdminDefaultPolicyGroups("7.3.1", 1, 6);
-        validateGetRangerAdminDefaultPolicyGroups("8.1.0", 1, 6);
+                {"cdhVersion=7.0.1", "7.0.1", 6, 0},
+                {"cdhVersion=7.1.0", "7.1.0", 6, 0},
+                {"cdhVersion=7.1.x", "7.1.x", 6, 0},
+                {"cdhVersion=7.2.0", "7.2.0", 6, 0},
+                {"cdhVersion=7.2.1", "7.2.1", 1, 6},
+                {"cdhVersion=7.3.1", "7.3.1", 1, 6},
+                {"cdhVersion=8.1.0", "8.1.0", 1, 6},
+        };
     }
 
-    private void validateGetRangerAdminDefaultPolicyGroups(String cdhVersion, int expectedRoleConfigCount, int expectedSvcConfigCount) {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("defaultPolicyGroupsDataProvider")
+    public void testGetRangerAdminDefaultPolicyGroups(String testCaseName, String cdhVersion, int expectedRoleConfigCount, int expectedSvcConfigCount) {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
 
@@ -87,29 +105,29 @@ public class RangerRoleConfigProviderTest {
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
         cmTemplateProcessor.setCdhVersion(cdhVersion);
 
-        String ldapAdminGroup = "cdh_test";
-        LdapView ldapView = ldapConfigBuilder()
-                .withDirectoryType(DirectoryType.LDAP)
-                .withAdminGroup(ldapAdminGroup)
-                .build();
-
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker))
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, worker))
                 .withBlueprintView(new BlueprintView(inputJson, "", "", cmTemplateProcessor))
                 .withRdsConfigs(Set.of(rdsConfig(DatabaseType.RANGER)))
-                .withLdapConfig(ldapView)
-                .withVirtualGroupView(new VirtualGroupRequest(TestConstants.CRN, "")).build();
-        Mockito.when(virtualGroupService.getVirtualGroup(preparationObject.getVirtualGroupRequest(), UmsRight.RANGER_ADMIN.getRight())).thenReturn("cdh_test");
+                .withVirtualGroupView(new VirtualGroupRequest(TestConstants.CRN, ""))
+                .withProductDetails(generateCmRepo(() -> cdhVersion), null)
+                .build();
+        if (expectedRoleConfigCount == 6) {
+            when(virtualGroupService.getVirtualGroup(preparationObject.getVirtualGroupRequest(), UmsRight.RANGER_ADMIN.getRight())).thenReturn(ADMIN_GROUP);
+        }
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
+
         List<ApiClusterTemplateConfig> masterRangerAdmin = roleConfigs.get("ranger-RANGER_ADMIN-BASE");
-        assertEquals(expectedRoleConfigCount, masterRangerAdmin.size());
+        assertThat(masterRangerAdmin.size()).isEqualTo(expectedRoleConfigCount);
 
         List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
-        assertEquals(expectedSvcConfigCount, serviceConfigs.size());
+
+        assertThat(serviceConfigs.size()).isEqualTo(expectedSvcConfigCount);
 
         if (expectedRoleConfigCount == 6) {
-            assertEquals("ranger.default.policy.groups", masterRangerAdmin.get(5).getName());
-            assertEquals(ldapAdminGroup, masterRangerAdmin.get(5).getValue());
+            assertThat(masterRangerAdmin.get(5).getName()).isEqualTo(RANGER_DEFAULT_POLICY_GROUPS);
+            assertThat(masterRangerAdmin.get(5).getValue()).isEqualTo(ADMIN_GROUP);
         }
     }
 
@@ -120,34 +138,36 @@ public class RangerRoleConfigProviderTest {
         String inputJson = getBlueprintText("input/clouderamanager-db-config.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker))
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, worker))
                 .withBlueprintView(new BlueprintView(inputJson, "", "", cmTemplateProcessor))
                 .withRdsConfigs(Set.of(rdsConfig(DatabaseType.RANGER)))
+                .withProductDetails(generateCmRepo(() -> "7.0.0"), null)
                 .build();
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
 
         //Shall be only a single match, which is the Ranger one
-        assertEquals(1, roleConfigs.size());
+        assertThat(roleConfigs.size()).isEqualTo(1);
 
         List<ApiClusterTemplateConfig> masterRangerAdmin = roleConfigs.get("ranger-RANGER_ADMIN-BASE");
 
-        assertEquals(5, masterRangerAdmin.size());
+        assertThat(masterRangerAdmin.size()).isEqualTo(5);
 
-        assertEquals("ranger_database_host", masterRangerAdmin.get(0).getName());
-        assertEquals("10.1.1.1", masterRangerAdmin.get(0).getValue());
+        assertThat(masterRangerAdmin.get(0).getName()).isEqualTo(RANGER_DATABASE_HOST);
+        assertThat(masterRangerAdmin.get(0).getValue()).isEqualTo("10.1.1.1");
 
-        assertEquals("ranger_database_name", masterRangerAdmin.get(1).getName());
-        assertEquals("ranger", masterRangerAdmin.get(1).getValue());
+        assertThat(masterRangerAdmin.get(1).getName()).isEqualTo(RANGER_DATABASE_NAME);
+        assertThat(masterRangerAdmin.get(1).getValue()).isEqualTo("ranger");
 
-        assertEquals("ranger_database_type", masterRangerAdmin.get(2).getName());
-        assertEquals("PostgreSQL", masterRangerAdmin.get(2).getValue());
+        assertThat(masterRangerAdmin.get(2).getName()).isEqualTo(RANGER_DATABASE_TYPE);
+        assertThat(masterRangerAdmin.get(2).getValue()).isEqualTo("PostgreSQL");
 
-        assertEquals("ranger_database_user", masterRangerAdmin.get(3).getName());
-        assertEquals("heyitsme", masterRangerAdmin.get(3).getValue());
+        assertThat(masterRangerAdmin.get(3).getName()).isEqualTo(RANGER_DATABASE_USER);
+        assertThat(masterRangerAdmin.get(3).getValue()).isEqualTo("heyitsme");
 
-        assertEquals("ranger_database_password", masterRangerAdmin.get(4).getName());
-        assertEquals("iamsoosecure", masterRangerAdmin.get(4).getValue());
+        assertThat(masterRangerAdmin.get(4).getName()).isEqualTo(RANGER_DATABASE_PASSWORD);
+        assertThat(masterRangerAdmin.get(4).getValue()).isEqualTo("iamsoosecure");
     }
 
     @Test
@@ -157,32 +177,34 @@ public class RangerRoleConfigProviderTest {
 
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
 
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master))
-            .withBlueprintView(new BlueprintView(inputJson, "", "", cmTemplateProcessor))
-            .withRdsConfigs(Set.of(rdsConfig(DatabaseType.RANGER)))
-            .build();
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master))
+                .withBlueprintView(new BlueprintView(inputJson, "", "", cmTemplateProcessor))
+                .withRdsConfigs(Set.of(rdsConfig(DatabaseType.RANGER)))
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .build();
 
         List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
 
-        assertEquals(6, serviceConfigs.size());
+        assertThat(serviceConfigs.size()).isEqualTo(6);
 
-        assertEquals("ranger_database_host", serviceConfigs.get(0).getName());
-        assertEquals("10.1.1.1", serviceConfigs.get(0).getValue());
+        assertThat(serviceConfigs.get(0).getName()).isEqualTo(RANGER_DATABASE_HOST);
+        assertThat(serviceConfigs.get(0).getValue()).isEqualTo("10.1.1.1");
 
-        assertEquals("ranger_database_name", serviceConfigs.get(1).getName());
-        assertEquals("ranger", serviceConfigs.get(1).getValue());
+        assertThat(serviceConfigs.get(1).getName()).isEqualTo(RANGER_DATABASE_NAME);
+        assertThat(serviceConfigs.get(1).getValue()).isEqualTo("ranger");
 
-        assertEquals("ranger_database_type", serviceConfigs.get(2).getName());
-        assertEquals("postgresql", serviceConfigs.get(2).getValue());
+        assertThat(serviceConfigs.get(2).getName()).isEqualTo(RANGER_DATABASE_TYPE);
+        assertThat(serviceConfigs.get(2).getValue()).isEqualTo("postgresql");
 
-        assertEquals("ranger_database_user", serviceConfigs.get(3).getName());
-        assertEquals("heyitsme", serviceConfigs.get(3).getValue());
+        assertThat(serviceConfigs.get(3).getName()).isEqualTo(RANGER_DATABASE_USER);
+        assertThat(serviceConfigs.get(3).getValue()).isEqualTo("heyitsme");
 
-        assertEquals("ranger_database_password", serviceConfigs.get(4).getName());
-        assertEquals("iamsoosecure", serviceConfigs.get(4).getValue());
+        assertThat(serviceConfigs.get(4).getName()).isEqualTo(RANGER_DATABASE_PASSWORD);
+        assertThat(serviceConfigs.get(4).getValue()).isEqualTo("iamsoosecure");
 
-        assertEquals("ranger_database_port", serviceConfigs.get(5).getName());
-        assertEquals("5432", serviceConfigs.get(5).getValue());
+        assertThat(serviceConfigs.get(5).getName()).isEqualTo(RANGER_DATABASE_PORT);
+        assertThat(serviceConfigs.get(5).getValue()).isEqualTo("5432");
     }
 
     @Test
@@ -191,37 +213,60 @@ public class RangerRoleConfigProviderTest {
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
 
         // We do not configure RANGER DB
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker))
-                .withRdsConfigs(new HashSet<>(Collections.singleton(rdsConfig(DatabaseType.HIVE)))).build();
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, worker))
+                .withRdsConfigs(Set.of(rdsConfig(DatabaseType.HIVE)))
+                .build();
 
         String inputJson = getBlueprintText("input/clouderamanager-db-config.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 
-        assertFalse(underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject));
+        assertThat(underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject)).isFalse();
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void testRoleConfigsForMultipleDb() {
-        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
-        HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
-
         // We configure multiple DBs
-        TemplatePreparationObject preparationObject = Builder.builder().withHostgroupViews(Set.of(master, worker))
-                .withRdsConfigs(new HashSet<>(List.of(rdsConfig(DatabaseType.RANGER), rdsConfig(DatabaseType.RANGER)))).build();
+        assertThatCode(() -> Builder.builder().withRdsConfigs(Set.of(rdsConfig(DatabaseType.RANGER), rdsConfig(DatabaseType.RANGER))).build())
+                .isInstanceOf(IllegalStateException.class);
+    }
 
-        String inputJson = getBlueprintText("input/clouderamanager-db-config.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+    @Test
+    public void testGetRoleConfigsDbWithSsl() {
+        RDSConfig rdsConfig = rdsConfig(DatabaseType.RANGER);
+        rdsConfig.setSslMode(RdsSslMode.ENABLED);
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withRdsConfigs(Set.of(rdsConfig))
+                .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
+                .build();
 
-        try {
-            underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
-        } catch (CloudbreakServiceException cse) {
-            assertEquals("Multiple databases have been provided for RANGER_ADMIN component", cse.getMessage());
-            throw cse;
-        }
+        when(virtualGroupService.getVirtualGroup(tpo.getVirtualGroupRequest(), UmsRight.RANGER_ADMIN.getRight())).thenReturn(ADMIN_GROUP);
+
+        List<ApiClusterTemplateConfig> result = underTest.getRoleConfigs(RangerRoles.RANGER_ADMIN, tpo);
+
+        Map<String, String> configNameToValueMap = getConfigNameToValueMap(result);
+        assertThat(configNameToValueMap).containsOnly(
+                entry(RANGER_ADMIN_SITE_XML_ROLE_SAFETY_VALVE,
+                        "<property>" +
+                        "<name>ranger.jpa.jdbc.url</name>" +
+                        "<value>jdbc:postgresql://10.1.1.1:5432/ranger?sslmode=verify-full&amp;sslrootcert=/hadoopfs/fs1/database-cacerts/certs.pem</value>" +
+                        "</property>"),
+                entry(RANGER_DEFAULT_POLICY_GROUPS, ADMIN_GROUP)
+        );
+        Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
+        assertThat(configNameToVariableNameMap).isEmpty();
     }
 
     private String getBlueprintText(String path) {
         return FileReaderUtils.readFileFromClasspathQuietly(path);
+    }
+
+    private ClouderaManagerRepo generateCmRepo(Versioned version) {
+        return new ClouderaManagerRepo()
+                .withBaseUrl("baseurl")
+                .withGpgKeyUrl("gpgurl")
+                .withPredefined(true)
+                .withVersion(version.getVersion());
     }
 
 }

--- a/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/views/RdsViewTest.java
+++ b/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/views/RdsViewTest.java
@@ -1,15 +1,22 @@
 package com.sequenceiq.cloudbreak.template.views;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DatabaseVendor;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.domain.RdsSslMode;
 
 public class RdsViewTest {
 
     private static final String ASSERT_ERROR_MSG = "The generated connection URL(connectionHost field) is not valid!";
+
+    private static final String SSL_OPTIONS_SUFFIX = "sslmode=verify-full&sslrootcert=/hadoopfs/fs1/database-cacerts/certs.pem";
 
     @Test
     public void testCreateRdsViewWhenConnectionUrlContainsSubprotocolAndSubname() {
@@ -18,10 +25,10 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "some-rds.1d3nt1f13r.eu-west-1.rds.amazonaws.com", underTest.getHost());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "5432", underTest.getPort());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "ranger", underTest.getDatabaseName());
-        Assert.assertEquals("postgresql:subname", underTest.getSubprotocol());
+        assertThat(underTest.getHost()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("some-rds.1d3nt1f13r.eu-west-1.rds.amazonaws.com");
+        assertThat(underTest.getPort()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("5432");
+        assertThat(underTest.getDatabaseName()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("ranger");
+        assertThat(underTest.getSubprotocol()).isEqualTo("postgresql:subname");
     }
 
     @Test
@@ -31,13 +38,13 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "some-rds.1d3nt1f13r.eu-west-1.rds.amazonaws.com", underTest.getHost());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "5432", underTest.getPort());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "ranger", underTest.getDatabaseName());
-        Assert.assertEquals("postgresql", underTest.getSubprotocol());
+        assertThat(underTest.getHost()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("some-rds.1d3nt1f13r.eu-west-1.rds.amazonaws.com");
+        assertThat(underTest.getPort()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("5432");
+        assertThat(underTest.getDatabaseName()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("ranger");
+        assertThat(underTest.getSubprotocol()).isEqualTo("postgresql");
 
-        Assert.assertEquals("admin", underTest.getConnectionUserName());
-        Assert.assertEquals("adminpassword", underTest.getConnectionPassword());
+        assertThat(underTest.getConnectionUserName()).isEqualTo("admin");
+        assertThat(underTest.getConnectionPassword()).isEqualTo("adminpassword");
     }
 
     // Do pass the Azure-specific hostname suffix to CM. See CB-3791.
@@ -49,7 +56,7 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals("admin@some-rds", underTest.getConnectionUserName());
+        assertThat(underTest.getConnectionUserName()).isEqualTo("admin@some-rds");
     }
 
     @Test
@@ -59,9 +66,9 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "some-rds.1d3nt1f13r.eu-west-1.rds.amazonaws.com", underTest.getHost());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "5432", underTest.getPort());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "ranger", underTest.getDatabaseName());
+        assertThat(underTest.getHost()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("some-rds.1d3nt1f13r.eu-west-1.rds.amazonaws.com");
+        assertThat(underTest.getPort()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("5432");
+        assertThat(underTest.getDatabaseName()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("ranger");
     }
 
     @Test
@@ -71,7 +78,8 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "some-rds.1d3nt1f13r.eu-west-1.rds.amazonaws.com:5432:5432/ranger", underTest.getConnectionString());
+        assertThat(underTest.getConnectionString()).withFailMessage(ASSERT_ERROR_MSG)
+                .isEqualTo("some-rds.1d3nt1f13r.eu-west-1.rds.amazonaws.com:5432:5432/ranger");
     }
 
     @Test
@@ -81,7 +89,7 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:5432", underTest.getConnectionString());
+        assertThat(underTest.getConnectionString()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:5432");
     }
 
     @Test
@@ -91,7 +99,8 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "jdbc:postgresql://ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:5432/ranger", underTest.getConnectionString());
+        assertThat(underTest.getConnectionString()).withFailMessage(ASSERT_ERROR_MSG)
+                .isEqualTo("jdbc:postgresql://ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:5432/ranger");
     }
 
     @Test
@@ -101,7 +110,7 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:1521/orcl", underTest.getConnectionString());
+        assertThat(underTest.getConnectionString()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:1521/orcl");
     }
 
     @Test
@@ -111,7 +120,8 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "jdbc:oracle:@ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:1521:orcl", underTest.getConnectionString());
+        assertThat(underTest.getConnectionString()).withFailMessage(ASSERT_ERROR_MSG)
+                .isEqualTo("jdbc:oracle:@ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:1521:orcl");
     }
 
     @Test
@@ -121,7 +131,7 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "orcl", underTest.getDatabaseName());
+        assertThat(underTest.getDatabaseName()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("orcl");
     }
 
     @Test
@@ -131,10 +141,11 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "1521", underTest.getPort());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "ranger.cmseikcocinw.us-east-1.rds.amazonaws.com", underTest.getHost());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "oracle:thin", underTest.getSubprotocol());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "jdbc:oracle:thin:@ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:1521", underTest.getHostWithPortWithJdbc());
+        assertThat(underTest.getPort()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("1521");
+        assertThat(underTest.getHost()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("ranger.cmseikcocinw.us-east-1.rds.amazonaws.com");
+        assertThat(underTest.getSubprotocol()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("oracle:thin");
+        assertThat(underTest.getHostWithPortWithJdbc()).withFailMessage(ASSERT_ERROR_MSG)
+                .isEqualTo("jdbc:oracle:thin:@ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:1521");
     }
 
     @Test
@@ -144,12 +155,13 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "1521", underTest.getPort());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "XE", underTest.getDatabaseName());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "ranger.cmseikcocinw.us-east-1.rds.amazonaws.com", underTest.getHost());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "oracle:thin", underTest.getSubprotocol());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "jdbc:oracle:thin:@ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:1521", underTest.getHostWithPortWithJdbc());
-        Assert.assertEquals(ASSERT_ERROR_MSG, "ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:1521/XE", underTest.getWithoutJDBCPrefix());
+        assertThat(underTest.getPort()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("1521");
+        assertThat(underTest.getDatabaseName()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("XE");
+        assertThat(underTest.getHost()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("ranger.cmseikcocinw.us-east-1.rds.amazonaws.com");
+        assertThat(underTest.getSubprotocol()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("oracle:thin");
+        assertThat(underTest.getHostWithPortWithJdbc()).withFailMessage(ASSERT_ERROR_MSG)
+                .isEqualTo("jdbc:oracle:thin:@ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:1521");
+        assertThat(underTest.getWithoutJDBCPrefix()).withFailMessage(ASSERT_ERROR_MSG).isEqualTo("ranger.cmseikcocinw.us-east-1.rds.amazonaws.com:1521/XE");
     }
 
     @Test
@@ -159,7 +171,87 @@ public class RdsViewTest {
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        Assert.assertEquals(ASSERT_ERROR_MSG, "jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306", underTest.getHostWithPortWithJdbc());
+        assertThat(underTest.getHostWithPortWithJdbc()).withFailMessage(ASSERT_ERROR_MSG)
+                .isEqualTo("jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306");
+    }
+
+    @Test
+    public void testCreateRdsViewWhenMalformedUrl() {
+        RDSConfig rdsConfig = createRdsConfig("jdbc:mysql://foo.com", DatabaseVendor.MYSQL);
+
+        assertThatCode(() -> new RdsView(rdsConfig)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testCreateRdsViewHostWithPortWithJdbcWhenQueryParameters() {
+        RDSConfig rdsConfig = createRdsConfig("jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306/ranger?foo=bar", DatabaseVendor.MYSQL);
+
+        RdsView underTest = new RdsView(rdsConfig);
+
+        assertThat(underTest.getHostWithPortWithJdbc()).isEqualTo("jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306");
+    }
+
+    @Test
+    public void testCreateRdsViewUseSslWhenDisabled() {
+        RDSConfig rdsConfig = createRdsConfig("jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306/ranger", DatabaseVendor.MYSQL);
+        rdsConfig.setSslMode(RdsSslMode.DISABLED);
+
+        RdsView underTest = new RdsView(rdsConfig);
+
+        assertThat(underTest.isUseSsl()).isFalse();
+    }
+
+    @Test
+    public void testCreateRdsViewUseSslWhenEnabled() {
+        RDSConfig rdsConfig = createRdsConfig("jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306/ranger", DatabaseVendor.MYSQL);
+        rdsConfig.setSslMode(RdsSslMode.ENABLED);
+
+        RdsView underTest = new RdsView(rdsConfig);
+
+        assertThat(underTest.isUseSsl()).isTrue();
+    }
+
+    @Test
+    public void testCreateRdsViewSslCertificateFileWhenDisabled() {
+        RDSConfig rdsConfig = createRdsConfig("jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306/ranger", DatabaseVendor.MYSQL);
+        rdsConfig.setSslMode(RdsSslMode.DISABLED);
+
+        RdsView underTest = new RdsView(rdsConfig);
+
+        assertThat(underTest.getSslCertificateFile()).isEqualTo("");
+    }
+
+    @Test
+    public void testCreateRdsViewSslCertificateFileWhenEnabled() {
+        RDSConfig rdsConfig = createRdsConfig("jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306/ranger", DatabaseVendor.MYSQL);
+        rdsConfig.setSslMode(RdsSslMode.ENABLED);
+
+        RdsView underTest = new RdsView(rdsConfig);
+
+        assertThat(underTest.getSslCertificateFile()).isEqualTo("/hadoopfs/fs1/database-cacerts/certs.pem");
+    }
+
+    static Object[][] sslConnectionUrlDataProvider() {
+        return new Object[][]{
+                // testCaseName connectionUrl connectionUrlExpected
+                {"No query parameters", "jdbc:mysql://foo.com:3306/hive", "jdbc:mysql://foo.com:3306/hive?" + SSL_OPTIONS_SUFFIX},
+                {"Empty query parameters", "jdbc:mysql://foo.com:3306/hive?", "jdbc:mysql://foo.com:3306/hive?" + SSL_OPTIONS_SUFFIX},
+                {"Query parameters ending in ampersand", "jdbc:mysql://foo.com:3306/hive?foo=bar&",
+                        "jdbc:mysql://foo.com:3306/hive?foo=bar&" + SSL_OPTIONS_SUFFIX},
+                {"Query parameters ending in regular char", "jdbc:mysql://foo.com:3306/hive?foo=bar",
+                        "jdbc:mysql://foo.com:3306/hive?foo=bar&" + SSL_OPTIONS_SUFFIX},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("sslConnectionUrlDataProvider")
+    public void testCreateRdsViewSslConnectionUrl(String testCaseName, String connectionUrl, String connectionUrlExpected) {
+        RDSConfig rdsConfig = createRdsConfig(connectionUrl, DatabaseVendor.MYSQL);
+        rdsConfig.setSslMode(RdsSslMode.ENABLED);
+
+        RdsView underTest = new RdsView(rdsConfig);
+
+        assertThat(underTest.getConnectionURL()).isEqualTo(connectionUrlExpected);
     }
 
     private RDSConfig createRdsConfig(String connectionUrl) {


### PR DESCRIPTION
* Persist DB SSL status in `RDSConfig`
  * Currently populated for external DBs only
* Return DB SSL status in `RDSDetails`
* Additions to `RdsView`:
  * DB SSL status
  * SSL certificate file path; empty when not using SSL
  * `ConnectionURL` extended wit SSL options as necessary
* Add new compile dependency to `template-manager-cmtemplate/build.gradle`: `org.apache.commons:commons-text:1.5`
* Inject DB SSL configs for HMS and Ranger Admin
* Honor custom HMS DB settings in cluster template
* Add new unit tests and migrate existing ones to JUnit 5 & AssertJ
