### PR TITLE
CDPSDX-1981: missing DNS a record in ipa

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
@@ -17,10 +17,15 @@ FQDN=$(hostname -f)
 IPADDR=$(hostname -i)
 REVERSE_IP=$(hostname -i | awk -F. '{print $4"."$3"." $2"."$1}')
 
-# dnsrecord-add must either add the record or modify it
-if ! ipa dnsrecord-find {{ pillar['sssd-ipa']['domain'] }}. "--name=${HOSTNAME}" "--a-rec=${IPADDR}"  --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} --all; then
-  ipa dnsrecord-add {{ pillar['sssd-ipa']['domain'] }}. "${HOSTNAME}" "--a-rec=${IPADDR}" --ttl {{ pillar['sssd-ipa']['dns_ttl'] }}
-fi
+# add dns a-record 3 times with a 10 seconds interval (see CDPSDX-1981)
+for attempt in {1..3}
+do
+  echo "add dns a-record hostname for ${HOSTNAME}, attempt ${attempt}"
+  if ! ipa dnsrecord-find {{ pillar['sssd-ipa']['domain'] }}. "--name=${HOSTNAME}" "--a-rec=${IPADDR}"  --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} --all; then
+    ipa dnsrecord-add {{ pillar['sssd-ipa']['domain'] }}. "${HOSTNAME}" "--a-rec=${IPADDR}" --ttl {{ pillar['sssd-ipa']['dns_ttl'] }}
+  fi
+  sleep 10
+done
 if ! ipa dnsrecord-find {{ pillar['sssd-ipa']['domain'] }}. "--name=${HOSTNAME}" "--a-rec=${IPADDR}"  --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} --all; then
   echo "Failed to set DNS A-record for ${HOSTNAME}"
   false


### PR DESCRIPTION
During datalake provisioning, an intermittent error of "does not have corresponding DNS A/AAAA record" happens. As we verified that dns a-record was first added and then went missing before adding service to kerbores later, we added 3 times retry with a random 10-15 seconds interval to remedy this. Also this will help to confirm how long the issue lasts and whether it comes back.

See detailed description in the commit message.