### PR TITLE
CB-9661 & CB-9663: Fix FreeIPA health checks so that they do not ...

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceMetaData.java
@@ -142,24 +142,8 @@ public class InstanceMetaData {
         this.terminationDate = terminationDate;
     }
 
-    public boolean isCreated() {
-        return InstanceStatus.CREATED.equals(instanceStatus);
-    }
-
     public boolean isAvailable() {
         return instanceStatus.isAvailable();
-    }
-
-    public boolean isFailed() {
-        return InstanceStatus.FAILED.equals(instanceStatus);
-    }
-
-    public boolean isDecommissioned() {
-        return InstanceStatus.DECOMMISSIONED.equals(instanceStatus);
-    }
-
-    public boolean isUnRegistered() {
-        return InstanceStatus.UNREGISTERED.equals(instanceStatus);
     }
 
     public boolean isTerminated() {
@@ -168,14 +152,6 @@ public class InstanceMetaData {
 
     public boolean isDeletedOnProvider() {
         return InstanceStatus.DELETED_ON_PROVIDER_SIDE.equals(instanceStatus) || InstanceStatus.DELETED_BY_PROVIDER.equals(instanceStatus);
-    }
-
-    public boolean isRegistered() {
-        return InstanceStatus.REGISTERED.equals(instanceStatus);
-    }
-
-    public boolean isRunning() {
-        return InstanceStatus.REGISTERED.equals(instanceStatus) || InstanceStatus.UNREGISTERED.equals(instanceStatus);
     }
 
     public String getLocalityIndicator() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -119,7 +119,7 @@ public class FreeIpaClientFactory {
                         throw new RetryableFreeIpaClientException("Unable to connect to FreeIPA using cluster proxy", e);
                     }
                 } else {
-                    List<InstanceMetaData> instanceMetaDatas = getPriorityOrderedFreeIpaInstances(stack).stream()
+                    List<InstanceMetaData> instanceMetaDatas = getPriorityOrderedFreeIpaInstances(stack, forceCheckUnreachable).stream()
                             .filter(instanceMetaData -> freeIpaFqdn.isEmpty() || freeIpaFqdn.get().equals(instanceMetaData.getDiscoveryFQDN()))
                             .collect(Collectors.toList());
                     for (Iterator<InstanceMetaData> instanceIterator = instanceMetaDatas.iterator();
@@ -167,9 +167,9 @@ public class FreeIpaClientFactory {
         return !lastInstance;
     }
 
-    private List<InstanceMetaData> getPriorityOrderedFreeIpaInstances(Stack stack) {
+    private List<InstanceMetaData> getPriorityOrderedFreeIpaInstances(Stack stack, boolean forceCheckUnreachable) {
         return stack.getNotDeletedInstanceMetaDataList().stream()
-                .filter(InstanceMetaData::isAvailable)
+                .filter(im -> forceCheckUnreachable || im.isAvailable())
                 .sorted(new PrimaryGatewayFirstThenSortByFqdnComparator())
                 .collect(Collectors.toList());
     }
@@ -179,13 +179,8 @@ public class FreeIpaClientFactory {
         return getFreeIpaClient(stack, false, false, Optional.empty());
     }
 
-    public FreeIpaClient getFreeIpaClientForStack(Stack stack, String freeIpaFqdn) throws FreeIpaClientException {
-        LOGGER.debug("Creating FreeIpaClient for stack {} for {}", stack.getResourceCrn(), freeIpaFqdn);
-        return getFreeIpaClient(stack, false, false, Optional.of(freeIpaFqdn));
-    }
-
-    public FreeIpaClient getFreeIpaClientForStackWithPing(Stack stack, String freeIpaFqdn) throws FreeIpaClientException {
-        LOGGER.debug("Ping the login endpoint and creating FreeIpaClient for stack {} for {}", stack.getResourceCrn(), freeIpaFqdn);
+    public FreeIpaClient getFreeIpaClientForStackForLegacyHealthCheck(Stack stack, String freeIpaFqdn) throws FreeIpaClientException {
+        LOGGER.debug("Creating FreeIpaClient for legacy health checks for stack {} for {}", stack.getResourceCrn(), freeIpaFqdn);
         return getFreeIpaClient(stack, true, true, Optional.of(freeIpaFqdn));
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactoryTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactoryTest.java
@@ -100,7 +100,7 @@ class FreeIpaClientFactoryTest {
     }
 
     @Test
-    void getFreeIpaClientForStackWithPingShouldReturnClientWhenStackStatusIsUnreachable() {
+    void getFreeIpaClientForStackForLegacyHealthCheckShouldReturnClientWhenStackStatusIsUnreachable() {
         Stack stack = createStack();
         stack.setGatewayport(80);
         FreeIpa freeIpa = new FreeIpa();
@@ -113,7 +113,7 @@ class FreeIpaClientFactoryTest {
         stack.setStackStatus(stackStatus);
 
         FreeIpaClientException exception = Assertions.assertThrows(FreeIpaClientException.class, () ->
-                underTest.getFreeIpaClientForStackWithPing(stack, FREEIPP_FQDN));
+                underTest.getFreeIpaClientForStackForLegacyHealthCheck(stack, FREEIPP_FQDN));
 
         verify(clusterProxyService, times(1)).isCreateConfigForClusterProxy(stack);
         verify(tlsSecurityService, times(1)).buildTLSClientConfig(any(), any(), any());
@@ -121,7 +121,7 @@ class FreeIpaClientFactoryTest {
     }
 
     @Test
-    void getFreeIpaClientForStackWithPingShouldReturnClientWhenStackStatusIsValid() {
+    void getFreeIpaClientForStackForLegacyHealthCheckShouldReturnClientWhenStackStatusIsValid() {
         Stack stack = createStack();
         stack.setGatewayport(80);
         FreeIpa freeIpa = new FreeIpa();
@@ -134,32 +134,11 @@ class FreeIpaClientFactoryTest {
         stack.setStackStatus(stackStatus);
 
         FreeIpaClientException exception = Assertions.assertThrows(FreeIpaClientException.class, () ->
-                underTest.getFreeIpaClientForStackWithPing(stack, FREEIPP_FQDN));
+                underTest.getFreeIpaClientForStackForLegacyHealthCheck(stack, FREEIPP_FQDN));
 
         verify(clusterProxyService, times(1)).isCreateConfigForClusterProxy(stack);
         verify(tlsSecurityService, times(1)).buildTLSClientConfig(any(), any(), any());
         Assertions.assertEquals(FreeIpaHostNotAvailableException.class, exception.getCause().getClass());
-    }
-
-    @Test
-    void getFreeIpaClientForStackShouldReturnClientWhenStackStatusIsValidAndFqdnIsProvided() throws FreeIpaClientException {
-        Stack stack = createStack();
-        stack.setGatewayport(80);
-        FreeIpa freeIpa = new FreeIpa();
-        freeIpa.setAdminPassword(new Secret("", ""));
-        when(freeIpaService.findByStack(stack)).thenReturn(freeIpa);
-        when(stackService.getByIdWithListsInTransaction(stack.getId())).thenReturn(stack);
-        when(tlsSecurityService.buildTLSClientConfig(any(), any(), any())).thenReturn(new HttpClientConfig(FREEIPP_FQDN));
-        Status unreachableState = Status.AVAILABLE;
-        StackStatus stackStatus = new StackStatus(stack, unreachableState, "The FreeIPA instance is reachable.", DetailedStackStatus.AVAILABLE);
-        stack.setStackStatus(stackStatus);
-        when(clusterProxyService.isCreateConfigForClusterProxy(stack)).thenReturn(false);
-
-        FreeIpaClientException exception = Assertions.assertThrows(FreeIpaClientException.class, () -> underTest.getFreeIpaClientForStack(stack, FREEIPP_FQDN));
-
-        verify(clusterProxyService, times(1)).isCreateConfigForClusterProxy(stack);
-        verify(tlsSecurityService, times(1)).buildTLSClientConfig(any(), any(), any());
-        Assertions.assertEquals(FreeIpaClientException.class, exception.getCause().getClass());
     }
 
     private Stack createStack() {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
@@ -206,7 +206,7 @@ public class FreeIpaHealthServiceTest {
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(false);
         Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStack());
-        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackWithPing(any(), any())).thenReturn(mockIpaClient);
+        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackForLegacyHealthCheck(any(), any())).thenReturn(mockIpaClient);
         Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getLegacyGoodPayload(HOST1));
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
         Assert.assertEquals(Status.AVAILABLE, response.getStatus());
@@ -223,7 +223,7 @@ public class FreeIpaHealthServiceTest {
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(false);
         Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStack());
-        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackWithPing(any(), any())).thenReturn(mockIpaClient);
+        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackForLegacyHealthCheck(any(), any())).thenReturn(mockIpaClient);
         Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenReturn(getLegacyErrorPayload(HOST1));
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
         Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
@@ -240,7 +240,7 @@ public class FreeIpaHealthServiceTest {
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(false);
         Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStack());
-        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackWithPing(any(), any())).thenReturn(mockIpaClient);
+        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackForLegacyHealthCheck(any(), any())).thenReturn(mockIpaClient);
         Mockito.when(mockIpaClient.serverConnCheck(anyString(), anyString())).thenThrow(ipaClientException);
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
         Assert.assertEquals(Status.UNHEALTHY, response.getStatus());
@@ -259,7 +259,7 @@ public class FreeIpaHealthServiceTest {
         Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(false);
         Mockito.when(mockIpaClient.getHostname()).thenReturn("test.host");
         Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getGoodStackTwoInstances());
-        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackWithPing(any(), any())).thenReturn(mockIpaClient);
+        Mockito.when(freeIpaClientFactory.getFreeIpaClientForStackForLegacyHealthCheck(any(), any())).thenReturn(mockIpaClient);
         Mockito.when(mockIpaClient.serverConnCheck(anyString(), eq(HOST1))).thenReturn(getLegacyGoodPayload(HOST1));
         Mockito.when(mockIpaClient.serverConnCheck(anyString(), eq(HOST2))).thenThrow(ipaClientException);
         HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);


### PR DESCRIPTION
... get stuck in unreachable/unhealthy state

    Fix the FreeIPA health checks so that they run in direct mode on
    instances that have been marked as unhealthy or unreachable.
    7f073c40338aa752cc4af8fe6d210f2a89fd8a7b introduced a regression where
    the instances status of unhealthy and unreachable was stored to the
    database. This caused the health checks to be bypassed for direct mode
    for these instances (they called isAvailable()). This resulted in a
    persistent failure until the instance was repaired. Now, only failed,
    stopped, deleted, and terminated instances use cached instance status
    for the health checks.
    
    Fix the FreeIPA health checks so that the instance status doesn't get
    stuck in an unreachable or unhealthy state.
    7f073c40338aa752cc4af8fe6d210f2a89fd8a7b introduced a regression where
    the instance status was not updated in the case where all instances
    reported a healthy status. It was because the StackStatusCheckerJob
    bypassed the ProviderChecker if the entire cluster reported it was
    available.
    
    This was tested with a local deployment of cloudbreak. The legacy
    health check was tested by first deploying a cluster using an old
    version of cloudbreak.

See detailed description in the commit message.