### PR TITLE
CB-10239. Increase the default node count for the compute group to 1 …

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering-ha.json
@@ -32,7 +32,7 @@
       "recipeNames": []
     },
       {
-        "nodeCount": 0,
+        "nodeCount": 1,
         "name": "compute",
         "type": "CORE",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering-spark3.json
@@ -53,7 +53,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering.json
@@ -53,7 +53,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering-ha.json
@@ -42,7 +42,7 @@
         "cloudPlatform": "AZURE"
       },
       {
-        "nodeCount": 0,
+        "nodeCount": 1,
         "name": "compute",
         "type": "CORE",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering-spark3.json
@@ -57,7 +57,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering.json
@@ -56,7 +56,7 @@
             "size": 50
           }
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },


### PR DESCRIPTION
…for the DE cluster shapes for 7.2.1 templates

Merged the original PR with a bad commit message (https://github.com/hortonworks/cloudbreak/pull/9599). This is just to fix the commit message, and link to a new jira instead of 9902 since that went into 2.34. 