### PR TITLE
CB-5472 remove unused parcel files before upgrade

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/upgrade.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/upgrade.sls
@@ -16,6 +16,41 @@ yum_cleanup_all_before_cm_agent_install:
 
 {% endif %}
 
+# .dont_delete files are created as part of the image burning process
+# because the parcels that the image contains are not registered in CM
+# when it starts for the first time and the scm-agent would just delete
+# them. To prevent this deletion we create these files, but after the
+# first start it can be deleted as they are registered at that point, but
+# when we call the delete parcel API the scm-server doesn't delete them
+# until these .dont_delete files are there.
+
+remove_dont_delete_files:
+  cmd.run:
+    - name: find /opt/cloudera/ -name ".dont_delete" | xargs -I@ rm -f @
+
+# The .flood directory is used by the torrent process, but not cleaned
+# up when the parcel distriburion is done. This folder contains all the
+# parcels that are distributed so it takes up lots of space on the disk
+# unnecessarily.
+
+remove_flood_files:
+  file.directory:
+    - name: /opt/cloudera/parcels/.flood/
+    - user: cloudera-scm
+    - group: cloudera-scm
+    - dir_mode: 750
+    - clean: True
+
+# The parcel-repo folder contains the same parcels as the parcels folder
+# along with the torrent file and the hash file. However, it is not used
+# at all so during image creation we replace these files with a 0 byte file.
+# Unfortunately, when the CM server downloads a new parcel it contains the
+# full parcel file, again taking up too much space on the disk.
+
+empty_the_parcel_files_in_parcel_repo:
+  cmd.run:
+    - name: find /opt/cloudera/parcel-repo -name "*.parcel" | while read file; do :>$file; done
+
 upgrade-cloudera-agent:
   pkg.latest:
     - pkgs:


### PR DESCRIPTION
Unfortunately, the parcel files are large and they are even
replicated across multiple folders. Most of these folders
are used by intermediate processes like the distribution, but
they are not used after that point. Before the next upgrade we
need to clean up these folders, otherwise we run out of free space
on the root disk. Eventually, the usage of the folders should be
fixed in CM and these are just workarounds.