### PR TITLE
CDPD-18761  change OOTB value of mapreduce input list status threads count

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.0/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.0/cdp-data-engineering-ha.bp
@@ -251,7 +251,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.0/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.0/cdp-data-engineering-spark3.bp
@@ -102,7 +102,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.0/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.0/cdp-data-engineering.bp
@@ -104,7 +104,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.1/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.1/cdp-data-engineering-ha.bp
@@ -251,7 +251,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.1/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.1/cdp-data-engineering-spark3.bp
@@ -102,7 +102,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.1/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.1/cdp-data-engineering.bp
@@ -108,7 +108,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-ha.bp
@@ -247,7 +247,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-spark3.bp
@@ -102,7 +102,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering.bp
@@ -108,7 +108,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-ha.bp
@@ -247,7 +247,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-spark3.bp
@@ -102,7 +102,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering.bp
@@ -108,7 +108,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-ha.bp
@@ -247,7 +247,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-spark3.bp
@@ -102,7 +102,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering.bp
@@ -108,7 +108,7 @@
           },
           {
             "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property>"
+            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
[CDPD-18761](https://jira.cloudera.com/browse/CDPD-18761)

In a customer env, split computation took longer time as FileInputFormat scanned files in single threaded mode. It has been recommended to set value of mapreduce.input.fileinputformat.list-status.num-threads to
100 OOTB. Hence setting following in DE templates for 7.2.0, 7.2.1, 7.2.2, 7.2.6, 7.2.7
mapreduce.input.fileinputformat.list-status.num-threads=100

Testing done :
Have created a DE cluster using a modified 7.2.6 template that includes above mentioned config changes. Cluster creation was successful on AWS using m5d.2xl instance types.