### PR TITLE
CB-9228 – unable to create a cluster definition for a stopped environment

### DIFF
--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
@@ -28,17 +28,17 @@ import org.springframework.stereotype.Controller;
 
 import com.google.common.base.Strings;
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
+import com.sequenceiq.authorization.annotation.CheckPermissionByRequestProperty;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrnList;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceName;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceNameList;
-import com.sequenceiq.authorization.annotation.CheckPermissionByRequestProperty;
 import com.sequenceiq.authorization.annotation.DisableCheckPermissions;
+import com.sequenceiq.authorization.annotation.RequestObject;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.annotation.ResourceCrnList;
 import com.sequenceiq.authorization.annotation.ResourceName;
 import com.sequenceiq.authorization.annotation.ResourceNameList;
-import com.sequenceiq.authorization.annotation.RequestObject;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
@@ -78,6 +78,7 @@ import com.sequenceiq.distrox.v1.distrox.converter.DistroXRepairV1RequestToClust
 import com.sequenceiq.distrox.v1.distrox.converter.DistroXScaleV1RequestToStackScaleV4RequestConverter;
 import com.sequenceiq.distrox.v1.distrox.converter.DistroXV1RequestToStackV4RequestConverter;
 import com.sequenceiq.distrox.v1.distrox.converter.cli.DelegatingRequestToCliRequestConverter;
+import com.sequenceiq.distrox.v1.distrox.service.DistroxService;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
 @Controller
@@ -125,6 +126,9 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
     @Inject
     private StackOperationService stackOperationService;
 
