### PR TITLE
CB-6028 Enable Solr Ranger Authorization.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.0/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.0/cdp-sdx.bp
@@ -160,7 +160,7 @@
           },
           {
           	"name": "enable_ranger_authorization",
-          	"value": "false"
+          	"value": "true"
           }
         ],
         "serviceType": "SOLR"

--- a/core/src/main/resources/defaults/blueprints/7.2.1/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.1/cdp-sdx.bp
@@ -192,7 +192,7 @@
           },
           {
           	"name": "enable_ranger_authorization",
-          	"value": "false"
+          	"value": "true"
           }
         ],
         "serviceType": "SOLR"

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
@@ -232,7 +232,7 @@
           },
           {
             "name": "enable_ranger_authorization",
-            "value": "false"
+            "value": "true"
           }
         ],
         "serviceType": "SOLR"

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx.bp
@@ -192,7 +192,7 @@
           },
           {
           	"name": "enable_ranger_authorization",
-          	"value": "false"
+          	"value": "true"
           }
         ],
         "serviceType": "SOLR"

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx.bp
@@ -192,7 +192,7 @@
           },
           {
           	"name": "enable_ranger_authorization",
-          	"value": "false"
+          	"value": "true"
           }
         ],
         "serviceType": "SOLR"

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
@@ -248,7 +248,7 @@
           },
           {
             "name": "enable_ranger_authorization",
-            "value": "false"
+            "value": "true"
           }
         ],
         "serviceType": "SOLR"

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx.bp
@@ -192,7 +192,7 @@
           },
           {
           	"name": "enable_ranger_authorization",
-          	"value": "false"
+          	"value": "true"
           }
         ],
         "serviceType": "SOLR"


### PR DESCRIPTION
This enables Ranger authorization for Solr from 7.2.0 -> 7.2.7.

See detailed description in the commit message.