### PR TITLE
CB-10042 Handle child environments when getting FreeIPA CA cert

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/RootCertRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/RootCertRepository.java
@@ -11,7 +11,7 @@ import com.sequenceiq.freeipa.entity.RootCert;
 @Transactional(Transactional.TxType.REQUIRED)
 public interface RootCertRepository extends CrudRepository<RootCert, Long> {
 
-    Optional<RootCert> findByEnvironmentCrn(String environmentCrn);
-
     int deleteByStackId(Long stackId);
+
+    Optional<RootCert> findByStackId(Long stackId);
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/cert/root/RootCertService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/cert/root/RootCertService.java
@@ -16,8 +16,8 @@ public class RootCertService {
     @Inject
     private RootCertRepository repository;
 
-    public Optional<RootCert> findByEnvironmentCrn(String environmentCrn) {
-        return repository.findByEnvironmentCrn(environmentCrn);
+    public Optional<RootCert> findByStackId(Long stackId) {
+        return repository.findByStackId(stackId);
     }
 
     public void deleteByStack(Stack stack) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/cert/root/FreeIpaRootCertificateServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/cert/root/FreeIpaRootCertificateServiceTest.java
@@ -25,6 +25,8 @@ class FreeIpaRootCertificateServiceTest {
 
     private static final String ACCOUNT_ID = "accountId";
 
+    private static final Long STACK_ID = 1L;
+
     @Mock
     private StackService stackService;
 
@@ -41,7 +43,10 @@ class FreeIpaRootCertificateServiceTest {
     public void testFetchFromDb() throws FreeIpaClientException {
         RootCert rootCert = new RootCert();
         rootCert.setCert("test");
-        when(rootCertService.findByEnvironmentCrn(ENV_CRN)).thenReturn(Optional.of(rootCert));
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        when(stackService.getByEnvironmentCrnAndAccountId(ENV_CRN, ACCOUNT_ID)).thenReturn(stack);
+        when(rootCertService.findByStackId(STACK_ID)).thenReturn(Optional.of(rootCert));
 
         String result = underTest.getRootCertificate(ENV_CRN, ACCOUNT_ID);
 
@@ -53,8 +58,8 @@ class FreeIpaRootCertificateServiceTest {
     public void testNotInDb() throws FreeIpaClientException {
         RootCert rootCert = new RootCert();
         rootCert.setCert("test");
-        when(rootCertService.findByEnvironmentCrn(ENV_CRN)).thenReturn(Optional.empty());
         Stack stack = new Stack();
+        stack.setId(STACK_ID);
         when(stackService.getByEnvironmentCrnAndAccountId(ENV_CRN, ACCOUNT_ID)).thenReturn(stack);
         when(rootCertRegisterService.register(stack)).thenReturn(rootCert);
 


### PR DESCRIPTION
In the previous implementation the cert was checked against
environment crn in the database. With this commit first the `Stack`
will be fetched by the environment crn, which already handles child
environments. Then stack id is used to fetch the cert from db or stack
is used to get the cert from FreeIPA.