### PR TITLE
CB-9109 Freeipa launch crippled by missing storage account

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.cloud.azure.util.CustomVMImageNameProvider;
 import com.sequenceiq.cloudbreak.cloud.azure.validator.AzureAcceleratedNetworkValidator;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureCredentialView;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureInstanceCredentialView;
@@ -50,6 +51,9 @@ public class AzureTemplateBuilder {
     private AzureUtils azureUtils;
 
     @Inject
+    private CustomVMImageNameProvider customVMImageNameProvider;
+
+    @Inject
     private AzureStorage azureStorage;
 
     @Inject
@@ -62,7 +66,7 @@ public class AzureTemplateBuilder {
             CloudStack cloudStack, AzureInstanceTemplateOperation azureInstanceTemplateOperation) {
         try {
             String imageUrl = cloudStack.getImage().getImageName();
-            String imageName = azureUtils.getImageNameFromConnectionString(imageUrl);
+            String imageName = customVMImageNameProvider.getImageNameFromConnectionString(imageUrl);
 
             Network network = cloudStack.getNetwork();
             Map<String, Object> model = new HashMap<>();

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -531,9 +531,4 @@ public class AzureUtils {
         }
     }
 
-    public String getImageNameFromConnectionString(String connectionString) {
-        int begin = connectionString.lastIndexOf('/') + 1;
-        int end = connectionString.contains("?") ? connectionString.indexOf('?') : connectionString.length();
-        return connectionString.substring(begin, end);
-    }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -351,7 +351,7 @@ public class AzureClient {
                 .getByResourceGroup(resourceGroup, imageName));
     }
 
-    public VirtualMachineCustomImage createCustomImage(String imageName, String resourceGroup, String fromVhdUri, String region) {
+    public VirtualMachineCustomImage createImage(String imageName, String resourceGroup, String fromVhdUri, String region) {
         return handleAuthException(() -> {
             LOGGER.info("check the existence of resource group '{}', creating if it doesn't exist on Azure side", resourceGroup);
             if (!azure.resourceGroups().contain(resourceGroup)) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageInfo.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageInfo.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image;
+
+public class AzureImageInfo {
+
+    private final String imageNameWithRegion;
+
+    private final String imageName;
+
+    private final String imageId;
+
+    private final String region;
+
+    private final String resourceGroup;
+
+    public AzureImageInfo(String imageNameWithRegion, String imageName, String imageId, String region, String resourceGroup) {
+        this.imageNameWithRegion = imageNameWithRegion;
+        this.imageId = imageId;
+        this.region = region;
+        this.resourceGroup = resourceGroup;
+        this.imageName = imageName;
+    }
+
+    public String getImageNameWithRegion() {
+        return imageNameWithRegion;
+    }
+
+    public String getImageName() {
+        return imageName;
+    }
+
+    public String getImageId() {
+        return imageId;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getResourceGroup() {
+        return resourceGroup;
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageInfoService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageInfoService.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.resource.AzureResourceIdProviderService;
+import com.sequenceiq.cloudbreak.cloud.azure.util.CustomVMImageNameProvider;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+
+@Service
+public class AzureImageInfoService {
+
+    @Inject
+    private AzureResourceIdProviderService azureResourceIdProviderService;
+
+    @Inject
+    private CustomVMImageNameProvider customVMImageNameProvider;
+
+    public AzureImageInfo getImageInfo(String resourceGroup, String fromVhdUri, AuthenticatedContext ac, AzureClient client) {
+        String region = getRegion(ac);
+        String imageNameWithRegion = customVMImageNameProvider.getImageNameWithRegion(region, fromVhdUri);
+        String imageName = customVMImageNameProvider.getImageNameFromConnectionString(fromVhdUri);
+        String imageId = getImageId(resourceGroup, client, imageNameWithRegion);
+
+        return new AzureImageInfo(imageNameWithRegion, imageName, imageId, region, resourceGroup);
+    }
+
+    private String getRegion(AuthenticatedContext ac) {
+        return ac.getCloudContext()
+                .getLocation()
+                .getRegion()
+                .getRegionName();
+    }
+
+    private String getImageId(String resourceGroup, AzureClient client, String imageName) {
+        return azureResourceIdProviderService.generateImageId(
+                client.getCurrentSubscription().subscriptionId(), resourceGroup, imageName);
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageService.java
@@ -12,11 +12,8 @@ import com.microsoft.azure.CloudException;
 import com.microsoft.azure.management.compute.VirtualMachineCustomImage;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureImage;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
-
-import com.sequenceiq.cloudbreak.cloud.azure.resource.AzureResourceIdProviderService;
 import com.sequenceiq.cloudbreak.cloud.azure.task.image.AzureManagedImageCreationCheckerContext;
 import com.sequenceiq.cloudbreak.cloud.azure.task.image.AzureManagedImageCreationPoller;
-import com.sequenceiq.cloudbreak.cloud.azure.util.CustomVMImageNameProvider;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
@@ -37,70 +34,56 @@ public class AzureImageService {
     private PersistenceNotifier persistenceNotifier;
 
     @Inject
-    private AzureResourceIdProviderService azureResourceIdProviderService;
-
-    @Inject
     private AzureManagedImageCreationPoller azureManagedImageCreationPoller;
 
     @Inject
     private AzureManagedImageService azureManagedImageService;
 
-    @Inject
-    private CustomVMImageNameProvider customVMImageNameProvider;
-
-    public AzureImage getCustomImageId(String resourceGroup, String fromVhdUri, AuthenticatedContext ac, boolean createIfNotFound, AzureClient client) {
-        String region = getRegion(ac);
-        String imageName = getImageName(region, fromVhdUri);
-        String imageId = getImageId(resourceGroup, client, imageName);
-        AzureManagedImageCreationCheckerContext checkerContext = new AzureManagedImageCreationCheckerContext(client, resourceGroup, imageName);
-
-        if (getCustomImage(resourceGroup, client, imageName).isPresent() || isRequested(imageId)) {
-            LOGGER.debug("Custom image found in '{}' resource group with name '{}'", resourceGroup, imageName);
-            azureManagedImageCreationPoller.startPolling(ac, checkerContext);
-            return new AzureImage(imageId, imageName, true);
-        } else {
-            LOGGER.debug("Custom image NOT found in '{}' resource group with name '{}', creating it now: {}", resourceGroup, imageName, createIfNotFound);
-            if (createIfNotFound) {
-                saveImage(ac, imageName, imageId);
-                Optional<VirtualMachineCustomImage> customImage;
-                try {
-                    customImage = Optional.of(client.createCustomImage(imageName, resourceGroup, fromVhdUri, region));
-                } catch (CloudException e) {
-                    customImage = handleImageCreationException(resourceGroup, ac, client, imageName, imageId, checkerContext, e);
-                }
-                return customImage
-                        .map(image -> createNewAzureImageAndNotify(ac, image))
-                        .orElseThrow(() -> new CloudConnectorException("Failed to create custom image."));
-            } else {
-                return null;
-            }
+    public Optional<AzureImage> findImage(AzureImageInfo azureImageInfo, AzureClient client, AuthenticatedContext ac) {
+        if (findImage(azureImageInfo, client).isEmpty() && !isCreateRequested(azureImageInfo)) {
+            return Optional.empty();
         }
+
+        LOGGER.debug("Custom image found in '{}' resource group with name '{}'", azureImageInfo.getResourceGroup(), azureImageInfo.getImageNameWithRegion());
+        azureManagedImageCreationPoller.startPolling(ac, new AzureManagedImageCreationCheckerContext(azureImageInfo, client));
+        return Optional.of(new AzureImage(azureImageInfo.getImageId(), azureImageInfo.getImageNameWithRegion(), true));
     }
 
-    private AzureImage createNewAzureImageAndNotify(AuthenticatedContext ac, VirtualMachineCustomImage customImage) {
+    public AzureImage createImage(AzureImageInfo azureImageInfo, String fromVhdUri, AzureClient client, AuthenticatedContext ac) {
+        saveImage(ac, azureImageInfo.getImageNameWithRegion(), azureImageInfo.getImageId());
+        Optional<VirtualMachineCustomImage> customImage;
+        AzureManagedImageCreationCheckerContext checkerContext = new AzureManagedImageCreationCheckerContext(azureImageInfo, client);
+        try {
+            customImage = Optional.of(
+                    client.createImage(azureImageInfo.getImageNameWithRegion(), azureImageInfo.getResourceGroup(), fromVhdUri, azureImageInfo.getRegion()));
+        } catch (CloudException e) {
+            customImage = handleCustomImageCreationException(azureImageInfo, ac, client, checkerContext, e);
+        }
+        return customImage
+                .map(image -> createImageAndNotify(ac, image))
+                .orElseThrow(() -> new CloudConnectorException("Failed to create custom image."));
+    }
+
+    private AzureImage createImageAndNotify(AuthenticatedContext ac, VirtualMachineCustomImage customImage) {
         updateImageStatus(ac, customImage.name(), customImage.id(), CommonStatus.CREATED);
         return new AzureImage(customImage.id(), customImage.name(), true);
     }
 
-    private Optional<VirtualMachineCustomImage> handleImageCreationException(String resourceGroup, AuthenticatedContext ac, AzureClient client,
-            String imageName, String imageId, AzureManagedImageCreationCheckerContext checkerContext, CloudException e) {
+    private Optional<VirtualMachineCustomImage> handleCustomImageCreationException(AzureImageInfo azureImageInfo, AuthenticatedContext ac,
+            AzureClient client, AzureManagedImageCreationCheckerContext checkerContext, CloudException e) {
         Optional<VirtualMachineCustomImage> customImage;
         azureManagedImageCreationPoller.startPolling(ac, checkerContext);
-        customImage = getCustomImage(resourceGroup, client, imageName);
+        customImage = findImage(azureImageInfo, client);
         if (customImage.isEmpty()) {
             LOGGER.error("Failed to create custom image.", e);
-            updateImageStatus(ac, imageName, imageId, CommonStatus.FAILED);
+            updateImageStatus(ac, azureImageInfo.getImageNameWithRegion(), azureImageInfo.getImageId(), CommonStatus.FAILED);
             throw new CloudConnectorException(e);
         }
         return customImage;
     }
 
-    private Optional<VirtualMachineCustomImage> getCustomImage(String resourceGroup, AzureClient client, String imageName) {
-        return azureManagedImageService.findVirtualMachineCustomImage(resourceGroup, imageName, client);
-    }
-
-    private String getImageName(String region, String fromVhdUri) {
-        return customVMImageNameProvider.get(region, fromVhdUri);
+    private Optional<VirtualMachineCustomImage> findImage(AzureImageInfo azureImageInfo, AzureClient client) {
+        return azureManagedImageService.findVirtualMachineCustomImage(azureImageInfo, client);
     }
 
     private void saveImage(AuthenticatedContext ac, String imageName, String imageId) {
@@ -109,23 +92,11 @@ public class AzureImageService {
     }
 
     private void updateImageStatus(AuthenticatedContext ac, String imageName, String imageId, CommonStatus commonStatus) {
-        LOGGER.debug("Updating image status to {}: {}", commonStatus.toString(), imageId);
+        LOGGER.debug("Updating image status to {}: {}", commonStatus, imageId);
         persistenceNotifier.notifyUpdate(buildCloudResource(imageName, imageId, commonStatus), ac.getCloudContext());
     }
 
-    private String getRegion(AuthenticatedContext ac) {
-        return ac.getCloudContext()
-                .getLocation()
-                .getRegion()
-                .getRegionName();
-    }
-
-    private String getImageId(String resourceGroup, AzureClient client, String imageName) {
-        return azureResourceIdProviderService.generateImageId(client.getCurrentSubscription()
-                .subscriptionId(), resourceGroup, imageName);
-    }
-
-    public CloudResource buildCloudResource(String name, String id, CommonStatus status) {
+    private CloudResource buildCloudResource(String name, String id, CommonStatus status) {
         return CloudResource.builder()
                 .name(name)
                 .status(status)
@@ -135,7 +106,7 @@ public class AzureImageService {
                 .build();
     }
 
-    private boolean isRequested(String imageId) {
-        return resourcePersistenceRetriever.notifyRetrieve(imageId, CommonStatus.REQUESTED, ResourceType.AZURE_MANAGED_IMAGE).isPresent();
+    private boolean isCreateRequested(AzureImageInfo azureImageInfo) {
+        return resourcePersistenceRetriever.notifyRetrieve(azureImageInfo.getImageId(), CommonStatus.REQUESTED, ResourceType.AZURE_MANAGED_IMAGE).isPresent();
     }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageService.java
@@ -14,7 +14,9 @@ public class AzureManagedImageService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureManagedImageService.class);
 
-    public Optional<VirtualMachineCustomImage> findVirtualMachineCustomImage(String resourceGroup, String imageName, AzureClient client) {
+    public Optional<VirtualMachineCustomImage> findVirtualMachineCustomImage(AzureImageInfo azureImageInfo, AzureClient client) {
+        String imageName = azureImageInfo.getImageNameWithRegion();
+        String resourceGroup = azureImageInfo.getResourceGroup();
         VirtualMachineCustomImage image = client.findImage(resourceGroup, imageName);
         if (image != null) {
             LOGGER.debug("Custom image {} is present in resource group {}", imageName, resourceGroup);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/image/AzureManagedImageCreationCheckerContext.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/image/AzureManagedImageCreationCheckerContext.java
@@ -1,30 +1,24 @@
 package com.sequenceiq.cloudbreak.cloud.azure.task.image;
 
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.image.AzureImageInfo;
 
 public class AzureManagedImageCreationCheckerContext {
 
     private final AzureClient azureClient;
 
-    private final String resourceGroupName;
+    private final AzureImageInfo azureImageInfo;
 
-    private final String imageName;
-
-    public AzureManagedImageCreationCheckerContext(AzureClient azureClient, String resourceGroupName, String imageName) {
+    public AzureManagedImageCreationCheckerContext(AzureImageInfo azureImageInfo, AzureClient azureClient) {
+        this.azureImageInfo = azureImageInfo;
         this.azureClient = azureClient;
-        this.resourceGroupName = resourceGroupName;
-        this.imageName = imageName;
     }
 
     public AzureClient getAzureClient() {
         return azureClient;
     }
 
-    public String getResourceGroupName() {
-        return resourceGroupName;
-    }
-
-    public String getImageName() {
-        return imageName;
+    public AzureImageInfo getAzureImageInfo() {
+        return azureImageInfo;
     }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/image/AzureManagedImageCreationCheckerTask.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/image/AzureManagedImageCreationCheckerTask.java
@@ -35,7 +35,7 @@ public class AzureManagedImageCreationCheckerTask extends PollBooleanStateTask {
 
     @Override
     protected Boolean doCall() {
-        LOGGER.info("Waiting for managed image to be created: {}", context.getImageName());
+        LOGGER.info("Waiting for managed image to be created: {}", context.getAzureImageInfo().getImageNameWithRegion());
         Optional<VirtualMachineCustomImage> virtualMachineCustomImage = findVirtualMachineCustomImage();
         if (virtualMachineCustomImage.isPresent()) {
             LOGGER.info("Managed image creation has been finished.");
@@ -47,6 +47,6 @@ public class AzureManagedImageCreationCheckerTask extends PollBooleanStateTask {
     }
 
     private Optional<VirtualMachineCustomImage> findVirtualMachineCustomImage() {
-        return azureManagedImageService.findVirtualMachineCustomImage(context.getResourceGroupName(), context.getImageName(), context.getAzureClient());
+        return azureManagedImageService.findVirtualMachineCustomImage(context.getAzureImageInfo(), context.getAzureClient());
     }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/image/AzureManagedImageCreationPoller.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/image/AzureManagedImageCreationPoller.java
@@ -36,7 +36,7 @@ public class AzureManagedImageCreationPoller {
     public void startPolling(AuthenticatedContext ac, AzureManagedImageCreationCheckerContext checkerContext) {
         PollTask<Boolean> managedImageCreationStatusCheckerTask = azurePollTaskFactory.managedImageCreationCheckerTask(ac, checkerContext);
         try {
-            LOGGER.info("Start polling managed image creation: {}", checkerContext.getImageName());
+            LOGGER.info("Start polling managed image creation: {}", checkerContext.getAzureImageInfo().getImageNameWithRegion());
             syncPollingScheduler.schedule(managedImageCreationStatusCheckerTask, creationCheckInterval,
                     creationCheckMaxAttempt, maxTolerableFailureNumber);
         } catch (Exception e) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProvider.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProvider.java
@@ -1,10 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.azure.util;
 
-import javax.inject.Inject;
-
 import org.springframework.stereotype.Component;
-
-import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
 
 @Component
 public class CustomVMImageNameProvider {
@@ -12,11 +8,8 @@ public class CustomVMImageNameProvider {
 
     private static final char DELIMITER = '-';
 
-    @Inject
-    private AzureUtils azureUtils;
-
-    public String get(String region, String vhdUri) {
-        String vhdName = azureUtils.getImageNameFromConnectionString(vhdUri);
+    public String getImageNameWithRegion(String region, String vhdUri) {
+        String vhdName = getImageNameFromConnectionString(vhdUri);
         String name = vhdName + DELIMITER + region.toLowerCase().replaceAll("\\s", "");
         if (name.length() > NAME_MAXIMUM_LENGTH) {
             int diff = name.length() - NAME_MAXIMUM_LENGTH;
@@ -25,4 +18,11 @@ public class CustomVMImageNameProvider {
         }
         return name;
     }
+
+    public String getImageNameFromConnectionString(String vhdUri) {
+        int begin = vhdUri.lastIndexOf('/') + 1;
+        int end = vhdUri.contains("?") ? vhdUri.indexOf('?') : vhdUri.length();
+        return vhdUri.substring(begin, end);
+    }
+
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.sequenceiq.cloudbreak.cloud.azure.subnetstrategy.AzureSubnetStrategy;
+import com.sequenceiq.cloudbreak.cloud.azure.util.CustomVMImageNameProvider;
 import com.sequenceiq.cloudbreak.cloud.azure.validator.AzureAcceleratedNetworkValidator;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureCredentialView;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureStackView;
@@ -102,6 +103,9 @@ public class AzureTemplateBuilderTest {
 
     @Mock
     private AzureAcceleratedNetworkValidator azureAcceleratedNetworkValidator;
+
+    @Mock
+    private CustomVMImageNameProvider customVMImageNameProvider;
 
     @Spy
     private FreeMarkerTemplateUtils freeMarkerTemplateUtils;
@@ -194,7 +198,7 @@ public class AzureTemplateBuilderTest {
         azureSubnetStrategy = AzureSubnetStrategy.getAzureSubnetStrategy(FILL, Collections.singletonList("existingSubnet"),
                 ImmutableMap.of("existingSubnet", 100L));
         reset(azureUtils);
-        when(azureUtils.getImageNameFromConnectionString(anyString())).thenCallRealMethod();
+        when(customVMImageNameProvider.getImageNameFromConnectionString(anyString())).thenCallRealMethod();
     }
 
     @Test

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtilsTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtilsTest.java
@@ -103,19 +103,4 @@ public class AzureUtilsTest {
         verify(azurePremiumValidatorService, times(1)).premiumDiskTypeConfigured(azureDiskType);
     }
 
-    @Test
-    public void getImageNameFromConnectionStringWithSASToken() {
-        String url = "https://sequenceiqwestus2.blob.core.windows.net/test/cb-hdp-31-1911052024.vhd"
-                + "?sp=rl&st=2020-10-26T11:45:18Z&se=2020-10-27T11:45:18Z&sv=2019-12-12&sr=b&sig=G6hkDHn7GezwXBzZhQBNLZD5kI3LXgWMvlxGbm1T8WU%3D";
-        String result = underTest.getImageNameFromConnectionString(url);
-        assertEquals("cb-hdp-31-1911052024.vhd", result);
-    }
-
-    @Test
-    public void getImageNameFromConnectionStringWithoutSASToken() {
-        String url = "https://sequenceiqwestus2.blob.core.windows.net/test/cb-hdp-31-1911052024.vhd";
-        String result = underTest.getImageNameFromConnectionString(url);
-        assertEquals("cb-hdp-31-1911052024.vhd", result);
-    }
-
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageInfoServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageInfoServiceTest.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.microsoft.azure.management.resources.Subscription;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.resource.AzureResourceIdProviderService;
+import com.sequenceiq.cloudbreak.cloud.azure.util.CustomVMImageNameProvider;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+
+public class AzureImageInfoServiceTest {
+
+    private static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+
+    private static final String FROM_VHD_URI = "https://somewhere.in.the.windows.net/images/freeipa-cdh--2010061458.vhd";
+
+    private static final String SUBSCRIPTION_ID = "subscriptionId";
+
+    private static final String REGION_NAME = "regionName";
+
+    private static final String CUSTOM_IMAGE_NAME = "customImageName";
+
+    private static final String CUSTOM_IMAGE_ID = "customImageId";
+
+    @Mock
+    private AzureResourceIdProviderService azureResourceIdProviderService;
+
+    @Mock
+    private CustomVMImageNameProvider customVMImageNameProvider;
+
+    @InjectMocks
+    private AzureImageInfoService underTest;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private AzureClient azureClient;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testGetImageDetails() {
+        setupAuthenticatedContext();
+        setupAzureClient();
+        when(azureResourceIdProviderService.generateImageId(SUBSCRIPTION_ID, RESOURCE_GROUP_NAME, CUSTOM_IMAGE_NAME)).thenReturn(CUSTOM_IMAGE_ID);
+        when(customVMImageNameProvider.getImageNameWithRegion(REGION_NAME, FROM_VHD_URI)).thenReturn(CUSTOM_IMAGE_NAME);
+
+        AzureImageInfo azureImageInfo = underTest.getImageInfo(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, azureClient);
+
+        assertEquals(REGION_NAME, azureImageInfo.getRegion());
+        assertEquals(CUSTOM_IMAGE_ID, azureImageInfo.getImageId());
+        assertEquals(CUSTOM_IMAGE_NAME, azureImageInfo.getImageNameWithRegion());
+        assertEquals(RESOURCE_GROUP_NAME, azureImageInfo.getResourceGroup());
+        verify(azureResourceIdProviderService).generateImageId(SUBSCRIPTION_ID, RESOURCE_GROUP_NAME, CUSTOM_IMAGE_NAME);
+        verify(customVMImageNameProvider).getImageNameWithRegion(REGION_NAME, FROM_VHD_URI);
+    }
+
+    private void setupAzureClient() {
+        Subscription subscription = mock(Subscription.class);
+        when(subscription.subscriptionId()).thenReturn(SUBSCRIPTION_ID);
+        when(azureClient.getCurrentSubscription()).thenReturn(subscription);
+    }
+
+    private void setupAuthenticatedContext() {
+        Region region = mock(Region.class);
+        Location location = mock(Location.class);
+        CloudContext cloudContext = mock(CloudContext.class);
+        when(region.getRegionName()).thenReturn(REGION_NAME);
+        when(location.getRegion()).thenReturn(region);
+        when(cloudContext.getLocation()).thenReturn(location);
+        when(authenticatedContext.getCloudContext()).thenReturn(cloudContext);
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageServiceTest.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure.image;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -25,19 +25,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.management.compute.VirtualMachineCustomImage;
-import com.microsoft.azure.management.resources.Subscription;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureImage;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
-import com.sequenceiq.cloudbreak.cloud.azure.resource.AzureResourceIdProviderService;
 import com.sequenceiq.cloudbreak.cloud.azure.task.image.AzureManagedImageCreationCheckerContext;
 import com.sequenceiq.cloudbreak.cloud.azure.task.image.AzureManagedImageCreationPoller;
-import com.sequenceiq.cloudbreak.cloud.azure.util.CustomVMImageNameProvider;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
-import com.sequenceiq.cloudbreak.cloud.model.Location;
-import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceRetriever;
 import com.sequenceiq.common.api.type.CommonStatus;
@@ -49,13 +44,13 @@ public class AzureImageServiceTest {
 
     private static final String FROM_VHD_URI = "fromVhdUri";
 
+    private static final String CUSTOM_IMAGE_NAME_WITH_REGION = "customImageNameWithRegion";
+
     private static final String CUSTOM_IMAGE_NAME = "customImageName";
 
     private static final String CUSTOM_IMAGE_ID = "customImageId";
 
     private static final String REGION_NAME = "regionName";
-
-    private static final String SUBSCRIPTION_ID = "subscriptionId";
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -65,9 +60,6 @@ public class AzureImageServiceTest {
 
     @Mock
     private PersistenceNotifier persistenceNotifier;
-
-    @Mock
-    private AzureResourceIdProviderService azureResourceIdProviderService;
 
     @Mock
     private AzureManagedImageCreationPoller azureManagedImageCreationPoller;
@@ -84,126 +76,106 @@ public class AzureImageServiceTest {
     @Mock
     private VirtualMachineCustomImage virtualMachineCustomImage;
 
-    @Mock
-    private CustomVMImageNameProvider customVMImageNameProvider;
-
     @InjectMocks
     private AzureImageService underTest;
+
+    private final AzureImageInfo azureImageInfo =
+            new AzureImageInfo(CUSTOM_IMAGE_NAME_WITH_REGION, CUSTOM_IMAGE_NAME, CUSTOM_IMAGE_ID, REGION_NAME, RESOURCE_GROUP_NAME);
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
         setupAuthenticatedContext();
-        setupAzureClient();
-        when(customVMImageNameProvider.get(anyString(), anyString())).thenReturn(CUSTOM_IMAGE_NAME);
-        when(azureResourceIdProviderService.generateImageId(anyString(), anyString(), anyString())).thenReturn(CUSTOM_IMAGE_ID);
     }
 
     @Test
-    public void testGetCustomImageIdWhenImageExistsOnAzure() {
-        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any())).thenReturn(Optional.of(virtualMachineCustomImage));
+    public void testFindCustomImageWhenImageExistsOnAzure() {
+        imagePresent(true);
 
-        AzureImage azureImage = underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, false, azureClient);
+        Optional<AzureImage> azureImageOptional = underTest.findImage(azureImageInfo, azureClient, authenticatedContext);
 
-        assertEquals(CUSTOM_IMAGE_ID, azureImage.getId());
-        assertEquals(CUSTOM_IMAGE_NAME, azureImage.getName());
+        assertImageFound(azureImageOptional);
         verifyPollingStarted();
     }
 
     @Test
-    public void testGetCustomImageIdWhenImageIsRequested() {
-        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any())).thenReturn(Optional.empty());
-        when(resourcePersistenceRetriever.notifyRetrieve(anyString(), any(), any())).thenReturn(Optional.of(mock(CloudResource.class)));
+    public void testFindCustomImageWhenImageIsRequested() {
+        imagePresent(false);
+        imageRequested(true);
 
-        AzureImage azureImage = underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, false, azureClient);
+        Optional<AzureImage> azureImageOptional = underTest.findImage(azureImageInfo, azureClient, authenticatedContext);
 
-        assertEquals(CUSTOM_IMAGE_ID, azureImage.getId());
-        assertEquals(CUSTOM_IMAGE_NAME, azureImage.getName());
+        assertImageFound(azureImageOptional);
         verifyPollingStarted();
     }
 
     @Test
-    public void testGetCustomImageIdWhenImageWasNotRequestedAndDoNotCreateIfNotFound() {
-        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any())).thenReturn(Optional.empty());
+    public void testFindCustomImageWhenImageWasNotRequested() {
+        imagePresent(false);
+        imageRequested(false);
 
-        AzureImage azureImage = underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, false, azureClient);
+        Optional<AzureImage> azureImageOptional = underTest.findImage(azureImageInfo, azureClient, authenticatedContext);
 
-        assertNull(azureImage);
+        assertTrue(azureImageOptional.isEmpty());
         verify(azureManagedImageCreationPoller, never()).startPolling(any(), any());
-        verify(azureClient, never()).createCustomImage(anyString(), anyString(), anyString(), anyString());
+        verify(azureClient, never()).createImage(anyString(), anyString(), anyString(), anyString());
     }
 
     @Test
-    public void testGetCustomImageIdWhenImageWasNotRequestedAndCreateIfNotFoundAndSuccess() {
-        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any())).thenReturn(Optional.empty());
-        when(azureClient.createCustomImage(anyString(), anyString(), anyString(), anyString())).thenReturn(virtualMachineCustomImage);
-        when(virtualMachineCustomImage.name()).thenReturn(CUSTOM_IMAGE_NAME);
+    public void testCreateCustomImageIfNotFoundAndSuccess() {
+        when(azureClient.createImage(anyString(), anyString(), anyString(), anyString())).thenReturn(virtualMachineCustomImage);
+        when(virtualMachineCustomImage.name()).thenReturn(CUSTOM_IMAGE_NAME_WITH_REGION);
         when(virtualMachineCustomImage.id()).thenReturn(CUSTOM_IMAGE_ID);
 
-        AzureImage azureImage = underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, true, azureClient);
+        AzureImage azureImage = underTest.createImage(azureImageInfo, FROM_VHD_URI, azureClient, authenticatedContext);
 
-        assertEquals(CUSTOM_IMAGE_ID, azureImage.getId());
-        assertEquals(CUSTOM_IMAGE_NAME, azureImage.getName());
+        assertImageProperties(azureImage);
         verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyAllocation(cr.capture(), any()), CommonStatus.REQUESTED);
         verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyUpdate(cr.capture(), any()), CommonStatus.CREATED);
-        verify(azureClient).createCustomImage(CUSTOM_IMAGE_NAME, RESOURCE_GROUP_NAME, FROM_VHD_URI, REGION_NAME);
+        verify(azureClient).createImage(CUSTOM_IMAGE_NAME_WITH_REGION, RESOURCE_GROUP_NAME, FROM_VHD_URI, REGION_NAME);
     }
 
     @Test
-    public void testGetCustomImageIdWhenImageWasNotRequestedAndCreateIfNotFoundAndError() {
-        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any())).thenReturn(Optional.empty());
-        when(azureClient.createCustomImage(anyString(), anyString(), anyString(), anyString())).thenThrow(new CloudException("", null));
+    public void testCreateCustomImageWhenErrorAndImageNotPresent() {
+        imagePresent(false);
+        when(azureClient.createImage(anyString(), anyString(), anyString(), anyString())).thenThrow(new CloudException("", null));
         thrown.expect(CloudConnectorException.class);
 
         try {
-            underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, true, azureClient);
+            underTest.createImage(azureImageInfo, FROM_VHD_URI, azureClient, authenticatedContext);
 
         } catch (CloudConnectorException e) {
             verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyAllocation(cr.capture(), any()), CommonStatus.REQUESTED);
             verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyUpdate(cr.capture(), any()), CommonStatus.FAILED);
-            verify(azureClient).createCustomImage(CUSTOM_IMAGE_NAME, RESOURCE_GROUP_NAME, FROM_VHD_URI, REGION_NAME);
+            verify(azureClient).createImage(CUSTOM_IMAGE_NAME_WITH_REGION, RESOURCE_GROUP_NAME, FROM_VHD_URI, REGION_NAME);
             throw e;
         }
     }
 
     @Test
-    public void testGetCustomImageIdWhenImageWasNotRequestedAndCreateIfNotFoundAndErrorButImagePresent() {
-        when(azureManagedImageService.findVirtualMachineCustomImage(anyString(), anyString(), any()))
-                .thenReturn(Optional.empty())
-                .thenReturn(Optional.of(virtualMachineCustomImage));
-        when(azureClient.createCustomImage(anyString(), anyString(), anyString(), anyString())).thenThrow(new CloudException("", null));
-        when(virtualMachineCustomImage.name()).thenReturn(CUSTOM_IMAGE_NAME);
+    public void testCreateCustomImageWhenErrorButImagePresent() {
+        imagePresent(true);
+        when(azureClient.createImage(anyString(), anyString(), anyString(), anyString())).thenThrow(new CloudException("", null));
+        when(virtualMachineCustomImage.name()).thenReturn(CUSTOM_IMAGE_NAME_WITH_REGION);
         when(virtualMachineCustomImage.id()).thenReturn(CUSTOM_IMAGE_ID);
 
-        AzureImage azureImage = underTest.getCustomImageId(RESOURCE_GROUP_NAME, FROM_VHD_URI, authenticatedContext, true, azureClient);
+        AzureImage azureImage = underTest.createImage(azureImageInfo, FROM_VHD_URI, azureClient, authenticatedContext);
 
-        assertEquals(CUSTOM_IMAGE_ID, azureImage.getId());
-        assertEquals(CUSTOM_IMAGE_NAME, azureImage.getName());
+        assertImageProperties(azureImage);
         verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyAllocation(cr.capture(), any()), CommonStatus.REQUESTED);
         verifyPersistenceNotification(cr -> verify(persistenceNotifier).notifyUpdate(cr.capture(), any()), CommonStatus.CREATED);
-        verify(azureClient).createCustomImage(CUSTOM_IMAGE_NAME, RESOURCE_GROUP_NAME, FROM_VHD_URI, REGION_NAME);
-    }
-
-    private void setupAzureClient() {
-        Subscription subscription = mock(Subscription.class);
-        when(subscription.subscriptionId()).thenReturn(SUBSCRIPTION_ID);
-        when(azureClient.getCurrentSubscription()).thenReturn(subscription);
+        verify(azureClient).createImage(CUSTOM_IMAGE_NAME_WITH_REGION, RESOURCE_GROUP_NAME, FROM_VHD_URI, REGION_NAME);
     }
 
     private void setupAuthenticatedContext() {
-        Region region = mock(Region.class);
-        Location location = mock(Location.class);
         CloudContext cloudContext = mock(CloudContext.class);
-        when(region.getRegionName()).thenReturn(REGION_NAME);
-        when(location.getRegion()).thenReturn(region);
-        when(cloudContext.getLocation()).thenReturn(location);
         when(authenticatedContext.getCloudContext()).thenReturn(cloudContext);
     }
 
     private void verifyPersistenceNotification(Consumer<ArgumentCaptor<CloudResource>> argumentCaptorConsumer, CommonStatus imageStatus) {
         ArgumentCaptor<CloudResource> argumentCaptor = ArgumentCaptor.forClass(CloudResource.class);
         argumentCaptorConsumer.accept(argumentCaptor);
-        assertEquals(CUSTOM_IMAGE_NAME, argumentCaptor.getValue().getName());
+        assertEquals(CUSTOM_IMAGE_NAME_WITH_REGION, argumentCaptor.getValue().getName());
         assertEquals(CUSTOM_IMAGE_ID, argumentCaptor.getValue().getReference());
         assertEquals(imageStatus, argumentCaptor.getValue().getStatus());
 
@@ -212,7 +184,32 @@ public class AzureImageServiceTest {
     private void verifyPollingStarted() {
         ArgumentCaptor<AzureManagedImageCreationCheckerContext> captor = ArgumentCaptor.forClass(AzureManagedImageCreationCheckerContext.class);
         verify(azureManagedImageCreationPoller).startPolling(any(), captor.capture());
-        assertEquals(CUSTOM_IMAGE_NAME, captor.getValue().getImageName());
-        assertEquals(RESOURCE_GROUP_NAME, captor.getValue().getResourceGroupName());
+        assertEquals(CUSTOM_IMAGE_NAME_WITH_REGION, captor.getValue().getAzureImageInfo().getImageNameWithRegion());
+        assertEquals(RESOURCE_GROUP_NAME, captor.getValue().getAzureImageInfo().getResourceGroup());
+    }
+
+    private void assertImageFound(Optional<AzureImage> azureImageOptional) {
+        assertTrue(azureImageOptional.isPresent());
+        assertImageProperties(azureImageOptional.get());
+    }
+
+    private void assertImageProperties(AzureImage azureImage) {
+        assertEquals(CUSTOM_IMAGE_ID, azureImage.getId());
+        assertEquals(CUSTOM_IMAGE_NAME_WITH_REGION, azureImage.getName());
+    }
+
+    private void imagePresent(boolean present) {
+        when(azureManagedImageService.findVirtualMachineCustomImage(azureImageInfo, azureClient))
+                .thenReturn(present
+                        ? Optional.of(virtualMachineCustomImage)
+                        : Optional.empty()
+                );
+    }
+
+    private void imageRequested(boolean requested) {
+        when(resourcePersistenceRetriever.notifyRetrieve(anyString(), any(), any()))
+                .thenReturn(requested
+                        ? Optional.of(mock(CloudResource.class))
+                        : Optional.empty());
     }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureManagedImageServiceTest.java
@@ -24,6 +24,8 @@ public class AzureManagedImageServiceTest {
 
     private static final String RESOURCE_GROUP = "resource-group";
 
+    private static final String IMAGE_NAME_WITH_REGION = "image-name-with-region";
+
     private static final String IMAGE_NAME = "image-name";
 
     @InjectMocks
@@ -37,24 +39,25 @@ public class AzureManagedImageServiceTest {
 
     @Test
     public void testGetVirtualMachineCustomImageShouldReturnTheImageWhenExistsOnProviderSide() {
+        AzureImageInfo azureImageInfo = new AzureImageInfo(IMAGE_NAME_WITH_REGION, IMAGE_NAME, "imageId", "region", RESOURCE_GROUP);
         VirtualMachineCustomImage image = Mockito.mock(VirtualMachineCustomImage.class);
+        when(azureClient.findImage(RESOURCE_GROUP, IMAGE_NAME_WITH_REGION)).thenReturn(image);
 
-        when(azureClient.findImage(RESOURCE_GROUP, IMAGE_NAME)).thenReturn(image);
-
-        Optional<VirtualMachineCustomImage> actual = underTest.findVirtualMachineCustomImage(RESOURCE_GROUP, IMAGE_NAME, azureClient);
+        Optional<VirtualMachineCustomImage> actual = underTest.findVirtualMachineCustomImage(azureImageInfo, azureClient);
 
         assertTrue(actual.isPresent());
         assertEquals(image, actual.get());
-        verify(azureClient).findImage(RESOURCE_GROUP, IMAGE_NAME);
+        verify(azureClient).findImage(RESOURCE_GROUP, IMAGE_NAME_WITH_REGION);
     }
 
     @Test
-    public void testGetVirtualMachineCustomImageShouldReturnTheImageWhenDoesNotExistsOnProviderSide() {
-        when(azureClient.findImage(RESOURCE_GROUP, IMAGE_NAME)).thenReturn(null);
+    public void testGetVirtualMachineCustomImageShouldReturnTheImageWhenDoesNotExistOnProviderSide() {
+        AzureImageInfo azureImageInfo = new AzureImageInfo(IMAGE_NAME_WITH_REGION, IMAGE_NAME, "imageId", "region", RESOURCE_GROUP);
+        when(azureClient.findImage(RESOURCE_GROUP, IMAGE_NAME_WITH_REGION)).thenReturn(null);
 
-        Optional<VirtualMachineCustomImage> actual = underTest.findVirtualMachineCustomImage(RESOURCE_GROUP, IMAGE_NAME, azureClient);
+        Optional<VirtualMachineCustomImage> actual = underTest.findVirtualMachineCustomImage(azureImageInfo, azureClient);
 
         assertTrue(actual.isEmpty());
-        verify(azureClient).findImage(RESOURCE_GROUP, IMAGE_NAME);
+        verify(azureClient).findImage(RESOURCE_GROUP, IMAGE_NAME_WITH_REGION);
     }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProviderTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.azure.util;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.regex.Pattern;
@@ -10,17 +9,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
-
-import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
 
 public class CustomVMImageNameProviderTest {
     private static final String AZURE_IMAGE_NAME_REGULAR_EXPRESSION = "^[^_\\W][\\w-._]{0,79}(?<![-.])$";
 
     private static final Pattern IMAGE_NAME_PATTERN = Pattern.compile(AZURE_IMAGE_NAME_REGULAR_EXPRESSION);
-
-    @Mock
-    private AzureUtils azureUtils;
 
     @InjectMocks
     private CustomVMImageNameProvider underTest;
@@ -28,7 +21,6 @@ public class CustomVMImageNameProviderTest {
     @Before
     public void setUp() {
         initMocks(this);
-        when(azureUtils.getImageNameFromConnectionString(anyString())).thenCallRealMethod();
     }
 
     @Test
@@ -36,7 +28,7 @@ public class CustomVMImageNameProviderTest {
         String vhdName = "cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.vhd";
         String region = "West US";
 
-        String actual = underTest.get(region, vhdName);
+        String actual = underTest.getImageNameWithRegion(region, vhdName);
 
         Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
         Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.vhd-westus", actual);
@@ -47,7 +39,7 @@ public class CustomVMImageNameProviderTest {
         String vhdName = "cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.vhd";
         String region = "South East Asia";
 
-        String actual = underTest.get(region, vhdName);
+        String actual = underTest.getImageNameWithRegion(region, vhdName);
 
         Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
         Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a.v-southeastasia", actual);
@@ -58,7 +50,7 @@ public class CustomVMImageNameProviderTest {
         String vhdName = "cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa.vhd";
         String region = "South East Asia";
 
-        String actual = underTest.get(region, vhdName);
+        String actual = underTest.getImageNameWithRegion(region, vhdName);
 
         Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
         Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa.-southeastasia", actual);
@@ -69,7 +61,7 @@ public class CustomVMImageNameProviderTest {
         String vhdName = "cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa-.vhd";
         String region = "South East Asia";
 
-        String actual = underTest.get(region, vhdName);
+        String actual = underTest.getImageNameWithRegion(region, vhdName);
 
         Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
         Assert.assertEquals("cb-hdp-26-1907121707-osDisk.cc5baaaa-717e-4551-b7ae-aaaa03c72a6aa--southeastasia", actual);
@@ -80,9 +72,25 @@ public class CustomVMImageNameProviderTest {
         String vhdName = "cb-hdp-26-1907121707-osDisk123.cc5baaaa-717e-4551-b7ae-aaaa03c72a6a-12345678.vhd";
         String region = "South East Asia";
 
-        String actual = underTest.get(region, vhdName);
+        String actual = underTest.getImageNameWithRegion(region, vhdName);
 
         Assert.assertTrue(IMAGE_NAME_PATTERN.matcher(actual).matches());
         Assert.assertEquals("cb-hdp-26-1907121707-osDisk123.cc5baaaa-717e-4551-b7ae-aaaa03c72a6-southeastasia", actual);
     }
+
+    @Test
+    public void getImageNameFromConnectionStringWithSASToken() {
+        String url = "https://sequenceiqwestus2.blob.core.windows.net/test/cb-hdp-31-1911052024.vhd"
+                + "?sp=rl&st=2020-10-26T11:45:18Z&se=2020-10-27T11:45:18Z&sv=2019-12-12&sr=b&sig=G6hkDHn7GezwXBzZhQBNLZD5kI3LXgWMvlxGbm1T8WU%3D";
+        String result = underTest.getImageNameFromConnectionString(url);
+        assertEquals("cb-hdp-31-1911052024.vhd", result);
+    }
+
+    @Test
+    public void getImageNameFromConnectionStringWithoutSASToken() {
+        String url = "https://sequenceiqwestus2.blob.core.windows.net/test/cb-hdp-31-1911052024.vhd";
+        String result = underTest.getImageNameFromConnectionString(url);
+        assertEquals("cb-hdp-31-1911052024.vhd", result);
+    }
+
 }


### PR DESCRIPTION
With rebase another small refactoring was necessary: 
azureUtils.getImageNameFromConnectionString(image) was moved into CustomVMImageNameProvider and into AzureImageInfo.

=====

On azure, during freeipa launch, a 1) storage account is created, 2) the corresponding vhd image file is copied into the storage account, and 3) an finally azure managed image is created from the vhd file.

If an image already exists, then the whole process should be bypassed. However, if the storage account is deleted but the image exists an error is produced.

In this commit the bug is fixed by refactoring.

See detailed description in the commit message.