### PR TITLE
CB-10171: Add templates with bursty EC2 types

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterShape.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterShape.java
@@ -3,5 +3,7 @@ package com.sequenceiq.sdx.api.model;
 public enum SdxClusterShape {
     CUSTOM,
     LIGHT_DUTY,
-    MEDIUM_DUTY_HA
+    LIGHT_DUTY_BURST,
+    MEDIUM_DUTY_HA,
+    MEDIUM_DUTY_HA_BURST
 }

--- a/datalake/src/main/resources/duties/7.0.2/aws/light_duty_burst.json
+++ b/datalake/src/main/resources/duties/7.0.2/aws/light_duty_burst.json
@@ -1,0 +1,51 @@
+{
+  "cluster": {
+    "blueprintName": "CDP 1.2 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3a.medium",
+        "attachedVolumes": [
+          {
+            "count": 0,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "t3a.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.1.0/aws/light_duty_burst.json
+++ b/datalake/src/main/resources/duties/7.1.0/aws/light_duty_burst.json
@@ -1,0 +1,51 @@
+{
+  "cluster": {
+    "blueprintName": "7.1.0 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3a.medium",
+        "attachedVolumes": [
+          {
+            "count": 0,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "t3a.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.2.0/aws/light_duty_burst.json
+++ b/datalake/src/main/resources/duties/7.2.0/aws/light_duty_burst.json
@@ -1,0 +1,51 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.0 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3a.medium",
+        "attachedVolumes": [
+          {
+            "count": 0,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "t3a.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.2.1/aws/light_duty_burst.json
+++ b/datalake/src/main/resources/duties/7.2.1/aws/light_duty_burst.json
@@ -1,0 +1,51 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.1 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3a.medium",
+        "attachedVolumes": [
+          {
+            "count": 0,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "t3a.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.2.2/aws/light_duty_burst.json
+++ b/datalake/src/main/resources/duties/7.2.2/aws/light_duty_burst.json
@@ -1,0 +1,51 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.2 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3a.medium",
+        "attachedVolumes": [
+          {
+            "count": 0,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "t3a.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.2.2/aws/medium_duty_ha_burst.json
+++ b/datalake/src/main/resources/duties/7.2.2/aws/medium_duty_ha_burst.json
@@ -1,0 +1,71 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.2 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "t3a.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "gateway",
+      "template": {
+        "instanceType": "t3a.xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3a.medium",
+        "attachedVolumes": [
+          {
+            "count": 0,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.2.6/aws/light_duty_burst.json
+++ b/datalake/src/main/resources/duties/7.2.6/aws/light_duty_burst.json
@@ -1,0 +1,51 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.6 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3a.medium",
+        "attachedVolumes": [
+          {
+            "count": 0,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "t3a.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.2.6/aws/medium_duty_ha_burst.json
+++ b/datalake/src/main/resources/duties/7.2.6/aws/medium_duty_ha_burst.json
@@ -1,0 +1,71 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.6 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "t3a.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "gateway",
+      "template": {
+        "instanceType": "t3a.xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3a.medium",
+        "attachedVolumes": [
+          {
+            "count": 0,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.2.7/aws/light_duty_burst.json
+++ b/datalake/src/main/resources/duties/7.2.7/aws/light_duty_burst.json
@@ -1,0 +1,51 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.7 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3a.medium",
+        "attachedVolumes": [
+          {
+            "count": 0,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "t3a.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}

--- a/datalake/src/main/resources/duties/7.2.7/aws/medium_duty_ha_burst.json
+++ b/datalake/src/main/resources/duties/7.2.7/aws/medium_duty_ha_burst.json
@@ -1,0 +1,111 @@
+{
+  "cluster": {
+    "blueprintName": "7.2.7 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas",
+    "validateBlueprint": false
+  },
+  "customDomain": {
+    "domainName": "cloudera.site",
+    "hostgroupNameAsHostname": true
+  },
+  "instanceGroups": [
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "t3a.xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "gateway",
+      "template": {
+        "instanceType": "t3a.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 2,
+      "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "core",
+      "template": {
+        "instanceType": "t3a.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 3,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "auxiliary",
+      "template": {
+        "instanceType": "t3a.xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 100
+        }
+      },
+      "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "idbroker",
+      "template": {
+        "instanceType": "t3a.medium",
+        "attachedVolumes": [
+          {
+            "count": 0,
+            "type": "standard"
+          }
+        ],
+        "rootVolume": {
+          "size": 50
+        }
+      },
+      "nodeCount": 2,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    }
+  ]
+}


### PR DESCRIPTION
The new burst templates are copied from original templates of the same version, then change the EC2 type from m5 family to the corresponding t3a family to save cost.