### PR TITLE
CB-9922 Cannot fetch the CB version at MOW Dev or Int CLOUDBREAK_SERV…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
@@ -54,7 +54,7 @@ public class ImageCatalogMockServerSetup {
     private String getCloudbreakUnderTestVersion(String cbServerAddress) {
         WebTarget target;
         Client client = RestClientUtil.get();
-        if (cbServerAddress.contains("dps.mow")) {
+        if (cbServerAddress.contains("dps.mow") || cbServerAddress.contains("cdp.mow")) {
             target = client.target(defaultCloudbreakServer + "/cloud/cb/info");
         } else {
             target = client.target(cbServerAddress + "/info");


### PR DESCRIPTION
It is related to #9489 Fix for CB Version and AppName for MOW environments. Unfortunately at that time I was not realised the MOW-Stage and MOW-Int URLs contains `cdp` instead of `dps`. So I had to change the related conditional as well.