### PR TITLE
CB-9675 GCP : Add missing GCP cluster definitions for Datalake creati…

### DIFF
--- a/datalake/src/main/resources/duties/7.2.6/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/gcp/light_duty.json
@@ -1,0 +1,52 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.6 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "e2-standard-2",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 100,
+            "type": "pd-standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "e2-standard-8",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "pd-standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.2.6/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.6/gcp/medium_duty_ha.json
@@ -1,0 +1,72 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.6 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "e2-standard-8",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "pd-standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "gateway",
+      "template": {
+        "instanceType": "e2-standard-8",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "pd-standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "e2-standard-2",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 100,
+            "type": "pd-standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.2.7/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/gcp/light_duty.json
@@ -1,0 +1,52 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.7 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "e2-standard-2",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 100,
+            "type": "pd-standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "e2-standard-8",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "pd-standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.2.7/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/gcp/medium_duty_ha.json
@@ -1,0 +1,72 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.7 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "e2-standard-8",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "pd-standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "gateway",
+      "template": {
+        "instanceType": "e2-standard-8",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "pd-standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "e2-standard-2",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 100,
+            "type": "pd-standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}


### PR DESCRIPTION
…on with 7.2.6 and 7.2.7

1. Without this we are not able to bring up GCP cluster with cloud storage.
2. I guess there is no IT test for the number of cluster definitions, only I see it for cluster templates.