### PR TITLE
CB-7552: IDBroker VM is provisioned with an attached disk that remain…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/CloudConfigValidationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/CloudConfigValidationActions.java
@@ -114,7 +114,7 @@ public class CloudConfigValidationActions {
                         StackType type = stack.getType();
                         templateValidator.validate(
                                 credential,
-                                instanceGroup.getTemplate(),
+                                instanceGroup,
                                 stack,
                                 fromStackType(type == null ? null : type.name()),
                                 user,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidatorTest.java
@@ -1,0 +1,216 @@
+package com.sequenceiq.cloudbreak.controller.validation.template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmTypes;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.PlatformDisks;
+import com.sequenceiq.cloudbreak.cloud.model.VmType;
+import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta;
+import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType;
+import com.sequenceiq.cloudbreak.cloud.service.CloudParameterService;
+import com.sequenceiq.cloudbreak.controller.validation.LocationService;
+import com.sequenceiq.cloudbreak.converter.spi.CredentialToExtendedCloudCredentialConverter;
+import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.dto.credential.Credential;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.common.api.type.CdpResourceType;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@ExtendWith(MockitoExtension.class)
+public class TemplateValidatorTest {
+
+    private Credential credential;
+
+    private User user;
+
+    private Optional<User> optionalUser;
+
+    private CloudVmTypes cloudVmTypes;
+
+    private PlatformDisks platformDisks;
+
+    @Mock
+    private ValidationResult.ValidationResultBuilder builder;
+
+    @Mock
+    private CredentialToExtendedCloudCredentialConverter extendedCloudCredentialConverter;
+
+    @Mock
+    private CloudParameterService cloudParameterService;
+
+    @Mock
+    private LocationService locationService;
+
+    @InjectMocks
+    private InstanceGroup instanceGroup;
+
+    private Stack stack;
+
+    @InjectMocks
+    private TemplateValidator underTest = new TemplateValidator();
+
+    @BeforeEach
+    public void setUp() {
+        credential = TestUtil.awsCredential();
+        user = new User();
+        optionalUser = Optional.of(user);
+        MockitoAnnotations.initMocks(this);
+        stack = TestUtil.stack(Status.AVAILABLE, credential);
+        Cluster cluster = TestUtil.cluster();
+        stack.setCluster(cluster);
+
+        String location = "fake location";
+        VmTypeMeta.VmTypeMetaBuilder vmMetaBuilder = VmTypeMeta.VmTypeMetaBuilder.builder()
+                .withCpuAndMemory(Integer.valueOf(8), Float.valueOf(15))
+                .withPrice(0.42)
+                .withVolumeEncryptionSupport(true)
+                .withSsdConfig(1, 17592,
+                        1, 24);
+        VmType c3VmType = VmType.vmTypeWithMeta("c3.2xlarge", vmMetaBuilder.create(), false);
+        Map<String, Set<VmType>> machines = new HashMap<>();
+        machines.put(location, Collections.singleton(c3VmType));
+        cloudVmTypes = new CloudVmTypes(machines, new HashMap<>());
+        when(cloudParameterService.getVmTypesV2(
+                isNull(), anyString(), isNull(), any(CdpResourceType.class), any(HashMap.class))).thenReturn(cloudVmTypes);
+
+        Platform platform = Platform.platform("AWS");
+        Map<Platform, Map<String, VolumeParameterType>> diskMappings = new HashMap<>();
+        Map<String, VolumeParameterType> diskTypeMap = new HashMap<>();
+        diskTypeMap.put("standard", VolumeParameterType.SSD);
+        diskMappings.put(platform, diskTypeMap);
+
+        platformDisks = new PlatformDisks(new HashMap<>(), new HashMap<>(), diskMappings, new HashMap<>());
+        when(cloudParameterService.getDiskTypes()).thenReturn(platformDisks);
+
+        when(locationService.location(anyString(), isNull())).thenReturn(location);
+    }
+
+    @Test
+    public void validateIDBrokerDataVolumeZeroCountZeroSize() {
+        instanceGroup = createInstanceGroup(0, 0, true);
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(0)).error(anyString());
+        verifyIDBrokerVolume(instanceGroup);
+    }
+
+    @Test
+    public void validateIDBrokerDataVolumeCountOne() {
+        instanceGroup = createInstanceGroup(1, 0, true);
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(0)).error(anyString());
+    }
+
+    @Test
+    public void validateIDBrokerDataVolumeInvalidCount() {
+        // volume count is larger than the max value of 24
+        instanceGroup = createInstanceGroup(25, 1, true);
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(1)).error(anyString());
+    }
+
+    @Test
+    public void validateIDBrokerDataVolumeDefaultSize() {
+        instanceGroup = createInstanceGroup(1, 100, true);
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(0)).error(anyString());
+    }
+
+    @Test
+    public void validateIDBrokerDataVolumeInvalidSize() {
+        instanceGroup = createInstanceGroup(1, 18000, true);
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(1)).error(anyString());
+    }
+
+    @Test
+    public void validateMasterDataVolumeZeroCountZeroSize() {
+        instanceGroup = createInstanceGroup(0, 0, false);
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(2)).error(anyString());
+    }
+
+    @Test
+    public void validateMasterDataVolumeCountOne() {
+        instanceGroup = createInstanceGroup(1, 1, false);
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(0)).error(anyString());
+    }
+
+    @Test
+    public void validateMasterDataVolumeInvalidCount() {
+        // volume count is larger than the max value of 24
+        instanceGroup = createInstanceGroup(25, 1, false);
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(1)).error(anyString());
+    }
+
+    @Test
+    public void validateMasterDataVolumeDefaultSize() {
+        instanceGroup = createInstanceGroup(1, 100, false);
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(0)).error(anyString());
+    }
+
+    @Test
+    public void validateMasterDataVolumeInvalidSize() {
+        instanceGroup = createInstanceGroup(1, 18000, false);
+        underTest.validate(credential, instanceGroup, stack, CdpResourceType.DATALAKE, optionalUser, builder);
+        Mockito.verify(builder, Mockito.times(1)).error(anyString());
+    }
+
+    private InstanceGroup createInstanceGroup(int dataVolumeCount, int dataVolumeSize, boolean createIDBroker) {
+        Template awsTemplate = TestUtil.awsTemplate(1L);
+        int volumeCount = dataVolumeCount;
+        int volumeSize = dataVolumeSize;
+        VolumeTemplate volumeTemplate = TestUtil.volumeTemplate(volumeCount, volumeSize, "standard");
+        awsTemplate.setVolumeTemplates(Sets.newHashSet(volumeTemplate));
+
+        if (createIDBroker) {
+            instanceGroup = TestUtil.instanceGroup(1L, InstanceGroupType.CORE, awsTemplate);
+            instanceGroup.setGroupName(TemplateValidator.GROUP_NAME_ID_BROKER);
+        } else {
+            instanceGroup = TestUtil.instanceGroup(1L, InstanceGroupType.GATEWAY, awsTemplate);
+            instanceGroup.setGroupName("master");
+        }
+
+        return instanceGroup;
+    }
+
+    private void verifyIDBrokerVolume(InstanceGroup instanceGroup) {
+        Template returnedTemplate = instanceGroup.getTemplate();
+        Set<VolumeTemplate> returnedVolumeTemplates = returnedTemplate.getVolumeTemplates();
+        assertThat(returnedVolumeTemplates.size()).isEqualTo(1);
+
+        VolumeTemplate firstVolumeTemplate = returnedVolumeTemplates.iterator().next();
+        assertThat(firstVolumeTemplate.getVolumeCount().intValue()).isEqualTo(0);
+        assertThat(firstVolumeTemplate.getVolumeSize().intValue()).isEqualTo(0);
+    }
+}

