### PR TITLE
CB-9525 DB SSL root cert file location customization

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
@@ -64,6 +64,7 @@ import com.sequenceiq.cloudbreak.service.idbroker.IdBrokerService;
 import com.sequenceiq.cloudbreak.service.identitymapping.AwsMockAccountMappingService;
 import com.sequenceiq.cloudbreak.service.identitymapping.AzureMockAccountMappingService;
 import com.sequenceiq.cloudbreak.service.identitymapping.GcpMockAccountMappingService;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
 import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.cloudbreak.tag.AccountTagValidationFailed;
 import com.sequenceiq.cloudbreak.template.BlueprintProcessingException;
@@ -93,6 +94,9 @@ public class StackToTemplatePreparationObjectConverter extends AbstractConversio
 
     @Inject
     private PostgresConfigService postgresConfigService;
+
+    @Inject
+    private RedbeamsDbCertificateProvider dbCertificateProvider;
 
     @Inject
     private FileSystemConfigurationProvider fileSystemConfigurationProvider;
@@ -210,6 +214,7 @@ public class StackToTemplatePreparationObjectConverter extends AbstractConversio
             Builder builder = Builder.builder()
                     .withCloudPlatform(CloudPlatform.valueOf(source.getCloudPlatform()))
                     .withRdsConfigs(postgresConfigService.createRdsConfigIfNeeded(source, cluster))
+                    .withRdsSslCertificateFilePath(dbCertificateProvider.getSslCertsFilePath())
                     .withHostgroups(hostGroupService.getByCluster(cluster.getId()))
                     .withGateway(gateway, gatewaySignKey, exposedServiceCollector.getAllKnoxExposed())
                     .withIdBroker(idbroker)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigService.java
