### PR TITLE
CB-10173 CLI flag for Public Gateway Endpoint

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -14,6 +14,8 @@ public class EnvironmentModelDescription {
     public static final String NETWORKCIDRS = "The network cidrs for the configured vpc";
     public static final String PRIVATE_SUBNET_CREATION = "A flag to enable or disable the private subnet creation.";
     public static final String SERVICE_ENDPOINT_CREATION = "A flag to enable or disable the service endpoint creation.";
+    public static final String PUBLIC_ENDPOINT_ACCESS_GATEWAY = "A flag to select a public or private endpoint access gateway.";
+    public static final String ENDPOINT_ACCESS_GATEWAY_SUBNET_IDS = "Subnet ids for the endpoint access gateway. (Optional)";
     public static final String OUTBOUND_INTERNET_TRAFFIC = "A flag to enable or disable the outbound internet traffic from the instances.";
     public static final String AWS_SPECIFIC_PARAMETERS = "Subnet ids of the specified networks";
     public static final String AZURE_SPECIFIC_PARAMETERS = "Subnet ids of the specified networks";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/EnvironmentNetworkBase.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/EnvironmentNetworkBase.java
@@ -42,6 +42,12 @@ public abstract class EnvironmentNetworkBase {
     @ApiModelProperty(EnvironmentModelDescription.SERVICE_ENDPOINT_CREATION)
     private ServiceEndpointCreation serviceEndpointCreation = ServiceEndpointCreation.DISABLED;
 
+    @ApiModelProperty(EnvironmentModelDescription.PUBLIC_ENDPOINT_ACCESS_GATEWAY)
+    private Boolean usePublicEndpointAccessGateway;
+
+    @ApiModelProperty(value = EnvironmentModelDescription.ENDPOINT_ACCESS_GATEWAY_SUBNET_IDS)
+    private Set<String> endpointAccessGatewaySubnetIds;
+
     @ApiModelProperty(EnvironmentModelDescription.OUTBOUND_INTERNET_TRAFFIC)
     private OutboundInternetTraffic outboundInternetTraffic = OutboundInternetTraffic.ENABLED;
 
@@ -92,6 +98,22 @@ public abstract class EnvironmentNetworkBase {
         this.serviceEndpointCreation = serviceEndpointCreation;
     }
 
+    public Boolean getUsePublicEndpointAccessGateway() {
+        return usePublicEndpointAccessGateway;
+    }
+
+    public void setUsePublicEndpointAccessGateway(Boolean usePublicEndpointAccessGateway) {
+        this.usePublicEndpointAccessGateway = usePublicEndpointAccessGateway;
+    }
+
+    public Set<String> getEndpointAccessGatewaySubnetIds() {
+        return endpointAccessGatewaySubnetIds;
+    }
+
+    public void setEndpointAccessGatewaySubnetIds(Set<String> endpointAccessGatewaySubnetIds) {
+        this.endpointAccessGatewaySubnetIds = endpointAccessGatewaySubnetIds;
+    }
+
     public OutboundInternetTraffic getOutboundInternetTraffic() {
         return outboundInternetTraffic;
     }
@@ -139,6 +161,8 @@ public abstract class EnvironmentNetworkBase {
                 ", networkCidr='" + networkCidr + '\'' +
                 ", privateSubnetCreation=" + privateSubnetCreation +
                 ", serviceEndpointCreation=" + serviceEndpointCreation +
+                ", usePublicEndpointAccessGateway=" + usePublicEndpointAccessGateway +
+                ", endpointAccessGatewaySubnetIds=" + endpointAccessGatewaySubnetIds +
                 ", outboundInternetTraffic=" + outboundInternetTraffic +
                 ", aws=" + aws +
                 ", gcp=" + gcp +


### PR DESCRIPTION
This adds two new parameters to the EnvironmentRequest for the feature called "semi-private
networks" also known as "public endpoint access gateway". Details of the feature can be
found in CRB-1318.

Since all of the network related and enableTunnel related parameters are at the environment
level (rather than per-datalake or per-datahub) I added these parameters at the environment-api
rather than datalake-api. Also logically it seemed appropriate to bundle these together in
the EnvironmentNetworkRequest since all network related configuration is there.

Testing done:
 - ./gradlew build

See detailed description in the commit message.