### PR TITLE
CB-9598: Use stack's account ID in the HealthCheckAvailbilityChecker

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/util/HealthCheckAvailabilityChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/util/HealthCheckAvailabilityChecker.java
@@ -17,13 +17,10 @@ public class HealthCheckAvailabilityChecker extends AvailabilityChecker {
     private static final Versioned CDP_FREEIPA_HEALTH_AGENT_AFTER_VERSION = () -> "2.31.0";
 
     @Inject
-    private CrnService crnService;
-
-    @Inject
     private EntitlementService entitlementService;
 
     public boolean isCdpFreeIpaHeathAgentAvailable(Stack stack) {
-        String accountId = crnService.getCurrentAccountId();
+        String accountId = stack.getAccountId();
         return isAvailable(stack, CDP_FREEIPA_HEALTH_AGENT_AFTER_VERSION) &&
                 entitlementService.freeIpaHealthCheckEnabled(INTERNAL_ACTOR_CRN, accountId);
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/util/HealthCheckAvailabilityCheckerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/util/HealthCheckAvailabilityCheckerTest.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.freeipa.util;
+
+import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.freeipa.entity.Stack;
+
+@ExtendWith(MockitoExtension.class)
+public class HealthCheckAvailabilityCheckerTest {
+
+    private static final String AVAILABLE_VERSION = "2.32.0";
+
+    private static final String UNAVAILABLE_VERSION = "2.31.0";
+
+    private static final String ACCOUNT_ID = "account-id";
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @InjectMocks
+    private HealthCheckAvailabilityChecker underTest;
+
+    @Test
+    public void testAvailable() {
+        when(entitlementService.freeIpaHealthCheckEnabled(any(), any())).thenReturn(true);
+        Stack stack = new Stack();
+
+        stack.setAppVersion(AVAILABLE_VERSION);
+        stack.setAccountId(ACCOUNT_ID);
+        assertTrue(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        verify(entitlementService).freeIpaHealthCheckEnabled(eq(INTERNAL_ACTOR_CRN), eq(ACCOUNT_ID));
+    }
+
+    @Test
+    public void testUnavailableVersion() {
+        Stack stack = new Stack();
+
+        stack.setAppVersion(UNAVAILABLE_VERSION);
+        stack.setAccountId(ACCOUNT_ID);
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+    }
+
+    @Test
+    public void testUnavailableEntitlement() {
+        when(entitlementService.freeIpaHealthCheckEnabled(any(), any())).thenReturn(false);
+        Stack stack = new Stack();
+
+        stack.setAppVersion(AVAILABLE_VERSION);
+        stack.setAccountId(ACCOUNT_ID);
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        verify(entitlementService).freeIpaHealthCheckEnabled(eq(INTERNAL_ACTOR_CRN), eq(ACCOUNT_ID));
+    }
+
+    @Test
+    public void testAppVersionIsBlank() {
+        Stack stack = new Stack();
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion("");
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+
+        stack.setAppVersion(" ");
+        assertFalse(underTest.isCdpFreeIpaHeathAgentAvailable(stack));
+    }
+}


### PR DESCRIPTION
Fixed the account ID because FreeIpa sync is running with the internal
user, so the current account ID was altus.

Added a test to ensure the entitlement check does not use "altus" for
the account ID.

See detailed description in the commit message.

There is thread-local storage which sets the internal actor (account ID altus). It does this for the entire quartz health check. The availability checker uses the crn service to get the account ID. The CRN service reads the thread-local storage. Every flow and every API call sets the thread-local storage to the real user's account ID. Previously in 2.32, the HealthCheckAvailbiltyChecker was only called for flows/API calls so the real account ID was used. In 2.33 (302e984637775cac69e0e6b1b706341cade5fa22 tag: 2.33.0-b15) it started to be called from the quartz job which means it uses account ID altus. There was a little confusion with this since both check had been there in 2.32 but what I didn't realize is that the thread local storage would have different values depending on how it was called. This was not caught by the mock UMS since the mock UMS doesn't validate account IDs.