### PR TITLE
CB-9674 7.2.6 has been branched by RE, and stable enough and we shall…

### DIFF
--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -98,8 +98,8 @@ datalake:
       cert.file: database.crt
       ssl: false
   runtimes:
-    default: "7.2.2"
-    advertised: "7.1.0,7.2.0,7.2.1,7.2.2,7.2.6"
+    default: "7.2.6"
+    advertised: "7.1.0,7.2.0,7.2.1,7.2.2,7.2.6,7.2.7"
     supported: "7.0.2,7.1.0,7.2.0,7.2.1,7.2.2,7.2.6,7.2.7"
 
 secret:

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -67,7 +67,7 @@ integrationtest:
     defaultPassword: Admin123
     defaultPort: 7180
   cloudProvider: MOCK
-  runtimeVersion: 7.2.2
+  runtimeVersion: 7.2.6
   upgrade:
     currentRuntimeVersion: 7.2.0
     targetRuntimeVersion: 7.2.6


### PR DESCRIPTION
… switch over the default version to it

See detailed description in the commit message.