### PR TITLE
CB-9451: Move deployment of RAZ to the master node for better supportability with medium duty datalake setups

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazBaseConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazBaseConfigProvider.java
@@ -15,7 +15,6 @@ import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
-import com.sequenceiq.common.api.type.InstanceGroupType;
 
 public abstract class RangerRazBaseConfigProvider extends AbstractRoleConfigProvider {
 
@@ -29,8 +28,9 @@ public abstract class RangerRazBaseConfigProvider extends AbstractRoleConfigProv
         if (isConfigurationNeeded(cmTemplateProcessor, source)) {
             ApiClusterTemplateService coreSettings = createTemplate();
             Set<HostgroupView> hostgroupViews = source.getHostgroupViews();
+
             return hostgroupViews.stream()
-                    .filter(hg -> InstanceGroupType.GATEWAY.equals(hg.getInstanceGroupType()))
+                    .filter(hg -> hg.getName().toLowerCase().equals("master"))
                     .collect(Collectors.toMap(HostgroupView::getName, v -> coreSettings));
         }
         return Map.of();


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-9451

Basically just made it so RAZ should be deploying on master nodes instead of CORE nodes, this is subject to change in the future as we modify the medium duty shape.

I tested this by running the core cloudbreak service locally and setting up both a light duty and medium duty Azure RAZ datalake, ensuring that the code change was hit by placing a breakpoint on it. Both of these were set up successfully.