### PR TITLE
CB-9526 Use SSL with cert&host verification for Salt external DB create

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/init.sls
@@ -1,4 +1,5 @@
 {%- from 'metadata/settings.sls' import metadata with context %}
+{%- from 'postgresql/settings.sls' import postgresql with context %}
 
 {% set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
 {% set postgres_directory = salt['pillar.get']('postgres:postgres_directory') %}
@@ -22,6 +23,9 @@ init-services-db-remote:
     - unless: test -f /var/log/init-services-db-remote-executed
     - require:
       - file: /opt/salt/scripts/init_db_remote.sh
+{% if postgresql.ssl_enabled == True %}
+      - file: {{ postgresql.root_certs_file }}
+{%- endif %}
 
 {%- else %}
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/init_db_remote.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/scripts/init_db_remote.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+{%- from 'postgresql/settings.sls' import postgresql with context %}
+{% if postgresql.ssl_enabled == True %}
+export PGSSLROOTCERT="{{ postgresql.root_certs_file }}"
+export PGSSLMODE=verify-full
+{%- endif %}
+
 {% for service, values in pillar.get('postgres', {}).items()  %}
 
 {% if values['user'] is defined %}


### PR DESCRIPTION
* When the external DB server has been provisioned with SSL enforcement (#9215), DB create operations shall always mandate SSL with DB server cert and host name verification.
* Depends on #9563.
