### PR TITLE
CB-9487 - [ASRG] Eliminate resource leakage if deleting during ARM te…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -174,14 +174,14 @@ public class AzureClient {
     }
 
     public ResourceStatus getTemplateDeploymentStatus(String resourceGroupName, String deploymentName) {
-        return handleAuthException(() -> Optional.ofNullable(azure.deployments().getByResourceGroup(resourceGroupName, deploymentName)))
+        return handleAuthException(() -> Optional.ofNullable(getTemplateDeployment(resourceGroupName, deploymentName)))
                 .map(Deployment::provisioningState)
                 .map(AzureStatusMapper::mapResourceStatus)
                 .orElse(ResourceStatus.DELETED);
     }
 
     public CommonStatus getTemplateDeploymentCommonStatus(String resourceGroupName, String deploymentName) {
-        return handleAuthException(() -> Optional.ofNullable(azure.deployments().getByResourceGroup(resourceGroupName, deploymentName)))
+        return handleAuthException(() -> Optional.ofNullable(getTemplateDeployment(resourceGroupName, deploymentName)))
                 .map(Deployment::provisioningState)
                 .map(AzureStatusMapper::mapCommonStatus)
                 .orElse(CommonStatus.DETACHED);
@@ -196,11 +196,11 @@ public class AzureClient {
     }
 
     public DeploymentOperations getTemplateDeploymentOperations(String resourceGroupName, String deploymentName) {
-        return handleAuthException(() -> azure.deployments().getByResourceGroup(resourceGroupName, deploymentName).deploymentOperations());
+        return handleAuthException(() -> getTemplateDeployment(resourceGroupName, deploymentName).deploymentOperations());
     }
 
-    public void cancelTemplateDeployments(String resourceGroupName, String deploymentName) {
-        handleAuthException(() -> azure.deployments().getByResourceGroup(resourceGroupName, deploymentName).cancel());
+    public void cancelTemplateDeployment(String resourceGroupName, String deploymentName) {
+        handleAuthException(() -> getTemplateDeployment(resourceGroupName, deploymentName).cancel());
     }
 
     public StorageAccounts getStorageAccounts() {
@@ -323,9 +323,13 @@ public class AzureClient {
         return azure.disks().getByResourceGroup(resourceGroupName, diskName);
     }
 
-    public Observable<String> deleteManagedDiskAsync(Collection<String> ids) {
+    public Observable<String> deleteManagedDisksAsync(Collection<String> ids) {
         LOGGER.debug("delete managed disk: id={}", ids);
         return handleAuthException(() -> azure.disks().deleteByIdsAsync(ids));
+    }
+
+    public Completable deleteManagedDiskAsync(String resourceGroup, String name) {
+        return handleAuthException(() -> azure.disks().deleteByResourceGroupAsync(resourceGroup, name));
     }
 
     public DiskSkuTypes convertAzureDiskTypeToDiskSkuTypes(AzureDiskType diskType) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/status/AzureStatusMapper.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/status/AzureStatusMapper.java
@@ -30,6 +30,7 @@ public class AzureStatusMapper {
                 mappedStatus =  ResourceStatus.CREATED;
                 break;
             case "Accepted":
+            case "Running":
             default:
                 mappedStatus =  ResourceStatus.IN_PROGRESS;
                 break;

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTransientDeploymentService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTransientDeploymentService.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.cloud.azure.template;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.microsoft.azure.management.resources.Deployment;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureCloudResourceService;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+
+@Component
+public class AzureTransientDeploymentService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureTransientDeploymentService.class);
+
+    @Inject
+    private AzureCloudResourceService azureCloudResourceService;
+
+    public List<CloudResource> handleTransientDeployment(AzureClient client, String resourceGroupName, String deploymentName) {
+        ResourceStatus deploymentStatus = client.getTemplateDeploymentStatus(resourceGroupName, deploymentName);
+        if (deploymentStatus.isTransient()) {
+            LOGGER.info("Template deployment {} has transient status {} , cancelling it now.", deploymentName, deploymentStatus);
+            Deployment deployment = client.getTemplateDeployment(resourceGroupName, deploymentName);
+            deployment.cancel();
+            List<CloudResource> deployedResources = azureCloudResourceService.getDeploymentCloudResources(deployment);
+            LOGGER.info("Found resources to be removed: {}", deployedResources);
+            return deployedResources;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceServiceTest.java
@@ -203,11 +203,10 @@ public class AzureCloudResourceServiceTest {
         when(osDisk.managedDisk()).thenReturn(managedDiskParameters);
         when(managedDiskParameters.id()).thenReturn("diskId1");
         when(osDisk.name()).thenReturn("diskName1");
-        when(ac.getParameter(AzureClient.class)).thenReturn(azureClient);
 
         when(azureClient.getVirtualMachines("resourceGroupName")).thenReturn(virtualMachines);
 
-        List<CloudResource> osDiskResources = underTest.getAttachedOsDiskResources(ac, List.of(vm1, vm2, vm3), "resourceGroupName");
+        List<CloudResource> osDiskResources = underTest.getAttachedOsDiskResources(List.of(vm1, vm2, vm3), "resourceGroupName", azureClient);
 
         assertEquals(1, osDiskResources.size());
         CloudResource diskResource = osDiskResources.get(0);

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperServiceTest.java
@@ -47,7 +47,7 @@ class AzureTerminationHelperServiceTest {
 
     private static final String NSG_ID = "securityGroupId";
 
-    private static final String MANAGED_DISK_ID = "managedDiskId";
+    private static final String MANAGED_DISK_NAME = "managedDiskName";
 
     private static final List<String> AVAILABILITY_SET_NAME_LIST = List.of(AVAILABILITY_SET_NAME);
 
@@ -55,7 +55,7 @@ class AzureTerminationHelperServiceTest {
 
     private static final List<String> NETWORK_INTERFACE_NAME_LIST = List.of(NETWORK_INTERFACE_NAME);
 
-    private static final List<String> MANAGED_DISK_ID_LIST = List.of(MANAGED_DISK_ID);
+    private static final List<String> MANAGED_DISK_NAME_LIST = List.of(MANAGED_DISK_NAME);
 
     private static final List<String> NSG_ID_LIST = List.of(NSG_ID);
 
@@ -112,7 +112,7 @@ class AzureTerminationHelperServiceTest {
         verify(azureUtils).waitForDetachNetworkInterfaces(eq(ac), any(), eq(RESOURCE_GROUP_NAME), eq(NETWORK_INTERFACE_NAME_LIST));
         verify(azureUtils).deleteNetworkInterfaces(any(), eq(RESOURCE_GROUP_NAME), eq(NETWORK_INTERFACE_NAME_LIST));
         verify(azureUtils).deletePublicIps(any(), eq(RESOURCE_GROUP_NAME), eq(PUBLIC_ADDRESS_NAME_LIST));
-        verify(azureUtils).deleteManagedDisks(any(), eq(MANAGED_DISK_ID_LIST));
+        verify(azureUtils).deleteManagedDisks(any(), eq(RESOURCE_GROUP_NAME), eq(MANAGED_DISK_NAME_LIST));
         verify(azureComputeResourceService).deleteComputeResources(any(), any(), eq(volumeSets), any());
         verify(azureUtils, never()).deleteAvailabilitySets(any(), eq(RESOURCE_GROUP_NAME), anyCollection());
         verify(azureUtils, never()).deleteSecurityGroups(any(), eq(NSG_ID_LIST));
@@ -129,7 +129,7 @@ class AzureTerminationHelperServiceTest {
         verify(azureUtils).waitForDetachNetworkInterfaces(eq(ac), any(), eq(RESOURCE_GROUP_NAME), eq(NETWORK_INTERFACE_NAME_LIST));
         verify(azureUtils).deleteNetworkInterfaces(any(), eq(RESOURCE_GROUP_NAME), eq(NETWORK_INTERFACE_NAME_LIST));
         verify(azureUtils).deletePublicIps(any(), eq(RESOURCE_GROUP_NAME), eq(PUBLIC_ADDRESS_NAME_LIST));
-        verify(azureUtils).deleteManagedDisks(any(), eq(MANAGED_DISK_ID_LIST));
+        verify(azureUtils).deleteManagedDisks(any(), eq(RESOURCE_GROUP_NAME), eq(MANAGED_DISK_NAME_LIST));
         verify(azureUtils).deleteAvailabilitySets(any(), any(), eq(AVAILABILITY_SET_NAME_LIST));
 
         verify(azureComputeResourceService).deleteComputeResources(any(), any(), eq(volumeSets), any());
@@ -142,7 +142,7 @@ class AzureTerminationHelperServiceTest {
                 createCloudResource(ResourceType.AZURE_INSTANCE, INSTANCE_NAME),
                 createCloudResource(ResourceType.AZURE_NETWORK_INTERFACE, NETWORK_INTERFACE_NAME),
                 createCloudResource(ResourceType.AZURE_PUBLIC_IP, PUBLIC_ADDRESS_NAME),
-                createCloudResource(ResourceType.AZURE_DISK, "aDisk", MANAGED_DISK_ID),
+                createCloudResource(ResourceType.AZURE_DISK, MANAGED_DISK_NAME),
                 createCloudResource(ResourceType.AZURE_AVAILABILITY_SET, AVAILABILITY_SET_NAME),
                 createCloudResource(ResourceType.AZURE_SUBNET, SUBNET_NAME),
                 createCloudResource(ResourceType.AZURE_VOLUMESET, VOLUMESET_NAME),

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTransientDeploymentServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTransientDeploymentServiceTest.java
@@ -1,0 +1,104 @@
+package com.sequenceiq.cloudbreak.cloud.azure.template;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.microsoft.azure.management.resources.Deployment;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureCloudResourceService;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.ResourceType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AzureTransientDeploymentServiceTest {
+
+    private static final String RESOURCE_GROUP = "resource_group";
+
+    private static final String DEPLOYMENT_NAME = "deployment_name";
+
+    private static final String INSTANCE_1 = "instance-1";
+
+    private static final String STORAGE_1 = "storage_1";
+
+    private static final String IP_1 = "ip_1";
+
+    @Mock
+    private AzureClient client;
+
+    @Mock
+    private Deployment deployment;
+
+    @Mock
+    private AzureCloudResourceService azureCloudResourceService;
+
+    @InjectMocks
+    private AzureTransientDeploymentService underTest;
+
+    @Test
+    public void testEmptyTransientDeploymentCancelled() {
+
+        when(client.getTemplateDeploymentStatus(RESOURCE_GROUP, DEPLOYMENT_NAME)).thenReturn(ResourceStatus.IN_PROGRESS);
+        when(client.getTemplateDeployment(RESOURCE_GROUP, DEPLOYMENT_NAME)).thenReturn(deployment);
+        when(azureCloudResourceService.getDeploymentCloudResources(deployment)).thenReturn(Collections.emptyList());
+
+        List<CloudResource> deployedResources = underTest.handleTransientDeployment(client, RESOURCE_GROUP, DEPLOYMENT_NAME);
+
+        verify(client).getTemplateDeploymentStatus(RESOURCE_GROUP, DEPLOYMENT_NAME);
+        verify(client).getTemplateDeployment(RESOURCE_GROUP, DEPLOYMENT_NAME);
+        verify(deployment).cancel();
+        assertEquals(0, deployedResources.size());
+    }
+
+    @Test
+    public void testNonEmptyTransientDeploymentCancelled() {
+        CloudResource vm1 = createCloudResource(INSTANCE_1, ResourceType.AZURE_INSTANCE);
+        CloudResource storage1 = createCloudResource(STORAGE_1, ResourceType.AZURE_STORAGE);
+        CloudResource ip1 = createCloudResource(IP_1, ResourceType.AZURE_PUBLIC_IP);
+
+        when(client.getTemplateDeploymentStatus(RESOURCE_GROUP, DEPLOYMENT_NAME)).thenReturn(ResourceStatus.IN_PROGRESS);
+        when(client.getTemplateDeployment(RESOURCE_GROUP, DEPLOYMENT_NAME)).thenReturn(deployment);
+        when(azureCloudResourceService.getDeploymentCloudResources(deployment)).thenReturn(List.of(vm1, storage1, ip1));
+
+        List<CloudResource> deployedResources = underTest.handleTransientDeployment(client, RESOURCE_GROUP, DEPLOYMENT_NAME);
+
+        verify(client).getTemplateDeploymentStatus(RESOURCE_GROUP, DEPLOYMENT_NAME);
+        verify(client).getTemplateDeployment(RESOURCE_GROUP, DEPLOYMENT_NAME);
+        verify(deployment).cancel();
+        assertEquals(3, deployedResources.size());
+    }
+
+    @Test
+    public void testNonTransientDeploymentNotCancelled() {
+        when(client.getTemplateDeploymentStatus(RESOURCE_GROUP, DEPLOYMENT_NAME)).thenReturn(ResourceStatus.CREATED);
+
+        List<CloudResource> deployedResources = underTest.handleTransientDeployment(client, RESOURCE_GROUP, DEPLOYMENT_NAME);
+
+        verify(client).getTemplateDeploymentStatus(RESOURCE_GROUP, DEPLOYMENT_NAME);
+        verify(client,  times(0)).getTemplateDeployment(RESOURCE_GROUP, DEPLOYMENT_NAME);
+        verify(deployment, times(0)).cancel();
+        assertEquals(0, deployedResources.size());
+    }
+
+    private CloudResource createCloudResource(String name, ResourceType resourceType) {
+        return new CloudResource.Builder()
+                .name(name)
+                .status(CommonStatus.CREATED)
+                .type(resourceType)
+                .instanceId("instanceId")
+                .params(Collections.emptyMap())
+                .build();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
@@ -81,11 +81,11 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
             if (InstanceGroupType.GATEWAY.equals(instanceGroup.getInstanceGroupType())) {
                 Optional<String> primaryGatewayHostName = instanceMetaDataService.getPrimaryGatewayDiscoveryFQDNByInstanceGroup(stack.getId(),
                         instanceGroup.getId());
-                boolean primaryGatewayReparaiable = primaryGatewayHostName.isPresent() && hostNames.contains(primaryGatewayHostName.get());
-                boolean singlePrimaryGatewayRepairable = primaryGatewayReparaiable && !stack.isMultipleGateway();
+                boolean primaryGatewayRepairable = primaryGatewayHostName.isPresent() && hostNames.contains(primaryGatewayHostName.get());
+                boolean singlePrimaryGatewayRepairable = primaryGatewayRepairable && !stack.isMultipleGateway();
                 if (singlePrimaryGatewayRepairable) {
                     repairConfig.setSinglePrimaryGateway(new Repair(instanceGroup.getGroupName(), hostGroup.getName(), hostNames));
-                } else if (primaryGatewayReparaiable) {
+                } else if (primaryGatewayRepairable) {
                     repairConfig.setChangePGW(true);
                     repairConfig.addRepairs(new Repair(instanceGroup.getGroupName(), hostGroup.getName(), hostNames));
                 }

--- a/environment/src/main/java/com/sequenceiq/environment/network/EnvironmentNetworkService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/EnvironmentNetworkService.java
@@ -108,19 +108,26 @@ public class EnvironmentNetworkService {
                 .withEnvId(environment.getId())
                 .withAccountId(environment.getAccountId())
                 .withUserId(environment.getCreator())
-                .withRegion(environment.getLocation().getName());
-        getResourceGroupName(environment.getNetwork()).ifPresent(builder::withResourceGroup);
-        getNetworkId(environment.getNetwork()).ifPresent(builder::withNetworkId);
+                .withRegion(environment.getLocation().getName())
+                .withNetworkId(getNetworkId(environment.getNetwork(), environment.getName()));
+        getResourceGroupName(environment).ifPresent(builder::withResourceGroup);
         builder.withExisting(environment.getNetwork().getRegistrationType() == RegistrationType.EXISTING);
         return builder.build();
     }
 
-    private Optional<String> getResourceGroupName(NetworkDto networkDto) {
-        return Optional.of(networkDto).map(NetworkDto::getAzure).map(AzureParams::getResourceGroupName);
+    private Optional<String> getResourceGroupName(EnvironmentDto environmentDto) {
+        return Optional.of(environmentDto)
+                .map(EnvironmentDto::getParameters)
+                .map(ParametersDto::getAzureParametersDto)
+                .map(AzureParametersDto::getAzureResourceGroupDto)
+                .map(AzureResourceGroupDto::getName);
     }
 
-    private Optional<String> getNetworkId(NetworkDto networkDto) {
-        return Optional.of(networkDto).map(NetworkDto::getAzure).map(AzureParams::getNetworkId);
+    private String getNetworkId(NetworkDto networkDto, String envName) {
+        return Optional.of(networkDto)
+                .map(NetworkDto::getAzure)
+                .map(AzureParams::getNetworkId)
+                .orElse(envName);
     }
 
     private boolean isSingleResourceGroup(EnvironmentDto environmentDto) {

--- a/environment/src/test/java/com/sequenceiq/environment/network/EnvironmentNetworkServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/network/EnvironmentNetworkServiceTest.java
@@ -194,7 +194,7 @@ class EnvironmentNetworkServiceTest {
         assertEquals(STACK_NAME, argumentCaptor.getValue().getStackName());
         assertEquals(cloudCredential, argumentCaptor.getValue().getCloudCredential());
         assertEquals(environmentDto.getLocation().getName(), argumentCaptor.getValue().getRegion());
-        assertEquals(environmentDto.getNetwork().getAzure().getResourceGroupName(), argumentCaptor.getValue().getResourceGroup());
+        assertEquals(environmentDto.getParameters().getAzureParametersDto().getAzureResourceGroupDto().getName(), argumentCaptor.getValue().getResourceGroup());
     }
 
     @ParameterizedTest
@@ -216,7 +216,7 @@ class EnvironmentNetworkServiceTest {
         assertEquals(STACK_NAME, argumentCaptor.getValue().getStackName());
         assertEquals(cloudCredential, argumentCaptor.getValue().getCloudCredential());
         assertEquals(environmentDto.getLocation().getName(), argumentCaptor.getValue().getRegion());
-        assertEquals(environmentDto.getNetwork().getAzure().getResourceGroupName(), argumentCaptor.getValue().getResourceGroup());
+        assertEquals(environmentDto.getParameters().getAzureParametersDto().getAzureResourceGroupDto().getName(), argumentCaptor.getValue().getResourceGroup());
         assertTrue(argumentCaptor.getValue().isSingleResourceGroup());
     }
 


### PR DESCRIPTION
…mplate deployment

This contains a fix for the following scenarios:

1. FreeIPA/SDX/RedBeams/DataHub deployment is launched
2. ARM template is sent in
3. Deletion request posted via template deployment

There are some edge cases which were not covered

1. template delete arrives when OS disks do not have valid id
2. template delete arrives when VM instance does not have valid id
3. deletion flow cleans up properly but in between the deletion end and the create flow interrupt, new resources get created  



