### PR TITLE
CB-10217 Add support for specifying CM hosts' roleRefNames in blueprint

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-ha.bp
@@ -109,6 +109,11 @@
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },
@@ -177,6 +182,10 @@
           {
             "name": "hue_service_safety_valve",
             "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
+          },
+          {
+            "name": "hue_webhdfs",
+            "ref": "hdfs-HTTPFS-BASE"
           }
         ],
         "roleConfigGroups": [
@@ -471,6 +480,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",
@@ -544,5 +554,16 @@
         ]
       }
     ]
-  }
-}
+  },
+       "instantiator": {
+           "hosts": [
+               {
+                   "hostTemplateRefName": "master",
+                   "roleRefNames": [
+                       "hdfs-HTTPFS-BASE"
+                   ]
+               }
+           ]
+       }
+   }
+

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdater.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdater.java
@@ -67,7 +67,12 @@ public class CentralCmTemplateUpdater implements BlueprintUpdater {
 
     @Override
     public String getBlueprintText(TemplatePreparationObject source) {
-        ApiClusterTemplate template = getCmTemplate(source, Map.of(), null, null, null);
+        return getBlueprintText(source, Map.of());
+    }
+
+    @Override
+    public String getBlueprintText(TemplatePreparationObject source, Map<String, List<Map<String, String>>> hostGroupMappings) {
+        ApiClusterTemplate template = getCmTemplate(source, hostGroupMappings, null, null, null);
         return JsonUtil.writeValueAsStringSilent(template);
     }
 

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
@@ -213,6 +213,14 @@ public class CentralCmTemplateUpdaterTest {
     }
 
     @Test
+    public void getCmTemplateWithHosts() {
+        when(blueprintView.getBlueprintText()).thenReturn(getBlueprintText("input/de-ha.bp"));
+        String generated = generator.getBlueprintText(templatePreparationObject, getHostgroupMappings());
+        String actual = new CmTemplateProcessor(generated).getTemplate().toString();
+        Assert.assertEquals(new CmTemplateProcessor(getBlueprintText("output/de-ha.bp")).getTemplate().toString(), actual);
+    }
+
+    @Test
     public void getKafkaPropertiesWhenNoHdfsInClusterShouldPresentCoreSettings() {
         CoreConfigProvider coreConfigProvider = new CoreConfigProvider();
         ReflectionTestUtils.setField(coreConfigProvider, "s3GuardConfigProvider", s3GuardConfigProvider);

--- a/template-manager-cmtemplate/src/test/resources/input/de-ha.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/de-ha.bp
@@ -73,6 +73,11 @@
                 "value": false
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },
@@ -145,6 +150,10 @@
           {
             "name": "hue_service_safety_valve",
             "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
+          },
+          {
+            "name": "hue_webhdfs",
+            "ref": "hdfs-HTTPFS-BASE"
           }
         ],
         "roleConfigGroups": [
@@ -385,6 +394,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",
@@ -454,5 +464,15 @@
           "yarn-GATEWAY-BASE"
         ]
       }
-    ]
+    ],
+    "instantiator": {
+        "hosts": [
+            {
+                "hostTemplateRefName": "master",
+                "roleRefNames": [
+                    "hdfs-HTTPFS-BASE"
+                ]
+            }
+        ]
+    }
 }

