### PR TITLE
ENGESC-5493 Retry CM API call on HTTP status code 0

### DIFF
--- a/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/ApiExceptionRetryPolicy.java
+++ b/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/ApiExceptionRetryPolicy.java
@@ -59,7 +59,7 @@ public class ApiExceptionRetryPolicy implements RetryPolicy {
             return handleStatusCodeNotZero(context, code);
         } else {
             LOGGER.debug("HTTP status code is 0");
-            return false;
+            return true;
         }
     }
 

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/client/retry/ApiExceptionRetryPolicyTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/client/retry/ApiExceptionRetryPolicyTest.java
@@ -52,6 +52,11 @@ public class ApiExceptionRetryPolicyTest {
         when(apiException.getCode()).thenReturn(502);
         policy.registerThrowable(context, apiException);
         assertTrue(policy.canRetry(context));
+
+        // ...and we can retry this one...
+        when(apiException.getCode()).thenReturn(0);
+        policy.registerThrowable(context, apiException);
+        assertTrue(policy.canRetry(context));
     }
 
     @Test


### PR DESCRIPTION
1. In the tagged escalation we saw couple of connection reset during CM API calls does not get retried.
2. Looking at the code, it looked like ony when there is retry for only 5XX status codes.
3. Logs indicated that the HTTP status code was mapped to 0 when the exception is due to connection reset.

./gradlew build

See detailed description in the commit message.

This is the cherry-pick of @cegganesh84 fix that was merged into master to backport it to 2.32 line.