### PR TITLE
CB-7210: Ensure that RAZ role is included when RAZ is requested, and isn't when it is not.

### DIFF
--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/StackRequestManifesterTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/StackRequestManifesterTest.java
@@ -217,6 +217,36 @@ public class StackRequestManifesterTest {
     }
 
     @Test
+    void testRAZSetupCloudStorageAccountMappingsWithRAZMapping() {
+        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
+        when(stackV4Request.getName()).thenReturn(STACK_NAME);
+        clusterV4Request.setCloudStorage(cloudStorage);
+        when(idbmmsClient.getMappingsConfig(INTERNAL_ACTOR_CRN, ENVIRONMENT_CRN, Optional.empty())).thenReturn(mappingsConfig);
+
+        // Enable RAZ for this test and make sure role is checked for.
+        clusterV4Request.setRangerRazEnabled(true);
+        when(mappingsConfig.getActorMappings()).thenReturn(Map.of("rangerraz", ""));
+
+        // Should not throw an error.
+        underTest.setupCloudStorageAccountMapping(stackV4Request, ENVIRONMENT_CRN, IdBrokerMappingSource.IDBMMS, CLOUD_PLATFORM_AWS);
+    }
+
+    @Test
+    void testRAZSetupCloudStorageAccountMappingsWithoutRAZMapping() {
+        when(stackV4Request.getCluster()).thenReturn(clusterV4Request);
+        when(stackV4Request.getName()).thenReturn(STACK_NAME);
+        clusterV4Request.setCloudStorage(cloudStorage);
+        when(idbmmsClient.getMappingsConfig(INTERNAL_ACTOR_CRN, ENVIRONMENT_CRN, Optional.empty())).thenReturn(mappingsConfig);
+
+        // Enable RAZ without mapping which should throw an error.
+        clusterV4Request.setRangerRazEnabled(true);
+        when(mappingsConfig.getActorMappings()).thenReturn(Map.of());
+        Assertions.assertThrows(
+                BadRequestException.class,
+                () -> underTest.setupCloudStorageAccountMapping(stackV4Request, ENVIRONMENT_CRN, IdBrokerMappingSource.IDBMMS, CLOUD_PLATFORM_AWS));
+    }
+
+    @Test
     public void testAddAzureIdbrokerMsiToTelemetry() {
         Map<String, Object> attributes = new HashMap<>();
         CloudStorageRequest cloudStorageRequest = new CloudStorageRequest();


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-7210

Specifically this should make it so that RAZ datalakes cannot be created if they don't include the rangerraz IDBMMS role. Similarly, if they do include the role and are note trying to create a RAZ datalake, should return an error. 

Note that while we definitely want the first of these changes, we are not sure if the second is ideal. I hope these changes facilitate a discussion on this.

I also included some quick tests that kind of test this, please let me know if I need to expand on them in any way.