### PR TITLE
CB-9433 Cannot download the event json in zip format on event histroy…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -177,9 +177,11 @@ public class OperationDescriptions {
     }
 
     public static class AuditOpDescription {
-        public static final String LIST_IN_WORKSPACE = "List audit events for the given workspace";
+        public static final String LIST_IN_WORKSPACE = "List audit events for the given workspace. Please use the API filter by resource crn, " +
+                "because the resource type and id combination is deprecated.";
         public static final String GET_BY_WORKSPACE = "Get audit event in workspace by id";
-        public static final String LIST_IN_WORKSPACE_ZIP = "List audit events for the given workspace in zip file";
+        public static final String LIST_IN_WORKSPACE_ZIP = "List audit events for the given workspace in zip file. Please use the API filter " +
+                "by resource crn, because the resource type and id combination is deprecated.";
     }
 
     public static class InfoOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/db/LegacyStructuredEventDBService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/db/LegacyStructuredEventDBService.java
@@ -144,8 +144,8 @@ public class LegacyStructuredEventDBService extends AbstractWorkspaceAwareResour
         return legacyStructuredEventRepository.findByWorkspaceIdAndId(workspaceId, id);
     }
 
-    public List<StructuredEventEntity> findByWorkspaceAndResourceTypeAndResourceCrn(Workspace workspace, String resourceType, String resourceCrn) {
-        return legacyStructuredEventRepository.findByWorkspaceAndResourceTypeAndResourceCrn(workspace, resourceType, resourceCrn);
+    public List<StructuredEventEntity> findByWorkspaceAndResourceTypeAndResourceCrn(Workspace workspace, String resourceCrn) {
+        return legacyStructuredEventRepository.findByWorkspaceAndResourceCrn(workspace, resourceCrn);
     }
 
     public List<StructuredEventEntity> findByWorkspaceAndResourceTypeAndResourceId(Workspace workspace, String resourceType, Long resourceId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/db/LegacyStructuredEventRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/db/LegacyStructuredEventRepository.java
@@ -28,7 +28,7 @@ public interface LegacyStructuredEventRepository extends WorkspaceResourceReposi
 
     List<StructuredEventEntity> findByWorkspaceAndResourceTypeAndResourceId(Workspace workspace, String resourceType, Long resourceId);
 
-    List<StructuredEventEntity> findByWorkspaceAndResourceTypeAndResourceCrn(Workspace workspace, String resourceType, String resourceCrn);
+    List<StructuredEventEntity> findByWorkspaceAndResourceCrn(Workspace workspace, String resourceCrn);
 
     List<StructuredEventEntity> findByWorkspaceAndEventType(Workspace workspace, StructuredEventType eventType);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/audit/AuditEventServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/audit/AuditEventServiceTest.java
@@ -2,9 +2,12 @@ package com.sequenceiq.cloudbreak.service.audit;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Collections;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -21,9 +24,9 @@ import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 import com.sequenceiq.cloudbreak.domain.StructuredEventEntity;
 import com.sequenceiq.cloudbreak.exception.NotFoundException;
-import com.sequenceiq.cloudbreak.structuredevent.LegacyRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.service.user.UserService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
+import com.sequenceiq.cloudbreak.structuredevent.LegacyRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.structuredevent.db.LegacyStructuredEventDBService;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
@@ -157,5 +160,43 @@ public class AuditEventServiceTest {
 
         verify(legacyStructuredEventDBService, times(1)).findByWorkspaceIdAndId(TEST_DEFAULT_ORG_ID, TEST_AUDIT_ID);
         verify(converterUtil, times(0)).convert(any(StructuredEventEntity.class), AuditEventV4Response.class);
+    }
+
+    @Test
+    public void testGetEventsForUserWithTypeAndResourceIdByWorkspaceWhenResourceCrnIsNull() {
+        Workspace workspace = new Workspace();
+        long resourceId = 0L;
+
+        when(legacyStructuredEventDBService.findByWorkspaceAndResourceTypeAndResourceId(workspace, null, resourceId)).thenReturn(Collections.emptyList());
+
+        underTest.getEventsForUserWithTypeAndResourceIdByWorkspace(workspace, null, resourceId, null);
+
+        verify(legacyStructuredEventDBService).findByWorkspaceAndResourceTypeAndResourceId(workspace, null, resourceId);
+    }
+
+    @Test
+    public void testGetEventsForUserWithTypeAndResourceIdByWorkspaceWhenResourceCrnIsEmpty() {
+        Workspace workspace = new Workspace();
+        long resourceId = 0L;
+
+        when(legacyStructuredEventDBService.findByWorkspaceAndResourceTypeAndResourceId(workspace, null, resourceId)).thenReturn(Collections.emptyList());
+
+        underTest.getEventsForUserWithTypeAndResourceIdByWorkspace(workspace, null, resourceId, "");
+
+        verify(legacyStructuredEventDBService).findByWorkspaceAndResourceTypeAndResourceId(workspace, null, resourceId);
+    }
+
+    @Test
+    public void testGetEventsForUserWithTypeAndResourceIdByWorkspaceWhenResourceCrnIsNotEmpty() {
+        Workspace workspace = new Workspace();
+        long resourceId = 0L;
+        String resourceCrn = "crn";
+
+        when(legacyStructuredEventDBService.findByWorkspaceAndResourceTypeAndResourceCrn(workspace, resourceCrn)).thenReturn(Collections.emptyList());
+
+        underTest.getEventsForUserWithTypeAndResourceIdByWorkspace(workspace, null, resourceId, resourceCrn);
+
+        verify(legacyStructuredEventDBService, never()).findByWorkspaceAndResourceTypeAndResourceId(workspace, null, resourceId);
+        verify(legacyStructuredEventDBService).findByWorkspaceAndResourceTypeAndResourceCrn(workspace, resourceCrn);
     }
 }


### PR DESCRIPTION
… page. When I try to download the event history in json format the response is only an empty list. We already filter by resource crn so we don't need to filter by resource type as well.

See detailed description in the commit message.