### PR TITLE
CB-9902. Increase the default node count for the compute group to 1

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering-ha.json
@@ -32,7 +32,7 @@
       "recipeNames": []
     },
       {
-        "nodeCount": 0,
+        "nodeCount": 1,
         "name": "compute",
         "type": "CORE",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering-spark3.json
@@ -53,7 +53,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering.json
@@ -53,7 +53,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering-ha.json
@@ -42,7 +42,7 @@
         "cloudPlatform": "AZURE"
       },
       {
-        "nodeCount": 0,
+        "nodeCount": 1,
         "name": "compute",
         "type": "CORE",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering-spark3.json
@@ -57,7 +57,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering.json
@@ -56,7 +56,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering-ha.json
@@ -32,7 +32,7 @@
       "recipeNames": []
     },
       {
-        "nodeCount": 0,
+        "nodeCount": 1,
         "name": "compute",
         "type": "CORE",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering-spark3.json
@@ -53,7 +53,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering.json
@@ -53,7 +53,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering-ha.json
@@ -42,7 +42,7 @@
         "cloudPlatform": "AZURE"
       },
       {
-        "nodeCount": 0,
+        "nodeCount": 1,
         "name": "compute",
         "type": "CORE",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering-spark3.json
@@ -57,7 +57,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering.json
@@ -56,7 +56,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering-ha.json
@@ -32,7 +32,7 @@
       "recipeNames": []
     },
       {
-        "nodeCount": 0,
+        "nodeCount": 1,
         "name": "compute",
         "type": "CORE",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering-spark3.json
@@ -53,7 +53,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering.json
@@ -53,7 +53,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering-ha.json
@@ -42,7 +42,7 @@
         "cloudPlatform": "AZURE"
       },
       {
-        "nodeCount": 0,
+        "nodeCount": 1,
         "name": "compute",
         "type": "CORE",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering-spark3.json
@@ -57,7 +57,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering.json
@@ -56,7 +56,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },


### PR DESCRIPTION
for the DE cluster shapes.
This is a workaround for OPSAPS-54928, where starting a compute group
with 0 nodes causes upscaled nodes belonging to this group to be
misconfigured, and not consume available resources (8GB for NMs).

See detailed description in the commit message.