### PR TITLE
CB-9901 Update load balancer when instances change

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetadataCollector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetadataCollector.java
@@ -181,13 +181,11 @@ public class AwsMetadataCollector implements MetadataCollector {
     public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes) {
         LOGGER.debug("Collect AWS load balancer metadata, for cluster {}", ac.getCloudContext().getName());
 
-        String region = ac.getCloudContext().getLocation().getRegion().value();
-
         List<CloudLoadBalancerMetadata> cloudLoadBalancerMetadata = new ArrayList<>();
         try {
             for (LoadBalancerType type : loadBalancerTypes) {
                 String loadBalancerName = AwsLoadBalancer.getLoadBalancerName(AwsLoadBalancerScheme.valueOf(type.name()));
-                LoadBalancer loadBalancer = cloudFormationStackUtil.getLoadBalancerByLogicalId(ac, loadBalancerName, region);
+                LoadBalancer loadBalancer = cloudFormationStackUtil.getLoadBalancerByLogicalId(ac, loadBalancerName);
                 cloudLoadBalancerMetadata.add(new CloudLoadBalancerMetadata(
                     type,
                     loadBalancer.getDNSName(),

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsDownscaleService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsDownscaleService.java
@@ -34,6 +34,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.view.AuthenticatedContextView;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
@@ -62,8 +63,7 @@ public class AwsDownscaleService {
     @Inject
     private AwsCloudWatchService awsCloudWatchService;
 
-    public List<CloudResourceStatus> downscale(AuthenticatedContext auth, CloudStack stack, List<CloudResource> resources, List<CloudInstance> vms,
-            Object resourcesToRemove) {
+    public List<CloudResourceStatus> downscale(AuthenticatedContext auth, CloudStack stack, List<CloudResource> resources, List<CloudInstance> vms) {
         if (!vms.isEmpty()) {
             List<String> instanceIds = new ArrayList<>();
             for (CloudInstance vm : vms) {
@@ -101,6 +101,10 @@ public class AwsDownscaleService {
                 amazonASClient.updateAutoScalingGroup(updateDesiredAndMax);
             } catch (AmazonServiceException e) {
                 LOGGER.warn("Failed to update asGroupName: {}, error: {}", asGroupName, e.getErrorMessage(), e);
+            }
+
+            for (CloudLoadBalancer loadBalancer : stack.getLoadBalancers()) {
+                cfStackUtil.removeLoadBalancerTargets(auth, loadBalancer, resourcesToDownscale);
             }
 
         }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -162,7 +162,7 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     @Override
     public List<CloudResourceStatus> downscale(AuthenticatedContext auth, CloudStack stack, List<CloudResource> resources, List<CloudInstance> vms,
             Object resourcesToRemove) {
-        return awsDownscaleService.downscale(auth, stack, resources, vms, resourcesToRemove);
+        return awsDownscaleService.downscale(auth, stack, resources, vms);
     }
 
     @Override

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
@@ -32,6 +32,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.view.AwsNetworkView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
@@ -119,6 +120,10 @@ public class AwsUpscaleService {
             }
             awsTaggingService.tagRootVolumes(ac, amazonEC2Client, instances, stack.getTags());
             awsCloudWatchService.addCloudWatchAlarmsForSystemFailures(instances, regionName, credentialView);
+
+            for (CloudLoadBalancer loadBalancer : stack.getLoadBalancers()) {
+                cfStackUtil.addLoadBalancerTargets(ac, loadBalancer, newInstances);
+            }
         } catch (RuntimeException runtimeException) {
             recoverOriginalState(ac, stack, amazonASClient, desiredAutoscalingGroupsByName, originalAutoScalingGroupsBySize, runtimeException);
             throw new CloudConnectorException(String.format("Failed to create some resource on AWS for upscaled nodes, please check your quotas on AWS. " +

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/loadbalancer/AwsTargetGroup.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/loadbalancer/AwsTargetGroup.java
@@ -49,7 +49,7 @@ public class AwsTargetGroup {
         return instanceIds;
     }
 
-    private static String getTargetGroupName(int port, AwsLoadBalancerScheme scheme) {
+    public static String getTargetGroupName(int port, AwsLoadBalancerScheme scheme) {
         return TARGET_GROUP_NAME_PREFIX + port +
             StringUtils.capitalize(scheme.name().toLowerCase());
     }


### PR DESCRIPTION
Adds new logic to AwsDownscaleService and AwsUpscaleService. The new logic will
update the load balancer's routing rules to either remove any instances that
are being deleted from the instance groups the load balancer routes traffic to,
or add any new instances in those groups to the load balancer's targets.

Tested with unit tests, and by terminating the Knox gateway node and initiating
a repair to verify the load balancer was correctly updated.