### PR TITLE
CB-9927: Restore flow is in stuck state when there is a failure in performing database restore.

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeDatabaseBackupFlowConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/DatalakeDatabaseBackupFlowConfig.java
@@ -46,10 +46,16 @@ public class DatalakeDatabaseBackupFlowConfig extends AbstractFlowConfiguration<
                     .failureState(DATALAKE_DATABASE_BACKUP_COULD_NOT_START_STATE)
                     .failureEvent(DATALAKE_DATABASE_BACKUP_COULD_NOT_START_EVENT)
 
+                    .from(DATALAKE_DATABASE_BACKUP_COULD_NOT_START_STATE)
+                    .to(DATALAKE_FULL_BACKUP_IN_PROGRESS_STATE)
+                    .event(DATALAKE_DATABASE_BACKUP_FAILURE_HANDLED_EVENT)
+                    .failureState(DATALAKE_FULL_BACKUP_IN_PROGRESS_STATE)
+                    .failureEvent(DATALAKE_DATABASE_BACKUP_FAILED_EVENT)
+
                     .from(DATALAKE_DATABASE_BACKUP_IN_PROGRESS_STATE)
                     .to(DATALAKE_FULL_BACKUP_IN_PROGRESS_STATE)
                     .event(DATALAKE_FULL_BACKUP_IN_PROGRESS_EVENT)
-                    .failureState(DATALAKE_FULL_BACKUP_IN_PROGRESS_STATE)
+                    .failureState(DATALAKE_DATABASE_BACKUP_FAILED_STATE)
                     .failureEvent(DATALAKE_DATABASE_BACKUP_FAILED_EVENT)
 
                     .from(DATALAKE_FULL_BACKUP_IN_PROGRESS_STATE)
@@ -63,8 +69,10 @@ public class DatalakeDatabaseBackupFlowConfig extends AbstractFlowConfiguration<
                     .event(DATALAKE_DATABASE_BACKUP_FINALIZED_EVENT).defaultFailureEvent()
 
                     .from(DATALAKE_DATABASE_BACKUP_FAILED_STATE)
-                    .to(FINAL_STATE)
-                    .event(DATALAKE_DATABASE_BACKUP_FAILURE_HANDLED_EVENT).defaultFailureEvent()
+                    .to(DATALAKE_FULL_BACKUP_IN_PROGRESS_STATE)
+                    .event(DATALAKE_DATABASE_BACKUP_FAILURE_HANDLED_EVENT)
+                    .failureState(DATALAKE_FULL_BACKUP_IN_PROGRESS_STATE)
+                    .failureEvent(DATALAKE_DATABASE_BACKUP_FAILED_EVENT)
 
                     .from(DATALAKE_BACKUP_FAILED_STATE)
                     .to(FINAL_STATE)
@@ -74,7 +82,7 @@ public class DatalakeDatabaseBackupFlowConfig extends AbstractFlowConfiguration<
                     .build();
 
     private static final FlowEdgeConfig<DatalakeDatabaseBackupState, DatalakeDatabaseBackupEvent> EDGE_CONFIG =
