### PR TITLE
CB-9998 set cluster proxy timeout to 120 seconds and CM client timouts to 125 seconds in our services

### DIFF
--- a/autoscale/src/main/resources/application.yml
+++ b/autoscale/src/main/resources/application.yml
@@ -60,10 +60,10 @@ cb:
     contextPath: "/cb"
   cm:
     client:
-      cluster.proxy.timeout: 90000
-      connect.timeout.seconds: 100
-      read.timeout.seconds: 100
-      write.timeout.seconds: 100
+      cluster.proxy.timeout: 120000
+      connect.timeout.seconds: 125
+      read.timeout.seconds: 125
+      write.timeout.seconds: 125
 
 rest:
   debug: false

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
@@ -128,13 +128,13 @@ public class DecommissionHandler implements EventHandler<DecommissionRequest> {
             hostOrchestrator.stopClusterManagerAgent(gatewayConfig, decommissionedNodes, clusterDeletionBasedModel(stack.getId(), cluster.getId()),
                     kerberosDetailService.isAdJoinable(kerberosConfig), kerberosDetailService.isIpaJoinable(kerberosConfig), forced);
             cleanUpFreeIpa(stack, hostsToRemove);
-            List<InstanceMetaData> decommisionedInstances = decommissionedHostNames.stream()
+            List<InstanceMetaData> decommissionedInstances = decommissionedHostNames.stream()
                     .map(hostsToRemove::get)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
-            decommisionedInstances.forEach(clusterDecomissionService::deleteHostFromCluster);
+            decommissionedInstances.forEach(clusterDecomissionService::deleteHostFromCluster);
             clusterDecomissionService.deleteUnusedCredentialsFromCluster();
-            updateInstanceStatuses(decommisionedInstances, InstanceStatus.DECOMMISSIONED, "instance successfully downscaled");
+            updateInstanceStatuses(decommissionedInstances, InstanceStatus.DECOMMISSIONED, "instance successfully downscaled");
             clusterDecomissionService.restartStaleServices();
 
             result = new DecommissionResult(request, decommissionedHostNames);

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -513,10 +513,10 @@ cb:
     missed.heartbeat.interval: 30
     kerberos.encryption.type: "aes256-cts"
     client:
-      cluster.proxy.timeout: 90000
-      connect.timeout.seconds: 100
-      read.timeout.seconds: 100
-      write.timeout.seconds: 100
+      cluster.proxy.timeout: 120000
+      connect.timeout.seconds: 125
+      read.timeout.seconds: 125
+      write.timeout.seconds: 125
 
   workspace.service.cache.ttl: 15
 

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -125,10 +125,10 @@ cb:
     disabled: false
   cm:
     client:
-      cluster.proxy.timeout: 90000
-      connect.timeout.seconds: 100
-      read.timeout.seconds: 100
-      write.timeout.seconds: 100
+      cluster.proxy.timeout: 120000
+      connect.timeout.seconds: 125
+      read.timeout.seconds: 125
+      write.timeout.seconds: 125
 
 notification:
   urls: http://localhost:3000/notifications

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/clouderamanager.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/clouderamanager.conf
@@ -4,4 +4,5 @@ location / {
   proxy_set_header   Host $host;
   proxy_set_header   X-Forwarded-Host $server_name;
   proxy_set_header   X-Forwarded-Proto $scheme;
+  proxy_read_timeout 120s;
 }


### PR DESCRIPTION
See detailed description in the commit message.