### PR TITLE
CB-9452 Fix image import/export issue for Google cloud

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpProvisionSetup.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpProvisionSetup.java
@@ -8,8 +8,10 @@ import static com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil.getProjectId
 import static com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil.getTarName;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
+import com.google.api.services.compute.model.GuestOsFeature;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,6 +78,8 @@ public class GcpProvisionSetup implements Setup {
                 RawDisk rawDisk = new RawDisk();
                 rawDisk.setSource(String.format("http://storage.googleapis.com/%s/%s", bucket.getName(), tarName));
                 gcpApiImage.setRawDisk(rawDisk);
+                GuestOsFeature guestOsFeature = new GuestOsFeature().setType("UEFI_COMPATIBLE");
+                gcpApiImage.setGuestOsFeatures(Collections.singletonList(guestOsFeature));
                 Insert ins = compute.images().insert(projectId, gcpApiImage);
                 ins.execute();
             }

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -522,6 +523,30 @@ public class GcpInstanceResourceBuilderTest {
         Map<String, Object> params = Map.of(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM.name(),
                 InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "Hello World");
         doTestCustomEncryption(params, customerEncryptionKey);
+    }
+
+    @Test
+    public void testPublicKeyWhenHasEmailAtTheEndShouldCutTheEmail() throws Exception {
+        String loginName = "cloudbreak";
+        String sshKey = "ssh-rsa key cloudbreak@cloudbreak.com";
+        String publicKey = builder.getPublicKey(sshKey, loginName);
+        Assert.assertEquals("ssh-rsa key cloudbreak", publicKey);
+    }
+
+    @Test
+    public void testPublicKeyWhenHasNoEmailAtTheEndShouldCutTheEmail() throws Exception {
+        String loginName = "cloudbreak";
+        String sshKey = "ssh-rsa key";
+        String publicKey = builder.getPublicKey(sshKey, loginName);
+        Assert.assertEquals("ssh-rsa key cloudbreak", publicKey);
+    }
+
+    @Test
+    public void testPublicKeyWhenHasLotOfSegmentAtTheEndShouldCutTheEmail() throws Exception {
+        String loginName = "cloudbreak";
+        String sshKey = "ssh-rsa key cloudbreak cloudbreak cloudbreak cloudbreak cloudbreak cloudbreak";
+        String publicKey = builder.getPublicKey(sshKey, loginName);
+        Assert.assertEquals("ssh-rsa key cloudbreak", publicKey);
     }
 
 }


### PR DESCRIPTION
1. Google for their default centos 7 deprecated SECURE_BOOT guest os feature and started using UEFI_COMPATIBLE flag https://github.com/hashicorp/packer/issues/9353#issuecomment-640484734
2. When we import such images without this flag, then instances could not be created from that
3. Tested by importing this flag with gcloud apis and made sure that the instance booted properly.