### PR TITLE
Resource deletion should break test case when a resource reaches the 'DELETE_FAILED' state

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
@@ -210,6 +210,9 @@ public class AwsYcloudHybridCloudTest extends AbstractE2ETest {
                     }
                     return dto;
                 })
+                .given(CHILD_ENVIRONMENT_KEY, EnvironmentTestDto.class, CHILD_CLOUD_PLATFORM)
+                .when(environmentTestClient.cascadingDelete(), RunningParameter.key(CHILD_ENVIRONMENT_KEY))
+                .await(EnvironmentStatus.ARCHIVED, RunningParameter.key(CHILD_ENVIRONMENT_KEY))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakTerminationChecker.java
@@ -78,7 +78,7 @@ public class CloudbreakTerminationChecker<T extends CloudbreakWaitObject> extend
             StackStatusV4Response stackStatus = waitObject.getStackEndpoint().getStatusByName(waitObject.getWorkspaceId(), name, waitObject.getAccountId());
             Map<String, Status> actualStatuses = Map.of("status", stackStatus.getStatus(), "clusterStatus", stackStatus.getClusterStatus());
             if (isDeleteFailed(actualStatuses)) {
-                return true;
+                return false;
             }
             return waitObject.isFailed(actualStatuses);
         } catch (ProcessingException clientException) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeTerminationChecker.java
@@ -71,7 +71,7 @@ public class DatalakeTerminationChecker<T extends DatalakeWaitObject> extends Ex
             SdxClusterResponse sdx = waitObject.getEndpoint().get(name);
             SdxClusterStatusResponse status = sdx.getStatus();
             if (status.equals(DELETE_FAILED)) {
-                return true;
+                return false;
             }
             return waitObject.isFailed(status);
         } catch (ProcessingException clientException) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentTerminationChecker.java
@@ -71,7 +71,7 @@ public class EnvironmentTerminationChecker<T extends EnvironmentWaitObject> exte
             DetailedEnvironmentResponse environment = waitObject.getEndpoint().getByCrn(crn);
             EnvironmentStatus status = environment.getEnvironmentStatus();
             if (status.equals(DELETE_FAILED)) {
-                return true;
+                return false;
             }
             return status.isFailed();
         } catch (ProcessingException clientException) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaTerminationChecker.java
@@ -68,7 +68,7 @@ public class FreeIpaTerminationChecker<T extends FreeIpaWaitObject> extends Exce
             DescribeFreeIpaResponse freeIpa = waitObject.getEndpoint().describe(environmentCrn);
             Status status = freeIpa.getStatus();
             if (status.equals(DELETE_FAILED)) {
-                return true;
+                return false;
             }
             return status.isFailed();
         } catch (ProcessingException clientException) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceTerminationChecker.java
@@ -117,7 +117,7 @@ public class InstanceTerminationChecker<T extends InstanceWaitObject> extends Ex
                     InstanceMetaDataV4Response instanceMetaDataV4Response = instanceMetaData.get();
                     InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
                     if (waitObject.isDeleteFailed(instanceStatus)) {
-                        return true;
+                        return false;
                     }
                     return waitObject.isFailed(instanceStatus);
                 } else {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/redbeams/RedbeamsTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/redbeams/RedbeamsTerminationChecker.java
@@ -71,7 +71,7 @@ public class RedbeamsTerminationChecker<T extends RedbeamsWaitObject> extends Ex
             DatabaseServerV4Response redbeams = waitObject.getEndpoint().getByCrn(crn);
             Status status = redbeams.getStatus();
             if (status.equals(DELETE_FAILED)) {
-                return true;
+                return false;
             }
             return waitObject.isFailed(status);
         } catch (ProcessingException clientException) {


### PR DESCRIPTION
Changes:
 - enforce delete yarn environment from test to be able to identify yarn environment deletion issues
 - enforce TestFailException in case of DELETE_FAILED status during resource terminations