### PR TITLE
CB-9610 extend the upgrade matrix with 7.0.2 -> 7.2.2 path

### DIFF
--- a/core/src/main/resources/definitions/upgrade-matrix-definition.json
+++ b/core/src/main/resources/definitions/upgrade-matrix-definition.json
@@ -6,6 +6,9 @@
       },
       "source_runtime":[
         {
+          "version":"7.0.2"
+        },
+        {
           "version":"7.1.0"
         },
         {


### PR DESCRIPTION
We have some customers who would like to upgrade from 7.0.2.
Previously this was not enabled due to the fact that it does
not work out of the box. It requires some manual pre-work on
the cluster to make the upgrade successful. Since, the upgrade
feature is behind and entitlement it will not cause any harm,
but should always ask the customer what is their upgrade plan
before we grant the entitlement.
