### PR TITLE
CB-9503 - Env creation fails with private endpoint when created with …

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/dnszone/AzureDnsZoneCreationCheckerTask.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/dnszone/AzureDnsZoneCreationCheckerTask.java
@@ -42,10 +42,10 @@ public class AzureDnsZoneCreationCheckerTask extends PollBooleanStateTask {
         ResourceStatus templateDeploymentStatus = azureClient.getTemplateDeploymentStatus(resourceGroupName, deploymentName);
 
         if (templateDeploymentStatus == ResourceStatus.DELETED) {
-            throw new CloudConnectorException(String.format("Deployment %s is either deleted of does not exist", deploymentName));
+            throw new CloudConnectorException(String.format("Deployment %s is either deleted or does not exist", deploymentName));
         }
 
-        if (templateDeploymentStatus.isPermanent() && templateDeploymentStatus != ResourceStatus.DELETED) {
+        if (templateDeploymentStatus.isPermanent()) {
             LOGGER.info("Deployment has been finished with status {}", templateDeploymentStatus);
 
             if (StringUtils.isNotEmpty(networkId)) {


### PR DESCRIPTION
…restricted resource group permissions

Contains 2 fixes:

1. sets the deployment status properly after exception
2. delegates the original exception to reach the UI