### PR TITLE
CB-9847 mask the RDS username and password parameters in the CF template

### DIFF
--- a/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-dbstack.ftl
@@ -56,13 +56,15 @@
         "Description": "Master username",
         "AllowedPattern": "[A-Za-z][A-Za-z0-9]+",
         "MinLength": 1,
-        "MaxLength": 16
+        "MaxLength": 16,
+        "NoEcho": "true"
     },
     "MasterUserPasswordParameter": {
         "Type": "String",
         "Description": "Master user password",
         "MinLength": 8,
-        "MaxLength": 30
+        "MaxLength": 30,
+        "NoEcho": "true"
     },
     "MultiAZParameter": {
         "Type": "String",


### PR DESCRIPTION
When we create RDS instances for Data Lakes and Data Hubs we create a CF
template which contains the RDS username and password as input parameter.
These parameters are visible on the AWS console, however it can be masked easily
with the "NoEcho" parameter. This is an intermediate solution. The best solution
would be to store these fileds in AWS secrets and reference them in the CF template.
