### PR TITLE
CB-9243 AWS PlacementGroup Support

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
@@ -76,6 +76,23 @@ public class AwsInstanceTemplate extends InstanceTemplate {
      */
     public static final String FAST_EBS_ENCRYPTION_ENABLED = "fastEbsEncryption";
 
+    /**
+     * Key of the optional dynamic parameter denoting PlacementGroup Strategy for the instance.
+     *
+     * <p>
+     *     Permitted values:
+     *     <ul>
+     *         <li>{@code "NONE"}: This setting does not configure any placement group.</li>
+     *         <li>{@code "CLUSTER"}: This setting configures placement group strategy as "cluster".</li>
+     *         <li>{@code "PARTITION"}: This setting configures placement group strategy as "partition".</li>
+     *         <li>{@code "SPREAD"}: This setting configures placement group strategy as "spread".</li>
+     *     </ul>
+     * </p>
+     *
+     * @see #putParameter(String, Object)
+     */
+    public static final String PLACEMENT_GROUP_STRATEGY = "placementGroupStrategy";
+
     public AwsInstanceTemplate(String flavor, String groupName, Long privateId, Collection<Volume> volumes, InstanceStatus status,
             Map<String, Object> parameters, Long templateId, String imageId) {
         super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId);

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilder.java
@@ -66,7 +66,8 @@ public class CloudFormationTemplateBuilder {
                     getInstanceProfile(group),
                     awsInstanceView.getOnDemandPercentage(),
                     awsInstanceView.isFastEbsEncryptionEnabled(),
-                    awsInstanceView.getSpotMaxPrice());
+                    awsInstanceView.getSpotMaxPrice(),
+                    awsInstanceView.getPlacementGroupStrategy().name());
             awsGroupViews.add(groupView);
             if (group.getType() == InstanceGroupType.GATEWAY) {
                 awsGatewayGroupViews.add(groupView);

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsGroupView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsGroupView.java
@@ -12,6 +12,8 @@ public class AwsGroupView {
 
     public static final String LAUNCH_TEMPLATE_NAME_PREFIX = "ClusterManagerNodeLaunchTemplate";
 
+    public static final String PLACEMENT_GROUP_NAME_PREFIX = "PlacementGroup";
+
     private final Integer instanceCount;
 
     private final String type;
@@ -42,6 +44,8 @@ public class AwsGroupView {
 
     private final String launchTemplateName;
 
+    private final String placementGroupName;
+
     private final Boolean useNetworkCidrAsSourceForDefaultRules;
 
     private final Boolean hasInstanceProfile;
@@ -54,10 +58,12 @@ public class AwsGroupView {
 
     private final Double spotMaxPrice;
 
+    private final String placementGroupStrategy;
+
     public AwsGroupView(Integer instanceCount, String type, String flavor, String groupName, Boolean ebsEncrypted, Integer rootVolumeSize,
             Map<String, Long> volumeCounts, List<SecurityRule> rules, List<String> cloudSecurityIds, String subnetId, Boolean kmsKeyDefined,
             String kmsKey, String encryptedAMI, boolean useNetworkCidrAsSourceForDefaultRules, String instanceProfile, int onDemandPercentage,
-            boolean fastEbsEncryptionEnabled, Double spotMaxPrice) {
+            boolean fastEbsEncryptionEnabled, Double spotMaxPrice, String placementGroupStrategy) {
         this.instanceCount = instanceCount;
         this.type = type;
         this.flavor = flavor;
@@ -73,16 +79,22 @@ public class AwsGroupView {
         this.volumeCounts = volumeCounts;
         autoScalingGroupName = getAutoScalingGroupName(groupName);
         launchTemplateName = getLaunchTemplateName(groupName);
+        placementGroupName = getPlacementGroupName(groupName);
         this.useNetworkCidrAsSourceForDefaultRules = useNetworkCidrAsSourceForDefaultRules;
         this.instanceProfile = instanceProfile;
         hasInstanceProfile = instanceProfile != null;
         this.onDemandPercentage = onDemandPercentage;
         this.fastEbsEncryptionEnabled = fastEbsEncryptionEnabled;
         this.spotMaxPrice = spotMaxPrice;
+        this.placementGroupStrategy = placementGroupStrategy;
     }
 
     public static String getAutoScalingGroupName(String groupName) {
         return AUTOSCALING_GROUP_NAME_PREFIX + sanitizeGroupName(groupName);
+    }
+
+    public static String getPlacementGroupName(String groupName) {
+        return PLACEMENT_GROUP_NAME_PREFIX + sanitizeGroupName(groupName);
     }
 
     public static String getLaunchTemplateName(String groupName) {
@@ -165,6 +177,10 @@ public class AwsGroupView {
         return launchTemplateName;
     }
 
+    public String getPlacementGroupName() {
+        return placementGroupName;
+    }
+
     public Boolean getUseNetworkCidrAsSourceForDefaultRules() {
         return useNetworkCidrAsSourceForDefaultRules;
     }
@@ -187,5 +203,9 @@ public class AwsGroupView {
 
     public Double getSpotMaxPrice() {
         return spotMaxPrice;
+    }
+
+    public String getPlacementGroupStrategy() {
+        return placementGroupStrategy.toLowerCase();
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceView.java
@@ -2,10 +2,12 @@ package com.sequenceiq.cloudbreak.cloud.aws.view;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
+import com.sequenceiq.common.api.placement.AwsPlacementGroupStrategy;
 import com.sequenceiq.common.api.type.EncryptionType;
 
 public class AwsInstanceView {
@@ -80,6 +82,12 @@ public class AwsInstanceView {
 
     public Integer getSpotPercentage() {
         return instanceTemplate.getParameter(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, Integer.class);
+    }
+
+    public AwsPlacementGroupStrategy getPlacementGroupStrategy() {
+        return Optional.ofNullable(instanceTemplate.getStringParameter(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY))
+                .map(placement -> AwsPlacementGroupStrategy.valueOf(placement))
+                .orElse(AwsPlacementGroupStrategy.NONE);
     }
 
     public Double getSpotMaxPrice() {

--- a/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
@@ -368,6 +368,9 @@
           </#if>
           "InstanceType"   : "${group.flavor}",
           "KeyName"        : { "Ref" : "KeyName" },
+          <#if group.placementGroupStrategy?has_content && group.placementGroupStrategy != "none">
+          "Placement" : { "GroupName" : { "Ref" : "${group.placementGroupName}" } },
+          </#if>
           <#if group.type == "CORE">
           "UserData"       : { "Fn::Base64" : { "Fn::Join" : ["", [ { "Ref" : "CBUserData"},
                                                                     { "Ref" : "CBUserData1"},
@@ -383,6 +386,15 @@
         }
       }
     }
+
+    <#if group.placementGroupStrategy?has_content && group.placementGroupStrategy != "none">,
+    "${group.placementGroupName}" : {
+      "Type" : "AWS::EC2::PlacementGroup",
+      "Properties" : {
+        "Strategy" : "${group.placementGroupStrategy}"
+      }
+    }
+    </#if>
 
 	<#if group.cloudSecurityIds?size == 0>,
     "ClusterNodeSecurityGroup${group.groupName?replace('_', '')}" : {

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceViewTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsInstanceViewTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
+import com.sequenceiq.common.api.placement.AwsPlacementGroupStrategy;
 import com.sequenceiq.common.api.type.EncryptionType;
 
 public class AwsInstanceViewTest {
@@ -108,4 +109,43 @@ public class AwsInstanceViewTest {
         assertNull(actual.getSpotMaxPrice());
     }
 
+    @Test
+    public void testPlacementGroupWhenPartition() {
+        InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.PARTITION.name()), 0L, "imageId");
+        AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
+        assertEquals("Placement Group Strategy should be partition.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.PARTITION);
+    }
+
+    @Test
+    public void testPlacementGroupWhenSpread() {
+        InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.SPREAD.name()), 0L, "imageId");
+        AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
+        assertEquals("Placement Group Strategy should be spread.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.SPREAD);
+    }
+
+    @Test
+    public void testPlacementGroupWhenCluster() {
+        InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.CLUSTER.name()), 0L, "imageId");
+        AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
+        assertEquals("Placement Group Strategy should be cluster.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.CLUSTER);
+    }
+
+    @Test
+    public void testPlacementGroupWhenMissing() {
+        InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
+                Map.of(), 0L, "imageId");
+        AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
+        assertEquals("Placement Group Strategy should be none.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.NONE);
+    }
+
+    @Test
+    public void testPlacementGroupWhenNone() {
+        InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.NONE.name()), 0L, "imageId");
+        AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
+        assertEquals("Placement Group Strategy should be none.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.NONE);
+    }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/placement/AwsPlacementGroupStrategy.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/placement/AwsPlacementGroupStrategy.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.common.api.placement;
+
+public enum AwsPlacementGroupStrategy {
+    NONE, PARTITION, SPREAD, CLUSTER;
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AwsInstanceTemplateV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AwsInstanceTemplateV4Parameters.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.util.NullUtil.doIfNotNull;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.validation.Valid;
 
@@ -16,6 +17,7 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.TemplateModelDescription;
+import com.sequenceiq.common.api.placement.AwsPlacementGroupStrategy;
 import com.sequenceiq.common.api.type.EncryptionType;
 
 import io.swagger.annotations.ApiModel;
@@ -33,6 +35,10 @@ public class AwsInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
     @ApiModelProperty(TemplateModelDescription.ENCRYPTION)
     private AwsEncryptionV4Parameters encryption;
 
+    @Valid
+    @ApiModelProperty(TemplateModelDescription.AWS_PLACEMENT_GROUP)
+    private AwsPlacementGroupV4Parameters placementGroup;
+
     public AwsInstanceTemplateV4SpotParameters getSpot() {
         return spot;
     }
@@ -49,6 +55,14 @@ public class AwsInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
         this.encryption = encryption;
     }
 
+    public AwsPlacementGroupV4Parameters getPlacementGroup() {
+        return placementGroup;
+    }
+
+    public void setPlacementGroup(AwsPlacementGroupV4Parameters placementGroup) {
+        this.placementGroup = placementGroup;
+    }
+
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
@@ -60,6 +74,10 @@ public class AwsInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
             putIfValueNotNull(map, InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, encryption.getType());
             putIfValueNotNull(map, AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, encryption.getType() != EncryptionType.NONE);
         }
+
+        putIfValueNotNull(map, AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, Optional.ofNullable(placementGroup)
+                .map(AwsPlacementGroupV4Parameters::getStrategy)
+                .orElse(AwsPlacementGroupStrategy.NONE).name());
         return map;
     }
 
@@ -98,6 +116,14 @@ public class AwsInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
         String type = getParameterOrNull(parameters, InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE);
         if (type != null) {
             encryption.setType(EncryptionType.valueOf(type));
+        }
+
+        String placementGroupStrategy = getParameterOrNull(parameters, AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY);
+        placementGroup = new AwsPlacementGroupV4Parameters();
+        if (placementGroupStrategy != null) {
+            placementGroup.setStrategy(AwsPlacementGroupStrategy.valueOf(placementGroupStrategy));
+        } else {
+            placementGroup.setStrategy(AwsPlacementGroupStrategy.NONE);
         }
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AwsPlacementGroupV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AwsPlacementGroupV4Parameters.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template;
+
+import javax.validation.Valid;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions.TemplateModelDescription;
+import com.sequenceiq.common.api.placement.AwsPlacementGroupStrategy;
+import com.sequenceiq.common.model.JsonEntity;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class AwsPlacementGroupV4Parameters implements JsonEntity {
+
+    @Valid
+    @ApiModelProperty(value = TemplateModelDescription.AWS_PLACEMENT_GROUP_STRATEGY, allowableValues = "NONE, PARTITION, SPREAD, CLUSTER")
+    private AwsPlacementGroupStrategy strategy;
+
+    public AwsPlacementGroupStrategy getStrategy() {
+        return strategy;
+    }
+
+    public void setStrategy(AwsPlacementGroupStrategy strategy) {
+        this.strategy = strategy;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -71,6 +71,8 @@ public class ModelDescriptions {
         public static final String YARN_PARAMETERS = "yarn specific parameters for template";
         public static final String AZURE_PARAMETERS = "azure specific parameters for template";
         public static final String AWS_SPOT_PARAMETERS = "aws specific spot instance parameters for template";
+        public static final String AWS_PLACEMENT_GROUP = "aws specific placement group parameter for vm";
+        public static final String AWS_PLACEMENT_GROUP_STRATEGY = "aws placement group strategy for vm";
         public static final String SPOT_PERCENTAGE = "percentage of spot instances launched in instance group";
         public static final String SPOT_MAX_PRICE = "max price per hour of spot instances launched in instance group";
         public static final String AZURE_PRIVATE_ID = "private id for azure";

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/instancegroup/template/AwsInstanceTemplateV1Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/instancegroup/template/AwsInstanceTemplateV1Parameters.java
@@ -24,6 +24,10 @@ public class AwsInstanceTemplateV1Parameters implements Serializable {
     @ApiModelProperty(TemplateModelDescription.ENCRYPTION)
     private AwsEncryptionV1Parameters encryption;
 
+    @Valid
+    @ApiModelProperty(TemplateModelDescription.AWS_PLACEMENT_GROUP)
+    private AwsPlacementGroupV1Parameters placementGroup;
+
     public AwsInstanceTemplateV1SpotParameters getSpot() {
         return spot;
     }
@@ -38,5 +42,13 @@ public class AwsInstanceTemplateV1Parameters implements Serializable {
 
     public void setEncryption(AwsEncryptionV1Parameters encryption) {
         this.encryption = encryption;
+    }
+
+    public AwsPlacementGroupV1Parameters getPlacementGroup() {
+        return placementGroup;
+    }
+
+    public void setPlacementGroup(AwsPlacementGroupV1Parameters placementGroup) {
+        this.placementGroup = placementGroup;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/instancegroup/template/AwsPlacementGroupV1Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/instancegroup/template/AwsPlacementGroupV1Parameters.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template;
+
+import java.io.Serializable;
+
+import javax.validation.Valid;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions.TemplateModelDescription;
+import com.sequenceiq.common.api.placement.AwsPlacementGroupStrategy;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class AwsPlacementGroupV1Parameters implements Serializable {
+
+    @Valid
+    @ApiModelProperty(value = TemplateModelDescription.AWS_PLACEMENT_GROUP_STRATEGY, allowableValues = "NONE, PARTITION, SPREAD, CLUSTER")
+    private AwsPlacementGroupStrategy strategy;
+
+    public AwsPlacementGroupStrategy getStrategy() {
+        return strategy;
+    }
+
+    public void setStrategy(AwsPlacementGroupStrategy strategy) {
+        this.strategy = strategy;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
@@ -7,12 +7,14 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsEncryptionV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4SpotParameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsPlacementGroupV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AzureInstanceTemplateV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.GcpInstanceTemplateV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.YarnInstanceTemplateV4Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsEncryptionV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsInstanceTemplateV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsInstanceTemplateV1SpotParameters;
+import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsPlacementGroupV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AzureInstanceTemplateV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.GcpInstanceTemplateV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.YarnInstanceTemplateV1Parameters;
@@ -24,6 +26,7 @@ public class InstanceTemplateParameterConverter {
         AwsInstanceTemplateV4Parameters response = new AwsInstanceTemplateV4Parameters();
         response.setEncryption(getIfNotNull(source.getEncryption(), this::convert));
         response.setSpot(getIfNotNull(source.getSpot(), this::convert));
+        response.setPlacementGroup(getIfNotNull(source.getPlacementGroup(), this::convert));
         return response;
     }
 
@@ -38,6 +41,12 @@ public class InstanceTemplateParameterConverter {
         AwsEncryptionV4Parameters response = new AwsEncryptionV4Parameters();
         response.setKey(source.getKey());
         response.setType(source.getType());
+        return response;
+    }
+
+    private AwsPlacementGroupV4Parameters convert(AwsPlacementGroupV1Parameters source) {
+        AwsPlacementGroupV4Parameters response = new AwsPlacementGroupV4Parameters();
+        response.setStrategy(source.getStrategy());
         return response;
     }
 
@@ -68,6 +77,7 @@ public class InstanceTemplateParameterConverter {
         AwsInstanceTemplateV1Parameters response = new AwsInstanceTemplateV1Parameters();
         response.setEncryption(getIfNotNull(source.getEncryption(), this::convert));
         response.setSpot(getIfNotNull(source.getSpot(), this::convert));
+        response.setPlacementGroup(getIfNotNull(source.getPlacementGroup(), this::convert));
         return response;
     }
 
@@ -75,6 +85,12 @@ public class InstanceTemplateParameterConverter {
         AwsEncryptionV1Parameters response = new AwsEncryptionV1Parameters();
         response.setKey(source.getKey());
         response.setType(source.getType());
+        return response;
+    }
+
+    private AwsPlacementGroupV1Parameters convert(AwsPlacementGroupV4Parameters source) {
+        AwsPlacementGroupV1Parameters response = new AwsPlacementGroupV1Parameters();
+        response.setStrategy(source.getStrategy());
         return response;
     }
 


### PR DESCRIPTION
Placement Group Configuration support for AWS Clusters via Cluster Definitions. The PlacementGroup configuration for AWS is done similar to existing AvailabilitySet Configuration for Azure Clusters.

1. Tested multiple DH Cluster launches with PG strategy as NONE, SPREAD, CLUSTER, PARTITION.
2. Tested multiple DH Cluster launches without any PG Configuration.
3. Tested default DH templates launched successfully and were configured with correct PG when PG Config was added.
4. Tested successful AWS Environment\DL launches without any PG Configuration. 