### PR TITLE
CB-10055 Fix base image validation: should check the image itself first in case of image id is available in the request.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -104,15 +104,15 @@ public class ImageService {
             Blueprint blueprint, boolean useBaseImage, boolean baseImageEnabled,
             User user, Predicate<com.sequenceiq.cloudbreak.cloud.model.catalog.Image> imagePredicate)
             throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
-        if (useBaseImage && !baseImageEnabled) {
-            throw new CloudbreakImageCatalogException("Inconsistent request, base images are disabled but custom repo information is submitted!");
-        }
 
         if (imageSettings != null && StringUtils.isNotEmpty(imageSettings.getId())) {
             LOGGER.debug("Image id is specified for the stack.");
             StatedImage image = imageCatalogService.getImageByCatalogName(workspaceId, imageSettings.getId(), imageSettings.getCatalog());
             return checkIfBasePermitted(image, baseImageEnabled);
+        } else if (useBaseImage && !baseImageEnabled) {
+            throw new CloudbreakImageCatalogException("Inconsistent request, base images are disabled but custom repo information is submitted!");
         }
+
         String clusterVersion = getClusterVersion(blueprint);
 
         Set<String> operatingSystems;


### PR DESCRIPTION
See detailed description in the commit message.