### PR TITLE
CB-9989 Remove class name from the error message presented during AmazonAutoscalingFailed

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AmazonAutoscalingFailed.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AmazonAutoscalingFailed.java
@@ -9,4 +9,11 @@ public class AmazonAutoscalingFailed extends Exception {
     public AmazonAutoscalingFailed(String message, Throwable cause) {
         super(message, cause);
     }
+
+    @Override
+    public String toString() {
+        String name = getClass().getName();
+        String message = getLocalizedMessage();
+        return message != null ? message : name;
+    }
 }


### PR DESCRIPTION
Overriding the exception's toString to leave out the class' full name