### PR TITLE
CB-9757 change-image does not work as part of the OS upgrade

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -69,8 +69,8 @@ public interface ClusterApi {
         clusterModificationService().stopCluster(disableKnoxAutorestart);
     }
 
-    default int startCluster(Set<InstanceMetaData> hostsInCluster) throws CloudbreakException {
-        return clusterModificationService().startCluster(hostsInCluster);
+    default int startCluster() throws CloudbreakException {
+        return clusterModificationService().startCluster();
     }
 
     default Map<String, String> gatherInstalledParcels(String stackName) {

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -19,7 +19,7 @@ public interface ClusterModificationService {
 
     void stopCluster(boolean full) throws CloudbreakException;
 
-    int startCluster(Set<InstanceMetaData> hostsInCluster) throws CloudbreakException;
+    int startCluster() throws CloudbreakException;
 
     Map<String, String> getComponentsByCategory(String blueprintName, String hostGroupName);
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosService.java
@@ -2,8 +2,6 @@ package com.sequenceiq.cloudbreak.cm;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_1_0;
 
-import java.util.Collections;
-
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -19,8 +17,8 @@ import com.cloudera.api.swagger.model.ApiCommand;
 import com.cloudera.api.swagger.model.ApiConfigureForKerberosArguments;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiClientProvider;
-import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientInitException;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -65,7 +63,7 @@ public class ClouderaManagerKerberosService {
             clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, generateCredentials.getId());
             ApiCommand deployClusterConfig = clustersResourceApi.deployClientConfig(cluster.getName());
             clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, deployClusterConfig.getId());
-            modificationService.startCluster(Collections.emptySet());
+            modificationService.startCluster();
         }
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -543,7 +543,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
     }
 
     @Override
-    public int startCluster(Set<InstanceMetaData> hostsInCluster) throws CloudbreakException {
+    public int startCluster() throws CloudbreakException {
         try {
             startClouderaManager(stack, apiClient);
             startAgents(stack, apiClient);

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosServiceTest.java
@@ -2,7 +2,6 @@ package com.sequenceiq.cloudbreak.cm;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -122,7 +121,7 @@ public class ClouderaManagerKerberosServiceTest {
         verify(clouderaManagerPollingServiceProvider).startPollingCmKerberosJob(stack, client, BigDecimal.TEN);
         verify(clouderaManagerPollingServiceProvider).startPollingCmKerberosJob(stack, client, BigDecimal.ZERO);
         verify(clustersResourceApi).deployClientConfig(cluster.getName());
-        verify(modificationService).startCluster(anySet());
+        verify(modificationService).startCluster();
     }
 
     @Test

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
@@ -69,6 +69,7 @@ public class ClusterManagerUpgradeService {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         stopClusterServices(stack);
         upgradeClusterManager(stack);
+        startClusterServices(stack);
     }
 
     private void upgradeClusterManager(Stack stack) throws CloudbreakOrchestratorException {
@@ -83,6 +84,10 @@ public class ClusterManagerUpgradeService {
 
     private void stopClusterServices(Stack stack) throws CloudbreakException {
         clusterApiConnectors.getConnector(stack).stopCluster(true);
+    }
+
+    private void startClusterServices(Stack stack) throws CloudbreakException {
+        clusterApiConnectors.getConnector(stack).startCluster();
     }
 
     private SaltConfig createSaltConfig(Cluster cluster) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandler.java
@@ -37,7 +37,7 @@ public class ClusterStartHandler implements EventHandler<ClusterStartRequest> {
         ClusterStartResult result;
         try {
             Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
-            int requestId = apiConnectors.getConnector(stack).startCluster(stack.getRunningInstanceMetaDataSet());
+            int requestId = apiConnectors.getConnector(stack).startCluster();
             result = new ClusterStartResult(request, requestId);
         } catch (Exception e) {
             result = new ClusterStartResult(e.getMessage(), e, request);


### PR DESCRIPTION
Previously, we had a simple check in the upgrade flow to see if we
need to upgrade CM server itself. In case of OS upgrade, obviously
we don't need it since the versions do not change. However, we
removed this check, because we can only update the CM license as part
of this flow step. This flow step also executes the user id migration
script and for that we need to stop all the services in CM. The next
step in the upgrade flow is the CDP upgrade which we skip since the
versions do not change. The CDP upgrade flow step would start the
services once the upgrade is complete. The change image flow consists
of 3 different flows:

Stack sync
Cluster sync
Repair all instances (to replace the images)
The cluster sync flow will see that we've stopped the services in CM
and sets the cluster's status to STOPPED. However, in the flow config
of the change image we only allow it when both stack and cluster are
available. As part of the CM upgrade we will start back up the services.

See detailed description in the commit message.