### PR TITLE
CB-9464 Flowchain id is not filled out in StructuredEvents, it is har…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
@@ -189,7 +189,7 @@ public class OfflineStateGenerator {
 
     private Flow initializeFlow() throws Exception {
         ((AbstractFlowConfiguration<?, ?>) flowConfiguration).init();
-        Flow flow = flowConfiguration.createFlow("", 0L);
+        Flow flow = flowConfiguration.createFlow("", "", 0L);
         flow.initialize(Map.of());
         return flow;
     }
@@ -259,8 +259,8 @@ public class OfflineStateGenerator {
         @Override
         public <T> T getBean(Class<T> requiredType, Object... args) throws BeansException {
             LegacyFlowStructuredEventHandler<?, ?> bean = new LegacyFlowStructuredEventHandler(args[FlowStructuredEventHandlerParams.INIT_STATE.ordinal()],
-                    args[FlowStructuredEventHandlerParams.FINAL_STATE.ordinal()], (String) args[FlowStructuredEventHandlerParams.FLOW_TYPE.ordinal()],
-                    (String) args[FlowStructuredEventHandlerParams.FLOW_ID.ordinal()], (Long) args[FlowStructuredEventHandlerParams.STACK_ID.ordinal()]);
+                    args[FlowStructuredEventHandlerParams.FINAL_STATE.ordinal()], "", (String) args[FlowStructuredEventHandlerParams.FLOW_TYPE.ordinal()],
+                    "", (String) args[FlowStructuredEventHandlerParams.FLOW_ID.ordinal()], (Long) args[FlowStructuredEventHandlerParams.STACK_ID.ordinal()]);
 
             inject(bean, "legacyStructuredEventClient", (LegacyBaseStructuredEventClient) structuredEvent -> {
             });

--- a/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
@@ -150,7 +150,7 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
                             acceptResult = FlowAcceptResult.runningInFlow(flowId);
                         }
                         flowParameters.setFlowId(flowId);
-                        Flow flow = flowConfig.createFlow(flowId, payload.getResourceId());
+                        Flow flow = flowConfig.createFlow(flowId, flowChainId, payload.getResourceId());
                         flow.initialize(contextParams);
                         runningFlows.put(flow, flowChainId);
                         try {
@@ -294,7 +294,7 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
                         .filter(fc -> fc.getClass().equals(flowLog.getFlowType())).findFirst();
                 try {
                     Payload payload = (Payload) JsonReader.jsonToJava(flowLog.getPayload());
-                    Flow flow = flowConfig.get().createFlow(flowLog.getFlowId(), payload.getResourceId());
+                    Flow flow = flowConfig.get().createFlow(flowLog.getFlowId(), flowLog.getFlowChainId(), payload.getResourceId());
                     runningFlows.put(flow, flowLog.getFlowChainId());
                     if (flowLog.getFlowChainId() != null) {
                         flowChainHandler.restoreFlowChain(flowLog.getFlowChainId());

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowEventListenerAdapter.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowEventListenerAdapter.java
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Scope("prototype")
 public class FlowEventListenerAdapter<S, E> extends StateMachineListenerAdapter<S, E> implements FlowEventListener<S, E> {
-    public FlowEventListenerAdapter(S initState, S finalState, String flowType, String flowId, Long stackId) {
+
+    public FlowEventListenerAdapter(S initState, S finalState, String flowChainType, String flowType,
+            String flowChainId, String flowId, Long resourceId) {
     }
 
     @Override

--- a/flow/src/main/java/com/sequenceiq/flow/core/config/AbstractFlowConfiguration.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/config/AbstractFlowConfiguration.java
@@ -79,10 +79,10 @@ public abstract class AbstractFlowConfiguration<S extends FlowState, E extends F
     }
 
     @Override
-    public Flow createFlow(String flowId, Long stackId) {
+    public Flow createFlow(String flowId, String flowChainId, Long stackId) {
         StateMachine<S, E> sm = stateMachineFactory.getStateMachine();
         FlowEventListener<S, E> fl = (FlowEventListener<S, E>) applicationContext.getBean(FlowEventListener.class, getEdgeConfig().initState,
-                getEdgeConfig().finalState, getClass().getSimpleName(), flowId, stackId);
+                getEdgeConfig().finalState, "", getClass().getSimpleName(), flowChainId, flowId, stackId);
         Flow flow = new FlowAdapter<>(flowId, sm, new MessageFactory<>(), new StateConverterAdapter<>(stateType),
                 new EventConverterAdapter<>(eventType), (Class<? extends FlowConfiguration<E>>) getClass(), fl);
         sm.addStateListener(fl);

--- a/flow/src/main/java/com/sequenceiq/flow/core/config/FlowConfiguration.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/config/FlowConfiguration.java
@@ -6,7 +6,8 @@ import com.sequenceiq.flow.core.FlowTriggerCondition;
 import com.sequenceiq.flow.core.RestartAction;
 
 public interface FlowConfiguration<E extends FlowEvent> {
-    Flow createFlow(String flowId, Long stackId);
+
+    Flow createFlow(String flowId, String flowChainId, Long stackId);
 
     FlowTriggerCondition getFlowTriggerCondition();
 

--- a/flow/src/test/java/com/sequenceiq/flow/core/Flow2HandlerTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/Flow2HandlerTest.java
@@ -187,7 +187,7 @@ public class Flow2HandlerTest {
     @Test
     public void testNewFlow() {
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
-        given(flowConfig.createFlow(anyString(), anyLong())).willReturn(flow);
+        given(flowConfig.createFlow(anyString(), any(), anyLong())).willReturn(flow);
         given(flowConfig.getFlowTriggerCondition()).willReturn(flowTriggerCondition);
         given(flowTriggerCondition.isFlowTriggerable(anyLong())).willReturn(true);
         given(flow.getCurrentState()).willReturn(flowState);
@@ -204,7 +204,7 @@ public class Flow2HandlerTest {
     @Test
     public void testFlowCanNotBeSaved() {
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
-        given(flowConfig.createFlow(anyString(), anyLong())).willReturn(flow);
+        given(flowConfig.createFlow(anyString(), any(), anyLong())).willReturn(flow);
         given(flowConfig.getFlowTriggerCondition()).willReturn(flowTriggerCondition);
         given(flowTriggerCondition.isFlowTriggerable(anyLong())).willReturn(true);
         given(flow.getCurrentState()).willReturn(flowState);
@@ -227,7 +227,7 @@ public class Flow2HandlerTest {
         given(helloWorldFlowConfig.getFlowTriggerCondition()).willReturn(new DefaultFlowTriggerCondition());
 
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(helloWorldFlowConfig);
-        given(helloWorldFlowConfig.createFlow(anyString(), anyLong())).willReturn(flow);
+        given(helloWorldFlowConfig.createFlow(anyString(), any(), anyLong())).willReturn(flow);
         given(helloWorldFlowConfig.getFlowTriggerCondition()).willReturn(flowTriggerCondition);
         given(flowTriggerCondition.isFlowTriggerable(anyLong())).willReturn(true);
         given(flow.getCurrentState()).willReturn(flowState);

--- a/flow/src/test/java/com/sequenceiq/flow/core/config/AbstractFlowConfigurationTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/config/AbstractFlowConfigurationTest.java
@@ -62,8 +62,9 @@ public class AbstractFlowConfigurationTest {
         MockitoAnnotations.initMocks(this);
         BDDMockito.given(applicationContext.getBean(ArgumentMatchers.anyString(), ArgumentMatchers.any(Class.class))).willReturn(action);
         BDDMockito.given(applicationContext.getBean(ArgumentMatchers.eq(FlowEventListener.class), ArgumentMatchers.eq(State.INIT),
-                ArgumentMatchers.eq(State.FINAL), ArgumentMatchers.anyString(), ArgumentMatchers.eq("flowId"),
-                ArgumentMatchers.anyLong())).willReturn(flowEventListener);
+                ArgumentMatchers.eq(State.FINAL), ArgumentMatchers.anyString(), ArgumentMatchers.anyString(),
+                ArgumentMatchers.eq("flowChainId"), ArgumentMatchers.eq("flowId"), ArgumentMatchers.anyLong()))
+                .willReturn(flowEventListener);
         transitions = new Builder<State, Event>()
                 .defaultFailureEvent(Event.FAILURE)
                 .from(State.INIT).to(State.DO).event(Event.START).noFailureEvent()
@@ -74,7 +75,7 @@ public class AbstractFlowConfigurationTest {
         edgeConfig = new FlowEdgeConfig<>(State.INIT, State.FINAL, State.FAILED, Event.FAIL_HANDLED);
         ((AbstractFlowConfiguration<State, Event>) underTest).init();
         Mockito.verify(applicationContext, Mockito.times(8)).getBean(ArgumentMatchers.anyString(), ArgumentMatchers.any(Class.class));
-        flow = underTest.createFlow("flowId", 0L);
+        flow = underTest.createFlow("flowId", "flowChainId", 0L);
         flow.initialize(Map.of());
     }
 
@@ -188,7 +189,7 @@ public class AbstractFlowConfigurationTest {
 
         @Override
         public Event[] getInitEvents() {
-            return new Event[]{ Event.START };
+            return new Event[]{Event.START};
         }
 
         @Override

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/CDPFlowStructuredEventHandler.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/CDPFlowStructuredEventHandler.java
@@ -34,6 +34,10 @@ public class CDPFlowStructuredEventHandler<S, E> extends StateMachineListenerAda
 
     private final S finalState;
 
+    private final String flowChainType;
+
+    private final String flowChainId;
+
     private final String flowType;
 
     private final String flowId;
@@ -44,11 +48,14 @@ public class CDPFlowStructuredEventHandler<S, E> extends StateMachineListenerAda
 
     private Exception exception;
 
-    public CDPFlowStructuredEventHandler(S initState, S finalState, String flowType, String flowId, Long resourceId) {
+    public CDPFlowStructuredEventHandler(S initState, S finalState, String flowChainType, String flowType,
+            String flowChainId, String flowId, Long resourceId) {
         this.initState = initState;
         this.finalState = finalState;
         this.flowType = flowType;
         this.flowId = flowId;
+        this.flowChainType = flowChainType;
+        this.flowChainId = flowChainId;
         this.resourceId = resourceId;
     }
 
@@ -83,7 +90,7 @@ public class CDPFlowStructuredEventHandler<S, E> extends StateMachineListenerAda
             String eventId = trigger != null ? trigger.getEvent().toString() : "unknown";
             Boolean detailed = toId.equals(initState.toString()) || toId.equals(finalState.toString());
             long duration = lastStateChange == null ? 0L : currentTime - lastStateChange;
-            FlowDetails flowDetails = new FlowDetails("", flowType, "", flowId, fromId, toId, eventId, duration);
+            FlowDetails flowDetails = new FlowDetails(flowChainType, flowType, flowChainId, flowId, fromId, toId, eventId, duration);
             CDPStructuredEvent structuredEvent;
             if (exception == null) {
                 structuredEvent = cdpStructuredFlowEventFactory.createStructuredFlowEvent(resourceId, flowDetails, detailed);
@@ -114,7 +121,7 @@ public class CDPFlowStructuredEventHandler<S, E> extends StateMachineListenerAda
             State<S, E> currentState = stateMachine.getState();
             Long currentTime = System.currentTimeMillis();
             String fromId = currentState != null ? currentState.getId().toString() : "unknown";
-            FlowDetails flowDetails = new FlowDetails("", flowType, "", flowId, fromId, "unknown", "FLOW_CANCEL",
+            FlowDetails flowDetails = new FlowDetails(flowChainType, flowType, flowChainId, flowId, fromId, "unknown", "FLOW_CANCEL",
                     lastStateChange == null ? 0L : currentTime - lastStateChange);
             CDPStructuredEvent structuredEvent = cdpStructuredFlowEventFactory.createStructuredFlowEvent(resourceId, flowDetails, true);
             cdpDefaultStructuredEventClient.sendStructuredEvent(structuredEvent);

--- a/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/CDPFlowStructuredEventHandlerTest.java
+++ b/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/CDPFlowStructuredEventHandlerTest.java
@@ -26,7 +26,7 @@ public class CDPFlowStructuredEventHandlerTest {
 
     @InjectMocks
     private final CDPFlowStructuredEventHandler<String, String> underTest = new CDPFlowStructuredEventHandler<>(
-            "init", "final", "flowType", "flowId", 0L);
+            "init", "final", "flowChainType", "flowType", "flowChainId", "flowId", 0L);
 
     @Mock
     private CDPDefaultStructuredEventClient cdpDefaultStructuredEventClient;

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/LegacyFlowStructuredEventHandler.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/LegacyFlowStructuredEventHandler.java
@@ -35,6 +35,10 @@ public class LegacyFlowStructuredEventHandler<S, E> extends StateMachineListener
 
     private final S finalState;
 
+    private final String flowChainType;
+
+    private final String flowChainId;
+
     private final String flowType;
 
     private final String flowId;
@@ -45,11 +49,14 @@ public class LegacyFlowStructuredEventHandler<S, E> extends StateMachineListener
 
     private Exception exception;
 
-    public LegacyFlowStructuredEventHandler(S initState, S finalState, String flowType, String flowId, Long stackId) {
+    public LegacyFlowStructuredEventHandler(S initState, S finalState, String flowChainType, String flowType,
+            String flowChainId, String flowId, Long stackId) {
         this.initState = initState;
         this.finalState = finalState;
         this.flowType = flowType;
         this.flowId = flowId;
+        this.flowChainType = flowChainType;
+        this.flowChainId = flowChainId;
         this.stackId = stackId;
     }
 
@@ -83,7 +90,7 @@ public class LegacyFlowStructuredEventHandler<S, E> extends StateMachineListener
             String toId = to != null ? to.getId().toString() : "unknown";
             String eventId = trigger != null ? trigger.getEvent().toString() : "unknown";
             Boolean detailed = toId.equals(initState.toString()) || toId.equals(finalState.toString());
-            FlowDetails flowDetails = new FlowDetails("", flowType, "", flowId, fromId, toId, eventId,
+            FlowDetails flowDetails = new FlowDetails(flowChainType, flowType, flowChainId, flowId, fromId, toId, eventId,
                     lastStateChange == null ? 0L : currentTime - lastStateChange);
             StructuredEvent structuredEvent;
             if (exception == null) {
@@ -115,7 +122,7 @@ public class LegacyFlowStructuredEventHandler<S, E> extends StateMachineListener
             State<S, E> currentState = stateMachine.getState();
             Long currentTime = System.currentTimeMillis();
             String fromId = currentState != null ? currentState.getId().toString() : "unknown";
-            FlowDetails flowDetails = new FlowDetails("", flowType, "", flowId, fromId, "unknown", "FLOW_CANCEL",
+            FlowDetails flowDetails = new FlowDetails(flowChainType, flowType, flowChainId, flowId, fromId, "unknown", "FLOW_CANCEL",
                     lastStateChange == null ? 0L : currentTime - lastStateChange);
             StructuredEvent structuredEvent = legacyStructuredFlowEventFactory.createStucturedFlowEvent(stackId, flowDetails, true);
             legacyStructuredEventClient.sendStructuredEvent(structuredEvent);


### PR DESCRIPTION
…dcoded to empty string, this makes it quite hard to figure out which flows are tied together. We have the same problem for Flowchain Type but that is addressed under CB-9465.

See detailed description in the commit message.