### PR TITLE
CB-9514 filter cdp hash password and Kerberos Principal Key

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
@@ -60,8 +60,24 @@ restart_krb5kdc:
     - mode: 644
     - source: salt://freeipa/templates/ipa-rewrite.conf.j2
 
+/etc/httpd/conf/httpd-log-filter.sh:
+  file.managed:
+    - makedirs: True
+    - user: root
+    - group: root
+    - mode: 700
+    - source: salt://freeipa/scripts/httpd-log-filter.sh
+
+configure_httpd_log_filter:
+  file.replace:
+    - name: /etc/httpd/conf/httpd.conf
+    - pattern: ^ErrorLog.*
+    - repl: ErrorLog "|/etc/httpd/conf/httpd-log-filter.sh"
+    - unless: grep "httpd-log-filter.sh" /etc/httpd/conf/httpd.conf
+
 restart_httpd:
   service.running:
     - name: httpd
     - watch:
       - file: /etc/httpd/conf.d/ipa-rewrite.conf
+      - file: /etc/httpd/conf/httpd.conf

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/httpd-log-filter.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/httpd-log-filter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+while read line; do
+  echo "$line" | sed -u -E 's/(cdpHashedPassword=|cdpUnencryptedKrbPrincipalKey=)([A-Za-z0-9{}/+]*)/\1[FILTERED]/g' >> /var/log/httpd/error_log
+done


### PR DESCRIPTION
By default FreeIPA client requests are logged in /var/log/httpd/error_log.
Even if they are not error logs. We have extended the user_mod request to
include additional parameters so we can set the cdpHashedPassword
and CdpUnencryptedKrbPrincipalKey request time (which we don't actually
store), but we use these parameters for configuring the users' password
without them specifying it all the time. This password is stored in UMS
in SHA512 format. However, since every request is logged in error_log
we log the password hash also. To prevent this we're extending the
httpd server config to use a filter, before it writes the actual log
lines to the file. This filter is simply replacing these 2 additional
parameters so they are masked in the log file.

See detailed description in the commit message.