### PR TITLE
CB-9434 CB-9437 Entitlement check for DB TLS

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementService.java
@@ -86,6 +86,9 @@ public class EntitlementService {
     @VisibleForTesting
     static final String CDP_SDX_HBASE_CLOUD_STORAGE = "CDP_SDX_HBASE_CLOUD_STORAGE";
 
+    @VisibleForTesting
+    static final String CDP_CB_DATABASE_WIRE_ENCRYPTION = "CDP_CB_DATABASE_WIRE_ENCRYPTION";
+
     @Inject
     private GrpcUmsClient umsClient;
 
@@ -179,6 +182,10 @@ public class EntitlementService {
 
     public boolean sdxHbaseCloudStorageEnabled(String actorCrn, String accountId) {
         return isEntitlementRegistered(actorCrn, accountId, CDP_SDX_HBASE_CLOUD_STORAGE);
+    }
+
+    public boolean databaseWireEncryptionEnabled(String actorCrn, String accountId) {
+        return isEntitlementRegistered(actorCrn, accountId, CDP_CB_DATABASE_WIRE_ENCRYPTION);
     }
 
     public List<String> getEntitlements(String actorCrn, String accountId) {

--- a/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
+++ b/auth-connector/src/test/java/com/sequenceiq/cloudbreak/auth/altus/EntitlementServiceTest.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AUTOMA
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AZURE;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_AZURE_SINGLE_RESOURCE_GROUP;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_BASE_IMAGE;
+import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_CB_DATABASE_WIRE_ENCRYPTION;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_CB_FAST_EBS_ENCRYPTION;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_CLOUD_IDENTITY_MAPPING;
 import static com.sequenceiq.cloudbreak.auth.altus.EntitlementService.CDP_CLOUD_STORAGE_VALIDATION;
@@ -138,6 +139,11 @@ class EntitlementServiceTest {
                         (EntitlementCheckFunction) EntitlementService::sdxHbaseCloudStorageEnabled, false},
                 {"CDP_SDX_HBASE_CLOUD_STORAGE == true", CDP_SDX_HBASE_CLOUD_STORAGE,
                         (EntitlementCheckFunction) EntitlementService::sdxHbaseCloudStorageEnabled, true},
+
+                {"CDP_CB_DATABASE_WIRE_ENCRYPTION == false", CDP_CB_DATABASE_WIRE_ENCRYPTION,
+                        (EntitlementCheckFunction) EntitlementService::databaseWireEncryptionEnabled, false},
+                {"CDP_CB_DATABASE_WIRE_ENCRYPTION == true", CDP_CB_DATABASE_WIRE_ENCRYPTION,
+                        (EntitlementCheckFunction) EntitlementService::databaseWireEncryptionEnabled, true},
         };
     }
 

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -223,6 +223,8 @@ public class MockUserManagementService extends UserManagementImplBase {
     // See com.cloudera.thunderhead.service.common.entitlements.CdpEntitlements.CDP_CP_CUSTOM_DL_TEMPLATE
     private static final String CDP_CP_CUSTOM_DL_TEMPLATE = "CDP_CM_ADMIN_CREDENTIALS";
 
+    private static final String CDP_CB_DATABASE_WIRE_ENCRYPTION = "CDP_CB_DATABASE_WIRE_ENCRYPTION";
+
     private static final String MOCK_RESOURCE = "mock_resource";
 
     private static final String SSH_PUBLIC_KEY_PATTERN = "^ssh-(rsa|ed25519)\\s+AAAA(B|C)3NzaC1.*(|\\n)";
@@ -301,6 +303,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Value("${auth.mock.hbase.cloudstorage.enable}")
     private boolean enableHbaseCloudStorage;
+
+    @Value("${auth.mock.database.wire.encryption.enable}")
+    private boolean enableDatabaseWireEncryption;
 
     private String cbLicense;
 
@@ -601,6 +606,9 @@ public class MockUserManagementService extends UserManagementImplBase {
         }
         if (enableHbaseCloudStorage) {
             builder.addEntitlements(createEntitlement(CDP_SDX_HBASE_CLOUD_STORAGE));
+        }
+        if (enableDatabaseWireEncryption) {
+            builder.addEntitlements(createEntitlement(CDP_CB_DATABASE_WIRE_ENCRYPTION));
         }
         responseObserver.onNext(
                 GetAccountResponse.newBuilder()

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -30,3 +30,4 @@ auth:
     mediumdutysdx.enable: true
     upgrade.internalrepo.enable: true
     hbase.cloudstorage.enable: true
+    database.wire.encryption.enable: true

--- a/mock-thunderhead/src/test/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementServiceTest.java
+++ b/mock-thunderhead/src/test/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementServiceTest.java
@@ -170,7 +170,7 @@ public class MockUserManagementServiceTest {
         Account account = res.getAccount();
         List<String> entitlements = account.getEntitlementsList().stream().map(Entitlement::getEntitlementName).collect(Collectors.toList());
         assertThat(entitlements).contains("CDP_AZURE", "CDP_GCP", "CDP_AUTOMATIC_USERSYNC_POLLER", "CLOUDERA_INTERNAL_ACCOUNT", "DATAHUB_AZURE_AUTOSCALING",
-                "DATAHUB_AWS_AUTOSCALING", "LOCAL_DEV", "CDP_CM_ADMIN_CREDENTIALS");
+                "DATAHUB_AWS_AUTOSCALING", "LOCAL_DEV", "DATAHUB_FLOW_SCALING", "DATAHUB_STREAMING_SCALING", "CDP_CM_ADMIN_CREDENTIALS");
     }
 
     static Object[][] conditionalEntitlementDataProvider() {
@@ -222,6 +222,9 @@ public class MockUserManagementServiceTest {
 
                 {"enableHbaseCloudStorage false", "enableHbaseCloudStorage", false, "CDP_SDX_HBASE_CLOUD_STORAGE", false},
                 {"enableHbaseCloudStorage true", "enableHbaseCloudStorage", true, "CDP_SDX_HBASE_CLOUD_STORAGE", true},
+
+                {"enableDatabaseWireEncryption false", "enableDatabaseWireEncryption", false, "CDP_CB_DATABASE_WIRE_ENCRYPTION", false},
+                {"enableDatabaseWireEncryption true", "enableDatabaseWireEncryption", true, "CDP_CB_DATABASE_WIRE_ENCRYPTION", true},
         };
     }
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4Request.java
@@ -61,8 +61,8 @@ public class AllocateDatabaseServerV4Request extends ProviderParametersBase {
     @ApiModelProperty(DBStack.AZURE_PARAMETERS)
     private GcpDBStackV4Parameters gcp;
 
-    @ApiModelProperty(DBStack.SSL_CONFIGURATION)
-    private SslConfigurationV4Request sslConfiguration;
+    @ApiModelProperty(DatabaseServer.SSL_CONFIG)
+    private SslConfigV4Request sslConfig;
 
     public String getName() {
         return name;
@@ -104,12 +104,12 @@ public class AllocateDatabaseServerV4Request extends ProviderParametersBase {
         this.clusterCrn = clusterCrn;
     }
 
-    public SslConfigurationV4Request getSslConfiguration() {
-        return sslConfiguration;
+    public SslConfigV4Request getSslConfig() {
+        return sslConfig;
     }
 
-    public void setSslConfiguration(SslConfigurationV4Request sslConfiguration) {
-        this.sslConfiguration = sslConfiguration;
+    public void setSslConfig(SslConfigV4Request sslConfig) {
+        this.sslConfig = sslConfig;
     }
 
     @Override

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/SslConfigV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/SslConfigV4Request.java
@@ -3,13 +3,16 @@ package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.redbeams.doc.ModelDescriptions;
+import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServer;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
-@ApiModel(description = ModelDescriptions.SSL_CONFIGURATION_REQUEST)
+@ApiModel(description = ModelDescriptions.SSL_CONFIG_REQUEST)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SslConfigurationV4Request {
+public class SslConfigV4Request {
 
+    @ApiModelProperty(DatabaseServer.SSL_MODE)
     private SslMode sslMode;
 
     public SslMode getSslMode() {
@@ -19,4 +22,5 @@ public class SslConfigurationV4Request {
     public void setSslMode(SslMode sslMode) {
         this.sslMode = sslMode;
     }
+
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/SslMode.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/SslMode.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests;
 
+/**
+ * SSL enforcement mode used by a database server.
+ */
 public enum SslMode {
     ENABLED,
     DISABLED;

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/responses/SslConfigV4Response.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/responses/SslConfigV4Response.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslMode;
 import com.sequenceiq.redbeams.doc.ModelDescriptions;
+import com.sequenceiq.redbeams.doc.ModelDescriptions.DatabaseServer;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -12,13 +13,13 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(description = ModelDescriptions.SSL_CONFIG_RESPONSE)
 public class SslConfigV4Response implements Serializable {
 
-    @ApiModelProperty(ModelDescriptions.DatabaseServer.SSL_CERTIFICATES)
+    @ApiModelProperty(DatabaseServer.SSL_CERTIFICATES)
     private Set<String> sslCertificates;
 
-    @ApiModelProperty(ModelDescriptions.DatabaseServer.SSL_CERTIFICATE_TYPE)
+    @ApiModelProperty(DatabaseServer.SSL_CERTIFICATE_TYPE)
     private SslCertificateType sslCertificateType = SslCertificateType.NONE;
 
-    @ApiModelProperty(ModelDescriptions.DatabaseServer.SSL_CONFIG)
+    @ApiModelProperty(DatabaseServer.SSL_MODE)
     private SslMode sslMode = SslMode.DISABLED;
 
     public Set<String> getSslCertificates() {
@@ -44,4 +45,5 @@ public class SslConfigV4Response implements Serializable {
     public void setSslMode(SslMode sslMode) {
         this.sslMode = sslMode;
     }
+
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ModelDescriptions.java
@@ -3,7 +3,7 @@ package com.sequenceiq.redbeams.doc;
 public final class ModelDescriptions {
 
     public static final String ALLOCATE_DATABASE_SERVER_REQUEST = "Request for allocating a new database server in a provider";
-    public static final String SSL_CONFIGURATION_REQUEST = "Request for SSL configuration";
+    public static final String SSL_CONFIG_REQUEST = "Request for the SSL config of a database server";
     public static final String CREATE_DATABASE_REQUEST = "Request for creating a new database on a registered database server";
     public static final String CREATE_DATABASE_RESPONSE = "Response for creating a new database on a registered database server";
     public static final String DATABASE_IDENTIFIERS = "Identifiers that together identify a database in an environment";
@@ -14,7 +14,7 @@ public final class ModelDescriptions {
     public static final String DATABASE_SERVER_RESPONSE = "Response containing information about a database server that was acted upon, e.g., retrieved, "
         + "deleted, listed";
     public static final String DATABASE_SERVER_RESPONSES = "A set of multiple database server responses";
-    public static final String SSL_CONFIG_RESPONSE = "SSL Config response";
+    public static final String SSL_CONFIG_RESPONSE = "Response for the SSL config of a database server";
     public static final String DATABASE_SERVER_STATUS_RESPONSE = "Response containing status information about a database server";
     public static final String DATABASE_SERVER_TEST_REQUEST = "Request for testing connectivity to a database server";
     public static final String DATABASE_SERVER_TEST_RESPONSE = "Response for testing connectivity to a database server";
@@ -63,9 +63,10 @@ public final class ModelDescriptions {
         public static final String RESOURCE_STATUS = "Ownership status of the database server";
         public static final String STATUS = "Status of the database server stack";
         public static final String STATUS_REASON = "Additional status information about the database server stack";
-        public static final String SSL_CERTIFICATES = "SSL certificate for the actual database server";
+        public static final String SSL_CERTIFICATES = "Set of SSL certificates for the actual database server";
         public static final String SSL_CERTIFICATE_TYPE = "SSL certificate type";
-        public static final String SSL_CONFIG = "SSL config";
+        public static final String SSL_MODE = "SSL enforcement mode for the actual database server";
+        public static final String SSL_CONFIG = "SSL config of the database server";
     }
 
     public static class DatabaseServerTest {
@@ -80,7 +81,6 @@ public final class ModelDescriptions {
         public static final String DATABASE_SERVER = "Database server information for the database stack";
         public static final String AWS_PARAMETERS = "AWS-specific parameters for the database stack";
         public static final String AZURE_PARAMETERS = "Azure-specific parameters for the database stack";
-        public static final String SSL_CONFIGURATION = "SSL configuration for the database stack";
     }
 
     public static class NetworkModelDescriptions {

--- a/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/SslModeTest.java
+++ b/redbeams-api/src/test/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/SslModeTest.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SslModeTest {
+
+    static Object[][] sslDataProvider() {
+        return new Object[][]{
+                // testCaseName sslMode resultExpected
+                {"sslMode=null", null, false},
+                {"sslMode=DISABLED", SslMode.DISABLED, false},
+                {"sslMode=ENABLED", SslMode.ENABLED, true},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("sslDataProvider")
+    void isEnabledTest(String testCaseName, SslMode sslMode, boolean resultExpected) {
+        assertThat(SslMode.isEnabled(sslMode)).isEqualTo(resultExpected);
+    }
+
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverter.java
@@ -176,7 +176,7 @@ public class AllocateDatabaseServerV4RequestToDBStackConverter {
 
     public SslConfig getSslConfig(AllocateDatabaseServerV4Request source, DBStack dbStack) {
         SslConfig sslConfig = new SslConfig();
-        if (sslEnabled && source.getSslConfiguration() != null && SslMode.isEnabled(source.getSslConfiguration().getSslMode())) {
+        if (sslEnabled && source.getSslConfig() != null && SslMode.isEnabled(source.getSslConfig().getSslMode())) {
             sslConfig.setSslCertificates(databaseServerSSlCertificateConfig.getCertsByPlatform(dbStack.getCloudPlatform()));
             sslConfig.setSslCertificateType(SslCertificateType.CLOUD_PROVIDER_OWNED);
         }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
@@ -51,7 +51,7 @@ import com.sequenceiq.environment.api.v1.environment.model.response.LocationResp
 import com.sequenceiq.environment.api.v1.environment.model.response.SecurityAccessResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.TagResponse;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
-import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslConfigurationV4Request;
+import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslConfigV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslMode;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.SslCertificateType;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
@@ -374,9 +374,9 @@ public class AllocateDatabaseServerV4RequestToDBStackConverterTest {
             allocateRequest.setNetwork(null);
             allocateRequest.getDatabaseServer().setSecurityGroup(null);
         }
-        SslConfigurationV4Request sslConfigurationV4Request = new SslConfigurationV4Request();
-        sslConfigurationV4Request.setSslMode(SslMode.ENABLED);
-        allocateRequest.setSslConfiguration(sslConfigurationV4Request);
+        SslConfigV4Request sslConfigV4Request = new SslConfigV4Request();
+        sslConfigV4Request.setSslMode(SslMode.ENABLED);
+        allocateRequest.setSslConfig(sslConfigV4Request);
 
         databaseServerRequest.setInstanceType("db.m3.medium");
         databaseServerRequest.setDatabaseVendor("postgres");


### PR DESCRIPTION
* Apply DL external DB SSL enforcement only if entitlement `CDP_CB_DATABASE_WIRE_ENCRYPTION` has been granted.
* The presence of `CDP_CB_DATABASE_WIRE_ENCRYPTION` in `MockUserManagementService.getAccount()` is conditional, depending on the app system property `auth.mock.database.wire.encryption.enable` .
* Minor Redbeams SSL API cleanup: `SslConfigurationV4Request` renamed to `SslConfigV4Request`, `AllocateDatabaseServerV4Request.sslConfiguration` renamed to `sslConfig`, correct field / type descriptions.
* Add & enhance unit tests.