### PR TITLE
CB-9757 change-image does not work as part of the OS upgrade

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -69,8 +69,8 @@ public interface ClusterApi {
         clusterModificationService().stopCluster(disableKnoxAutorestart);
     }
 
-    default int startCluster(Set<InstanceMetaData> hostsInCluster) throws CloudbreakException {
-        return clusterModificationService().startCluster(hostsInCluster);
+    default int startCluster() throws CloudbreakException {
+        return clusterModificationService().startCluster();
     }
 
     default Map<String, String> gatherInstalledParcels(String stackName) {

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -19,7 +19,7 @@ public interface ClusterModificationService {
 
     void stopCluster(boolean full) throws CloudbreakException;
 
-    int startCluster(Set<InstanceMetaData> hostsInCluster) throws CloudbreakException;
+    int startCluster() throws CloudbreakException;
 
     Map<String, String> getComponentsByCategory(String blueprintName, String hostGroupName);
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosService.java
@@ -2,8 +2,6 @@ package com.sequenceiq.cloudbreak.cm;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_1_0;
 
-import java.util.Collections;
-
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -19,8 +17,8 @@ import com.cloudera.api.swagger.model.ApiCommand;
 import com.cloudera.api.swagger.model.ApiConfigureForKerberosArguments;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiClientProvider;
-import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientInitException;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -65,7 +63,7 @@ public class ClouderaManagerKerberosService {
             clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, generateCredentials.getId());
             ApiCommand deployClusterConfig = clustersResourceApi.deployClientConfig(cluster.getName());
             clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, deployClusterConfig.getId());
-            modificationService.startCluster(Collections.emptySet());
+            modificationService.startCluster();
         }
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -543,7 +543,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
     }
 
     @Override
