### PR TITLE
CB-10087 - InstanceGroup conversion does not copy the original type

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceGroupToInstanceGroupV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceGroupToInstanceGroupV4ResponseConverter.java
@@ -40,6 +40,7 @@ public class InstanceGroupToInstanceGroupV4ResponseConverter extends AbstractCon
         }
         instanceGroupResponse.setNodeCount(source.getNodeCount());
         instanceGroupResponse.setName(source.getGroupName());
+        instanceGroupResponse.setType(source.getInstanceGroupType());
         return instanceGroupResponse;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceGroupToInstanceGroupV4ResponseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceGroupToInstanceGroupV4ResponseConverterTest.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.cloudbreak.converter.v4.stacks.instancegroup;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
+import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
+import com.sequenceiq.cloudbreak.common.mappable.ProviderParameterCalculator;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+class InstanceGroupToInstanceGroupV4ResponseConverterTest {
+
+    @Mock
+    private ConverterUtil converterUtil;
+
+    @Mock
+    private ProviderParameterCalculator providerParameterCalculator;
+
+    @InjectMocks
+    private InstanceGroupToInstanceGroupV4ResponseConverter underTest;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @ParameterizedTest
+    @EnumSource(InstanceGroupType.class)
+    @DisplayName("When conversion happens the original type of the InstanceGroup must be copied into the result InstanceGroupV4Response")
+    void copyInstanceGroupType(InstanceGroupType originalType) {
+        InstanceGroup source = new InstanceGroup();
+        source.setInstanceGroupType(originalType);
+
+        InstanceGroupV4Response result = underTest.convert(source);
+
+        Assertions.assertEquals(originalType, result.getType());
+    }
+
+}


### PR DESCRIPTION
CB-10087 - InstanceGroup conversion does not copy the original type, so added this operation alongside with the associated test case