--- a/template-manager-cmtemplate/src/test/resources/output/de-ha.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/de-ha.bp
@@ -1,0 +1,495 @@
+{
+	"cdhVersion": "7.1.0",
+	"services": [{
+			"refName": "zookeeper",
+			"serviceType": "ZOOKEEPER",
+			"roleConfigGroups": [{
+				"refName": "zookeeper-SERVER-BASE",
+				"roleType": "SERVER",
+				"base": true
+			}]
+		},
+		{
+			"refName": "hdfs",
+			"serviceType": "HDFS",
+			"serviceConfigs": [{
+					"name": "redaction_policy_enabled",
+					"value": "false"
+				},
+				{
+					"name": "zookeeper_service",
+					"ref": "zookeeper"
+				}
+			],
+			"roleConfigGroups": [{
+					"refName": "hdfs-NAMENODE-BASE",
+					"roleType": "NAMENODE",
+					"base": true
+				},
+				{
+					"refName": "hdfs-FAILOVERCONTROLLER-BASE",
+					"roleType": "FAILOVERCONTROLLER",
+					"base": true
+				},
+				{
+					"refName": "hdfs-JOURNALNODE-BASE",
+					"roleType": "JOURNALNODE",
+					"base": true
+				},
+				{
+					"refName": "hdfs-DATANODE-BASE",
+					"roleType": "DATANODE",
+					"base": true
+				},
+				{
+					"refName": "hdfs-SECONDARYNAMENODE-BASE",
+					"roleType": "SECONDARYNAMENODE",
+					"base": true,
+					"configs": [{
+						"name": "fs_checkpoint_dir_list",
+						"value": "/should_not_be_required_in_HA_setup"
+					}]
+				},
+				{
+					"refName": "hdfs-BALANCER-BASE",
+					"roleType": "BALANCER",
+					"base": true
+				},
+				{
+					"refName": "hdfs-GATEWAY-BASE",
+					"roleType": "GATEWAY",
+					"base": true,
+					"configs": [{
+						"name": "dfs_client_use_trash",
+						"value": "false"
+					}]
+				},
+				{
+					"refName": "hdfs-HTTPFS-BASE",
+					"roleType": "HTTPFS",
+					"base": true
+				}
+			]
+		},
+		{
+			"refName": "hms",
+			"serviceType": "HIVE",
+			"serviceConfigs": [{
+					"name": "hive_metastore_database_host",
+					"value": "10.1.1.1"
+				},
+				{
+					"name": "hive_metastore_database_name",
+					"value": "hive"
+				},
+				{
+					"name": "hive_metastore_database_password",
+					"value": "iamsoosecure"
+				},
+				{
+					"name": "hive_metastore_database_port",
+					"value": "5432"
+				},
+				{
+					"name": "hive_metastore_database_type",
+					"value": "postgresql"
+				},
+				{
+					"name": "hive_metastore_database_user",
+					"value": "heyitsme"
+				}
+			],
+			"roleConfigGroups": [{
+					"refName": "hms-GATEWAY-BASE",
+					"roleType": "GATEWAY",
+					"base": true
+				},
+				{
+					"refName": "hms-HIVEMETASTORE-BASE",
+					"roleType": "HIVEMETASTORE",
+					"base": true,
+					"configs": [{
+						"name": "metastore_canary_health_enabled",
+						"value": "false"
+					}]
+				}
+			],
+			"displayName": "Hive Metastore"
+		},
+		{
+			"refName": "hive",
+			"serviceType": "HIVE_ON_TEZ",
+			"serviceConfigs": [{
+					"name": "tez_container_size",
+					"value": "4096"
+				},
+				{
+					"name": "tez_auto_reducer_parallelism",
+					"value": "false"
+				},
+				{
+					"name": "hive_service_config_safety_valve",
+					"value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
+				}
+			],
+			"roleConfigGroups": [{
+					"refName": "hive-GATEWAY-BASE",
+					"roleType": "GATEWAY",
+					"base": true
+				},
+				{
+					"refName": "hive-HIVESERVER2-BASE",
+					"roleType": "HIVESERVER2",
+					"base": true,
+					"configs": [{
+							"name": "hive_server2_transport_mode",
+							"value": "http"
+						},
+						{
+							"name": "hiveserver2_mv_files_thread",
+							"value": "20"
+						},
+						{
+							"name": "hiveserver2_load_dynamic_partitions_thread_count",
+							"value": "20"
+						}
+					]
+				}
+			],
+			"displayName": "Hive"
+		},
+		{
+			"refName": "hue",
+			"serviceType": "HUE",
+			"serviceConfigs": [{
+					"name": "hue_service_safety_valve",
+					"value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
+				},
+				{
+					"name": "hue_webhdfs",
+					"ref": "hdfs-HTTPFS-BASE"
+				}
+			],
+			"roleConfigGroups": [{
+					"refName": "hue-HUE_SERVER-BASE",
+					"roleType": "HUE_SERVER",
+					"base": true
+				},
+				{
+					"refName": "hue-HUE_LOAD_BALANCER-BASE",
+					"roleType": "HUE_LOAD_BALANCER",
+					"base": true
+				}
+			]
+		},
+		{
+			"refName": "livy",
+			"serviceType": "LIVY",
+			"roleConfigGroups": [{
+					"refName": "livy-GATEWAY-BASE",
+					"roleType": "GATEWAY",
+					"base": true
+				},
+				{
+					"refName": "livy-LIVY_SERVER-BASE",
+					"roleType": "LIVY_SERVER",
+					"base": true
+				}
+			]
+		},
+		{
+			"refName": "oozie",
+			"serviceType": "OOZIE",
+			"roleConfigGroups": [{
+				"refName": "oozie-OOZIE_SERVER-BASE",
+				"roleType": "OOZIE_SERVER",
+				"base": true
+			}]
+		},
+		{
+			"refName": "yarn",
+			"serviceType": "YARN",
+			"serviceConfigs": [{
+					"name": "yarn_admin_acl",
+					"value": "yarn,hive,hdfs,mapred"
+				},
+				{
+					"name": "yarn_log_aggregation_IFile_remote_app_log_dir",
+					"value": ""
+				}
+			],
+			"roleConfigGroups": [{
+					"refName": "yarn-RESOURCEMANAGER-BASE",
+					"roleType": "RESOURCEMANAGER",
+					"base": true,
+					"configs": [{
+							"name": "resourcemanager_config_safety_valve",
+							"value": "<property><name>yarn.scheduler.configuration.store.class</name><value>file</value></property>"
+						},
+						{
+							"name": "yarn_resourcemanager_scheduler_class",
+							"value": "org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler"
+						},
+						{
+							"name": "yarn_scheduler_capacity_resource_calculator",
+							"value": "org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator"
+						},
+						{
+							"name": "resourcemanager_capacity_scheduler_configuration",
+							"value": "<configuration><property><name>yarn.scheduler.capacity.root.queues</name><value>default</value></property><property><name>yarn.scheduler.capacity.root.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.default.capacity</name><value>100</value></property><property><name>yarn.scheduler.capacity.root.acl_submit_applications</name><value> </value></property><property><name>yarn.scheduler.capacity.root.acl_administer_queue</name><value> </value></property><property><name>yarn.scheduler.capacity.root.default.acl_submit_applications</name><value>*</value></property><property><name>yarn.scheduler.capacity.root.default.minimum-user-limit-percent</name><value>100</value></property><property><name>yarn.scheduler.capacity.maximum-am-resource-percent</name><value>0.33</value></property><property><name>yarn.scheduler.capacity.node-locality-delay</name><value>0</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.maximum-threads</name><value>1</value></property><property><name>yarn.scheduler.capacity.schedule-asynchronously.scheduling-interval-ms</name><value>10</value></property></configuration>"
+						}
+					]
+				},
+				{
+					"refName": "yarn-NODEMANAGER-WORKER",
+					"roleType": "NODEMANAGER",
+					"base": false
+				},
+				{
+					"refName": "yarn-NODEMANAGER-COMPUTE",
+					"roleType": "NODEMANAGER",
+					"base": false
+				},
+				{
+					"refName": "yarn-JOBHISTORY-BASE",
+					"roleType": "JOBHISTORY",
+					"base": true
+				},
+				{
+					"refName": "yarn-GATEWAY-BASE",
+					"roleType": "GATEWAY",
+					"base": true,
+					"configs": [{
+							"name": "mapreduce_map_memory_mb",
+							"value": "4096"
+						},
+						{
+							"name": "mapreduce_reduce_memory_mb",
+							"value": "4096"
+						}
+					]
+				}
+			]
+		},
+		{
+			"refName": "spark_on_yarn",
+			"serviceType": "SPARK_ON_YARN",
+			"roleConfigGroups": [{
+					"refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+					"roleType": "SPARK_YARN_HISTORY_SERVER",
+					"base": true
+				},
+				{
+					"refName": "spark_on_yarn-GATEWAY-BASE",
+					"roleType": "GATEWAY",
+					"base": true
+				}
+			]
+		},
+		{
+			"refName": "tez",
+			"serviceType": "TEZ",
+			"serviceConfigs": [{
+					"name": "yarn_service",
+					"ref": "yarn"
+				},
+				{
+					"name": "tez.am.container.reuse.non-local-fallback.enabled",
+					"value": "true"
+				},
+				{
+					"name": "tez.am.container.reuse.locality.delay-allocation-millis",
+					"value": "0"
+				},
+				{
+					"name": "tez.am.launch.cmd-opts",
+					"value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+				},
+				{
+					"name": "tez.task.launch.cmd-opts",
+					"value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
+				}
+			],
+			"roleConfigGroups": [{
+				"refName": "tez-GATEWAY-BASE",
+				"roleType": "GATEWAY",
+				"base": true
+			}]
+		},
+		{
+			"refName": "das",
+			"serviceType": "DAS",
+			"roleConfigGroups": [{
+					"refName": "das-DAS_WEBAPP",
+					"roleType": "DAS_WEBAPP",
+					"base": true,
+					"configs": [{
+						"name": "data_analytics_studio_admin_users",
+						"value": "*"
+					}]
+				},
+				{
+					"refName": "das-DAS_EVENT_PROCESSOR",
+					"roleType": "DAS_EVENT_PROCESSOR",
+					"base": true
+				}
+			]
+		},
+		{
+			"refName": "knox",
+			"serviceType": "KNOX",
+			"roleConfigGroups": [{
+				"refName": "knox-KNOX_GATEWAY-BASE",
+				"roleType": "KNOX_GATEWAY",
+				"base": true
+			}]
+		},
+		{
+			"refName": "zeppelin",
+			"serviceType": "ZEPPELIN",
+			"serviceConfigs": [{
+					"name": "yarn_service",
+					"ref": "yarn"
+				},
+				{
+					"name": "hdfs_service",
+					"ref": "hdfs"
+				},
+				{
+					"name": "spark_on_yarn_service",
+					"ref": "spark_on_yarn"
+				}
+			],
+			"roleConfigGroups": [{
+				"refName": "zeppelin-ZEPPELIN_SERVER-BASE",
+				"roleType": "ZEPPELIN_SERVER",
+				"base": true
+			}]
+		}
+	],
+	"hostTemplates": [{
+			"refName": "gateway",
+			"roleConfigGroupsRefNames": [
+				"hdfs-GATEWAY-BASE",
+				"hive-GATEWAY-BASE",
+				"hms-GATEWAY-BASE",
+				"livy-GATEWAY-BASE",
+				"spark_on_yarn-GATEWAY-BASE",
+				"tez-GATEWAY-BASE",
+				"yarn-GATEWAY-BASE"
+			],
+			"cardinality": 0
+		},
+		{
+			"refName": "master",
+			"roleConfigGroupsRefNames": [
+				"hdfs-FAILOVERCONTROLLER-BASE",
+				"hdfs-NAMENODE-BASE",
+				"hdfs-GATEWAY-BASE",
+				"hdfs-HTTPFS-BASE",
+				"hive-GATEWAY-BASE",
+				"hive-HIVESERVER2-BASE",
+				"hms-GATEWAY-BASE",
+				"hms-HIVEMETASTORE-BASE",
+				"hue-HUE_SERVER-BASE",
+				"knox-KNOX_GATEWAY-BASE",
+				"livy-GATEWAY-BASE",
+				"spark_on_yarn-GATEWAY-BASE",
+				"tez-GATEWAY-BASE",
+				"yarn-RESOURCEMANAGER-BASE",
+				"hdfs-JOURNALNODE-BASE",
+				"zookeeper-SERVER-BASE",
+				"yarn-GATEWAY-BASE"
+			],
+			"cardinality": 2
+		},
+		{
+			"refName": "manager",
+			"roleConfigGroupsRefNames": [
+				"hdfs-BALANCER-BASE",
+				"hdfs-GATEWAY-BASE",
+				"hive-GATEWAY-BASE",
+				"hms-GATEWAY-BASE",
+				"hue-HUE_LOAD_BALANCER-BASE",
+				"livy-GATEWAY-BASE",
+				"livy-LIVY_SERVER-BASE",
+				"spark_on_yarn-GATEWAY-BASE",
+				"spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+				"tez-GATEWAY-BASE",
+				"yarn-JOBHISTORY-BASE",
+				"oozie-OOZIE_SERVER-BASE",
+				"zeppelin-ZEPPELIN_SERVER-BASE",
+				"das-DAS_EVENT_PROCESSOR",
+				"das-DAS_WEBAPP",
+				"knox-KNOX_GATEWAY-BASE",
+				"hdfs-JOURNALNODE-BASE",
+				"zookeeper-SERVER-BASE",
+				"yarn-GATEWAY-BASE"
+			],
+			"cardinality": 1
+		},
+		{
+			"refName": "worker",
+			"roleConfigGroupsRefNames": [
+				"hdfs-DATANODE-BASE",
+				"hdfs-GATEWAY-BASE",
+				"hive-GATEWAY-BASE",
+				"hms-GATEWAY-BASE",
+				"livy-GATEWAY-BASE",
+				"spark_on_yarn-GATEWAY-BASE",
+				"tez-GATEWAY-BASE",
+				"yarn-NODEMANAGER-WORKER",
+				"yarn-GATEWAY-BASE"
+			],
+			"cardinality": 3
+		},
+		{
+			"refName": "compute",
+			"roleConfigGroupsRefNames": [
+				"hdfs-GATEWAY-BASE",
+				"hive-GATEWAY-BASE",
+				"hms-GATEWAY-BASE",
+				"livy-GATEWAY-BASE",
+				"spark_on_yarn-GATEWAY-BASE",
+				"tez-GATEWAY-BASE",
+				"yarn-NODEMANAGER-COMPUTE",
+				"yarn-GATEWAY-BASE"
+			],
+			"cardinality": 0
+		}
+	],
+	"displayName": "testcluster",
+	"instantiator": {
+		"clusterName": "testcluster",
+		"hosts": [{
+				"hostName": "host3",
+				"hostTemplateRefName": "worker"
+			},
+			{
+				"hostName": "host4",
+				"hostTemplateRefName": "worker"
+			},
+			{
+				"hostName": "host1",
+				"hostTemplateRefName": "master",
+				"roleRefNames": [
+					"hdfs-HTTPFS-BASE"
+				]
+			},
+			{
+				"hostName": "host2",
+				"hostTemplateRefName": "master",
+				"roleRefNames": [
+					"hdfs-HTTPFS-BASE"
+				]
+			}
+		],
+		"roleConfigGroups": [{
+				"rcgRefName": "yarn-NODEMANAGER-WORKER"
+			},
+			{
+				"rcgRefName": "yarn-NODEMANAGER-COMPUTE"
+			}
+		]
+	}
+}

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/BlueprintUpdater.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/BlueprintUpdater.java
@@ -1,7 +1,12 @@
 package com.sequenceiq.cloudbreak.template;
 
+import java.util.List;
+import java.util.Map;
+
 public interface BlueprintUpdater {
     String getBlueprintText(TemplatePreparationObject source);
+
+    String getBlueprintText(TemplatePreparationObject source, Map<String, List<Map<String, String>>> hostGroupMappings);
 
     String getVariant();
 }


### PR DESCRIPTION
1. At the moment the Hue does not point to the current namenode in an HA cluster after failovers.
2. The fix is to use HTTPFS.
3. Adding this role requires support for specifying roleRefNames in the hosts' section of the CM template.
4. Added support for the same and tested via unit tests and end to end tests.