### PR TITLE
CDPCP-3350. Provide user sync with an uncached hasRights implementation

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -457,6 +457,20 @@ public class GrpcUmsClient {
      */
     @Cacheable(cacheNames = "umsUserHasRightsCache", key = "{ #actorCrn, #memberCrn, #rightChecks }")
     public List<Boolean> hasRights(String actorCrn, String memberCrn, List<AuthorizationProto.RightCheck> rightChecks, Optional<String> requestId) {
+        return hasRightsNoCache(actorCrn, memberCrn, rightChecks, requestId);
+    }
+
+    /**
+     * Retrieves whether the member has the specified rights. This method specifically does not cache
+     * results for cases where caching affects application correctness.
+     *
+     * @param actorCrn    the CRN of the actor
+     * @param memberCrn   the CRN of the member
+     * @param rightChecks the rights to check
+     * @param requestId   an optional request id
+     * @return a list of booleans indicating whether the member has the specified rights
+     */
+    public List<Boolean> hasRightsNoCache(String actorCrn, String memberCrn, List<AuthorizationProto.RightCheck> rightChecks, Optional<String> requestId) {
         LOGGER.info("Checking whether member [{}] has rights [{}]", memberCrn,
                 rightChecks.stream().map(this::rightCheckToString).collect(Collectors.toList()));
         if (InternalCrnBuilder.isInternalCrn(memberCrn)) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/EnvironmentAccessChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/EnvironmentAccessChecker.java
@@ -51,7 +51,7 @@ public class EnvironmentAccessChecker {
         requireNonNull(requestId, "requestId is null");
 
         try {
-            List<Boolean> hasRights = grpcUmsClient.hasRights(INTERNAL_ACTOR_CRN, memberCrn, rightChecks, requestId);
+            List<Boolean> hasRights = grpcUmsClient.hasRightsNoCache(INTERNAL_ACTOR_CRN, memberCrn, rightChecks, requestId);
             return new EnvironmentAccessRights(hasRights.get(0), hasRights.get(1));
         } catch (StatusRuntimeException e) {
             // NOT_FOUND errors indicate that a user/machineUser has been deleted after we have

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/DefaultUmsUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/DefaultUmsUsersStateProviderTest.java
@@ -95,7 +95,7 @@ class DefaultUmsUsersStateProviderTest extends BaseUmsUsersStateProviderTest {
             return UserSyncConstants.RIGHTS.stream()
                     .map(right -> actorRights.get(right))
                     .collect(Collectors.toList());
-        }).when(grpcUmsClient).hasRights(eq(INTERNAL_ACTOR_CRN), anyString(), any(List.class), any(Optional.class));
+        }).when(grpcUmsClient).hasRightsNoCache(eq(INTERNAL_ACTOR_CRN), anyString(), any(List.class), any(Optional.class));
 
         doAnswer(invocation -> {
             String memberCrn = invocation.getArgument(2, String.class);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/EnvironmentAccessCheckerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/EnvironmentAccessCheckerTest.java
@@ -73,12 +73,12 @@ class EnvironmentAccessCheckerTest {
     void testEnvironmentAccessCheckerChecksRightRightChecks() {
         EnvironmentAccessChecker underTest = environmentAccessCheckerFactory.create(ENV_CRN);
         ArgumentCaptor<List<AuthorizationProto.RightCheck>> argumentCaptor = ArgumentCaptor.forClass((Class) List.class);
-        when(grpcUmsClient.hasRights(
+        when(grpcUmsClient.hasRightsNoCache(
                 anyString(), eq(MEMBER_CRN), anyList(), any(Optional.class))).thenReturn(List.of(true, true));
 
         underTest.hasAccess(MEMBER_CRN, Optional.empty());
 
-        verify(grpcUmsClient).hasRights(eq(INTERNAL_ACTOR_CRN), eq(MEMBER_CRN), argumentCaptor.capture(), any());
+        verify(grpcUmsClient).hasRightsNoCache(eq(INTERNAL_ACTOR_CRN), eq(MEMBER_CRN), argumentCaptor.capture(), any());
         List<AuthorizationProto.RightCheck> capturedRightChecks = argumentCaptor.getValue();
         assertEquals(2, capturedRightChecks.size());
         AuthorizationProto.RightCheck hasAccess = capturedRightChecks.get(0);
@@ -94,7 +94,8 @@ class EnvironmentAccessCheckerTest {
 
         for (boolean hasAccess : new boolean[] { false, true}) {
             for (boolean ipaAdmin : new boolean[] { false, true}) {
-                when(grpcUmsClient.hasRights(anyString(), eq(MEMBER_CRN), anyList(), any(Optional.class))).thenReturn(List.of(hasAccess, ipaAdmin));
+                when(grpcUmsClient.hasRightsNoCache(anyString(), eq(MEMBER_CRN), anyList(), any(Optional.class)))
+                        .thenReturn(List.of(hasAccess, ipaAdmin));
 
                 EnvironmentAccessRights environmentAccessRights = underTest.hasAccess(MEMBER_CRN, Optional.empty());
 
@@ -109,7 +110,8 @@ class EnvironmentAccessCheckerTest {
         EnvironmentAccessChecker underTest = environmentAccessCheckerFactory.create(ENV_CRN);
 
         Throwable ex = new StatusRuntimeException(Status.Code.NOT_FOUND.toStatus());
-        when(grpcUmsClient.hasRights(anyString(), eq(MEMBER_CRN), anyList(), any(Optional.class))).thenThrow(ex);
+        when(grpcUmsClient.hasRightsNoCache(anyString(), eq(MEMBER_CRN), anyList(), any(Optional.class)))
+                .thenThrow(ex);
 
         EnvironmentAccessRights environmentAccessRights = underTest.hasAccess(MEMBER_CRN, Optional.empty());
 


### PR DESCRIPTION
We discovered through a failing systest that caching has been added to the hasRights call. User sync needs uncached hasRights. I tossed this change together (tested locally) because we need this fixed immediately.
