### PR TITLE
Cluster validation flow fix

### DIFF
--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -152,7 +152,7 @@ cluster.externaldatabase.stop.finished=External database stop finished.
 
 cluster.kerberosconfig.validation.failed=Kerberos config validation failed.
 
-cluster.cloudconfig.validation.failed=Cloud config validation failed.
+cluster.cloudconfig.validation.failed=Cloud config validation failed with the following errors: {0}
 
 cm.cluster.services.started=Cloudera Manager services have been started.
 cm.cluster.services.starting=Starting Cloudera Manager services.

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
@@ -169,6 +169,7 @@ public class StackCreatorService {
                 "Stack request converted to stack took {} ms for stack {}", stackName);
         stackStub.setWorkspace(workspace);
         stackStub.setCreator(user);
+        stackStub.setType(determineStackTypeBasedOnTheUsedApi(stackStub, distroxRequest));
         String platformString = stackStub.getCloudPlatform().toLowerCase();
 
         MDCBuilder.buildMdcContext(stackStub);
@@ -211,7 +212,7 @@ public class StackCreatorService {
                         "Set stacktype for stack object took {} ms");
 
                     measure(() -> clusterCreationService.validate(
-                            stackRequest.getCluster(), cloudCredential, stack, user, workspace, environment, distroxRequest),
+                            stackRequest.getCluster(), cloudCredential, stack, user, workspace, environment),
                             LOGGER,
                             "Validate cluster rds and autotls took {} ms");
                 }
@@ -270,6 +271,16 @@ public class StackCreatorService {
         metricService.submit(STACK_PREPARATION, System.currentTimeMillis() - start);
 
         return response;
+    }
+
+    StackType determineStackTypeBasedOnTheUsedApi(Stack stack, boolean distroxRequest) {
+        StackType stackType = stack.getType();
+        boolean stackTypeIsWorkloadAndNotDistroXRequest = stack.getType() != null && StackType.WORKLOAD.equals(stack.getType()) && !distroxRequest;
+        boolean stackTypeIsNullAndNotDistroXRequest = stack.getType() == null && !distroxRequest;
+        if (stackTypeIsWorkloadAndNotDistroXRequest || stackTypeIsNullAndNotDistroXRequest) {
+            stackType = StackType.LEGACY;
+        }
+        return stackType;
     }
 
     private void assignOwnerRoleOnDataHub(User user, StackV4Request stackRequest, Stack newStack) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -71,6 +71,7 @@ public class StackV4Controller extends NotificationController implements StackV4
         } else {
             types.add(StackType.DATALAKE);
             types.add(StackType.WORKLOAD);
+            types.add(StackType.LEGACY);
         }
         return stackOperations.listByEnvironmentCrn(restRequestThreadLocalService.getRequestedWorkspaceId(), environmentCrn, types);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/StackUpdaterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/StackUpdaterService.java
