### PR TITLE
Cb 9934 - Salt orchestrator could not execute tear down when the instances don't have FQDN in our metadata

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_CM_CLUSTER_S
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_CM_CLUSTER_SERVICES_STARTING;
 import static com.sequenceiq.cloudbreak.polling.PollingResult.isExited;
 import static com.sequenceiq.cloudbreak.polling.PollingResult.isTimeout;
+import static com.sequenceiq.cloudbreak.util.Benchmark.checkedMeasure;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -282,7 +283,10 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
                 .map(it -> it.getName() + ": " + it.getClientConfigStalenessStatus())
                 .collect(Collectors.joining(", ")));
         List<ApiCommand> commands = clustersResourceApi.listActiveCommands(stack.getName(), SUMMARY).getItems();
-        ApiCommand deployClientConfigCmd = getApiCommand(commands, "DeployClusterClientConfig", stack.getName(), clustersResourceApi::deployClientConfig);
+        ApiCommand deployClientConfigCmd = checkedMeasure(
+                () -> getApiCommand(commands, "DeployClusterClientConfig", stack.getName(), clustersResourceApi::deployClientConfig),
+                LOGGER,
+                "The DeployClusterClientConfig command registration to CM took {} ms");
         pollDeployConfig(deployClientConfigCmd);
         ApiCommand refreshServicesCmd = getApiCommand(commands, "RefreshCluster", stack.getName(), clustersResourceApi::refresh);
         pollRefresh(refreshServicesCmd);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperTest.java
@@ -35,6 +35,7 @@ import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.orchestrator.OrchestratorService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -88,6 +89,9 @@ public class ClusterBootstrapperTest {
     @Mock
     private HostOrchestrator hostOrchestrator;
 
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
+
     @Test
     public void shouldUseReachableInstances() throws CloudbreakException, CloudbreakImageNotFoundException {
         when(stackService.getByIdWithListsInTransaction(1L)).thenReturn(stack);
@@ -115,5 +119,6 @@ public class ClusterBootstrapperTest {
         verify(stack).getReachableInstanceMetaDataSet();
         verify(gatewayConfigService).getAllGatewayConfigs(stack);
         verify(componentConfigProviderService).getImage(1L);
+        verify(instanceMetaDataService).saveAll(stack.getReachableInstanceMetaDataSet());
     }
 }


### PR DESCRIPTION
Some of the issues that come up during Abbvie's support case at the weekend are covered by this PR.
The fix provides that:
 - FQDNs be persisted in our metadata at the beginning of bootstrap phase to avoid cases when downscale/specific node termination is not able to run due to the missing FQDNs in our metadata
 - Measure the request-response time of CM's deployeClientConfig command 