### PR TITLE
CB-9449 if AWS returns that DBInstance does not exsist, then we shall…

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupService.java
@@ -37,6 +37,7 @@ public class AwsRdsStatusLookupService {
         try {
             describeDBInstancesResult = rdsClient.describeDBInstances(describeDBInstancesRequest);
         } catch (DBInstanceNotFoundException ex) {
+            LOGGER.debug("DB Instance does not exist: {}", ex.getMessage());
             return ExternalDatabaseStatus.DELETED;
         } catch (RuntimeException ex) {
             throw new CloudConnectorException(ex.getMessage(), ex);
@@ -61,6 +62,9 @@ public class AwsRdsStatusLookupService {
         try {
             LOGGER.debug("RDS Checking if delete protection is enabled");
             describeDBInstancesResult = rdsClient.describeDBInstances(describeDBInstancesRequest);
+        } catch (DBInstanceNotFoundException ex) {
+            LOGGER.debug("DB Instance does not exist! Therefore termination protection check is not relevant anymore: {}", ex.getMessage());
+            return false;
         } catch (RuntimeException ex) {
             throw new CloudConnectorException(ex.getMessage(), ex);
         }

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupServiceTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsRdsStatusLookupServiceTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -158,11 +158,12 @@ public class AwsRdsStatusLookupServiceTest {
 
     }
 
-    @Test(expected = CloudConnectorException.class)
     public void isDeleteProtectionEnabledShouldThrowCloudConnectorExceptionInCaseOfDBInstanceNotFoundException() {
         when(amazonRDS.describeDBInstances(any(DescribeDBInstancesRequest.class))).thenThrow(DBInstanceNotFoundException.class);
         victim.isDeleteProtectionEnabled(authenticatedContext, dbStack);
-        fail("Exception should be been thrown");
+
+        //if AWS returns that DBInstance does not exist, then we shall consider this as the termination protection is not enabled
+        assertFalse(victim.isDeleteProtectionEnabled(authenticatedContext, dbStack));
     }
 
     @Test(expected = CloudConnectorException.class)


### PR DESCRIPTION
… consider this as the termination protection is not enabled.

Before this change if somebody went to AWS console and removed the protection and deleted the DB instance, that caused Environment/SDX/DH delete failures, since Redbeams would just thorw a CloudConnectorException for delete call and Environment/SDX/DH deletion stuck forever. After this change Redbeams realises that DB does not exsist anymore and it just proceeds and Environment/SDX/DH deletion will be successful.

I have intentionally changed the unit test as well, to make sure that it reflects the the expected behaviour.

See detailed description in the commit message.