### PR TITLE
CB-10025. Remove getObject requirement from cdp logging policy (S3).

### DIFF
--- a/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-log-policy.json
+++ b/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-log-policy.json
@@ -12,19 +12,10 @@
       "Effect": "Allow",
       "Action": [
         "s3:AbortMultipartUpload",
-        "s3:GetObject",
         "s3:ListMultipartUploadParts",
         "s3:PutObject"
       ],
       "Resource": "arn:aws:s3:::${LOGS_LOCATION_BASE}/*"
-    },
-    {
-      "Effect": "Deny",
-      "Action": "s3:GetObject",
-      "Resource": [
-        "arn:aws:s3:::${LOGS_LOCATION_BASE}/cluster-backups",
-        "arn:aws:s3:::${LOGS_LOCATION_BASE}/cluster-backups/*"
-      ]
     }
   ]
 }


### PR DESCRIPTION
See detailed description in the commit message.