### PR TITLE
ENGESC-4921 Handle Azure custom image with SAS token

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
@@ -72,6 +72,9 @@ public class AzureStorage {
     @Inject
     private AzureImageService azureImageService;
 
+    @Inject
+    private AzureUtils azureUtils;
+
     public ArmAttachedStorageOption getArmAttachedStorageOption(Map<String, String> parameters) {
         String attachedStorageOption = parameters.get("attachedStorageOption");
         if (Strings.isNullOrEmpty(attachedStorageOption)) {
@@ -84,10 +87,11 @@ public class AzureStorage {
         return getCustomImage(client, ac, stack, stack.getImage().getImageName());
     }
 
-    public AzureImage getCustomImage(AzureClient client, AuthenticatedContext ac, CloudStack stack, String imageName) {
+    public AzureImage getCustomImage(AzureClient client, AuthenticatedContext ac, CloudStack stack, String image) {
         String imageResourceGroupName = azureResourceGroupMetadataProvider.getImageResourceGroupName(ac.getCloudContext(), stack);
         AzureCredentialView acv = new AzureCredentialView(ac.getCloudCredential());
         String imageStorageName = getImageStorageName(acv, ac.getCloudContext(), stack);
+        String imageName = azureUtils.getImageNameFromConnectionString(image);
         String imageBlobUri = client.getImageBlobUri(imageResourceGroupName, imageStorageName, IMAGES_CONTAINER, imageName);
         return getCustomImage(imageBlobUri, imageResourceGroupName, ac, client);
     }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
@@ -62,7 +62,7 @@ public class AzureTemplateBuilder {
             CloudStack cloudStack, AzureInstanceTemplateOperation azureInstanceTemplateOperation) {
         try {
             String imageUrl = cloudStack.getImage().getImageName();
-            String imageName = imageUrl.substring(imageUrl.lastIndexOf('/') + 1);
+            String imageName = azureUtils.getImageNameFromConnectionString(imageUrl);
 
             Network network = cloudStack.getNetwork();
             Map<String, Object> model = new HashMap<>();

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -530,4 +530,10 @@ public class AzureUtils {
             return new CloudConnectorException(String.format("%s failed: '%s', please go to Azure Portal for detailed message", actionDescription, e));
         }
     }
+
+    public String getImageNameFromConnectionString(String connectionString) {
+        int begin = connectionString.lastIndexOf('/') + 1;
+        int end = connectionString.contains("?") ? connectionString.indexOf('?') : connectionString.length();
+        return connectionString.substring(begin, end);
+    }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -373,12 +373,12 @@ public class AzureClient {
         });
     }
 
-    public void copyImageBlobInStorageContainer(String resourceGroup, String storageName, String containerName, String sourceBlob) {
+    public void copyImageBlobInStorageContainer(String resourceGroup, String storageName, String containerName, String sourceBlob, String sourceBlobName) {
         LOGGER.debug("copy image in storage container: RG={}, storageName={}, containerName={}, sourceBlob={}",
                 resourceGroup, storageName, containerName, sourceBlob);
         CloudBlobContainer container = getBlobContainer(resourceGroup, storageName, containerName);
         try {
-            CloudPageBlob cloudPageBlob = container.getPageBlobReference(sourceBlob.substring(sourceBlob.lastIndexOf('/') + 1));
+            CloudPageBlob cloudPageBlob = container.getPageBlobReference(sourceBlobName);
             String copyId = cloudPageBlob.startCopy(new URI(sourceBlob));
             LOGGER.debug("Image copy started, copy id: {}", copyId);
         } catch (URISyntaxException e) {
@@ -388,12 +388,12 @@ public class AzureClient {
         }
     }
 
-    public CopyState getCopyStatus(String resourceGroup, String storageName, String containerName, String sourceBlob) {
+    public CopyState getCopyStatus(String resourceGroup, String storageName, String containerName, String sourceBlobName) {
         LOGGER.debug("get image copy status: RG={}, storageName={}, containerName={}, sourceBlob={}",
-                resourceGroup, storageName, containerName, sourceBlob);
+                resourceGroup, storageName, containerName, sourceBlobName);
         CloudBlobContainer container = getBlobContainer(resourceGroup, storageName, containerName);
         try {
-            CloudPageBlob cloudPageBlob = container.getPageBlobReference(sourceBlob.substring(sourceBlob.lastIndexOf('/') + 1));
+            CloudPageBlob cloudPageBlob = container.getPageBlobReference(sourceBlobName);
             LOGGER.debug("Downloading {} container attributes.", container.getName());
             container.downloadAttributes();
             LOGGER.debug("Downloading {} cloudPageBlob attributes.", cloudPageBlob.getName());
@@ -406,9 +406,8 @@ public class AzureClient {
         }
     }
 
-    public String getImageBlobUri(String resourceGroup, String storageName, String containerName, String sourceBlob) {
+    public String getImageBlobUri(String resourceGroup, String storageName, String containerName, String vhdName) {
         CloudBlobContainer blobContainer = getBlobContainer(resourceGroup, storageName, containerName);
-        String vhdName = sourceBlob.substring(sourceBlob.lastIndexOf('/') + 1);
         try {
             CloudPageBlob pageBlobReference = blobContainer.getPageBlobReference(vhdName);
             return pageBlobReference.getUri().toString();

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProvider.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProvider.java
@@ -1,6 +1,10 @@
 package com.sequenceiq.cloudbreak.cloud.azure.util;
 
+import javax.inject.Inject;
+
 import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
 
 @Component
 public class CustomVMImageNameProvider {
@@ -8,8 +12,11 @@ public class CustomVMImageNameProvider {
 
     private static final char DELIMITER = '-';
 
+    @Inject
+    private AzureUtils azureUtils;
+
     public String get(String region, String vhdUri) {
-        String vhdName = vhdUri.substring(vhdUri.lastIndexOf('/') + 1);
+        String vhdName = azureUtils.getImageNameFromConnectionString(vhdUri);
         String name = vhdName + DELIMITER + region.toLowerCase().replaceAll("\\s", "");
         if (name.length() > NAME_MAXIMUM_LENGTH) {
             int diff = name.length() - NAME_MAXIMUM_LENGTH;

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -193,6 +194,7 @@ public class AzureTemplateBuilderTest {
         azureSubnetStrategy = AzureSubnetStrategy.getAzureSubnetStrategy(FILL, Collections.singletonList("existingSubnet"),
                 ImmutableMap.of("existingSubnet", 100L));
         reset(azureUtils);
+        when(azureUtils.getImageNameFromConnectionString(anyString())).thenCallRealMethod();
     }
 
     @Test

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtilsTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtilsTest.java
@@ -103,4 +103,19 @@ public class AzureUtilsTest {
         verify(azurePremiumValidatorService, times(1)).premiumDiskTypeConfigured(azureDiskType);
     }
 
+    @Test
+    public void getImageNameFromConnectionStringWithSASToken() {
+        String url = "https://sequenceiqwestus2.blob.core.windows.net/test/cb-hdp-31-1911052024.vhd"
+                + "?sp=rl&st=2020-10-26T11:45:18Z&se=2020-10-27T11:45:18Z&sv=2019-12-12&sr=b&sig=G6hkDHn7GezwXBzZhQBNLZD5kI3LXgWMvlxGbm1T8WU%3D";
+        String result = underTest.getImageNameFromConnectionString(url);
+        assertEquals("cb-hdp-31-1911052024.vhd", result);
+    }
+
+    @Test
+    public void getImageNameFromConnectionStringWithoutSASToken() {
+        String url = "https://sequenceiqwestus2.blob.core.windows.net/test/cb-hdp-31-1911052024.vhd";
+        String result = underTest.getImageNameFromConnectionString(url);
+        assertEquals("cb-hdp-31-1911052024.vhd", result);
+    }
+
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/CustomVMImageNameProviderTest.java
@@ -1,16 +1,35 @@
 package com.sequenceiq.cloudbreak.cloud.azure.util;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import java.util.regex.Pattern;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
 
 public class CustomVMImageNameProviderTest {
     private static final String AZURE_IMAGE_NAME_REGULAR_EXPRESSION = "^[^_\\W][\\w-._]{0,79}(?<![-.])$";
 
     private static final Pattern IMAGE_NAME_PATTERN = Pattern.compile(AZURE_IMAGE_NAME_REGULAR_EXPRESSION);
 
-    private CustomVMImageNameProvider underTest = new CustomVMImageNameProvider();
+    @Mock
+    private AzureUtils azureUtils;
+
+    @InjectMocks
+    private CustomVMImageNameProvider underTest;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        when(azureUtils.getImageNameFromConnectionString(anyString())).thenCallRealMethod();
+    }
 
     @Test
     public void testNameGenerationWhenRegionAndWhdNameWithDelimiterDoesNotExceedMaximumLength() {


### PR DESCRIPTION
When extracting image name from connection string expect query paramters to follow the image name.

Related 2.9 change: https://github.com/hortonworks/cloudbreak/pull/9314