### PR TITLE
Add comment related to cdpcp-2612

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaChecks.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaChecks.java
@@ -4,15 +4,15 @@ import java.util.List;
 import java.util.function.Supplier;
 
 public class FreeIpaChecks {
-    /* Users in this list should not be added/deleted. */
+    /* Users in this list should not be added to or deleted from FreeIPA. */
     public static final List<String> IPA_PROTECTED_USERS = List.of("admin");
 
-    /* Groups in this list should not be added/deleted. These groups are considered to be reserved in CDP-UMS.
-    Therefore,
+    /* Groups in this list should not be added to or deleted from FreeIPA.
+    These groups are considered to be reserved in CDP-UMS. Therefore,
     https://github.infra.cloudera.com/thunderhead/thunderhead/blob/master/services/usermanagement/src/main/resources/com/cloudera/thunderhead/service/usermanagement/server/ipa_protected_groups.txt needs to be updated when the following list is updated. */
     public static final List<String> IPA_PROTECTED_GROUPS = List.of("admins", "editors", "ipausers", "trust admins");
 
-    /* Group membership in these groups should not be changed. */
+    /* Group membership in these groups should not be explicitly changed in FreeIPA. */
     public static final List<String> IPA_UNMANAGED_GROUPS = List.of("editors", "ipausers", "trust admins");
 
     private FreeIpaChecks() {

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaChecks.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaChecks.java
@@ -7,7 +7,9 @@ public class FreeIpaChecks {
     /* Users in this list should not be added/deleted. */
     public static final List<String> IPA_PROTECTED_USERS = List.of("admin");
 
-    /* Groups in this list should not be added/deleted. */
+    /* Groups in this list should not be added/deleted. These groups are considered to be reserved in CDP-UMS.
+    Therefore,
+    https://github.infra.cloudera.com/thunderhead/thunderhead/blob/master/services/usermanagement/src/main/resources/com/cloudera/thunderhead/service/usermanagement/server/ipa_protected_groups.txt needs to be updated when the following list is updated. */
     public static final List<String> IPA_PROTECTED_GROUPS = List.of("admins", "editors", "ipausers", "trust admins");
 
     /* Group membership in these groups should not be changed. */

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaChecks.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaChecks.java
@@ -7,9 +7,12 @@ public class FreeIpaChecks {
     /* Users in this list should not be added to or deleted from FreeIPA. */
     public static final List<String> IPA_PROTECTED_USERS = List.of("admin");
 
+    // CHECKSTYLE:OFF
     /* Groups in this list should not be added to or deleted from FreeIPA.
     These groups are considered to be reserved in CDP-UMS. Therefore,
-    https://github.infra.cloudera.com/thunderhead/thunderhead/blob/master/services/usermanagement/src/main/resources/com/cloudera/thunderhead/service/usermanagement/server/ipa_protected_groups.txt needs to be updated when the following list is updated. */
+    https://github.infra.cloudera.com/thunderhead/thunderhead/blob/master/services/usermanagement/src/main/resources/com/cloudera/thunderhead/service/usermanagement/server/ipa_protected_groups.txt
+    needs to be updated when the following list is updated. */
+    // CHECKSTYLE:ON
     public static final List<String> IPA_PROTECTED_GROUPS = List.of("admins", "editors", "ipausers", "trust admins");
 
     /* Group membership in these groups should not be explicitly changed in FreeIPA. */


### PR DESCRIPTION
We started considering few group names to be reserved on CDP UMS-service. Those reserved group names also contain IPA protected groups taken from this file. Therefore, whenever IPA protected groups are updated, we need to update reserved group names in UMS as well. This commit adds a comment to track that.