### PR TITLE
CB-9981 Add retry to FreeIPA healthcheck

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/RetryableFreeIpaClientException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/RetryableFreeIpaClientException.java
@@ -27,6 +27,11 @@ public class RetryableFreeIpaClientException extends FreeIpaClientException {
         this.exceptionForRestApi = exceptionForRestApi;
     }
 
+    public RetryableFreeIpaClientException(String message, RetryableFreeIpaClientException cause) {
+        super(message, cause, cause.getStatusCode());
+        exceptionForRestApi = cause.exceptionForRestApi;
+    }
+
     public Exception getExceptionForRestApi() {
         return exceptionForRestApi;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClientFactory.java
@@ -79,7 +79,7 @@ public class FreeIpaHealthCheckClientFactory {
             restClient = RestClientUtil.createClient(clientConfig.getServerCert(), clientConfig.getClientCert(), clientConfig.getClientKey(),
                     connetionTimeoutMillis, readTimeoutMillis, restDebug);
         } catch (Exception e) {
-            throw new FreeIpaClientException("Unable to create client for FreeIPA health checks", e);
+            throw new RetryableFreeIpaClientException("Unable to create client for FreeIPA health checks", e);
         }
         URL freeIpaHealthCheckUrl = getIpaHealthCheckUrl(clientConfig, port, basePath);
         return new FreeIpaHealthCheckClient(restClient, freeIpaHealthCheckUrl, headers, listener);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaHealthServiceTest.java
@@ -322,7 +322,7 @@ public class FreeIpaHealthServiceTest {
             Assert.assertTrue(!nodeHealth.getIssues().isEmpty());
             Assert.assertEquals(InstanceStatus.UNREACHABLE, nodeHealth.getStatus());
             Assert.assertTrue(nodeHealth.getIssues().size() == 1);
-            Assert.assertTrue(nodeHealth.getIssues().get(0).equals("failure"));
+            Assert.assertTrue(nodeHealth.getIssues().get(0).equals("Error during healthcheck"));
         }
     }
 


### PR DESCRIPTION
Unfortunately CCM is not stable and can cause random momentary network
outage. If this happens during health check it would render FreeIPA
unreachable/unusable for 3 minutes, until the next sync.
To handle this more gracefully this commit adds `@Retryable` to the
call which invokes FreeIPA API in `FreeIpaHealthDetailsService`.
By default it will try 3 times with 1 sec delay which should be
enough for CCM to recover and fails fast enough to avoid congestion in
quartz thread pool.