### PR TITLE
CB-9943: Extend the Data Hub CDH runtime upgrade process with upgrading the non-CDH services to a new version what we burned into the new image.

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
@@ -110,8 +110,7 @@ public class ClouderaManagerClusterDecomissionService implements ClusterDecomiss
     public void restartStaleServices() throws CloudbreakException {
         try {
             applicationContext.getBean(ClouderaManagerModificationService.class, stack, clientConfig)
-                    .restartStaleServices(clouderaManagerApiFactory.getMgmtServiceResourceApi(client),
-                            clouderaManagerApiFactory.getClustersResourceApi(client));
+                    .restartStaleServices(clouderaManagerApiFactory.getClustersResourceApi(client));
         } catch (ApiException e) {
             LOGGER.error("Couldn't restart stale services", e);
             throw new CloudbreakException("Couldn't restart stale services", e);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionService.java
@@ -31,8 +31,9 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.polling.PollingResult;
 
 @Service
-class ClouderaManagerParcelService {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelService.class);
+class ClouderaManagerParcelDecommissionService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelDecommissionService.class);
 
     @Inject
     private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelManagementService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelManagementService.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.cloudera.api.swagger.ClouderaManagerResourceApi;
+import com.cloudera.api.swagger.ParcelResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiConfig;
+import com.cloudera.api.swagger.model.ApiConfigList;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cm.model.ParcelResource;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
+import com.sequenceiq.cloudbreak.cm.polling.PollingResultErrorHandler;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.polling.PollingResult;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+
+@Service
+class ClouderaManagerParcelManagementService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerParcelManagementService.class);
+
+    @Inject
+    private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;
+
+    @Inject
+    private PollingResultErrorHandler pollingResultErrorHandler;
+
+    void setParcelRepos(Set<ClouderaManagerProduct> products, ClouderaManagerResourceApi clouderaManagerResourceApi) throws ApiException {
+        Set<String> stackProductParcels = products.stream()
+                .map(ClouderaManagerProduct::getParcel)
+                .collect(Collectors.toSet());
+        LOGGER.info("Setting parcel repo to {}", stackProductParcels);
+        ApiConfigList apiConfigList = new ApiConfigList()
+                .addItemsItem(new ApiConfig()
+                        .name("remote_parcel_repo_urls")
+                        .value(String.join(",", stackProductParcels)));
+        clouderaManagerResourceApi.updateConfig("Updated configurations.", apiConfigList);
+    }
+
+    void refreshParcelRepos(ClouderaManagerResourceApi clouderaManagerResourceApi, Stack stack, ApiClient apiClient) {
+        try {
+            LOGGER.info("Refreshing parcel repos.");
+            ApiCommand apiCommand = clouderaManagerResourceApi.refreshParcelRepos();
+            clouderaManagerPollingServiceProvider.startPollingCmParcelRepositoryRefresh(stack, apiClient, apiCommand.getId());
+        } catch (ApiException e) {
+            LOGGER.info("Unable to refresh parcel repo", e);
+            throw new ClouderaManagerOperationFailedException(e.getMessage(), e);
+        }
+    }
+
+    void downloadParcels(Set<ClouderaManagerProduct> products, ParcelResourceApi parcelResourceApi, Stack stack, ApiClient apiClient)
+            throws ApiException, CloudbreakException {
+        for (ClouderaManagerProduct product : products) {
+            LOGGER.info("Downloading {} parcel.", product.getName());
+            ApiCommand apiCommand = parcelResourceApi.startDownloadCommand(stack.getName(), product.getName(), product.getVersion());
+            PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCdpRuntimeParcelDownload(
+                    stack, apiClient, apiCommand.getId(), new ParcelResource(stack.getName(), product.getName(), product.getVersion()));
+            handlePollingResult(pollingResult, "Cluster was terminated while waiting for CDP Runtime Parcel to be downloaded",
+                    "Timeout during the updated CDP Runtime Parcel download.");
+        }
+    }
+
+    void distributeParcels(Set<ClouderaManagerProduct> products, ParcelResourceApi parcelResourceApi, Stack stack, ApiClient apiClient)
+            throws ApiException, CloudbreakException {
+        for (ClouderaManagerProduct product : products) {
+            LOGGER.info("Distributing downloaded {} parcel", product.getName());
+            ApiCommand apiCommand = parcelResourceApi.startDistributionCommand(stack.getName(), product.getName(), product.getVersion());
+            PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCdpRuntimeParcelDistribute(
+                    stack, apiClient, apiCommand.getId(), new ParcelResource(stack.getName(), product.getName(), product.getVersion()));
+            handlePollingResult(pollingResult, "Cluster was terminated while waiting for CDP Runtime Parcel to be distributed",
+                    "Timeout during the updated CDP Runtime Parcel distribution.");
+        }
+    }
+
+    void activateParcels(Set<ClouderaManagerProduct> products, ParcelResourceApi parcelResourceApi, Stack stack, ApiClient apiClient)
+            throws ApiException, CloudbreakException {
+        for (ClouderaManagerProduct product : products) {
+            String productName = product.getName();
+            LOGGER.info("Activating {} parcel", productName);
+            ApiCommand apiCommand = parcelResourceApi.activateCommand(stack.getName(), productName, product.getVersion());
+            PollingResult result = clouderaManagerPollingServiceProvider.startPollingCmSingleParcelActivation(stack, apiClient, apiCommand.getId(), product);
+            handlePollingResult(result, "Cluster was terminated while waiting for CDP Runtime Parcel to be activated",
+                    "Timeout during the updated CDP Runtime Parcel activation.");
+        }
+    }
+
+    void checkParcelApiAvailability(Stack stack, ApiClient apiClient) throws CloudbreakException {
+        LOGGER.debug("Checking if Parcels API is available");
+        PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingParcelsApiAvailable(stack, apiClient);
+        handlePollingResult(pollingResult, "Cluster was terminated while waiting for Parcels API to be available",
+                "Timeout during waiting for CM Parcels API to be available.");
+    }
+
+    private void handlePollingResult(PollingResult pollingResult, String cancellationMessage, String timeoutMessage) throws CloudbreakException {
+        pollingResultErrorHandler.handlePollingResult(pollingResult, cancellationMessage, timeoutMessage);
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerUpgradeService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerUpgradeService.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import com.cloudera.api.swagger.ClustersResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCdhUpgradeArgs;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiCommandList;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
+import com.sequenceiq.cloudbreak.cm.polling.PollingResultErrorHandler;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.polling.PollingResult;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+
+@Service
+class ClouderaManagerUpgradeService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerUpgradeService.class);
+
+    private static final String SUMMARY = "SUMMARY";
+
+    @Inject
+    private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;
+
+    @Inject
+    private PollingResultErrorHandler pollingResultErrorHandler;
+
+    void callUpgradeCdhCommand(String stackProductVersion, ClustersResourceApi clustersResourceApi, Stack stack, ApiClient apiClient)
+            throws ApiException, CloudbreakException {
+        LOGGER.info("Upgrading the CDP Runtime...");
+        Optional<ApiCommand> optionalUpgradeCommand = findUpgradeApiCommand(clustersResourceApi, stack);
+        try {
+            ApiCommand upgradeCommand;
+            if (optionalUpgradeCommand.isPresent()) {
+                upgradeCommand = optionalUpgradeCommand.get();
+                LOGGER.debug("Upgrade of CDP Runtime is already running with id: [{}]", upgradeCommand.getId());
+            } else {
+                ApiCdhUpgradeArgs upgradeArgs = new ApiCdhUpgradeArgs();
+                upgradeArgs.setCdhParcelVersion(stackProductVersion);
+                upgradeCommand = clustersResourceApi.upgradeCdhCommand(stack.getName(), upgradeArgs);
+            }
+            PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCdpRuntimeUpgrade(stack, apiClient, upgradeCommand.getId());
+            pollingResultErrorHandler.handlePollingResult(pollingResult, "Cluster was terminated while waiting for CDP Runtime to be upgraded",
+                    "Timeout during CDP Runtime upgrade.");
+        } catch (ApiException ex) {
+            String responseBody = ex.getResponseBody();
+            if (StringUtils.hasText(responseBody) && responseBody.contains("Cannot upgrade because the version is already CDH")) {
+                LOGGER.info("The Runtime has already been upgraded to {}", stackProductVersion);
+            } else {
+                throw ex;
+            }
+        }
+        LOGGER.info("Runtime is successfully upgraded!");
+    }
+
+    private Optional<ApiCommand> findUpgradeApiCommand(ClustersResourceApi clustersResourceApi, Stack stack) throws ApiException {
+        ApiCommandList apiCommandList = clustersResourceApi.listActiveCommands(stack.getName(), SUMMARY);
+        return apiCommandList.getItems().stream()
+                .filter(cmd -> "UpgradeCluster".equals(cmd.getName()))
+                .findFirst();
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/ClouderaManagerPollingServiceProvider.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.cloudera.api.swagger.client.ApiClient;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
 import com.sequenceiq.cloudbreak.cm.model.ParcelResource;
 import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
@@ -33,6 +34,7 @@ import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerParcelsApiListen
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerRefreshServiceConfigsListenerTask;
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerRestartServicesListenerTask;
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerServiceStartListenerTask;
+import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerSingleParcelActivationListenerTask;
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerStartManagementServiceListenerTask;
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerStartupListenerTask;
 import com.sequenceiq.cloudbreak.cm.polling.task.ClouderaManagerStopListenerTask;
@@ -117,6 +119,12 @@ public class ClouderaManagerPollingServiceProvider {
         LOGGER.debug("Waiting for Cloudera Manager to deploy client configuratuions. [Server address: {}]", stack.getClusterManagerIp());
         return pollCommandWithTimeListener(stack, apiClient, commandId, POLL_FOR_ONE_HOUR,
                 new ClouderaManagerParcelActivationListenerTask(clouderaManagerApiPojoFactory, cloudbreakEventService));
+    }
+
+    public PollingResult startPollingCmSingleParcelActivation(Stack stack, ApiClient apiClient, BigDecimal commandId, ClouderaManagerProduct product) {
+        LOGGER.debug("Waiting for Cloudera Manager to activate {} parcel. [Server address: {}]", product.getName(), stack.getClusterManagerIp());
+        return pollCommandWithTimeListener(stack, apiClient, commandId, POLL_FOR_ONE_HOUR,
+                new ClouderaManagerSingleParcelActivationListenerTask(clouderaManagerApiPojoFactory, cloudbreakEventService, product));
     }
 
     public PollingResult startPollingCmParcelStatus(Stack stack, ApiClient apiClient, Map<String, String> parcelVersions,

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/PollingResultErrorHandler.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/PollingResultErrorHandler.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.cm.polling;
+
+import static com.sequenceiq.cloudbreak.polling.PollingResult.isExited;
+import static com.sequenceiq.cloudbreak.polling.PollingResult.isTimeout;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
+import com.sequenceiq.cloudbreak.polling.PollingResult;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+
+@Service
+public class PollingResultErrorHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PollingResultErrorHandler.class);
+
+    public void handlePollingResult(PollingResult pollingResult, String cancellationMessage, String timeoutMessage) throws CloudbreakException {
+        LOGGER.info("Poller finished with state: {}", pollingResult);
+        if (isExited(pollingResult)) {
+            throw new CancellationException(cancellationMessage);
+        } else if (isTimeout(pollingResult)) {
+            throw new CloudbreakException(timeoutMessage);
+        }
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerSingleParcelActivationListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerSingleParcelActivationListenerTask.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.cloudbreak.cm.polling.task;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cloudera.api.swagger.CommandsResourceApi;
+import com.cloudera.api.swagger.ParcelResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
+import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+
+public class ClouderaManagerSingleParcelActivationListenerTask extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerSingleParcelActivationListenerTask.class);
+
+    private final ClouderaManagerProduct product;
+
+    public ClouderaManagerSingleParcelActivationListenerTask(ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory,
+            CloudbreakEventService cloudbreakEventService, ClouderaManagerProduct product) {
+        super(clouderaManagerApiPojoFactory, cloudbreakEventService);
+        this.product = product;
+    }
+
+    @Override
+    protected boolean doStatusCheck(ClouderaManagerCommandPollerObject pollerObject, CommandsResourceApi commandsResourceApi) throws ApiException {
+        ApiClient apiClient = pollerObject.getApiClient();
+        ParcelResourceApi parcelResourceApi = clouderaManagerApiPojoFactory.getParcelResourceApi(apiClient);
+        String parcelStatus = getParcelStatus(pollerObject, parcelResourceApi);
+        if (ParcelStatus.ACTIVATED.name().equals(parcelStatus)) {
+            LOGGER.debug("{} parcel is activated.", product.getName());
+            return true;
+        } else {
+            LOGGER.debug("{} [{}] parcel is not yet activated. Current status: {}.", product.getName(), product.getVersion(), parcelStatus);
+            return false;
+        }
+    }
+
+    private String getParcelStatus(ClouderaManagerCommandPollerObject pollerObject, ParcelResourceApi parcelResourceApi) throws ApiException {
+        return parcelResourceApi.readParcel(pollerObject.getStack().getName(), product.getName(), product.getVersion()).getStage();
+    }
+
+    @Override
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
+        throw new ClouderaManagerOperationFailedException(String.format("Operation timed out. Failed to activate %s parcel.", product.getName()));
+    }
+
+    @Override
+    public String successMessage(ClouderaManagerCommandPollerObject toolsResourceApi) {
+        return String.format("%s parcel activation finished with success result.", product.getName());
+    }
+
+    @Override
+    protected String getCommandName() {
+        return "Activate parcel";
+    }
+}

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionServiceTest.java
@@ -21,7 +21,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.cloudera.api.swagger.ClustersResourceApi;
-import com.cloudera.api.swagger.MgmtServiceResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.sequenceiq.cloudbreak.client.HttpClientConfig;
@@ -165,18 +164,15 @@ public class ClouderaManagerClusterDecomissionServiceTest {
     @Test
     public void testRestartStaleServices() throws CloudbreakException, ApiException {
         ClouderaManagerModificationService modificationService = Mockito.mock(ClouderaManagerModificationService.class);
-        MgmtServiceResourceApi mgmtServiceResourceApi = Mockito.mock(MgmtServiceResourceApi.class);
         ClustersResourceApi clustersResourceApi = Mockito.mock(ClustersResourceApi.class);
         when(applicationContext.getBean(ClouderaManagerModificationService.class, stack, clientConfig)).thenReturn(modificationService);
-        when(clouderaManagerApiFactory.getMgmtServiceResourceApi(apiClient)).thenReturn(mgmtServiceResourceApi);
         when(clouderaManagerApiFactory.getClustersResourceApi(apiClient)).thenReturn(clustersResourceApi);
 
         underTest.restartStaleServices();
 
         verify(applicationContext).getBean(ClouderaManagerModificationService.class, stack, clientConfig);
-        verify(clouderaManagerApiFactory).getMgmtServiceResourceApi(apiClient);
         verify(clouderaManagerApiFactory).getClustersResourceApi(apiClient);
-        verify(modificationService).restartStaleServices(mgmtServiceResourceApi, clustersResourceApi);
+        verify(modificationService).restartStaleServices(clustersResourceApi);
     }
 
     private Stack createStack() {

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionServiceTest.java
@@ -29,9 +29,9 @@ import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 
 @ExtendWith(MockitoExtension.class)
-public class ClouderaManagerParcelServiceTest {
+public class ClouderaManagerParcelDecommissionServiceTest {
     @InjectMocks
-    private ClouderaManagerParcelService underTest;
+    private ClouderaManagerParcelDecommissionService underTest;
 
     @Mock
     private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerUpgradeServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerUpgradeServiceTest.java
@@ -1,0 +1,154 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloudera.api.swagger.ClustersResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiCommandList;
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
+import com.sequenceiq.cloudbreak.cm.polling.PollingResultErrorHandler;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.polling.PollingResult;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClouderaManagerUpgradeServiceTest {
+
+    private static final String SUMMARY = "SUMMARY";
+
+    private static final String STACK_PRODUCT_VERSION = "7.2.6";
+
+    private static final String CLUSTER_NAME = "test-cluster";
+
+    @InjectMocks
+    private ClouderaManagerUpgradeService underTest;
+
+    @Mock
+    private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;
+
+    @Mock
+    private ClustersResourceApi clustersResourceApi;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private PollingResultErrorHandler pollingResultErrorHandler;
+
+    @Test
+    public void testCallUpgradeCdhCommandShouldUpgradeCdpRuntimeWhenTheUpgradeCommendIsNotPresent() throws CloudbreakException, ApiException {
+        Stack stack = createStack();
+        ApiCommandList apiCommandList = createApiCommandList(Collections.emptyList());
+        ApiCommand apiCommand = createApiCommand();
+
+        when(clustersResourceApi.listActiveCommands(CLUSTER_NAME, SUMMARY)).thenReturn(apiCommandList);
+        when(clustersResourceApi.upgradeCdhCommand(eq(CLUSTER_NAME), any())).thenReturn(apiCommand);
+        when(clouderaManagerPollingServiceProvider.startPollingCdpRuntimeUpgrade(stack, apiClient, BigDecimal.ONE)).thenReturn(PollingResult.SUCCESS);
+
+        underTest.callUpgradeCdhCommand(STACK_PRODUCT_VERSION, clustersResourceApi, stack, apiClient);
+
+        verify(clustersResourceApi).listActiveCommands(CLUSTER_NAME, SUMMARY);
+        verify(clustersResourceApi).upgradeCdhCommand(eq(CLUSTER_NAME), any());
+        verify(clouderaManagerPollingServiceProvider).startPollingCdpRuntimeUpgrade(stack, apiClient, BigDecimal.ONE);
+    }
+
+    @Test
+    public void testCallUpgradeCdhCommandShouldUpgradeCdpRuntimeWhenTheUpgradeCommendIsAlreadyPresent() throws CloudbreakException, ApiException {
+        Stack stack = createStack();
+        ApiCommand apiCommand = createApiCommand();
+        ApiCommandList apiCommandList = createApiCommandList(Collections.singletonList(apiCommand));
+
+        when(clustersResourceApi.listActiveCommands(CLUSTER_NAME, SUMMARY)).thenReturn(apiCommandList);
+        when(clouderaManagerPollingServiceProvider.startPollingCdpRuntimeUpgrade(stack, apiClient, BigDecimal.ONE)).thenReturn(PollingResult.SUCCESS);
+
+        underTest.callUpgradeCdhCommand(STACK_PRODUCT_VERSION, clustersResourceApi, stack, apiClient);
+
+        verify(clustersResourceApi).listActiveCommands(CLUSTER_NAME, SUMMARY);
+        verify(clouderaManagerPollingServiceProvider).startPollingCdpRuntimeUpgrade(stack, apiClient, BigDecimal.ONE);
+        verifyNoMoreInteractions(clustersResourceApi);
+    }
+
+    @Test(expected = CancellationException.class)
+    public void testCallUpgradeCdhCommandShouldThrowCancellationExceptionWhenTheCommandIsExited() throws CloudbreakException, ApiException {
+        Stack stack = createStack();
+        ApiCommandList apiCommandList = createApiCommandList(Collections.emptyList());
+        ApiCommand apiCommand = createApiCommand();
+        PollingResult pollingResult = PollingResult.EXIT;
+
+        when(clustersResourceApi.listActiveCommands(CLUSTER_NAME, SUMMARY)).thenReturn(apiCommandList);
+        when(clustersResourceApi.upgradeCdhCommand(eq(CLUSTER_NAME), any())).thenReturn(apiCommand);
+        when(clouderaManagerPollingServiceProvider.startPollingCdpRuntimeUpgrade(stack, apiClient, BigDecimal.ONE)).thenReturn(pollingResult);
+        doThrow(new CancellationException("Exit")).when(pollingResultErrorHandler).handlePollingResult(eq(pollingResult), any(), any());
+
+        underTest.callUpgradeCdhCommand(STACK_PRODUCT_VERSION, clustersResourceApi, stack, apiClient);
+    }
+
+    @Test(expected = CloudbreakException.class)
+    public void testCallUpgradeCdhCommandShouldThrowCloudbreakExceptionWhenTheCommandFailedWithTimeout() throws CloudbreakException, ApiException {
+        Stack stack = createStack();
+        ApiCommandList apiCommandList = createApiCommandList(Collections.emptyList());
+        ApiCommand apiCommand = createApiCommand();
+        PollingResult pollingResult = PollingResult.TIMEOUT;
+
+        when(clustersResourceApi.listActiveCommands(CLUSTER_NAME, SUMMARY)).thenReturn(apiCommandList);
+        when(clustersResourceApi.upgradeCdhCommand(eq(CLUSTER_NAME), any())).thenReturn(apiCommand);
+        when(clouderaManagerPollingServiceProvider.startPollingCdpRuntimeUpgrade(stack, apiClient, BigDecimal.ONE)).thenReturn(pollingResult);
+        doThrow(new CloudbreakException("Timeout")).when(pollingResultErrorHandler).handlePollingResult(eq(pollingResult), any(), any());
+
+        underTest.callUpgradeCdhCommand(STACK_PRODUCT_VERSION, clustersResourceApi, stack, apiClient);
+    }
+
+    @Test
+    public void testCallUpgradeCdhCommandShouldExitWithoutErrorWhenTheClusterAlreadyUpgraded() throws CloudbreakException, ApiException {
+        Stack stack = createStack();
+        ApiCommandList apiCommandList = createApiCommandList(Collections.emptyList());
+        ApiException apiException = new ApiException(0, "error", Collections.emptyMap(), "Cannot upgrade because the version is already CDH");
+
+        when(clustersResourceApi.listActiveCommands(CLUSTER_NAME, SUMMARY)).thenReturn(apiCommandList);
+        when(clustersResourceApi.upgradeCdhCommand(eq(CLUSTER_NAME), any())).thenThrow(apiException);
+
+        underTest.callUpgradeCdhCommand(STACK_PRODUCT_VERSION, clustersResourceApi, stack, apiClient);
+
+        verify(clustersResourceApi).listActiveCommands(CLUSTER_NAME, SUMMARY);
+        verify(clustersResourceApi).upgradeCdhCommand(eq(CLUSTER_NAME), any());
+        verifyNoInteractions(clouderaManagerPollingServiceProvider);
+    }
+
+    private ApiCommand createApiCommand() {
+        ApiCommand apiCommand = new ApiCommand();
+        apiCommand.setId(BigDecimal.ONE);
+        apiCommand.setName("UpgradeCluster");
+        return apiCommand;
+    }
+
+    private ApiCommandList createApiCommandList(List<ApiCommand> apiCommands) {
+        ApiCommandList apiCommandList = new ApiCommandList();
+        apiCommandList.setItems(apiCommands);
+        return apiCommandList;
+    }
+
+    private Stack createStack() {
+        Stack stack = new Stack();
+        stack.setName(CLUSTER_NAME);
+        return stack;
+    }
+}

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/PollingResultErrorHandlerTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/PollingResultErrorHandlerTest.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.cm.polling;
+
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.polling.PollingResult;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+
+public class PollingResultErrorHandlerTest {
+
+    private static final String CANCELLATION_MESSAGE = "Poller exited with error";
+
+    private static final String TIMEOUT_MESSAGE = "Poller exited with timeout";
+
+    private final PollingResultErrorHandler underTest = new PollingResultErrorHandler();
+
+    @Test
+    public void testHandlePollingResultShouldNotDoAnythingWhenTheResultIsSuccess() throws CloudbreakException {
+        underTest.handlePollingResult(PollingResult.SUCCESS, CANCELLATION_MESSAGE, TIMEOUT_MESSAGE);
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/ImageBasedDefaultCDHEntries.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/cloud/model/component/ImageBasedDefaultCDHEntries.java
@@ -66,7 +66,7 @@ public class ImageBasedDefaultCDHEntries {
     private List<ClouderaManagerProduct> getParcels(Image image) {
         return image.getPreWarmParcels()
                 .stream()
-                .map(parcel -> preWarmParcelParser.parseProductFromParcel(parcel))
+                .map(parcel -> preWarmParcelParser.parseProductFromParcel(parcel, image.getPreWarmCsd()))
                 .flatMap(Optional::stream)
                 .collect(Collectors.toList());
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -481,7 +481,7 @@ public class ClusterHostServiceRunner {
         return pillarValues;
     }
 
-    private void decoratePillarWithClouderaManagerCsds(Cluster cluster, Map<String, SaltPillarProperties> servicePillar) {
+    public void decoratePillarWithClouderaManagerCsds(Cluster cluster, Map<String, SaltPillarProperties> servicePillar) {
         List<String> csdUrls = getCsdUrlList(cluster);
         servicePillar.put("csd-downloader", new SaltPillarProperties("/cloudera-manager/csd.sls",
                 singletonMap("cloudera-manager",

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
@@ -86,7 +87,7 @@ public class ClusterManagerUpgradeService {
         GatewayConfig gatewayConfig = gatewayConfigService.getGatewayConfig(stack, gatewayInstance, cluster.getGateway() != null);
         Set<String> gatewayFQDN = Collections.singleton(gatewayInstance.getDiscoveryFQDN());
         ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), cluster.getId());
-        SaltConfig pillar = createSaltConfig(cluster);
+        SaltConfig pillar = createSaltConfig(stack.getId(), stack.getType(), cluster);
         hostOrchestrator.upgradeClusterManager(gatewayConfig, gatewayFQDN, stackUtil.collectReachableNodes(stack), pillar, exitCriteriaModel);
     }
 
@@ -98,12 +99,21 @@ public class ClusterManagerUpgradeService {
         clusterApiConnectors.getConnector(stack).startCluster();
     }
 
-    private SaltConfig createSaltConfig(Cluster cluster) {
+    private SaltConfig createSaltConfig(Long stackId, StackType stackType, Cluster cluster) {
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
         ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId());
-        Optional<String> license = clusterHostServiceRunner.decoratePillarWithClouderaManagerLicense(cluster.getStack().getId(), servicePillar);
+        Optional<String> license = clusterHostServiceRunner.decoratePillarWithClouderaManagerLicense(stackId, servicePillar);
         clusterHostServiceRunner.decoratePillarWithClouderaManagerRepo(clouderaManagerRepo, servicePillar, license);
         clusterHostServiceRunner.decoratePillarWithClouderaManagerSettings(servicePillar, clouderaManagerRepo);
+        decorateWorkloadClusterPillarWithCsdDownloader(stackType, cluster, servicePillar);
         return new SaltConfig(servicePillar);
+    }
+
+    private void decorateWorkloadClusterPillarWithCsdDownloader(StackType stackType, Cluster cluster, Map<String, SaltPillarProperties> servicePillar) {
+        if (StackType.WORKLOAD.equals(stackType)) {
+            clusterHostServiceRunner.decoratePillarWithClouderaManagerCsds(cluster, servicePillar);
+        } else {
+            LOGGER.debug("Skipping the CSD downloading because the stack type is {}", stackType);
+        }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -228,7 +228,7 @@ public class ImageService {
             components.add(getClusterManagerComponent(stack, statedImage.getImage(), stackType));
         }
         statedImage.getImage().getPreWarmParcels().forEach(parcel -> {
-            Optional<ClouderaManagerProduct> product = preWarmParcelParser.parseProductFromParcel(parcel);
+            Optional<ClouderaManagerProduct> product = preWarmParcelParser.parseProductFromParcel(parcel, statedImage.getImage().getPreWarmCsd());
             product.ifPresent(p -> components.add(new Component(CDH_PRODUCT_DETAILS, p.getName(), new Json(p), stack)));
         });
         return components;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/PreWarmParcelParser.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/PreWarmParcelParser.java
@@ -6,6 +6,7 @@ import static org.apache.commons.lang3.StringUtils.substringBeforeLast;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +19,7 @@ public class PreWarmParcelParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PreWarmParcelParser.class);
 
-    public Optional<ClouderaManagerProduct> parseProductFromParcel(List<String> parcel) {
+    public Optional<ClouderaManagerProduct> parseProductFromParcel(List<String> parcel, List<String> csdList) {
         Optional<String> url = parcel.stream().filter(parcelPart -> parcelPart.startsWith("http://") || parcelPart.startsWith("https://"))
                 .findFirst();
         Optional<String> nameAndVersion = parcel.stream().filter(parcelPart -> parcelPart.endsWith(".parcel"))
@@ -38,7 +39,14 @@ public class PreWarmParcelParser {
             product.setVersion(version);
             LOGGER.info("The URL of the parcel is: '{}'", url.get());
             product.setParcel(url.get());
+            product.setCsd(collectCsdParcels(csdList, name));
             return Optional.of(product);
         }
+    }
+
+    private List<String> collectCsdParcels(List<String> csdList, String name) {
+        return csdList.stream()
+                .filter(csd -> csd.toLowerCase().contains(name.toLowerCase()))
+                .collect(Collectors.toList());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/locked/ParcelMatcher.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/locked/ParcelMatcher.java
@@ -51,7 +51,7 @@ public class ParcelMatcher {
     private Map<String, String> getPreWarmedParcels(Image image) {
         return image.getPreWarmParcels()
                 .stream()
-                .map(parcel -> preWarmParcelParser.parseProductFromParcel(parcel))
+                .map(parcel -> preWarmParcelParser.parseProductFromParcel(parcel, image.getPreWarmCsd()))
                 .flatMap(Optional::stream)
                 .collect(Collectors.toMap(ClouderaManagerProduct::getName, ClouderaManagerProduct::getVersion));
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/cloud/model/component/ImageBasedDefaultCDHEntriesTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/cloud/model/component/ImageBasedDefaultCDHEntriesTest.java
@@ -138,7 +138,7 @@ public class ImageBasedDefaultCDHEntriesTest {
 
     private List<List<String>> getParcels() {
         List<String> parcel = asList("parcel");
-        when(preWarmParcelParser.parseProductFromParcel(parcel)).thenReturn(Optional.of(mock(ClouderaManagerProduct.class)));
+        when(preWarmParcelParser.parseProductFromParcel(parcel, PRE_WARM_CSD)).thenReturn(Optional.of(mock(ClouderaManagerProduct.class)));
 
         return asList(parcel);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/PreWarmParcelParserTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/PreWarmParcelParserTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.service.image;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,7 +23,7 @@ public class PreWarmParcelParserTest {
     public void testWithValidParcel() {
         List<String> parcel = List.of(PARCEL_VERSION, PARCEL_URL);
 
-        Optional<ClouderaManagerProduct> result = preWarmParcelParser.parseProductFromParcel(parcel);
+        Optional<ClouderaManagerProduct> result = preWarmParcelParser.parseProductFromParcel(parcel, Collections.emptyList());
 
         assertTrue(result.isPresent());
         assertEquals("SCHEMAREGISTRY", result.get().getName());
@@ -35,7 +36,7 @@ public class PreWarmParcelParserTest {
     public void testWithMissingParcelPart() {
         List<String> parcel = List.of(PARCEL_VERSION);
 
-        Optional<ClouderaManagerProduct> result = preWarmParcelParser.parseProductFromParcel(parcel);
+        Optional<ClouderaManagerProduct> result = preWarmParcelParser.parseProductFromParcel(parcel, Collections.emptyList());
 
         assertTrue(result.isEmpty());
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/locked/ParcelMatcherTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/locked/ParcelMatcherTest.java
@@ -3,8 +3,10 @@ package com.sequenceiq.cloudbreak.service.upgrade.image.locked;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -39,15 +41,15 @@ class ParcelMatcherTest {
     @BeforeEach
     public void init() {
         when(image.getPreWarmParcels()).thenReturn(List.of(PREWARMED_PARCEL1, PREWARMED_PARCEL2));
-        when(preWarmParcelParser.parseProductFromParcel(anyList())).thenReturn(Optional.empty());
+        when(preWarmParcelParser.parseProductFromParcel(anyList(), eq(Collections.emptyList()))).thenReturn(Optional.empty());
     }
 
     @Test
     public void testPrewarmedAndActivatedMatching() {
         Map<String, String> activatedParcels = Map.of("PARCEL1NAME", "PARCEL1VERSION", "PARCEL2NAME", "PARCEL2VERSION");
-        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL1))
+        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL1, Collections.emptyList()))
                 .thenReturn(createClouderaManagerProduct("PARCEL1NAME", "PARCEL1VERSION"));
-        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL2))
+        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL2, Collections.emptyList()))
                 .thenReturn(createClouderaManagerProduct("PARCEL2NAME", "PARCEL2VERSION"));
 
         boolean result = underTest.isMatchingNonCdhParcels(image, activatedParcels);
@@ -58,9 +60,9 @@ class ParcelMatcherTest {
     @Test
     public void testPrewarmedMissingParcel() {
         Map<String, String> activatedParcels = Map.of("PARCEL1NAME", "PARCEL1VERSION", "PARCEL2NAME", "PARCEL2VERSION");
-        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL1))
+        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL1, Collections.emptyList()))
                 .thenReturn(createClouderaManagerProduct("PARCEL1NAME", "PARCEL1VERSION"));
-        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL2))
+        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL2, Collections.emptyList()))
                 .thenReturn(Optional.empty());
 
         boolean result = underTest.isMatchingNonCdhParcels(image, activatedParcels);
@@ -71,9 +73,9 @@ class ParcelMatcherTest {
     @Test
     public void testPrewarmedAndActivatedHasDifferentVersion() {
         Map<String, String> activatedParcels = Map.of("PARCEL1NAME", "PARCEL1VERSION", "PARCEL2NAME", "PARCEL2VERSION");
-        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL1))
+        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL1, Collections.emptyList()))
                 .thenReturn(createClouderaManagerProduct("PARCEL1NAME", "PARCEL1VERSION"));
-        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL2))
+        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL2, Collections.emptyList()))
                 .thenReturn(createClouderaManagerProduct("PARCEL2NAME", "PARCEL2VERSIONDIFF"));
 
         boolean result = underTest.isMatchingNonCdhParcels(image, activatedParcels);
@@ -84,9 +86,9 @@ class ParcelMatcherTest {
     @Test
     public void testPrewarmedHasExtraParcel() {
         Map<String, String> activatedParcels = Map.of("PARCEL1NAME", "PARCEL1VERSION");
-        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL1))
+        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL1, Collections.emptyList()))
                 .thenReturn(createClouderaManagerProduct("PARCEL1NAME", "PARCEL1VERSION"));
-        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL2))
+        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL2, Collections.emptyList()))
                 .thenReturn(createClouderaManagerProduct("PARCEL2NAME", "PARCEL2VERSION"));
 
         boolean result = underTest.isMatchingNonCdhParcels(image, activatedParcels);
