### PR TITLE
CB-10221. Support bundle: Use unifieddiagnostics-app header key for U…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
@@ -23,7 +23,7 @@
 {% set uuid = salt['pillar.get']('filecollector:uuid') %}
 {% set dbus_url = salt['pillar.get']('filecollector:dbusUrl') %}
 {% if salt['pillar.get']('filecollector:supportBundleDbusAppName') %}
-  {% set support_bundle_dbus_headers = '@support-bundle-app:' + salt['pillar.get']('filecollector:supportBundleDbusAppName') %}
+  {% set support_bundle_dbus_headers = '--header unifieddiagnostics-app:' + salt['pillar.get']('filecollector:supportBundleDbusAppName') %}
 {% else %}
   {% set support_bundle_dbus_headers = '' %}
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/upload.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/upload.sls
@@ -26,7 +26,7 @@ filecollector_upload_to_cloud_storage:
 
 filecollector_upload_to_support:
   cmd.run:
-    - name: "cdp-telemetry databus upload -p {{ filecollector.compressedFilePattern }} -c /opt/cdp-telemetry/conf/support_bundle_databus.conf --stream {{ filecollector.supportBundleDbusStreamName }} --url {{ filecollector.dbusUrl }}"
+    - name: "cdp-telemetry databus upload -p {{ filecollector.compressedFilePattern }} -c /opt/cdp-telemetry/conf/support_bundle_databus.conf --stream {{ filecollector.supportBundleDbusStreamName }} --url {{ filecollector.dbusUrl }} {{ filecollector.supportBundleDbusHeaders}}"
     - failhard: True
     - env:
         - CDP_TELEMETRY_LOGGER_FILENAME: "upload.log"{% if filecollector.proxyUrl %}{% if filecollector.proxyProtocol == "https" %}


### PR DESCRIPTION
…nifiedDiagnostics stream.

details:
- the new UnifiedDiangostics streams have a requirement: contain a specific app header
- the app header was picked randomly before - it was not used at all, now we know the name so we need to start to use 'unifieddiagnostics-app' as the header key name

See detailed description in the commit message.