### PR TITLE
CB-9761 Do not check upgrade matrix for CM version

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/CmAndStackVersionFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/CmAndStackVersionFilter.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.service.upgrade.image;
 
-import static com.sequenceiq.cloudbreak.service.upgrade.image.ClusterUpgradeImageFilter.CM_PACKAGE_KEY;
-
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -16,12 +14,6 @@ import com.sequenceiq.cloudbreak.service.upgrade.image.locked.LockedComponentChe
 
 @Component
 public class CmAndStackVersionFilter {
-
-    private static final String STACK_PACKAGE_KEY = "stack";
-
-    private static final String CDH_BUILD_NUMBER_KEY = "cdh-build-number";
-
-    private static final String CM_BUILD_NUMBER_KEY = "cm-build-number";
 
     @Inject
     private LockedComponentChecker lockedComponentChecker;
@@ -52,11 +44,7 @@ public class CmAndStackVersionFilter {
     }
 
     private boolean isUnlockedCmAndStackUpgradePermitted(ImageFilterParams imageFilterParams, Image candidateImage) {
-        return isCmAndStackUpgradePermitted(imageFilterParams, candidateImage, CM_PACKAGE_KEY, CM_BUILD_NUMBER_KEY)
-                && isCmAndStackUpgradePermitted(imageFilterParams, candidateImage, STACK_PACKAGE_KEY, CDH_BUILD_NUMBER_KEY);
-    }
-
-    private boolean isCmAndStackUpgradePermitted(ImageFilterParams imageFilterParams, Image candidateImage, String versionKey, String buildNumberKey) {
-        return upgradePermissionProvider.permitCmAndStackUpgrade(imageFilterParams, candidateImage, versionKey, buildNumberKey);
+        return upgradePermissionProvider.permitCmUpgrade(imageFilterParams, candidateImage)
+                && upgradePermissionProvider.permitStackUpgrade(imageFilterParams, candidateImage);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CmAndStackVersionFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CmAndStackVersionFilterTest.java
@@ -28,14 +28,6 @@ import com.sequenceiq.cloudbreak.service.upgrade.image.locked.LockedComponentChe
 class CmAndStackVersionFilterTest {
     private static final String V_7_0_3 = "7.0.3";
 
-    private static final String STACK_PACKAGE_KEY = "stack";
-
-    private static final String CM_PACKAGE_KEY = "cm";
-
-    private static final String CDH_BUILD_NUMBER_KEY = "cdh-build-number";
-
-    private static final String CM_BUILD_NUMBER_KEY = "cm-build-number";
-
     @Mock
     private LockedComponentChecker lockedComponentChecker;
 
@@ -61,9 +53,9 @@ class CmAndStackVersionFilterTest {
     @Test
     public void testFilterShouldReturnFalseWhenNotLockedAndStackPermitcheckIsFalse() {
         ImageFilterParams imageFilterParams = createImageFilterParams(false, true);
-        when(upgradePermissionProvider.permitCmAndStackUpgrade(imageFilterParams, candidateImage, STACK_PACKAGE_KEY, CDH_BUILD_NUMBER_KEY))
+        when(upgradePermissionProvider.permitStackUpgrade(imageFilterParams, candidateImage))
                 .thenReturn(Boolean.FALSE);
-        when(upgradePermissionProvider.permitCmAndStackUpgrade(imageFilterParams, candidateImage, CM_PACKAGE_KEY, CM_BUILD_NUMBER_KEY))
+        when(upgradePermissionProvider.permitCmUpgrade(imageFilterParams, candidateImage))
                 .thenReturn(Boolean.TRUE);
 
         Predicate<Image> predicate = underTest.filterCmAndStackVersion(imageFilterParams, reason);
@@ -76,9 +68,9 @@ class CmAndStackVersionFilterTest {
     @Test
     public void testFilterShouldReturnFalseWhenNotLockedAndCMPermitcheckIsFalse() {
         ImageFilterParams imageFilterParams = createImageFilterParams(false, true);
-        lenient().when(upgradePermissionProvider.permitCmAndStackUpgrade(imageFilterParams, candidateImage, STACK_PACKAGE_KEY, CDH_BUILD_NUMBER_KEY))
+        lenient().when(upgradePermissionProvider.permitStackUpgrade(imageFilterParams, candidateImage))
                 .thenReturn(Boolean.TRUE);
-        when(upgradePermissionProvider.permitCmAndStackUpgrade(imageFilterParams, candidateImage, CM_PACKAGE_KEY, CM_BUILD_NUMBER_KEY))
+        when(upgradePermissionProvider.permitCmUpgrade(imageFilterParams, candidateImage))
                 .thenReturn(Boolean.FALSE);
 
         Predicate<Image> predicate = underTest.filterCmAndStackVersion(imageFilterParams, reason);
@@ -91,9 +83,9 @@ class CmAndStackVersionFilterTest {
     @Test
     public void testFilterShouldReturnFalseWhenNotLockedAndCMAndStackPermitcheckIsFalse() {
         ImageFilterParams imageFilterParams = createImageFilterParams(false, true);
-        lenient().when(upgradePermissionProvider.permitCmAndStackUpgrade(imageFilterParams, candidateImage, STACK_PACKAGE_KEY, CDH_BUILD_NUMBER_KEY))
+        lenient().when(upgradePermissionProvider.permitStackUpgrade(imageFilterParams, candidateImage))
                 .thenReturn(Boolean.FALSE);
-        when(upgradePermissionProvider.permitCmAndStackUpgrade(imageFilterParams, candidateImage, CM_PACKAGE_KEY, CM_BUILD_NUMBER_KEY))
+        when(upgradePermissionProvider.permitCmUpgrade(imageFilterParams, candidateImage))
                 .thenReturn(Boolean.FALSE);
 
         Predicate<Image> predicate = underTest.filterCmAndStackVersion(imageFilterParams, reason);
@@ -106,9 +98,9 @@ class CmAndStackVersionFilterTest {
     @Test
     public void testFilterShouldReturnTrueWhenNotLockedAndCMAndStackPermitcheckIsTrue() {
         ImageFilterParams imageFilterParams = createImageFilterParams(false, true);
-        when(upgradePermissionProvider.permitCmAndStackUpgrade(imageFilterParams, candidateImage, STACK_PACKAGE_KEY, CDH_BUILD_NUMBER_KEY))
+        when(upgradePermissionProvider.permitStackUpgrade(imageFilterParams, candidateImage))
                 .thenReturn(Boolean.TRUE);
-        when(upgradePermissionProvider.permitCmAndStackUpgrade(imageFilterParams, candidateImage, CM_PACKAGE_KEY, CM_BUILD_NUMBER_KEY))
+        when(upgradePermissionProvider.permitCmUpgrade(imageFilterParams, candidateImage))
                 .thenReturn(Boolean.TRUE);
 
         Predicate<Image> predicate = underTest.filterCmAndStackVersion(imageFilterParams, reason);


### PR DESCRIPTION
CDH and CM versions may be different from now on, so the upgrade matrix should only be used for CDH versions.

See detailed description in the commit message.