### PR TITLE
CB-9933 - The polling of Grain append takes more than 3 hours

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -453,6 +453,9 @@ cb:
     salt.new.service.leave.retry: 5
     salt.new.service.retry.onerror: 20
     salt.recipe.execution.retry: 180
+    salt.modifygrain:
+        maxretry: 30
+        maxerrorretry: 10
 
   address.resolving.timeout: 60000
 

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -215,6 +215,9 @@ cb:
     salt.new.service.leave.retry: 10
     salt.new.service.retry.onerror: 20
     salt.recipe.execution.retry: 180
+    salt.modifygrain:
+        maxretry: 30
+        maxerrorretry: 10
 
   address.resolving.timeout: 60000
 

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/grain/GrainUploader.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/grain/GrainUploader.java
@@ -49,7 +49,7 @@ public class GrainUploader {
 
     private void addGrainToHosts(Set<Node> allNodes, ExitCriteriaModel exitModel, SaltConnector sc, ExitCriteria exitCriteria,
             Entry<Entry<String, String>, Collection<String>> grainForHosts) throws Exception {
-        saltCommandRunner.runSaltCommand(sc, new GrainAddRunner(new HashSet<>(grainForHosts.getValue()), allNodes, grainForHosts.getKey().getKey(),
+        saltCommandRunner.runModifyGrainCommand(sc, new GrainAddRunner(new HashSet<>(grainForHosts.getValue()), allNodes, grainForHosts.getKey().getKey(),
                         grainForHosts.getKey().getValue()), exitModel, exitCriteria);
     }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/runner/SaltCommandRunner.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/runner/SaltCommandRunner.java
@@ -4,17 +4,25 @@ import java.util.concurrent.Callable;
 
 import javax.inject.Inject;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.orchestrator.OrchestratorBootstrap;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.BaseSaltJobRunner;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.SaltCommandTracker;
+import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.ModifyGrainBase;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteria;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
 
 @Component
 public class SaltCommandRunner {
+
+    @Value("${cb.max.salt.modifygrain.maxerrorretry}")
+    private int modifyGrainMaxErrorRetry;
+
+    @Value("${cb.max.salt.modifygrain.maxretry}")
+    private int modifyGrainMaxRetry;
 
     @Inject
     private SaltRunner saltRunner;
@@ -30,6 +38,14 @@ public class SaltCommandRunner {
             ExitCriteria exitCriteria) throws Exception {
         OrchestratorBootstrap saltCommandTracker = new SaltCommandTracker(sc, baseSaltJobRunner);
         Callable<Boolean> saltCommandRunBootstrapRunner = saltRunner.runner(saltCommandTracker, exitCriteria, exitCriteriaModel, retry, false);
+        saltCommandRunBootstrapRunner.call();
+    }
+
+    public void runModifyGrainCommand(SaltConnector sc, ModifyGrainBase modifyGrainRunner, ExitCriteriaModel exitCriteriaModel,
+            ExitCriteria exitCriteria) throws Exception {
+        OrchestratorBootstrap saltCommandTracker = new SaltCommandTracker(sc, modifyGrainRunner);
+        Callable<Boolean> saltCommandRunBootstrapRunner = saltRunner.runner(saltCommandTracker, exitCriteria,
+                exitCriteriaModel, modifyGrainMaxRetry, modifyGrainMaxErrorRetry);
         saltCommandRunBootstrapRunner.call();
     }
 }

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
@@ -70,6 +70,7 @@ import com.sequenceiq.cloudbreak.orchestrator.salt.poller.SaltJobIdTracker;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.GrainAddRunner;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.HighStateAllRunner;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.MineUpdateRunner;
+import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.ModifyGrainBase;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.SyncAllRunner;
 import com.sequenceiq.cloudbreak.orchestrator.salt.runner.SaltCommandRunner;
 import com.sequenceiq.cloudbreak.orchestrator.salt.runner.SaltRunner;
@@ -216,7 +217,9 @@ public class SaltOrchestratorTest {
         verifyNew(HighStateAllRunner.class, atLeastOnce()).withArguments(eq(allNodes),
                 eq(targets));
         verifyNew(SaltJobIdTracker.class, atLeastOnce()).withArguments(eq(saltConnector), eq(highStateAllRunner), eq(true));
-        verify(saltCommandRunner, times(4)).runSaltCommand(any(SaltConnector.class), any(BaseSaltJobRunner.class),
+        verify(saltCommandRunner, times(2)).runSaltCommand(any(SaltConnector.class), any(BaseSaltJobRunner.class),
+                any(ExitCriteriaModel.class), any(ExitCriteria.class));
+        verify(saltCommandRunner, times(2)).runModifyGrainCommand(any(SaltConnector.class), any(ModifyGrainBase.class),
                 any(ExitCriteriaModel.class), any(ExitCriteria.class));
         verify(grainUploader, times(1)).uploadGrains(anySet(), anyList(), any(ExitCriteriaModel.class), any(SaltConnector.class),
                 any(ExitCriteria.class));

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/grain/GrainUploaderTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/grain/GrainUploaderTest.java
@@ -68,7 +68,7 @@ public class GrainUploaderTest {
 
         ArgumentCaptor<GrainAddRunner> grainAddRunnerArgumentCaptor = ArgumentCaptor.forClass(GrainAddRunner.class);
 
-        verify(saltCommandRunner, atLeastOnce()).runSaltCommand(eq(saltConnector), grainAddRunnerArgumentCaptor.capture(), eq(exitCriteriaModel),
+        verify(saltCommandRunner, atLeastOnce()).runModifyGrainCommand(eq(saltConnector), grainAddRunnerArgumentCaptor.capture(), eq(exitCriteriaModel),
                 eq(exitCriteria));
         List<GrainAddRunner> allValues = grainAddRunnerArgumentCaptor.getAllValues();
         assertEquals(8, allValues.size());


### PR DESCRIPTION
In this commit I reduced significantly the polling time for grain add and remove operations in salt.
grain addition and removal should be a fast operation and we should wait hours for it.
with the new configuration, polling will fail after 5-10 minutes (in worst case).
