### PR TITLE
CB-9594 We shall use the test catalog in local development.  The dev …

### DIFF
--- a/core/src/main/resources/application-dev.yml
+++ b/core/src/main/resources/application-dev.yml
@@ -1,1 +1,1 @@
-cb.image.catalog.url: https://cloudbreak-imagecatalog.s3.amazonaws.com/v3-dev-cb-image-catalog.json
+cb.image.catalog.url: https://cloudbreak-imagecatalog.s3.amazonaws.com/v3-test-cb-image-catalog.json

--- a/freeipa/src/main/resources/application-dev.yml
+++ b/freeipa/src/main/resources/application-dev.yml
@@ -1,1 +1,1 @@
-freeipa.image.catalog.url: https://cloudbreak-imagecatalog.s3.amazonaws.com/v3-dev-freeipa-image-catalog.json
+freeipa.image.catalog.url: https://cloudbreak-imagecatalog.s3.amazonaws.com/v3-test-freeipa-image-catalog.json


### PR DESCRIPTION
…catalog is unstable since we add new images right after image burning, but before the validation, and if the local dev relies on an unstable catalog then we can accidentally break every local dev env. The test catalog is updated immediately after the validation is executed on dev catalog, therefore it is a good candidate also for local development.

See detailed description in the commit message.