+    @Inject
+    private DistroxService distroxService;
+
     @Override
     @DisableCheckPermissions
     public StackViewV4Responses list(String environmentName, String environmentCrn) {
@@ -142,10 +146,7 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
     @CheckPermissionByRequestProperty(path = "cluster.blueprintName", type = NAME, action = DESCRIBE_CLUSTER_TEMPLATE)
     @CheckPermissionByRequestProperty(path = "allRecipes", type = NAME_LIST, action = DESCRIBE_RECIPE)
     public StackV4Response post(@Valid @RequestObject DistroXV1Request request) {
-        return stackOperations.post(
-                workspaceService.getForCurrentUser().getId(),
-                stackRequestConverter.convert(request),
-                true);
+        return distroxService.post(request);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXV1RequestToStackV4RequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXV1RequestToStackV4RequestConverter.java
@@ -75,9 +75,6 @@ public class DistroXV1RequestToStackV4RequestConverter {
     public StackV4Request convert(DistroXV1Request source) {
         DetailedEnvironmentResponse environment = Optional.ofNullable(environmentClientService.getByName(source.getEnvironmentName()))
                 .orElseThrow(() -> new BadRequestException("No environment name provided hence unable to obtain some important data"));
-        if (environment != null && environment.getEnvironmentStatus() != EnvironmentStatus.AVAILABLE) {
-            throw new BadRequestException(String.format("Environment state is %s instead of AVAILABLE", environment.getEnvironmentStatus()));
-        }
         StackV4Request request = new StackV4Request();
         SdxClusterResponse sdxClusterResponse = getSdxClusterResponse(environment);
         request.setName(source.getName());

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/DistroxService.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/DistroxService.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.distrox.v1.distrox.service;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
+import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
+import com.sequenceiq.distrox.v1.distrox.StackOperations;
+import com.sequenceiq.distrox.v1.distrox.converter.DistroXV1RequestToStackV4RequestConverter;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+
+@Service
+public class DistroxService {
+
+    private final StackOperations stackOperations;
+
+    private final WorkspaceService workspaceService;
+
+    private final EnvironmentClientService environmentClientService;
+
+    private final DistroXV1RequestToStackV4RequestConverter stackRequestConverter;
+
+    public DistroxService(EnvironmentClientService environmentClientService, StackOperations stackOperations, WorkspaceService workspaceService,
+            DistroXV1RequestToStackV4RequestConverter stackRequestConverter) {
+        this.environmentClientService = environmentClientService;
+        this.stackRequestConverter = stackRequestConverter;
+        this.workspaceService = workspaceService;
+        this.stackOperations = stackOperations;
+    }
+
+    public StackV4Response post(DistroXV1Request request) {
+        validate(request);
+        return stackOperations.post(
+                workspaceService.getForCurrentUser().getId(),
+                stackRequestConverter.convert(request),
+                true);
+    }
+
+    private void validate(DistroXV1Request request) {
+        DetailedEnvironmentResponse environment = Optional.ofNullable(environmentClientService.getByName(request.getEnvironmentName()))
+                .orElseThrow(() -> new BadRequestException("No environment name provided hence unable to obtain some important data"));
+        if (environment != null && environment.getEnvironmentStatus() != EnvironmentStatus.AVAILABLE) {
+            throw new BadRequestException(String.format("Environment state is %s instead of AVAILABLE", environment.getEnvironmentStatus()));
+        }
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/DistroxServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/DistroxServiceTest.java
@@ -1,0 +1,137 @@
+package com.sequenceiq.distrox.v1.distrox.service;
+
+import static com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus.AVAILABLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.verification.VerificationMode;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
+import com.sequenceiq.cloudbreak.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
+import com.sequenceiq.distrox.v1.distrox.StackOperations;
+import com.sequenceiq.distrox.v1.distrox.converter.DistroXV1RequestToStackV4RequestConverter;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+
+class DistroxServiceTest {
+
+    private static final Long USER_ID = 123456L;
+
+    @Mock
+    private DistroXV1RequestToStackV4RequestConverter stackRequestConverter;
+
+    @Mock
+    private EnvironmentClientService environmentClientService;
+
+    @Mock
+    private WorkspaceService workspaceService;
+
+    @Mock
+    private StackOperations stackOperations;
+
+    @InjectMocks
+    private DistroxService underTest;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+        Workspace workspace = new Workspace();
+        workspace.setId(USER_ID);
+        when(workspaceService.getForCurrentUser()).thenReturn(workspace);
+    }
+
+    @Test
+    @DisplayName("When request doesn't contains a valid environment name then BadRequestException should come")
+    void testWithInvalidEnvironmentNameValue() {
+        String invalidEnvNameValue = "somethingInvalidStuff";
+        DistroXV1Request r = new DistroXV1Request();
+        r.setEnvironmentName(invalidEnvNameValue);
+
+        when(environmentClientService.getByName(invalidEnvNameValue)).thenReturn(null);
+
+        BadRequestException err = assertThrows(BadRequestException.class, () -> underTest.post(r));
+
+        assertEquals("No environment name provided hence unable to obtain some important data", err.getMessage());
+
+        verify(environmentClientService, calledOnce()).getByName(any());
+        verify(environmentClientService, calledOnce()).getByName(invalidEnvNameValue);
+        verify(stackOperations, never()).post(any(), any(), anyBoolean());
+        verify(workspaceService, never()).getForCurrentUser();
+        verify(stackRequestConverter, never()).convert(any(DistroXV1Request.class));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = EnvironmentStatus.class, names = "AVAILABLE", mode = EnumSource.Mode.EXCLUDE)
+    @DisplayName("When request contains a valid environment name but that environment is not in the AVAILABLE state then BadRequestException should come")
+    void testWithValidEnvironmentNameValueButTheActualEnvIsNotAvailableBadRequestExceptionShouldCome(EnvironmentStatus status) {
+        String envName = "someAwesomeExistingButNotAvailableEnvironment";
+        DistroXV1Request r = new DistroXV1Request();
+        r.setEnvironmentName(envName);
+
+        DetailedEnvironmentResponse envResponse = new DetailedEnvironmentResponse();
+        envResponse.setEnvironmentStatus(status);
+
+        when(environmentClientService.getByName(envName)).thenReturn(envResponse);
+
+        BadRequestException err = assertThrows(BadRequestException.class, () -> underTest.post(r));
+
+
+        assertEquals(String.format("Environment state is %s instead of AVAILABLE", status.name()), err.getMessage());
+
+        verify(environmentClientService, calledOnce()).getByName(any());
+        verify(environmentClientService, calledOnce()).getByName(eq(envName));
+        verify(stackOperations, never()).post(any(), any(), anyBoolean());
+        verify(workspaceService, never()).getForCurrentUser();
+        verify(stackRequestConverter, never()).convert(any(DistroXV1Request.class));
+    }
+
+    @Test
+    @DisplayName("When the environment that has the given name is exist and also in the state AVAILABLE then no exception should come")
+    void testWhenEnvExistsAndItIsAvailable() {
+        String envName = "someAwesomeEnvironment";
+        DistroXV1Request r = new DistroXV1Request();
+        r.setEnvironmentName(envName);
+
+        DetailedEnvironmentResponse envResponse = new DetailedEnvironmentResponse();
+        envResponse.setEnvironmentStatus(AVAILABLE);
+
+        when(environmentClientService.getByName(envName)).thenReturn(envResponse);
+
+        StackV4Request converted = new StackV4Request();
+        when(stackRequestConverter.convert(r)).thenReturn(converted);
+
+        underTest.post(r);
+
+        verify(environmentClientService, calledOnce()).getByName(any());
+        verify(environmentClientService, calledOnce()).getByName(envName);
+        verify(stackOperations, calledOnce()).post(any(), any(), anyBoolean());
+        verify(stackOperations, calledOnce()).post(USER_ID, converted, true);
+        verify(workspaceService, calledOnce()).getForCurrentUser();
+        verify(stackRequestConverter, calledOnce()).convert(any(DistroXV1Request.class));
+        verify(stackRequestConverter, calledOnce()).convert(r);
+    }
+
+    private static VerificationMode calledOnce() {
+        return times(1);
+    }
+
+}


### PR DESCRIPTION
CB-9228 – unable to create a cluster definition for a stopped environment, since one of the DH creation validation has been placed to an inappropriate place which will be moved to the service layer, allowing one to create c.def for an existing but not necessarily available environment

See detailed description in the commit message.