### PR TITLE
CB-8962: Added a Cloudwatch alarm to each AWS instance created.

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersConsts.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersConsts.java
@@ -22,8 +22,6 @@ public class PlatformParametersConsts {
 
     public static final String FREEIPA_STACK_TYPE = "freeipa";
 
-    public static final String CLOUDWATCH_CREATE_PARAMETER = "createCloudWatchAlarm";
-
     public static final String CLOUD_STACK_TYPE_PARAMETER = "cloudStackType";
 
     public static final String RESOURCE_GROUP_NAME_PARAMETER = "resourceGroupName";

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchService.java
@@ -169,7 +169,7 @@ public class AwsLaunchService {
 
         awsTaggingService.tagRootVolumes(ac, amazonEC2Client, instances, stack.getTags());
 
-        awsCloudWatchService.addCloudWatchAlarmsForSystemFailures(instances, stack, regionName, credentialView);
+        awsCloudWatchService.addCloudWatchAlarmsForSystemFailures(instances, regionName, credentialView);
 
         return awsResourceConnector.check(ac, instances);
     }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
@@ -109,7 +109,7 @@ public class AwsUpscaleService {
 
         awsTaggingService.tagRootVolumes(ac, amazonEC2Client, instances, stack.getTags());
 
-        awsCloudWatchService.addCloudWatchAlarmsForSystemFailures(instances, stack, regionName, credentialView);
+        awsCloudWatchService.addCloudWatchAlarmsForSystemFailures(instances, regionName, credentialView);
 
         return singletonList(new CloudResourceStatus(cfStackUtil.getCloudFormationStackResource(resources), ResourceStatus.UPDATED));
     }

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsLaunchTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsLaunchTest.java
@@ -15,6 +15,7 @@ import java.util.function.Supplier;
 
 import javax.inject.Inject;
 
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
@@ -148,6 +149,9 @@ public class AwsLaunchTest {
     private AwsClient awsClient;
 
     @MockBean
+    private AmazonCloudWatchClient cloudWatchClient;
+
+    @MockBean
     private Waiter<DescribeAutoScalingGroupsRequest> describeAutoScalingGroupsRequestWaiter;
 
     @MockBean
@@ -211,6 +215,7 @@ public class AwsLaunchTest {
         when(ecWaiters.instanceTerminated()).thenReturn(instanceWaiter);
         when(customAmazonWaiterProvider.getAutoscalingInstancesInServiceWaiter(any(), any())).thenReturn(describeAutoScalingGroupsRequestWaiter);
         when(customAmazonWaiterProvider.getAutoscalingActivitiesWaiter(any(), any())).thenReturn(describeScalingActivitiesRequestWaiter);
+        when(awsClient.createCloudWatchClient(any(), anyString())).thenReturn(cloudWatchClient);
     }
 
     private void setupRetryService() {

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +28,8 @@ import java.util.function.Supplier;
 
 import javax.inject.Inject;
 
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClient;
+import com.amazonaws.services.cloudwatch.model.DescribeAlarmsResult;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -169,6 +172,12 @@ public class AwsRepairTest {
     private AwsClient awsClient;
 
     @MockBean
+    private AmazonCloudWatchClient cloudWatchClient;
+
+    @MockBean
+    private DescribeAlarmsResult describeAlarmsResult;
+
+    @MockBean
     private Waiter<DescribeAutoScalingGroupsRequest> describeAutoScalingGroupsRequestWaiter;
 
     @MockBean
@@ -196,6 +205,9 @@ public class AwsRepairTest {
         when(cfWaiters.stackDeleteComplete()).thenReturn(cfStackWaiter);
         when(awsClient.createAutoScalingRetryClient(any(), anyString())).thenReturn(amazonAutoScalingRetryClient);
         when(awsClient.createAutoScalingClient(any(), anyString())).thenReturn(amazonAutoScalingClient);
+        when(awsClient.createCloudWatchClient(any(), anyString())).thenReturn(cloudWatchClient);
+        when(cloudWatchClient.describeAlarms(any())).thenReturn(describeAlarmsResult);
+        when(describeAlarmsResult.getMetricAlarms()).thenReturn(Collections.emptyList());
         when(amazonAutoScalingClient.waiters()).thenReturn(asWaiters);
         when(asWaiters.groupInService()).thenReturn(describeAutoScalingGroupsRequestWaiter);
         when(amazonEC2Client.waiters()).thenReturn(ecWaiters);

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsCloudWatchServiceTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsCloudWatchServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -38,8 +37,6 @@ import com.sequenceiq.cloudbreak.cloud.model.Group;
 class AwsCloudWatchServiceTest {
 
     private static final String REGION = "region";
-
-    private static final Map<String, String> PARAMETERS = Map.of("createCloudWatchAlarm", Boolean.TRUE.toString());
 
     @Mock
     private AwsClient awsClient;
@@ -72,7 +69,6 @@ class AwsCloudWatchServiceTest {
         CloudInstance instance2 = mock(CloudInstance.class);
         CloudInstance instance3 = mock(CloudInstance.class);
         List<Group> groups = List.of(group);
-        when(stack.getParameters()).thenReturn(PARAMETERS);
         when(stack.getGroups()).thenReturn(groups);
         when(group.getInstances()).thenReturn(List.of(instance1, instance2, instance3));
         when(instance1.getInstanceId()).thenReturn(instanceId1);
@@ -144,7 +140,6 @@ class AwsCloudWatchServiceTest {
         CloudStack stack = mock(CloudStack.class);
         Group group = mock(Group.class);
         List<Group> groups = List.of(group);
-        when(stack.getParameters()).thenReturn(PARAMETERS);
         when(stack.getGroups()).thenReturn(groups);
         when(group.getInstances()).thenReturn(cloudInstances);
         when(awsClient.createCloudWatchClient(credentialView, REGION)).thenReturn(cloudWatchClient);
@@ -195,11 +190,10 @@ class AwsCloudWatchServiceTest {
         CloudStack stack = mock(CloudStack.class);
         Group group = mock(Group.class);
         List<Group> groups = List.of(group);
-        when(stack.getParameters()).thenReturn(PARAMETERS);
         when(stack.getGroups()).thenReturn(groups);
         when(group.getInstances()).thenReturn(cloudInstances);
         when(awsClient.createCloudWatchClient(credentialView, REGION)).thenReturn(cloudWatchClient);
-        AmazonCloudWatchException exception = new AmazonCloudWatchException("No permissions to descrive cloudwatch alarms");
+        AmazonCloudWatchException exception = new AmazonCloudWatchException("No permissions to describe cloudwatch alarms");
         when(cloudWatchClient.describeAlarms(any())).thenThrow(exception);
 
         underTest.deleteCloudWatchAlarmsForSystemFailures(stack, REGION, credentialView);

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleServiceTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleServiceTest.java
@@ -177,7 +177,7 @@ class AwsUpscaleServiceTest {
         verify(awsComputeResourceService, times(1))
                 .buildComputeResourcesForUpscale(eq(authenticatedContext), eq(cloudStack), anyList(), captor.capture(), any(), any());
         verify(awsTaggingService, times(1)).tagRootVolumes(eq(authenticatedContext), any(AmazonEC2Client.class), eq(allInstances), eq(tags));
-        verify(awsCloudWatchService, times(1)).addCloudWatchAlarmsForSystemFailures(any(), eq(cloudStack), eq("eu-west-1"),
+        verify(awsCloudWatchService, times(1)).addCloudWatchAlarmsForSystemFailures(any(), eq("eu-west-1"),
                 any(AwsCredentialView.class));
         List<CloudResource> newInstances = captor.getValue();
         assertEquals("Two new instances should be created", 2, newInstances.size());

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -198,7 +198,7 @@ public class ModelDescriptions {
         public static final String SUBNET_ID = "cluster subnet id";
         public static final String FILE_SYSTEM = "external file system configuration";
         public static final String CLOUD_STORAGE = "external cloud storage configuration";
-        public static final String INSTANCE_GROUPS = "collection of instance groupst";
+        public static final String INSTANCE_GROUPS = "collection of instance groups";
         public static final String IMAGE_SETTINGS = "settings for custom images";
         public static final String IMAGE_CATALOG = "custom image catalog URL";
         public static final String IMAGE_ID = "virtual machine image id from ImageCatalog, machines of the cluster will be started from this image";

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.freeipa.converter.cloud;
 
-import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.CLOUDWATCH_CREATE_PARAMETER;
 import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.CLOUD_STACK_TYPE_PARAMETER;
 import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.FREEIPA_STACK_TYPE;
 import static com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts.RESOURCE_GROUP_NAME_PARAMETER;
@@ -27,7 +26,6 @@ import javax.inject.Inject;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudGcsView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -88,9 +86,6 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
 
     @Inject
     private ImageConverter imageConverter;
-
-    @Value("${freeipa.aws.cloudwatch.enabled:true}")
-    private boolean enableCloudwatch;
 
     @Inject
     private CachedEnvironmentClientService cachedEnvironmentClientService;
@@ -362,7 +357,6 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
     private Map<String, String> buildCloudStackParameters(String environmentCrn) {
         Map<String, String> params = new HashMap<>();
         params.put(CLOUD_STACK_TYPE_PARAMETER, FREEIPA_STACK_TYPE);
-        params.put(CLOUDWATCH_CREATE_PARAMETER, Boolean.toString(enableCloudwatch));
         Optional<AzureResourceGroup> resourceGroupOptional = getAzureResourceGroup(environmentCrn);
         if (resourceGroupOptional.isPresent() && !ResourceGroupUsage.MULTIPLE.equals(resourceGroupOptional.get().getResourceGroupUsage())) {
             AzureResourceGroup resourceGroup = resourceGroupOptional.get();


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-8962

We specifically wanted to extend the FreeIPA Cloudwatch alarm feature to all AWS nodes created. In order to do this I simply rolled back the specific FreeIPA logic that added a Cloudwatch parameter to the Cloudstacks created for the instances, and removed the check for that parameter in the Cloudwatch alarm parameter.

As far as I know, removing this check will simply cause all AWS instances created by cloudbreak to create the Cloudwatch alarm by default. Please let me know if I am forgetting or overlooking something that could possibly break by removing this check.

All of the logic for automatically removing the Cloudwatch alarm when the instances are terminated, or on some failure, already exists from the FreeIPA changes made before and is still in use.

I tested this by setting up a light duty and medium duty environment/datalake locally, running both the core cloudbreak service and the FreeIPA service locally. I ensured that both cases created the same alarm for all instances as shown in the images below:

* [All Nodes with Alarms](https://drive.google.com/file/d/16xR4eAPjHraymt-SynUI9pdjT2fRCCsH/view?usp=sharing)
* [Alarm per Node](https://drive.google.com/file/d/1VXLQzEq66qgDyYwQ3Yfie6CAf3rdy7W5/view?usp=sharing)

I am not really sure why the alarm count went down from 2 to 1 (previously each node had 2 of the same alarms), but we can discuss this and why it is happening after the unplug days.