### PR TITLE
CB-9925 HDFS service health warnings

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
@@ -314,12 +314,6 @@
             },
             {
               "base": true,
-              "configs": [
-                {
-                  "name": "dfs_journalnode_edits_dir",
-                  "value": "/dfs/jn"
-                }
-              ],
               "refName": "hdfs-JOURNALNODE-BASE",
               "roleType": "JOURNALNODE"
             }

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx-medium-ha.bp
@@ -314,12 +314,6 @@
             },
             {
               "base": true,
-              "configs": [
-                {
-                  "name": "dfs_journalnode_edits_dir",
-                  "value": "/dfs/jn"
-                }
-              ],
               "refName": "hdfs-JOURNALNODE-BASE",
               "roleType": "JOURNALNODE"
             }

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
@@ -330,12 +330,6 @@
           },
           {
             "base": true,
-            "configs": [
-              {
-                "name": "dfs_journalnode_edits_dir",
-                "value": "/dfs/jn"
-              }
-            ],
             "refName": "hdfs-JOURNALNODE-BASE",
             "roleType": "JOURNALNODE"
           }


### PR DESCRIPTION
This removes the setting of dfs_journalnode_edits_dir from the medium
duty blueprints along with changing the HdfsVolumeConfigProvider to
be more in line with the other configs.

See detailed description in the commit message.