### PR TITLE
CB-9783 update SDX HA to final shape.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
@@ -11,33 +11,40 @@
         "cardinality": 2,
         "refName": "master",
         "roleConfigGroupsRefNames": [
-          "hdfs-DATANODE-BASE",
-          "hdfs-JOURNALNODE-BASE",
-          "hdfs-FAILOVERCONTROLLER-BASE",
-          "hdfs-NAMENODE-BASE",
           "hive-HIVEMETASTORE-BASE",
-          "zookeeper-SERVER-BASE",
-          "kafka-GATEWAY-BASE",
-          "kafka-KAFKA_BROKER-BASE",
-          "solr-SOLR_SERVER-BASE",
           "ranger-RANGER_ADMIN-BASE",
           "hdfs-GATEWAY-BASE",
+          "hive-GATEWAY-BASE",
+          "hbase-GATEWAY-BASE",
+          "solr-GATEWAY-BASE",
+          "kafka-GATEWAY-BASE",
+          "hdfs-NAMENODE-BASE",
+          "hdfs-FAILOVERCONTROLLER-BASE"
+        ]
+      },
+      {
+        "cardinality": 2,
+        "refName": "gateway",
+        "roleConfigGroupsRefNames": [
+          "atlas-ATLAS_SERVER-BASE",
+          "ranger-RANGER_ADMIN-BASE",
+          "zookeeper-SERVER-BASE",
+          "knox-KNOX_GATEWAY-BASE",
+          "solr-GATEWAY-BASE",
+          "hdfs-GATEWAY-BASE",
+          "kafka-GATEWAY-BASE",
           "hive-GATEWAY-BASE",
           "hbase-GATEWAY-BASE"
         ]
       },
       {
-        "cardinality": 1,
-        "refName": "gateway",
+        "cardinality": 3,
+        "refName": "core",
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
           "hdfs-JOURNALNODE-BASE",
-          "ranger-RANGER_ADMIN-BASE",
-          "ranger-RANGER_USERSYNC-BASE",
-          "ranger-RANGER_TAGSYNC-BASE",
-          "zookeeper-SERVER-BASE",
-          "knox-KNOX_GATEWAY-BASE",
-          "atlas-ATLAS_SERVER-BASE",
+          "kafka-KAFKA_BROKER-BASE",
+          "solr-SOLR_SERVER-BASE",
           "hbase-REGIONSERVER-BASE",
           "hbase-MASTER-BASE",
           "solr-GATEWAY-BASE",
@@ -45,6 +52,15 @@
           "kafka-GATEWAY-BASE",
           "hive-GATEWAY-BASE",
           "hbase-GATEWAY-BASE"
+        ]
+      },
+      {
+        "cardinality": 1,
+        "refName": "auxiliary",
+        "roleConfigGroupsRefNames": [
+          "ranger-RANGER_USERSYNC-BASE",
+          "ranger-RANGER_TAGSYNC-BASE",
+          "zookeeper-SERVER-BASE"
         ]
       },
       {
@@ -113,7 +129,7 @@
               },
               {
                 "name": "ranger.audit.solr.no.shards",
-                "value": "1"
+                "value": "3"
               },
               {
                 "name": "ranger.audit.solr.max.shards.per.node",
@@ -166,7 +182,7 @@
               },
               {
                 "name": "atlas_solr_shards",
-                "value": "2"
+                "value": "3"
               },
               {
                 "name": "atlas_solr_replication_factor",
@@ -308,21 +324,21 @@
             "roleType": "GATEWAY"
           },
           {
-              "base": true,
-              "refName": "hdfs-FAILOVERCONTROLLER-BASE",
-              "roleType": "FAILOVERCONTROLLER"
-            },
-            {
-              "base": true,
-              "configs": [
-                {
-                  "name": "dfs_journalnode_edits_dir",
-                  "value": "/dfs/jn"
-                }
-              ],
-              "refName": "hdfs-JOURNALNODE-BASE",
-              "roleType": "JOURNALNODE"
-            }
+            "base": true,
+            "refName": "hdfs-FAILOVERCONTROLLER-BASE",
+            "roleType": "FAILOVERCONTROLLER"
+          },
+          {
+            "base": true,
+            "configs": [
+              {
+                "name": "dfs_journalnode_edits_dir",
+                "value": "/dfs/jn"
+              }
+            ],
+            "refName": "hdfs-JOURNALNODE-BASE",
+            "roleType": "JOURNALNODE"
+          }
         ],
         "serviceConfigs": [
           {
@@ -361,51 +377,11 @@
           },
           {
             "name": "default.replication.factor",
-            "value": "2"
-          },
-          {
-            "name": "offsets.topic.replication.factor",
-            "value": "2"
-          },
-          {
-            "name": "transaction.state.log.replication.factor",
-            "value": "2"
-          },
-          {
-            "name": "offset.storage.replication.factor",
-            "value": "2"
-          },
-          {
-            "name": "config.storage.replication.factor",
-            "value": "2"
-          },
-          {
-            "name": "status.storage.replication.factor",
-            "value": "2"
-          },
-          {
-            "name": "transaction.state.log.min.isr",
-            "value": "1"
+            "value": "3"
           },
           {
             "name": "min.insync.replicas",
-            "value": "1"
-          },
-          {
-            "name": "unclean.leader.election.enable",
-            "value": "true"
-          },
-          {
-            "name": "service_config_suppression_offsets.topic.replication.factor",
-            "value": "true"
-          },
-          {
-            "name": "service_config_suppression_transaction.state.log.replication.factor",
-            "value": "true"
-          },
-          {
-            "name": "service_config_suppression_kafka_broker_count_validator",
-            "value": "true"
+            "value": "2"
           }
         ],
         "serviceType": "KAFKA"

