### PR TITLE
CB-10065 We didn't handle the cause exceptions in the mappers. In thi…

### DIFF
--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/credential/CredentialVerificationResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/credential/CredentialVerificationResult.java
@@ -12,6 +12,11 @@ public class CredentialVerificationResult extends CloudPlatformResult {
         this.cloudCredentialStatus = cloudCredentialStatus;
     }
 
+    public CredentialVerificationResult(String statusReason, Exception errorDetails, Long resourceId, CloudCredentialStatus cloudCredentialStatus) {
+        super(statusReason, errorDetails, resourceId);
+        this.cloudCredentialStatus = cloudCredentialStatus;
+    }
+
     public CredentialVerificationResult(String statusReason, Exception errorDetails, Long resourceId) {
         super(statusReason, errorDetails, resourceId);
     }

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/CredentialVerificationHandler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/CredentialVerificationHandler.java
@@ -52,7 +52,13 @@ public class CredentialVerificationHandler implements CloudPlatformEventHandler<
                 LOGGER.warn(errorMessage, e);
                 cloudCredentialStatus = new CloudCredentialStatus(request.getCloudCredential(), CredentialStatus.FAILED, e, errorMessage);
             }
-            CredentialVerificationResult credentialVerificationResult = new CredentialVerificationResult(request.getResourceId(), cloudCredentialStatus);
+            CredentialVerificationResult credentialVerificationResult;
+            if (cloudCredentialStatus.getException() == null) {
+                credentialVerificationResult = new CredentialVerificationResult(request.getResourceId(), cloudCredentialStatus);
+            } else {
+                credentialVerificationResult = new CredentialVerificationResult(cloudCredentialStatus.getStatusReason(), cloudCredentialStatus.getException(),
+                        request.getResourceId(), cloudCredentialStatus);
+            }
             request.getResult().onNext(credentialVerificationResult);
             LOGGER.debug("Credential verification has finished");
         } catch (RuntimeException e) {

--- a/environment/src/main/java/com/sequenceiq/environment/exception/mapper/AmazonServiceExceptionMapper.java
+++ b/environment/src/main/java/com/sequenceiq/environment/exception/mapper/AmazonServiceExceptionMapper.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.environment.exception.mapper;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.springframework.stereotype.Component;
+
+import com.amazonaws.AmazonServiceException;
+
+@Component
+public class AmazonServiceExceptionMapper extends BaseExceptionMapper<AmazonServiceException> {
+
+    @Override
+    Status getResponseStatus(AmazonServiceException exception) {
+        return Status.fromStatusCode(exception.getStatusCode());
+    }
+
+    @Override
+    Class<AmazonServiceException> getExceptionType() {
+        return AmazonServiceException.class;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/exception/mapper/BaseExceptionMapper.java
+++ b/environment/src/main/java/com/sequenceiq/environment/exception/mapper/BaseExceptionMapper.java
@@ -19,6 +19,9 @@ import com.sequenceiq.cloudbreak.common.exception.ExceptionResponse;
 
 import ch.qos.logback.classic.Level;
 
+/**
+ * We can add the superclass as a {@code T}, the @{code {@link org.glassfish.jersey.spi.ExceptionMappers}} will find the closest type to the mapped exception.
+ */
 abstract class BaseExceptionMapper<T extends Throwable> implements ExceptionMapper<T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BaseExceptionMapper.class);
@@ -71,7 +74,7 @@ abstract class BaseExceptionMapper<T extends Throwable> implements ExceptionMapp
         return ExceptionUtils.getRootCause(throwable).getMessage();
     }
 
-    private boolean logException() {
+    protected boolean logException() {
         return true;
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/exception/mapper/CredentialVerificationExceptionMapper.java
+++ b/environment/src/main/java/com/sequenceiq/environment/exception/mapper/CredentialVerificationExceptionMapper.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.environment.exception.mapper;
 
-import javax.ws.rs.core.Response;
+import org.springframework.stereotype.Component;
 
 import com.sequenceiq.environment.credential.exception.CredentialVerificationException;
 
-public class CredentialVerificationExceptionMapper extends BaseExceptionMapper<CredentialVerificationException> {
-
-    @Override
-    Response.Status getResponseStatus(CredentialVerificationException exception) {
-        return Response.Status.BAD_REQUEST;
-    }
+@Component
+public class CredentialVerificationExceptionMapper extends SearchCauseExceptionMapper<CredentialVerificationException> {
 
     @Override
     Class<CredentialVerificationException> getExceptionType() {

--- a/environment/src/main/java/com/sequenceiq/environment/exception/mapper/GetCloudParameterExceptionMapper.java
+++ b/environment/src/main/java/com/sequenceiq/environment/exception/mapper/GetCloudParameterExceptionMapper.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.environment.exception.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.service.GetCloudParameterException;
+
+@Component
+    public class GetCloudParameterExceptionMapper extends SearchCauseExceptionMapper<GetCloudParameterException> {
+
+    @Override
+    Class<GetCloudParameterException> getExceptionType() {
+        return GetCloudParameterException.class;
+    }
+
+    @Override
+    protected boolean logException() {
+        return false;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/exception/mapper/SearchCauseExceptionMapper.java
+++ b/environment/src/main/java/com/sequenceiq/environment/exception/mapper/SearchCauseExceptionMapper.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.environment.exception.mapper;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Providers;
+
+public abstract class SearchCauseExceptionMapper<T extends Throwable> extends BaseExceptionMapper<T> {
+
+    @Context
+    private Providers providers;
+
+    @Override
+    Response.Status getResponseStatus(T exception) {
+        BaseExceptionMapper exceptionMapper = (BaseExceptionMapper<? extends Throwable>) providers.getExceptionMapper(exception.getCause().getClass());
+        if (exceptionMapper == null) {
+            return Response.Status.BAD_REQUEST;
+        }
+        return exceptionMapper.getResponseStatus(exception.getCause());
+    }
+}


### PR DESCRIPTION
…s PR we try to fetch a mapper for the cause, if we don't find we set the status to BAD_REQUEST. At the beginning, 2 exception mappers will use it: GetCloudParameterExceptionMapper and CredentialVerificationExceptionMapper

See detailed description in the commit message.