### PR TITLE
CB-10085 adding AccountIdAwareResource as the base class of AccountAw…

### DIFF
--- a/structuredevent-service-cdp/build.gradle
+++ b/structuredevent-service-cdp/build.gradle
@@ -24,4 +24,5 @@ dependencies {
     compile project(':structuredevent-api-cdp')
     compile project(':auth-connector')
     compile project(':audit-connector')
+    compile project(':secret-engine')
 }

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/repository/AccountAwareResource.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/repository/AccountAwareResource.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.structuredevent.repository;
 
-public interface AccountAwareResource {
+import com.sequenceiq.cloudbreak.service.secret.domain.AccountIdAwareResource;
+
+public interface AccountAwareResource extends AccountIdAwareResource {
 
     Long getId();
 


### PR DESCRIPTION
…areResource. Secret aspect will be able to read the account information from any object with this change. Currently secret ascpect try to use AccountIdAwareResource which iswas removed eas part of the structured event effort. Vault pathes will be fixed and we will not point to undefined path. As a followup I will remove the 'undefined' logic from secret aspect because it is risky and hiding potential problems.

See detailed description in the commit message.