### PR TITLE
CB-9298: Instance status is incorrect on UI

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/instance/InstanceStatus.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/instance/InstanceStatus.java
@@ -16,6 +16,7 @@ public enum InstanceStatus {
     STOPPED,
     REBOOTING,
     UNREACHABLE,
+    UNHEALTHY,
     DELETE_REQUESTED;
 
     public static final Collection<InstanceStatus> AVAILABLE_STATUSES = List.of(CREATED);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/SyncResult.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/SyncResult.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.freeipa.sync;
 
+import java.util.Map;
+
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
 
 public class SyncResult {
 
@@ -8,9 +11,12 @@ public class SyncResult {
 
     private DetailedStackStatus status;
 
-    public SyncResult(String message, DetailedStackStatus status) {
+    private Map<InstanceMetaData, DetailedStackStatus> instanceStatusMap;
+
+    public SyncResult(String message, DetailedStackStatus status, Map<InstanceMetaData, DetailedStackStatus> instanceStatusMap) {
         this.message = message;
         this.status = status;
+        this.instanceStatusMap = instanceStatusMap;
     }
 
     public String getMessage() {
@@ -19,5 +25,9 @@ public class SyncResult {
 
     public DetailedStackStatus getStatus() {
         return status;
+    }
+
+    public Map<InstanceMetaData, DetailedStackStatus> getInstanceStatusMap() {
+        return instanceStatusMap;
     }
 }


### PR DESCRIPTION
Integrated freeipa health check and platform instance check results to show actual instance statuses on UI. Currently instance status is incorrect on UI when the instances are unreachable because only platform instance check is used. The platform instance check doesn't check if the instance is reachable. If instances are not available, the UI will show incorrect running status. With this fix, the UI will show the instance as unreachable.

See detailed description in the commit message.