@@ -97,9 +99,9 @@ class ParcelMatcherTest {
     @Test
     public void testCdhActivatedParcelIgnored() {
         Map<String, String> activatedParcels = Map.of("PARCEL1NAME", "PARCEL1VERSION", "PARCEL2NAME", "PARCEL2VERSION", "CDH", "CDHVERSION");
-        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL1))
+        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL1, Collections.emptyList()))
                 .thenReturn(createClouderaManagerProduct("PARCEL1NAME", "PARCEL1VERSION"));
-        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL2))
+        when(preWarmParcelParser.parseProductFromParcel(PREWARMED_PARCEL2, Collections.emptyList()))
                 .thenReturn(createClouderaManagerProduct("PARCEL2NAME", "PARCEL2VERSION"));
 
         boolean result = underTest.isMatchingNonCdhParcels(image, activatedParcels);

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/csd/csd-downloader.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/csd/csd-downloader.sh
@@ -6,11 +6,27 @@ mkdir -p /opt/cloudera/csd
 cd /opt/cloudera/csd
 
 {% if salt['pillar.get']('cloudera-manager:csd-urls') %}
-{% for url in salt['pillar.get']('cloudera-manager:csd-urls') %}
-curl -L -O -R {{ url }}
-{% endfor %}
-{% else %}
-echo "No CSDs to download." >> /var/csd_downloaded
-{% endif %}
+csdUrls=({%- for url in salt['pillar.get']('cloudera-manager:csd-urls') -%}
+{{ url + " " }}
+{%- endfor %})
 