@@ -40,7 +40,8 @@ public class PostgresConfigService {
 
         Set<String> rootCerts = dbCertificateProvider.getRelatedSslCerts(stack, cluster);
         if (CollectionUtils.isNotEmpty(rootCerts)) {
-            Map<String, String> rootSslCertsMap = Map.of("ssl_certs", String.join("\n", rootCerts));
+            Map<String, String> rootSslCertsMap = Map.of("ssl_certs", String.join("\n", rootCerts),
+                    "ssl_certs_file_path", dbCertificateProvider.getSslCertsFilePath());
             servicePillar.put("postgres-common", new SaltPillarProperties("/postgresql/root-certs.sls",
                     singletonMap("postgres_root_certs", rootSslCertsMap)));
         }

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -146,6 +146,8 @@ cb:
     cert.file: database.crt
     ssl: false
 
+  externaldatabase.ssl.rootcerts.path: /hadoopfs/fs1/database-cacerts/certs.pem
+
   aws:
     spotinstances.enabled: true
     disabled.instance.types:

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigServiceTest.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigProviderFactory;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbServerConfigurer;
+
+@ExtendWith(MockitoExtension.class)
+class PostgresConfigServiceTest {
+
+    private static final String SSL_CERTS_FILE_PATH = "/foo/bar.pem";
+
+    @Mock
+    private RdsConfigProviderFactory rdsConfigProviderFactory;
+
+    @Mock
+    private RedbeamsDbServerConfigurer dbServerConfigurer;
+
+    @Mock
+    private RedbeamsDbCertificateProvider dbCertificateProvider;
+
+    @Mock
+    private EmbeddedDatabaseConfigProvider embeddedDatabaseConfigProvider;
+
+    @InjectMocks
+    private PostgresConfigService underTest;
+
+    private Stack stack;
+
+    private Cluster cluster;
+
+    @BeforeEach
+    void setUp() {
+        stack = new Stack();
+        cluster = new Cluster();
+    }
+
+    @Test
+    void decorateServicePillarWithPostgresIfNeededTestCertsWhenSslDisabled() {
+        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
+
+        underTest.decorateServicePillarWithPostgresIfNeeded(servicePillar, stack, cluster);
+
+        assertThat(servicePillar).isEmpty();
+    }
+
+    @Test
+    void decorateServicePillarWithPostgresIfNeededTestCertsWhenSslEnabled() {
+        Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
+
+        Set<String> rootCerts = new LinkedHashSet<>();
+        rootCerts.add("cert1");
+        rootCerts.add("cert2");
+        when(dbCertificateProvider.getRelatedSslCerts(stack, cluster)).thenReturn(rootCerts);
+        when(dbCertificateProvider.getSslCertsFilePath()).thenReturn(SSL_CERTS_FILE_PATH);
+
+        underTest.decorateServicePillarWithPostgresIfNeeded(servicePillar, stack, cluster);
+
+        SaltPillarProperties saltPillarProperties = servicePillar.get("postgres-common");
+        assertThat(saltPillarProperties).isNotNull();
+        assertThat(saltPillarProperties.getPath()).isEqualTo("/postgresql/root-certs.sls");
+
+        Map<String, Object> properties = saltPillarProperties.getProperties();
+        assertThat(properties).isNotNull();
+        assertThat(properties).hasSize(1);
+
+        Map<String, String> rootSslCertsMap = (Map<String, String>) properties.get("postgres_root_certs");
+        assertThat(rootSslCertsMap).isNotNull();
+        assertThat(rootSslCertsMap).containsOnly(entry("ssl_certs", "cert1\ncert2"), entry("ssl_certs_file_path", SSL_CERTS_FILE_PATH));
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbCertificateProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbCertificateProviderTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.service.rdsconfig;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
@@ -15,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
@@ -31,6 +31,8 @@ import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.SslConfi
 @ExtendWith(MockitoExtension.class)
 class RedbeamsDbCertificateProviderTest {
 
+    private static final String SSL_CERTS_FILE_PATH = "/foo/bar.pem";
+
     @Mock
     private RedbeamsDbServerConfigurer dbServerConfigurer;
 
@@ -45,6 +47,7 @@ class RedbeamsDbCertificateProviderTest {
 
     @BeforeEach
     void setUp() {
+        ReflectionTestUtils.setField(underTest, "certsPath", SSL_CERTS_FILE_PATH);
     }
 
     @Test
@@ -57,7 +60,7 @@ class RedbeamsDbCertificateProviderTest {
 
         Set<String> actual = underTest.getRelatedSslCerts(stack, cluster);
 
-        assertTrue(actual.isEmpty());
+        assertThat(actual).isEmpty();
     }
 
     @Test
@@ -74,7 +77,7 @@ class RedbeamsDbCertificateProviderTest {
 
         Set<String> actual = underTest.getRelatedSslCerts(stack, cluster);
 
-        assertTrue(actual.isEmpty());
+        assertThat(actual).isEmpty();
     }
 
     @Test
@@ -92,7 +95,7 @@ class RedbeamsDbCertificateProviderTest {
 
         Set<String> actual = underTest.getRelatedSslCerts(stack, cluster);
 
-        assertTrue(actual.isEmpty());
+        assertThat(actual).isEmpty();
     }
 
     @Test
@@ -112,8 +115,8 @@ class RedbeamsDbCertificateProviderTest {
 
         Set<String> actual = underTest.getRelatedSslCerts(stack, cluster);
 
-        assertFalse(actual.isEmpty());
-        assertTrue(actual.contains(certificateA));
+        assertThat(actual).isNotEmpty();
+        assertThat(actual).contains(certificateA);
     }
 
     @Test
@@ -132,8 +135,8 @@ class RedbeamsDbCertificateProviderTest {
 
         Set<String> actual = underTest.getRelatedSslCerts(stack, cluster);
 
-        assertFalse(actual.isEmpty());
-        assertTrue(actual.contains(certificateA));
+        assertThat(actual).isNotEmpty();
+        assertThat(actual).contains(certificateA);
     }
 
     @Test
@@ -168,8 +171,8 @@ class RedbeamsDbCertificateProviderTest {
 
         Set<String> actual = underTest.getRelatedSslCerts(stack, cluster);
 
-        assertFalse(actual.isEmpty());
-        assertTrue(actual.contains(certificateA));
+        assertThat(actual).isNotEmpty();
+        assertThat(actual).contains(certificateA);
     }
 
     @Test
@@ -204,8 +207,8 @@ class RedbeamsDbCertificateProviderTest {
 
         Set<String> actual = underTest.getRelatedSslCerts(stack, cluster);
 
-        assertFalse(actual.isEmpty());
-        assertTrue(actual.contains(certificateB));
+        assertThat(actual).isNotEmpty();
+        assertThat(actual).contains(certificateB);
     }
 
     @Test
@@ -245,8 +248,8 @@ class RedbeamsDbCertificateProviderTest {
 
         Set<String> actual = underTest.getRelatedSslCerts(stack, cluster);
 
-        assertFalse(actual.isEmpty());
-        assertTrue(actual.contains(certificateA));
+        assertThat(actual).isNotEmpty();
+        assertThat(actual).contains(certificateA);
     }
 
     @Test
@@ -285,8 +288,13 @@ class RedbeamsDbCertificateProviderTest {
 
         Set<String> actual = underTest.getRelatedSslCerts(stack, cluster);
 
-        assertFalse(actual.isEmpty());
-        assertTrue(actual.containsAll(Set.of(certificateA, certificateB)));
+        assertThat(actual).isNotEmpty();
+        assertThat(actual).contains(certificateA, certificateB);
+    }
+
+    @Test
+    void getSslCertsFilePathTest() {
+        assertThat(underTest.getSslCertsFilePath()).isEqualTo(SSL_CERTS_FILE_PATH);
     }
 
     private SslConfigV4Response getSslConfigV4ResponseWithCertificate(Set<String> certs) {
@@ -296,4 +304,5 @@ class RedbeamsDbCertificateProviderTest {
         sslConfig.setSslCertificates(certs);
         return sslConfig;
     }
+
 }

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -28,10 +28,11 @@ RANGERGROUP="$5"
 LOGFILE=${6:-/var/log/}/dl_postgres_backup.log
 echo "Logs at ${LOGFILE}"
 
-if [[ -f /hadoopfs/fs1/database-cacerts/certs.pem ]]; then
-  export PGSSLROOTCERT=/hadoopfs/fs1/database-cacerts/certs.pem
-  export PGSSLMODE=verify-full
-fi
+{%- from 'postgresql/settings.sls' import postgresql with context %}
+{% if postgresql.ssl_enabled == True %}
+export PGSSLROOTCERT="{{ postgresql.root_certs_file }}"
+export PGSSLMODE=verify-full
+{%- endif %}
 
 doLog() {
   set +x

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -29,10 +29,11 @@ echo "Logs at ${LOGFILE}"
 
 BACKUPS_DIR="/var/tmp/postgres_restore_staging"
 
-if [[ -f /hadoopfs/fs1/database-cacerts/certs.pem ]]; then
-  export PGSSLROOTCERT=/hadoopfs/fs1/database-cacerts/certs.pem
-  export PGSSLMODE=verify-full
-fi
+{%- from 'postgresql/settings.sls' import postgresql with context %}
+{% if postgresql.ssl_enabled == True %}
+export PGSSLROOTCERT="{{ postgresql.root_certs_file }}"
+export PGSSLMODE=verify-full
+{%- endif %}
 
 doLog() {
   set +x

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/root-certs.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/root-certs.sls
@@ -1,11 +1,13 @@
-{% if salt['pillar.get']('postgres_root_certs:ssl_certs') is defined and salt['pillar.get']('postgres_root_certs:ssl_certs')|length > 1 %}
+{%- from 'postgresql/settings.sls' import postgresql with context %}
+
+{% if postgresql.ssl_enabled == True %}
 create-root-certs-file:
   file.managed:
-    - name: /hadoopfs/fs1/database-cacerts/certs.pem
+    - name: {{ postgresql.root_certs_file }}
     - makedirs: True
     - contents_pillar: postgres_root_certs:ssl_certs
     - user: root
     - group: root
     - mode: 644
-    - unless: test -f /hadoopfs/fs1/database-cacerts/certs.pem
+    - unless: test -f {{ postgresql.root_certs_file }}
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/settings.sls
@@ -1,0 +1,10 @@
+{% set ssl_enabled = salt['pillar.get']('postgres_root_certs:ssl_certs') is defined and salt['pillar.get']('postgres_root_certs:ssl_certs')|length > 1 %}
+{% set root_certs = salt['pillar.get']('postgres_root_certs:ssl_certs') %}
+{% set root_certs_file = salt['pillar.get']('postgres_root_certs:ssl_certs_file_path') %}
+
+{% set postgresql = {} %}
+{% do postgresql.update({
+    'ssl_enabled': ssl_enabled,
+    'root_certs': root_certs,
+    'root_certs_file': root_certs_file
+}) %}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRdsRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/AbstractRdsRoleConfigProvider.java
@@ -23,7 +23,7 @@ public abstract class AbstractRdsRoleConfigProvider extends AbstractRoleConfigPr
     }
 
     protected RdsView getRdsView(TemplatePreparationObject source) {
-        return new RdsView(getRdsConfig(source));
+        return new RdsView(getRdsConfig(source), source.getRdsSslCertificateFilePath());
     }
 
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hive/HiveMetastoreConfigProviderTest.java
@@ -50,6 +50,8 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 @ExtendWith(MockitoExtension.class)
 class HiveMetastoreConfigProviderTest {
 
+    private static final String SSL_CERTS_FILE_PATH = "/foo/bar.pem";
+
     @Mock
     private CmTemplateProcessor templateProcessor;
 
@@ -126,6 +128,7 @@ class HiveMetastoreConfigProviderTest {
     void getServiceConfigsTestDbOnlyWithSsl() {
         TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
                 .withRdsConfigs(Set.of(createRdsConfig(RdsSslMode.ENABLED)))
+                .withRdsSslCertificateFilePath(SSL_CERTS_FILE_PATH)
                 .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
                 .build();
 
@@ -143,7 +146,7 @@ class HiveMetastoreConfigProviderTest {
                 entry(HIVE_METASTORE_DATABASE_PORT, "5432"),
                 entry(HIVE_METASTORE_DATABASE_TYPE, "postgresql"),
                 entry(HIVE_METASTORE_DATABASE_USER, "heyitsme"),
-                entry(JDBC_URL_OVERRIDE, "jdbc:postgresql://10.1.1.1:5432/hive?sslmode=verify-full&sslrootcert=/hadoopfs/fs1/database-cacerts/certs.pem")
+                entry(JDBC_URL_OVERRIDE, "jdbc:postgresql://10.1.1.1:5432/hive?sslmode=verify-full&sslrootcert=" + SSL_CERTS_FILE_PATH)
         );
         Map<String, String> configNameToVariableNameMap = getConfigNameToVariableNameMap(result);
         assertThat(configNameToVariableNameMap).isEmpty();
@@ -174,6 +177,7 @@ class HiveMetastoreConfigProviderTest {
     void getServiceConfigsTestDbOnlyWithSslAndTemplateWithHarmlessHmsServiceConfigs() {
         TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
                 .withRdsConfigs(Set.of(createRdsConfig(RdsSslMode.ENABLED)))
+                .withRdsSslCertificateFilePath(SSL_CERTS_FILE_PATH)
                 .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
                 .build();
         initHmsServiceConfigs(List.of(config("foo", "bar")));
@@ -193,6 +197,7 @@ class HiveMetastoreConfigProviderTest {
     void getServiceConfigsTestDbOnlyWithSslAndTemplateWithHarmlessHmsServiceConfigsAndDummyCustomHmsDbKeys() {
         TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
                 .withRdsConfigs(Set.of(createRdsConfig(RdsSslMode.ENABLED)))
+                .withRdsSslCertificateFilePath(SSL_CERTS_FILE_PATH)
                 .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
                 .build();
         initHmsServiceConfigs(List.of(config("foo", "bar"), config(HIVE_METASTORE_DATABASE_HOST, null)));

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerRoleConfigProviderTest.java
@@ -50,6 +50,8 @@ import com.sequenceiq.common.api.type.InstanceGroupType;
 @ExtendWith(MockitoExtension.class)
 public class RangerRoleConfigProviderTest {
 
+    private static final String SSL_CERTS_FILE_PATH = "/foo/bar.pem";
+
     private static final String ADMIN_GROUP = "cdh_test";
 
     @Mock
@@ -237,6 +239,7 @@ public class RangerRoleConfigProviderTest {
         rdsConfig.setSslMode(RdsSslMode.ENABLED);
         TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
                 .withRdsConfigs(Set.of(rdsConfig))
+                .withRdsSslCertificateFilePath(SSL_CERTS_FILE_PATH)
                 .withProductDetails(generateCmRepo(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2), null)
                 .build();
 
@@ -249,7 +252,7 @@ public class RangerRoleConfigProviderTest {
                 entry(RANGER_ADMIN_SITE_XML_ROLE_SAFETY_VALVE,
                         "<property>" +
                         "<name>ranger.jpa.jdbc.url</name>" +
-                        "<value>jdbc:postgresql://10.1.1.1:5432/ranger?sslmode=verify-full&amp;sslrootcert=/hadoopfs/fs1/database-cacerts/certs.pem</value>" +
+                        "<value>jdbc:postgresql://10.1.1.1:5432/ranger?sslmode=verify-full&amp;sslrootcert=" + SSL_CERTS_FILE_PATH + "</value>" +
                         "</property>"),
                 entry(RANGER_DEFAULT_POLICY_GROUPS, ADMIN_GROUP)
         );

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
@@ -53,6 +53,8 @@ public class TemplatePreparationObject {
 
     private final Map<String, RDSConfig> rdsConfigs;
 
+    private final String rdsSslCertificateFilePath;
+
     private final Set<HostgroupView> hostgroupViews;
 
     private final Optional<LdapView> ldapConfig;
@@ -93,6 +95,7 @@ public class TemplatePreparationObject {
                 rdsConfig -> rdsConfig.getType().toLowerCase(),
                 Function.identity()
         ));
+        rdsSslCertificateFilePath = builder.rdsSslCertificateFilePath;
         hostgroupViews = builder.hostgroupViews;
         ldapConfig = builder.ldapConfig;
         gatewayView = builder.gatewayView;
@@ -132,6 +135,10 @@ public class TemplatePreparationObject {
 
     public RDSConfig getRdsConfig(DatabaseType type) {
         return rdsConfigs.get(type.name().toLowerCase());
+    }
+
+    public String getRdsSslCertificateFilePath() {
+        return rdsSslCertificateFilePath;
     }
 
     public Set<HostgroupView> getHostgroupViews() {
@@ -220,6 +227,8 @@ public class TemplatePreparationObject {
 
         private Set<RDSConfig> rdsConfigs = new HashSet<>();
 
+        private String rdsSslCertificateFilePath;
+
         private Set<HostgroupView> hostgroupViews = new HashSet<>();
 
         private Optional<LdapView> ldapConfig = Optional.empty();
@@ -271,6 +280,11 @@ public class TemplatePreparationObject {
 
         public Builder withRdsConfigs(Set<RDSConfig> rdsConfigs) {
             this.rdsConfigs = rdsConfigs;
+            return this;
+        }
+
+        public Builder withRdsSslCertificateFilePath(String rdsSslCertificateFilePath) {
+            this.rdsSslCertificateFilePath = rdsSslCertificateFilePath;
             return this;
         }
 
@@ -400,6 +414,7 @@ public class TemplatePreparationObject {
         public TemplatePreparationObject build() {
             return new TemplatePreparationObject(this);
         }
+
     }
 
 }

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/RdsView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/RdsView.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.template.views;
 
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -24,15 +25,13 @@ public class RdsView {
 
     private static final int DATABASE_GROUP_INDEX = 3;
 
-    private static final String SSL_CERTIFICATE_FILE = "/hadoopfs/fs1/database-cacerts/certs.pem";
-
-    private static final String SSL_OPTIONS = "sslmode=verify-full&sslrootcert=" + SSL_CERTIFICATE_FILE;
+    private static final String SSL_OPTIONS_WITHOUT_CERTIFICATE_FILE_PATH = "sslmode=verify-full&sslrootcert=";
 
     private final String connectionURL;
 
     private final boolean useSsl;
 
-    private final String sslCertificateFile;
+    private final String sslCertificateFilePath;
 
     private final String connectionDriver;
 
@@ -59,6 +58,12 @@ public class RdsView {
     private final RdsViewDialect rdsViewDialect;
 
     public RdsView(RDSConfig rdsConfig) {
+        this(rdsConfig, "");
+    }
+
+    public RdsView(RDSConfig rdsConfig, String sslCertificateFilePath) {
+        // Note: any value is valid for sslCertificateFile for sake of backward compatibility.
+        this.sslCertificateFilePath = Objects.requireNonNullElse(sslCertificateFilePath, "");
         useSsl = RdsSslMode.isEnabled(rdsConfig.getSslMode());
         if (useSsl) {
             String configConnectionURL = rdsConfig.getConnectionURL();
@@ -69,12 +74,11 @@ public class RdsView {
             } else {
                 sb.append('?');
             }
-            sb.append(SSL_OPTIONS);
+            sb.append(SSL_OPTIONS_WITHOUT_CERTIFICATE_FILE_PATH);
+            sb.append(this.sslCertificateFilePath);
             connectionURL = sb.toString();
-            sslCertificateFile = SSL_CERTIFICATE_FILE;
         } else {
             connectionURL = rdsConfig.getConnectionURL();
-            sslCertificateFile = "";
         }
 
         connectionUserName = rdsConfig.getConnectionUserName();
@@ -125,8 +129,8 @@ public class RdsView {
         return useSsl;
     }
 
-    public String getSslCertificateFile() {
-        return sslCertificateFile;
+    public String getSslCertificateFilePath() {
+        return sslCertificateFilePath;
     }
 
     public String getConnectionUserName() {

--- a/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObjectTest.java
+++ b/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObjectTest.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.template;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TemplatePreparationObjectTest {
+
+    private static final String SSL_CERTS_FILE_PATH = "/foo/bar.pem";
+
+    @Test
+    void getRdsSslCertificateFilePathTestWhenFilePathAbsent() {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .build();
+
+        assertThat(tpo.getRdsSslCertificateFilePath()).isNull();
+    }
+
+    @Test
+    void getRdsSslCertificateFilePathTestWhenFilePathPresent() {
+        TemplatePreparationObject tpo = new TemplatePreparationObject.Builder()
+                .withRdsSslCertificateFilePath(SSL_CERTS_FILE_PATH)
+                .build();
+
+        assertThat(tpo.getRdsSslCertificateFilePath()).isEqualTo(SSL_CERTS_FILE_PATH);
+    }
+
+}

--- a/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/views/RdsViewTest.java
+++ b/template-manager-core/src/test/java/com/sequenceiq/cloudbreak/template/views/RdsViewTest.java
@@ -16,7 +16,9 @@ public class RdsViewTest {
 
     private static final String ASSERT_ERROR_MSG = "The generated connection URL(connectionHost field) is not valid!";
 
-    private static final String SSL_OPTIONS_SUFFIX = "sslmode=verify-full&sslrootcert=/hadoopfs/fs1/database-cacerts/certs.pem";
+    private static final String SSL_CERTS_FILE_PATH = "/foo/bar.pem";
+
+    private static final String SSL_OPTIONS_SUFFIX = "sslmode=verify-full&sslrootcert=" + SSL_CERTS_FILE_PATH;
 
     @Test
     public void testCreateRdsViewWhenConnectionUrlContainsSubprotocolAndSubname() {
@@ -212,23 +214,39 @@ public class RdsViewTest {
     }
 
     @Test
-    public void testCreateRdsViewSslCertificateFileWhenDisabled() {
+    public void testCreateRdsViewSslCertificateFilePathWhenNoFilePath() {
         RDSConfig rdsConfig = createRdsConfig("jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306/ranger", DatabaseVendor.MYSQL);
-        rdsConfig.setSslMode(RdsSslMode.DISABLED);
 
         RdsView underTest = new RdsView(rdsConfig);
 
-        assertThat(underTest.getSslCertificateFile()).isEqualTo("");
+        assertThat(underTest.getSslCertificateFilePath()).isEqualTo("");
     }
 
     @Test
-    public void testCreateRdsViewSslCertificateFileWhenEnabled() {
+    public void testCreateRdsViewSslCertificateFilePathWhenNullFilePath() {
         RDSConfig rdsConfig = createRdsConfig("jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306/ranger", DatabaseVendor.MYSQL);
-        rdsConfig.setSslMode(RdsSslMode.ENABLED);
 
-        RdsView underTest = new RdsView(rdsConfig);
+        RdsView underTest = new RdsView(rdsConfig, null);
 
-        assertThat(underTest.getSslCertificateFile()).isEqualTo("/hadoopfs/fs1/database-cacerts/certs.pem");
+        assertThat(underTest.getSslCertificateFilePath()).isEqualTo("");
+    }
+
+    @Test
+    public void testCreateRdsViewSslCertificateFilePathWhenEmptyFilePath() {
+        RDSConfig rdsConfig = createRdsConfig("jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306/ranger", DatabaseVendor.MYSQL);
+
+        RdsView underTest = new RdsView(rdsConfig, "");
+
+        assertThat(underTest.getSslCertificateFilePath()).isEqualTo("");
+    }
+
+    @Test
+    public void testCreateRdsViewSslCertificateFilePathWhenValidFilePath() {
+        RDSConfig rdsConfig = createRdsConfig("jdbc:mysql://ranger-mysql.cmseikcocinw.us-east-1.rds.amazonaws.com:3306/ranger", DatabaseVendor.MYSQL);
+
+        RdsView underTest = new RdsView(rdsConfig, SSL_CERTS_FILE_PATH);
+
+        assertThat(underTest.getSslCertificateFilePath()).isEqualTo(SSL_CERTS_FILE_PATH);
     }
 
     static Object[][] sslConnectionUrlDataProvider() {
@@ -249,7 +267,7 @@ public class RdsViewTest {
         RDSConfig rdsConfig = createRdsConfig(connectionUrl, DatabaseVendor.MYSQL);
         rdsConfig.setSslMode(RdsSslMode.ENABLED);
 
-        RdsView underTest = new RdsView(rdsConfig);
+        RdsView underTest = new RdsView(rdsConfig, SSL_CERTS_FILE_PATH);
 
         assertThat(underTest.getConnectionURL()).isEqualTo(connectionUrlExpected);
     }


### PR DESCRIPTION
* Extract DB SSL root cert file name `/hadoopfs/fs1/database-cacerts/certs.pem` as the new property `cb.externaldatabase.ssl.rootcerts.path` in `core/src/main/resources/application.yml`
* Remove all other former occurrences of `/hadoopfs/fs1/database-cacerts/certs.pem` and let them be populated from the above application property (for Java) and the new pillar property `postgres_root_certs:ssl_certs_file_path` (for Salt)
  * Note: `RedbeamsDbCertificateProvider.getSslCertsFilePath()` depends on neither the `Stack` nor the `Cluster` at the moment. Conditional calculation of the file path may be added later as needed.
* Introduce a new Python dict for DB SSL settings; see `orchestrator-salt/src/main/resources/salt/salt/postgresql/settings.sls`
* Add new unit tests and adapt / migrate existing ones to JUnit 5 & AspectJ
  * Use `org.junit.jupiter.api.Assertions.assertThrows()` instead of `org.assertj.core.api.Assertions.assertThatCode()` for better readability.

