### PR TITLE
CB-9580 Introduce new test cases in upgrade mock tests for embedded database

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/InstanceGroupTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/InstanceGroupTestDto.java
@@ -11,10 +11,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.RecoveryMode;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.InstanceGroupV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -121,6 +121,14 @@ public class InstanceGroupTestDto extends AbstractCloudbreakTestDto<InstanceGrou
     public InstanceGroupTestDto withSecurityGroup(SecurityGroupTestDto securityGroup) {
         getRequest().setSecurityGroup(securityGroup.getRequest());
         return this;
+    }
+
+    public InstanceGroupTestDto withTemplate(String key) {
+        InstanceTemplateV4TestDto template = getTestContext().get(key);
+        if (template == null) {
+            throw new IllegalArgumentException("Instance template does not exist for key: " + key + " in test context!");
+        }
+        return withTemplate(template);
     }
 
     public InstanceGroupTestDto withTemplate(InstanceTemplateV4TestDto template) {

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -33,5 +33,5 @@ auth:
     differentdatahubversionthandatalake.enabled: true
     database.wire.encryption.enable: true
     datahub.runtime.upgrade.enable: true
-    embedded.database.on.attached.disk.enable: false
+    embedded.database.on.attached.disk.enable: true
     datalake.loadbalancer.enable: false


### PR DESCRIPTION
CB-9580 Introduce new test cases in upgrade mock tests:
1. if embedded database is on attached disk, upgrade have to be successful
2. if embedded database is on root disk, upgrade have to fail
