### PR TITLE
Azure image copy speedup POC - do not commit!

### DIFF
--- a/cloud-azure/build.gradle
+++ b/cloud-azure/build.gradle
@@ -30,8 +30,13 @@ dependencies {
   compile (group: 'com.microsoft.azure',         name: 'azure-mgmt-datalake-store',  version: '1.22.0') { exclude group: 'org.slf4j' }
   compile (group: 'com.microsoft.azure',         name: 'azure-mgmt-sql',             version: azureSdkVersion) { exclude group: 'org.slf4j' }
   compile (group: 'com.microsoft.azure.privatedns.v2018_09_01',         name: 'azure-mgmt-privatedns',             version: '1.0.0-beta') { exclude group: 'org.slf4j' }
-  compile group: 'com.microsoft.azure',         name: 'azure-storage',              version: azureStorageSdkVersion
-  compile group: 'com.microsoft.azure',         name: 'adal4j',                     version: '1.6.4'
+  compile group: 'com.microsoft.azure',          name: 'azure-storage',              version: azureStorageSdkVersion
+  compile group: 'com.azure',                    name: 'azure-storage-blob',         version: '12.6.0'
+  compile group: 'com.microsoft.azure',          name: 'adal4j',                     version: '1.6.4'
+  compile group: 'com.microsoft.azure',          name: 'msal4j',                     version: '1.8.0'
+  compile group: 'io.projectreactor.addons', name: 'reactor-adapter', version: '3.0.2.RELEASE'
+
+
   compile group: 'org.apache.commons',                 name: 'commons-collections4', version: commonsCollections4Version
   compile (group: 'com.fasterxml.jackson.core', name: 'jackson-databind',           version: jacksonVersion) {
     force = true

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureTestCredentials.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureTestCredentials.java
@@ -1,0 +1,73 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.microsoft.azure.AzureEnvironment;
+import com.microsoft.azure.credentials.ApplicationTokenCredentials;
+
+/**
+ * In order to prevent leaking credential info in unit tests the tests use this class to get credentials.
+ * This class, in turn, tries to read file $HOME/.cb-poc-creds/azure-creds
+ *
+ * To test if the credentials could be read please run {@link AzureTestCredentialsTest} class. Please note it does not check if supplied values are valid.
+ *
+ * Its format is as follows:
+ *
+ * azure.cred.tenant=[TENANT_ID]
+ * azure.cred.subscription=[SUBSCRIPTION_ID]
+ * azure.cred.client=[CLIENT_ID]
+ * azure.cred.secret=[CLIENT_SECRET]
+ * azure.storage.connectionstring=[STORAGE_ACCOUNT_CONNECTION_STRING]
+ *
+ */
+public class AzureTestCredentials {
+
+    public static final String AZURE_CREDS_FILE = ".cb-poc-creds/azure-creds";
+
+    private Map<String, String> credentialMap = null;
+
+    public ApplicationTokenCredentials getCredentials() {
+        return new ApplicationTokenCredentials(
+                getApplicationId(),
+                getTenantId(),
+                getClientSecret(),
+                AzureEnvironment.AZURE);
+    }
+
+    public String getTenantId() {
+        return getVariableFromFile("azure.cred.tenant");
+    }
+
+    public String getApplicationId() {
+        return getVariableFromFile("azure.cred.client");
+    }
+
+    public String getClientSecret() {
+        return getVariableFromFile("azure.cred.secret");
+    }
+
+    public String getStorageAccountConnectionString() {
+        return getVariableFromFile("azure.storage.connectionstring");
+    }
+
+    private String getVariableFromFile(String envVarName) {
+        try {
+            if (credentialMap == null) {
+                String userHome = System.getenv("HOME");
+                credentialMap = Files.readAllLines(Paths.get(userHome, AZURE_CREDS_FILE)).stream()
+                        .map(l -> l.split("=", 2))
+                        .collect(Collectors.toMap(a -> a[0], a -> String.join("", a[1])));
+            }
+            return Optional.ofNullable(credentialMap.get(envVarName))
+                    .orElseThrow(() -> new RuntimeException(String.format("Env var %s not defined", envVarName)));
+        } catch (IOException e) {
+            throw new RuntimeException("Could not open " + AZURE_CREDS_FILE + ", please check the file exists", e);
+        }
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureTestCredentialsTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureTestCredentialsTest.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class AzureTestCredentialsTest {
+
+    private AzureTestCredentials underTest = new AzureTestCredentials();
+
+    @Test
+    public void testCredentialIsFilledIn() {
+        assertNotNull(underTest.getCredentials());
+    }
+
+    @Test
+    public void testGetStorageAccountStringNotNull() {
+        assertNotNull(underTest.getStorageAccountConnectionString());
+        assertTrue(underTest.getStorageAccountConnectionString().contains(";"));
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/ImageCopy.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/ImageCopy.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.microsoft.azure.management.Azure;
+import com.microsoft.azure.management.storage.StorageAccount;
+import com.microsoft.azure.management.storage.StorageAccountKey;
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.BlobRequestOptions;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.microsoft.azure.storage.blob.CloudPageBlob;
+import com.microsoft.rest.LogLevel;
+
+import okhttp3.JavaNetAuthenticator;
+
+public class ImageCopy {
+
+    public static final long NO_OFFSET = 0L;
+    private AzureTestCredentials azureTestCredentials = new AzureTestCredentials();
+
+    @Test
+    public void copyImage() throws URISyntaxException, InvalidKeyException, StorageException {
+        Azure azure = Azure
+                .configure()
+                .withProxyAuthenticator(new JavaNetAuthenticator())
+                .withLogLevel(LogLevel.BODY_AND_HEADERS)
+                .authenticate(azureTestCredentials.getCredentials())
+                .withSubscription("3ddda1c7-d1f5-4e7b-ac81-0523f483b3b3");
+
+        String destResourceGroup = "rg-gpapp-single-rg";
+        String destStorageName = "cbimgwu9d62091440e606d4";
+        String destContainerName = "images";
+        String sourceBlob = "https://cldrwestus.blob.core.windows.net/images/freeipa-cdh--2008121423.vhd";
+
+        copyImage(azure, destResourceGroup, destStorageName, destContainerName, sourceBlob);
+    }
+
+    private void copyImage(Azure azure, String resourceGroup, String storageName, String containerName, String sourceBlob) throws URISyntaxException, InvalidKeyException, StorageException {
+        List<StorageAccountKey> keys = getStorageAccountKeys(resourceGroup, storageName, azure);
+        String storageConnectionString = String.format("DefaultEndpointsProtocol=https;AccountName=%s;AccountKey=%s", storageName, keys.get(0).value());
+
+        CloudStorageAccount storageAccount = CloudStorageAccount.parse(storageConnectionString);
+        CloudBlobClient blobClient = storageAccount.createCloudBlobClient();
+        setDefaultPageBlobOptions(blobClient);
+        CloudBlobContainer container = blobClient.getContainerReference(containerName);
+
+        CloudPageBlob cloudPageBlob = container.getPageBlobReference(sourceBlob.substring(sourceBlob.lastIndexOf('/') + 1));
+//        String copyId = cloudPageBlob.startCopy(new URI(sourceBlob));
+
+        String copyId = copyWithPageBlobOptions(sourceBlob, cloudPageBlob);
+        System.out.println(copyId);
+    }
+
+    /*
+    Setting of BlobRequestOptions is not in production code, we just experimented with it to parametrize image copy in our trials.
+    - setConcurrentRequestCount: does not seem to have any effect on copy operation.
+     */
+    private void setDefaultPageBlobOptions(CloudBlobClient blobClient) {
+        // Set PageBlobOptions, this might set the default
+        BlobRequestOptions blobRequestOptions = blobClient.getDefaultRequestOptions();
+        blobRequestOptions.setConcurrentRequestCount(10);
+        blobRequestOptions.setSingleBlobPutThresholdInBytes(4194303);
+    }
+
+    private String copyWithPageBlobOptions(String sourceBlob, CloudPageBlob cloudPageBlob) throws StorageException, URISyntaxException {
+        // BlobRequestOptions are not used in production code, we just experimented with it to parametrize image copy in our trials.
+        // Set PageBlobOption for one copy, leaves default intact
+        BlobRequestOptions blobRequestOptions = new BlobRequestOptions();
+        blobRequestOptions.setConcurrentRequestCount(10);
+        String copyId = cloudPageBlob.startCopy(new URI(sourceBlob), null, null, blobRequestOptions, null);
+        return copyId;
+    }
+
+    public List<StorageAccountKey> getStorageAccountKeys(String resourceGroup, String storageName, Azure azure) {
+        return getStorageAccountByGroup(resourceGroup, storageName, azure).getKeys();
+    }
+
+    public StorageAccount getStorageAccountByGroup(String resourceGroup, String storageName, Azure azure) {
+        return azure.storageAccounts().getByResourceGroup(resourceGroup, storageName);
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/ImageCopyPageBlobCopy.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/ImageCopyPageBlobCopy.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.Test;
+
+import com.azure.core.util.polling.SyncPoller;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobClientBuilder;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.RehydratePriority;
+import com.azure.storage.blob.specialized.PageBlobClient;
+
+public class ImageCopyPageBlobCopy {
+    public static final Duration TIMEOUT = Duration.of(20, ChronoUnit.MINUTES);
+    private final String connectionString2 = "DefaultEndpointsProtocol=https;AccountName=cbimgwu9d62091440e606d4;AccountKey=tYEGBt9rjo2Ql5ZV7vcnndbE+/5MBV9PZbRY5wU50nzuRsg6TphTCniVSbVvPXe6MLct5a66t6gaLryBlpw8Fw==;EndpointSuffix=core.windows.net";
+
+    @Test
+    public void copyWithv12CopyMethod() {
+        String sourceBlob = "https://cldrwestus.blob.core.windows.net/images/cb-cdh-72-2011180019.vhd";
+        long chunkSize = 4194304L;
+        String destinationFilename = "kiscica-datalake3.vhd";
+        int parallelism = 320;
+        Duration taskTimeout = Duration.of(20, ChronoUnit.MINUTES);
+
+        BlobProperties sourceBlobProperties = getPublicBlobProperties(sourceBlob);
+        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder().connectionString(connectionString2).buildClient();
+        BlobContainerClient blobContainerClient = blobServiceClient.getBlobContainerClient("images");
+        BlobClient blobClient = blobContainerClient.getBlobClient(destinationFilename);
+        PageBlobClient destinationPageBlobClient = blobClient.getPageBlobClient();
+
+        SyncPoller poller = destinationPageBlobClient.beginCopy(sourceBlob, sourceBlobProperties.getMetadata(), null, RehydratePriority.HIGH, null, null, TIMEOUT);
+        poller.waitForCompletion();
+
+    }
+
+    private BlobProperties getPublicBlobProperties(String sourceBlobUrl) {
+        BlobClient blobClient = new BlobClientBuilder().endpoint(sourceBlobUrl).buildClient();
+        return blobClient.getProperties();
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/ImageCopyWithAzCopy.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/ImageCopyWithAzCopy.java
@@ -1,0 +1,125 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.UserDelegationKey;
+import com.azure.storage.blob.sas.BlobContainerSasPermission;
+import com.azure.storage.blob.sas.BlobServiceSasSignatureValues;
+
+public class ImageCopyWithAzCopy {
+
+    @Test
+    public void imageCopyWithAzCopy() {
+//        ProcessResult result = executeCommand(List.of("cp", "Makefile", "/bin"));
+        ProcessResult result = executeCommand(List.of("cpa"));
+        if(result.hasResult()) {
+            System.out.println("exit code: " + result.getExitCode());
+            System.out.println("output: " + result.getOutput());
+        } else {
+            System.out.println("Exception happened: " + result.getException());
+        }
+    }
+
+    private ProcessResult executeCommand(List<String> command) {
+        try {
+            Process process = new ProcessBuilder()
+                    .command(command)
+                    .redirectErrorStream(true)
+                    .start();
+            List<String> response = readStdout(process);
+            process.exitValue();
+            return ProcessResult.of(response, process.exitValue());
+        } catch (IOException | UnsupportedOperationException | SecurityException e) {
+            return ProcessResult.ofError(e);
+        }
+    }
+
+    private List<String> readStdout(Process process) {
+        try{
+            try (BufferedReader bfReader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                List<String> output = bfReader.lines().collect(Collectors.toList());
+                while (process.isAlive()) {
+                    String line = bfReader.readLine();
+                    output.add(line);
+                }
+                return output;
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return Collections.emptyList();
+    }
+
+    private String getSasToken(BlobContainerClient blobContainerClient) {
+        BlobServiceSasSignatureValues blobServiceSasSignatureValues =
+                new BlobServiceSasSignatureValues(OffsetDateTime.now().plusMinutes(10), getBlobSasPermissions())
+                        .setStartTime(OffsetDateTime.now().minusDays(1));
+        UserDelegationKey userDelegationKey = new UserDelegationKey();
+        userDelegationKey.setSignedExpiry(OffsetDateTime.now().plusMinutes(10));
+        return blobContainerClient.generateSas(blobServiceSasSignatureValues);
+//        return blobContainerClient.generateUserDelegationSas(blobServiceSasSignatureValues, userDelegationKey);
+    }
+
+    @NotNull
+    private BlobContainerSasPermission getBlobSasPermissions() {
+        BlobContainerSasPermission blobSasPermission = new BlobContainerSasPermission()
+                .setAddPermission(true)
+                .setCreatePermission(true)
+                .setWritePermission(true);
+        return blobSasPermission;
+    }
+
+
+    private static class ProcessResult {
+        private List<String> output;
+
+        private int exitCode;
+
+        private Throwable exception;
+
+        public static ProcessResult of(List<String> output, int exitCode) {
+            return new ProcessResult(output, exitCode);
+        }
+
+        public static ProcessResult ofError(Throwable t) {
+            return new ProcessResult(t);
+        }
+
+        private ProcessResult(List<String> output, int exitCode) {
+            this.output = output;
+            this.exitCode = exitCode;
+            exception = null;
+        }
+
+        private ProcessResult(Throwable exception) {
+            this.exception = exception;
+        }
+
+        public List<String> getOutput() {
+            return output;
+        }
+
+        public int getExitCode() {
+            return exitCode;
+        }
+
+        public Throwable getException() {
+            return exception;
+        }
+
+        public boolean hasResult() {
+            return exception == null;
+        }
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/ImageCopyWithPutBlobRestApi.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/ImageCopyWithPutBlobRestApi.java
@@ -1,0 +1,122 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image;
+
+import java.net.MalformedURLException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import com.microsoft.aad.msal4j.ClientCredentialFactory;
+import com.microsoft.aad.msal4j.ClientCredentialParameters;
+import com.microsoft.aad.msal4j.ConfidentialClientApplication;
+import com.microsoft.aad.msal4j.IAuthenticationResult;
+import com.microsoft.azure.management.Azure;
+import com.microsoft.rest.LogLevel;
+
+import okhttp3.JavaNetAuthenticator;
+
+public class ImageCopyWithPutBlobRestApi {
+
+    public static final String AZURE_PUBLIC_AUTHORITY = "https://login.microsoftonline.com/%s/";
+    private static final String SCOPE = "https://storage.azure.com/.default";
+    public static final String STORAGE_API_VERSION = "2019-12-12";
+    private AzureTestCredentials azureTestCredentials = new AzureTestCredentials();
+    private RestTemplate restTemplate = new RestTemplate();
+
+    @Test
+    public void runCopy() {
+        Azure azure = Azure
+                .configure()
+                .withProxyAuthenticator(new JavaNetAuthenticator())
+                .withLogLevel(LogLevel.BODY_AND_HEADERS)
+                .authenticate(azureTestCredentials.getCredentials())
+                .withSubscription("3ddda1c7-d1f5-4e7b-ac81-0523f483b3b3");
+
+        String destResourceGroup = "rg-gpapp-single-rg";
+        String destStorageName = "cbimgwu9d62091440e606d4";
+        String destContainerName = "images";
+        String sourceBlob = "https://cldrwestus.blob.core.windows.net/images/freeipa-cdh--2008121423.vhd";
+
+        Optional<IAuthenticationResult> authenticationResultOptional = getAccessToken(azureTestCredentials);
+        if (authenticationResultOptional.isPresent()) {
+            String oauthToken = authenticationResultOptional.get().accessToken();
+            copyImage(azure, destResourceGroup, destStorageName, destContainerName, sourceBlob, oauthToken);
+//            getSourceBlobProperties(sourceBlob, oauthToken);
+        }
+    }
+
+    private void copyImage(Azure azure, String resourceGroup, String storageName, String containerName, String sourceBlob, String oauthToken) {
+        String url = String.format("https://%s.blob.core.windows.net/mycontainer/myblob", storageName);
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("", "");
+        HttpEntity httpEntity = new HttpEntity(httpHeaders);
+
+        restTemplate.exchange(url, HttpMethod.POST, httpEntity, Void.class);
+    }
+
+    private void getSourceBlobProperties(String sourceBlobUrl, String token) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+//        httpHeaders.add("Authorization", "Bearer " + token);
+//        httpHeaders.add("x-ms-date", "Wed, 03 Dec 2020 20:24:11 GMT");
+//        httpHeaders.add("x-ms-date", getUtcTime());
+        httpHeaders.add("x-ms-version", STORAGE_API_VERSION);
+//        httpHeaders.add("x-ms-client-request-id", generateRequestId());
+        HttpEntity httpEntity = new HttpEntity(httpHeaders);
+
+//        try {
+            ResponseEntity<Void> response = restTemplate.exchange(sourceBlobUrl, HttpMethod.HEAD, httpEntity, Void.class);
+            HttpHeaders responseHeaders = response.getHeaders();
+            System.out.println(responseHeaders);
+//        } catch(HttpClientErrorException e) {
+//            System.out.println(e);
+//        }
+
+    }
+
+    private String getUtcTime() {
+        return DateTimeFormatter.RFC_1123_DATE_TIME.format(ZonedDateTime.now(ZoneId.of("UTC")));
+    }
+
+    private Optional<IAuthenticationResult> getAccessToken(AzureTestCredentials azureTestCredentials) {
+        String authority = String.format(AZURE_PUBLIC_AUTHORITY, azureTestCredentials.getTenantId());
+        try {
+            ConfidentialClientApplication app = ConfidentialClientApplication.builder(
+                    azureTestCredentials.getApplicationId(),
+                    ClientCredentialFactory.createFromSecret(azureTestCredentials.getClientSecret())
+            )
+                    .authority(authority)
+                    .build();
+
+            // With client credentials flows the scope is ALWAYS of the shape "resource/.default", as the
+            // application permissions need to be set statically (in the portal), and then granted by a tenant administrator
+            ClientCredentialParameters clientCredentialParam = ClientCredentialParameters.builder(
+                    Collections.singleton(SCOPE))
+                    .build();
+            CompletableFuture<IAuthenticationResult> future = app.acquireToken(clientCredentialParam);
+            return Optional.of(future.get());
+        } catch (MalformedURLException e) {
+            System.out.println("error with URL");
+        } catch (InterruptedException e) {
+            System.out.println("Interrupted exception: " + e);
+        } catch (ExecutionException e) {
+            System.out.println("Execution exception" + e);
+        }
+        return Optional.empty();
+    }
+
+    private String generateRequestId() {
+        return "gpapp" + UUID.randomUUID();
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/ChunkCalculator.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/ChunkCalculator.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12;
+
+public class ChunkCalculator {
+
+    /**
+     * Size of a chunk, expressed in bytes
+     */
+    private final long chunkSize;
+
+
+    /**
+     * Size of the file, expressed in bytes
+     */
+    private final long fileSize;
+
+    /**
+     * Number of chunks in total
+     */
+    private final long chunkCountTotal;
+
+    /**
+     * Start address in bytes of leftover bytes
+     */
+    private final long remainderBytesStart;
+
+    public ChunkCalculator(long fileSize, long chunkSize) {
+        this.chunkSize = chunkSize;
+        this.fileSize = fileSize;
+
+        this.chunkCountTotal = fileSize / chunkSize;
+        this.remainderBytesStart = chunkCountTotal * chunkSize;
+    }
+
+    public long getChunkSize() {
+        return chunkSize;
+    }
+
+    public long getFileSize() {
+        return fileSize;
+    }
+
+    public long getChunkCountTotal() {
+        return chunkCountTotal;
+    }
+
+    /**
+     * Depending on {@link chunkSize} there will be a partial-chunk leftover from the copy process
+     * This returns the start address expressed in bytes where from the leftover bytes can be copied.
+     * The end address is the {@link fileSize - 1}.
+     *
+     * @return start address of remainder bytes to copy.
+     **/
+    public long getRemainderBytesStart() {
+        return remainderBytesStart;
+    }
+
+    public boolean hasRemainderBytes() {
+        return remainderBytesStart < fileSize;
+    }
+
+    public long getChunkStartAddress(long id) {
+        return id * chunkSize;
+    }
+
+    public long getChunkEndAddress(long id) {
+        return (id + 1) * chunkSize - 1;
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/async/CopyTaskSubmitter.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/async/CopyTaskSubmitter.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.async;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.azure.storage.blob.models.PageBlobRequestConditions;
+import com.azure.storage.blob.models.PageRange;
+import com.azure.storage.blob.specialized.PageBlobAsyncClient;
+
+public class CopyTaskSubmitter {
+
+    private PageBlobAsyncClient destinationClient;
+
+    private String sourceBlobUrl;
+
+    private PageBlobRequestConditions destinationRequestConditions;
+
+    public void submitAll(List<PageRange> copyRanges) {
+        List<PageRange> failedRanges = new ArrayList<>();
+
+//        List<Completable> responseList = copyRanges.stream().map(r -> {
+//
+//                    Mono<Response<PageBlobItem>> response = destinationClient.uploadPagesFromUrlWithResponse(
+//                            r,
+//                            sourceBlobUrl,
+//                            r.getStart(),
+//                            null,
+//                            destinationRequestConditions,
+//                            null
+//                    ).doOnError(t -> failedRanges.add(r))
+//                            .subscribeOn(Scheduler.Worker));
+//
+//            return RxJava2Adapter.monoToCompletable(response);
+//                }
+//        ).collect(Collectors.toList());
+    }
+}
+

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/async/ImageCopyAsync.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/async/ImageCopyAsync.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.async;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.junit.Ignore;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobClientBuilder;
+import com.azure.storage.blob.BlobContainerAsyncClient;
+import com.azure.storage.blob.BlobServiceAsyncClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.PageRange;
+import com.azure.storage.blob.specialized.PageBlobAsyncClient;
+import com.sequenceiq.cloudbreak.cloud.azure.image.AzureTestCredentials;
+import com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.ChunkCalculator;
+
+public class ImageCopyAsync {
+
+    public static final int INFINITE_LEASE = -1;
+    public static final int MAX_LEASE_DURATION = 60;
+    private static int not201 = 0;
+    private static int foundException = 0;
+    private final AzureTestCredentials azureTestCredentials = new AzureTestCredentials();
+
+    @Ignore("The rx version does not yet work")
+//    @Test
+    public void copyAsync() {
+        String sourceBlob = "https://cldrwestus.blob.core.windows.net/images/freeipa-cdh--2008121423.vhd";
+//        String sourceBlob = "https://cldrwestus.blob.core.windows.net/images/cb-cdh-72-2011180019.vhd";
+        long chunkSize = 4194304L;
+        String destinationFilename = "kiscica-datalake.vhd";
+        int parallelism = 320;
+        Duration taskTimeout = Duration.of(20, ChronoUnit.MINUTES);
+
+        BlobProperties sourceBlobProperties = getPublicBlobProperties(sourceBlob);
+        long fileSize = sourceBlobProperties.getBlobSize();
+
+
+        BlobServiceAsyncClient bsac = new BlobServiceClientBuilder().connectionString(azureTestCredentials.getStorageAccountConnectionString()).buildAsyncClient();
+        BlobContainerAsyncClient bccasync = bsac.getBlobContainerAsyncClient("images");
+        PageBlobAsyncClient pageBlobAsyncClient = new BlobServiceClientBuilder().connectionString(azureTestCredentials.getStorageAccountConnectionString()).buildAsyncClient()
+                .getBlobContainerAsyncClient("images")
+                .getBlobAsyncClient(destinationFilename)
+                .getPageBlobAsyncClient();
+
+        ChunkCalculator chunkCalculator = new ChunkCalculator(fileSize, chunkSize);
+        PageRangeCalculator pageRangeCalculator = new PageRangeCalculator();
+        List<PageRange> pageRanges = pageRangeCalculator.getAll(chunkCalculator);
+        CopyTaskSubmitter copyTaskSubmitter =  new CopyTaskSubmitter();
+        copyTaskSubmitter.submitAll(pageRanges);
+    }
+
+    private BlobProperties getPublicBlobProperties(String sourceBlobUrl) {
+        BlobClient blobClient = new BlobClientBuilder().endpoint(sourceBlobUrl).buildClient();
+        return blobClient.getProperties();
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/async/PageRangeCalculator.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/async/PageRangeCalculator.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.async;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.azure.storage.blob.models.PageRange;
+import com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.ChunkCalculator;
+
+public class PageRangeCalculator {
+
+    public List<PageRange> getAll(ChunkCalculator chunkCalculator) {
+        List<PageRange> ranges = new ArrayList<>();
+
+        for (int c = 0; c < chunkCalculator.getChunkCountTotal(); c++) {
+            ranges.add(new PageRange()
+                    .setStart(chunkCalculator.getChunkStartAddress(c))
+                    .setEnd(chunkCalculator.getChunkEndAddress(c)));
+        }
+        if(chunkCalculator.hasRemainderBytes()) {
+            ranges.add(new PageRange()
+                    .setStart(chunkCalculator.getRemainderBytesStart())
+                    .setEnd(chunkCalculator.getFileSize() - 1));
+        }
+        return ranges;
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/ByteCopyTask.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/ByteCopyTask.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.sync;
+
+import com.azure.storage.blob.models.PageBlobRequestConditions;
+import com.azure.storage.blob.specialized.PageBlobClient;
+
+public class ByteCopyTask implements Runnable {
+
+    private final long startByte;
+    private final long endByte;
+    private final PageBlobClient destinationPageBlobClient;
+    private final String sourceBlobUrl;
+    private final PageBlobRequestConditions destinationRequestConditions;
+    private final PageBlobCopy pageBlobCopy = new PageBlobCopy();
+
+    public ByteCopyTask(PageBlobClient destinationPageBlobClient, String sourceBlobUrl, long startByte, long endByte, PageBlobRequestConditions destinationRequestConditions) {
+        this.startByte = startByte;
+        this.endByte = endByte;
+        this.destinationPageBlobClient = destinationPageBlobClient;
+        this.sourceBlobUrl = sourceBlobUrl;
+        this.destinationRequestConditions = destinationRequestConditions;
+    }
+
+    @Override
+    public void run() {
+        pageBlobCopy.copyChunkWithRetry(destinationPageBlobClient, startByte, endByte, sourceBlobUrl, destinationRequestConditions);
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/CopyTaskFactory.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/CopyTaskFactory.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.sync;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.azure.storage.blob.models.PageBlobRequestConditions;
+import com.azure.storage.blob.specialized.PageBlobClient;
+import com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.ChunkCalculator;
+
+public class CopyTaskFactory {
+
+    public List<Runnable> createCopyTasks(PageBlobClient destinationPageBlobClient, String sourceBlobUrl, PageBlobRequestConditions destinationRequestConditions, ChunkCalculator chunkCalculator) {
+        List<Runnable> byteCopyTasks = new ArrayList<>();
+        for (int c = 0; c < chunkCalculator.getChunkCountTotal(); c++) {
+            ByteCopyTask byteCopyTask = new ByteCopyTask(
+                    destinationPageBlobClient,
+                    sourceBlobUrl,
+                    chunkCalculator.getChunkStartAddress(c),
+                    chunkCalculator.getChunkEndAddress(c),
+                    destinationRequestConditions
+            );
+            byteCopyTasks.add(byteCopyTask);
+        }
+
+        if (chunkCalculator.hasRemainderBytes()) {
+            byteCopyTasks.add(new ByteCopyTask(
+                            destinationPageBlobClient,
+                            sourceBlobUrl,
+                            chunkCalculator.getRemainderBytesStart(),
+                            chunkCalculator.getFileSize() - 1,
+                            destinationRequestConditions
+                    )
+            );
+        }
+
+        return byteCopyTasks;
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/ImageCopySync.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/ImageCopySync.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.sync;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Test;
+
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobClientBuilder;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobServiceClient;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobProperties;
+import com.sequenceiq.cloudbreak.cloud.azure.image.AzureTestCredentials;
+
+public class ImageCopySync {
+
+    private final AzureTestCredentials azureTestCredentials = new AzureTestCredentials();
+
+    private List<String> freeipaSourceBlobs = List.of(
+            "https://cldrwestus.blob.core.windows.net/images/freeipa-cdh--2008121423.vhd",
+            "https://cldrwestus.blob.core.windows.net/images/freeipa-cdh--2010061458.vhd"
+    );
+
+    private List<String> cdhSourceBlobs = List.of(
+            "https://cldrwestus.blob.core.windows.net/images/cb-cdh--2012021538.vhd",
+            "https://cldrwestus.blob.core.windows.net/images/cb-cdh--2012010839.vhd",
+            "https://cldrwestus.blob.core.windows.net/images/cb-cdh--2011300854.vhd",
+            "https://cldrwestus.blob.core.windows.net/images/cb-cdh--2011261322.vhd",
+            "https://cldrwestus.blob.core.windows.net/images/cb-cdh--2011251004.vhd",
+            "https://cldrwestus.blob.core.windows.net/images/cb-cdh--2011240904.vhd",
+            "https://cldrwestus.blob.core.windows.net/images/cb-cdh--2011191715.vhd",
+            "https://cldrwestus.blob.core.windows.net/images/cb-cdh--2011191044.vhd",
+            "https://cldrwestus.blob.core.windows.net/images/cb-cdh--2011171355.vhd",
+            "https://cldrwestus.blob.core.windows.net/images/cb-cdh--2011161934.vhd"
+    );
+
+    private static final int THREAD_POOL_SIZE = 320;
+
+    private static final int THREAD_POOL_COUNT = 8;
+
+    private static final int NUMBER_OF_PARALLEL_COPIES = 8;
+
+    @Test
+    public void newStorageBlobSdk() {
+        List<String> sourceBlobList = freeipaSourceBlobs;
+
+        ThreadPoolManager threadPoolManager = new ThreadPoolManager(THREAD_POOL_COUNT, THREAD_POOL_SIZE);
+
+        List<ImageCopyTask> imageCopyTasks = new ArrayList<>();
+        for (int i = 0; i < NUMBER_OF_PARALLEL_COPIES; i++) {
+            String sourceBlob = sourceBlobList.get(i % sourceBlobList.size());
+            String destinationFileName = "copyTask_8c_" + i + ".vhd";
+            imageCopyTasks.add(new ImageCopyTask(azureTestCredentials, sourceBlob, destinationFileName, threadPoolManager.get(i)));
+        }
+
+        CompletableFuture copyTasks = CompletableFuture.allOf(
+                imageCopyTasks.stream()
+                        .map(imageCopyTask -> CompletableFuture.runAsync(imageCopyTask))
+                        .toArray(CompletableFuture[]::new)
+        );
+        copyTasks.join();
+        System.out.println("Finished");
+    }
+
+    @Test
+    public void getPropertiesofSourceAndDestinationBlobs() {
+        String sourceBlob = "https://cldrwestus.blob.core.windows.net/images/freeipa-cdh--2008121423.vhd";
+        String filenameDest = "kiscica2.vhd";
+
+        BlobProperties propertiesOriginal = getPublicBlobProperties(sourceBlob);
+        BlobProperties propertiesDestination = getBlobClient(filenameDest);
+
+        System.out.println(propertiesOriginal);
+        System.out.println(propertiesDestination);
+    }
+
+    private BlobProperties getPublicBlobProperties(String sourceBlobUrl) {
+        BlobClient blobClient = new BlobClientBuilder().endpoint(sourceBlobUrl).buildClient();
+        return blobClient.getProperties();
+    }
+
+    private BlobProperties getBlobClient(String filenameOrig) {
+        BlobServiceClient blobServiceClient = new BlobServiceClientBuilder().connectionString(azureTestCredentials.getStorageAccountConnectionString()).buildClient();
+        BlobContainerClient blobContainerClient = blobServiceClient.getBlobContainerClient("images");
+        BlobClient blobClient = blobContainerClient.getBlobClient(filenameOrig);
+        return blobClient.getProperties();
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/ImageCopyTask.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/ImageCopyTask.java
@@ -1,0 +1,144 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.sync;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import com.azure.core.util.Context;
+import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobClientBuilder;
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import com.azure.storage.blob.models.BlobProperties;
+import com.azure.storage.blob.models.PageBlobRequestConditions;
+import com.azure.storage.blob.specialized.BlobLeaseClient;
+import com.azure.storage.blob.specialized.BlobLeaseClientBuilder;
+import com.azure.storage.blob.specialized.PageBlobClient;
+import com.sequenceiq.cloudbreak.cloud.azure.image.AzureTestCredentials;
+import com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.ChunkCalculator;
+
+public class ImageCopyTask implements Runnable {
+
+    public static final int MAX_LEASE_DURATION = 60;
+
+    private static final long MAX_CHUNK_SIZE = 4194304L;
+
+    private static final Duration TASK_TIMEOUT = Duration.of(20, ChronoUnit.MINUTES);
+
+    private final AzureTestCredentials azureTestCredentials;
+
+    private final String sourceBlobUrl;
+
+    private final String destinationFilename;
+
+    private final ThreadPoolExecutor threadPoolExecutor;
+
+    private TaskState taskState;
+
+    private Exception exception;
+
+    public ImageCopyTask(AzureTestCredentials azureTestCredentials, String sourceBlobUrl, String destinationFilename, ThreadPoolExecutor threadPoolExecutor) {
+        this.azureTestCredentials = azureTestCredentials;
+        this.sourceBlobUrl = sourceBlobUrl;
+        this.destinationFilename = destinationFilename;
+        this.threadPoolExecutor = threadPoolExecutor;
+        this.taskState = TaskState.REQUESTED;
+    }
+
+    public TaskState getTaskState() {
+        return taskState;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+
+    @Override
+    public void run() {
+        try {
+            BlobProperties sourceBlobProperties = getPublicBlobProperties(sourceBlobUrl);
+            long fileSize = sourceBlobProperties.getBlobSize();
+            ChunkCalculator chunkCalculator = new ChunkCalculator(fileSize, MAX_CHUNK_SIZE);
+
+            PageBlobClient destinationPageBlobClient = new BlobServiceClientBuilder().connectionString(azureTestCredentials.getStorageAccountConnectionString()).buildClient()
+                    .getBlobContainerClient("images")
+                    .getBlobClient(destinationFilename)
+                    .getPageBlobClient();
+
+            destinationPageBlobClient.create(fileSize, true);
+            try (BlobLeaser blobLeaser = new BlobLeaser(destinationPageBlobClient)) {
+                PageBlobRequestConditions destinationRequestConditions = new PageBlobRequestConditions().setLeaseId(blobLeaser.getLeaseId());
+                destinationPageBlobClient.setMetadataWithResponse(sourceBlobProperties.getMetadata(), destinationRequestConditions, Duration.of(120, ChronoUnit.SECONDS), Context.NONE);
+
+                List<Runnable> copyTaskList = new CopyTaskFactory().createCopyTasks(destinationPageBlobClient, sourceBlobUrl, destinationRequestConditions, chunkCalculator);
+                CompletableFuture<Void>[] completableFutures = copyTaskList.stream()
+                        .map(task -> CompletableFuture.runAsync(task, threadPoolExecutor))
+                        .toArray(CompletableFuture[]::new);
+                CompletableFuture copyTasks = CompletableFuture.allOf(completableFutures);
+                taskState = TaskState.STARTED;
+                pollWithTimeout(copyTasks, blobLeaser, TASK_TIMEOUT);
+            }
+        } catch (Exception e) {
+            System.out.println("Finished with exception: " + e);
+            exception = e;
+            taskState = TaskState.FAILED;
+        }
+    }
+
+    private BlobProperties getPublicBlobProperties(String sourceBlobUrl) {
+        BlobClient blobClient = new BlobClientBuilder().endpoint(sourceBlobUrl).buildClient();
+        return blobClient.getProperties();
+    }
+
+    private void pollWithTimeout(CompletableFuture copyTasks, BlobLeaser blobLeaser, Duration timeout) {
+        Instant instant = Instant.now();
+        Instant timeoutAt = instant.plus(timeout);
+
+        do {
+            if (copyTasks.isDone()) {
+                return;
+            }
+            try {
+                Thread.sleep(5000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            blobLeaser.renew();
+        } while (Instant.now().isBefore(timeoutAt));
+
+        if (copyTasks.isCompletedExceptionally()) {
+            taskState = TaskState.FAILED;
+        } else if (copyTasks.isDone()) {
+            taskState = TaskState.READY;
+        } else {
+            taskState = TaskState.TIMEOUT;
+        }
+    }
+
+    private static final class BlobLeaser implements AutoCloseable {
+
+        private final BlobLeaseClient destinationBlobLeaseClient;
+
+        private final String leaseId;
+
+        public BlobLeaser(PageBlobClient destinationPageBlobClient) {
+            this.destinationBlobLeaseClient = new BlobLeaseClientBuilder().blobClient(destinationPageBlobClient).buildClient();
+            leaseId = destinationBlobLeaseClient.acquireLease(MAX_LEASE_DURATION);
+        }
+
+        public void renew() {
+            destinationBlobLeaseClient.renewLease();
+        }
+
+        @Override
+        public void close() {
+            destinationBlobLeaseClient.releaseLease();
+        }
+
+        public String getLeaseId() {
+            return leaseId;
+        }
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/PageBlobCopy.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/PageBlobCopy.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.sync;
+
+import static com.azure.storage.blob.models.BlobErrorCode.SERVER_BUSY;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.Context;
+import com.azure.storage.blob.models.BlobStorageException;
+import com.azure.storage.blob.models.PageBlobItem;
+import com.azure.storage.blob.models.PageBlobRequestConditions;
+import com.azure.storage.blob.models.PageRange;
+import com.azure.storage.blob.specialized.PageBlobClient;
+
+public class PageBlobCopy {
+
+    public static final int SERVER_BUSY_WAIT_TIME = 100;
+
+    public void copyChunkWithRetry(PageBlobClient pageBlobClient, long from, long to, String sourceBlobUrl, PageBlobRequestConditions destinationRequestConditions) {
+        PageRange pageRange = new PageRange().setStart(from).setEnd(to);
+        copyChunkWithRetry(pageBlobClient, pageRange, sourceBlobUrl, destinationRequestConditions);
+    }
+
+    public void copyChunkWithRetry(PageBlobClient pageBlobClient, PageRange pageRange, String sourceBlobUrl, PageBlobRequestConditions destinationRequestConditions) {
+        int maxRetry = 5;
+        int retryCount = 0;
+        boolean retry = false;
+        Exception originalException = null;
+        do {
+            try {
+                retry = false;
+                Response<PageBlobItem> copyResult = pageBlobClient.uploadPagesFromUrlWithResponse(pageRange, sourceBlobUrl, pageRange.getStart(), null, destinationRequestConditions, null, Duration.of(120, ChronoUnit.SECONDS), Context.NONE);
+                if (copyResult.getStatusCode() != 201) {
+                    System.out.println("It is not 201");
+                    ++retryCount;
+                }
+            } catch (BlobStorageException e) {
+                if (e.getStatusCode() == 503 && SERVER_BUSY.equals(e.getErrorCode())) {
+                    sleep(SERVER_BUSY_WAIT_TIME);
+                }
+            } catch (Exception e) {
+                System.out.println(e);
+                originalException = e;
+                ++retryCount;
+            }
+        } while (retry && retryCount < maxRetry);
+        if (retry) {
+            throw new RuntimeException("Too many retries, with original exception.", originalException);
+        }
+    }
+
+    private void sleep(long millisecs) {
+        try {
+            Thread.sleep(millisecs);
+        } catch (InterruptedException interruptedException) {
+            interruptedException.printStackTrace();
+        }
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/TaskState.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/TaskState.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.sync;
+
+public enum TaskState {
+
+    REQUESTED,
+    STARTED,
+    READY,
+    FAILED,
+    TIMEOUT
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/ThreadPoolManager.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/pageblobv12/sync/ThreadPoolManager.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image.pageblobv12.sync;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class ThreadPoolManager {
+
+    private final List<ThreadPoolExecutor> threadPoolExecutorList = new ArrayList<>();
+
+    public ThreadPoolManager(int threadPoolCount, int threadPoolSize) {
+        for (int i = 0; i < threadPoolCount; i++) {
+            threadPoolExecutorList.add((ThreadPoolExecutor) Executors.newFixedThreadPool(threadPoolSize));
+        }
+    }
+
+    public ThreadPoolExecutor get(int jobId) {
+        System.out.println(jobId % threadPoolExecutorList.size());
+        return threadPoolExecutorList.get(jobId % threadPoolExecutorList.size());
+    }
+}


### PR DESCRIPTION
In this commit I evaluate several possibilities for speeding up azure image copy in form of junit tests.
- PageBlob v12, ImageCopySync: the most complete and working example of com.azure.azure-storage-blob aka storage blob v12. Features synchronous copy funneled into a threadpool.
- PageBlob v12, ImageCopyAsync: not working, should be the above but with reactive model
- Put blob REST api: ImageCopyWithPutBlobRestApi: token request and public blob reading works, not implemented further.
- AzCopy: ImageCopyWithAzCopy: not complete, features how to run an external process from java, with redirection, output parsing etc.
- CloudPageBlob v8: the current production implementation of image copy, put to a test. It works.

See detailed description in the commit message.

You have to add a class AzureTestCredentials to make the code work.