### PR TITLE
CB-10032: Fix LazyInitializationException during reboot

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/RebootActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/RebootActions.java
@@ -152,7 +152,7 @@ public class RebootActions {
                     return md;
                 }).collect(Collectors.toList());
                 Long stackId = payload.getResourceId();
-                Stack stack = stackService.getStackById(stackId);
+                Stack stack = stackService.getByIdWithListsInTransaction(stackId);
                 MDCBuilder.buildMdcContext(stack);
                 return new RebootContext(flowParameters, stack, instances, null, null);
             }


### PR DESCRIPTION
Fixed a regression that was introduced in
99a3d0019a986ce95cedb27c0c8459e29c8da63c. The reboot flow did not load
the FreeIPA stack metadatalist but it accessed.

This was tested by manually deploying a cluster and rebooting FreeIPA
using a local cloudbreak deployment.

See detailed description in the commit message.