-            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, DATALAKE_DATABASE_BACKUP_FAILED_STATE, DATALAKE_DATABASE_BACKUP_FAILURE_HANDLED_EVENT);
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, DATALAKE_BACKUP_FAILED_STATE, DATALAKE_BACKUP_FAILURE_HANDLED_EVENT);
 
     public DatalakeDatabaseBackupFlowConfig() {
         super(DatalakeDatabaseBackupState.class, DatalakeDatabaseBackupEvent.class);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeDatabaseRestoreFlowConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeDatabaseRestoreFlowConfig.java
@@ -46,10 +46,16 @@ public class DatalakeDatabaseRestoreFlowConfig extends AbstractFlowConfiguration
                     .failureState(DATALAKE_DATABASE_RESTORE_COULD_NOT_START_STATE)
                     .failureEvent(DATALAKE_DATABASE_RESTORE_COULD_NOT_START_EVENT)
 
+                    .from(DATALAKE_DATABASE_RESTORE_COULD_NOT_START_STATE)
+                    .to(DATALAKE_FULL_RESTORE_IN_PROGRESS_STATE)
+                    .event(DATALAKE_DATABASE_RESTORE_FAILURE_HANDLED_EVENT)
+                    .failureState(DATALAKE_FULL_RESTORE_IN_PROGRESS_STATE)
+                    .failureEvent(DATALAKE_DATABASE_RESTORE_FAILED_EVENT)
+
                     .from(DATALAKE_DATABASE_RESTORE_IN_PROGRESS_STATE)
                     .to(DATALAKE_FULL_RESTORE_IN_PROGRESS_STATE)
                     .event(DATALAKE_FULL_RESTORE_IN_PROGRESS_EVENT)
-                    .failureState(DATALAKE_FULL_RESTORE_IN_PROGRESS_STATE)
+                    .failureState(DATALAKE_DATABASE_RESTORE_FAILED_STATE)
                     .failureEvent(DATALAKE_DATABASE_RESTORE_FAILED_EVENT)
 
                     .from(DATALAKE_FULL_RESTORE_IN_PROGRESS_STATE)
@@ -63,8 +69,10 @@ public class DatalakeDatabaseRestoreFlowConfig extends AbstractFlowConfiguration
                     .event(DATALAKE_DATABASE_RESTORE_FINALIZED_EVENT).defaultFailureEvent()
 
                     .from(DATALAKE_DATABASE_RESTORE_FAILED_STATE)
-                    .to(FINAL_STATE)
-                    .event(DATALAKE_DATABASE_RESTORE_FAILURE_HANDLED_EVENT).defaultFailureEvent()
+                    .to(DATALAKE_FULL_RESTORE_IN_PROGRESS_STATE)
+                    .event(DATALAKE_DATABASE_RESTORE_FAILURE_HANDLED_EVENT)
+                    .failureState(DATALAKE_FULL_RESTORE_IN_PROGRESS_STATE)
+                    .failureEvent(DATALAKE_DATABASE_RESTORE_FAILED_EVENT)
 
                     .from(DATALAKE_RESTORE_FAILED_STATE)
                     .to(FINAL_STATE)
@@ -73,7 +81,7 @@ public class DatalakeDatabaseRestoreFlowConfig extends AbstractFlowConfiguration
                     .build();
 
     private static final FlowEdgeConfig<DatalakeDatabaseRestoreState, DatalakeDatabaseRestoreEvent> EDGE_CONFIG =
-            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, DATALAKE_DATABASE_RESTORE_FAILED_STATE, DATALAKE_DATABASE_RESTORE_FAILURE_HANDLED_EVENT);
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, DATALAKE_RESTORE_FAILED_STATE, DATALAKE_RESTORE_FAILURE_HANDLED_EVENT);
 
     public DatalakeDatabaseRestoreFlowConfig() {
         super(DatalakeDatabaseRestoreState.class, DatalakeDatabaseRestoreEvent.class);
@@ -108,6 +116,6 @@ public class DatalakeDatabaseRestoreFlowConfig extends AbstractFlowConfiguration
 
     @Override
     public DatalakeDatabaseRestoreEvent getRetryableEvent() {
-        return DATALAKE_DATABASE_RESTORE_FAILURE_HANDLED_EVENT;
+        return DATALAKE_RESTORE_FAILURE_HANDLED_EVENT;
     }
 }


### PR DESCRIPTION
There are changes needed in both backup-restore flows to handle failures properly. There were issues in flow configurations causing the flows to be stuck in a pending state.

Below were the issues.
1. When the flows enter the DATALAKE_DATABASE_RESTORE_COULD_NOT_START_STATE and DATALAKE_DATABASE_BACKUP_COULD_NOT_START_STATE states, flows do not wait for the completion of the datalake backup.
2. When the flows enter FullBackupInProgress and FullRestoreInProgress states, database operation status was always set to SUCCESS. That need not be true.
3. Corrected the bean DATALAKE_DATABASE_RESTORE_FINISHED_STATE to DATALAKE_RESTORE_FINISHED_STATE.