--- a/datalake/src/main/resources/duties/7.0.2/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.0.2/aws/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "t3.medium",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.0.2/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.0.2/azure/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "Standard_D2s_v3",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "StandardSSD_LRS"
           }
         ],

--- a/datalake/src/main/resources/duties/7.0.2/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.0.2/mock/light_duty.json
@@ -28,8 +28,7 @@
         },
         "attachedVolumes": [
           {
-            "size": 100,
-            "count": 1,
+            "count": 0,
             "type": "magnetic"
           }
         ]

--- a/datalake/src/main/resources/duties/7.1.0/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.1.0/aws/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "t3.medium",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.1.0/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.1.0/azure/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "Standard_D2s_v3",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "StandardSSD_LRS"
           }
         ],

--- a/datalake/src/main/resources/duties/7.1.0/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.1.0/mock/light_duty.json
@@ -28,8 +28,7 @@
         },
         "attachedVolumes": [
           {
-            "size": 100,
-            "count": 1,
+            "count": 0,
             "type": "magnetic"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.0/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.0/aws/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "t3.medium",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.0/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.0/azure/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "Standard_D2s_v3",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "StandardSSD_LRS"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.0/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.0/mock/light_duty.json
@@ -28,8 +28,7 @@
         },
         "attachedVolumes": [
           {
-            "size": 100,
-            "count": 1,
+            "count": 0,
             "type": "magnetic"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.1/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.1/aws/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "t3.medium",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.1/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.1/azure/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "Standard_D2s_v3",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "StandardSSD_LRS"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.1/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.1/mock/light_duty.json
@@ -28,8 +28,7 @@
         },
         "attachedVolumes": [
           {
-            "size": 100,
-            "count": 1,
+            "count": 0,
             "type": "magnetic"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.2/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.2/aws/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "t3.medium",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.2/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.2/aws/medium_duty_ha.json
@@ -54,8 +54,7 @@
         "instanceType": "t3.medium",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.2/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.2/azure/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "Standard_D2s_v3",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "StandardSSD_LRS"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.2/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.2/azure/medium_duty_ha.json
@@ -54,8 +54,7 @@
         "instanceType": "Standard_D2s_v3",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "StandardSSD_LRS"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.2/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.2/mock/light_duty.json
@@ -28,8 +28,7 @@
         },
         "attachedVolumes": [
           {
-            "size": 100,
-            "count": 1,
+            "count": 0,
             "type": "magnetic"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.6/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/aws/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "t3.medium",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.6/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.6/aws/medium_duty_ha.json
@@ -54,8 +54,7 @@
         "instanceType": "t3.medium",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.6/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/azure/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "Standard_D2s_v3",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "StandardSSD_LRS"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.6/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.6/azure/medium_duty_ha.json
@@ -54,8 +54,7 @@
         "instanceType": "Standard_D2s_v3",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "StandardSSD_LRS"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.6/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/gcp/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "e2-standard-2",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "pd-standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.6/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.6/gcp/medium_duty_ha.json
@@ -54,8 +54,7 @@
         "instanceType": "e2-standard-2",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "pd-standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.6/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/mock/light_duty.json
@@ -28,8 +28,7 @@
         },
         "attachedVolumes": [
           {
-            "size": 100,
-            "count": 1,
+            "count": 0,
             "type": "magnetic"
           }
         ]

--- a/datalake/src/main/resources/duties/7.2.7/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/aws/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "t3.medium",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.7/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/aws/medium_duty_ha.json
@@ -94,8 +94,7 @@
         "instanceType": "t3.medium",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.7/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/azure/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "Standard_D2s_v3",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "StandardSSD_LRS"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.7/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/azure/medium_duty_ha.json
@@ -94,8 +94,7 @@
         "instanceType": "Standard_D2s_v3",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "StandardSSD_LRS"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.7/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/gcp/light_duty.json
@@ -14,8 +14,7 @@
         "instanceType": "e2-standard-2",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "pd-standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.7/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/gcp/medium_duty_ha.json
@@ -54,8 +54,7 @@
         "instanceType": "e2-standard-2",
         "attachedVolumes": [
           {
-            "count": 1,
-            "size": 100,
+            "count": 0,
             "type": "pd-standard"
           }
         ],

--- a/datalake/src/main/resources/duties/7.2.7/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/mock/light_duty.json
@@ -28,8 +28,7 @@
         },
         "attachedVolumes": [
           {
-            "size": 100,
-            "count": 1,
+            "count": 0,
             "type": "magnetic"
           }
         ]

--- a/orchestrator-salt/src/main/resources/salt/bootstrapnodes/mount-disks.sh
+++ b/orchestrator-salt/src/main/resources/salt/bootstrapnodes/mount-disks.sh
@@ -115,10 +115,10 @@ mount_common() {
 }
 
 create_directories() {
-    cd /hadoopfs/fs1 && mkdir logs logs/ambari-server logs/ambari-agent logs/consul-watch logs/kerberos >> $LOG_FILE 2>&1
+    cd /hadoopfs/fs1 && mkdir logs >> $LOG_FILE 2>&1
 
     fs1_logs_dir=/hadoopfs/fs1/logs
-    [[ -d $fs1_logs_dir  && -d $fs1_logs_dir/ambari-server  && -d $fs1_logs_dir/ambari-agent  && -d $fs1_logs_dir/consul-watch  && -d $fs1_logs_dir/kerberos ]] && return 0
+    [[ -d $fs1_logs_dir ]] && return 0
 
     log $LOG_FILE there was an error creating log directories in /hadoopfs/fs1
     return 1

--- a/orchestrator-salt/src/main/resources/salt/salt/disks/mount/scripts/mount-disks.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/disks/mount/scripts/mount-disks.j2
@@ -121,10 +121,10 @@ mount_common() {
 }
 
 create_directories() {
-    cd /hadoopfs/fs1 && mkdir logs logs/ambari-server logs/ambari-agent logs/consul-watch logs/kerberos >> $LOG_FILE 2>&1
+    cd /hadoopfs/fs1 && mkdir logs >> $LOG_FILE 2>&1
 
     fs1_logs_dir=/hadoopfs/fs1/logs
-    [[ -d $fs1_logs_dir  && -d $fs1_logs_dir/ambari-server  && -d $fs1_logs_dir/ambari-agent  && -d $fs1_logs_dir/consul-watch  && -d $fs1_logs_dir/kerberos ]] && return 0
+    [[ -d $fs1_logs_dir  ]] && return 0
 
     log $LOG_FILE there was an error creating log directories in /hadoopfs/fs1
     return 1


### PR DESCRIPTION
This is the initial version of the code change.
a. I have checked on long running environment that the data volume of the IDBroker is not used. Details are in CB-7552
b. I only tested on AWS, not on Azure yet. Waiting on getting access to Azure.

When I tried to remove the data volume at IDBroker by setting the volume count to be 0 or the size to be 0GB, the deployment failed. So I set the data volume at IDBroker to be 1 GB, which is the min volume size allowed at https://github.com/hortonworks/cloudbreak/blob/master/cloud-aws/src/main/resources/definitions/aws-vm.json. The validation code that enforces this is at https://github.com/hortonworks/cloudbreak/blob/master/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidator.java#L168 and https://github.com/hortonworks/cloudbreak/blob/master/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/template/TemplateValidator.java#L184

Should I change the min volume size to be 0 GB in aws-vm.json? That may cause validation useless for other scenarios. What is your suggestion?