### PR TITLE
CB-9825: Make the API change to database restore backward compatible.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeDatabaseRestoreActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeDatabaseRestoreActions.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.datalake.flow.dr.restore.DatalakeDatabaseRestoreEve
 import static com.sequenceiq.datalake.flow.dr.restore.DatalakeDatabaseRestoreEvent.DATALAKE_DATABASE_RESTORE_FINALIZED_EVENT;
 import static com.sequenceiq.datalake.flow.dr.restore.DatalakeDatabaseRestoreEvent.DATALAKE_DATABASE_RESTORE_IN_PROGRESS_EVENT;
 
+import com.google.common.base.Strings;
 import com.sequenceiq.datalake.entity.operation.SdxOperationStatus;
 import com.sequenceiq.datalake.flow.SdxContext;
 import com.sequenceiq.datalake.flow.SdxEvent;
@@ -58,7 +59,9 @@ public class DatalakeDatabaseRestoreActions {
             protected void prepareExecution(DatalakeDatabaseRestoreStartEvent payload, Map<Object, Object> variables) {
                 super.prepareExecution(payload, variables);
                 variables.put(BACKUP_ID, payload.getBackupId());
-                variables.put(RESTORE_ID, payload.getRestoreId());
+                if (!Strings.isNullOrEmpty(payload.getRestoreId())) {
+                    variables.put(RESTORE_ID, payload.getRestoreId());
+                }
                 variables.put(OPERATION_ID, payload.getDrStatus().getOperationId());
             }
 


### PR DESCRIPTION
The promotion cadence for thunderhead and data lake services are different so we should make sure that the API changes are backward compatible. 

With the recent change made to API restoreDatabaseByName is not backward compatible as the older API does not provide restoreId. This is causing issues.

Verified the change by running CB running locally.