### PR TITLE
CB-10053 GCP database can be stopped. Adding the provider to datalake…

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/PlatformConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/PlatformConfig.java
@@ -36,7 +36,7 @@ public class PlatformConfig {
     @Value("${datalake.experimental.externaldb.platform:MOCK}")
     private Set<CloudPlatform> dbServiceExperimentalPlatforms;
 
-    @Value("${datalake.supported.externaldb.pause.platform:AWS}")
+    @Value("${datalake.supported.externaldb.pause.platform:AWS,GCP}")
     private Set<CloudPlatform> dbServicePauseSupportedPlatforms;
 
     @Value("${datalake.supported.externaldb.sslenforcement.platform:AWS,AZURE}")


### PR DESCRIPTION
….supported.externaldb.pause.platform

See detailed description in the commit message.