### PR TITLE
CB-9362 on aws rds postgres version is 10.14 instead of 10.6

### DIFF
--- a/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
@@ -47,7 +47,7 @@
     },
     "EngineVersionParameter": {
         "Type": "String",
-        "Default": "10.6",
+        "Default": "10.14",
         "Description": "Engine version",
         "MinLength": 1,
         "MaxLength": 64


### PR DESCRIPTION
CB-9362 on aws rds postgres version is 10.14 instead of 10.6