### PR TITLE
CB-9818 Azure image copy check failed

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/CheckImageAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/CheckImageAction.java
@@ -26,7 +26,7 @@ import reactor.fn.timer.Timer;
 public class CheckImageAction extends AbstractStackCreationAction<StackEvent> {
     private static final Logger LOGGER = LoggerFactory.getLogger(CheckImageAction.class);
 
-    private static final int REPEAT_TIME = 5000;
+    private static final int REPEAT_TIME = 30000;
 
     private static final int FAULT_TOLERANCE = 5;
 
@@ -47,6 +47,7 @@ public class CheckImageAction extends AbstractStackCreationAction<StackEvent> {
         CheckImageResult checkImageResult = stackCreationService.checkImage(context);
         switch (checkImageResult.getImageStatus()) {
             case IN_PROGRESS:
+                setFaultNum(variables, 0);
                 repeat(context);
                 break;
             case CREATE_FINISHED:

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/CheckImageActionTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/CheckImageActionTest.java
@@ -1,0 +1,148 @@
+package com.sequenceiq.cloudbreak.core.flow2.stack.provision.action;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.event.setup.CheckImageResult;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.core.flow2.stack.StackContext;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.common.api.type.ImageStatus;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.FlowRegister;
+import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
+
+import io.opentracing.SpanContext;
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+import reactor.fn.timer.Timer;
+
+@ExtendWith(MockitoExtension.class)
+public class CheckImageActionTest {
+
+    public static final long STACK_ID = 2L;
+
+    private static final String IMAGE_COPY_FAULT_NUM = "IMAGE_COPY_FAULT_NUM";
+
+    private static final int ANY_STATUS_PROGRESS_VALUE = 10;
+
+    private static final long REPEAT_WAIT_TIME = 30000L;
+
+    private static final int FAULT_TOLERANCE = 5;
+
+    @Mock
+    private StackCreationService stackCreationService;
+
+    @Mock
+    private Timer timer;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private FlowRegister runningFlows;
+
+    @Mock
+    private ErrorHandlerAwareReactorEventFactory reactorEventFactory;
+
+    @InjectMocks
+    private CheckImageAction underTest;
+
+    @Mock
+    private StackContext stackContext;
+
+    @Mock
+    private StackEvent stackEvent;
+
+    private Map<Object, Object> variables = new HashMap<>();
+
+    @Test
+    void testWhenInProgressThenRepeat() {
+        CheckImageResult checkImageResult = new CheckImageResult(1L, ImageStatus.IN_PROGRESS, ANY_STATUS_PROGRESS_VALUE);
+        when(stackCreationService.checkImage(stackContext)).thenReturn(checkImageResult);
+
+        underTest.doExecute(stackContext, stackEvent, variables);
+
+        assertEquals(0, variables.get(IMAGE_COPY_FAULT_NUM));
+        verify(timer).submit(any(), eq(REPEAT_WAIT_TIME), eq(TimeUnit.MILLISECONDS));
+        verify(eventBus, never()).notify((Object) any(), any(Event.class));
+    }
+
+    @Test
+    void testWhenCreateFinishedThenSendEvent() {
+        Stack stack = mock(Stack.class);
+        when(stack.getId()).thenReturn(STACK_ID);
+        FlowParameters flowParameters = new FlowParameters("flowId", "flowTriggerUserCrn", mock(SpanContext.class));
+        when(stackContext.getStack()).thenReturn(stack);
+        when(stackContext.getFlowParameters()).thenReturn(flowParameters);
+        when(reactorEventFactory.createEvent(any(Map.class), any())).thenReturn(mock(Event.class));
+        CheckImageResult checkImageResult = new CheckImageResult(1L, ImageStatus.CREATE_FINISHED, ANY_STATUS_PROGRESS_VALUE);
+        when(stackCreationService.checkImage(stackContext)).thenReturn(checkImageResult);
+
+        underTest.doExecute(stackContext, stackEvent, variables);
+
+        verify(eventBus).notify((Object) any(), any(Event.class));
+    }
+
+    @Test
+    void testWhenCreateFailedThenIncreaseFaultNumAndRepeat() {
+        variables.put(IMAGE_COPY_FAULT_NUM, 0);
+        CheckImageResult checkImageResult = new CheckImageResult(1L, ImageStatus.CREATE_FAILED, ANY_STATUS_PROGRESS_VALUE);
+        when(stackCreationService.checkImage(stackContext)).thenReturn(checkImageResult);
+
+        underTest.doExecute(stackContext, stackEvent, variables);
+
+        assertEquals(1, variables.get(IMAGE_COPY_FAULT_NUM));
+        verify(timer).submit(any(), anyLong(), any());
+        verify(eventBus, never()).notify((Object) any(), any(Event.class));
+    }
+
+    @Test
+    void testWhenCreateFailedFiveTimesInARowThenThrow() {
+        variables.put(IMAGE_COPY_FAULT_NUM, FAULT_TOLERANCE - 1);
+        CheckImageResult checkImageResult = new CheckImageResult(1L, ImageStatus.CREATE_FAILED, ANY_STATUS_PROGRESS_VALUE);
+        when(stackCreationService.checkImage(stackContext)).thenReturn(checkImageResult);
+
+        Assertions.assertThrows(CloudbreakServiceException.class, () ->
+                underTest.doExecute(stackContext, stackEvent, variables),
+                "Image copy failed."
+        );
+
+        assertNull(variables.get(IMAGE_COPY_FAULT_NUM));
+        verify(timer, never()).submit(any(), anyLong(), any());
+        verify(eventBus, never()).notify((Object) any(), any(Event.class));
+    }
+
+    @Test
+    void testWhenInProgressAfterCreateFailedThenResetFaultNumAndRepeat() {
+        variables.put(IMAGE_COPY_FAULT_NUM, 1);
+        CheckImageResult checkImageResult = new CheckImageResult(1L, ImageStatus.IN_PROGRESS, ANY_STATUS_PROGRESS_VALUE);
+        when(stackCreationService.checkImage(stackContext)).thenReturn(checkImageResult);
+
+        underTest.doExecute(stackContext, stackEvent, variables);
+
+        assertEquals(0, variables.get(IMAGE_COPY_FAULT_NUM));
+        verify(timer).submit(any(), eq(REPEAT_WAIT_TIME), eq(TimeUnit.MILLISECONDS));
+        verify(eventBus, never()).notify((Object) any(), any(Event.class));
+    }
+
+}


### PR DESCRIPTION
On azure a throttling error caused the failure of the image copy checking task. This was mainly caused by not resetting the failure number after a successful response arrived. In this way the maximum 5 errors was easily reached during the 10-minute-long copy process.
Besides the fix, the checking interval was increased from 5 to 30 seconds, to decrease the probability of a throttling error.

See detailed description in the commit message.