### PR TITLE
CB-7951. Send collected diagnostic data to EDH

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/model/diagnostics/DiagnosticParameters.java
+++ b/common-model/src/main/java/com/sequenceiq/common/model/diagnostics/DiagnosticParameters.java
@@ -47,6 +47,16 @@ public class DiagnosticParameters {
 
     private String clusterVersion;
 
+    private String dbusUrl;
+
+    private String supportBundleDbusAccessKey;
+
+    private String supportBundleDbusPrivateKey;
+
+    private String supportBundleDbusAppName;
+
+    private String supportBundleDbusStreamName;
+
     private CloudStorageDiagnosticsParameters cloudStorageDiagnosticsParameters;
 
     public Map<String, Object> toMap() {
@@ -70,6 +80,11 @@ public class DiagnosticParameters {
         parameters.put("clusterType", clusterType);
         parameters.put("clusterVersion", clusterVersion);
         parameters.put("mode", null);
+        parameters.put("dbusUrl", dbusUrl);
+        parameters.put("supportBundleDbusAccessKey", supportBundleDbusAccessKey);
+        parameters.put("supportBundleDbusPrivateKey", supportBundleDbusPrivateKey);
+        parameters.put("supportBundleDbusStreamName", supportBundleDbusStreamName);
+        parameters.put("supportBundleDbusAppName", supportBundleDbusAppName);
         if (cloudStorageDiagnosticsParameters != null) {
             for (Map.Entry<String, Object> cloudStorageEntry : cloudStorageDiagnosticsParameters.toMap().entrySet()) {
                 parameters.put(cloudStorageEntry.getKey(), cloudStorageEntry.getValue());
@@ -144,6 +159,26 @@ public class DiagnosticParameters {
         this.clusterVersion = clusterVersion;
     }
 
+    public void setDbusUrl(String dbusUrl) {
+        this.dbusUrl = dbusUrl;
+    }
+
+    public void setSupportBundleDbusAccessKey(String supportBundleDbusAccessKey) {
+        this.supportBundleDbusAccessKey = supportBundleDbusAccessKey;
+    }
+
+    public void setSupportBundleDbusPrivateKey(String supportBundleDbusPrivateKey) {
+        this.supportBundleDbusPrivateKey = supportBundleDbusPrivateKey;
+    }
+
+    public void setSupportBundleDbusAppName(String supportBundleDbusAppName) {
+        this.supportBundleDbusAppName = supportBundleDbusAppName;
+    }
+
+    public void setSupportBundleDbusStreamName(String supportBundleDbusStreamName) {
+        this.supportBundleDbusStreamName = supportBundleDbusStreamName;
+    }
+
     public void setCloudStorageDiagnosticsParameters(CloudStorageDiagnosticsParameters cloudStorageDiagnosticsParameters) {
         this.cloudStorageDiagnosticsParameters = cloudStorageDiagnosticsParameters;
     }
@@ -210,6 +245,26 @@ public class DiagnosticParameters {
 
     public String getClusterVersion() {
         return clusterVersion;
+    }
+
+    public String getDbusUrl() {
+        return dbusUrl;
+    }
+
+    public String getSupportBundleDbusAccessKey() {
+        return supportBundleDbusAccessKey;
+    }
+
+    public String getSupportBundleDbusPrivateKey() {
+        return supportBundleDbusPrivateKey;
+    }
+
+    public String getSupportBundleDbusAppName() {
+        return supportBundleDbusAppName;
+    }
+
+    public String getSupportBundleDbusStreamName() {
+        return supportBundleDbusStreamName;
     }
 
     public CloudStorageDiagnosticsParameters getCloudStorageDiagnosticsParameters() {
@@ -308,6 +363,21 @@ public class DiagnosticParameters {
 
         public DiagnosticParametersBuilder withSkipValidation(Boolean skipValidation) {
             diagnosticParameters.setSkipValidation(skipValidation);
+            return this;
+        }
+
+        public DiagnosticParametersBuilder withDbusUrl(String dbusUrl) {
+            diagnosticParameters.setDbusUrl(dbusUrl);
+            return this;
+        }
+
+        public DiagnosticParametersBuilder withSupportBundleDbusStreamName(String supportBundleDbusStreamName) {
+            diagnosticParameters.setSupportBundleDbusStreamName(supportBundleDbusStreamName);
+            return this;
+        }
+
+        public DiagnosticParametersBuilder withSupportBundleDbusAppName(String supportBundleDbusAppName) {
+            diagnosticParameters.setSupportBundleDbusAppName(supportBundleDbusAppName);
             return this;
         }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -184,6 +184,7 @@ public enum ResourceEvent {
     STACK_DATALAKE_UPDATE_FINISHED("stack.datalake.update.finished"),
     STACK_DATALAKE_UPDATE_FAILED("stack.datalake.update.failed"),
     STACK_DIAGNOSTICS_INIT_RUNNING("stack.diagnostics.init.running"),
+    STACK_DIAGNOSTICS_ENSURE_MACHINE_USER("stack.diagnostics.ensure.machine.user"),
     STACK_DIAGNOSTICS_COLLECTION_RUNNING("stack.diagnostics.collection.running"),
     STACK_DIAGNOSTICS_UPLOAD_RUNNING("stack.diagnostics.upload.running"),
     STACK_DIAGNOSTICS_CLEANUP_RUNNING("stack.diagnostics.cleanup.running"),

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryConfiguration.java
@@ -6,6 +6,7 @@ import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.metering.MeteringConfiguration;
 import com.sequenceiq.cloudbreak.telemetry.monitoring.MonitoringConfiguration;
+import com.sequenceiq.cloudbreak.telemetry.support.SupportBundleConfiguration;
 
 @Configuration
 public class TelemetryConfiguration {
@@ -18,14 +19,18 @@ public class TelemetryConfiguration {
 
     private final MonitoringConfiguration monitoringConfiguration;
 
+    private final SupportBundleConfiguration supportBundleConfiguration;
+
     public TelemetryConfiguration(AltusDatabusConfiguration altusDatabusConfiguration,
             MeteringConfiguration meteringConfiguration,
             ClusterLogsCollectionConfiguration clusterLogsCollectionConfiguration,
-            MonitoringConfiguration monitoringConfiguration) {
+            MonitoringConfiguration monitoringConfiguration,
+            SupportBundleConfiguration supportBundleConfiguration) {
         this.altusDatabusConfiguration = altusDatabusConfiguration;
         this.meteringConfiguration = meteringConfiguration;
         this.clusterLogsCollectionConfiguration = clusterLogsCollectionConfiguration;
         this.monitoringConfiguration = monitoringConfiguration;
+        this.supportBundleConfiguration = supportBundleConfiguration;
     }
 
     public AltusDatabusConfiguration getAltusDatabusConfiguration() {
@@ -42,5 +47,9 @@ public class TelemetryConfiguration {
 
     public MonitoringConfiguration getMonitoringConfiguration() {
         return monitoringConfiguration;
+    }
+
+    public SupportBundleConfiguration getSupportBundleConfiguration() {
+        return supportBundleConfiguration;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/DiagnosticsDataToParameterConverter.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/DiagnosticsDataToParameterConverter.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.GcsConfig;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.GcsConfigGenerator;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3Config;
 import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.S3ConfigGenerator;
+import com.sequenceiq.cloudbreak.telemetry.support.SupportBundleConfiguration;
 import com.sequenceiq.common.api.diagnostics.BaseDiagnosticsCollectionRequest;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -29,6 +30,9 @@ import com.sequenceiq.common.model.diagnostics.GcsDiagnosticsParameters.GcsDiagn
 public class DiagnosticsDataToParameterConverter {
 
     private static final String DIAGNOSTICS_SUFFIX_PATH = "diagnostics";
+
+    @Inject
+    private SupportBundleConfiguration supportBundleConfiguration;
 
     @Inject
     private S3ConfigGenerator s3ConfigGenerator;
@@ -80,6 +84,11 @@ public class DiagnosticsDataToParameterConverter {
         builder.withUpdatePackage(request.getUpdatePackage());
         builder.withSkipValidation(request.getSkipValidation());
         builder.withAdditionalLogs(request.getAdditionalLogs());
+        if (supportBundleConfiguration.isEnabled()) {
+            builder.withDbusUrl(telemetry.getDatabusEndpoint());
+            builder.withSupportBundleDbusStreamName(supportBundleConfiguration.getDbusStreamName());
+            builder.withSupportBundleDbusAppName(supportBundleConfiguration.getDbusAppName());
+        }
         return builder.build();
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/support/SupportBundleConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/support/SupportBundleConfiguration.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.telemetry.support;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.telemetry.databus.AbstractDatabusStreamConfiguration;
+
+@Component
+public class SupportBundleConfiguration extends AbstractDatabusStreamConfiguration {
+
+    public SupportBundleConfiguration(
+            @Value("${cluster.support.bundle.enabled:false}") boolean enabled,
+            @Value("${cluster.support.bundle.dbus.app.name:}") String dbusAppName,
+            @Value("${cluster.support.bundle.dbus.stream.name:UnifiedDiagnostics}") String dbusStreamName) {
+        super(enabled, dbusAppName, dbusStreamName);
+    }
+
+    @Override
+    protected String getDbusServiceName() {
+        return "UnifiedDiagnostics";
+    }
+}

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -46,6 +46,7 @@ stack.infrastructure.create.rollback=Could not create {0} instance(s), node coun
 stack.cleanup.service.trigger.sync=Couldn't retrieve the cluster's status, starting to sync.
 
 stack.diagnostics.init.running=Diagnostics collection initialization in progress. Hosts: {0}, Host-groups: {1}
+stack.diagnostics.ensure.machine.user=Check availability of UMS resources for diagnostics.
 stack.diagnostics.collection.running=Diagnostics collection in progress. Destination for logs: {0}
 stack.diagnostics.upload.running=Diagnostics uploading in progress. {0}
 stack.diagnostics.cleanup.running=Diagnostics cleanup in progress

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -41,7 +41,7 @@ public class FluentConfigServiceTest {
         ClusterLogsCollectionConfiguration logCollectionConfig =
                 new ClusterLogsCollectionConfiguration(false, null, null);
         TelemetryConfiguration telemetryConfiguration =
-                new TelemetryConfiguration(null, meteringConfiguration, logCollectionConfig, null);
+                new TelemetryConfiguration(null, meteringConfiguration, logCollectionConfig, null, null);
         underTest = new FluentConfigService(new S3ConfigGenerator(), new AdlsGen2ConfigGenerator(), new GcsConfigGenerator(),
                 new AnonymizationRuleResolver(), telemetryConfiguration);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionsState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionsState.java
@@ -5,6 +5,7 @@ import com.sequenceiq.flow.core.FlowState;
 public enum DiagnosticsCollectionsState implements FlowState {
     INIT_STATE,
     DIAGNOSTICS_INIT_STATE,
+    DIAGNOSTICS_ENSURE_MACHINE_USER_STATE,
     DIAGNOSTICS_COLLECTION_STATE,
     DIAGNOSTICS_UPLOAD_STATE,
     DIAGNOSTICS_CLEANUP_STATE,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/config/DiagnosticsCollectionFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/config/DiagnosticsCollectionFlowConfig.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollec
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_COLLECTION_FAILED_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_COLLECTION_FINISHED_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_COLLECTION_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_ENSURE_MACHINE_USER_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_INIT_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_UPLOAD_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.FINAL_STATE;
@@ -14,6 +15,7 @@ import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.Diagnostics
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.HANDLED_FAILED_DIAGNOSTICS_COLLECTION_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_CLEANUP_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_COLLECTION_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_INIT_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_UPLOAD_EVENT;
 
@@ -39,7 +41,12 @@ public class DiagnosticsCollectionFlowConfig extends AbstractFlowConfiguration<D
             .failureState(DIAGNOSTICS_COLLECTION_FAILED_STATE)
             .defaultFailureEvent()
 
-            .from(DIAGNOSTICS_INIT_STATE).to(DIAGNOSTICS_COLLECTION_STATE)
+            .from(DIAGNOSTICS_INIT_STATE).to(DIAGNOSTICS_ENSURE_MACHINE_USER_STATE)
+            .event(START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT)
+            .failureState(DIAGNOSTICS_COLLECTION_FAILED_STATE)
+            .defaultFailureEvent()
+
+            .from(DIAGNOSTICS_ENSURE_MACHINE_USER_STATE).to(DIAGNOSTICS_COLLECTION_STATE)
             .event(START_DIAGNOSTICS_COLLECTION_EVENT)
             .failureState(DIAGNOSTICS_COLLECTION_FAILED_STATE)
             .defaultFailureEvent()

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionHandlerSelectors.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionHandlerSelectors.java
@@ -4,6 +4,7 @@ import com.sequenceiq.flow.core.FlowEvent;
 
 public enum DiagnosticsCollectionHandlerSelectors implements FlowEvent {
     INIT_DIAGNOSTICS_EVENT,
+    ENSURE_MACHINE_USER_EVENT,
     COLLECT_DIAGNOSTICS_EVENT,
     UPLOAD_DIAGNOSTICS_EVENT,
     CLEANUP_DIAGNOSTICS_EVENT;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionStateSelectors.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionStateSelectors.java
@@ -4,6 +4,7 @@ import com.sequenceiq.flow.core.FlowEvent;
 
 public enum DiagnosticsCollectionStateSelectors implements FlowEvent {
     START_DIAGNOSTICS_INIT_EVENT,
+    START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT,
     START_DIAGNOSTICS_COLLECTION_EVENT,
     START_DIAGNOSTICS_UPLOAD_EVENT,
     START_DIAGNOSTICS_CLEANUP_EVENT,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -47,7 +47,7 @@ public class TelemetryConverterTest {
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, "app", "stream");
         MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(true, null, null);
         TelemetryConfiguration telemetryConfiguration =
-                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig);
+                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig, null);
         underTest = new TelemetryConverter(telemetryConfiguration, true, true);
     }
 
@@ -185,7 +185,7 @@ public class TelemetryConverterTest {
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
         MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(false, null, null);
         TelemetryConfiguration telemetryConfiguration =
-                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig);
+                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig, null);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, true, false);
         // WHEN
         TelemetryRequest result = converter.convert(null, sdxClusterResponse);
@@ -261,7 +261,7 @@ public class TelemetryConverterTest {
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
         MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(false, null, null);
         TelemetryConfiguration telemetryConfiguration =
-                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig);
+                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig, null);
         TelemetryConverter converter = new TelemetryConverter(telemetryConfiguration, false, true);
         // WHEN
         TelemetryRequest result = converter.convert(response, sdxClusterResponse);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserServiceTest.java
@@ -20,7 +20,9 @@ import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.auth.altus.service.AltusIAMService;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -35,7 +37,13 @@ public class AltusMachineUserServiceTest {
     private AltusIAMService altusIAMService;
 
     @Mock
+    private StackService stackService;
+
+    @Mock
     private ClusterService clusterService;
+
+    @Mock
+    private ComponentConfigProviderService componentConfigProviderService;
 
     private Stack stack;
 
@@ -57,7 +65,8 @@ public class AltusMachineUserServiceTest {
         Features features = new Features();
         features.addClusterLogsCollection(true);
         telemetry.setFeatures(features);
-        underTest = new AltusMachineUserService(altusIAMService, clusterService);
+        underTest = new AltusMachineUserService(altusIAMService, stackService,
+                clusterService, componentConfigProviderService);
     }
 
     @Test

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/validation/diagnostics/DiagnosticsCollectionValidator.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/validation/diagnostics/DiagnosticsCollectionValidator.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.telemetry.support.SupportBundleConfiguration;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.common.api.diagnostics.BaseCmDiagnosticsCollectionRequest;
 import com.sequenceiq.common.api.diagnostics.BaseDiagnosticsCollectionRequest;
@@ -12,6 +13,12 @@ import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 
 @Component
 public class DiagnosticsCollectionValidator {
+
+    private final SupportBundleConfiguration supportBundleConfiguration;
+
+    public DiagnosticsCollectionValidator(SupportBundleConfiguration supportBundleConfiguration) {
+        this.supportBundleConfiguration = supportBundleConfiguration;
+    }
 
     public void validate(BaseCmDiagnosticsCollectionRequest request, StackV4Response stackV4Response) {
         validate(request.getDestination(), stackV4Response, true);
@@ -33,7 +40,7 @@ public class DiagnosticsCollectionValidator {
         } else if (DiagnosticsDestination.ENG.equals(destination) && isClusterLogCollectionDisabled(telemetry)) {
             validationBuilder.error(
                     String.format("Cluster log collection is not enabled for this stack '%s'", stackV4Response.getName()));
-        } else if (DiagnosticsDestination.SUPPORT.equals(destination) && !cmBundle) {
+        } else if (DiagnosticsDestination.SUPPORT.equals(destination) && !isSupportBundleEnabled(cmBundle)) {
             validationBuilder.error(
                     String.format("Destination %s is not supported yet.", DiagnosticsDestination.SUPPORT.name()));
         }
@@ -41,6 +48,10 @@ public class DiagnosticsCollectionValidator {
         if (validationResult.hasError()) {
             throw new BadRequestException(validationResult.getFormattedErrors());
         }
+    }
+
+    private boolean isSupportBundleEnabled(boolean cmBundle) {
+        return cmBundle || supportBundleConfiguration.isEnabled();
     }
 
     private boolean isClusterLogCollectionDisabled(TelemetryResponse telemetry) {

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/validation/diagnostics/DiagnosticsCollectionValidatorTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/validation/diagnostics/DiagnosticsCollectionValidatorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.telemetry.support.SupportBundleConfiguration;
 import com.sequenceiq.common.api.diagnostics.BaseDiagnosticsCollectionRequest;
 import com.sequenceiq.common.api.telemetry.model.DiagnosticsDestination;
 import com.sequenceiq.common.api.telemetry.response.FeaturesResponse;
@@ -16,7 +17,9 @@ import com.sequenceiq.common.api.type.FeatureSetting;
 
 class DiagnosticsCollectionValidatorTest {
 
-    private final DiagnosticsCollectionValidator underTest = new DiagnosticsCollectionValidator();
+    private final DiagnosticsCollectionValidator underTest =
+            new DiagnosticsCollectionValidator(
+                    new SupportBundleConfiguration(false, null, null));
 
     @Test
     void testWithoutTelemetry() {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
@@ -41,7 +41,7 @@ public class TelemetryApiConverterTest {
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
         MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(true, null, null);
         TelemetryConfiguration telemetryConfiguration = new TelemetryConfiguration(
-                altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig);
+                altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig, null);
         underTest = new TelemetryApiConverter(telemetryConfiguration);
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
@@ -31,6 +31,9 @@ import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonToString;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.converter.TunnelConverter;
+import com.sequenceiq.cloudbreak.service.secret.SecretValue;
+import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
+import com.sequenceiq.cloudbreak.service.secret.domain.SecretToString;
 import com.sequenceiq.cloudbreak.structuredevent.repository.AccountAwareResource;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.common.api.type.Tunnel;
@@ -106,6 +109,10 @@ public class Stack implements AccountAwareResource {
 
     @OneToOne(cascade = CascadeType.ALL)
     private StackStatus stackStatus;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret databusCredential = Secret.EMPTY;
 
     private String template;
 
@@ -294,6 +301,14 @@ public class Stack implements AccountAwareResource {
 
     public void setStackStatus(StackStatus stackStatus) {
         this.stackStatus = stackStatus;
+    }
+
+    public String getDatabusCredential() {
+        return databusCredential.getRaw();
+    }
+
+    public void setDatabusCredential(String databusCredential) {
+        this.databusCredential = new Secret(databusCredential);
     }
 
     public String getOwner() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionActions.java
@@ -46,6 +46,24 @@ public class DiagnosticsCollectionActions {
         };
     }
 
+    @Bean(name = "DIAGNOSTICS_ENSURE_MACHINE_USER_STATE")
+    public Action<?, ?> diagnosticsCreateMachineUserAction() {
+        return new AbstractDiagnosticsCollectionActions<>(DiagnosticsCollectionEvent.class) {
+            @Override
+            protected void doExecute(CommonContext context, DiagnosticsCollectionEvent payload, Map<Object, Object> variables) {
+                String resourceCrn = payload.getResourceCrn();
+                LOGGER.debug("Flow entered into DIAGNOSTICS_CREATE_MACHINE_USER_STATE. resourceCrn: '{}'", resourceCrn);
+                DiagnosticsCollectionEvent event = DiagnosticsCollectionEvent.builder()
+                        .withResourceId(payload.getResourceId())
+                        .withResourceCrn(payload.getResourceCrn())
+                        .withSelector(DiagnosticsCollectionHandlerSelectors.ENSURE_MACHINE_USER_EVENT.selector())
+                        .withParameters(payload.getParameters())
+                        .build();
+                sendEvent(context, event);
+            }
+        };
+    }
+
     @Bean(name = "DIAGNOSTICS_COLLECTION_STATE")
     public Action<?, ?> diagnosticsCollectionAction() {
         return new AbstractDiagnosticsCollectionActions<>(DiagnosticsCollectionEvent.class) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionsState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionsState.java
@@ -5,6 +5,7 @@ import com.sequenceiq.flow.core.FlowState;
 public enum DiagnosticsCollectionsState implements FlowState {
     INIT_STATE,
     DIAGNOSTICS_INIT_STATE,
+    DIAGNOSTICS_ENSURE_MACHINE_USER_STATE,
     DIAGNOSTICS_COLLECTION_STATE,
     DIAGNOSTICS_UPLOAD_STATE,
     DIAGNOSTICS_CLEANUP_STATE,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/config/DiagnosticsCollectionFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/config/DiagnosticsCollectionFlowConfig.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollect
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_COLLECTION_FINISHED_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_COLLECTION_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_COLLECTION_FAILED_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_ENSURE_MACHINE_USER_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_INIT_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_UPLOAD_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.FINAL_STATE;
@@ -14,6 +15,7 @@ import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsC
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.HANDLED_FAILED_DIAGNOSTICS_COLLECTION_EVENT;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_CLEANUP_EVENT;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_COLLECTION_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_INIT_EVENT;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_UPLOAD_EVENT;
 
@@ -39,7 +41,12 @@ public class DiagnosticsCollectionFlowConfig extends AbstractFlowConfiguration<D
             .failureState(DIAGNOSTICS_COLLECTION_FAILED_STATE)
             .defaultFailureEvent()
 
-            .from(DIAGNOSTICS_INIT_STATE).to(DIAGNOSTICS_COLLECTION_STATE)
+            .from(DIAGNOSTICS_INIT_STATE).to(DIAGNOSTICS_ENSURE_MACHINE_USER_STATE)
+            .event(START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT)
+            .failureState(DIAGNOSTICS_COLLECTION_FAILED_STATE)
+            .defaultFailureEvent()
+
+            .from(DIAGNOSTICS_ENSURE_MACHINE_USER_STATE).to(DIAGNOSTICS_COLLECTION_STATE)
             .event(START_DIAGNOSTICS_COLLECTION_EVENT)
             .failureState(DIAGNOSTICS_COLLECTION_FAILED_STATE)
             .defaultFailureEvent()

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionHandlerSelectors.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionHandlerSelectors.java
@@ -4,6 +4,7 @@ import com.sequenceiq.flow.core.FlowEvent;
 
 public enum DiagnosticsCollectionHandlerSelectors implements FlowEvent {
     INIT_DIAGNOSTICS_EVENT,
+    ENSURE_MACHINE_USER_EVENT,
     COLLECT_DIAGNOSTICS_EVENT,
     UPLOAD_DIAGNOSTICS_EVENT,
     CLEANUP_DIAGNOSTICS_EVENT;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionStateSelectors.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionStateSelectors.java
@@ -4,6 +4,7 @@ import com.sequenceiq.flow.core.FlowEvent;
 
 public enum DiagnosticsCollectionStateSelectors implements FlowEvent {
     START_DIAGNOSTICS_INIT_EVENT,
+    START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT,
     START_DIAGNOSTICS_COLLECTION_EVENT,
     START_DIAGNOSTICS_UPLOAD_EVENT,
     START_DIAGNOSTICS_CLEANUP_EVENT,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/handler/MachineUserRemoveHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/handler/MachineUserRemoveHandler.java
@@ -2,6 +2,7 @@ package com.sequenceiq.freeipa.flow.stack.termination.handler;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -51,7 +52,7 @@ public class MachineUserRemoveHandler implements EventHandler<RemoveMachineUserR
     private void cleanupMachineUser(Long stackId) {
         Stack stack = stackService.getStackById(stackId);
         Telemetry telemetry = stack.getTelemetry();
-        if (telemetry != null && telemetry.isClusterLogsCollectionEnabled()) {
+        if (telemetry != null && (telemetry.isClusterLogsCollectionEnabled() || StringUtils.isNotBlank(stack.getDatabusCredential()))) {
             ThreadBasedUserCrnProvider.doAsInternalActor(() -> altusMachineUserService.cleanupMachineUser(stack, telemetry));
         } else {
             LOGGER.info("Machine user cleanup is not needed.");

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/AltusMachineUserService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/AltusMachineUserService.java
@@ -1,8 +1,11 @@
 package com.sequenceiq.freeipa.service;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
@@ -10,18 +13,26 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.model.AltusCredential;
 import com.sequenceiq.cloudbreak.auth.altus.service.AltusIAMService;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.common.api.telemetry.model.DataBusCredential;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.stack.StackService;
 
 @Service
 public class AltusMachineUserService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AltusMachineUserService.class);
 
     private static final String FREEIPA_FLUENT_DATABUS_MACHINE_USER_PATTERN = "freeipa-fluent-databus-uploader-%s";
 
     private final AltusIAMService altusIAMService;
 
-    public AltusMachineUserService(AltusIAMService altusIAMService) {
+    private final StackService stackService;
+
+    public AltusMachineUserService(AltusIAMService altusIAMService, StackService stackService) {
         this.altusIAMService = altusIAMService;
+        this.stackService = stackService;
     }
 
     public Optional<AltusCredential> createMachineUserWithAccessKeys(Stack stack, Telemetry telemetry) {
@@ -62,6 +73,76 @@ public class AltusMachineUserService {
     public String getFluentMachineUser(Stack stack) {
         return String.format(FREEIPA_FLUENT_DATABUS_MACHINE_USER_PATTERN,
                 Crn.fromString(stack.getResourceCrn()).getResource());
+    }
+
+    /**
+     * Gather or create DataBus credential for a stack.
+     * On creation it will generate aa new workload user with new access/private keys.
+     * @param stackId id of the stack
+     * @return databus credential holder
+     */
+    public DataBusCredential getOrCreateDataBusCredentialIfNeeded(Long stackId) throws IOException {
+        return getOrCreateDataBusCredentialIfNeeded(stackService.getStackById(stackId));
+    }
+
+    /**
+     * Gather or create DataBus credential for a stack.
+     * On creation it will generate aa new workload user with new access/private keys.
+     * @param stack stack object that holds details about the cluster
+     * @return databus credential holder
+     */
+    public DataBusCredential getOrCreateDataBusCredentialIfNeeded(Stack stack) throws IOException {
+        LOGGER.debug("Get or create databus credential for stack");
+        Telemetry telemetry = stack.getTelemetry();
+        if (stack.getDatabusCredential() != null) {
+            LOGGER.debug("Databus credential has been found for the stack");
+            DataBusCredential dataBusCredential = new Json(stack.getDatabusCredential()).get(DataBusCredential.class);
+            if (isDataBusCredentialStillExist(telemetry, dataBusCredential, stack)) {
+                LOGGER.debug("Databus credential exists both in the stack and on UMS side");
+                return dataBusCredential;
+            } else {
+                LOGGER.debug("Databus credential exists on stack side but does not exists on UMS side, it will be updated ...");
+            }
+        } else {
+            LOGGER.debug("Databus credential does not exist for the stack, it will be created ...");
+        }
+        Optional<AltusCredential> altusCredential = createMachineUserWithAccessKeys(stack, telemetry);
+        return storeDataBusCredential(altusCredential, stack);
+    }
+
+    /**
+     * Store databus access / secret keypair and machine user name in the cluster if altus credential exists
+     * @param altusCredential dto for databus access/private key
+     * @param stack component will be attached to this stack
+     * @return domain object that holds databus credential
+     */
+    public DataBusCredential storeDataBusCredential(Optional<AltusCredential> altusCredential, Stack stack) {
+        if (altusCredential.isPresent()) {
+            DataBusCredential dataBusCredential = new DataBusCredential();
+            dataBusCredential.setMachineUserName(getFluentMachineUser(stack));
+            dataBusCredential.setAccessKey(altusCredential.get().getAccessKey());
+            dataBusCredential.setPrivateKey(altusCredential.get().getPrivateKey() != null ? new String(altusCredential.get().getPrivateKey()) : null);
+            String databusCredentialJsonString = new Json(dataBusCredential).getValue();
+            stack.setDatabusCredential(databusCredentialJsonString);
+            stackService.save(stack);
+            return dataBusCredential;
+        }
+        return null;
+    }
+
+    /**
+     * Check that machine user still have the access key on UMS side
+     * @param dataBusCredential databus credential DTO that comes from cloudbreak database which contains access key and machune user name as well.
+     * @param stack stack object holder that can be used to calculate the machine user name
+     * @return check result - if true, no need to regenerate keys
+     */
+    public boolean isDataBusCredentialStillExist(Telemetry telemetry, DataBusCredential dataBusCredential, Stack stack) {
+        return ThreadBasedUserCrnProvider.doAsInternalActor(
+                () -> altusIAMService.doesMachineUserHasAccessKey(
+                        ThreadBasedUserCrnProvider.getUserCrn(),
+                        Crn.fromString(stack.getResourceCrn()).getAccountId(),
+                        dataBusCredential.getMachineUserName(), dataBusCredential.getAccessKey(),
+                        telemetry.isUseSharedAltusCredentialEnabled()));
     }
 
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/diagnostics/DiagnosticsCollectionValidator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/diagnostics/DiagnosticsCollectionValidator.java
@@ -1,11 +1,10 @@
-package com.sequenceiq.cloudbreak.controller.validation.diagnostics;
+package com.sequenceiq.freeipa.service.diagnostics;
 
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.telemetry.support.SupportBundleConfiguration;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
-import com.sequenceiq.common.api.diagnostics.BaseCmDiagnosticsCollectionRequest;
 import com.sequenceiq.common.api.diagnostics.BaseDiagnosticsCollectionRequest;
 import com.sequenceiq.common.api.telemetry.model.DiagnosticsDestination;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -13,32 +12,30 @@ import com.sequenceiq.common.api.telemetry.model.Telemetry;
 @Component
 public class DiagnosticsCollectionValidator {
 
+    private static final int MIN_MAJOR_VERSION = 2;
+
+    private static final int MIN_MINOR_VERSION = 33;
+
     private final SupportBundleConfiguration supportBundleConfiguration;
 
     public DiagnosticsCollectionValidator(SupportBundleConfiguration supportBundleConfiguration) {
         this.supportBundleConfiguration = supportBundleConfiguration;
     }
 
-    public void validate(BaseDiagnosticsCollectionRequest request, Telemetry telemetry, String stackCrn) {
-        validate(request.getDestination(), telemetry, stackCrn, false);
-    }
-
-    public void validate(BaseCmDiagnosticsCollectionRequest request, Telemetry telemetry, String stackCrn) {
-        validate(request.getDestination(), telemetry, stackCrn, true);
-    }
-
-    public void validate(DiagnosticsDestination destination, Telemetry telemetry, String stackCrn, Boolean cmBundle) {
+    public void validate(BaseDiagnosticsCollectionRequest request, Telemetry telemetry, String stackCrn, String appVersion) {
         ValidationResult.ValidationResultBuilder validationBuilder = new ValidationResult.ValidationResultBuilder();
-        if (telemetry == null) {
+        DiagnosticsDestination destination = request.getDestination();
+        if (!isAppVersionValid(appVersion)) {
+            validationBuilder.error(String.format("Required freeipa min major/minor version is %d.%d for using diagnostics. " +
+                            "Try it on newer environment.", MIN_MAJOR_VERSION, MIN_MINOR_VERSION));
+        } else if (telemetry == null) {
             validationBuilder.error(String.format("Telemetry is not enabled for stack '%s'", stackCrn));
         } else if (DiagnosticsDestination.CLOUD_STORAGE.equals(destination)) {
             validateCloudStorageSettings(telemetry, stackCrn, validationBuilder);
-        } else if (DiagnosticsDestination.ENG.equals(destination) && cmBundle) {
-            validationBuilder.error("Cluster log collection with ENG destination is not supported for CM based diagnostics");
-        } else if (DiagnosticsDestination.ENG.equals(destination) && isClusterLogCollectionDisabled(telemetry)) {
+        } else if (DiagnosticsDestination.ENG.equals(destination) && !telemetry.isClusterLogsCollectionEnabled()) {
             validationBuilder.error(
                     String.format("Cluster log collection is not enabled for this stack '%s'", stackCrn));
-        } else if (DiagnosticsDestination.SUPPORT.equals(destination) && !isSupportBundleEnabled(cmBundle)) {
+        } else if (DiagnosticsDestination.SUPPORT.equals(destination) && !supportBundleConfiguration.isEnabled()) {
             validationBuilder.error(
                     String.format("Destination %s is not supported yet.", DiagnosticsDestination.SUPPORT.name()));
         }
@@ -48,12 +45,23 @@ public class DiagnosticsCollectionValidator {
         }
     }
 
-    private boolean isSupportBundleEnabled(boolean cmBundle) {
-        return cmBundle || supportBundleConfiguration.isEnabled();
-    }
-
-    private boolean isClusterLogCollectionDisabled(Telemetry telemetry) {
-        return !telemetry.isClusterLogsCollectionEnabled();
+    private boolean isAppVersionValid(String appVersion) {
+        boolean result = true;
+        if (appVersion == null) {
+            return result;
+        }
+        String withoutBuildNumber = appVersion.split("-")[0];
+        String[] versionParts = withoutBuildNumber.split("\\.");
+        if (versionParts.length > 1) {
+            int majorVersion = Integer.parseInt(versionParts[0]);
+            int minorVersion = Integer.parseInt(versionParts[1]);
+            if (majorVersion < MIN_MAJOR_VERSION) {
+                result = false;
+            } else if (majorVersion == MIN_MAJOR_VERSION && minorVersion < MIN_MINOR_VERSION) {
+                result = false;
+            }
+        }
+        return result;
     }
 
     private void validateCloudStorageSettings(Telemetry telemetry, String stackCrn,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/diagnostics/DiagnosticsTriggerService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/diagnostics/DiagnosticsTriggerService.java
@@ -37,11 +37,15 @@ public class DiagnosticsTriggerService {
     private FreeIpaFlowManager flowManager;
 
     @Inject
+    private DiagnosticsCollectionValidator diagnosticsCollectionValidator;
+
+    @Inject
     private DiagnosticsDataToParameterConverter diagnosticsDataToParameterConverter;
 
     public FlowIdentifier startDiagnosticsCollection(DiagnosticsCollectionRequest request, String accountId, String userCrn) {
         Stack stack = stackService.getByEnvironmentCrnAndAccountIdWithLists(request.getEnvironmentCrn(), accountId);
         MDCBuilder.buildMdcContext(stack);
+        diagnosticsCollectionValidator.validate(request, stack.getTelemetry(), stack.getResourceCrn(), stack.getAppVersion());
         LOGGER.debug("Starting diagnostics collection for FreeIpa. Crn: '{}'", stack.getResourceCrn());
         DiagnosticParameters parameters = diagnosticsDataToParameterConverter.convert(request, stack.getTelemetry(), FREEIPA_CLUSTER_TYPE,
                 stack.getAppVersion(), stack.getAccountId(), stack.getRegion());

--- a/freeipa/src/main/resources/schema/app/20201206175412_CB-7951_add_databus_credential.sql
+++ b/freeipa/src/main/resources/schema/app/20201206175412_CB-7951_add_databus_credential.sql
@@ -1,0 +1,9 @@
+-- // CB-7951 Store databus credentials in stack
+-- Migration SQL that makes the change goes here.
+
+alter table stack add COLUMN IF NOT EXISTS databuscredential varchar(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+alter table stack drop COLUMN IF EXISTS databuscredential;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
@@ -39,7 +39,7 @@ public class TelemetryConverterTest {
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
         MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(false, null, null);
         TelemetryConfiguration telemetryConfiguration =
-                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig);
+                new TelemetryConfiguration(altusDatabusConfiguration, meteringConfiguration, logCollectionConfig, monitoringConfig, null);
         underTest = new TelemetryConverter(telemetryConfiguration, true);
     }
 

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/init.sls
@@ -111,4 +111,12 @@ check_td_agent_running_systemctl:
   cmd.run:
     - name: "systemctl is-active --quiet td-agent"
     - failhard: True
+{% elif not filecollector.skipValidation and filecollector.destination == "SUPPORT" %}
+check_support_dbus_connection:
+  cmd.run:
+    - name: "cdp-telemetry utils check-connection --url {{ filecollector.dbusUrl }}"
+    - failhard: True{% if filecollector.proxyUrl %}
+    - env: {% if filecollector.proxyProtocol == "https" %}
+       - HTTPS_PROXY: {{ filecollector.proxyUrl }}{% else %}
+       - HTTP_PROXY: {{ filecollector.proxyUrl }}{% endif %}{% endif %}
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
@@ -21,6 +21,15 @@
 {% set additional_logs = salt['pillar.get']('filecollector:additionalLogs') %}
 {% set mode = salt['pillar.get']('filecollector:mode') %}
 {% set uuid = salt['pillar.get']('filecollector:uuid') %}
+{% set dbus_url = salt['pillar.get']('filecollector:dbusUrl') %}
+{% if salt['pillar.get']('filecollector:supportBundleDbusAppName') %}
+  {% set support_bundle_dbus_headers = '@support-bundle-app:' + salt['pillar.get']('filecollector:supportBundleDbusAppName') %}
+{% else %}
+  {% set support_bundle_dbus_headers = '' %}
+{% endif %}
+{% set support_bundle_dbus_stream_name = salt['pillar.get']('filecollector:supportBundleDbusStreamName') %}
+{% set support_bundle_dbus_access_key = salt['pillar.get']('filecollector:supportBundleDbusAccessKey') %}
+{% set support_bundle_dbus_private_key = salt['pillar.get']('filecollector:supportBundleDbusPrivateKey') %}
 
 {% if s3_location and not s3_region %}
   {%- set instanceDetails = salt.cmd.run('curl -s http://169.254.169.254/latest/dynamic/instance-identity/document') | load_json %}
@@ -135,5 +144,11 @@
     "clusterVersion": cluster_version,
     "uuid": uuid,
     "accountId": account_id,
-    "cdpTelemetryVersion": cdp_telemetry_version
+    "cdpTelemetryVersion": cdp_telemetry_version,
+    "supportBundleDbusStreamName": support_bundle_dbus_stream_name,
+    "supportBundleDbusHeaders": support_bundle_dbus_headers,
+    "supportBundleDbusAccessKey": support_bundle_dbus_access_key,
+    "supportBundleDbusPrivateKey": support_bundle_dbus_private_key,
+    "compressedFilePattern": compressed_file_pattern,
+    "dbusUrl": dbus_url
 }) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/support_bundle_databus.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/support_bundle_databus.conf.j2
@@ -1,0 +1,4 @@
+{%- from 'filecollector/settings.sls' import filecollector with context %}[dbus]
+databus_access_key_id={{ filecollector.supportBundleDbusAccessKey }}
+databus_access_secret_key={{ filecollector.supportBundleDbusPrivateKey }}
+databus_access_secret_key_algo=Ed25519

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/upload.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/upload.sls
@@ -13,3 +13,23 @@ filecollector_upload_to_cloud_storage:
     - env:
         - CDP_TELEMETRY_LOGGER_FILENAME: "upload.log"
 {% endif %}
+
+{% if filecollector.destination == "SUPPORT" %}
+/opt/cdp-telemetry/conf/support_bundle_databus.conf:
+   file.managed:
+    - source: salt://filecollector/template/support_bundle_databus.conf.j2
+    - template: jinja
+    - user: "root"
+    - group: "root"
+    - mode: '0600'
+    - failhard: True
+
+filecollector_upload_to_support:
+  cmd.run:
+    - name: "cdp-telemetry databus upload -p {{ filecollector.compressedFilePattern }} -c /opt/cdp-telemetry/conf/support_bundle_databus.conf --stream {{ filecollector.supportBundleDbusStreamName }} --url {{ filecollector.dbusUrl }}"
+    - failhard: True
+    - env:
+        - CDP_TELEMETRY_LOGGER_FILENAME: "upload.log"{% if filecollector.proxyUrl %}{% if filecollector.proxyProtocol == "https" %}
+        - HTTPS_PROXY: {{ filecollector.proxyUrl }}{% else %}
+        - HTTP_PROXY: {{ filecollector.proxyUrl }}{% endif %}{% endif %}
+{% endif %}


### PR DESCRIPTION
details:
- add new SupportBundle configuration that contains dbus details (stream name + app name) that can be used for diagnostics with SUPPORT destination
- users can use diagnostics with SUPPORT destination based on a global CB configuration
- persist dbusCredential on freeipa side (in order to not regenerate machine user + access keys on restart VMs by salt - if it will be supported)
- generate new machine user + access key for clusters that are not using dbus features but diagnostics with SUPPORT destination is used, if any dbus features are used, then use the stored dbusCredential for the stacks/clusters (if not stored yet, try to create new UMS resources, and persist them)
- add new flow step (ensure machine users) to diagnostics - that should create UMS resources if needed (required for SUPPORT destination) - that has done both for freeipa and core service

See detailed description in the commit message.