### PR TITLE
CB-8962: Added a Cloudwatch alarm to each AWS datalake instance created.

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsCloudWatchService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsCloudWatchService.java
@@ -34,19 +34,19 @@ public class AwsCloudWatchService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsCloudWatchService.class);
 
-    @Value("${freeipa.aws.cloudwatch.suffix:-Status-Check-Failed-System}")
+    @Value("${aws.cloudwatch.suffix:-Status-Check-Failed-System}")
     private String alarmSuffix;
 
-    @Value("${freeipa.aws.cloudwatch.period:60}")
+    @Value("${aws.cloudwatch.period:60}")
     private int cloudwatchPeriod;
 
-    @Value("${freeipa.aws.cloudwatch.evaluationPeriods:2}")
+    @Value("${aws.cloudwatch.evaluationPeriods:2}")
     private int cloudwatchEvaluationPeriods;
 
-    @Value("${freeipa.aws.cloudwatch.threshold:1.0}")
+    @Value("${aws.cloudwatch.threshold:1.0}")
     private double cloudwatchThreshhold;
 
-    @Value("${freeipa.aws.cloudwatch.max-batchsize:100}")
+    @Value("${aws.cloudwatch.max-batchsize:100}")
     private int maxBatchsize;
 
     @Inject

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/stack/AwsStackV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/stack/AwsStackV4Parameters.java
@@ -6,20 +6,40 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
+import java.util.Map;
+
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(Include.NON_NULL)
 public class AwsStackV4Parameters extends StackV4ParameterBase {
+    @ApiModelProperty
+    private boolean createCloudwatch;
+
+    @Override
+    public Map<String, Object> asMap() {
+        Map<String, Object> map = super.asMap();
+        putIfValueNotNull(map, PlatformParametersConsts.CLOUDWATCH_CREATE_PARAMETER, Boolean.toString(createCloudwatch));
+        return map;
+    }
 
     @Override
     @JsonIgnore
     @ApiModelProperty(hidden = true)
     public CloudPlatform getCloudPlatform() {
         return AWS;
+    }
+
+    public boolean getCreateCloudwatch() {
+        return createCloudwatch;
+    }
+
+    public void setCreateCloudwatch(boolean createCloudwatch) {
+        this.createCloudwatch = createCloudwatch;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -198,7 +198,7 @@ public class ModelDescriptions {
         public static final String SUBNET_ID = "cluster subnet id";
         public static final String FILE_SYSTEM = "external file system configuration";
         public static final String CLOUD_STORAGE = "external cloud storage configuration";
-        public static final String INSTANCE_GROUPS = "collection of instance groupst";
+        public static final String INSTANCE_GROUPS = "collection of instance groups";
         public static final String IMAGE_SETTINGS = "settings for custom images";
         public static final String IMAGE_CATALOG = "custom image catalog URL";
         public static final String IMAGE_ID = "virtual machine image id from ImageCatalog, machines of the cluster will be started from this image";


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-8962

What I did:

* Used the FreeIPA cloudwatch alarm knowledge to understand how to extend this to the datalake AWS instances
* Added the Cloudwatch alarm parameter to the stackv4request when it is created in the datalake setup flow
* Changed the AwsStackV4Parameters class to include the logic for this new parameter

Images of the results are shown in the following links:

* [All of the instances having alarms associated with them](https://drive.google.com/file/d/1uaAubywsGSkfQQHO5ouGSbefHAKGKbX7/view?usp=sharing)
* [The alarm associated with each instance](https://drive.google.com/file/d/111JpPJt6JuNfpbEr4_X4vPqt_E_HSExV/view?usp=sharing)