### PR TITLE
CB-9631. Diagnostics cluster type is WORKLOAD instead of DATAHUB for …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/DiagnosticsTriggerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/DiagnosticsTriggerService.java
@@ -71,7 +71,8 @@ public class DiagnosticsTriggerService {
                 && StringUtils.isNotBlank(stack.getCluster().getBlueprint().getStackVersion())) {
             clusterVersion = stack.getCluster().getBlueprint().getStackVersion();
         }
-        DiagnosticParameters parameters = diagnosticsDataToParameterConverter.convert(request, telemetry, stack.getType().name(), clusterVersion,
+        DiagnosticParameters parameters = diagnosticsDataToParameterConverter.convert(request, telemetry,
+                StringUtils.upperCase(stack.getType().getResourceType()), clusterVersion,
                 Crn.fromString(stack.getResourceCrn()).getAccountId(), stack.getRegion());
         DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                 .withAccepted(new Promise<>())

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
@@ -83,6 +83,18 @@
    {% set cluster_version = '' %}
 {% endif %}
 
+{% set version_data = namespace(entities=[]) %}
+{% for role in grains.get('roles', []) %}
+{% if role.startswith("cdp_telemetry_prewarmed") %}
+  {% set version_data.entities = version_data.entities + [role.split("cdp_telemetry_prewarmed_v")[1]]%}
+{% endif %}
+{% endfor %}
+{% if version_data.entities|length > 0 %}
+{% set cdp_telemetry_version = version_data.entities[0] | int %}
+{% else %}
+{% set cdp_telemetry_version = 0 %}
+{% endif %}
+
 {% do filecollector.update({
     "destination": destination,
     "cloudStorageUploadParams": cloud_storage_upload_params,
@@ -105,5 +117,6 @@
     "clusterType": cluster_type,
     "clusterVersion": cluster_version,
     "uuid": uuid,
-    "accountId": account_id
+    "accountId": account_id,
+    "cdpTelemetryVersion": cdp_telemetry_version
 }) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/cdp-doctor-commands.yaml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/cdp-doctor-commands.yaml.j2
@@ -2,6 +2,7 @@
 commands:
     - command: ps aux
       output: /tmp/doctor_ps_aux.txt
+      report: false
     - command: netstat -tlpn
       output: /tmp/doctor_netstat.txt
     - command: nslookup $(hostname -i)
@@ -11,10 +12,13 @@ commands:
     - command: cdp-doctor network status
       output: /tmp/doctor_network.txt
     - command: cdp-doctor service status
-      output: /tmp/doctor_services.txt
-{% if filecollector.clusterType != "FREEIPA" %}
+      output: /tmp/doctor_services.txt{% if filecollector.clusterType != "FREEIPA" %}
     - command: cdp-doctor recipe results
       output: /tmp/doctor_recipes.txt
     - command: cdp-doctor scm list-commands
-      output: /tmp/doctor_scm_agent_commands.txt
-{% endif %}
+      output: /tmp/doctor_scm_agent_commands.txt{% endif %}{% if filecollector.clusterType == "DATAHUB" and filecollector.cdpTelemetryVersion > 0 %}
+    - command: cdp-doctor metering status
+      output: /tmp/doctor_metering.txt{% endif %}
+report:
+    location: /tmp/cdp_report.html
+    title: CDP commands report

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/filecollector.yaml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/filecollector.yaml.j2
@@ -29,7 +29,13 @@ collector:
       skipLabelFromPath: true
       skipAnonymization: true
       useFullPath: false
-      folderPrefix: doctor
+      folderPrefix: doctor{% if destination in ["CLOUD_STORAGE", "LOCAL"] %}
+    - path: /tmp/cdp_report.html
+      label: report
+      skipLabelFromPath: true
+      skipAnonymization: true
+      useFullPath: false
+      folderPrefix: report{% endif %}
 {% if filecollector.additionalLogs %}{% for extra_log in filecollector.additionalLogs %}
     - path: "{{ extra_log["path"] }}"
       folderPrefix: logs{% if destination in ["CLOUD_STORAGE", "LOCAL", "SUPPORT"] %}


### PR DESCRIPTION
…datahub

details: resourceType for WORKLOAD is DATAHUB (for stack type), but WORKLOAD is used in the diagnostics bundle -> use DATAHUB.
also: start using cdp_telemetry_prewarmed_vX and base on that include new commands (like cdp-doctor metering command) + create report html for the cdp-doctor commands

See detailed description in the commit message.