### PR TITLE
CB-10006 More than 60k log messages are written by hibernate in 15min…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLogger.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLogger.java
@@ -28,7 +28,7 @@ public class HibernateNPlusOneLogger extends HibernateStatementStatistics {
         if (queryCount > maxStatementWarning) {
             LOGGER.warn("Warning threshold: {}, {}", maxStatementWarning, message, new HibernateNPlusOneException(queryCount));
         } else {
-            LOGGER.debug("Warning threshold: {}, {}", maxStatementWarning, message);
+            LOGGER.trace("Warning threshold: {}, {}", maxStatementWarning, message);
         }
     }
 }

--- a/integration-test/integcb/Profile_template
+++ b/integration-test/integcb/Profile_template
@@ -29,7 +29,7 @@ export MEMORY_FOR_CLOUDBREAK=4096M
 export MEMORY_FOR_SERVICES=2048M
 
 # hibernate.session.circuitbreak.* is intended to catch inefficient queries in IT time
-export CB_JAVA_OPTS="-Drest.debug=true -Dcb.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=250 -Dhibernate.session.circuitbreak.max.count=2500"
+export CB_JAVA_OPTS="-Drest.debug=true -Dcb.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=25 -Dhibernate.session.circuitbreak.max.count=250"
 export PERISCOPE_JAVA_OPTS="-Dperiscope.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=10 -Dhibernate.session.circuitbreak.max.count=25"
 export FREEIPA_JAVA_OPTS="-Dfreeipa.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=25 -Dhibernate.session.circuitbreak.max.count=50"
 export REDBEAMS_JAVA_OPTS="-Dredbeams.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=10 -Dhibernate.session.circuitbreak.max.count=25"


### PR DESCRIPTION
…s, we shall reduce the verbosity, because it makes log analysis very hard. We need to ensure that IT tests will fail if somebody adds an inefficient query, therefore I have reduced the threshold for IT tests.

See detailed description in the commit message.