### PR TITLE
CB-6964: Wrong freeIpa status after instance is deleted on provider side

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
@@ -118,6 +118,10 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                                 LOGGER.debug("results is empty, skip update");
                             }
                         }
+                    } else if (alreadyDeletedCount > 0) {
+                        SyncResult syncResult =  new SyncResult("FreeIpa is " + DetailedStackStatus.DELETED_ON_PROVIDER_SIDE,
+                                DetailedStackStatus.DELETED_ON_PROVIDER_SIDE, null);
+                        updateStackStatus(stack, syncResult, null, alreadyDeletedCount);
                     }
                 });
                 return null;


### PR DESCRIPTION
During a freeipa health check, it first update instances' status and then the freeipa status. In a particular case, if the instance is deleted on provider side, the freeipa will first updates instance status to deleted. But if the environment runtime breaks ad restarts, the healthcheck will skip and won't update the freeipa status because all instances are already deleted. Therefore, after environment recovers, freeipa shows wrong stopped status. This fix will correct the freeipa status as deleted.

See detailed description in the commit message.