### PR TITLE
CDPSDX-1981: missing DNS a record in ipa during datalake provisioning 

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
@@ -65,7 +65,7 @@ removing_dns_entries:
 
 add_dns_record:
   cmd.run:
-    - name: /opt/salt/scripts/add_dns_record.sh && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/dnsrecord-add-executed
+    - name: /opt/salt/scripts/add_dns_record.sh 2>&1 | tee -a /var/log/dnsrecord-add.log && test ${PIPESTATUS[0]} -eq 0 && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/dnsrecord-add-executed
     - runas: root
     - failhard: True
     - unless: test -f /var/log/dnsrecord-add-executed


### PR DESCRIPTION
During datalake provisioning, an intermittent error of "does not have corresponding DNS A/AAAA record" happens. Currently we don't have logging for dnsrecord add operation. Only a timestamp exists in the log to show the dns add operation is done. This fix will log the added DNS record and the success return information in the add operation. This will help to confirm and debug the missing DNS a record issue.

See detailed description in the commit message.