### PR TITLE
CB-9598 use stack's accountid in HealthCheckAvailabilityChecker.java …

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/util/HealthCheckAvailabilityChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/util/HealthCheckAvailabilityChecker.java
@@ -23,7 +23,7 @@ public class HealthCheckAvailabilityChecker extends AvailabilityChecker {
     private EntitlementService entitlementService;
 
     public boolean isCdpFreeIpaHeathAgentAvailable(Stack stack) {
-        String accountId = crnService.getCurrentAccountId();
+        String accountId = stack.getAccountId();
         return isAvailable(stack, CDP_FREEIPA_HEALTH_AGENT_AFTER_VERSION) &&
                 entitlementService.freeIpaHealthCheckEnabled(INTERNAL_ACTOR_CRN, accountId);
     }


### PR DESCRIPTION
…instead of crnService.getCurrentAccountId() (which is altus in internal case)

Freeipa sync is running with internal user, so we can not use current accountId because it is 'altus' at this point.