### PR TITLE
CB-10157 Store the original tags in our services and transform GCP la…

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpTagValidator.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpTagValidator.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.gcp;
 
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import javax.annotation.PostConstruct;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.CommonTagValidator;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpLabelUtil;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 
 @Component
@@ -29,7 +31,8 @@ public class GcpTagValidator extends CommonTagValidator {
 
     @Override
     public void validate(AuthenticatedContext ac, CloudStack cloudStack) {
-        validate(platformParameters.tagSpecification(), cloudStack.getTags());
+        Map<String, String> labels = GcpLabelUtil.createLabelsFromTags(cloudStack);
+        validate(platformParameters.tagSpecification(), labels);
     }
 
     @Override

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilder.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.gcp.compute;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -19,6 +18,7 @@ import com.sequenceiq.cloudbreak.cloud.gcp.GcpPlatformParameters.GcpDiskType;
 import com.sequenceiq.cloudbreak.cloud.gcp.GcpResourceException;
 import com.sequenceiq.cloudbreak.cloud.gcp.context.GcpContext;
 import com.sequenceiq.cloudbreak.cloud.gcp.service.GcpDiskEncryptionService;
+import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpLabelUtil;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
@@ -56,9 +56,8 @@ public class GcpDiskResourceBuilder extends AbstractGcpComputeBuilder {
         InstanceTemplate template = group.getReferenceInstanceTemplate();
         gcpDiskEncryptionService.addEncryptionKeyToDisk(template, disk);
 
-        Map<String, String> customTags = new HashMap<>();
-        customTags.putAll(cloudStack.getTags());
-        disk.setLabels(customTags);
+        Map<String, String> labels = GcpLabelUtil.createLabelsFromTags(cloudStack);
+        disk.setLabels(labels);
 
         Insert insDisk = context.getCompute().disks().insert(projectId, location.getAvailabilityZone().value(), disk);
         insDisk.setSourceImage(GcpStackUtil.getAmbariImage(projectId, cloudStack.getImage().getImageName()));

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/sql/GcpDatabaseServerLaunchService.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/sql/GcpDatabaseServerLaunchService.java
@@ -27,6 +27,7 @@ import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.gcp.GcpResourceException;
 import com.sequenceiq.cloudbreak.cloud.gcp.poller.DatabasePollerService;
+import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpLabelUtil;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
 import com.sequenceiq.cloudbreak.cloud.gcp.view.GcpDatabaseNetworkView;
 import com.sequenceiq.cloudbreak.cloud.gcp.view.GcpDatabaseServerView;
@@ -181,7 +182,7 @@ public class GcpDatabaseServerLaunchService extends GcpDatabaseServerBaseService
                         .setPrivateNetwork(subnetworkForRedbeams.getNetwork())
                         .setIpv4Enabled(false)
                 )
-                .setUserLabels(stack.getTags())
+                .setUserLabels(GcpLabelUtil.createLabelsFromTagsMap(stack.getTags()))
                 .setBackupConfiguration(
                         new BackupConfiguration()
                                 .setEnabled(true)

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpLabelUtil.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpLabelUtil.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+
+public final class GcpLabelUtil {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GcpLabelUtil.class);
+
+    private static final int GCP_MAX_TAG_LEN = 63;
+
+    private GcpLabelUtil() {
+    }
+
+    public static Map<String, String> createLabelsFromTags(CloudStack cloudStack) {
+        Map<String, String> tags = cloudStack.getTags();
+        return createLabelsFromTagsMap(tags);
+    }
+
+    public static Map<String, String> createLabelsFromTagsMap(Map<String, String> tags) {
+        Map<String, String> result = new HashMap<>();
+        if (tags != null) {
+            tags.forEach((key, value) -> result.put(transform(key), transform(value)));
+        }
+        return result;
+    }
+
+    private static String transform(String value) {
+        // GCP labels have strict rules https://cloud.google.com/compute/docs/labeling-resources
+        LOGGER.debug("Transforming tag key/value for GCP.");
+        if (Crn.isCrn(value)) {
+            try {
+                Crn crn = Crn.fromString(value);
+                value = crn == null ? value : crn.getResource();
+            } catch (Exception e) {
+                LOGGER.debug("Ignoring CRN ({}) parse error during tag value generation : {}", value, e.getMessage());
+            }
+        }
+        String sanitized = value.split("@")[0].toLowerCase().replaceAll("[^\\w]", "-");
+        String shortenedValue = StringUtils.right(sanitized, GCP_MAX_TAG_LEN);
+        LOGGER.debug("GCP label element has been transformed from '{}' to '{}'", value, shortenedValue);
+        return shortenedValue;
+    }
+}

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpLabelUtilTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpLabelUtilTest.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+
+class GcpLabelUtilTest {
+    private static final String ENVIRONMENT_CRN = "Cloudera-Environment-Resource-Name";
+
+    private static final String CREATOR_CRN = "Cloudera-Creator-Resource-Name";
+
+    private static final String RESOURCE_CRN = "Cloudera-Resource-Name";
+
+    @Test
+    void createLabelsFromTags() {
+        Map<String, String> tags = new HashMap<>();
+        tags.put(CREATOR_CRN, "crn:altus:timbuk2:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:user:05ca1026-c028-466b-8943-b04f765fa3f6");
+        tags.put(RESOURCE_CRN, "crn:cdp:freeipa:us-west-2:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:freeipa:8111d534-8c7e-4a68-a8ba-7ebb389a3a20");
+        tags.put(ENVIRONMENT_CRN, "crn:cdp:environments:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:environment:12474ddc-6e44-4f4c-806a-b197ef12cbb8");
+        CloudStack cloudStack = new CloudStack(new HashSet<>(), null, null, new HashMap<>(), tags, null, null, null, null, null);
+
+        Map<String, String> result = GcpLabelUtil.createLabelsFromTags(cloudStack);
+
+        assertEquals(3L, result.size());
+        assertEquals("12474ddc-6e44-4f4c-806a-b197ef12cbb8", result.get(ENVIRONMENT_CRN.toLowerCase()));
+        assertEquals("5d7-b645-7ccf9edbb73d-user-05ca1026-c028-466b-8943-b04f765fa3f6", result.get(CREATOR_CRN.toLowerCase()));
+        assertEquals("-b645-7ccf9edbb73d-freeipa-8111d534-8c7e-4a68-a8ba-7ebb389a3a20", result.get(RESOURCE_CRN.toLowerCase()));
+    }
+}

--- a/template-manager-tag/src/main/java/com/sequenceiq/cloudbreak/tag/DefaultCostTaggingService.java
+++ b/template-manager-tag/src/main/java/com/sequenceiq/cloudbreak/tag/DefaultCostTaggingService.java
@@ -14,14 +14,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 import com.google.common.base.Strings;
-import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.tag.request.CDPTagGenerationRequest;
 import com.sequenceiq.cloudbreak.tag.request.CDPTagMergeRequest;
 
 @Service
 public class DefaultCostTaggingService implements CostTagging {
-
-    public static final int GCP_MAX_TAG_LEN = 63;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultCostTaggingService.class);
 
@@ -117,22 +114,7 @@ public class DefaultCostTaggingService implements CostTagging {
     }
 
     private String transform(String value, String platform) {
-        String valueAfterCheck = Strings.isNullOrEmpty(value) ? "unknown" : value;
-        // GCP labels have strict rules https://cloud.google.com/compute/docs/labeling-resources
-        if ("GCP".equalsIgnoreCase(platform)) {
-            LOGGER.debug("Transforming tag key/value for GCP.");
-            if (Crn.isCrn(valueAfterCheck)) {
-                try {
-                    Crn crn = Crn.fromString(valueAfterCheck);
-                    valueAfterCheck = crn == null ? valueAfterCheck : crn.getResource();
-                } catch (Exception e) {
-                    LOGGER.debug("Ignoring CRN ({}) parse error during tag value generation : {}", valueAfterCheck, e.getMessage());
-                }
-            }
-            String sanitized = valueAfterCheck.split("@")[0].toLowerCase().replaceAll("[^\\w]", "-");
-            return StringUtils.right(sanitized, GCP_MAX_TAG_LEN);
-        }
-        return valueAfterCheck;
+        return Strings.isNullOrEmpty(value) ? "unknown" : value;
     }
 
     private void validateResourceTagsNotContainTheSameTag(Map<String, String> userDefinedResourceTags, Map<String, String> accountTags) {

--- a/template-manager-tag/src/test/java/com/sequenceiq/cloudbreak/DefaultCostTaggingServiceTest.java
+++ b/template-manager-tag/src/test/java/com/sequenceiq/cloudbreak/DefaultCostTaggingServiceTest.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak;
 
-import com.sequenceiq.cloudbreak.tag.AccountTagValidationFailed;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -13,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.sequenceiq.cloudbreak.tag.AccountTagValidationFailed;
 import com.sequenceiq.cloudbreak.tag.CentralTagUpdater;
 import com.sequenceiq.cloudbreak.tag.DefaultApplicationTag;
 import com.sequenceiq.cloudbreak.tag.DefaultCostTaggingService;
@@ -51,18 +51,6 @@ public class DefaultCostTaggingServiceTest {
         Assert.assertEquals("environment-crn", result.get(DefaultApplicationTag.ENVIRONMENT_CRN.key()));
         Assert.assertEquals("creator-crn", result.get(DefaultApplicationTag.CREATOR_CRN.key()));
         Assert.assertEquals("resource-crn", result.get(DefaultApplicationTag.RESOURCE_CRN.key()));
-    }
-
-    @Test
-    public void testPrepareDefaultTagsForGCPShouldReturnAllDefaultMap() {
-        Map<String, String> result = underTest.prepareDefaultTags(tagRequest("GCP"));
-
-        Assert.assertEquals(3L, result.size());
-        Assert.assertEquals("12474ddc-6e44-4f4c-806a-b197ef12cbb8", result.get(DefaultApplicationTag.ENVIRONMENT_CRN.key().toLowerCase()));
-        Assert.assertEquals("5d7-b645-7ccf9edbb73d-user-05ca1026-c028-466b-8943-b04f765fa3f6",
-                result.get(DefaultApplicationTag.CREATOR_CRN.key().toLowerCase()));
-        Assert.assertEquals("-b645-7ccf9edbb73d-freeipa-8111d534-8c7e-4a68-a8ba-7ebb389a3a20",
-                result.get(DefaultApplicationTag.RESOURCE_CRN.key().toLowerCase()));
     }
 
     @Test
@@ -139,9 +127,6 @@ public class DefaultCostTaggingServiceTest {
     }
 
     private CDPTagGenerationRequest tagRequest(String platform, Map<String, String> sourceMap, Map<String, String> accountTags) {
-        if ("GCP".equalsIgnoreCase(platform)) {
-            return tagRequestForGcp(sourceMap, accountTags, new HashMap<>());
-        }
         return tagRequest(platform, sourceMap, accountTags, new HashMap<>());
     }
 
@@ -153,22 +138,6 @@ public class DefaultCostTaggingServiceTest {
             .withResourceCrn("resource-crn")
             .withUserName("apache1@apache.com")
             .withPlatform(platform)
-            .withAccountId("pepsi")
-            .withIsInternalTenant(true)
-            .withSourceMap(sourceMap)
-            .withAccountTags(accountTags)
-            .withUserDefinedTags(userTags)
-            .build();
-    }
-
-    private CDPTagGenerationRequest tagRequestForGcp(Map<String, String> sourceMap,
-            Map<String, String> accountTags, Map<String, String> userTags) {
-        return CDPTagGenerationRequest.Builder.builder()
-            .withEnvironmentCrn("crn:cdp:environments:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:environment:12474ddc-6e44-4f4c-806a-b197ef12cbb8")
-            .withCreatorCrn("crn:altus:timbuk2:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:user:05ca1026-c028-466b-8943-b04f765fa3f6")
-            .withResourceCrn("crn:cdp:freeipa:us-west-2:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:freeipa:8111d534-8c7e-4a68-a8ba-7ebb389a3a20")
-            .withUserName("apache1@apache.com")
-            .withPlatform("GCP")
             .withAccountId("pepsi")
             .withIsInternalTenant(true)
             .withSourceMap(sourceMap)


### PR DESCRIPTION
…bels only in cloud-gcp module. This is necessary because we stored the label transformed tags previously. This way we can get the original tags in the pillar which are fundamental from telemtry perspective

@oleewere the pillars will look like this:
`cat /srv/pillar/tags/init.sls
#!json
{
	"tags": {
		"Cloudera-Creator-Resource-Name": "crn:cdp:iam:us-west-1:cloudera:user:tbihari",
		"Cloudera-Environment-Resource-Name": "crn:cdp:environments:us-west-1:cloudera:environment:7d322e9f-5085-4154-80f1-effafa52ac01",
		"Cloudera-Resource-Name": "crn:cdp:datahub:us-west-1:cloudera:cluster:d5cc4415-7a30-4760-aa23-d9981c28c47d",
		"Cloudera-Service-Type": "DATAHUB",
		"Owner": "tbihari@ums.mock",
		"creation-timestamp": "1607345447",
		"owner": "tbihari@ums.mock"
	}
}`