### PR TITLE
CB-10162 Add log message every time the FreeIPA status is checked

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackStatusRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackStatusRepository.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.freeipa.repository;
+
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+import javax.transaction.Transactional.TxType;
+
+import com.sequenceiq.freeipa.entity.StackStatus;
+import org.springframework.data.repository.CrudRepository;
+
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+
+@EntityType(entityClass = StackStatus.class)
+@Transactional(TxType.REQUIRED)
+public interface StackStatusRepository extends CrudRepository<StackStatus, Long> {
+
+    Optional<StackStatus> findFirstByStackIdOrderByCreatedDesc(long stackId);
+
+}
+
+

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackStatusService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackStatusService.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import javax.inject.Inject;
+
+import com.sequenceiq.freeipa.entity.StackStatus;
+import com.sequenceiq.freeipa.repository.StackStatusRepository;
+import org.springframework.stereotype.Service;
+
+import static com.sequenceiq.cloudbreak.exception.NotFoundException.notFound;
+
+@Service
+public class StackStatusService {
+
+    @Inject
+    private StackStatusRepository repository;
+
+    public StackStatus findFirstByStackIdOrderByCreatedDesc(long stackId) {
+        return repository.findFirstByStackIdOrderByCreatedDesc(stackId).orElseThrow(notFound("stackStatus", stackId));
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/InstanceMetaDataService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/InstanceMetaDataService.java
@@ -69,6 +69,10 @@ public class InstanceMetaDataService {
         return instanceMetaDataRepository.findAllByInstanceIdIn(Set.of(instanceId));
     }
 
+    public Set<InstanceMetaData> getByInstanceIds(Iterable<String>  instanceIds) {
+        return instanceMetaDataRepository.findAllByInstanceIdIn(instanceIds);
+    }
+
     public Optional<InstanceMetaData> getById(Long id) {
         return instanceMetaDataRepository.findById(id);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaStatusInfoLogger.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/FreeipaStatusInfoLogger.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.freeipa.sync;
+
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.StackStatus;
+import com.sequenceiq.freeipa.service.stack.StackStatusService;
+import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+public class FreeipaStatusInfoLogger {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeipaStatusInfoLogger.class);
+
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Inject
+    private StackStatusService stackStatusService;
+
+    public void logFreeipaStatus(Long stackId, Set<InstanceMetaData> checkableInstances) {
+        StackStatus freeipaStatus = stackStatusService.findFirstByStackIdOrderByCreatedDesc(stackId);
+        String freeipaStatusInfo = String.format("freeipa stack is %s.", freeipaStatus.getStatus());
+        String allInstanceStatusInfo = createInstancesStatusInfo(checkableInstances);
+        LOGGER.debug(":::Auto sync::: freeipa status from healtch check: {} {}", freeipaStatusInfo, allInstanceStatusInfo);
+    }
+
+    private String createInstancesStatusInfo(Set<InstanceMetaData> checkableInstances) {
+        Set<InstanceMetaData> allInstanceMetaData = fetchCheckableInstancesFromDb(checkableInstances);
+        String allInstanceStatusInfo = allInstanceMetaData.stream()
+                .map(instance -> String.format("instance %s is %s", instance.getInstanceId(), instance.getInstanceStatus()))
+                .collect(Collectors.joining("; "));
+        return allInstanceStatusInfo;
+    }
+
+    private Set<InstanceMetaData> fetchCheckableInstancesFromDb(Set<InstanceMetaData> checkableInstances) {
+        Set<String> checkableInstanceIds = collectCheckableInstanceIds(checkableInstances);
+        Set<InstanceMetaData> allInstanceMetaData = instanceMetaDataService
+                .getByInstanceIds(checkableInstanceIds);
+        return allInstanceMetaData;
+    }
+
+    private Set<String> collectCheckableInstanceIds(Set<InstanceMetaData> checkableInstances) {
+        return checkableInstances.stream()
+                .map(InstanceMetaData::getInstanceId)
+                .collect(Collectors.toSet());
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
@@ -25,6 +25,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackSta
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.stack.instance.InstanceMetaDataService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 import com.sequenceiq.freeipa.service.stack.StackUpdater;
 
@@ -53,6 +54,12 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
 
     @Inject
     private AutoSyncConfig autoSyncConfig;
+
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Inject
+    private FreeipaStatusInfoLogger freeipaStatusInfoLogger;
 
     @Value("${freeipa.autosync.update.status:true}")
     private boolean updateStatus;
@@ -123,6 +130,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                                 DetailedStackStatus.DELETED_ON_PROVIDER_SIDE, null);
                         updateStackStatus(stack, syncResult, null, alreadyDeletedCount);
                     }
+                    freeipaStatusInfoLogger.logFreeipaStatus(stack.getId(), checkableInstances);
                 });
                 return null;
             }, LOGGER, ":::Auto sync::: freeipa stack sync in {}ms");

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/sync/StackStatusTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/sync/StackStatusTest.java
@@ -77,6 +77,9 @@ class StackStatusTest {
     private StackUpdater stackUpdater;
 
     @MockBean
+    private FreeipaStatusInfoLogger freeipaStatusInfoLogger;
+
+    @MockBean
     private Tracer tracer;
 
     @Mock


### PR DESCRIPTION
During ENGESC-5655, we had a hard time debugging the freeipa status. Currently we only log freeipa status when there is a transition (eg. from healthy to unreachable) and it was determined that adding a log message for both freeipa status and instance status during health check would be helpful. Now we added logging for every health check.

See detailed description in the commit message.