### PR TITLE
CB-10013 - added validation to ssh public key registration in environment service

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/AuthenticationDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/AuthenticationDtoConverter.java
@@ -1,16 +1,34 @@
 package com.sequenceiq.environment.environment.dto;
 
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.environment.environment.domain.EnvironmentAuthentication;
+import com.sequenceiq.environment.environment.validation.validators.PublicKeyValidator;
 
 @Component
 public class AuthenticationDtoConverter {
 
+    private final PublicKeyValidator publicKeyValidator;
+
+    public AuthenticationDtoConverter(PublicKeyValidator publicKeyValidator) {
+        this.publicKeyValidator = publicKeyValidator;
+    }
+
     public EnvironmentAuthentication dtoToAuthentication(AuthenticationDto authenticationDto) {
         EnvironmentAuthentication environmentAuthentication = new EnvironmentAuthentication();
+        if (StringUtils.isNotEmpty(authenticationDto.getPublicKey())) {
+            ValidationResult validationResult = publicKeyValidator.validatePublicKey(authenticationDto.getPublicKey());
+            if (!validationResult.hasError()) {
+                List<String> parts = Arrays.asList(StringUtils.split(authenticationDto.getPublicKey(), " "));
+                environmentAuthentication.setPublicKey(String.format("%s %s %s", parts.get(0), parts.get(1), authenticationDto.getLoginUserName()));
+            }
+        }
         environmentAuthentication.setLoginUserName(authenticationDto.getLoginUserName());
-        environmentAuthentication.setPublicKey(authenticationDto.getPublicKey());
         environmentAuthentication.setPublicKeyId(authenticationDto.getPublicKeyId());
         environmentAuthentication.setManagedKey(authenticationDto.isManagedKey());
         return environmentAuthentication;

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
@@ -129,6 +129,7 @@ public class EnvironmentCreationService {
     private void validateCreation(EnvironmentCreationDto creationDto, Environment environment) {
         LOGGER.info("Validating environment creation. CreationDto: '{}', Environment: '{}'.", creationDto, environment);
         ValidationResultBuilder validationBuilder = validatorService.validateNetworkCreation(environment, creationDto.getNetwork());
+        validationBuilder.merge(validatorService.validatePublicKey(creationDto.getAuthentication().getPublicKey()));
         ValidationResult parentChildValidation = validatorService.validateParentChildRelation(environment, creationDto.getParentEnvironmentName());
         validationBuilder.merge(parentChildValidation);
         validationBuilder.ifError(() -> isCloudPlatformInvalid(creationDto.getCreator(), creationDto.getCloudPlatform()),

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
@@ -217,7 +217,7 @@ public class EnvironmentModificationService {
                     environmentResourceService.deletePublicKey(environment, oldSshKeyId);
                 }
             } else {
-                LOGGER.info("Create and update was not run successfully. We are reverting the authentication to the previous version");
+                LOGGER.info("Authentication modification was unsuccessful. The authentication was reverted to the previous version.");
                 environment.setAuthentication(originalAuthentication);
             }
         }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/PublicKeyValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/PublicKeyValidator.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.environment.environment.validation.validators;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+
+@Component
+public class PublicKeyValidator {
+
+    private static final List<String> SUPPORTED_ALGORITHMS
+            = List.of("ssh-rsa", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521", "ssh-ed25519", "ssh-dss");
+
+    private static final String ALGORITHM_TEXT_LIST = String.join(", ", SUPPORTED_ALGORITHMS);
+
+    private static final Pattern SSH_PUBLIC_KEY_PATTERN = Pattern.compile("^(ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|"
+            + "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|"
+            + "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+\\/]+[=]{0,3}( .*)?$");
+
+    public ValidationResult validatePublicKey(String publicKey) {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = ValidationResult.builder();
+        if (StringUtils.isNotEmpty(publicKey)) {
+            Matcher matcher = SSH_PUBLIC_KEY_PATTERN.matcher(publicKey.trim());
+            if (!matcher.matches()) {
+                validationResultBuilder.error(String.format(
+                        "The uploaded SSH Public Key is invalid. Correct format is <algorithm> <key> <comment> where <algorithm> can be one of"
+                                + " %n'%s' and the <comment> is optional.", ALGORITHM_TEXT_LIST));
+            }
+        }
+        return validationResultBuilder.build();
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
@@ -21,10 +21,12 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -94,6 +96,11 @@ class EnvironmentCreationServiceTest {
     @Inject
     private EnvironmentCreationService environmentCreationServiceUnderTest;
 
+    @BeforeEach
+    void setup() {
+        when(validatorService.validatePublicKey(any())).thenReturn(ValidationResult.empty());
+    }
+
     @Test
     void testCreateOccupied() {
         EnvironmentCreationDto environmentCreationDto = EnvironmentCreationDto.builder()
@@ -101,8 +108,10 @@ class EnvironmentCreationServiceTest {
                 .withAccountId(ACCOUNT_ID)
                 .build();
         when(environmentService.isNameOccupied(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(true);
+
         assertThrows(BadRequestException.class, () -> environmentCreationServiceUnderTest.create(environmentCreationDto));
 
+        verify(validatorService, Mockito.times(0)).validatePublicKey(any());
         verify(environmentService, never()).save(any());
         verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any());
         verify(reactorFlowManager, never()).triggerCreationFlow(anyLong(), eq(ENVIRONMENT_NAME), eq(USER), anyString());
@@ -142,8 +151,10 @@ class EnvironmentCreationServiceTest {
         when(environmentService.getRegionsByEnvironment(eq(environment))).thenReturn(getCloudRegions());
         when(environmentService.save(any())).thenReturn(environment);
         when(entitlementService.azureEnabled(eq(CRN), eq(ACCOUNT_ID))).thenReturn(false);
+
         assertThrows(BadRequestException.class, () -> environmentCreationServiceUnderTest.create(environmentCreationDto));
 
+        verify(validatorService, Mockito.times(1)).validatePublicKey(any());
         verify(environmentService, never()).save(any());
         verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any());
         verify(reactorFlowManager, never()).triggerCreationFlow(anyLong(), eq(ENVIRONMENT_NAME), eq(USER), anyString());
@@ -186,6 +197,7 @@ class EnvironmentCreationServiceTest {
 
         environmentCreationServiceUnderTest.create(environmentCreationDto);
 
+        verify(validatorService, Mockito.times(1)).validatePublicKey(any());
         verify(environmentService).save(any());
         verify(parametersService).saveParameters(eq(environment), eq(parametersDto));
         verify(environmentResourceService).createAndSetNetwork(any(), any(), any(), any());
@@ -240,6 +252,7 @@ class EnvironmentCreationServiceTest {
 
         environmentCreationServiceUnderTest.create(environmentCreationDto);
 
+        verify(validatorService, Mockito.times(1)).validatePublicKey(any());
         verify(environmentService).save(any());
         verify(parametersService).saveParameters(eq(environment), eq(parametersDto));
         verify(environmentResourceService).createAndSetNetwork(any(), any(), any(), any());
@@ -287,6 +300,7 @@ class EnvironmentCreationServiceTest {
 
         assertThrows(BadRequestException.class, () -> environmentCreationServiceUnderTest.create(environmentCreationDto));
 
+        verify(validatorService, Mockito.times(1)).validatePublicKey(any());
         verify(environmentService, never()).save(any());
         verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any());
         verify(reactorFlowManager, never()).triggerCreationFlow(anyLong(), eq(ENVIRONMENT_NAME), eq(USER), anyString());
@@ -334,6 +348,7 @@ class EnvironmentCreationServiceTest {
 
         assertThrows(BadRequestException.class, () -> environmentCreationServiceUnderTest.create(environmentCreationDto));
 
+        verify(validatorService, Mockito.times(1)).validatePublicKey(any());
         verify(environmentService, never()).save(any());
         verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any());
         verify(reactorFlowManager, never()).triggerCreationFlow(anyLong(), eq(ENVIRONMENT_NAME), eq(USER), anyString());

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
@@ -40,6 +40,7 @@ import com.sequenceiq.environment.environment.dto.FreeIpaCreationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
 import com.sequenceiq.environment.environment.service.EnvironmentResourceService;
 import com.sequenceiq.environment.environment.validation.validators.NetworkCreationValidator;
+import com.sequenceiq.environment.environment.validation.validators.PublicKeyValidator;
 import com.sequenceiq.environment.platformresource.PlatformParameterService;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,6 +62,9 @@ class EnvironmentValidatorServiceTest {
     @Mock
     private CredentialService credentialService;
 
+    @Mock
+    private PublicKeyValidator publicKeyValidator;
+
     @InjectMocks
     private EnvironmentValidatorService underTest;
 
@@ -71,6 +75,7 @@ class EnvironmentValidatorServiceTest {
                 platformParameterService,
                 environmentResourceService,
                 credentialService,
+                publicKeyValidator,
                 singleton(CloudPlatform.AWS.name()),
                 singleton(CloudPlatform.YARN.name())
         );
@@ -243,9 +248,10 @@ class EnvironmentValidatorServiceTest {
 
         when(environmentResourceService.isPublicKeyIdExists(environment, "pub-key-id")).thenReturn(true);
         when(environmentResourceService.getPublicKeyConnector(environment.getCloudPlatform())).thenReturn(Optional.of(connector));
+        when(publicKeyValidator.validatePublicKey(anyString())).thenReturn(ValidationResult.empty());
 
         ValidationResult validationResult = underTest.validateAuthenticationModification(environmentEditDto, environment);
-        assertEquals("1. You should define either publicKey or publicKeyId only", validationResult.getFormattedErrors());
+        assertEquals("1. You should define either publicKey or publicKeyId only, but not both.", validationResult.getFormattedErrors());
     }
 
     @Test
@@ -257,7 +263,7 @@ class EnvironmentValidatorServiceTest {
                 .build();
 
         ValidationResult validationResult = underTest.validateAuthenticationModification(environmentEditDto, environment);
-        assertEquals("1. You should define publicKey or publicKeyId", validationResult.getFormattedErrors());
+        assertEquals("1. You should define either the publicKey or the publicKeyId.", validationResult.getFormattedErrors());
     }
 
     @Test
@@ -276,7 +282,7 @@ class EnvironmentValidatorServiceTest {
 
 
         ValidationResult validationResult = underTest.validateAuthenticationModification(environmentEditDto, environment);
-        assertEquals("1. The publicKeyId with name of 'pub-key-id' does not exists on the provider", validationResult.getFormattedErrors());
+        assertEquals("1. The publicKeyId with name of 'pub-key-id' does not exist on the provider.", validationResult.getFormattedErrors());
     }
 
     @Test

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/PublicKeyValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/PublicKeyValidatorTest.java
@@ -1,0 +1,176 @@
+package com.sequenceiq.environment.environment.validation.validators;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+
+class PublicKeyValidatorTest {
+
+    private final PublicKeyValidator underTest = new PublicKeyValidator();
+
+    @Test
+    void testPublicKeyValidationWithValidKeyAndCommentIsValid() {
+        String validKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXF9paZtj6ibDgRGtw2jTls1fysxETxG/rbCN9vYlpDw6ROK90rjXnC0qi43kXbs5Z/Ny" +
+                "FDDcYW4U1nUmJCIhQqNJv00ukTbS4McfeNYrZF78KNLtbUP57SfKzjcH1Txz9Zr3ILEADqMyNRzgSB2gw5XnfbbLUFQYcF3hT11gjEw99Qi9eCQ6nC" +
+                "M37iy9tCIfMyB5CI24LECv+8UMFdYw+X9JQXgkAlcPi1zmVNckD6dDGGC2nY9mK7jw0dqZ2W/Q2HvGVgP7iSxnKIFIylifPMz0jmtzpjPi4czgr34" +
+                "d4PFlQsv8LgwWEQMyTJGQmtF3GGa1o/qT07gePY2tl1sAzOLszfglmkBZS+POYi65fxYGepF5C0Rmc3427dLp+HPl8QSAuq0j92/3LGLOKTjn1qC2" +
+                "MjBNhbkhFhDKnv0VQslmN/nkgDKUSHfQqfMwo4HXFIIydUWxT+5PxFCaS4axzGQ2HYylxqonnU3P0DJkh/omegI36HyxxlMNlpf/zn3/zrwSFvKN" +
+                "CFvbQezJg8jdqq7VEHx4DH6WhYQ02TLsjmcA0EFp1HxTCbJojD/Ixev/Wc5duHotOBiS0CXdJwyzKSQttQS9NGn+/LvUyiD/Z/Rz2r3B0LpQsQu4" +
+                "tI/8F5Jq+QiRgS9cQRnuLZuvAwbSNYI+g+zPdhaZq8fvumWarcQ== apalfi@cloudera.com\n" +
+                "\n";
+
+        ValidationResult validationResult = underTest.validatePublicKey(validKey);
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testPublicKeyValidationWithBackSlashesInCommentIsValid() {
+        String validKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXF9paZtj6ibDgRGtw2jTls1fysxETxG/rbCN9vYlpDw6ROK90rjXnC0qi43kXbs5Z/Ny" +
+                "FDDcYW4U1nUmJCIhQqNJv00ukTbS4McfeNYrZF78KNLtbUP57SfKzjcH1Txz9Zr3ILEADqMyNRzgSB2gw5XnfbbLUFQYcF3hT11gjEw99Qi9eCQ6nC" +
+                "M37iy9tCIfMyB5CI24LECv+8UMFdYw+X9JQXgkAlcPi1zmVNckD6dDGGC2nY9mK7jw0dqZ2W/Q2HvGVgP7iSxnKIFIylifPMz0jmtzpjPi4czgr34" +
+                "d4PFlQsv8LgwWEQMyTJGQmtF3GGa1o/qT07gePY2tl1sAzOLszfglmkBZS+POYi65fxYGepF5C0Rmc3427dLp+HPl8QSAuq0j92/3LGLOKTjn1qC2" +
+                "MjBNhbkhFhDKnv0VQslmN/nkgDKUSHfQqfMwo4HXFIIydUWxT+5PxFCaS4axzGQ2HYylxqonnU3P0DJkh/omegI36HyxxlMNlpf/zn3/zrwSFvKN" +
+                "CFvbQezJg8jdqq7VEHx4DH6WhYQ02TLsjmcA0EFp1HxTCbJojD/Ixev/Wc5duHotOBiS0CXdJwyzKSQttQS9NGn+/LvUyiD/Z/Rz2r3B0LpQsQu4" +
+                "tI/8F5Jq+QiRgS9cQRnuLZuvAwbSNYI+g+zPdhaZq8fvumWarcQ== office01\\\\en10022@PCL15925\n" +
+                "\n";
+
+        ValidationResult validationResult = underTest.validatePublicKey(validKey);
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testPublicKeyValidationWithNoCommentIsValid() {
+        String validKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXF9paZtj6ibDgRGtw2jTls1fysxETxG/rbCN9vYlpDw6ROK90rjXnC0qi43kXbs5Z/Ny" +
+                "FDDcYW4U1nUmJCIhQqNJv00ukTbS4McfeNYrZF78KNLtbUP57SfKzjcH1Txz9Zr3ILEADqMyNRzgSB2gw5XnfbbLUFQYcF3hT11gjEw99Qi9eCQ6nC" +
+                "M37iy9tCIfMyB5CI24LECv+8UMFdYw+X9JQXgkAlcPi1zmVNckD6dDGGC2nY9mK7jw0dqZ2W/Q2HvGVgP7iSxnKIFIylifPMz0jmtzpjPi4czgr34" +
+                "d4PFlQsv8LgwWEQMyTJGQmtF3GGa1o/qT07gePY2tl1sAzOLszfglmkBZS+POYi65fxYGepF5C0Rmc3427dLp+HPl8QSAuq0j92/3LGLOKTjn1qC2" +
+                "MjBNhbkhFhDKnv0VQslmN/nkgDKUSHfQqfMwo4HXFIIydUWxT+5PxFCaS4axzGQ2HYylxqonnU3P0DJkh/omegI36HyxxlMNlpf/zn3/zrwSFvKN" +
+                "CFvbQezJg8jdqq7VEHx4DH6WhYQ02TLsjmcA0EFp1HxTCbJojD/Ixev/Wc5duHotOBiS0CXdJwyzKSQttQS9NGn+/LvUyiD/Z/Rz2r3B0LpQsQu4" +
+                "tI/8F5Jq+QiRgS9cQRnuLZuvAwbSNYI+g+zPdhaZq8fvumWarcQ==";
+
+        ValidationResult validationResult = underTest.validatePublicKey(validKey);
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testPublicKeyValidationWith45PartsIsValid() {
+        String validKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXF9paZtj6ibDgRGtw2jTls1fysxETxG/rbCN9vYlpDw6ROK90rjXnC0qi43kXbs5Z/Ny" +
+                "FDDcYW4U1nUmJCIhQqNJv00ukTbS4McfeNYrZF78KNLtbUP57SfKzjcH1Txz9Zr3ILEADqMyNRzgSB2gw5XnfbbLUFQYcF3hT11gjEw99Qi9eCQ6nC" +
+                "M37iy9tCIfMyB5CI24LECv+8UMFdYw+X9JQXgkAlcPi1zmVNckD6dDGGC2nY9mK7jw0dqZ2W/Q2HvGVgP7iSxnKIFIylifPMz0jmtzpjPi4czgr34" +
+                "d4PFlQsv8LgwWEQMyTJGQmtF3GGa1o/qT07gePY2tl1sAzOLszfglmkBZS+POYi65fxYGepF5C0Rmc3427dLp+HPl8QSAuq0j92/3LGLOKTjn1qC2" +
+                "MjBNhbkhFhDKnv0VQslmN/nkgDKUSHfQqfMwo4HXFIIydUWxT+5PxFCaS4axzGQ2HYylxqonnU3P0DJkh/omegI36HyxxlMNlpf/zn3/zrwSFvKN" +
+                "CFvbQezJg8jdqq7VEHx4DH6WhYQ02TLsjmcA0EFp1HxTCbJojD/Ixev/Wc5duHotOBiS0CXdJwyzKSQttQS9NGn+/LvUyiD/Z/Rz2r3B0LpQsQu4" +
+                "tI/8F5Jq+QiRgS9cQRnuLZuvAwbSNYI+g+zPdhaZq8fvumWarcQ== Comment@comment.comment 4thpart 5thpartlool";
+
+        ValidationResult validationResult = underTest.validatePublicKey(validKey);
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testPublicKeyValidationWithValidNistp256() {
+        String validKey = "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTF9paZtj6ibDgRGtw2jTls1fysxETxG/rbCN9vYlpDw6ROK90rjXnC0qi43kXbs5Z/Ny" +
+                "FDDcYW4U1nUmJCIhQqNJv00ukTbS4McfeNYrZF78KNLtbUP57SfKzjcH1Txz9Zr3ILEADqMyNRzgSB2gw5XnfbbLUFQYcF3hT11gjEw99Qi9eCQ6nC" +
+                "M37iy9tCIfMyB5CI24LECv+8UMFdYw+X9JQXgkAlcPi1zmVNckD6dDGGC2nY9mK7jw0dqZ2W/Q2HvGVgP7iSxnKIFIylifPMz0jmtzpjPi4czgr34" +
+                "d4PFlQsv8LgwWEQMyTJGQmtF3GGa1o/qT07gePY2tl1sAzOLszfglmkBZS+POYi65fxYGepF5C0Rmc3427dLp+HPl8QSAuq0j92/3LGLOKTjn1qC2" +
+                "MjBNhbkhFhDKnv0VQslmN/nkgDKUSHfQqfMwo4HXFIIydUWxT+5PxFCaS4axzGQ2HYylxqonnU3P0DJkh/omegI36HyxxlMNlpf/zn3/zrwSFvKN" +
+                "CFvbQezJg8jdqq7VEHx4DH6WhYQ02TLsjmcA0EFp1HxTCbJojD/Ixev/Wc5duHotOBiS0CXdJwyzKSQttQS9NGn+/LvUyiD/Z/Rz2r3B0LpQsQu4" +
+                "tI/8F5Jq+QiRgS9cQRnuLZuvAwbSNYI+g+zPdhaZq8fvumWarcQ== apalfi@cloudera.com\n" +
+                "\n";
+
+        ValidationResult validationResult = underTest.validatePublicKey(validKey);
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testPublicKeyValidationWithValidNistp384() {
+        String validKey = "ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzODOK90rjXnC0qi43kXbs5Z/Ny" +
+                "FDDcYW4U1nUmJCIhQqNJv00ukTbS4McfeNYrZF78KNLtbUP57SfKzjcH1Txz9Zr3ILEADqMyNRzgSB2gw5XnfbbLUFQYcF3hT11gjEw99Qi9eCQ6nC" +
+                "M37iy9tCIfMyB5CI24LECv+8UMFdYw+X9JQXgkAlcPi1zmVNckD6dDGGC2nY9mK7jw0dqZ2W/Q2HvGVgP7iSxnKIFIylifPMz0jmtzpjPi4czgr34" +
+                "d4PFlQsv8LgwWEQMyTJGQmtF3GGa1o/qT07gePY2tl1sAzOLszfglmkBZS+POYi65fxYGepF5C0Rmc3427dLp+HPl8QSAuq0j92/3LGLOKTjn1qC2" +
+                "MjBNhbkhFhDKnv0VQslmN/nkgDKUSHfQqfMwo4HXFIIydUWxT+5PxFCaS4axzGQ2HYylxqonnU3P0DJkh/omegI36HyxxlMNlpf/zn3/zrwSFvKN" +
+                "CFvbQezJg8jdqq7VEHx4DH6WhYQ02TLsjmcA0EFp1HxTCbJojD/Ixev/Wc5duHotOBiS0CXdJwyzKSQttQS9NGn+/LvUyiD/Z/Rz2r3B0LpQsQu4" +
+                "tI/8F5Jq+QiRgS9cQRnuLZuvAwbSNYI+g+zPdhaZq8fvumWarcQ== apalfi@cloudera.com\n" +
+                "\n";
+
+        ValidationResult validationResult = underTest.validatePublicKey(validKey);
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testPublicKeyValidationWithValidNistp521() {
+        String validKey = "ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj" +
+                "FDDcYW4U1nUmJCIhQqNJv00ukTbS4McfeNYrZF78KNLtbUP57SfKzjcH1Txz9Zr3ILEADqMyNRzgSB2gw5XnfbbLUFQYcF3hT11gjEw99Qi9eCQ6nC" +
+                "M37iy9tCIfMyB5CI24LECv+8UMFdYw+X9JQXgkAlcPi1zmVNckD6dDGGC2nY9mK7jw0dqZ2W/Q2HvGVgP7iSxnKIFIylifPMz0jmtzpjPi4czgr34" +
+                "d4PFlQsv8LgwWEQMyTJGQmtF3GGa1o/qT07gePY2tl1sAzOLszfglmkBZS+POYi65fxYGepF5C0Rmc3427dLp+HPl8QSAuq0j92/3LGLOKTjn1qC2" +
+                "MjBNhbkhFhDKnv0VQslmN/nkgDKUSHfQqfMwo4HXFIIydUWxT+5PxFCaS4axzGQ2HYylxqonnU3P0DJkh/omegI36HyxxlMNlpf/zn3/zrwSFvKN" +
+                "CFvbQezJg8jdqq7VEHx4DH6WhYQ02TLsjmcA0EFp1HxTCbJojD/Ixev/Wc5duHotOBiS0CXdJwyzKSQttQS9NGn+/LvUyiD/Z/Rz2r3B0LpQsQu4" +
+                "tI/8F5Jq+QiRgS9cQRnuLZuvAwbSNYI+g+zPdhaZq8fvumWarcQ== apalfi@cloudera.com\n" +
+                "\n";
+
+        ValidationResult validationResult = underTest.validatePublicKey(validKey);
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testPublicKeyValidationWithValidSshEd25519() {
+        String validKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5NoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj" +
+                "FDDcYW4U1nUmJCIhQqNJv00ukTbS4McfeNYrZF78KNLtbUP57SfKzjcH1Txz9Zr3ILEADqMyNRzgSB2gw5XnfbbLUFQYcF3hT11gjEw99Qi9eCQ6nC" +
+                "M37iy9tCIfMyB5CI24LECv+8UMFdYw+X9JQXgkAlcPi1zmVNckD6dDGGC2nY9mK7jw0dqZ2W/Q2HvGVgP7iSxnKIFIylifPMz0jmtzpjPi4czgr34" +
+                "d4PFlQsv8LgwWEQMyTJGQmtF3GGa1o/qT07gePY2tl1sAzOLszfglmkBZS+POYi65fxYGepF5C0Rmc3427dLp+HPl8QSAuq0j92/3LGLOKTjn1qC2" +
+                "MjBNhbkhFhDKnv0VQslmN/nkgDKUSHfQqfMwo4HXFIIydUWxT+5PxFCaS4axzGQ2HYylxqonnU3P0DJkh/omegI36HyxxlMNlpf/zn3/zrwSFvKN" +
+                "CFvbQezJg8jdqq7VEHx4DH6WhYQ02TLsjmcA0EFp1HxTCbJojD/Ixev/Wc5duHotOBiS0CXdJwyzKSQttQS9NGn+/LvUyiD/Z/Rz2r3B0LpQsQu4" +
+                "tI/8F5Jq+QiRgS9cQRnuLZuvAwbSNYI+g+zPdhaZq8fvumWarcQ== apalfi@cloudera.com\n" +
+                "\n";
+
+        ValidationResult validationResult = underTest.validatePublicKey(validKey);
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testPublicKeyValidationWithValidSshDss() {
+        String validKey = "ssh-dss AAAAB3NzaC1kc3AAAAC3NzaC1lZDI1NTE5NoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj" +
+                "FDDcYW4U1nUmJCIhQqNJv00ukTbS4McfeNYrZF78KNLtbUP57SfKzjcH1Txz9Zr3ILEADqMyNRzgSB2gw5XnfbbLUFQYcF3hT11gjEw99Qi9eCQ6nC" +
+                "M37iy9tCIfMyB5CI24LECv+8UMFdYw+X9JQXgkAlcPi1zmVNckD6dDGGC2nY9mK7jw0dqZ2W/Q2HvGVgP7iSxnKIFIylifPMz0jmtzpjPi4czgr34" +
+                "d4PFlQsv8LgwWEQMyTJGQmtF3GGa1o/qT07gePY2tl1sAzOLszfglmkBZS+POYi65fxYGepF5C0Rmc3427dLp+HPl8QSAuq0j92/3LGLOKTjn1qC2" +
+                "MjBNhbkhFhDKnv0VQslmN/nkgDKUSHfQqfMwo4HXFIIydUWxT+5PxFCaS4axzGQ2HYylxqonnU3P0DJkh/omegI36HyxxlMNlpf/zn3/zrwSFvKN" +
+                "CFvbQezJg8jdqq7VEHx4DH6WhYQ02TLsjmcA0EFp1HxTCbJojD/Ixev/Wc5duHotOBiS0CXdJwyzKSQttQS9NGn+/LvUyiD/Z/Rz2r3B0LpQsQu4" +
+                "tI/8F5Jq+QiRgS9cQRnuLZuvAwbSNYI+g+zPdhaZq8fvumWarcQ== apalfi@cloudera.com\n" +
+                "\n";
+
+        ValidationResult validationResult = underTest.validatePublicKey(validKey);
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testPublicKeyValidationWithInvalidAlgorithm() {
+        String validKey = "invalid-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDXF9paZtj6ibDgRGtw2jTls1fysxETxG/rbCN9vYlpDw6ROK90rjXnC0qi43kXbs5Z/Ny" +
+                "FDDcYW4U1nUmJCIhQqNJv00ukTbS4McfeNYrZF78KNLtbUP57SfKzjcH1Txz9Zr3ILEADqMyNRzgSB2gw5XnfbbLUFQYcF3hT11gjEw99Qi9eCQ6nC" +
+                "M37iy9tCIfMyB5CI24LECv+8UMFdYw+X9JQXgkAlcPi1zmVNckD6dDGGC2nY9mK7jw0dqZ2W/Q2HvGVgP7iSxnKIFIylifPMz0jmtzpjPi4czgr34" +
+                "d4PFlQsv8LgwWEQMyTJGQmtF3GGa1o/qT07gePY2tl1sAzOLszfglmkBZS+POYi65fxYGepF5C0Rmc3427dLp+HPl8QSAuq0j92/3LGLOKTjn1qC2" +
+                "MjBNhbkhFhDKnv0VQslmN/nkgDKUSHfQqfMwo4HXFIIydUWxT+5PxFCaS4axzGQ2HYylxqonnU3P0DJkh/omegI36HyxxlMNlpf/zn3/zrwSFvKN" +
+                "CFvbQezJg8jdqq7VEHx4DH6WhYQ02TLsjmcA0EFp1HxTCbJojD/Ixev/Wc5duHotOBiS0CXdJwyzKSQttQS9NGn+/LvUyiD/Z/Rz2r3B0LpQsQu4" +
+                "tI/8F5Jq+QiRgS9cQRnuLZuvAwbSNYI+g+zPdhaZq8fvumWarcQ== apalfi@hortonworks.com\n" +
+                "\n";
+
+        ValidationResult validationResult = underTest.validatePublicKey(validKey);
+        assertTrue(validationResult.hasError());
+    }
+
+    @Test
+    void testPublicKeyValidationWithInvalidKey() {
+        String validKey = "ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHAdAACAQDXF9paZtj6ibDgRGtYlpDw6ROK90rjXnC0qi43kXbs5Z/Ny" +
+                "FDDcYW4U1nUmJCIhQqNJv00ukTbS4McfeNYrZF78KNLtbUP57SfKzjcH1Txz9Zr3ILEADqMyNRzgSB2gw5XnfbbLUFQYcF3hT11gjEw99Qi9eCQ6nC" +
+                "M37iy9tCIfMyB5CI24LECv+8UMFdYw+X9JQXgkAlcPi1zmVNckD6dDGGC2nY9mK7jw0dqZ2W/Q2HvGVgP7iSxnKIFIylifPMz0jmtzpjPi4czgr34" +
+                "d4PFlQsv8LgwWEQMyTJGQmtF3GGa1o/qT07gePY2tl1sAzOLszfglmkBZS+POYi65fxYGepF5C0Rmc3427dLp+HPl8QSAuq0j92/3LGLOKTjn1qC2" +
+                "MjBNhbkhFhDKnv0VQslmN/nkgDKUSHfQqfMwo4HXFIIydUWxT+5PxFCaS4axzGQ2HYylxqonnU3P0DJkh/omegI36HyxxlMNlpf/zn3/zrwSFvKN" +
+                "CFvbQezJg8jdqq7VEHx4DH6WhYQ02TLsjmcA0EFp1HxTCbJojD/Ixev/Wc5duHotOBiS0CXdJwyzKSQttQS9NGn+/LvUyiD/Z/Rz2r3B0LpQsQu4" +
+                "tI/8F5Jq+QiRgS9cQRnuLZuvAwbSNYI+g+zPdhaZq8fvumWarcQ== apalfi@hortonworks.com\n" +
+                "\n";
+
+        ValidationResult validationResult = underTest.validatePublicKey(validKey);
+        assertTrue(validationResult.hasError());
+    }
+}


### PR DESCRIPTION
- Validating for all the supported algorithm for SSH public key and replacing the comment part with the login user name which has the default value: "cloudbreak".
- We had multiple issues with invalid public keys, one particular customer had backslashes in the comment section
which rendered the Azure ARM template invalid. This change will mitigate such errors.

The regex is based on this: https://gist.github.com/paranoiq/1932126#gistcomment-3211232