### PR TITLE
CB-9527 Ensure that we are using the latest available build, and not build - 1 for swagger compatibility check

### DIFF
--- a/integration-test/scripts/swagger-check.sh
+++ b/integration-test/scripts/swagger-check.sh
@@ -34,7 +34,7 @@ MINOR_VERSION=$(echo $VERSION | cut -f 2 -d '.')
 PATCH_VERSION=$(echo $VERSION | cut -f 3 -d '.')
 PREVIOUS_MINOR_VERSION=$MAJOR_VERSION.$(expr $MINOR_VERSION - 1).$PATCH_VERSION
 PREVIOUS_MINOR_BUILD=$(curl "http://release.infra.cloudera.com/hwre-api/listbuilds?stack=CB&release=${PREVIOUS_MINOR_VERSION}" | jq -r '.latest_build_version')
-PREVIOUS_BUILD=$(curl "http://release.infra.cloudera.com/hwre-api/listbuilds?stack=CB&release=$VERSION" | jq '.full_list_versions[1]' | tr -d '"')
+PREVIOUS_BUILD=$(curl "http://release.infra.cloudera.com/hwre-api/listbuilds?stack=CB&release=$VERSION" | jq '.full_list_versions[0]' | tr -d '"')
 Services="cloudbreak,freeipa,environment,datalake,redbeams"
 declare -A zone=( ["cloudbreak"]="eu-central-1" ["environment"]="us-east-2" ["datalake"]="us-east-2" ["redbeams"]="us-east-2" ["freeipa"]="us-east-2")
 Field_Separator=$IFS


### PR DESCRIPTION
CB-9527 Ensure that we are using the latest available build, and not build - 1 for swagger compatibility check. The main problem is that if the compatibility is fixed, you need to wait that the pipeline is executed twice. 

The only catch to moving it to the 0th index is that if RE is updating the RE DB first and uploading the swagger after that then it will fail. But as we see the last step of pipeline is the RE DB update, therefore it is considered to be safe.