### PR TITLE
DISTX-539 Drop container size configs from templates

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-ha.bp
@@ -135,10 +135,6 @@
         "displayName": "Hive",
         "serviceConfigs": [
           {
-            "name": "tez_container_size",
-            "value": "4096"
-          },
-          {
             "name": "tez_auto_reducer_parallelism",
             "value": "false"
           },
@@ -298,14 +294,6 @@
             "roleType": "GATEWAY",
             "base": true,
             "configs": [
-              {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              },
               {
                 "name": "mapreduce_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-spark3.bp
@@ -148,15 +148,6 @@
             "refName": "yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
             "base": true,
-            "configs": [
-              {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              },
               {
                 "name": "mapreduce_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
@@ -285,10 +276,6 @@
           {
             "name": "mapreduce_yarn_service",
             "ref": "yarn"
-          },
-          {
-            "name": "tez_container_size",
-            "value": "4096"
           },
           {
             "name": "tez_auto_reducer_parallelism",

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-spark3.bp
@@ -148,6 +148,7 @@
             "refName": "yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
             "base": true,
+            "configs": [
               {
                 "name": "mapreduce_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering.bp
@@ -156,14 +156,6 @@
             "base": true,
             "configs": [
               {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              },
-              {
                 "name": "mapreduce_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
@@ -275,10 +267,6 @@
           {
             "name": "mapreduce_yarn_service",
             "ref": "yarn"
-          },
-          {
-            "name": "tez_container_size",
-            "value": "4096"
           },
           {
             "name": "tez_auto_reducer_parallelism",

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-ha.bp
@@ -135,10 +135,6 @@
         "displayName": "Hive",
         "serviceConfigs": [
           {
-            "name": "tez_container_size",
-            "value": "4096"
-          },
-          {
             "name": "tez_auto_reducer_parallelism",
             "value": "false"
           },
@@ -298,14 +294,6 @@
             "roleType": "GATEWAY",
             "base": true,
             "configs": [
-              {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              },
               {
                 "name": "mapreduce_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-spark3.bp
@@ -150,14 +150,6 @@
             "base": true,
             "configs": [
               {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              },
-              {
                 "name": "mapreduce_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
@@ -285,10 +277,6 @@
           {
             "name": "mapreduce_yarn_service",
             "ref": "yarn"
-          },
-          {
-            "name": "tez_container_size",
-            "value": "4096"
           },
           {
             "name": "tez_auto_reducer_parallelism",

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering.bp
@@ -156,14 +156,6 @@
             "base": true,
             "configs": [
               {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              },
-              {
                 "name": "mapreduce_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
@@ -275,10 +267,6 @@
           {
             "name": "mapreduce_yarn_service",
             "ref": "yarn"
-          },
-          {
-            "name": "tez_container_size",
-            "value": "4096"
           },
           {
             "name": "tez_auto_reducer_parallelism",

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-ha.bp
@@ -135,10 +135,6 @@
         "displayName": "Hive",
         "serviceConfigs": [
           {
-            "name": "tez_container_size",
-            "value": "4096"
-          },
-          {
             "name": "tez_auto_reducer_parallelism",
             "value": "false"
           },
@@ -298,14 +294,6 @@
             "roleType": "GATEWAY",
             "base": true,
             "configs": [
-              {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              },
               {
                 "name": "mapreduce_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-spark3.bp
@@ -150,14 +150,6 @@
             "base": true,
             "configs": [
               {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              },
-              {
                 "name": "mapreduce_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
@@ -285,10 +277,6 @@
           {
             "name": "mapreduce_yarn_service",
             "ref": "yarn"
-          },
-          {
-            "name": "tez_container_size",
-            "value": "4096"
           },
           {
             "name": "tez_auto_reducer_parallelism",

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering.bp
@@ -156,14 +156,6 @@
             "base": true,
             "configs": [
               {
-                "name": "mapreduce_map_memory_mb",
-                "value": 4096
-              },
-              {
-                "name": "mapreduce_reduce_memory_mb",
-                "value": 4096
-              },
-              {
                 "name": "mapreduce_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
@@ -275,10 +267,6 @@
           {
             "name": "mapreduce_yarn_service",
             "ref": "yarn"
-          },
-          {
-            "name": "tez_container_size",
-            "value": "4096"
           },
           {
             "name": "tez_auto_reducer_parallelism",


### PR DESCRIPTION
[DISTX-539](https://jira.cloudera.com/browse/DISTX-539)

Fix for OPSAPS-56088 now auto tunes lot of machine dependent configs. Hence there is no need to provide static values to some of these configs in cluster templates. Also value of some of the configs are sub-optimal.
Thus removing following configs from 7.2.2, 7.2.6, 7.2.7 DE templates:
 hive.tez.container.size
 mapreduce.map.memory.mb
 mapreduce.reduce.memory.mb

Testing done:
Have created a DE cluster using a modified 7.2.6 template that includes above mentioned config changes. Cluster creation was successful on AWS using m5d.2xl instance types.