### PR TITLE
CB-9208 CM license is only updated when CM itself is upgraded as well

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeActions.java
@@ -98,15 +98,8 @@ public class ClusterUpgradeActions {
 
             @Override
             protected void doExecute(ClusterUpgradeContext context, ClusterUpgradeInitSuccess payload, Map<Object, Object> variables) {
-                StatedImage currentImage = getCurrentImage(variables);
-                StatedImage targetImage = getTargetImage(variables);
-                boolean clusterManagerUpdateNeeded = clusterUpgradeService.upgradeClusterManager(context.getStackId(), currentImage, targetImage);
-                Selectable event;
-                if (clusterManagerUpdateNeeded) {
-                    event = new ClusterManagerUpgradeRequest(context.getStackId());
-                } else {
-                    event = new ClusterManagerUpgradeSuccess(context.getStackId());
-                }
+                clusterUpgradeService.upgradeClusterManager(context.getStackId());
+                Selectable event = new ClusterManagerUpgradeRequest(context.getStackId());
                 sendEvent(context, event.selector(), event);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeService.java
@@ -3,7 +3,6 @@ package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_MANAGER_UPGRADE;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_MANAGER_UPGRADE_FAILED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_MANAGER_UPGRADE_FINISHED;
-import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_MANAGER_UPGRADE_NOT_NEEDED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_UPGRADE;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_UPGRADE_FAILED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_UPGRADE_FINISHED;
@@ -43,15 +42,8 @@ public class ClusterUpgradeService {
         clusterService.updateClusterStatusByStackId(stackId, Status.UPDATE_IN_PROGRESS);
     }
 
-    public boolean upgradeClusterManager(long stackId, StatedImage currentImage, StatedImage targetImage) {
-        String currentCmBuildNumber = currentImage.getImage().getCmBuildNumber();
-        boolean clusterManagerUpdateNeeded = isUpdateNeeded(currentCmBuildNumber, targetImage.getImage().getCmBuildNumber());
-        if (clusterManagerUpdateNeeded) {
-            flowMessageService.fireEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), CLUSTER_MANAGER_UPGRADE);
-        } else {
-            flowMessageService.fireEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), CLUSTER_MANAGER_UPGRADE_NOT_NEEDED, currentCmBuildNumber);
-        }
-        return clusterManagerUpdateNeeded;
+    public void upgradeClusterManager(long stackId) {
+        flowMessageService.fireEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), CLUSTER_MANAGER_UPGRADE);
     }
 
     public boolean upgradeCluster(long stackId, Image currentImage, Image targetImage) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeServiceTest.java
@@ -84,29 +84,11 @@ public class ClusterUpgradeServiceTest {
     }
 
     @Test
-    public void testClusterManagerUpgradeNotNeeded() {
+    public void testClusterManagerUpgrade() {
         // GIVEN
-        Image currImage = createImage(CURRENT_BUILD_NUMBER, CURRENT_BUILD_NUMBER);
-        StatedImage currentImage = StatedImage.statedImage(currImage, null, null);
-        StatedImage targetImage = StatedImage.statedImage(currImage, null, null);
         // WHEN
-        boolean actualResult = underTest.upgradeClusterManager(STACK_ID, currentImage, targetImage);
+        underTest.upgradeClusterManager(STACK_ID);
         // THEN
-        Assertions.assertFalse(actualResult);
-        verify(flowMessageService).fireEventAndLog(STACK_ID, Status.UPDATE_IN_PROGRESS.name(), CLUSTER_MANAGER_UPGRADE_NOT_NEEDED, CURRENT_BUILD_NUMBER);
-        verify(flowMessageService, times(0)).fireEventAndLog(STACK_ID, Status.UPDATE_IN_PROGRESS.name(), CLUSTER_MANAGER_UPGRADE);
-    }
-
-    @ParameterizedTest
-    @MethodSource("upgradeNeededVersions")
-    public void testClusterManagerUpgradeNeeded(String currentCmVersion, String targetCmVersion) {
-        // GIVEN
-        StatedImage currentImage = StatedImage.statedImage(createImage(currentCmVersion, CURRENT_BUILD_NUMBER), null, null);
-        StatedImage targetImage = StatedImage.statedImage(createImage(targetCmVersion, CURRENT_BUILD_NUMBER), null, null);
-        // WHEN
-        boolean actualResult = underTest.upgradeClusterManager(STACK_ID, currentImage, targetImage);
-        // THEN
-        Assertions.assertTrue(actualResult);
         verify(flowMessageService, times(0))
                 .fireEventAndLog(STACK_ID, Status.UPDATE_IN_PROGRESS.name(), CLUSTER_MANAGER_UPGRADE_NOT_NEEDED, CURRENT_BUILD_NUMBER);
         verify(flowMessageService).fireEventAndLog(STACK_ID, Status.UPDATE_IN_PROGRESS.name(), CLUSTER_MANAGER_UPGRADE);


### PR DESCRIPTION
CB-9208 CM license is only updated when CM itself is upgraded as well …

Solution is to turn off CM patch release upgrade check, CM will always be upgraded. In this case license will always be updated.
License update is needed because with wrong license CB doesn't allow Runtime upgrade. But if the license has changed in UMS to a good one, we need to update it on the cluster side. It is only updatable on cluster side with CM upgrade.
