### PR TITLE
CB-9270 [GCP] Do not set hostnames for non-freeipa hosts while creati…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersConsts.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersConsts.java
@@ -20,7 +20,11 @@ public class PlatformParametersConsts {
 
     public static final String REGIONS_SUPPORTED = "regionsSupported";
 
+    public static final String FREEIPA_STACK_TYPE = "freeipa";
+
     public static final String CLOUDWATCH_CREATE_PARAMETER = "createCloudWatchAlarm";
+
+    public static final String CLOUD_STACK_TYPE_PARAMETER = "cloudStackType";
 
     public static final String RESOURCE_GROUP_NAME_PARAMETER = "resourceGroupName";
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.freeipa.converter.cloud;
 
 import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.CLOUDWATCH_CREATE_PARAMETER;
+import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.CLOUD_STACK_TYPE_PARAMETER;
+import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.FREEIPA_STACK_TYPE;
 import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.RESOURCE_GROUP_NAME_PARAMETER;
 import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.RESOURCE_GROUP_USAGE_PARAMETER;
 import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.CREATE_REQUESTED;
@@ -354,6 +356,7 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
 
     private Map<String, String> buildCloudStackParameters(String environmentCrn) {
         Map<String, String> params = new HashMap<>();
+        params.put(CLOUD_STACK_TYPE_PARAMETER, FREEIPA_STACK_TYPE);
         params.put(CLOUDWATCH_CREATE_PARAMETER, Boolean.toString(enableCloudwatch));
         Optional<AzureResourceGroup> resourceGroupOptional = getAzureResourceGroup(environmentCrn);
         if (resourceGroupOptional.isPresent() && !ResourceGroupUsage.MULTIPLE.equals(resourceGroupOptional.get().getResourceGroupUsage())) {


### PR DESCRIPTION
…ng the instances

1. If the hostname is not set at creation during FreeIPA bootstrapping they were reset by Google Cloud causing salt script failures that depend on `hostname -f`
2. But this need not be set for other host groups.
3. Also for FreeIPA do not hard code a single instance because that assumption breaks down in repair and HA scenarios.

./gradlew build