### PR TITLE
CB-9670 [GCP] Propagate the GCS logging parameters everywhere

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -239,6 +239,7 @@ public class TelemetryConverter {
             loggingRequest = new LoggingRequest();
             loggingRequest.setS3(logging.getS3());
             loggingRequest.setAdlsGen2(logging.getAdlsGen2());
+            loggingRequest.setGcs(logging.getGcs());
             loggingRequest.setCloudwatch(CloudwatchParams.copy(logging.getCloudwatch()));
             loggingRequest.setStorageLocation(logging.getStorageLocation());
         }
@@ -298,6 +299,7 @@ public class TelemetryConverter {
             loggingResponse.setStorageLocation(logging.getStorageLocation());
             loggingResponse.setS3(logging.getS3());
             loggingResponse.setAdlsGen2(logging.getAdlsGen2());
+            loggingResponse.setGcs(logging.getGcs());
             loggingResponse.setCloudwatch(CloudwatchParams.copy(logging.getCloudwatch()));
         }
         return loggingResponse;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudGcsView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -283,6 +284,10 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
                     adlsGen2View.setSecure(adlsGen2Params.isSecure());
                     adlsGen2View.setManagedIdentity(adlsGen2Params.getManagedIdentity());
                     return Optional.of(adlsGen2View);
+                } else if (logging.getGcs() != null) {
+                    CloudGcsView cloudGcsView = new CloudGcsView(CloudIdentityType.LOG);
+                    cloudGcsView.setServiceAccountEmail(logging.getGcs().getServiceAccountEmail());
+                    return Optional.of(cloudGcsView);
                 } else if (logging.getCloudwatch() != null) {
                     CloudS3View s3View = new CloudS3View(CloudIdentityType.LOG);
                     s3View.setInstanceProfile(logging.getCloudwatch().getInstanceProfile());


### PR DESCRIPTION
1. The GCS settings were missed in couple of conversion classes.
2. Without this we can not set the datalake using cloud storage.

./gradlew test