### PR TITLE
DISTX-533 Set S3A buffer dir to Yarn local dir

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-ha.bp
@@ -29,7 +29,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-spark3.bp
@@ -25,7 +25,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering.bp
@@ -31,7 +31,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-ha.bp
@@ -29,7 +29,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-spark3.bp
@@ -25,7 +25,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering.bp
@@ -31,7 +31,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-ha.bp
@@ -29,7 +29,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-spark3.bp
@@ -25,7 +25,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering.bp
@@ -31,7 +31,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
[DISTX-533](https://jira.cloudera.com/browse/DISTX-533)

An escalation ENGESC-3559 identified the problem where spark applications were filling up local disks.
The solution provided was to set fs.s3a.buffer.dir config to YARN local dir so that when spark job finishes YARN can clean those up. But if YARN LOCAL_DIRS is not set then it should fallback to something like /tmp/s3a, hence configuring following in 722, 726, 727 data engineering templates
fs.s3a.buffer.dir=${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a

Testing done:
Have created a DE cluster using a modified 7.2.6 template that includes above mentioned config changes. Cluster creation was successful on AWS using m5d.2xl instance types.