### PR TITLE
CB-9948. Create internal access keys instead on non-internal access k…

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -588,6 +588,7 @@ public class UmsClient {
         CreateAccessKeyRequest.Builder builder = CreateAccessKeyRequest.newBuilder();
         builder.setAccountId(accountId)
                 .setMachineUserNameOrCrn(machineUserName)
+                .setInternal(true)
                 .setType(accessKeyType);
         if (!UserManagementProto.AccessKeyType.Value.UNSET.equals(accessKeyType)) {
             builder.setType(accessKeyType);

--- a/auth-connector/src/main/proto/usermanagement.proto
+++ b/auth-connector/src/main/proto/usermanagement.proto
@@ -608,7 +608,7 @@ message AccessKey {
   // The creation date in ms from the Java epoch of 1970-01-01T00:00:00Z.
   uint64 creationDateMs = 8;
   AccessKeyUsage lastUsage = 6;
-  // Whether this is an internal machine user. Internal machine users are made
+  // Whether this is an internal access key. Internal access keys are made
   // by platform services and not end-users. They are filtered out of default
   // listing operations and cannot be modified by end-user operations. Note that
   // it is possible for end-users to list by ID or CRN and otherwise
@@ -1009,6 +1009,12 @@ message CreateAccessKeyRequest {
   }
   // The type of access key to create
   AccessKeyType.Value type = 5;
+  // Whether this should be an internal access key. Internal access keys are made
+  // by platform services and not end-users. They are filtered out of default
+  // listing operations and cannot be modified by end-user operations. Note that
+  // it is possible for end-users to list by ID or CRN and otherwise
+  // determine the existence of an internal access key.
+  bool internal = 11;
 }
 
 message CreateAccessKeyResponse {


### PR DESCRIPTION
…eys for generated machine users

- with this we can avoid UMS resource limitations for workloadUser access keys