### PR TITLE
CB-9757 change-image does not work as part of the OS upgrade

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateFlowTriggerCondition.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateFlowTriggerCondition.java
@@ -4,10 +4,9 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
-import com.sequenceiq.flow.core.FlowTriggerCondition;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.flow.core.FlowTriggerCondition;
 
 @Component
 public class StackImageUpdateFlowTriggerCondition implements FlowTriggerCondition {
@@ -17,7 +16,6 @@ public class StackImageUpdateFlowTriggerCondition implements FlowTriggerConditio
     @Override
     public boolean isFlowTriggerable(Long stackId) {
         StackView stack = stackService.getViewByIdWithoutAuth(stackId);
-        Status clusterStatus = stack.getClusterView().getStatus();
-        return stack.isAvailable() && (clusterStatus.isAvailable());
+        return stack.isAvailable();
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
@@ -168,6 +168,8 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
                         acceptFlow(payload, acceptResult);
                         logFlowId(flowId);
                         flow.sendEvent(key, flowParameters.getFlowTriggerUserCrn(), payload, flowParameters.getSpanContext());
+                    } else {
+                        LOGGER.debug("Flow is not triggerable: key: {}, payload: {}", key, payload);
                     }
                 } else {
                     handleFlowControlEventAndTerminateOnFail(key, payload, flowParameters, flowChainId, flowId);


### PR DESCRIPTION
Previously, we had a simple check in the upgrade flow to see if we
need to upgrade CM server itself. In case of OS upgrade, obviously
we don't need it since the versions do not change. However, we
removed this check, because we can only update the CM license as part
of this flow step. This flow step also executes the user id migration
script and for that we need to stop all the services in CM. The next
step in the upgrade flow is the CDP upgrade which we skip since the
versions do not change. The CDP upgrade flow step would start the
services once the upgrade is complete. The change image flow consists
of 3 different flows:
- Stack sync
- Cluster sync
- Repair all instances (to replace the images)
The cluster sync flow will see that we've stopped the services in CM
and sets the cluster's status to STOPPED. However, in the flow config
of the change image we only allow it when both stack and cluster are
available. There is no point that the cluster should be in available
state so as part of this fix I'm removing this condition.

See detailed description in the commit message.