### PR TITLE
Cb 9450 Revert back to 2 master, 1 gateway and 2 idbroker.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
@@ -9,7 +9,7 @@
     "hostTemplates": [
       {
         "cardinality": 2,
-        "refName": "main",
+        "refName": "master",
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hdfs-JOURNALNODE-BASE",
@@ -27,14 +27,17 @@
         ]
       },
       {
-        "cardinality": 2,
+        "cardinality": 1,
         "refName": "gateway",
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hdfs-JOURNALNODE-BASE",
           "ranger-RANGER_ADMIN-BASE",
+          "ranger-RANGER_USERSYNC-BASE",
+          "ranger-RANGER_TAGSYNC-BASE",
           "zookeeper-SERVER-BASE",
           "knox-KNOX_GATEWAY-BASE",
+          "atlas-ATLAS_SERVER-BASE",
           "hbase-REGIONSERVER-BASE",
           "hbase-MASTER-BASE",
           "solr-GATEWAY-BASE",
@@ -42,16 +45,6 @@
           "kafka-GATEWAY-BASE",
           "hive-GATEWAY-BASE",
           "hbase-GATEWAY-BASE"
-        ]
-      },
-      {
-        "cardinality": 1,
-        "refName": "auxiliary",
-        "roleConfigGroupsRefNames": [
-          "hdfs-JOURNALNODE-BASE",
-          "ranger-RANGER_USERSYNC-BASE",
-          "ranger-RANGER_TAGSYNC-BASE",
-          "atlas-ATLAS_SERVER-BASE"
         ]
       },
       {

--- a/core/src/main/resources/defaults/blueprints/7.2.3/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.3/cdp-sdx-medium-ha.bp
@@ -9,7 +9,7 @@
     "hostTemplates": [
       {
         "cardinality": 2,
-        "refName": "main",
+        "refName": "master",
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hdfs-JOURNALNODE-BASE",
@@ -27,14 +27,17 @@
         ]
       },
       {
-        "cardinality": 2,
+        "cardinality": 1,
         "refName": "gateway",
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hdfs-JOURNALNODE-BASE",
           "ranger-RANGER_ADMIN-BASE",
+          "ranger-RANGER_USERSYNC-BASE",
+          "ranger-RANGER_TAGSYNC-BASE",
           "zookeeper-SERVER-BASE",
           "knox-KNOX_GATEWAY-BASE",
+          "atlas-ATLAS_SERVER-BASE",
           "hbase-REGIONSERVER-BASE",
           "hbase-MASTER-BASE",
           "solr-GATEWAY-BASE",
@@ -42,16 +45,6 @@
           "kafka-GATEWAY-BASE",
           "hive-GATEWAY-BASE",
           "hbase-GATEWAY-BASE"
-        ]
-      },
-      {
-        "cardinality": 1,
-        "refName": "auxiliary",
-        "roleConfigGroupsRefNames": [
-        "hdfs-JOURNALNODE-BASE",
-        "ranger-RANGER_USERSYNC-BASE",
-        "ranger-RANGER_TAGSYNC-BASE",
-        "atlas-ATLAS_SERVER-BASE"
         ]
       },
       {

--- a/datalake/src/main/resources/duties/7.2.2/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.2/aws/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "main",
+      "name": "master",
       "template": {
         "instanceType": "m5.2xlarge",
         "attachedVolumes": [
@@ -43,28 +43,8 @@
           "size": 100
         }
       },
-      "nodeCount": 2,
-      "type": "GATEWAY",
-      "recoveryMode": "MANUAL",
-      "recipeNames": []
-    },
-    {
-      "name": "auxiliary",
-      "template": {
-        "instanceType": "m5.xlarge",
-        "attachedVolumes": [
-          {
-            "count": 1,
-            "size": 250,
-            "type": "standard"
-          }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
-      },
       "nodeCount": 1,
-      "type": "CORE",
+      "type": "GATEWAY",
       "recoveryMode": "MANUAL",
       "recipeNames": []
     },

--- a/datalake/src/main/resources/duties/7.2.2/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.2/azure/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "main",
+      "name": "master",
       "template": {
         "instanceType": "Standard_D16s_v3",
         "attachedVolumes": [
@@ -43,28 +43,8 @@
           "size": 100
         }
       },
-      "nodeCount": 2,
-      "type": "GATEWAY",
-      "recoveryMode": "MANUAL",
-      "recipeNames": []
-    },
-    {
-      "name": "auxiliary",
-      "template": {
-        "instanceType": "Standard_D4s_v3",
-        "attachedVolumes": [
-          {
-            "count": 1,
-            "size": 250,
-            "type": "StandardSSD_LRS"
-          }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
-      },
       "nodeCount": 1,
-      "type": "CORE",
+      "type": "GATEWAY",
       "recoveryMode": "MANUAL",
       "recipeNames": []
     },

--- a/datalake/src/main/resources/duties/7.2.2/yarn/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.2/yarn/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "main",
+      "name": "master",
       "template": {
         "yarn": {
           "cpus": 4,
@@ -27,19 +27,8 @@
           "memory": 16384
         }
       },
-      "nodeCount": 2,
-      "type": "GATEWAY"
-    },
-    {
-      "name": "auxiliary",
-      "template": {
-        "yarn": {
-          "cpus": 4,
-          "memory": 16384
-        }
-      },
       "nodeCount": 1,
-      "type": "CORE"
+      "type": "GATEWAY"
     },
     {
       "name": "idbroker",

--- a/datalake/src/main/resources/duties/7.2.3/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.3/aws/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "main",
+      "name": "master",
       "template": {
         "instanceType": "m5.2xlarge",
         "attachedVolumes": [
@@ -43,28 +43,8 @@
           "size": 100
         }
       },
-      "nodeCount": 2,
-      "type": "GATEWAY",
-      "recoveryMode": "MANUAL",
-      "recipeNames": []
-    },
-    {
-      "name": "auxiliary",
-      "template": {
-        "instanceType": "m5.xlarge",
-        "attachedVolumes": [
-          {
-            "count": 1,
-            "size": 250,
-            "type": "standard"
-          }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
-      },
       "nodeCount": 1,
-      "type": "CORE",
+      "type": "GATEWAY",
       "recoveryMode": "MANUAL",
       "recipeNames": []
     },

--- a/datalake/src/main/resources/duties/7.2.3/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.3/azure/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "main",
+      "name": "master",
       "template": {
         "instanceType": "Standard_D16s_v3",
         "attachedVolumes": [
@@ -43,28 +43,8 @@
           "size": 100
         }
       },
-      "nodeCount": 2,
-      "type": "GATEWAY",
-      "recoveryMode": "MANUAL",
-      "recipeNames": []
-    },
-    {
-      "name": "auxiliary",
-      "template": {
-        "instanceType": "Standard_D4s_v3",
-        "attachedVolumes": [
-          {
-            "count": 1,
-            "size": 250,
-            "type": "StandardSSD_LRS"
-          }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
-      },
       "nodeCount": 1,
-      "type": "CORE",
+      "type": "GATEWAY",
       "recoveryMode": "MANUAL",
       "recipeNames": []
     },

--- a/datalake/src/main/resources/duties/7.2.3/yarn/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.3/yarn/medium_duty_ha.json
@@ -9,7 +9,7 @@
   },
   "instanceGroups": [
     {
-      "name": "main",
+      "name": "master",
       "template": {
         "yarn": {
           "cpus": 4,
@@ -27,19 +27,8 @@
           "memory": 16384
         }
       },
-      "nodeCount": 2,
-      "type": "GATEWAY"
-    },
-    {
-      "name": "auxiliary",
-      "template": {
-        "yarn": {
-          "cpus": 4,
-          "memory": 16384
-        }
-      },
       "nodeCount": 1,
-      "type": "CORE"
+      "type": "GATEWAY"
     },
     {
       "name": "idbroker",


### PR DESCRIPTION
This reverts commit 22c20a6f8b9a050e7115e4d827a2bea4dedab1da.

Since we cannot deploy a intermediatary shape, we're rolling this back
and plan to use the final shape later in 7.2.4

See detailed description in the commit message.