--- a/datalake/src/main/resources/duties/7.2.7/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/aws/medium_duty_ha.json
@@ -11,7 +11,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "m5.xlarge",
         "attachedVolumes": [
           {
             "count": 1,
@@ -31,6 +31,46 @@
     {
       "name": "gateway",
       "template": {
+        "instanceType": "m5.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 2,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "core",
+      "template": {
+        "instanceType": "m5.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 3,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "auxiliary",
+      "template": {
         "instanceType": "m5.xlarge",
         "attachedVolumes": [
           {
@@ -44,7 +84,7 @@
         }
       },
       "nodeCount": 1,
-      "type": "GATEWAY",
+      "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []
     },

--- a/datalake/src/main/resources/duties/7.2.7/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/azure/medium_duty_ha.json
@@ -43,8 +43,48 @@
           "size": 100
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "core",
+      "template": {
+        "instanceType": "Standard_D4s_v3",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "StandardSSD_LRS"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 3,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "auxiliary",
+      "template": {
+        "instanceType": "Standard_D16s_v3",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "StandardSSD_LRS"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []
     },

--- a/datalake/src/main/resources/duties/7.2.7/yarn/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/yarn/medium_duty_ha.json
@@ -27,8 +27,30 @@
           "memory": 16384
         }
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "GATEWAY"
+    },
+    {
+      "name": "core",
+      "template": {
+        "yarn": {
+          "cpus": 4,
+          "memory": 16384
+        }
+      },
+      "nodeCount": 3,
+      "type": "CORE"
+    },
+    {
+      "name": "auxiliary",
+      "template": {
+        "yarn": {
+          "cpus": 4,
+          "memory": 16384
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE"
     },
     {
       "name": "idbroker",


### PR DESCRIPTION
For 7.2.7+, SDX HA now has 2 gateway nodes and additional 3 core node that primarily
runs Hadoop services that are dependencies of other groups.  As a result there is
reshuffling of where services are installed.  This also includes renaming master
to main.

See detailed description in the commit message.