### PR TITLE
CDPSDX-1981: Add retries when registering DNS A records

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
@@ -18,9 +18,17 @@ IPADDR=$(hostname -i)
 REVERSE_IP=$(hostname -i | awk -F. '{print $4"."$3"." $2"."$1}')
 
 # dnsrecord-add must either add the record or modify it
-if ! ipa dnsrecord-find {{ pillar['sssd-ipa']['domain'] }}. "--name=${HOSTNAME}" "--a-rec=${IPADDR}"  --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} --all; then
-  ipa dnsrecord-add {{ pillar['sssd-ipa']['domain'] }}. "${HOSTNAME}" "--a-rec=${IPADDR}" --ttl {{ pillar['sssd-ipa']['dns_ttl'] }}
-fi
+# loop since the records do not appear to always persist (this bug has been fixed about a dozen times see CDPSDX-1981 and all linked JIRAs)
+for attempt in {1..3}
+do
+  if ! ipa dnsrecord-find {{ pillar['sssd-ipa']['domain'] }}. "--name=${HOSTNAME}" "--a-rec=${IPADDR}"  --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} --all; then
+    if [ $attempt -ne 1 ]; then
+      echo "Retrying adding hostname for ${HOSTNAME}, attempt ${attempt}"
+    fi
+    ipa dnsrecord-add {{ pillar['sssd-ipa']['domain'] }}. "${HOSTNAME}" "--a-rec=${IPADDR}" --ttl {{ pillar['sssd-ipa']['dns_ttl'] }}
+  fi
+  sleep 1
+done
 if ! ipa dnsrecord-find {{ pillar['sssd-ipa']['domain'] }}. "--name=${HOSTNAME}" "--a-rec=${IPADDR}"  --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} --all; then
   echo "Failed to set DNS A-record for ${HOSTNAME}"
   false


### PR DESCRIPTION
Register DNS A records up to 3 times for datalake nodes waiting 1
second between attempts.

While I agree this change should not be required, in practise there
there is evidence that something isn't persisting as expected. See
CDPSDX-1981 for details and reference the linked JIRAs. This has been
"fixed" about a dozen times. While I know this will not fix the
underlying problem, I think it will likley reduce the frequency of the
intermittent issue.

See detailed description in the commit message.