### PR TITLE
Revert "CB-8861. Enable diagnostics (CM & VM based) tests for AWS"

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
@@ -11,4 +11,3 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.spot.AwsDistroXSpotInstanceTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxSecurityTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.diagnostics.DiagnosticsTests


### PR DESCRIPTION
This reverts commit f2dc0ebff7ba915048280f8cd91ebf3128499a70.

See detailed description in the commit message.

seems like there is some config error for diagnostics tests, until im figuring it out (im not sure how much time it is), maybe better to revert it for now