### PR TITLE
CB-9468. LogConsumer related DataBus stream changes.

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
@@ -1,11 +1,11 @@
 package com.sequenceiq.cloudbreak.telemetry;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfiguration;
 
 @Configuration
 public class TelemetryConfiguration {
@@ -16,16 +16,16 @@ public class TelemetryConfiguration {
 
     private final ClusterLogsCollectionConfiguration clusterLogsCollectionConfiguration;
 
-    private final boolean monitoringEnabled;
+    private final MonitoringConfiguration monitoringConfiguration;
 
     public TelemetryConfiguration(AltusDatabusConfiguration altusDatabusConfiguration,
             MeteringConfiguration meteringConfiguration,
             ClusterLogsCollectionConfiguration clusterLogsCollectionConfiguration,
-            @Value("${cluster.monitoring.enabled:false}") boolean monitoringEnabled) {
+            MonitoringConfiguration monitoringConfiguration) {
         this.altusDatabusConfiguration = altusDatabusConfiguration;
         this.meteringConfiguration = meteringConfiguration;
         this.clusterLogsCollectionConfiguration = clusterLogsCollectionConfiguration;
-        this.monitoringEnabled = monitoringEnabled;
+        this.monitoringConfiguration = monitoringConfiguration;
     }
 
     public AltusDatabusConfiguration getAltusDatabusConfiguration() {
@@ -40,7 +40,7 @@ public class TelemetryConfiguration {
         return clusterLogsCollectionConfiguration;
     }
 
-    public boolean isMonitoringEnabled() {
-        return monitoringEnabled;
+    public MonitoringConfiguration getMonitoringConfiguration() {
+        return monitoringConfiguration;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 
 @Configuration
@@ -13,17 +14,17 @@ public class TelemetryConfiguration {
 
     private final MeteringConfiguration meteringConfiguration;
 
-    private final boolean clusterLogsCollection;
+    private final ClusterLogsCollectionConfiguration clusterLogsCollectionConfiguration;
 
     private final boolean monitoringEnabled;
 
     public TelemetryConfiguration(AltusDatabusConfiguration altusDatabusConfiguration,
             MeteringConfiguration meteringConfiguration,
-            @Value("${cluster.logs.collection.enabled:false}") boolean clusterLogsCollection,
+            ClusterLogsCollectionConfiguration clusterLogsCollectionConfiguration,
             @Value("${cluster.monitoring.enabled:false}") boolean monitoringEnabled) {
         this.altusDatabusConfiguration = altusDatabusConfiguration;
         this.meteringConfiguration = meteringConfiguration;
-        this.clusterLogsCollection = clusterLogsCollection;
+        this.clusterLogsCollectionConfiguration = clusterLogsCollectionConfiguration;
         this.monitoringEnabled = monitoringEnabled;
     }
 
@@ -35,8 +36,8 @@ public class TelemetryConfiguration {
         return meteringConfiguration;
     }
 
-    public boolean isClusterLogsCollection() {
-        return clusterLogsCollection;
+    public ClusterLogsCollectionConfiguration getClusterLogsCollectionConfiguration() {
+        return clusterLogsCollectionConfiguration;
     }
 
     public boolean isMonitoringEnabled() {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/databus/AbstractDatabusStreamConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/databus/AbstractDatabusStreamConfiguration.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.telemetry.databus;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public abstract class AbstractDatabusStreamConfiguration {
 
     private final boolean enabled;
@@ -24,5 +27,14 @@ public abstract class AbstractDatabusStreamConfiguration {
 
     public String getDbusStreamName() {
         return dbusStreamName;
+    }
+
+    protected abstract String getDbusServiceName();
+
+    public Map<String, String> getDbusConfigs() {
+        Map<String, String> map = new HashMap<>();
+        map.put(String.format("dbus%sStreamName", getDbusServiceName()), dbusStreamName);
+        map.put(String.format("dbus%sAppName", getDbusServiceName()), dbusAppName);
+        return map;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/databus/AbstractDatabusStreamConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/databus/AbstractDatabusStreamConfiguration.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.telemetry.databus;
+
+public abstract class AbstractDatabusStreamConfiguration {
+
+    private final boolean enabled;
+
+    private final String dbusAppName;
+
+    private final String dbusStreamName;
+
+    public AbstractDatabusStreamConfiguration(boolean enabled, String dbusAppName, String dbusStreamName) {
+        this.enabled = enabled;
+        this.dbusAppName = dbusAppName;
+        this.dbusStreamName = dbusStreamName;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public String getDbusAppName() {
+        return dbusAppName;
+    }
+
+    public String getDbusStreamName() {
+        return dbusStreamName;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.common.AnonymizationRuleResolver;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2Config;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
@@ -16,6 +17,7 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.GcsConfig;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.GcsConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3Config;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
+import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
@@ -49,16 +51,20 @@ public class FluentConfigService {
 
     private final MeteringConfiguration meteringConfiguration;
 
+    private final ClusterLogsCollectionConfiguration clusterLogsCollectionConfiguration;
+
     public FluentConfigService(S3ConfigGenerator s3ConfigGenerator,
             AdlsGen2ConfigGenerator adlsGen2ConfigGenerator,
             GcsConfigGenerator gcsConfigGenerator,
             AnonymizationRuleResolver anonymizationRuleResolver,
-            MeteringConfiguration meteringConfiguration) {
+            TelemetryConfiguration telemetryConfiguration) {
         this.s3ConfigGenerator = s3ConfigGenerator;
         this.adlsGen2ConfigGenerator = adlsGen2ConfigGenerator;
         this.gcsConfigGenerator = gcsConfigGenerator;
         this.anonymizationRuleResolver = anonymizationRuleResolver;
-        this.meteringConfiguration = meteringConfiguration;
+        this.meteringConfiguration = telemetryConfiguration.getMeteringConfiguration();
+        this.clusterLogsCollectionConfiguration = telemetryConfiguration.getClusterLogsCollectionConfiguration();
+
     }
 
     public FluentConfigView createFluentConfigs(TelemetryClusterDetails clusterDetails,
@@ -134,6 +140,8 @@ public class FluentConfigService {
             if (databusEnabled && telemetry.isClusterLogsCollectionEnabled()) {
                 builder.withClusterLogsCollection(true);
                 LOGGER.debug("Fluent based cluster log collection is enabled.");
+                builder.withClusterLogsCollectionAppName(clusterLogsCollectionConfiguration.getDbusAppName())
+                        .withClusterLogsCollectionStreamName(clusterLogsCollectionConfiguration.getDbusAppName());
                 validDatabusLogging = true;
             }
             if (databusEnabled && telemetry.isMonitoringFeatureEnabled()) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -19,6 +19,7 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3Config;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
@@ -53,6 +54,8 @@ public class FluentConfigService {
 
     private final ClusterLogsCollectionConfiguration clusterLogsCollectionConfiguration;
 
+    private final MonitoringConfiguration monitoringConfiguration;
+
     public FluentConfigService(S3ConfigGenerator s3ConfigGenerator,
             AdlsGen2ConfigGenerator adlsGen2ConfigGenerator,
             GcsConfigGenerator gcsConfigGenerator,
@@ -64,6 +67,7 @@ public class FluentConfigService {
         this.anonymizationRuleResolver = anonymizationRuleResolver;
         this.meteringConfiguration = telemetryConfiguration.getMeteringConfiguration();
         this.clusterLogsCollectionConfiguration = telemetryConfiguration.getClusterLogsCollectionConfiguration();
+        this.monitoringConfiguration = telemetryConfiguration.getMonitoringConfiguration();
 
     }
 
@@ -84,8 +88,7 @@ public class FluentConfigService {
             }
             if (enabled && meteringEnabled) {
                 builder
-                        .withMeteringAppName(meteringConfiguration.getDbusAppName())
-                        .withMeteringStreamName(meteringConfiguration.getDbusAppName());
+                        .withMeteringConfiguration(meteringConfiguration);
             }
         }
         if (!enabled) {
@@ -140,13 +143,13 @@ public class FluentConfigService {
             if (databusEnabled && telemetry.isClusterLogsCollectionEnabled()) {
                 builder.withClusterLogsCollection(true);
                 LOGGER.debug("Fluent based cluster log collection is enabled.");
-                builder.withClusterLogsCollectionAppName(clusterLogsCollectionConfiguration.getDbusAppName())
-                        .withClusterLogsCollectionStreamName(clusterLogsCollectionConfiguration.getDbusAppName());
+                builder.withClusterLogsCollectionConfiguration(clusterLogsCollectionConfiguration);
                 validDatabusLogging = true;
             }
             if (databusEnabled && telemetry.isMonitoringFeatureEnabled()) {
                 builder.withMonitoringEnabled(true);
                 LOGGER.debug("Fluent based cluster monitoring is enabled.");
+                builder.withMonitoringConfiguration(monitoringConfiguration);
                 validDatabusLogging = true;
             }
         }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
@@ -47,6 +47,10 @@ public class FluentConfigView implements TelemetryConfigView {
 
     private final String meteringStreamName;
 
+    private final String clusterLogsCollectionAppName;
+
+    private final String clusterLogsCollectionStreamName;
+
     private final TelemetryClusterDetails clusterDetails;
 
     private final String user;
@@ -94,6 +98,8 @@ public class FluentConfigView implements TelemetryConfigView {
         this.cloudStorageLoggingEnabled = builder.cloudStorageLoggingEnabled;
         this.cloudLoggingServiceEnabled = builder.cloudLoggingServiceEnabled;
         this.clusterLogsCollection = builder.clusterLogsCollection;
+        this.clusterLogsCollectionAppName = builder.clusterLogsCollectionAppName;
+        this.clusterLogsCollectionStreamName = builder.clusterLogsCollectionStreamName;
         this.meteringEnabled = builder.meteringEnabled;
         this.meteringAppName = builder.meteringAppName;
         this.meteringStreamName = builder.meteringStreamName;
@@ -244,6 +250,8 @@ public class FluentConfigView implements TelemetryConfigView {
         map.put("dbusMeteringStreamName", this.meteringStreamName);
         map.put("dbusMonitoringEnabled", this.monitoringEnabled);
         map.put("dbusClusterLogsCollection", this.clusterLogsCollection);
+        map.put("dbusClusterLogsCollectionAppName", this.clusterLogsCollectionAppName);
+        map.put("dbusClusterLogsCollectionStreamName", this.clusterLogsCollectionStreamName);
         map.put("dbusClusterLogsCollectionDisableStop", DBUS_DISABLE_STOP_CLUSTER_LOG_COLLECTION_DEFAULT);
         map.put("dbusIncludeSaltLogs", DBUS_INCLUDE_SALT_LOGS_DEFAULT);
         map.put("user", ObjectUtils.defaultIfNull(this.user, TD_AGENT_USER_DEFAULT));
@@ -291,6 +299,10 @@ public class FluentConfigView implements TelemetryConfigView {
         private boolean cloudLoggingServiceEnabled;
 
         private boolean clusterLogsCollection;
+
+        private String clusterLogsCollectionAppName;
+
+        private String clusterLogsCollectionStreamName;
 
         private boolean meteringEnabled;
 
@@ -433,6 +445,16 @@ public class FluentConfigView implements TelemetryConfigView {
 
         public Builder withClusterLogsCollection(boolean clusterLogsCollection) {
             this.clusterLogsCollection = clusterLogsCollection;
+            return this;
+        }
+
+        public Builder withClusterLogsCollectionAppName(String clusterLogsCollectionAppName) {
+            this.clusterLogsCollectionAppName = clusterLogsCollectionAppName;
+            return this;
+        }
+
+        public Builder withClusterLogsCollectionStreamName(String clusterLogsCollectionStreamName) {
+            this.clusterLogsCollectionStreamName = clusterLogsCollectionStreamName;
             return this;
         }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/logcollection/ClusterLogsCollectionConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/logcollection/ClusterLogsCollectionConfiguration.java
@@ -14,4 +14,9 @@ public class ClusterLogsCollectionConfiguration extends AbstractDatabusStreamCon
             @Value("${cluster.logs.collection.dbus.stream.name:LogCollection}") String dbusStreamName) {
         super(enabled, dbusAppName, dbusStreamName);
     }
+
+    @Override
+    public String getDbusServiceName() {
+        return "ClusterLogsCollection";
+    }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/logcollection/ClusterLogsCollectionConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/logcollection/ClusterLogsCollectionConfiguration.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.cloudbreak.telemetry.logcollection;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.telemetry.databus.AbstractDatabusStreamConfiguration;
+
+@Component
+public class ClusterLogsCollectionConfiguration extends AbstractDatabusStreamConfiguration {
+
+    public ClusterLogsCollectionConfiguration(
+            @Value("${cluster.logs.collection.enabled:false}") boolean enabled,
+            @Value("${cluster.logs.collection.dbus.app.name:}") String dbusAppName,
+            @Value("${cluster.logs.collection.dbus.stream.name:LogCollection}") String dbusStreamName) {
+        super(enabled, dbusAppName, dbusStreamName);
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfiguration.java
@@ -13,4 +13,9 @@ public class MeteringConfiguration extends AbstractDatabusStreamConfiguration {
             @Value("${metering.dbus.stream.name:Metering}") String dbusStreamName) {
         super(enabled, dbusAppName, dbusStreamName);
     }
+
+    @Override
+    public String getDbusServiceName() {
+        return "Metering";
+    }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/metering/MeteringConfiguration.java
@@ -3,32 +3,14 @@ package com.sequenceiq.cloudbreak.telemetry.metering;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
+import com.sequenceiq.cloudbreak.telemetry.databus.AbstractDatabusStreamConfiguration;
+
 @Configuration
-public class MeteringConfiguration {
-
-    private final boolean enabled;
-
-    private final String dbusAppName;
-
-    private final String dbusStreamName;
+public class MeteringConfiguration extends AbstractDatabusStreamConfiguration {
 
     public MeteringConfiguration(@Value("${metering.enabled:false}") boolean enabled,
             @Value("${metering.dbus.app.name:}") String dbusAppName,
             @Value("${metering.dbus.stream.name:Metering}") String dbusStreamName) {
-        this.enabled = enabled;
-        this.dbusAppName = dbusAppName;
-        this.dbusStreamName = dbusStreamName;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public String getDbusAppName() {
-        return dbusAppName;
-    }
-
-    public String getDbusStreamName() {
-        return dbusStreamName;
+        super(enabled, dbusAppName, dbusStreamName);
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/monitoring/MonitoringConfiguration.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.telemetry.monitoring;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.telemetry.databus.AbstractDatabusStreamConfiguration;
+
+@Component
+public class MonitoringConfiguration extends AbstractDatabusStreamConfiguration {
+
+    public MonitoringConfiguration(
+            @Value("${cluster.monitoring.enabled:false}") boolean enabled,
+            @Value("${cluster.monitoring.dbus.app.name:}") String dbusAppName,
+            @Value("${cluster.monitoring.dbus.stream.name:CdpVmMetrics}") String dbusStreamName) {
+        super(enabled, dbusAppName, dbusStreamName);
+    }
+
+    @Override
+    public String getDbusServiceName() {
+        return "Monitoring";
+    }
+
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -9,10 +9,12 @@ import org.junit.Test;
 
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
+import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.common.AnonymizationRuleResolver;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.GcsConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
+import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
@@ -34,9 +36,14 @@ public class FluentConfigServiceTest {
 
     @Before
     public void setUp() {
-        MeteringConfiguration meteringConfiguration = new MeteringConfiguration(false, null, null);
+        MeteringConfiguration meteringConfiguration =
+                new MeteringConfiguration(false, null, null);
+        ClusterLogsCollectionConfiguration logCollectionConfig =
+                new ClusterLogsCollectionConfiguration(false, null, null);
+        TelemetryConfiguration telemetryConfiguration =
+                new TelemetryConfiguration(null, meteringConfiguration, logCollectionConfig, false);
         underTest = new FluentConfigService(new S3ConfigGenerator(), new AdlsGen2ConfigGenerator(), new GcsConfigGenerator(),
-                new AnonymizationRuleResolver(), meteringConfiguration);
+                new AnonymizationRuleResolver(), telemetryConfiguration);
     }
 
     @Test

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -41,7 +41,7 @@ public class FluentConfigServiceTest {
         ClusterLogsCollectionConfiguration logCollectionConfig =
                 new ClusterLogsCollectionConfiguration(false, null, null);
         TelemetryConfiguration telemetryConfiguration =
-                new TelemetryConfiguration(null, meteringConfiguration, logCollectionConfig, false);
+                new TelemetryConfiguration(null, meteringConfiguration, logCollectionConfig, null);
         underTest = new FluentConfigService(new S3ConfigGenerator(), new AdlsGen2ConfigGenerator(), new GcsConfigGenerator(),
                 new AnonymizationRuleResolver(), telemetryConfiguration);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -62,7 +62,7 @@ public class TelemetryConverter {
         this.useSharedAltusCredential = configuration.getAltusDatabusConfiguration().isUseSharedAltusCredential();
         this.meteringEnabled = configuration.getMeteringConfiguration().isEnabled();
         this.monitoringEnabled = configuration.isMonitoringEnabled();
-        this.clusterLogsCollection = configuration.isClusterLogsCollection();
+        this.clusterLogsCollection = configuration.getClusterLogsCollectionConfiguration().isEnabled();
     }
 
     public TelemetryResponse convert(Telemetry telemetry) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -61,7 +61,7 @@ public class TelemetryConverter {
         this.databusEndpoint = configuration.getAltusDatabusConfiguration().getAltusDatabusEndpoint();
         this.useSharedAltusCredential = configuration.getAltusDatabusConfiguration().isUseSharedAltusCredential();
         this.meteringEnabled = configuration.getMeteringConfiguration().isEnabled();
-        this.monitoringEnabled = configuration.isMonitoringEnabled();
+        this.monitoringEnabled = configuration.getMonitoringConfiguration().isEnabled();
         this.clusterLogsCollection = configuration.getClusterLogsCollectionConfiguration().isEnabled();
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -17,6 +17,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.model.Logging;
@@ -44,7 +45,9 @@ public class TelemetryConverterTest {
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, true, "****", "****");
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, "app", "stream");
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, "app", "stream");
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, true);
+        MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(true, null, null);
+        TelemetryConfiguration telemetryConfiguration =
+                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig);
         underTest = new TelemetryConverter(telemetryConfiguration, true, true);
     }
 
@@ -180,7 +183,9 @@ public class TelemetryConverterTest {
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, null, null);
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, false);
+        MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(false, null, null);
+        TelemetryConfiguration telemetryConfiguration =
+                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, true, false);
         // WHEN
         TelemetryRequest result = converter.convert(null, sdxClusterResponse);
@@ -254,7 +259,9 @@ public class TelemetryConverterTest {
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, null, null);
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, false);
+        MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(false, null, null);
+        TelemetryConfiguration telemetryConfiguration =
+                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, false, true);
         // WHEN
         TelemetryRequest result = converter.convert(response, sdxClusterResponse);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Features;
@@ -42,7 +43,8 @@ public class TelemetryConverterTest {
     public void setUp() {
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, true, "****", "****");
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, "app", "stream");
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, true, true);
+        ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, "app", "stream");
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, true);
         underTest = new TelemetryConverter(telemetryConfiguration, true, true);
     }
 
@@ -177,7 +179,8 @@ public class TelemetryConverterTest {
         SdxClusterResponse sdxClusterResponse = null;
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, null, null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, true, false);
+        ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, false);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, true, false);
         // WHEN
         TelemetryRequest result = converter.convert(null, sdxClusterResponse);
@@ -250,7 +253,8 @@ public class TelemetryConverterTest {
         sdxClusterResponse.setName("sdxName");
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, null, null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, true, false);
+        ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, false);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, false, true);
         // WHEN
         TelemetryRequest result = converter.convert(response, sdxClusterResponse);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverter.java
@@ -2,11 +2,11 @@ package com.sequenceiq.environment.environment.v1.converter;
 
 import java.util.HashMap;
 
-import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
 import com.sequenceiq.common.api.telemetry.model.Features;
@@ -34,7 +34,7 @@ public class TelemetryApiConverter {
     private final boolean useSharedAltusCredential;
 
     public TelemetryApiConverter(TelemetryConfiguration configuration) {
-        this.clusterLogsCollection = configuration.isClusterLogsCollection();
+        this.clusterLogsCollection = configuration.getClusterLogsCollectionConfiguration().isEnabled();
         this.monitoringEnabled = configuration.isMonitoringEnabled();
         this.useSharedAltusCredential = configuration.getAltusDatabusConfiguration().isUseSharedAltusCredential();
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverter.java
@@ -35,7 +35,7 @@ public class TelemetryApiConverter {
 
     public TelemetryApiConverter(TelemetryConfiguration configuration) {
         this.clusterLogsCollection = configuration.getClusterLogsCollectionConfiguration().isEnabled();
-        this.monitoringEnabled = configuration.isMonitoringEnabled();
+        this.monitoringEnabled = configuration.getMonitoringConfiguration().isEnabled();
         this.useSharedAltusCredential = configuration.getAltusDatabusConfiguration().isUseSharedAltusCredential();
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
@@ -38,7 +39,9 @@ public class TelemetryApiConverterTest {
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", true, "****", "****");
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(false, null, null);
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, true);
+        MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(true, null, null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(
+                altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig);
         underTest = new TelemetryApiConverter(telemetryConfiguration);
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
@@ -12,6 +12,7 @@ import org.mockito.MockitoAnnotations;
 
 import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Features;
@@ -36,7 +37,8 @@ public class TelemetryApiConverterTest {
         MockitoAnnotations.initMocks(this);
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", true, "****", "****");
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(false, null, null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, true, true);
+        ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, true);
         underTest = new TelemetryApiConverter(telemetryConfiguration);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.freeipa.converter.telemetry;
 
-import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
 import com.sequenceiq.common.api.telemetry.model.Features;
@@ -36,7 +36,7 @@ public class TelemetryConverter {
     public TelemetryConverter(TelemetryConfiguration configuration,
             @Value("${freeipa.telemetry.enabled:true}") boolean freeIpaTelemetryEnabled) {
         this.freeIpaTelemetryEnabled = freeIpaTelemetryEnabled;
-        this.clusterLogsCollection = configuration.isClusterLogsCollection();
+        this.clusterLogsCollection = configuration.getClusterLogsCollectionConfiguration().isEnabled();
         this.useSharedAltusCredential = configuration.getAltusDatabusConfiguration().isUseSharedAltusCredential();
         this.databusEndpoint = configuration.getAltusDatabusConfiguration().getAltusDatabusEndpoint();
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Logging;
@@ -36,7 +37,9 @@ public class TelemetryConverterTest {
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(false, null, null);
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, false);
+        MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(false, null, null);
+        TelemetryConfiguration telemetryConfiguration =
+                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig);
         underTest = new TelemetryConverter(telemetryConfiguration, true);
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
@@ -5,13 +5,14 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.IsNull.nullValue;
 
-import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
+import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -34,7 +35,8 @@ public class TelemetryConverterTest {
     public void setUp() {
         AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(false, null, null);
-        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, true, false);
+        ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
+        TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, false);
         underTest = new TelemetryConverter(telemetryConfiguration, true);
     }
 

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -171,6 +171,19 @@
   {% set dbus_cluster_logs_collection_stream_name = None %}
 {% endif %}
 
+{% if dbus_monitoring_enabled %}
+  {% if salt['pillar.get']('fluent:dbusMonitoringAppName') and salt['pillar.get']('fluent:dbusMonitoringStreamName') %}
+    {% set dbus_monitoring_app_headers = 'app:' + cluster_type + ',@monitoring-app:' + salt['pillar.get']('fluent:dbusMonitoringAppName') %}
+    {% set dbus_monitoring_stream_name = salt['pillar.get']('fluent:dbusMonitoringStreamName') %}
+  {% else %}
+    {% set dbus_monitoring_app_headers = 'app:' + cluster_type %}
+    {% set dbus_monitoring_stream_name = 'CdpVmMetrics' %}
+  {% endif %}
+{% else %}
+  {% set dbus_monitoring_app_headers = None %}
+  {% set dbus_monitoring_stream_name = None %}
+{% endif %}
+
 {% set forward_port = 24224 %}
 
 {% set version_data = namespace(entities=[]) %}
@@ -235,6 +248,8 @@
     "dbusMeteringAppHeaders": dbus_metering_app_headers,
     "dbusMeteringStreamName": dbus_metering_stream_name,
     "dbusMonitoringEnabled": dbus_monitoring_enabled,
+    "dbusMonitoringAppHeaders": dbus_monitoring_app_headers,
+    "dbusMonitoringStreamName":  dbus_monitoring_stream_name,
     "clouderaPublicGemRepo": cloudera_public_gem_repo,
     "clouderaAzurePluginVersion": cloudera_azure_plugin_version,
     "clouderaAzureGen2PluginVersion": cloudera_azure_gen2_plugin_version,

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -158,6 +158,19 @@
   {% set dbus_metering_stream_name = None %}
 {% endif %}
 
+{% if dbus_cluster_logs_collection_enabled %}
+  {% if salt['pillar.get']('fluent:dbusClusterLogsCollectionAppName') and salt['pillar.get']('fluent:dbusClusterLogsCollectionStreamName') %}
+    {% set dbus_cluster_logs_collection_app_headers = 'app:' + cluster_type + ',@logging-app:' + salt['pillar.get']('fluent:dbusClusterLogsCollectionAppName') %}
+    {% set dbus_cluster_logs_collection_stream_name = salt['pillar.get']('fluent:dbusClusterLogsCollectionStreamName') %}
+  {% else %}
+    {% set dbus_cluster_logs_collection_app_headers = 'app:' + cluster_type %}
+    {% set dbus_cluster_logs_collection_stream_name = 'LogCollection' %}
+  {% endif %}
+{% else %}
+  {% set dbus_cluster_logs_collection_app_headers = None %}
+  {% set dbus_cluster_logs_collection_stream_name = None %}
+{% endif %}
+
 {% set forward_port = 24224 %}
 
 {% set version_data = namespace(entities=[]) %}
@@ -216,6 +229,8 @@
     "gcsProjectId": gcs_project_id,
     "dbusClusterLogsCollection": dbus_cluster_logs_collection_enabled,
     "dbusClusterLogsCollectionDisableStop": dbus_cluster_logs_collection_disable_stop,
+    "dbusClusterLogsCollectionAppHeaders": dbus_cluster_logs_collection_app_headers,
+    "dbusClusterLogsCollectionStreamName": dbus_cluster_logs_collection_stream_name,
     "dbusMeteringEnabled": dbus_metering_enabled,
     "dbusMeteringAppHeaders": dbus_metering_app_headers,
     "dbusMeteringStreamName": dbus_metering_stream_name,

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_monitoring.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_monitoring.conf.j2
@@ -21,8 +21,8 @@
     debug                            false
     endpoint                         "{{ databus.endpoint }}"
     event_message_field              message
-    headers                          app:{{ fluent.clusterType }}
-    stream_name                      CdpVmMetrics
+    headers                          {{ fluent.dbusMonitoringAppHeaders }}
+    stream_name                      {{ fluent.dbusMonitoringStreamName }}
     partition_key                    "#{Socket.gethostname}"
     {%- if fluent.proxyUrl %}
     proxy_url                        "{{ fluent.proxyUrl }}"

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
@@ -11,10 +11,10 @@
     credential_file_reload_interval  60
     debug                            false
     endpoint                         "{{ databus.endpoint }}"
-    headers                          app:{{ fluent.clusterType }},clusterName:{{ fluent.clusterName }},clusterType:{{ fluent.clusterType }},clusterCrn:{{ fluent.clusterCrn }},clusterOwner:{{ fluent.clusterOwner}},clusterVersion:{{ fluent.clusterVersion }}
+    headers                          {{ fluent.dbusClusterLogsCollectionAppHeaders }},clusterName:{{ fluent.clusterName }},clusterType:{{ fluent.clusterType }},clusterCrn:{{ fluent.clusterCrn }},clusterOwner:{{ fluent.clusterOwner}},clusterVersion:{{ fluent.clusterVersion }}
     extra_headers_field              bundleContext
     event_message_field              message
-    stream_name                      LogCollection
+    stream_name                      {{ fluent.dbusClusterLogsCollectionStreamName }}
     partition_key                    "#{Socket.gethostname}"
     {%- if fluent.proxyUrl %}
     proxy_url                        "{{ fluent.proxyUrl }}"


### PR DESCRIPTION
details:
- Changes for dbus stream names: we now use streams named in the following format: $ENV-$CLUSTER-LogCollection. Example for the clusters in dev environment can be found here (look for LOGCOLLECTION_STREAMNAME). The existing "LogCollection" stream will continue to exist as long as there are workload clusters pushing data to it.
A- n additional logcollection related header in the fluentd config: We now expect a new header in the fluentd config with the key as @logging-app. Its value will, again, be $ENV-$CLUSTER-LogCollection. For private stacks, the value will be $ENV-$CLUSTER-$WORKSPACE-PREFIX-LogCollection. An example for the clusters in dev environment can be found here (look for LOGCOLLECTION_STREAMAPP). We will continue to accept events without the header.

See detailed description in the commit message.