-echo "$(date +%Y-%m-%d:%H:%M:%S)" >> /var/csd_downloaded
+for url in ${csdUrls[@]}
+do
+  fileName=$(basename $url)
+  echo "$(date '+%d/%m/%Y %H:%M:%S') - CSD file name ($fileName) from URL: ($url) " |& tee -a /var/log/csd_downloader.log
+  if test -f $fileName
+  then
+    echo "$(date '+%d/%m/%Y %H:%M:%S') - ($fileName) already exists " |& tee -a /var/log/csd_downloader.log
+
+  else
+    echo "$(date '+%d/%m/%Y %H:%M:%S') - Downloading ($url) " |& tee -a /var/log/csd_downloader.log
+
+    curl -L -O -R $url
+  fi
+done
+
+{% else %}
+echo "No CSDs to download." >> /var/log/csd_downloaded
+echo "$(date '+%d/%m/%Y %H:%M:%S') - No CSDs to download. " |& tee -a /var/log/csd_downloader.log
+
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/csd/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/csd/init.sls
@@ -11,4 +11,3 @@ download-csd:
     - require:
       - file: /opt/salt/scripts/csd-downloader.sh
     - shell: /bin/bash
-    - unless: test -f /var/csd_downloaded

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/upgrade.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/upgrade.sls
@@ -3,6 +3,7 @@
 include:
   - postgresql.repo
   - cloudera.repo
+  - cloudera.csd
 
 stop-cloudera-scm-server:
   service.dead:


### PR DESCRIPTION
In this commit we've introduced some changes in connection with Data Hub upgrade:
- CSD downloading: To upgrade a non-CDH service may require the same version of the CSD what the new version is. By default the old CSD files are already present in the image, therefore we need to download the new ones. This process is handled by a shell script that we add to the host at the beginning of the upgrade process.
  In the case of Data Lake upgrade, we don't need to download the new CSD files because we're not upgrading the non-CDH services.

- Upgrading the non-CDH services (Spark, Nifi, etc...) has a different flow than the regular CDH runtime upgrade. We need to download, distribute, and activate the new parcels, then restart the affected services. There is no upgrade command to call.
  After the non-CDH services have been upgraded the flow continues with upgrading the CDH runtime. This whole process does not affect to the Data Lake upgrade flow. We just upgrade only the CDH version like before.