### PR TITLE
CB-9037 Test case for base image validation

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -170,7 +170,7 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
                 .when(imageCatalogTestClient.createIfNotExistV4());
     }
 
-    protected void validateDefaultImage(TestContext testContext, String imageUuid) {
+    protected void validateDefaultPrewarmedImage(TestContext testContext, String imageUuid) {
         testContext.given(ImageCatalogTestDto.class)
                 .when(imageCatalogTestClient.getV4(true))
                 .valid();
@@ -178,7 +178,21 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
         ImageV4Response image = dto.getResponse().getImages().getCdhImages().stream()
                 .filter(img -> img.getUuid().equalsIgnoreCase(imageUuid))
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException(imageUuid + " image is missing from the catalog."));
+                .orElseThrow(() -> new RuntimeException(imageUuid + " cdh image is missing from the catalog."));
+        if (!image.isDefaultImage()) {
+            throw new RuntimeException(imageUuid + " image is not a default image. Validation picks up the default one so it does not make sense to run it.");
+        }
+    }
+
+    protected void validateDefaultBaseImage(TestContext testContext, String imageUuid) {
+        testContext.given(ImageCatalogTestDto.class)
+                .when(imageCatalogTestClient.getV4(true))
+                .valid();
+        ImageCatalogTestDto dto = testContext.get(ImageCatalogTestDto.class);
+        ImageV4Response image = dto.getResponse().getImages().getBaseImages().stream()
+                .filter(img -> img.getUuid().equalsIgnoreCase(imageUuid))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException(imageUuid + " base image is missing from the catalog."));
         if (!image.isDefaultImage()) {
             throw new RuntimeException(imageUuid + " image is not a default image. Validation picks up the default one so it does not make sense to run it.");
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/imagevalidation/AbstractImageValidatorE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/imagevalidation/AbstractImageValidatorE2ETest.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.it.cloudbreak.testcase.e2e.sdx;
+package com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,9 +14,9 @@ import org.testng.util.Strings;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 
-public abstract class ImageValidatorE2ETest extends AbstractE2ETest {
+public abstract class AbstractImageValidatorE2ETest extends AbstractE2ETest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ImageValidatorE2ETest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractImageValidatorE2ETest.class);
 
     @Override
     protected void setupTest(TestContext testContext) {
@@ -45,6 +45,8 @@ public abstract class ImageValidatorE2ETest extends AbstractE2ETest {
 
     protected abstract String getImageId(TestContext testContext);
 
+    protected abstract boolean isPrewarmedImageTest();
+
     private void createSourceCatalogIfNotExistsAndValidateDefaultImage(TestContext testContext) {
         createImageValidationSourceCatalog(testContext,
                 commonCloudProperties().getImageValidation().getSourceCatalogUrl(),
@@ -52,7 +54,11 @@ public abstract class ImageValidatorE2ETest extends AbstractE2ETest {
 
         String imageUuid = commonCloudProperties().getImageValidation().getExpectedDefaultImageUuid();
         if (Strings.isNotNullAndNotEmpty(imageUuid)) {
-            validateDefaultImage(testContext, imageUuid);
+            if (isPrewarmedImageTest()) {
+                validateDefaultPrewarmedImage(testContext, imageUuid);
+            } else {
+                validateDefaultBaseImage(testContext, imageUuid);
+            }
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/imagevalidation/BaseImageValidatorE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/imagevalidation/BaseImageValidatorE2ETest.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.ClouderaManagerTestDto;
+import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
+import com.sequenceiq.it.cloudbreak.dto.ImageSettingsTestDto;
+import com.sequenceiq.it.cloudbreak.dto.InstanceGroupTestDto;
+import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
+import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.IDBROKER;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
+public class BaseImageValidatorE2ETest extends AbstractImageValidatorE2ETest {
+
+    private static final Map<String, InstanceStatus> HEALTY_STATUSES = new HashMap<>() {{
+        put(HostGroupType.MASTER.getName(), InstanceStatus.SERVICES_HEALTHY);
+        put(HostGroupType.IDBROKER.getName(), InstanceStatus.SERVICES_HEALTHY);
+    }};
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(
+            given = "there is a running Cloudbreak",
+            when = "a valid SDX create request is sent (latest Base Image)",
+            then = "SDX should be available AND deletable")
+    public void testSDXWithBaseImage(TestContext testContext) {
+        String sdxInternal = resourcePropertyProvider().getName();
+        String cluster = resourcePropertyProvider().getName();
+        String clouderaManager = resourcePropertyProvider().getName();
+        String imageSettings = resourcePropertyProvider().getName();
+        String imageCatalog = resourcePropertyProvider().getName();
+        String stack = resourcePropertyProvider().getName();
+        String masterInstanceGroup = "master";
+        String idbrokerInstanceGroup = "idbroker";
+
+        testContext
+                .given(imageCatalog, ImageCatalogTestDto.class)
+                .given(imageSettings, ImageSettingsTestDto.class)
+                .given(clouderaManager, ClouderaManagerTestDto.class)
+                .given(cluster, ClusterTestDto.class)
+                .withBlueprintName(commonClusterManagerProperties().getInternalSdxBlueprintName())
+                .withValidateBlueprint(Boolean.FALSE)
+                .withClouderaManager(clouderaManager)
+                .given(masterInstanceGroup, InstanceGroupTestDto.class).withHostGroup(MASTER).withNodeCount(1)
+                .given(idbrokerInstanceGroup, InstanceGroupTestDto.class).withHostGroup(IDBROKER).withNodeCount(1)
+                .given(stack, StackTestDto.class).withCluster(cluster).withImageSettings(imageSettings)
+                .withInstanceGroups(masterInstanceGroup, idbrokerInstanceGroup)
+                .given(sdxInternal, SdxInternalTestDto.class)
+                .withCloudStorage(getCloudStorageRequest(testContext))
+                .withStackRequest(key(cluster), key(stack))
+                .when(sdxTestClient.createInternal(), key(sdxInternal))
+                .awaitForFlow(key(sdxInternal))
+                .await(SdxClusterStatusResponse.RUNNING)
+                .awaitForInstance(HEALTY_STATUSES)
+                .validate();
+    }
+
+    @Override
+    protected String getImageId(TestContext testContext) {
+        return testContext.get(SdxInternalTestDto.class).getResponse().getStackV4Response().getImage().getId();
+    }
+
+    @Override
+    protected boolean isPrewarmedImageTest() {
+        return false;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/imagevalidation/PrewarmImageValidatorE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/imagevalidation/PrewarmImageValidatorE2ETest.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.it.cloudbreak.testcase.e2e.sdx;
+package com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
@@ -18,7 +18,7 @@ import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 
-public class InternalSdxDistroxTest extends ImageValidatorE2ETest {
+public class PrewarmImageValidatorE2ETest extends AbstractImageValidatorE2ETest {
 
     @Inject
     private SdxTestClient sdxTestClient;
@@ -67,5 +67,10 @@ public class InternalSdxDistroxTest extends ImageValidatorE2ETest {
     @Override
     protected String getImageId(TestContext testContext) {
         return testContext.get(SdxInternalTestDto.class).getResponse().getStackV4Response().getImage().getId();
+    }
+
+    @Override
+    protected boolean isPrewarmedImageTest() {
+        return true;
     }
 }

--- a/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
@@ -6,7 +6,7 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXEncryptedVolumeTest
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxDistroxTest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.spot.AwsDistroXSpotInstanceTest

--- a/integration-test/src/main/resources/testsuites/e2e/aws-image-validation-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-image-validation-tests.yaml
@@ -1,5 +1,0 @@
-name: "aws-image-validation-tests"
-tests:
-  - name: "aws_image_validation_e2e_tests"
-    classes:
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxDistroxTest

--- a/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
@@ -5,6 +5,6 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.NewNetworkEnvironmentTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXEncryptedVolumeTest
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxDistroxTest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests

--- a/integration-test/src/main/resources/testsuites/e2e/azure-image-validation-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-image-validation-tests.yaml
@@ -1,5 +1,0 @@
-name: "azure-image-validation-tests"
-tests:
-  - name: "azure_image_validation_e2e_tests"
-    classes:
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxDistroxTest

--- a/integration-test/src/main/resources/testsuites/e2e/base-image-validation-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/base-image-validation-tests.yaml
@@ -1,0 +1,5 @@
+name: "base-image-validation-tests"
+tests:
+  - name: "base_image_validation_e2e_tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.BaseImageValidatorE2ETest

--- a/integration-test/src/main/resources/testsuites/e2e/prewarm-image-validation-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/prewarm-image-validation-tests.yaml
@@ -1,0 +1,5 @@
+name: "prewarm-image-validation-tests"
+tests:
+  - name: "prewarm_image_validation_e2e_tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest

--- a/integration-test/src/main/resources/testsuites/e2e/yarn-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/yarn-e2e-tests.yaml
@@ -2,5 +2,5 @@ name: "yarn-e2e-tests"
 tests:
   - name: "yarn_e2e_tests"
     classes:
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.InternalSdxDistroxTest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.BasicEnvironmentTests


### PR DESCRIPTION
Test case for base image validation: creates an sdx cluster by using the default base image. Test is going to fail in case of any issue with the cluster creation and in case of the expected image id is not the actually used one.