### PR TITLE
CB-10112 fix retry feature

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
@@ -198,7 +198,7 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
                 Optional<FlowLog> lastFlowLog = flowLogService.getLastFlowLog(flow.getFlowId());
                 lastFlowLog.ifPresent(flowLog -> {
                     String nodeId = nodeConfig.getId();
-                    if (flowLog.getCloudbreakNodeId() == null || flowLog.getCloudbreakNodeId().equals(nodeId)) {
+                    if (flowLog.getFinalized() || flowLog.getCloudbreakNodeId() == null || flowLog.getCloudbreakNodeId().equals(nodeId)) {
                         updateFlowLogStatus(key, payload, flowChainId, flow, flowLog, flowParameters);
                     } else {
                         LOGGER.info("Flow {} was handled by another node {}, current node ID is {}, abandoning.",


### PR DESCRIPTION
The following change broke retry feature:

https://github.com/hortonworks/cloudbreak/pull/9126
2020-12-02 14:40:02,946 [reactorDispatcher-77] lambda$handleFlowControlEvent$1:204 INFO c.s.f.c.Flow2Handler - [type:SDX] [crn:] [name:pdnd-prod-dl-1] [flow:] [requestid:ce7006b7-6f00-4e8b-a228-f88c7e4cf625] [tenant:9ad782ee-3322-4342-a3be-3a2348e0414e] [userCrn:crn:altus:iam:us-west-1:9ad782ee-3322-4342-a3be-3a2348e0414e:user:cf95a1a5-7858-488d-a69f-3b1c5b20df91] [environment:] [traceId:357a8cb5399c0674] [spanId:cb749a7f78372593] Flow 6835f9c4-a1fa-42d5-9ebb-8660e3ae5177 was handled by another node cloudbreak-datalake-55d977fb4b-hdkls, current node ID is cloudbreak-datalake-74c57b894d-64stl, abandoning.

See detailed description in the commit message.