### PR TITLE
CFM-1555 We need to enable file provider, since otherwise it won’t write out that block in the resulting file. Also without this change, NiFi and NiFi Registry failed to start

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-flow-management-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-flow-management-small.bp
@@ -50,7 +50,7 @@
             "configs": [
               {
                 "name": "xml.authorizers.userGroupProvider.file-user-group-provider.enabled",
-                "value": "false"
+                "value": "true"
               },
               {
                 "name": "xml.authorizers.accessPolicyProvider.file-access-policy-provider.enabled",
@@ -188,7 +188,7 @@
             "configs": [
               {
                 "name": "xml.authorizers.userGroupProvider.file-user-group-provider.enabled",
-                "value": "false"
+                "value": "true"
               },
               {
                 "name": "xml.authorizers.accessPolicyProvider.file-access-policy-provider.enabled",

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-flow-management.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-flow-management.bp
@@ -50,7 +50,7 @@
             "configs": [
               {
                 "name": "xml.authorizers.userGroupProvider.file-user-group-provider.enabled",
-                "value": "false"
+                "value": "true"
               },
               {
                 "name": "xml.authorizers.accessPolicyProvider.file-access-policy-provider.enabled",
@@ -188,7 +188,7 @@
             "configs": [
               {
                 "name": "xml.authorizers.userGroupProvider.file-user-group-provider.enabled",
-                "value": "false"
+                "value": "true"
               },
               {
                 "name": "xml.authorizers.accessPolicyProvider.file-access-policy-provider.enabled",


### PR DESCRIPTION
After previous changes committed in scope of CFM-1555, we need to set "xml.authorizers.userGroupProvider.file-user-group-provider.enabled"="true" for the file provider, since otherwise it won’t write out that block in the resulting file. Also without this change, NiFi and NiFi Registry throws such exception: 
"AuthorizerCreationException: Unable to locate the Configurable User Group Provider: file-user-group-provider"