### PR TITLE
CB-10160 - Increase socket timeout and update maxFailoverAttempts=0 for NiFi service

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -318,13 +318,13 @@
              {% if 'NIFI' in exposed and 'NIFI_NODE' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>NIFI</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enabled=true;maxFailoverAttempts=0;failoverSleep=1000</value>
              </param>
              {%- endif %}
              {% if 'NIFI-REGISTRY' in exposed and 'NIFI_REGISTRY_SERVER' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>NIFI-REGISTRY</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enabled=true;maxFailoverAttempts=0;failoverSleep=1000</value>
              </param>
              {%- endif %}
              {% if 'DATA-DISCOVERY-SERVICE-API' in exposed and 'DATA_DISCOVERY_SERVICE_AGENT' in salt['pillar.get']('gateway:location') -%}
@@ -636,6 +636,14 @@
     <service>
         <role>NIFI</role>
         <param name="useTwoWaySsl" value="true" />
+        <param>
+            <name>httpclient.connectionTimeout</name>
+            <value>1m</value>
+        </param>
+        <param>
+            <name>httpclient.socketTimeout</name>
+            <value>1m</value>
+        </param>
         {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_NODE'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI'] }}</url>
         {%- endfor %}
@@ -648,6 +656,14 @@
         <service>
             <role>NIFI-REGISTRY</role>
             <param name="useTwoWaySsl" value="true" />
+            <param>
+                <name>httpclient.connectionTimeout</name>
+                <value>1m</value>
+            </param>
+            <param>
+                <name>httpclient.socketTimeout</name>
+                <value>1m</value>
+            </param>
             {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_REGISTRY_SERVER'] -%}
             <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI-REGISTRY'] }}</url>
             {%- endfor %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -638,11 +638,11 @@
         <param name="useTwoWaySsl" value="true" />
         <param>
             <name>httpclient.connectionTimeout</name>
-            <value>1m</value>
+            <value>2m</value>
         </param>
         <param>
             <name>httpclient.socketTimeout</name>
-            <value>1m</value>
+            <value>2m</value>
         </param>
         {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_NODE'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI'] }}</url>
@@ -658,11 +658,11 @@
             <param name="useTwoWaySsl" value="true" />
             <param>
                 <name>httpclient.connectionTimeout</name>
-                <value>1m</value>
+                <value>2m</value>
             </param>
             <param>
                 <name>httpclient.socketTimeout</name>
-                <value>1m</value>
+                <value>2m</value>
             </param>
             {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_REGISTRY_SERVER'] -%}
             <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI-REGISTRY'] }}</url>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -233,7 +233,7 @@
             {% if 'NIFI_REST' in exposed and 'NIFI_NODE' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>NIFI</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enabled=true;maxFailoverAttempts=0;failoverSleep=1000</value>
              </param>
             {%- endif %}
             {% if 'AVATICA' in exposed and 'PHOENIX_QUERY_SERVER' in salt['pillar.get']('gateway:location') -%}
@@ -245,7 +245,7 @@
             {% if 'NIFI-REGISTRY-REST' in exposed and 'NIFI_REGISTRY_SERVER' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>NIFI-REGISTRY</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enabled=true;maxFailoverAttempts=0;failoverSleep=1000</value>
              </param>
              {%- endif %}
              {% if 'SCHEMA-REGISTRY' in exposed and 'SCHEMA_REGISTRY_SERVER' in salt['pillar.get']('gateway:location') -%}
@@ -455,6 +455,14 @@
     <service>
         <role>NIFI</role>
         <param name="useTwoWaySsl" value="true" />
+        <param>
+            <name>httpclient.connectionTimeout</name>
+            <value>1m</value>
+        </param>
+        <param>
+            <name>httpclient.socketTimeout</name>
+            <value>1m</value>
+        </param>
         {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_NODE'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI_REST'] }}</url>
         {%- endfor %}
@@ -467,6 +475,14 @@
     <service>
         <role>NIFI-REGISTRY</role>
         <param name="useTwoWaySsl" value="true" />
+        <param>
+            <name>httpclient.connectionTimeout</name>
+            <value>1m</value>
+        </param>
+        <param>
+            <name>httpclient.socketTimeout</name>
+            <value>1m</value>
+        </param>
         {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_REGISTRY_SERVER'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI-REGISTRY'] }}</url>
         {%- endfor %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -457,11 +457,11 @@
         <param name="useTwoWaySsl" value="true" />
         <param>
             <name>httpclient.connectionTimeout</name>
-            <value>1m</value>
+            <value>2m</value>
         </param>
         <param>
             <name>httpclient.socketTimeout</name>
-            <value>1m</value>
+            <value>2m</value>
         </param>
         {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_NODE'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI_REST'] }}</url>
@@ -477,11 +477,11 @@
         <param name="useTwoWaySsl" value="true" />
         <param>
             <name>httpclient.connectionTimeout</name>
-            <value>1m</value>
+            <value>2m</value>
         </param>
         <param>
             <name>httpclient.socketTimeout</name>
-            <value>1m</value>
+            <value>2m</value>
         </param>
         {% for hostloc in salt['pillar.get']('gateway:location')['NIFI_REGISTRY_SERVER'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['NIFI-REGISTRY'] }}</url>


### PR DESCRIPTION
**Describe the change you are making here!**
_This is for a hotfix issue CB-10160_
NiFi team ran into issues with a customer with large uploads. This issue is identified as a critical fix and needs to land as quick as possible (hotfix).

The changes proposed in this PR are:

increase the socket timeout for Nifi
set retry and failover counts to zero
**Testing**
The patch was tested on a cluster running NiFi