### PR TITLE
CB-9500 Azure database termination fails when using private endpoint

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
@@ -160,6 +160,11 @@ public class AzureDatabaseResourceService {
 
         // TODO simplify after final form of template is reached
 
+        List<CloudResource> postgresCloudresources = findResources(resources, List.of(AZURE_DATABASE));
+        List<String> postgresIds = postgresCloudresources.stream().map(CloudResource::getReference).collect(Collectors.toList());
+        List<String> privateEndpointConnections = client.getPostgresPrivateEndpoints(postgresIds);
+        azureUtils.deleteGenericResources(client, privateEndpointConnections);
+
         List<CloudResource> azureGenericResources = findResources(resources, List.of(AZURE_PRIVATE_ENDPOINT));
         LOGGER.debug("Deleting dns zone groups and azure private endpoints {}", azureGenericResources);
         azureUtils.deleteGenericResources(client, azureGenericResources.stream().map(CloudResource::getReference).collect(Collectors.toList()));


### PR DESCRIPTION
This one is a trial - here we check if deleting the private endpoint connection first helps to get rid of the PE deletion error or not.

See detailed description in the commit message.