### PR TITLE
ENGESC-5519 remove e64 instances because of the missing billing.

### DIFF
--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePremiumInstanceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePremiumInstanceTest.java
@@ -55,8 +55,6 @@ public class AzurePremiumInstanceTest {
                 {"Standard_D64s_v3", true},
                 {"Standard_D64a_v4", false},
                 {"Standard_D64as_v4", true},
-                {"Standard_E64_v3", false},
-                {"Standard_E64a_v4", false},
                 {"Standard_DS13_v2_Promo", true},
                 {"Standard_NC24", false},
                 {"Standard_DS14-8_v2", true},

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -257,8 +257,6 @@ cb:
         Standard_D64s_v3,
         Standard_D64a_v4,
         Standard_D64as_v4,
-        Standard_E64_v3,
-        Standard_E64a_v4,
         Standard_E8_v3,
         Standard_E16_v3,
         Standard_E32_v3,


### PR DESCRIPTION
See detailed description in the commit message.