@@ -21,6 +21,11 @@ public class StackUpdaterService {
     public void updateStatus(Long stackId, DetailedStackStatus detailedStackStatus, ResourceEvent resourceEvent, String statusReason) {
         stackUpdater.updateStackStatus(stackId, detailedStackStatus, statusReason);
         flowMessageService.fireEventAndLog(stackId, detailedStackStatus.getStatus().name(), resourceEvent);
+    }
 
+    public void updateStatusAndSendEventWithArgs(Long stackId, DetailedStackStatus detailedStackStatus, ResourceEvent resourceEvent, String statusReason,
+            String eventArgs) {
+        stackUpdater.updateStackStatus(stackId, detailedStackStatus, statusReason);
+        flowMessageService.fireEventAndLog(stackId, detailedStackStatus.getStatus().name(), resourceEvent, eventArgs);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/CloudConfigValidationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/CloudConfigValidationActions.java
@@ -131,8 +131,9 @@ public class CloudConfigValidationActions {
                         validationBuilder);
                 parametersValidator.waitResult(parametersValidationRequest, validationBuilder);
 
-                dataLakeValidator.validate(stack, validationBuilder);
-
+                if (!StackType.LEGACY.equals(stack.getType())) {
+                    dataLakeValidator.validate(stack, validationBuilder);
+                }
 
                 environmentValidator.validate(
                         stack,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/CloudConfigValidationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/CloudConfigValidationActions.java
@@ -144,11 +144,17 @@ public class CloudConfigValidationActions {
                 ValidationResult validationResult = validationBuilder.build();
                 if (validationResult.getState() == ValidationResult.State.ERROR || validationResult.hasError()) {
                     LOGGER.debug("Stack request has validation error(s): {}.", validationResult.getFormattedErrors());
+                    StackFailureEvent failureEvent = new StackFailureEvent(CloudConfigValidationEvent.VALIDATE_CLOUD_CONFIG_FAILED_EVENT.selector(),
+                            payload.getResourceId(),
+                            new IllegalStateException(validationResult.getFormattedErrors()));
                     sendEvent(context,
                             CloudConfigValidationEvent.VALIDATE_CLOUD_CONFIG_FAILED_EVENT.selector(),
-                            new IllegalStateException(validationResult.getFormattedErrors()));
+                            failureEvent);
+
+                } else {
+                    LOGGER.debug("Stack validation has been finished without any error.");
+                    sendEvent(context, CloudConfigValidationEvent.VALIDATE_CLOUD_CONFIG_FINISHED_EVENT.selector(), payload);
                 }
-                sendEvent(context, CloudConfigValidationEvent.VALIDATE_CLOUD_CONFIG_FINISHED_EVENT.selector(), payload);
             }
 
             @Override
@@ -173,9 +179,10 @@ public class CloudConfigValidationActions {
             }
 
             @Override
-            protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
-                stackUpdaterService.updateStatus(context.getStackView().getId(), DetailedStackStatus.PROVISION_FAILED,
-                        ResourceEvent.CLOUD_CONFIG_VALIDATION_FAILED, payload.getException().getMessage());
+            protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) {
+                String statusReason = payload.getException().getMessage();
+                stackUpdaterService.updateStatusAndSendEventWithArgs(context.getStackView().getId(), DetailedStackStatus.PROVISION_FAILED,
+                        ResourceEvent.CLOUD_CONFIG_VALIDATION_FAILED, statusReason, statusReason);
                 sendEvent(context);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/config/CloudConfigValidationFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/config/CloudConfigValidationFlowConfig.java
@@ -24,12 +24,8 @@ public class CloudConfigValidationFlowConfig extends AbstractFlowConfiguration<C
     private static final List<Transition<CloudConfigValidationState, CloudConfigValidationEvent>> TRANSITIONS =
             new Builder<CloudConfigValidationState, CloudConfigValidationEvent>()
             .defaultFailureEvent(VALIDATE_CLOUD_CONFIG_FAILED_EVENT)
-            .from(INIT_STATE)
-            .to(VALIDATE_CLOUD_CONFIG_STATE)
-            .event(VALIDATE_CLOUD_CONFIG_EVENT).defaultFailureEvent()
-            .from(VALIDATE_CLOUD_CONFIG_STATE)
-            .to(FINAL_STATE)
-            .event(VALIDATE_CLOUD_CONFIG_FINISHED_EVENT).defaultFailureEvent()
+            .from(INIT_STATE).to(VALIDATE_CLOUD_CONFIG_STATE).event(VALIDATE_CLOUD_CONFIG_EVENT).defaultFailureEvent()
+            .from(VALIDATE_CLOUD_CONFIG_STATE).to(FINAL_STATE).event(VALIDATE_CLOUD_CONFIG_FINISHED_EVENT).defaultFailureEvent()
             .build();
 
     private static final FlowEdgeConfig<CloudConfigValidationState, CloudConfigValidationEvent> EDGE_CONFIG =

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCreationSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ClusterCreationSetupService.java
@@ -81,13 +81,13 @@ public class ClusterCreationSetupService {
     private CloudStorageConverter cloudStorageConverter;
 
     public void validate(ClusterV4Request request, Stack stack, User user, Workspace workspace,
-        DetailedEnvironmentResponse environment, boolean distroxRequest) {
-        validate(request, null, stack, user, workspace, environment, distroxRequest);
+        DetailedEnvironmentResponse environment) {
+        validate(request, null, stack, user, workspace, environment);
     }
 
     @Measure(ClusterCreationSetupService.class)
     public void validate(ClusterV4Request request, CloudCredential cloudCredential, Stack stack, User user,
-            Workspace workspace, DetailedEnvironmentResponse environment, boolean distroxRequest) {
+            Workspace workspace, DetailedEnvironmentResponse environment) {
         MdcContext.builder().userCrn(user.getUserCrn()).tenant(user.getTenant().getName()).buildMdc();
         CloudCredential credential = cloudCredential;
         if (credential == null) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/StackCreatorServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/StackCreatorServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
@@ -388,6 +389,56 @@ public class StackCreatorServiceTest {
 
         privateIdStart = 5L;
         validateInstanceMetadataPrivateId("worker", 3, privateIdStart, hostGroupInstances.get("worker"));
+    }
+
+    @Test
+    public void testDetermineStackTypeBasedOnTheUsedApiShouldReturnWhenDatalakeStackTypeAndNotDistroXRequest() {
+        Stack stack = new Stack();
+        stack.setType(StackType.DATALAKE);
+
+        StackType actual = underTest.determineStackTypeBasedOnTheUsedApi(stack, false);
+
+        assertEquals(StackType.DATALAKE, actual);
+    }
+
+    @Test
+    public void testDetermineStackTypeBasedOnTheUsedApiShouldReturnWhenDatalakeStackTypeAndDistroXRequest() {
+        Stack stack = new Stack();
+        stack.setType(StackType.DATALAKE);
+
+        StackType actual = underTest.determineStackTypeBasedOnTheUsedApi(stack, true);
+
+        assertEquals(StackType.DATALAKE, actual);
+    }
+
+    @Test
+    public void testDetermineStackTypeBasedOnTheUsedApiShouldReturnWhenWorkloadStackTypeAndDistroXRequest() {
+        Stack stack = new Stack();
+        stack.setType(StackType.WORKLOAD);
+
+        StackType actual = underTest.determineStackTypeBasedOnTheUsedApi(stack, true);
+
+        assertEquals(StackType.WORKLOAD, actual);
+    }
+
+    @Test
+    public void testDetermineStackTypeBasedOnTheUsedApiShouldReturnWhenWorkloadStackTypeAndNotDistroXRequest() {
+        Stack stack = new Stack();
+        stack.setType(StackType.WORKLOAD);
+
+        StackType actual = underTest.determineStackTypeBasedOnTheUsedApi(stack, false);
+
+        assertEquals(StackType.LEGACY, actual);
+    }
+
+    @Test
+    public void testDetermineStackTypeBasedOnTheUsedApiShouldReturnWhenStackTypeIsNullAndNotDistroXRequest() {
+        Stack stack = new Stack();
+        stack.setType(null);
+
+        StackType actual = underTest.determineStackTypeBasedOnTheUsedApi(stack, false);
+
+        assertEquals(StackType.LEGACY, actual);
     }
 
     private void validateInstanceMetadataPrivateId(String hostGroup, int nodeCount,


### PR DESCRIPTION
Changes:
 - Fix the behaviour that sent a failure and successful event a the same time from `VALIDATE_CLOUD_CONFIG_STATE`
 - Fix the payload of the `VALIDATE_CLOUD_CONFIG_FAILED_EVENT` that's sent from `VALIDATE_CLOUD_CONFIG_STATE`
 - Clusters that's created on old `v4/../stack` APIs be marked with `LEGACY` stack type, this will result in cases where cluster "legacy" clusters could not be found on the UI as these kind of clusters won't be presented in DistroX related API calls