### PR TITLE
CB-9476 Clear the cert status when the renewal process is started

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationService.java
@@ -33,6 +33,7 @@ public class ClusterCertificatesRotationService {
         LOGGER.debug(statusReason);
         stackUpdater.updateStackStatus(stackId, DetailedStackStatus.CLUSTER_OPERATION, statusReason);
         clusterService.updateClusterStatusByStackId(stackId, Status.UPDATE_IN_PROGRESS);
+        clusterService.updateClusterCertExpirationState(stackId, false);
         flowMessageService.fireEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), ResourceEvent.CLUSTER_CERTIFICATES_ROTATION_STARTED);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -384,6 +384,11 @@ public class ClusterService {
                 }).collect(Collectors.toList());
     }
 
+    public void updateClusterCertExpirationState(Long stackId, boolean hostCertificateExpiring) {
+        Optional<Cluster> cluster = findOneByStackId(stackId);
+        cluster.ifPresent(c -> updateClusterCertExpirationState(c, hostCertificateExpiring));
+    }
+
     public void updateClusterCertExpirationState(Cluster cluster, boolean hostCertificateExpiring) {
         if (VALID == cluster.getCertExpirationState() && hostCertificateExpiring) {
             LOGGER.info("Update cert expiration state from {} to {}", cluster.getCertExpirationState(), HOST_CERT_EXPIRING);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -62,6 +62,7 @@ import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
 import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
+import com.sequenceiq.common.api.type.CertExpirationState;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.datalake.configuration.CDPConfigService;
@@ -733,4 +734,9 @@ public class SdxService implements ResourceIdProvider, ResourceBasedCrnProvider 
             stackV4Endpoint.renewCertificate(0L, sdxCluster.getClusterName(), userCrn);
         });
     }
+
+    public void updateCertExpirationState(Long id, CertExpirationState state) {
+        sdxClusterRepository.updateCertExpirationState(id, state);
+    }
+
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/cert/CertRotationService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/cert/CertRotationService.java
@@ -16,6 +16,7 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.common.api.type.CertExpirationState;
 import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.SdxReactorFlowManager;
@@ -67,6 +68,7 @@ public class CertRotationService {
                     stackV4Endpoint.rotateAutoTlsCertificates(0L, sdxCluster.getClusterName(), initiatorUserCrn, request));
             cloudbreakFlowService.saveLastCloudbreakFlowChainId(sdxCluster, response.getFlowIdentifier());
             sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.CERT_ROTATION_IN_PROGRESS, "Datalake cert rotation in progress", sdxCluster);
+            sdxService.updateCertExpirationState(id, CertExpirationState.VALID);
         } catch (WebApplicationException e) {
             String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
             LOGGER.error("Couldn't start certiificate rotation in CB: {}", errorMessage, e);


### PR DESCRIPTION
When the cert rotation flow is started the cert expiration state will
be set to `VALID`, so on the UI the button and notification will
disappear.
In case the flow fails, the syncer will set it it to expiring again.