### PR TITLE
CB-9501 Redbeams logging: env crn was not filled in on mow-dev.

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/logger/MDCBuilder.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/logger/MDCBuilder.java
@@ -52,6 +52,10 @@ public class MDCBuilder {
         MDC.put(LoggerContextKey.ENV_CRN.toString(), env);
     }
 
+    public static void addEnvironmentCrn(String env) {
+        MDC.put(LoggerContextKey.ENVIRONMENT_CRN.toString(), env);
+    }
+
     public static void addResourceCrn(String crn) {
         MDC.put(LoggerContextKey.RESOURCE_CRN.toString(), crn);
     }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/GcpNetworkV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/GcpNetworkV4Parameters.java
@@ -99,4 +99,15 @@ public class GcpNetworkV4Parameters extends MappableBase implements JsonEntity {
         noFirewallRules = getBoolean(parameters, "noFirewallRules");
         noPublicIp = getBoolean(parameters, "noPublicIp");
     }
+
+    @Override
+    public String toString() {
+        return "GcpNetworkV4Parameters{" +
+                "networkId='" + networkId + '\'' +
+                ", subnetId='" + subnetId + '\'' +
+                ", sharedProjectId='" + sharedProjectId + '\'' +
+                ", noPublicIp=" + noPublicIp +
+                ", noFirewallRules=" + noFirewallRules +
+                '}';
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/metrics/CloudbreakMetricService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/metrics/CloudbreakMetricService.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.service.metrics;
 import java.util.ArrayList;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.metrics.AbstractMetricService;
@@ -13,6 +15,8 @@ import com.sequenceiq.cloudbreak.workspace.model.Tenant;
 
 @Service("MetricService")
 public class CloudbreakMetricService extends AbstractMetricService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudbreakMetricService.class);
 
     private static final String METRIC_PREFIX = "cloudbreak";
 
@@ -77,6 +81,7 @@ public class CloudbreakMetricService extends AbstractMetricService {
                 MetricTag.REGION.name(), Optional.ofNullable(stack.getRegion()).orElse("NA")};
 
         long millispassed = System.currentTimeMillis() - startMillis;
+        LOGGER.debug("Image copy duration report: {} ms", millispassed);
         recordTimer(millispassed, MetricType.STACK_IMAGE_COPY, tags);
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4Request.java
@@ -174,4 +174,18 @@ public class AllocateDatabaseServerV4Request extends ProviderParametersBase {
         return aws;
     }
 
