### PR TITLE
CB-9636 add request ID to quartz sync jobs

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentStatusCheckerJob.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/sync/EnvironmentStatusCheckerJob.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.environment.environment.sync;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobExecutionContext;
@@ -102,6 +103,7 @@ public class EnvironmentStatusCheckerJob extends StatusCheckerJob {
                 .resourceCrn(environment.getResourceCrn())
                 .resourceName(environment.getName())
                 .resourceType("ENVIRONMENT")
+                .requestId(UUID.randomUUID().toString())
                 .buildMdc();
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.util.Benchmark.checkedMeasure;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -80,6 +81,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                 .resourceName(stack.getName())
                 .resourceType("STACK")
                 .environmentCrn(stack.getEnvironmentCrn())
+                .requestId(UUID.randomUUID().toString())
                 .buildMdc();
     }
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncJob.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/sync/DBStackStatusSyncJob.java
@@ -2,6 +2,8 @@ package com.sequenceiq.redbeams.sync;
 
 import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
 
+import java.util.UUID;
+
 import javax.inject.Inject;
 
 import org.quartz.DisallowConcurrentExecution;
@@ -36,6 +38,7 @@ public class DBStackStatusSyncJob extends StatusCheckerJob {
         DBStack dbStack = dbStackService.getById(dbStackId);
 
         MDCBuilder.buildMdcContext(dbStack);
+        MDCBuilder.addRequestId(UUID.randomUUID().toString());
 
         if (flowLogService.isOtherFlowRunning(dbStackId)) {
             LOGGER.debug("DBStackStatusCheckerJob cannot run, because flow is running for stack: {}", dbStackId);


### PR DESCRIPTION
`StatusCheckerJob` implementations haven't filled the request id in
`MDCContext`, and it made hard to investigate status changes during
sync.