### PR TITLE
CB-10054 clean the yum metadata before updating the CM server and agent

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/upgrade.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/upgrade.sls
@@ -8,6 +8,14 @@ stop-cloudera-scm-agent:
   service.dead:
     - name: cloudera-scm-agent
 
+{% if grains['os_family'] == 'RedHat' %}
+
+yum_cleanup_all_before_cm_agent_install:
+  cmd.run:
+    - name: yum clean all
+
+{% endif %}
+
 upgrade-cloudera-agent:
   pkg.latest:
     - pkgs:

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/upgrade.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/upgrade.sls
@@ -8,6 +8,14 @@ stop-cloudera-scm-server:
   service.dead:
     - name: cloudera-scm-server
 
+{% if grains['os_family'] == 'RedHat' %}
+
+yum_cleanup_all_before_cm_server_install:
+  cmd.run:
+    - name: yum clean all
+
+{% endif %}
+
 upgrade-cloudera-server:
   pkg.latest:
     - pkgs:


### PR DESCRIPTION
Whenever we're upgrading the CM version it can happen that the new version
was built before the current one. One example is when we're upgrading from
7.2.6 to 7.3.0 and the 7.2.6 build was created on 20th of Nov, but the 7.3.0
build was create on 6th of Nov. In this case yum will not perform the update:

Not using downloaded cloudera-manager/repomd.xml because it is older than what we have:
  Current   : Fri Nov 20 09:59:52 2020
  Downloaded: Fri Nov  6 02:43:27 2020
No packages marked for update

If we remove the yum caches then the update can be performed. Unfortunately, there is no
clean way of doing it from the SLS files. There are modules available which can be used
from the CLI, like:

salt '*' pkg.clean_metadata

but in SLS states this cannot be used, hece, we're going to use the cmd.run to do the work.
This will be limited to Redhat based OSs, but there is no support for anything else at
the moment.

See detailed description in the commit message.