+    @Override
+    public String toString() {
+        return "AllocateDatabaseServerV4Request{" +
+                "name='" + name + '\'' +
+                ", environmentCrn='" + environmentCrn + '\'' +
+                ", clusterCrn='" + clusterCrn + '\'' +
+                ", network=" + network +
+                ", databaseServer=" + databaseServer +
+                ", aws=" + aws +
+                ", azure=" + azure +
+                ", gcp=" + gcp +
+                ", sslConfig=" + sslConfig +
+                '}';
+    }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/DatabaseServerV4Request.java
@@ -48,4 +48,12 @@ public class DatabaseServerV4Request extends DatabaseServerV4Base {
     // public void setOracle(OracleParameters oracle) {
     //     this.oracle = oracle;
     // }
+
+    @Override
+    public String toString() {
+        return "DatabaseServerV4Request{" +
+                "connectionUserName='" + connectionUserName + '\'' +
+                ", connectionPassword='" + connectionPassword + '\'' +
+                '}';
+    }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/SslConfigV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/SslConfigV4Request.java
@@ -23,4 +23,10 @@ public class SslConfigV4Request {
         this.sslMode = sslMode;
     }
 
+    @Override
+    public String toString() {
+        return "SslConfigV4Request{" +
+                "sslMode=" + sslMode +
+                '}';
+    }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4StackRequest.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/DatabaseServerV4StackRequest.java
@@ -24,4 +24,10 @@ public class DatabaseServerV4StackRequest extends DatabaseServerV4StackBase {
         this.securityGroup = securityGroup;
     }
 
+    @Override
+    public String toString() {
+        return "DatabaseServerV4StackRequest{" +
+                "securityGroup=" + securityGroup +
+                '}';
+    }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4StackBase.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/NetworkV4StackBase.java
@@ -95,4 +95,13 @@ public class NetworkV4StackBase extends ProviderParametersBase {
     public void setGcp(GcpNetworkV4Parameters gcp) {
         this.gcp = gcp;
     }
+
+    @Override
+    public String toString() {
+        return "NetworkV4StackBase{" +
+                "aws=" + aws +
+                ", azure=" + azure +
+                ", gcp=" + gcp +
+                '}';
+    }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/SecurityGroupV4StackRequest.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/SecurityGroupV4StackRequest.java
@@ -25,4 +25,11 @@ public class SecurityGroupV4StackRequest {
     public void setSecurityGroupIds(Set<String> securityGroupIds) {
         this.securityGroupIds = securityGroupIds;
     }
+
+    @Override
+    public String toString() {
+        return "SecurityGroupV4StackRequest{" +
+                "securityGroupIds=" + securityGroupIds +
+                '}';
+    }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsNetworkV4Parameters.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/aws/AwsNetworkV4Parameters.java
@@ -47,4 +47,11 @@ public class AwsNetworkV4Parameters extends MappableBase {
     public void parse(Map<String, Object> parameters) {
         subnetId = getParameterOrNull(parameters, "subnetId");
     }
+
+    @Override
+    public String toString() {
+        return "AwsNetworkV4Parameters{" +
+                "subnetId='" + subnetId + '\'' +
+                '}';
+    }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureNetworkV4Parameters.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/stacks/azure/AzureNetworkV4Parameters.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.redbeams.api.endpoint.v4.stacks.azure;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -10,8 +12,6 @@ import com.sequenceiq.redbeams.doc.ModelDescriptions.AzureNetworkModelDescriptio
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-
-import java.util.Map;
 
 @ApiModel
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -48,5 +48,12 @@ public class AzureNetworkV4Parameters extends MappableBase {
     @Override
     public void parse(Map<String, Object> parameters) {
         subnets = getParameterOrNull(parameters, SUBNETS);
+    }
+
+    @Override
+    public String toString() {
+        return "AzureNetworkV4Parameters{" +
+                "subnets='" + subnets + '\'' +
+                '}';
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -14,21 +14,22 @@ import javax.validation.constraints.NotNull;
 import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
+import com.sequenceiq.authorization.annotation.CheckPermissionByRequestProperty;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrnList;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceName;
-import com.sequenceiq.authorization.annotation.CheckPermissionByRequestProperty;
 import com.sequenceiq.authorization.annotation.DisableCheckPermissions;
 import com.sequenceiq.authorization.annotation.InternalOnly;
+import com.sequenceiq.authorization.annotation.RequestObject;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.annotation.ResourceCrnList;
 import com.sequenceiq.authorization.annotation.ResourceName;
-import com.sequenceiq.authorization.annotation.RequestObject;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.security.internal.InitiatorUserCrn;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.validation.ValidCrn;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.request.CreateDatabaseV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.responses.CreateDatabaseV4Response;
@@ -100,6 +101,7 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.CREATE_DATABASE_SERVER)
     public DatabaseServerStatusV4Response create(AllocateDatabaseServerV4Request request) {
+        MDCBuilder.addEnvironmentCrn(request.getEnvironmentCrn());
         DBStack dbStack = dbStackConverter.convert(request, ThreadBasedUserCrnProvider.getUserCrn());
         DBStack savedDBStack = redbeamsCreationService.launchDatabaseServer(dbStack, request.getClusterCrn());
         return converterUtil.convert(savedDBStack, DatabaseServerStatusV4Response.class);
@@ -121,6 +123,7 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
 
     @CheckPermissionByAccount(action = AuthorizationResourceAction.REGISTER_DATABASE_SERVER)
     public DatabaseServerV4Response register(DatabaseServerV4Request request) {
+        MDCBuilder.addEnvironmentCrn(request.getEnvironmentCrn());
         DatabaseServerConfig server = databaseServerConfigService.create(converterUtil.convert(request, DatabaseServerConfig.class), DEFAULT_WORKSPACE, false);
         //notify(ResourceEvent.DATABASE_SERVER_CONFIG_CREATED);
         return converterUtil.convert(server, DatabaseServerV4Response.class);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsStartService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsStartService.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.RedbeamsFlowManager;
@@ -28,6 +29,7 @@ public class RedbeamsStartService {
 
     public void startDatabaseServer(String crn) {
         DBStack dbStack = dbStackService.getByCrn(crn);
+        MDCBuilder.addEnvironmentCrn(dbStack.getEnvironmentId());
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Start called for: {}", dbStack);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsStopService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsStopService.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.RedbeamsFlowManager;
@@ -28,6 +29,7 @@ public class RedbeamsStopService {
 
     public void stopDatabaseServer(String crn) {
         DBStack dbStack = dbStackService.getByCrn(crn);
+        MDCBuilder.addEnvironmentCrn(dbStack.getEnvironmentId());
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Stop called for: {}", dbStack);

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsTerminationService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsTerminationService.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.flow.service.FlowCancelService;
 import com.sequenceiq.redbeams.api.endpoint.v4.ResourceStatus;
 import com.sequenceiq.redbeams.api.model.common.DetailedDBStackStatus;
@@ -59,6 +60,7 @@ public class RedbeamsTerminationService {
         }
 
         DBStack dbStack = dbStackService.getByCrn(crn);
+        MDCBuilder.addEnvironmentCrn(dbStack.getEnvironmentId());
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Terminate called for: {} with force: {}", dbStack, force);
         }


### PR DESCRIPTION
It was hard to find log messages cross-service when looking up by env-crn. This commit adds env-crn to MDC context in controller when it is present in the request body but not in request parameters.
Also, redbeams create parameters received toStrings to be logged properly.
Unrelated change: one-line log message to track azure image copy.

See detailed description in the commit message.