### PR TITLE
CB-9222 delete volume/disk resources that's in REQUESTED state not to leak resources in case of disk quota exceeded

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/type/CommonStatus.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/CommonStatus.java
@@ -7,6 +7,8 @@ public enum CommonStatus {
     FAILED;
 
     public boolean resourceExists() {
-        return CREATED.equals(this) || DETACHED.equals(this);
+        return CREATED.equals(this)
+                || DETACHED.equals(this)
+                || REQUESTED.equals(this);
     }
 }


### PR DESCRIPTION
This change solved the leaked disk issues on Azure and GCP side as we create and terminate disks/volumes with dedicated name that's created programatically.
But this is not a solution for AWS, because if a disk quota limitation occurs that means the disk identifiers could not be persisted in our side and later the termination could not be done due to the missing of disk identifiers.