### PR TITLE
CB-9849 GCP : For FreeIPA use the GCP shared project id to query the …

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpPlatformResources.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpPlatformResources.java
@@ -46,6 +46,7 @@ import com.google.api.services.compute.model.Subnetwork;
 import com.google.api.services.compute.model.SubnetworkList;
 import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.cloud.PlatformResources;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
 import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
 import com.sequenceiq.cloudbreak.cloud.model.CloudAccessConfigs;
@@ -71,8 +72,8 @@ import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta;
 import com.sequenceiq.cloudbreak.cloud.model.VmTypeMeta.VmTypeMetaBuilder;
 import com.sequenceiq.cloudbreak.cloud.model.nosql.CloudNoSqlTables;
 import com.sequenceiq.cloudbreak.cloud.model.resourcegroup.CloudResourceGroups;
-import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
 
 @Service
 public class GcpPlatformResources implements PlatformResources {
@@ -129,18 +130,18 @@ public class GcpPlatformResources implements PlatformResources {
         Map<String, Set<CloudNetwork>> result = new HashMap<>();
 
         String networkId = null;
-        String subnetId = null;
+        List<String> subnetIds = new ArrayList<>();
         String sharedProjectId = null;
         if (filters != null) {
             networkId = filters.getOrDefault("networkId", null);
-            subnetId = filters.getOrDefault("subnetId", null);
+            subnetIds = getSubnetIds(filters);
             sharedProjectId = filters.getOrDefault("sharedProjectId", null);
         }
 
-        LOGGER.debug("Get subnets with filter values, networkId : {}, subnetId : {}", networkId, subnetId);
+        LOGGER.debug("Get subnets with filter values, networkId : {}, subnetId : {}", networkId, subnetIds);
         Set<CloudNetwork> cloudNetworks = new HashSet<>();
         NetworkList networkList = getNetworkList(compute, projectId, networkId, sharedProjectId);
-        SubnetworkList subnetworkList = getSubnetworkList(region, compute, projectId, subnetId, sharedProjectId);
+        SubnetworkList subnetworkList = getSubnetworkList(region, compute, projectId, subnetIds, sharedProjectId);
 
         // GCP VPCs are global. Subnets have a global scope in region. So picking the first availability zone in the region for subnet.
         String zone = compute.regions().get(projectId, region.value())
@@ -184,21 +185,41 @@ public class GcpPlatformResources implements PlatformResources {
         return new CloudNetworks(result);
     }
 
-    public SubnetworkList getSubnetworkList(Region region, Compute compute, String projectId, String subnetId, String sharedProjectId) throws IOException {
-        SubnetworkList subnetworkList;
-        if (StringUtils.isEmpty(subnetId)) {
-            subnetworkList = compute.subnetworks()
-                    .list(projectId, region.value()).execute();
+    public List<String> getSubnetIds(Map<String, String> filters) {
+        List<String> subnetIds = new ArrayList<>();
+        String subnetId = filters.getOrDefault("subnetId", null);
+        if (!Strings.isNullOrEmpty(subnetId)) {
+            subnetIds.add(subnetId);
         } else {
-            if (!Strings.isNullOrEmpty(sharedProjectId)) {
-                subnetworkList = new SubnetworkList()
-                        .setItems(Collections.singletonList(compute.subnetworks().get(sharedProjectId, region.value(), subnetId).execute()));
-            } else {
-                subnetworkList = new SubnetworkList()
-                        .setItems(Collections.singletonList(compute.subnetworks().get(projectId, region.value(), subnetId).execute()));
+            String subnetIdsString = filters.getOrDefault("subnetIds", null);
+            if (!Strings.isNullOrEmpty(subnetIdsString)) {
+                subnetIds = List.of(subnetIdsString.split(","));
+            }
+        }
+        return subnetIds;
+    }
+
+    private SubnetworkList getSubnetworkList(Region region, Compute compute, String projectId, List<String> subnetIds,
+        String sharedProjectId) throws IOException {
+        SubnetworkList subnetworkList;
+        validateSubnetRequest(subnetIds, sharedProjectId);
+        if (subnetIds.isEmpty()) {
+            subnetworkList = compute.subnetworks().list(projectId, region.value()).execute();
+        } else {
+            String tmpProjectId = !Strings.isNullOrEmpty(sharedProjectId) ? sharedProjectId : projectId;
+            subnetworkList = new SubnetworkList().setItems(new ArrayList<>());
+            for (String subnetId : subnetIds) {
+                Subnetwork subnetwork = compute.subnetworks().get(tmpProjectId, region.value(), subnetId).execute();
+                subnetworkList.getItems().add(subnetwork);
             }
         }
         return subnetworkList;
+    }
+
+    private void validateSubnetRequest(List<String> subnetIds, String sharedProjectId) {
+        if (!Strings.isNullOrEmpty(sharedProjectId) && subnetIds.isEmpty()) {
+            throw new CloudConnectorException("If shared project id defined then subnet Id required.");
+        }
     }
 
     public NetworkList getNetworkList(Compute compute, String projectId, String networkId, String sharedProjectId) throws IOException {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/AppConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/AppConfig.java
@@ -1,5 +1,11 @@
 package com.sequenceiq.freeipa.configuration;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,9 +15,11 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.concurrent.MDCCleanerTaskDecorator;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteria;
 import com.sequenceiq.freeipa.orchestrator.StackBasedExitCriteria;
+import com.sequenceiq.freeipa.service.filter.NetworkFilterProvider;
 
 @Configuration
 @EnableRetry
@@ -24,6 +32,9 @@ public class AppConfig {
     @Value("${freeipa.intermediate.threadpool.capacity.size}")
     private int intermediateQueueCapacity;
 
+    @Inject
+    private List<NetworkFilterProvider> networkFilterProviders;
+
     @Bean
     @Primary
     public AsyncTaskExecutor intermediateBuilderExecutor() {
@@ -34,6 +45,15 @@ public class AppConfig {
         executor.setTaskDecorator(new MDCCleanerTaskDecorator());
         executor.initialize();
         return executor;
+    }
+
+    @Bean
+    public Map<CloudPlatform, NetworkFilterProvider> networkFilterProviderMap() {
+        Map<CloudPlatform, NetworkFilterProvider> result = new HashMap<>();
+        for (NetworkFilterProvider networkFilterProvider : networkFilterProviders) {
+            result.put(networkFilterProvider.cloudPlatform(), networkFilterProvider);
+        }
+        return result;
     }
 
     @Bean

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/filter/GcpNetworkFilterProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/filter/GcpNetworkFilterProvider.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.freeipa.service.filter;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.freeipa.entity.Network;
+
+@Service
+public class GcpNetworkFilterProvider implements NetworkFilterProvider {
+
+    private static final String SHARED_PROJECT_ID = "sharedProjectId";
+
+    @Override
+    public Map<String, String> provide(Network network, String networkId, Collection<String> subnetIds) {
+        Map<String, String> filter = new HashMap<>();
+        if (network.getAttributes() != null && network.getAttributes().getMap() != null) {
+            Map<String, Object> attributes = network.getAttributes().getMap();
+            String sharedProjectId = (String) attributes.get(SHARED_PROJECT_ID);
+            if (!Strings.isNullOrEmpty(sharedProjectId)) {
+                filter.put(SHARED_PROJECT_ID, sharedProjectId);
+            }
+        }
+        filter.put("networkId", networkId);
+        filter.putAll(buildSubnetIdFilter(subnetIds));
+        return filter;
+    }
+
+    @Override
+    public CloudPlatform cloudPlatform() {
+        return CloudPlatform.GCP;
+    }
+
+    private Map<String, String> buildSubnetIdFilter(Collection<String> subnetIds) {
+        Map<String, String> filter = new HashMap<>();
+        if (subnetIds != null && !subnetIds.isEmpty()) {
+            filter.put("subnetIds", String.join(",", subnetIds));
+        }
+        return filter;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/filter/NetworkFilterProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/filter/NetworkFilterProvider.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.freeipa.service.filter;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.freeipa.entity.Network;
+
+public interface NetworkFilterProvider {
+
+    Map<String, String> provide(Network network, String networkId, Collection<String> subnetIds);
+
+    CloudPlatform cloudPlatform();
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/filter/GcpNetworkFilterProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/filter/GcpNetworkFilterProviderTest.java
@@ -1,0 +1,80 @@
+package com.sequenceiq.freeipa.service.filter;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.freeipa.entity.Network;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class GcpNetworkFilterProviderTest {
+
+    private static final String SHARED_PROJECT_ID = "sharedProjectId";
+
+    private static final String NETWORK_ID = "networkId";
+
+    private static final String SUBNET_IDS = "subnetIds";
+
+    private static final String TEST_PROJECT = "testproject";
+
+    private static final String TEST_NETWORK = "testnetwork";
+
+    private static final String TEST_SUBNET_ID1 = "testsubnetid1";
+
+    private static final String TEST_SUBNET_ID2 = "testsubnetid2";
+
+    private GcpNetworkFilterProvider gcpNetworkFilterProvider;
+
+    private Network network;
+
+    private String networkId;
+
+    private Collection<String> subnetIds;
+
+    @Before
+    public void setUp() {
+        gcpNetworkFilterProvider = new GcpNetworkFilterProvider();
+        network = new Network();
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(SHARED_PROJECT_ID, TEST_PROJECT);
+        networkId = TEST_NETWORK;
+        subnetIds = Collections.singletonList(TEST_SUBNET_ID1);
+        network.setAttributes(new Json(parameters));
+    }
+
+    @Test
+    public void provide() {
+        Map<String, String> provide = gcpNetworkFilterProvider.provide(network, networkId, subnetIds);
+        assertEquals(TEST_SUBNET_ID1, provide.get(SUBNET_IDS));
+        assertEquals(TEST_NETWORK, provide.get(NETWORK_ID));
+        assertEquals(TEST_PROJECT, provide.get(SHARED_PROJECT_ID));
+    }
+
+    @Test
+    public void provideProjectLocalVPC() {
+        Map<String, Object> parameters = new HashMap<>();
+        network.setAttributes(new Json(parameters));
+        Map<String, String> provide = gcpNetworkFilterProvider.provide(network, networkId, subnetIds);
+        assertEquals(TEST_SUBNET_ID1, provide.get(SUBNET_IDS));
+        assertEquals(TEST_NETWORK, provide.get(NETWORK_ID));
+        assertNull(provide.get(SHARED_PROJECT_ID));
+    }
+
+    @Test
+    public void provideMultipleSubnets() {
+        subnetIds = new ArrayList<>();
+        subnetIds.add(TEST_SUBNET_ID1);
+        subnetIds.add(TEST_SUBNET_ID2);
+        Map<String, String> provide = gcpNetworkFilterProvider.provide(network, networkId, subnetIds);
+        assertEquals(TEST_SUBNET_ID1 + ',' + TEST_SUBNET_ID2, provide.get(SUBNET_IDS));
+        assertEquals(TEST_NETWORK, provide.get(NETWORK_ID));
+        assertEquals(TEST_PROJECT, provide.get(SHARED_PROJECT_ID));
+    }
+}


### PR DESCRIPTION
…networks

1. If a user gives a shared project id and a vpc in it, then the reverse DNS zone calculations in FreeIPA is not done correctly.
2. To fix this we need to look at the network and subnet in the shared project.
3. This is fixed everywhere except at one place here.
4. The ultimate issue will be that DH can not talk to IDBroker, it will receive 401 due to lack of reverse DNS.
5. CB-9180 will take care of bailing out if we can not calculate reverse DNS zones.

./gradlew build