### PR TITLE
CB-9614 [thunderhead-mock] Throw exception if ums getAccount called with 'altus'

### DIFF
--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockCrnService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockCrnService.java
@@ -1,13 +1,14 @@
 package com.sequenceiq.thunderhead.grpc.service.auth;
 
+import static com.sequenceiq.cloudbreak.auth.InternalCrnBuilder.INTERNAL_ACCOUNT;
 import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.thunderhead.grpc.GrpcActorContext;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.thunderhead.grpc.GrpcActorContext;
 
 import io.grpc.Status;
 
@@ -36,6 +37,13 @@ class MockCrnService {
         LOGGER.info("Ensure internal actor: {}", actorCrn);
         if (!INTERNAL_ACTOR_CRN.equals(actorCrn)) {
             throw Status.PERMISSION_DENIED.withDescription("This operation is only allowed for internal services").asRuntimeException();
+        }
+    }
+
+    void ensureProperAccountIdUsage(String accountId) {
+        LOGGER.info("Ensure correct account id: {}", accountId);
+        if (INTERNAL_ACCOUNT.equals(accountId)) {
+            throw Status.INVALID_ARGUMENT.withDescription("This operation cannot be used with internal account id").asRuntimeException();
         }
     }
 }

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -567,6 +567,7 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Override
     public void getAccount(GetAccountRequest request, StreamObserver<GetAccountResponse> responseObserver) {
+        mockCrnService.ensureProperAccountIdUsage(request.getAccountId());
         LOGGER.info("Get account: {}", request.getAccountId());
         Account.Builder builder = Account.newBuilder();
         if (enableBaseImages) {

--- a/mock-thunderhead/src/test/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementServiceTest.java
+++ b/mock-thunderhead/src/test/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementServiceTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.thunderhead.grpc.service.auth;
 
+import static com.sequenceiq.cloudbreak.auth.InternalCrnBuilder.INTERNAL_ACCOUNT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -18,6 +19,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -33,6 +35,7 @@ import com.cloudera.thunderhead.service.usermanagement.UserManagementProto.Workl
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.thunderhead.util.JsonUtil;
 
+import io.grpc.StatusRuntimeException;
 import io.grpc.internal.testing.StreamRecorder;
 
 @ExtendWith(ExpectedExceptionSupport.class)
@@ -47,6 +50,9 @@ public class MockUserManagementServiceTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    @Spy
+    private MockCrnService mockCrnService;
 
     @InjectMocks
     private MockUserManagementService underTest;
@@ -271,6 +277,18 @@ public class MockUserManagementServiceTest {
         Account account = res.getAccount();
         assertThat(account.getAccountId()).isEqualTo(ACCOUNT_ID);
         assertThat(account.getExternalAccountId()).isEqualTo("external-" + ACCOUNT_ID);
+    }
+
+    @Test
+    void testGetAccountWithAltusAccountId() {
+        GetAccountRequest req = GetAccountRequest.newBuilder()
+                .setAccountId(INTERNAL_ACCOUNT)
+                .build();
+
+        expectedException.expect(StatusRuntimeException.class);
+        expectedException.expectMessage("INVALID_ARGUMENT");
+
+        underTest.getAccount(req, null);
     }
 
     @Test


### PR DESCRIPTION
…instead of crnService.getCurrentAccountId() (which is altus in internal case)

Freeipa sync is running with internal user, so we can not use current accountId because it is 'altus' at this point.

Also this commit will ensure that mock ums getAccount call fails if we are calling it with 'altus' anywhere. This should prevent further issues with 'altus' accountId during getAccount call.

See detailed description in the commit message.