### PR TITLE
CB-9548 enable firewall rules in case google cloud which are comming …

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpNetworkConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpNetworkConnector.java
@@ -28,6 +28,7 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.compute.Compute;
 import com.google.api.services.compute.model.Subnetwork;
 import com.google.api.services.compute.model.SubnetworkList;
+import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.cloud.DefaultNetworkConnector;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
@@ -147,9 +148,9 @@ public class GcpNetworkConnector extends AbstractGcpResourceBuilder implements D
             SubnetworkList ownProjectSubnets = compute.subnetworks().list(projectId, region).execute();
             Set<Subnetwork> collect = ownProjectSubnets.getItems()
                     .stream()
-                    .filter(e -> e.getName().equals(subnetId))
+                    .filter(e -> e.getName().equals(subnetId) || e.getId().toString().equals(subnetId))
                     .collect(Collectors.toSet());
-            if (collect.isEmpty()) {
+            if (collect.isEmpty() && !Strings.isNullOrEmpty(sharedProjectId)) {
                 subnet = compute.subnetworks().get(sharedProjectId, region, subnetId).execute();
             } else {
                 subnet = collect

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/securitygroup/SecurityGroupV4RequestToSecurityGroupConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/securitygroup/SecurityGroupV4RequestToSecurityGroupConverter.java
@@ -55,6 +55,6 @@ public class SecurityGroupV4RequestToSecurityGroupConverter extends AbstractConv
             }
             return convertedSet;
         }
-        return Set.of();
+        return new HashSet<>();
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
@@ -122,7 +122,7 @@ public class EnvironmentApiConverter {
         NullUtil.doIfNotNull(request.getSecurityAccess(), securityAccess -> builder.withSecurityAccess(securityAccessRequestToDto(securityAccess)));
 
         // TODO temporary until CCM not really integrated
-        if (request.getSecurityAccess() == null) {
+        if (request.getSecurityAccess() == null && !CloudPlatform.GCP.name().equals(cloudPlatform)) {
             SecurityAccessDto securityAccess = SecurityAccessDto.builder()
                     .withCidr("0.0.0.0/0")
                     .build();

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/securitygroup/gcp/GcpEnvironmentSecurityGroupValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/securitygroup/gcp/GcpEnvironmentSecurityGroupValidator.java
@@ -2,11 +2,14 @@ package com.sequenceiq.environment.environment.validation.securitygroup.gcp;
 
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.GCP;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSecurityGroup;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSecurityGroups;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -53,6 +56,12 @@ public class GcpEnvironmentSecurityGroupValidator implements EnvironmentSecurity
                 region.getName(),
                 getCloudPlatform().name(),
                 null);
+
+        Map<String, String> filters = new HashMap<>();
+        if (!Strings.isNullOrEmpty(environmentDto.getNetwork().getGcp().getSharedProjectId())) {
+            filters.put(GcpStackUtil.SHARED_PROJECT_ID, environmentDto.getNetwork().getGcp().getSharedProjectId());
+        }
+        request.setFilters(filters);
 
         CloudSecurityGroups securityGroups = platformParameterService.getSecurityGroups(request);
 


### PR DESCRIPTION
…from the shared/host project or the user create environment without any firewall rule. Tested scenarios are 1. the vpc information coming from the base project without firewall information. 2. the vpc is shared vpc and the firewall rule coming from the host project. 3. the vpc is shared vpc and the firewall rule coming from the base project.

See detailed description in the commit message.