### PR TITLE
CB-10106 Reduce the AWS SDK dependency size by using specific libraries

### DIFF
--- a/cloud-aws/build.gradle
+++ b/cloud-aws/build.gradle
@@ -24,9 +24,22 @@ dependencies {
   compile group: 'org.apache.commons',            name: 'commons-lang3',                  version: apacheCommonsLangVersion
   compile group: 'commons-io',                    name: 'commons-io',                     version: '2.4'
   compile group: 'commons-codec',                 name: 'commons-codec',                  version: commonsCodecVersion
-  compile (group: 'com.amazonaws',                name: 'aws-java-sdk',                   version: awsSdkVersion) {
-      exclude group: 'commons-logging'
+
+  compile(group: 'com.amazonaws',                 name: 'aws-java-sdk-core',              version: awsSdkVersion) {
+    exclude group: 'commons-logging'
   }
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-ec2',               version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-autoscaling',       version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-cloudformation',    version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-dynamodb',          version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-s3',                version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-iam',               version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-kms',               version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-rds',               version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-sts',               version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-cloudwatch',        version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-elasticloadbalancingv2',  version: awsSdkVersion
+
   compile group: 'org.freemarker',                name: 'freemarker',                     version: freemarkerVersion
   compile group: 'commons-net',                   name: 'commons-net',                    version: '3.6'
 

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -102,9 +102,12 @@ dependencies {
 
   compile group: 'xerces',              name: 'xercesImpl',            version: xerces
 
-  compile (group: 'com.amazonaws',                name: 'aws-java-sdk',                   version: awsSdkVersion) {
+  compile(group: 'com.amazonaws',                 name: 'aws-java-sdk-core',              version: awsSdkVersion) {
     exclude group: 'commons-logging'
   }
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-ec2',               version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-lambda',            version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-s3',                version: awsSdkVersion
 
   compile group: 'org.kohsuke', name: 'wordnet-random-name', version: '1.3'
   compile group: 'com.google.code.gson',          name: 'gson',                           version: '2.6.2'


### PR DESCRIPTION
Checked AWS provisioning, worked fine with datalake, datahub.

Before merging in, please be sure that no other dependency was introduced for aws sdk, nobody started to use another functionality from aws sdk since this would cause compile error.

Two module that depends on are:
- cloud-aws,
- integration-test.

I checked them up until this (730d5a1bf3bf21ef4a7cdd64ce616139a45d3284) point.