-    public int startCluster(Set<InstanceMetaData> hostsInCluster) throws CloudbreakException {
+    public int startCluster() throws CloudbreakException {
         try {
             startClouderaManager(stack, apiClient);
             startAgents(stack, apiClient);

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosServiceTest.java
@@ -2,7 +2,6 @@ package com.sequenceiq.cloudbreak.cm;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -122,7 +121,7 @@ public class ClouderaManagerKerberosServiceTest {
         verify(clouderaManagerPollingServiceProvider).startPollingCmKerberosJob(stack, client, BigDecimal.TEN);
         verify(clouderaManagerPollingServiceProvider).startPollingCmKerberosJob(stack, client, BigDecimal.ZERO);
         verify(clustersResourceApi).deployClientConfig(cluster.getName());
-        verify(modificationService).startCluster(anySet());
+        verify(modificationService).startCluster();
     }
 
     @Test

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeActions.java
@@ -98,8 +98,11 @@ public class ClusterUpgradeActions {
 
             @Override
             protected void doExecute(ClusterUpgradeContext context, ClusterUpgradeInitSuccess payload, Map<Object, Object> variables) {
+                Image currentImage = getCurrentImage(variables).getImage();
+                Image targetImage = getTargetImage(variables).getImage();
                 clusterUpgradeService.upgradeClusterManager(context.getStackId());
-                Selectable event = new ClusterManagerUpgradeRequest(context.getStackId());
+                Selectable event = new ClusterManagerUpgradeRequest(context.getStackId(),
+                        !clusterUpgradeService.isClusterRuntimeUpgradeNeeded(currentImage, targetImage));
                 sendEvent(context, event.selector(), event);
             }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeService.java
@@ -94,6 +94,11 @@ public class ClusterUpgradeService {
         }
     }
 
+    public boolean isClusterRuntimeUpgradeNeeded(Image currentImage, Image targetImage) {
+        return isUpdateNeeded(NullUtil.getIfNotNull(currentImage.getStackDetails(), StackDetails::getStackBuildNumber),
+                NullUtil.getIfNotNull(targetImage.getStackDetails(), StackDetails::getStackBuildNumber));
+    }
+
     private boolean isUpdateNeeded(String currentBuildNumber, String targetBuildNumber) {
         if (StringUtils.isEmpty(currentBuildNumber) || StringUtils.isEmpty(targetBuildNumber)) {
             return true;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterManagerUpgradeRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterManagerUpgradeRequest.java
@@ -3,9 +3,15 @@ package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 public class ClusterManagerUpgradeRequest extends StackEvent {
+    private boolean runtimeServicesStartNeeded;
 
-    public ClusterManagerUpgradeRequest(Long stackId) {
+    public ClusterManagerUpgradeRequest(Long stackId, boolean runtimeServicesStartNeeded) {
         super(stackId);
+        this.runtimeServicesStartNeeded = runtimeServicesStartNeeded;
+    }
+
+    public boolean isRuntimeServicesStartNeeded() {
+        return runtimeServicesStartNeeded;
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandler.java
@@ -37,7 +37,7 @@ public class ClusterStartHandler implements EventHandler<ClusterStartRequest> {
         ClusterStartResult result;
         try {
             Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
-            int requestId = apiConnectors.getConnector(stack).startCluster(stack.getRunningInstanceMetaDataSet());
+            int requestId = apiConnectors.getConnector(stack).startCluster();
             result = new ClusterStartResult(request, requestId);
         } catch (Exception e) {
             result = new ClusterStartResult(e.getMessage(), e, request);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterManagerUpgradeHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterManagerUpgradeHandler.java
@@ -40,7 +40,7 @@ public class ClusterManagerUpgradeHandler extends ExceptionCatcherEventHandler<C
         ClusterManagerUpgradeRequest request = event.getData();
         Selectable result;
         try {
-            clusterManagerUpgradeService.upgradeClusterManager(request.getResourceId());
+            clusterManagerUpgradeService.upgradeClusterManager(request.getResourceId(), request.isRuntimeServicesStartNeeded());
             result = new ClusterManagerUpgradeSuccess(request.getResourceId());
         } catch (Exception e) {
             LOGGER.info("Cluster Manager upgrade event failed", e);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.core.cluster;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -73,12 +74,27 @@ public class ClusterManagerUpgradeServiceTest {
     public void testUpgradeClusterManager() throws CloudbreakOrchestratorException, CloudbreakException {
         Cluster cluster = stack.getCluster();
 
-        underTest.upgradeClusterManager(STACK_ID);
+        underTest.upgradeClusterManager(STACK_ID, true);
 
         verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getPrimaryGatewayInstance(), cluster.getGateway() != null);
         verify(clusterComponentConfigProvider, times(1)).getClouderaManagerRepoDetails(cluster.getId());
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
         verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any());
+        verify(clusterApi).startCluster();
+    }
+
+    @Test
+    public void testUpgradeClusterManagerWithoutStartServices() throws CloudbreakOrchestratorException, CloudbreakException {
+        Cluster cluster = stack.getCluster();
+
+        underTest.upgradeClusterManager(STACK_ID, false);
+
+        verify(gatewayConfigService, times(1)).getGatewayConfig(stack, stack.getPrimaryGatewayInstance(), cluster.getGateway() != null);
+        verify(clusterComponentConfigProvider, times(1)).getClouderaManagerRepoDetails(cluster.getId());
+        verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
+        verify(clusterApi).stopCluster(true);
+        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any());
+        verify(clusterApi, never()).startCluster();
     }
 }


### PR DESCRIPTION
Previously, we had a simple check in the upgrade flow to see if we
need to upgrade CM server itself. In case of OS upgrade, obviously
we don't need it since the versions do not change. However, we
removed this check, because we can only update the CM license as part
of this flow step. This flow step also executes the user id migration
script and for that we need to stop all the services in CM. The next
step in the upgrade flow is the CDP upgrade which we skip since the
versions do not change. The CDP upgrade flow step would start the
services once the upgrade is complete. The change image flow consists
of 3 different flows:

Stack sync
Cluster sync
Repair all instances (to replace the images)
The cluster sync flow will see that we've stopped the services in CM
and sets the cluster's status to STOPPED. However, in the flow config
of the change image we only allow it when both stack and cluster are
available. As part of the CM upgrade we will start back up the services.

See detailed description in the commit message.