### PR TITLE
CB-9313 - added Vault client side tracing

### DIFF
--- a/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/SecretEngine.java
+++ b/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/SecretEngine.java
@@ -7,7 +7,7 @@ import com.sequenceiq.cloudbreak.service.secret.model.SecretResponse;
 public interface SecretEngine {
     String put(String key, String value);
 
-    boolean isExists(String secret);
+    boolean exists(String secret);
 
     String get(String secret);
 

--- a/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/service/SecretService.java
+++ b/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/service/SecretService.java
@@ -41,7 +41,7 @@ public class SecretService {
 
     private SecretEngine persistentEngine;
 
-    private VaultRetryService vaultRetryService;
+    private final VaultRetryService vaultRetryService;
 
     public SecretService(MetricService metricService, List<SecretEngine> engines, VaultRetryService vaultRetryService) {
         this.metricService = metricService;
@@ -66,7 +66,7 @@ public class SecretService {
      */
     public String put(String key, String value) throws Exception {
         long start = System.currentTimeMillis();
-        boolean exists = vaultRetryService.tryReadingVault(() -> persistentEngine.isExists(key));
+        boolean exists = vaultRetryService.tryReadingVault(() -> persistentEngine.exists(key));
         long duration = System.currentTimeMillis() - start;
         metricService.submit(MetricType.VAULT_READ, duration);
         LOGGER.trace("Secret read took {} ms", duration);

--- a/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/service/VaultRetryService.java
+++ b/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/service/VaultRetryService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.service.secret.service;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import org.slf4j.Logger;
@@ -11,6 +12,12 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.common.metrics.MetricService;
 import com.sequenceiq.cloudbreak.common.metrics.type.MetricType;
 import com.sequenceiq.cloudbreak.service.Retry;
+import com.sequenceiq.cloudbreak.tracing.TracingUtil;
+
+import io.opentracing.References;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
 
 @Service
 public class VaultRetryService {
@@ -19,8 +26,11 @@ public class VaultRetryService {
 
     private final MetricService metricService;
 
-    public VaultRetryService(MetricService metricService) {
+    private final Tracer tracer;
+
+    public VaultRetryService(MetricService metricService, Tracer tracer) {
         this.metricService = metricService;
+        this.tracer = tracer;
     }
 
     @Retryable(
@@ -31,13 +41,7 @@ public class VaultRetryService {
                     maxDelayExpression = "${vault.retry.maxdelay:10000}")
     )
     public <T> T tryReadingVault(Supplier<T> action) throws Retry.ActionFailedException {
-        try {
-            return action.get();
-        } catch (RuntimeException e) {
-            LOGGER.error("Exception during reading vault", e);
-            metricService.incrementMetricCounter(MetricType.VAULT_READ_FAILED);
-            throw new Retry.ActionFailedException(e.getMessage());
-        }
+        return executeVaultOperationWithTrace(action, "read", MetricType.VAULT_READ_FAILED);
     }
 
     @Retryable(
@@ -48,12 +52,45 @@ public class VaultRetryService {
                     maxDelayExpression = "${vault.retry.maxdelay:10000}")
     )
     public <T> T tryWritingVault(Supplier<T> action) throws Retry.ActionFailedException {
-        try {
-            return action.get();
-        } catch (RuntimeException e) {
-            LOGGER.error("Exception during writing vault", e);
-            metricService.incrementMetricCounter(MetricType.VAULT_READ_FAILED);
-            throw new Retry.ActionFailedException(e.getMessage());
-        }
+        return executeVaultOperationWithTrace(action, "write", MetricType.VAULT_WRITE_FAILED);
+    }
+
+    private <T> T executeVaultOperationWithTrace(Supplier<T> action, String operation, MetricType metricType) {
+        Optional<Span> optionalSpan = initSpan(operation);
+        return optionalSpan.map(span -> {
+            try (Scope ignored = tracer.activateSpan(span)) {
+                try {
+                    return action.get();
+                } catch (RuntimeException e) {
+                    span.setTag(TracingUtil.ERROR, true);
+                    span.setTag(TracingUtil.MESSAGE, e.getMessage());
+                    return handleException(operation, e, metricType);
+                }
+            } finally {
+                span.finish();
+            }
+        }).orElseGet(() -> {
+            try {
+                return action.get();
+            } catch (RuntimeException e) {
+                return handleException(operation, e, metricType);
+            }
+        });
+    }
+
+    private Optional<Span> initSpan(String operationType) {
+        return Optional.ofNullable(tracer.activeSpan()).map(activeSpan -> {
+            Span span = tracer.buildSpan("Vault - " + operationType)
+                    .addReference(References.FOLLOWS_FROM, activeSpan.context())
+                    .start();
+            span.setTag(TracingUtil.COMPONENT, "Vault");
+            return span;
+        });
+    }
+
+    private <T> T handleException(String operation, RuntimeException e, MetricType metricType) {
+        LOGGER.error("Exception during vault " + operation, e);
+        metricService.incrementMetricCounter(metricType);
+        throw new Retry.ActionFailedException(e.getMessage());
     }
 }

--- a/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/vault/VaultKvV1Engine.java
+++ b/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/vault/VaultKvV1Engine.java
@@ -48,7 +48,7 @@ public class VaultKvV1Engine extends AbstractVaultEngine<VaultKvV1Engine> {
     }
 
     @Override
-    public boolean isExists(String secret) {
+    public boolean exists(String secret) {
         return Optional.ofNullable(convertToVaultSecret(secret)).map(s -> {
             VaultResponse response = template.read(s.getPath());
             return response != null && response.getData() != null;

--- a/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/vault/VaultKvV2Engine.java
+++ b/secret-engine/src/main/java/com/sequenceiq/cloudbreak/service/secret/vault/VaultKvV2Engine.java
@@ -47,7 +47,7 @@ public class VaultKvV2Engine extends AbstractVaultEngine<VaultKvV2Engine> {
     }
 
     @Override
-    public boolean isExists(String secret) {
+    public boolean exists(String secret) {
         return Optional.ofNullable(convertToVaultSecret(secret)).map(s -> {
             Versioned<Map<String, Object>> response = template.opsForVersionedKeyValue(s.getEnginePath()).get(s.getPath());
             return response != null && response.getData() != null;

--- a/secret-engine/src/test/java/com/sequenceiq/cloudbreak/service/secret/service/SecretServiceTest.java
+++ b/secret-engine/src/test/java/com/sequenceiq/cloudbreak/service/secret/service/SecretServiceTest.java
@@ -63,7 +63,7 @@ public class SecretServiceTest {
 
     @Test
     public void testPutExists() throws Exception {
-        when(persistentEngine.isExists(anyString())).thenReturn(true);
+        when(persistentEngine.exists(anyString())).thenReturn(true);
 
         thrown.expect(InvalidKeyException.class);
 
@@ -78,7 +78,7 @@ public class SecretServiceTest {
     @Test
     public void testPutOk() throws Exception {
         when(persistentEngine.put("key", "value")).thenReturn("secret");
-        when(persistentEngine.isExists("key")).thenReturn(false);
+        when(persistentEngine.exists("key")).thenReturn(false);
 
         String result = underTest.put("key", "value");
 

--- a/secret-engine/src/test/java/com/sequenceiq/cloudbreak/service/secret/vault/VaultKvV1EngineTest.java
+++ b/secret-engine/src/test/java/com/sequenceiq/cloudbreak/service/secret/vault/VaultKvV1EngineTest.java
@@ -38,7 +38,7 @@ public class VaultKvV1EngineTest {
     public void testIsExistsNull() {
         when(template.read(anyString())).thenReturn(null);
 
-        Assert.assertFalse(underTest.isExists(gson.toJson(secret)));
+        Assert.assertFalse(underTest.exists(gson.toJson(secret)));
     }
 
     @Test
@@ -46,7 +46,7 @@ public class VaultKvV1EngineTest {
         when(vaultResponse.getData()).thenReturn(null);
         when(template.read(anyString())).thenReturn(vaultResponse);
 
-        Assert.assertFalse(underTest.isExists(gson.toJson(secret)));
+        Assert.assertFalse(underTest.exists(gson.toJson(secret)));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class VaultKvV1EngineTest {
         when(vaultResponse.getData()).thenReturn(Collections.emptyMap());
         when(template.read(anyString())).thenReturn(vaultResponse);
 
-        Assert.assertTrue(underTest.isExists(gson.toJson(secret)));
+        Assert.assertTrue(underTest.exists(gson.toJson(secret)));
     }
 
     @Test

--- a/secret-engine/src/test/java/com/sequenceiq/cloudbreak/service/secret/vault/VaultKvV2EngineTest.java
+++ b/secret-engine/src/test/java/com/sequenceiq/cloudbreak/service/secret/vault/VaultKvV2EngineTest.java
@@ -49,7 +49,7 @@ public class VaultKvV2EngineTest {
     public void testIsExistsNull() {
         when(vaultVersionedKeyValueOperations.get(anyString())).thenReturn(null);
 
-        Assert.assertFalse(underTest.isExists(gson.toJson(secret)));
+        Assert.assertFalse(underTest.exists(gson.toJson(secret)));
     }
 
     @Test
@@ -57,7 +57,7 @@ public class VaultKvV2EngineTest {
         when(vaultResponse.getData()).thenReturn(null);
         when(vaultVersionedKeyValueOperations.get(anyString())).thenReturn(vaultResponse);
 
-        Assert.assertFalse(underTest.isExists(gson.toJson(secret)));
+        Assert.assertFalse(underTest.exists(gson.toJson(secret)));
     }
 
     @Test
@@ -65,7 +65,7 @@ public class VaultKvV2EngineTest {
         when(vaultResponse.getData()).thenReturn(Collections.emptyMap());
         when(vaultVersionedKeyValueOperations.get(anyString())).thenReturn(vaultResponse);
 
-        Assert.assertTrue(underTest.isExists(gson.toJson(secret)));
+        Assert.assertTrue(underTest.exists(gson.toJson(secret)));
     }
 
     @Test


### PR DESCRIPTION
Using this optional construct to avoid tracing of lonely vault spans.
Not adding the usual tags from the MDC Context because it would be very very redundant and consume lot of memory unnecessarily.

