### PR TITLE
CB-10196. Datalake diagnostics flow only finishes after the flow poll…

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/diagnostics/SdxDiagnosticsFlowService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/diagnostics/SdxDiagnosticsFlowService.java
@@ -14,6 +14,7 @@ import com.dyngr.core.AttemptResults;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.DiagnosticsV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.model.CmDiagnosticsCollectionRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.model.DiagnosticsCollectionRequest;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.datalake.converter.DiagnosticsParamsConverter;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.SdxService;
@@ -67,7 +68,8 @@ public class SdxDiagnosticsFlowService {
                 .stopIfException(pollingConfig.getStopPollingIfExceptionOccured())
                 .stopAfterDelay(pollingConfig.getDuration(), pollingConfig.getDurationTimeUnit())
                 .run(() -> {
-                    List<FlowLogResponse> flowLogs = flowEndpoint.getFlowLogsByFlowId(flowIdentifier.getPollableId());
+                    List<FlowLogResponse> flowLogs = ThreadBasedUserCrnProvider.doAsInternalActor(
+                            () -> flowEndpoint.getFlowLogsByFlowId(flowIdentifier.getPollableId()));
                     if (hasFlowFailed(flowLogs)) {
                         return AttemptResults.breakFor(failedMessage);
                     }


### PR DESCRIPTION
…ing timeout (permission problem)

details:
In case of a user is not a power user and starts a datalake diagnostics -> datalake app uses the user's CRN for polling the results against CB app -> got 403 responses, because of this it will poll against the results until the flow is timed out

It also causes that, the user cannot start any flow as a flow is already in progress

See detailed description in the commit message.