### PR TITLE
CB-9474 - cli throws unrecognised field exception for env cli command generation for response in CloudSubnet

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/generic/DynamicModel.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/generic/DynamicModel.java
@@ -4,11 +4,16 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  * Generic mode to hold dynamic data, any data stored in the DynamicModel must be threadsafe in that sense that multiple threads might be
  * using it, but of course it is never used concurrently. In other words if you store anything in thread local then it might not be available
  * in a subsequent calls.
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DynamicModel {
 
     private final Map<String, Object> parameters;
@@ -57,4 +62,5 @@ public class DynamicModel {
                 "parameters=" + parameters +
                 '}';
     }
+
 }


### PR DESCRIPTION
CB-9474 - cli throws unrecognised field exception for env cli command generation for response in CloudSubnet, because of the missing jackson property from the DynamicModel that has been added in this commit

See detailed description in the commit message.