### PR TITLE
CB-9757 change-image does not work as part of the OS upgrade

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateFlowTriggerCondition.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateFlowTriggerCondition.java
@@ -4,10 +4,9 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
-import com.sequenceiq.flow.core.FlowTriggerCondition;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.flow.core.FlowTriggerCondition;
 
 @Component
 public class StackImageUpdateFlowTriggerCondition implements FlowTriggerCondition {
@@ -17,7 +16,6 @@ public class StackImageUpdateFlowTriggerCondition implements FlowTriggerConditio
     @Override
     public boolean isFlowTriggerable(Long stackId) {
         StackView stack = stackService.getViewByIdWithoutAuth(stackId);
-        Status clusterStatus = stack.getClusterView().getStatus();
-        return stack.isAvailable() && (clusterStatus.isAvailable());
+        return stack.isAvailable();
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeChangeImageWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeChangeImageWaitHandler.java
@@ -54,7 +54,7 @@ public class DatalakeChangeImageWaitHandler extends ExceptionCatcherEventHandler
         try {
             LOGGER.info("Start polling change image process for id: {}", sdxId);
             PollingConfig pollingConfig = new PollingConfig(SLEEP_TIME_IN_SEC, TimeUnit.SECONDS, DURATION_IN_MINUTES, TimeUnit.MINUTES);
-            upgradeService.waitCloudbreakFlow(sdxId, pollingConfig, "Change image");
+            upgradeService.waitCloudbreakFlowDuringUpgrade(sdxId, pollingConfig, "Change image");
             String imageId = upgradeService.getImageId(sdxId);
             String expectedImageId = request.getUpgradeOption().getUpgrade().getImageId();
             if (Objects.equals(imageId, expectedImageId)) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeUpgradeWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeUpgradeWaitHandler.java
@@ -52,7 +52,7 @@ public class DatalakeUpgradeWaitHandler extends ExceptionCatcherEventHandler<Dat
         try {
             LOGGER.info("Start polling cluster upgrade process for id: {}", sdxId);
             PollingConfig pollingConfig = new PollingConfig(SLEEP_TIME_IN_SEC, TimeUnit.SECONDS, DURATION_IN_MINUTES, TimeUnit.MINUTES);
-            upgradeService.waitCloudbreakFlow(sdxId, pollingConfig, "Stack Upgrade");
+            upgradeService.waitCloudbreakFlowDuringUpgrade(sdxId, pollingConfig, "Stack Upgrade");
             response = new DatalakeImageChangeEvent(sdxId, userId, request.getImageId());
         } catch (UserBreakException userBreakException) {
             LOGGER.error("Upgrade polling exited before timeout. Cause: ", userBreakException);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeVmReplaceWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeVmReplaceWaitHandler.java
@@ -53,7 +53,7 @@ public class DatalakeVmReplaceWaitHandler extends ExceptionCatcherEventHandler<D
         try {
             LOGGER.info("Start polling cluster VM replacement process for id: {}", sdxId);
             PollingConfig pollingConfig = new PollingConfig(SLEEP_TIME_IN_SEC, TimeUnit.SECONDS, DURATION_IN_MINUTES, TimeUnit.MINUTES);
-            upgradeService.waitCloudbreakFlow(sdxId, pollingConfig, "VM replace");
+            upgradeService.waitCloudbreakFlowDuringUpgrade(sdxId, pollingConfig, "VM replace");
             response = new DatalakeUpgradeSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
             LOGGER.error("VM replace polling exited before timeout. Cause: ", userBreakException);


### PR DESCRIPTION
Previously, we had a simple check in the upgrade flow to see if we
need to upgrade CM server itself. In case of OS upgrade, obviously
we don't need it since the versions do not change. However, we
removed this check, because we can only update the CM license as part
of this flow step. This flow step also executes the user id migration
script and for that we need to stop all the services in CM. The next
step in the upgrade flow is the CDP upgrade which we skip since the
versions do not change. The CDP upgrade flow step would start the
services once the upgrade is complete. The change image flow consists
of 3 different flows:

* Stack sync
* Cluster sync
* Repair all instances (to replace the images)

The cluster sync flow will see that we've stopped the services in CM
and sets the cluster's status to STOPPED. However, in the flow config
of the change image we only allow it when both stack and cluster are
available. There is no point checking if the cluster is in stopped
state.

