### PR TITLE
Cb 9470

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SecurityAccessManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SecurityAccessManifester.java
@@ -26,8 +26,7 @@ public class SecurityAccessManifester {
     public void overrideSecurityAccess(InstanceGroupType instanceGroupType, List<InstanceGroupV4Request> instanceGroups, String securityGroupId, String cidrs) {
         instanceGroups.stream()
                 .filter(ig -> ig.getType() == instanceGroupType)
-                .findFirst()
-                .ifPresent(ig -> {
+                .forEach(ig -> {
                     SecurityGroupV4Request securityGroup = ig.getSecurityGroup();
                     if (securityGroup == null) {
                         securityGroup = new SecurityGroupV4Request();


### PR DESCRIPTION
This removes the find first filter in SecurityAccessManifest so that secuirty groups will be applied to all instance groups.