### PR TITLE
CB-10242 API changes to support semi-private networks

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/type/PublicEndpointAccessGateway.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/PublicEndpointAccessGateway.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.common.api.type;
+
+public enum PublicEndpointAccessGateway {
+    ENABLED,
+    DISABLED
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/converter/PublicEndpointAccessGatewayConverter.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/converter/PublicEndpointAccessGatewayConverter.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+
+public class PublicEndpointAccessGatewayConverter extends DefaultEnumConverter<PublicEndpointAccessGateway> {
+    @Override
+    public PublicEndpointAccessGateway getDefault() {
+        return PublicEndpointAccessGateway.DISABLED;
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -14,6 +14,14 @@ public class EnvironmentModelDescription {
     public static final String NETWORKCIDRS = "The network cidrs for the configured vpc";
     public static final String PRIVATE_SUBNET_CREATION = "A flag to enable or disable the private subnet creation.";
     public static final String SERVICE_ENDPOINT_CREATION = "A flag to enable or disable the service endpoint creation.";
+    public static final String PUBLIC_ENDPOINT_ACCESS_GATEWAY = "A flag to enable the Public Endpoint Access Gateway, which provides public UI/API " +
+        "access to private data lakes and data hubs.";
+    public static final String ENDPOINT_ACCESS_GATEWAY_SUBNET_IDS = "Subnet ids for the Public Endpoint Access Gateway. If provided, these " +
+        "are the subnets that will be used to create a public Knox endpoint for out-of-network UI/API access. If not provided, public subnets will be " +
+        "selected from the subnet list provided for environment creation. (Optional)";
+    public static final String ENDPOINT_ACCESS_GATEWAY_SUBNET_METAS = "Subnet metadata for the Public Endpoint Access Gateway. If provided, these " +
+        "are the subnets that will be used to create a public Knox endpoint for out-of-network UI/API access. If not provided, public subnets will be " +
+        "selected from the subnet list provided for environment creation. (Optional)";
     public static final String OUTBOUND_INTERNET_TRAFFIC = "A flag to enable or disable the outbound internet traffic from the instances.";
     public static final String AWS_SPECIFIC_PARAMETERS = "Subnet ids of the specified networks";
     public static final String AZURE_SPECIFIC_PARAMETERS = "Subnet ids of the specified networks";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/EnvironmentNetworkBase.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/EnvironmentNetworkBase.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.validation.SubnetType;
 import com.sequenceiq.cloudbreak.validation.ValidSubnet;
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams;
@@ -41,6 +42,12 @@ public abstract class EnvironmentNetworkBase {
 
     @ApiModelProperty(EnvironmentModelDescription.SERVICE_ENDPOINT_CREATION)
     private ServiceEndpointCreation serviceEndpointCreation = ServiceEndpointCreation.DISABLED;
+
+    @ApiModelProperty(EnvironmentModelDescription.PUBLIC_ENDPOINT_ACCESS_GATEWAY)
+    private PublicEndpointAccessGateway publicEndpointAccessGateway = PublicEndpointAccessGateway.DISABLED;
+
+    @ApiModelProperty(value = EnvironmentModelDescription.ENDPOINT_ACCESS_GATEWAY_SUBNET_IDS)
+    private Set<String> endpointGatewaySubnetIds = Set.of();
 
     @ApiModelProperty(EnvironmentModelDescription.OUTBOUND_INTERNET_TRAFFIC)
     private OutboundInternetTraffic outboundInternetTraffic = OutboundInternetTraffic.ENABLED;
@@ -92,6 +99,22 @@ public abstract class EnvironmentNetworkBase {
         this.serviceEndpointCreation = serviceEndpointCreation;
     }
 
+    public PublicEndpointAccessGateway getPublicEndpointAccessGateway() {
+        return publicEndpointAccessGateway;
+    }
+
+    public void setPublicEndpointAccessGateway(PublicEndpointAccessGateway publicEndpointAccessGateway) {
+        this.publicEndpointAccessGateway = publicEndpointAccessGateway;
+    }
+
+    public Set<String> getEndpointGatewaySubnetIds() {
+        return endpointGatewaySubnetIds;
+    }
+
+    public void setEndpointGatewaySubnetIds(Set<String> endpointGatewaySubnetIds) {
+        this.endpointGatewaySubnetIds = endpointGatewaySubnetIds;
+    }
+
     public OutboundInternetTraffic getOutboundInternetTraffic() {
         return outboundInternetTraffic;
     }
@@ -139,6 +162,8 @@ public abstract class EnvironmentNetworkBase {
                 ", networkCidr='" + networkCidr + '\'' +
                 ", privateSubnetCreation=" + privateSubnetCreation +
                 ", serviceEndpointCreation=" + serviceEndpointCreation +
+                ", publicEndpointAccessGateway=" + publicEndpointAccessGateway +
+                ", endpointGatewaySubnetIds=" + endpointGatewaySubnetIds +
                 ", outboundInternetTraffic=" + outboundInternetTraffic +
                 ", aws=" + aws +
                 ", gcp=" + gcp +

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentNetworkResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentNetworkResponse.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.api.doc.ModelDescriptions;
 import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams;
@@ -52,6 +53,9 @@ public class EnvironmentNetworkResponse extends EnvironmentNetworkBase {
 
     @ApiModelProperty(EnvironmentModelDescription.NETWORKCIDRS)
     private Set<String> networkCidrs = new HashSet<>();
+
+    @ApiModelProperty(value = EnvironmentModelDescription.ENDPOINT_ACCESS_GATEWAY_SUBNET_METAS)
+    private Map<String, CloudSubnet> gatewayEndpointSubnetMetas;
 
     public String getCrn() {
         return crn;
@@ -133,6 +137,14 @@ public class EnvironmentNetworkResponse extends EnvironmentNetworkBase {
         this.networkCidrs = networkCidrs;
     }
 
+    public Map<String, CloudSubnet> getGatewayEndpointSubnetMetas() {
+        return gatewayEndpointSubnetMetas;
+    }
+
+    public void setGatewayEndpointSubnetMetas(Map<String, CloudSubnet> gatewayEndpointSubnetMetas) {
+        this.gatewayEndpointSubnetMetas = gatewayEndpointSubnetMetas;
+    }
+
     public static final class EnvironmentNetworkResponseBuilder {
         private String crn;
 
@@ -173,6 +185,12 @@ public class EnvironmentNetworkResponse extends EnvironmentNetworkBase {
         private EnvironmentNetworkMockParams mock;
 
         private EnvironmentNetworkGcpParams gcp;
+
+        private PublicEndpointAccessGateway publicEndpointAccessGateway;
+
+        private Map<String, CloudSubnet> endpointGatewaySubnetMetas;
+
+        private Set<String> endpointGatewaySubnetIds;
 
         private EnvironmentNetworkResponseBuilder() {
         }
@@ -281,6 +299,21 @@ public class EnvironmentNetworkResponse extends EnvironmentNetworkBase {
             return this;
         }
 
+        public EnvironmentNetworkResponseBuilder withUsePublicEndpointAccessGateway(PublicEndpointAccessGateway publicEndpointAccessGateway) {
+            this.publicEndpointAccessGateway = publicEndpointAccessGateway;
+            return this;
+        }
+
+        public EnvironmentNetworkResponseBuilder withEndpointGatewaySubnetMetas(Map<String, CloudSubnet> endpointGatewaySubnetMetas) {
+            this.endpointGatewaySubnetMetas = endpointGatewaySubnetMetas;
+            return this;
+        }
+
+        public EnvironmentNetworkResponseBuilder withEndpointGatewaySubnetIds(Set<String> endpointGatewaySubnetIds) {
+            this.endpointGatewaySubnetIds = endpointGatewaySubnetIds;
+            return this;
+        }
+
         public EnvironmentNetworkResponse build() {
             EnvironmentNetworkResponse environmentNetworkResponse = new EnvironmentNetworkResponse();
             environmentNetworkResponse.setCrn(crn);
@@ -303,6 +336,9 @@ public class EnvironmentNetworkResponse extends EnvironmentNetworkBase {
             environmentNetworkResponse.setMlxSubnets(mlxSubnets);
             environmentNetworkResponse.setDwxSubnets(dwxSubnets);
             environmentNetworkResponse.setLiftieSubnets(liftieSubnets);
+            environmentNetworkResponse.setPublicEndpointAccessGateway(publicEndpointAccessGateway);
+            environmentNetworkResponse.setGatewayEndpointSubnetMetas(endpointGatewaySubnetMetas);
+            environmentNetworkResponse.setEndpointGatewaySubnetIds(endpointGatewaySubnetIds);
             return environmentNetworkResponse;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/NetworkCreationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/NetworkCreationHandler.java
@@ -80,8 +80,10 @@ public class NetworkCreationHandler extends EventSenderAwareHandler<EnvironmentD
                             LOGGER.debug("Environment ({}) dto has network, hence we're filling it's related subnet fields", environment.getName());
                             environmentDto.getNetwork().setSubnetMetas(cloudNetworkService.retrieveSubnetMetadata(environmentDto,
                                     environmentDto.getNetwork()));
+                            environmentDto.getNetwork().setEndpointGatewaySubnetMetas(cloudNetworkService.retrieveEndpointGatewaySubnetMetadata(
+                                environmentDto, environmentDto.getNetwork()));
                             environmentResourceService.createAndSetNetwork(environment, environmentDto.getNetwork(), environment.getAccountId(),
-                                    environmentDto.getNetwork().getSubnetMetas());
+                                    environmentDto.getNetwork().getSubnetMetas(), environmentDto.getNetwork().getEndpointGatewaySubnetMetas());
                         } else {
                             LOGGER.debug("Environment ({}) dto has no network!", environment.getName());
                         }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
@@ -95,7 +95,8 @@ public class EnvironmentCreationService {
         try {
             environment = environmentService.save(environment);
             environmentResourceService.createAndSetNetwork(environment, creationDto.getNetwork(), creationDto.getAccountId(),
-                    getIfNotNull(creationDto.getNetwork(), NetworkDto::getSubnetMetas));
+                    getIfNotNull(creationDto.getNetwork(), NetworkDto::getSubnetMetas),
+                    getIfNotNull(creationDto.getNetwork(), NetworkDto::getEndpointGatewaySubnetMetas));
             createAndSetParameters(environment, creationDto.getParameters());
             environmentService.saveWithOwnerRoleAssignment(environment);
             reactorFlowManager.triggerCreationFlow(environment.getId(), environment.getName(), creationDto.getCreator(), environment.getResourceCrn());

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentResourceService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentResourceService.java
@@ -147,8 +147,9 @@ public class EnvironmentResourceService {
                 .build();
     }
 
-    public BaseNetwork createAndSetNetwork(Environment environment, NetworkDto networkDto, String accountId, Map<String, CloudSubnet> subnetMetas) {
-        BaseNetwork network = networkService.saveNetwork(environment, networkDto, accountId, subnetMetas);
+    public BaseNetwork createAndSetNetwork(Environment environment, NetworkDto networkDto, String accountId, Map<String, CloudSubnet> subnetMetas,
+            Map<String, CloudSubnet> endpointGatewaySubnetMetas) {
+        BaseNetwork network = networkService.saveNetwork(environment, networkDto, accountId, subnetMetas, endpointGatewaySubnetMetas);
         if (network != null) {
             environment.setNetwork(network);
         }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
@@ -40,6 +40,9 @@ public class NetworkDtoToResponseConverter {
                 .withServiceEndpointCreation(network.getServiceEndpointCreation())
                 .withOutboundInternetTraffic(network.getOutboundInternetTraffic())
                 .withExistingNetwork(RegistrationType.EXISTING == network.getRegistrationType())
+                .withUsePublicEndpointAccessGateway(network.getPublicEndpointAccessGateway())
+                .withEndpointGatewaySubnetMetas(network.getEndpointGatewaySubnetMetas())
+                .withEndpointGatewaySubnetIds(network.getEndpointGatewaySubnetIds())
                 .withAws(getIfNotNull(network.getAws(), p -> EnvironmentNetworkAwsParams.EnvironmentNetworkAwsParamsBuilder
                         .anEnvironmentNetworkAwsParams()
                         .withVpcId(p.getVpcId())

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkRequestToDtoConverter.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.environment.environment.v1.converter;
 
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -86,12 +87,17 @@ public class NetworkRequestToDtoConverter {
             builder.withSubnetMetas(network.getSubnetIds().stream()
                     .collect(Collectors.toMap(id -> id, id -> new CloudSubnet(id, id))));
         }
+        if (network.getEndpointGatewaySubnetIds() != null) {
+            builder.withEndpointGatewaySubnetMetas(network.getEndpointGatewaySubnetIds().stream()
+                .collect(Collectors.toMap(id -> id, id -> new CloudSubnet(id, id))));
+        }
         return builder
                 .withNetworkCidr(network.getNetworkCidr())
                 .withNetworkCidrs(getNetworkCidrs(network))
                 .withPrivateSubnetCreation(getPrivateSubnetCreation(network))
                 .withServiceEndpointCreation(getServiceEndpointCreation(network))
                 .withOutboundInternetTraffic(getOutboundInternetTraffic(network))
+                .withUsePublicEndpointAccessGateway(getUsePublicEndpointAccessGateway(network))
                 .build();
     }
 
@@ -109,5 +115,9 @@ public class NetworkRequestToDtoConverter {
 
     private OutboundInternetTraffic getOutboundInternetTraffic(EnvironmentNetworkRequest network) {
         return Optional.ofNullable(network.getOutboundInternetTraffic()).orElse(OutboundInternetTraffic.ENABLED);
+    }
+
+    private PublicEndpointAccessGateway getUsePublicEndpointAccessGateway(EnvironmentNetworkRequest network) {
+        return Optional.ofNullable(network.getPublicEndpointAccessGateway()).orElse(PublicEndpointAccessGateway.DISABLED);
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/network/NetworkService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/NetworkService.java
@@ -53,12 +53,13 @@ public class NetworkService {
         this.networkCreationValidator = networkCreationValidator;
     }
 
-    public BaseNetwork saveNetwork(Environment environment, NetworkDto networkDto, String accountId, Map<String, CloudSubnet> subnetMetas) {
+    public BaseNetwork saveNetwork(Environment environment, NetworkDto networkDto, String accountId, Map<String, CloudSubnet> subnetMetas,
+            Map<String, CloudSubnet> endpointGatewaySubnetMetas) {
         BaseNetwork baseNetwork = null;
         if (networkDto != null) {
             EnvironmentNetworkConverter environmentNetworkConverter = environmentNetworkConverterMap.get(getCloudPlatform(environment));
             if (environmentNetworkConverter != null) {
-                baseNetwork = environmentNetworkConverter.convert(environment, networkDto, subnetMetas);
+                baseNetwork = environmentNetworkConverter.convert(environment, networkDto, subnetMetas, endpointGatewaySubnetMetas);
                 baseNetwork.setId(getIfNotNull(networkDto, NetworkDto::getId));
                 baseNetwork.setResourceCrn(createCRN(accountId));
                 baseNetwork.setAccountId(accountId);
@@ -100,6 +101,10 @@ public class NetworkService {
         try {
             Map<String, CloudSubnet> subnetMetadatas = cloudNetworkService.retrieveSubnetMetadata(environment, cloneNetworkDto);
             originalNetwork.setSubnetMetas(subnetMetadatas.values().stream().collect(toMap(CloudSubnet::getId, c -> c)));
+
+            Map<String, CloudSubnet> endpointGatewaySubnetMetadatas =
+                cloudNetworkService.retrieveEndpointGatewaySubnetMetadata(environment, cloneNetworkDto);
+            originalNetwork.setEndpointGatewaySubnetMetas(endpointGatewaySubnetMetadatas.values().stream().collect(toMap(CloudSubnet::getId, c -> c)));
 
             Network network = environmentNetworkConverter.convertToNetwork(originalNetwork);
             NetworkCidr networkCidr = environmentNetworkService.getNetworkCidr(network, environment.getCloudPlatform(), environment.getCredential());

--- a/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/BaseNetwork.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/dao/domain/BaseNetwork.java
@@ -28,9 +28,11 @@ import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonToString;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.converter.OutboundInternetTrafficConverter;
+import com.sequenceiq.cloudbreak.converter.PublicEndpointAccessGatewayConverter;
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
-import com.sequenceiq.environment.api.v1.environment.model.base.PrivateSubnetCreation;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.common.api.type.ServiceEndpointCreation;
+import com.sequenceiq.environment.api.v1.environment.model.base.PrivateSubnetCreation;
 import com.sequenceiq.environment.environment.domain.EnvironmentAwareResource;
 import com.sequenceiq.environment.environment.domain.EnvironmentView;
 import com.sequenceiq.environment.network.dao.domain.converter.ServiceEndpointCreationConverter;
@@ -78,6 +80,13 @@ public abstract class BaseNetwork implements EnvironmentAwareResource {
     @Column(nullable = false)
     @Convert(converter = ServiceEndpointCreationConverter.class)
     private ServiceEndpointCreation serviceEndpointCreation;
+
+    @Convert(converter = PublicEndpointAccessGatewayConverter.class)
+    private PublicEndpointAccessGateway publicEndpointAccessGateway;
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json endpointGatewaySubnetMetas = new Json(Map.of());
 
     @Column(nullable = false)
     @Convert(converter = OutboundInternetTrafficConverter.class)
@@ -166,6 +175,23 @@ public abstract class BaseNetwork implements EnvironmentAwareResource {
 
     public Map<String, CloudSubnet> getSubnetMetas() {
         return JsonUtil.jsonToType(subnetMetas.getValue(), new TypeReference<>() {
+        });
+    }
+
+    public PublicEndpointAccessGateway getPublicEndpointAccessGateway() {
+        return publicEndpointAccessGateway;
+    }
+
+    public void setPublicEndpointAccessGateway(PublicEndpointAccessGateway publicEndpointAccessGateway) {
+        this.publicEndpointAccessGateway = publicEndpointAccessGateway;
+    }
+
+    public void setEndpointGatewaySubnetMetas(Map<String, CloudSubnet> endpointGatewaySubnetMetas) {
+        this.endpointGatewaySubnetMetas = new Json(endpointGatewaySubnetMetas);
+    }
+
+    public Map<String, CloudSubnet> getEndpointGatewaySubnetMetas() {
+        return JsonUtil.jsonToType(endpointGatewaySubnetMetas.getValue(), new TypeReference<>() {
         });
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/EnvironmentBaseNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/EnvironmentBaseNetworkConverter.java
@@ -28,7 +28,8 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
     }
 
     @Override
-    public BaseNetwork convert(Environment environment, NetworkDto creationDto, Map<String, CloudSubnet> subnetMetas) {
+    public BaseNetwork convert(Environment environment, NetworkDto creationDto, Map<String, CloudSubnet> subnetMetas,
+            Map<String, CloudSubnet> gatewayEndpointSubnetMetas) {
         BaseNetwork result = createProviderSpecificNetwork(creationDto);
         result.setName(creationDto.getNetworkName() != null ? creationDto.getNetworkName() : environment.getName());
         result.setNetworkCidr(creationDto.getNetworkCidr());
@@ -39,6 +40,8 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
         result.setOutboundInternetTraffic(creationDto.getOutboundInternetTraffic());
         setRegistrationType(result, creationDto);
         result.setSubnetMetas(subnetMetas);
+        result.setPublicEndpointAccessGateway(creationDto.getPublicEndpointAccessGateway());
+        result.setEndpointGatewaySubnetMetas(gatewayEndpointSubnetMetas);
         return result;
     }
 
@@ -55,7 +58,9 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
                 .withServiceEndpointCreation(source.getServiceEndpointCreation())
                 .withOutboundInternetTraffic(source.getOutboundInternetTraffic())
                 .withRegistrationType(source.getRegistrationType())
-                .withNetworkId(source.getNetworkId());
+                .withNetworkId(source.getNetworkId())
+                .withUsePublicEndpointAccessGateway(source.getPublicEndpointAccessGateway())
+                .withEndpointGatewaySubnetMetas(source.getEndpointGatewaySubnetMetas());
 
         convertSubnets(source, builder);
 

--- a/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/EnvironmentNetworkConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/v1/converter/EnvironmentNetworkConverter.java
@@ -12,7 +12,8 @@ import com.sequenceiq.environment.network.dto.NetworkDto;
 
 public interface EnvironmentNetworkConverter {
 
-    BaseNetwork convert(Environment environment, NetworkDto creationDto, Map<String, CloudSubnet> subnetMetas);
+    BaseNetwork convert(Environment environment, NetworkDto creationDto, Map<String, CloudSubnet> subnetMetas,
+            Map<String, CloudSubnet> gatewayEndpointSubnetMetas);
 
     BaseNetwork setCreatedCloudNetwork(BaseNetwork baseNetwork, CreatedCloudNetwork createdCloudNetwork);
 

--- a/environment/src/main/resources/schema/app/20201208195427_CB-10242_API_changes_for_semi-private_networks.sql
+++ b/environment/src/main/resources/schema/app/20201208195427_CB-10242_API_changes_for_semi-private_networks.sql
@@ -1,0 +1,16 @@
+-- // CB-10242 API changes for semi-private networks
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE environment_network ADD COLUMN IF NOT EXISTS publicendpointaccessgateway CHARACTER VARYING(255);
+ALTER TABLE environment_network ALTER COLUMN publicendpointaccessgateway SET DEFAULT FALSE;
+UPDATE environment_network SET publicendpointaccessgateway = 'DISABLED' WHERE publicendpointaccessgateway IS NULL;
+
+ALTER TABLE environment_network ADD COLUMN IF NOT EXISTS endpointgatewaysubnetmetas TEXT;
+ALTER TABLE environment_network ALTER COLUMN endpointgatewaysubnetmetas SET DEFAULT '{}';
+UPDATE environment_network SET endpointgatewaysubnetmetas = '{}' WHERE endpointgatewaysubnetmetas IS NULL;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE environment_network DROP COLUMN IF EXISTS endpointgatewaysubnetmetas;
+ALTER TABLE environment_network DROP COLUMN IF EXISTS publicendpointaccessgateway;

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
@@ -113,7 +113,7 @@ class EnvironmentCreationServiceTest {
 
         verify(validatorService, Mockito.times(0)).validatePublicKey(any());
         verify(environmentService, never()).save(any());
-        verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any());
+        verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any(), any());
         verify(reactorFlowManager, never()).triggerCreationFlow(anyLong(), eq(ENVIRONMENT_NAME), eq(USER), anyString());
     }
 
@@ -156,7 +156,7 @@ class EnvironmentCreationServiceTest {
 
         verify(validatorService, Mockito.times(1)).validatePublicKey(any());
         verify(environmentService, never()).save(any());
-        verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any());
+        verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any(), any());
         verify(reactorFlowManager, never()).triggerCreationFlow(anyLong(), eq(ENVIRONMENT_NAME), eq(USER), anyString());
     }
 
@@ -200,7 +200,7 @@ class EnvironmentCreationServiceTest {
         verify(validatorService, Mockito.times(1)).validatePublicKey(any());
         verify(environmentService).save(any());
         verify(parametersService).saveParameters(eq(environment), eq(parametersDto));
-        verify(environmentResourceService).createAndSetNetwork(any(), any(), any(), any());
+        verify(environmentResourceService).createAndSetNetwork(any(), any(), any(), any(), any());
         verify(reactorFlowManager).triggerCreationFlow(eq(1L), eq(ENVIRONMENT_NAME), eq(CRN), anyString());
     }
 
@@ -255,7 +255,7 @@ class EnvironmentCreationServiceTest {
         verify(validatorService, Mockito.times(1)).validatePublicKey(any());
         verify(environmentService).save(any());
         verify(parametersService).saveParameters(eq(environment), eq(parametersDto));
-        verify(environmentResourceService).createAndSetNetwork(any(), any(), any(), any());
+        verify(environmentResourceService).createAndSetNetwork(any(), any(), any(), any(), any());
         verify(reactorFlowManager).triggerCreationFlow(anyLong(), eq(ENVIRONMENT_NAME), eq(CRN), anyString());
         assertEquals(environmentArgumentCaptor.getValue().getParentEnvironment(), parentEnvironment);
     }
@@ -302,7 +302,7 @@ class EnvironmentCreationServiceTest {
 
         verify(validatorService, Mockito.times(1)).validatePublicKey(any());
         verify(environmentService, never()).save(any());
-        verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any());
+        verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any(), any());
         verify(reactorFlowManager, never()).triggerCreationFlow(anyLong(), eq(ENVIRONMENT_NAME), eq(USER), anyString());
     }
 
@@ -350,7 +350,7 @@ class EnvironmentCreationServiceTest {
 
         verify(validatorService, Mockito.times(1)).validatePublicKey(any());
         verify(environmentService, never()).save(any());
-        verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any());
+        verify(environmentResourceService, never()).createAndSetNetwork(any(), any(), any(), any(), any());
         verify(reactorFlowManager, never()).triggerCreationFlow(anyLong(), eq(ENVIRONMENT_NAME), eq(USER), anyString());
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentModificationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentModificationServiceTest.java
@@ -135,7 +135,7 @@ class EnvironmentModificationServiceTest {
         when(environmentService
                 .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(value));
         when(networkService.findByEnvironment(any())).thenReturn(Optional.empty());
-        when(networkService.saveNetwork(any(), any(), anyString(), any())).thenReturn(new AwsNetwork());
+        when(networkService.saveNetwork(any(), any(), anyString(), any(), any())).thenReturn(new AwsNetwork());
 
         environmentModificationServiceUnderTest.editByName(ENVIRONMENT_NAME, environmentDto);
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentResourceServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentResourceServiceTest.java
@@ -103,8 +103,8 @@ class EnvironmentResourceServiceTest {
         Environment environment = new Environment();
         NetworkDto networkDto = null;
         BaseNetwork network = new AwsNetwork();
-        when(networkService.saveNetwork(eq(environment), eq(networkDto), eq(ACCOUNT_ID), any())).thenReturn(network);
-        assertEquals(network, environmentResourceServiceUnderTest.createAndSetNetwork(environment, networkDto, ACCOUNT_ID, Map.of()));
+        when(networkService.saveNetwork(eq(environment), eq(networkDto), eq(ACCOUNT_ID), any(), any())).thenReturn(network);
+        assertEquals(network, environmentResourceServiceUnderTest.createAndSetNetwork(environment, networkDto, ACCOUNT_ID, Map.of(), Map.of()));
     }
 
     @Test

--- a/environment/src/test/java/com/sequenceiq/environment/network/CloudNetworkServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/network/CloudNetworkServiceTest.java
@@ -38,6 +38,8 @@ class CloudNetworkServiceTest {
 
     private static final Set<String> DEFAULT_TEST_SUBNET_ID_SET = Set.of("test-subnet-id");
 
+    private static final Set<String> DEFAULT_TEST_PUBLIC_SUBNET_ID_SET = Set.of("test-public-subnet-id");
+
     private static final String DEFAULT_TEST_VPC_ID = "test-vpc-id";
 
     private static final String AWS_CLOUD_PLATFORM = "AWS";
@@ -82,19 +84,26 @@ class CloudNetworkServiceTest {
     @DisplayName("when retrieveSubnetMetadata has called with EnvironmentDto and with a null NetworkDto then empty map should return")
     void testRetrieveSubnetMetadataByEnvironmentDtoWhenNetworkIsNullThenEmptyMapReturns() {
         Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironmentDto, null);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, null);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
+        assertNotNull(gatewayResult);
+        assertTrue(gatewayResult.isEmpty());
     }
 
     @Test
     @DisplayName("when retrieveSubnetMetadata has called with EnvironmentDto and empty subnetIds, then empty map should return")
     void testRetrieveSubnetMetadataByEnvironmentDtoWhenNetworkIsNotNullButSubnetIdSetIsEmptyThenEmptyMapReturns() {
         when(testNetworkDto.getSubnetIds()).thenReturn(Collections.emptySet());
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(Collections.emptySet());
         Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironmentDto, testNetworkDto);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
+        assertNotNull(gatewayResult);
+        assertTrue(gatewayResult.isEmpty());
     }
 
     @Test
@@ -109,18 +118,105 @@ class CloudNetworkServiceTest {
         cloudNetworksFromProvider.put(DEFAULT_TEST_REGION_NAME, Set.of(cloudNetwork));
 
         when(testNetworkDto.getSubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
+        when(testNetworkDto.getAws()).thenReturn(awsParams);
+        when(testEnvironmentDto.getCloudPlatform()).thenReturn(AWS_CLOUD_PLATFORM);
+        when(cloudNetworks.getCloudNetworkResponses()).thenReturn(cloudNetworksFromProvider);
+
+        Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironmentDto, testNetworkDto);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
+
+        byte expectedAmountOfResultCloudSubnet = 1;
+
+        assertNotNull(result);
+        assertEquals(expectedAmountOfResultCloudSubnet, result.size(), "The amount of result CloudSubnet(s) must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), result.get(result.keySet().iterator().next()).getId());
+
+        assertNotNull(gatewayResult);
+        assertEquals(expectedAmountOfResultCloudSubnet, gatewayResult.size(),
+            "The amount of result CloudSubnet(s) for the gateway endpoint must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), gatewayResult.get(gatewayResult.keySet().iterator().next()).getId());
+
+        verify(platformParameterService, times(2)).getCloudNetworks(any());
+    }
+
+    @Test
+    @DisplayName("when retrieveSubnetMetadata has called with EnvironmentDto and the platform is AWS and no endpoint subnets are provided " +
+        "then an empty endpoint map should return")
+    void testRetrieveSubnetMetadataByEnvironmentDtoWhenPlatformIsAwsAndNoEndpointSubnetsAreProvided() {
+        AwsParams awsParams = NetworkTestUtils.getAwsParams(DEFAULT_TEST_VPC_ID);
+
+        CloudSubnet cloudSubnet = new CloudSubnet(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), "someSubnet");
+        CloudNetwork cloudNetwork = new CloudNetwork("someCloudNetwork", DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), Set.of(cloudSubnet),
+            Collections.emptyMap());
+        Map<String, Set<CloudNetwork>> cloudNetworksFromProvider = new LinkedHashMap<>();
+        cloudNetworksFromProvider.put(DEFAULT_TEST_REGION_NAME, Set.of(cloudNetwork));
+
+        when(testNetworkDto.getSubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(Set.of());
+        when(testNetworkDto.getAws()).thenReturn(awsParams);
+        when(testEnvironmentDto.getCloudPlatform()).thenReturn(AWS_CLOUD_PLATFORM);
+        when(cloudNetworks.getCloudNetworkResponses()).thenReturn(cloudNetworksFromProvider);
+
+        Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironmentDto, testNetworkDto);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
+
+        byte expectedAmountOfResultCloudSubnet = 1;
+        byte expectedAmountOfResultCloudEndpointSubnet = 0;
+
+        assertNotNull(result);
+        assertEquals(expectedAmountOfResultCloudSubnet, result.size(), "The amount of result CloudSubnet(s) must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), result.get(result.keySet().iterator().next()).getId());
+
+        assertNotNull(gatewayResult);
+        assertEquals(expectedAmountOfResultCloudEndpointSubnet, gatewayResult.size(),
+            "The amount of result CloudSubnet(s) for the gateway endpoint must be: " + expectedAmountOfResultCloudEndpointSubnet);
+
+        verify(platformParameterService, times(1)).getCloudNetworks(any());
+    }
+
+    @Test
+    @DisplayName("when retrieveSubnetMetadata has called with EnvironmentDto and the platform is AWS and endpoint subnets are provided that do not match the " +
+        "environment subnets, then endpoint subnet information unique those subnets should be returned")
+    void testRetrieveSubnetMetadataByEnvironmentDtoWhenPlatformIsAwsAndDifferentEndpointSubnetsAreProvided() {
+        AwsParams awsParams = NetworkTestUtils.getAwsParams(DEFAULT_TEST_VPC_ID);
+
+        CloudSubnet cloudSubnet = new CloudSubnet(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), "someSubnet");
+        CloudNetwork cloudNetwork = new CloudNetwork("someCloudNetwork", DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), Set.of(cloudSubnet),
+            Collections.emptyMap());
+        Map<String, Set<CloudNetwork>> cloudNetworksFromProvider = new LinkedHashMap<>();
+        cloudNetworksFromProvider.put(DEFAULT_TEST_REGION_NAME, Set.of(cloudNetwork));
+
+        CloudSubnet publicCloudSubnet = new CloudSubnet(DEFAULT_TEST_PUBLIC_SUBNET_ID_SET.iterator().next(), "someSubnet");
+        CloudNetwork publicCloudNetwork = new CloudNetwork("someCloudNetwork", DEFAULT_TEST_PUBLIC_SUBNET_ID_SET.iterator().next(), Set.of(publicCloudSubnet),
+            Collections.emptyMap());
+        Map<String, Set<CloudNetwork>> publicCloudNetworksFromProvider = new LinkedHashMap<>();
+        publicCloudNetworksFromProvider.put(DEFAULT_TEST_REGION_NAME, Set.of(publicCloudNetwork));
+
+        when(testNetworkDto.getSubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(DEFAULT_TEST_PUBLIC_SUBNET_ID_SET);
         when(testNetworkDto.getAws()).thenReturn(awsParams);
         when(testEnvironmentDto.getCloudPlatform()).thenReturn(AWS_CLOUD_PLATFORM);
         when(cloudNetworks.getCloudNetworkResponses()).thenReturn(cloudNetworksFromProvider);
 
         Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironmentDto, testNetworkDto);
 
+        when(cloudNetworks.getCloudNetworkResponses()).thenReturn(publicCloudNetworksFromProvider);
+
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
+
         byte expectedAmountOfResultCloudSubnet = 1;
+
         assertNotNull(result);
         assertEquals(expectedAmountOfResultCloudSubnet, result.size(), "The amount of result CloudSubnet(s) must be: " + expectedAmountOfResultCloudSubnet);
         assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), result.get(result.keySet().iterator().next()).getId());
 
-        verify(platformParameterService, times(1)).getCloudNetworks(any());
+        assertNotNull(gatewayResult);
+        assertEquals(expectedAmountOfResultCloudSubnet, gatewayResult.size(),
+            "The amount of result CloudSubnet(s) for the gateway endpoint must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_PUBLIC_SUBNET_ID_SET.iterator().next(), gatewayResult.get(gatewayResult.keySet().iterator().next()).getId());
+
+        verify(platformParameterService, times(2)).getCloudNetworks(any());
     }
 
     @Test
@@ -136,11 +232,13 @@ class CloudNetworkServiceTest {
         cloudNetworksFromProvider.put(DEFAULT_TEST_REGION_NAME, Set.of(cloudNetwork));
 
         when(testNetworkDto.getSubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
         when(testNetworkDto.getAzure()).thenReturn(azureParams);
         when(testEnvironmentDto.getCloudPlatform()).thenReturn(AZURE_CLOUD_PLATFORM);
         when(cloudNetworks.getCloudNetworkResponses()).thenReturn(cloudNetworksFromProvider);
 
         Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironmentDto, testNetworkDto);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
 
         byte expectedAmountOfResultCloudSubnet = 1;
 
@@ -148,7 +246,91 @@ class CloudNetworkServiceTest {
         assertEquals(expectedAmountOfResultCloudSubnet, result.size(), "The amount of result CloudSubnet(s) must be: " + expectedAmountOfResultCloudSubnet);
         assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), result.get(result.keySet().iterator().next()).getId());
 
+        assertNotNull(gatewayResult);
+        assertEquals(expectedAmountOfResultCloudSubnet, gatewayResult.size(),
+            "The amount of result CloudSubnet(s) for the gateway endpoint must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), gatewayResult.get(gatewayResult.keySet().iterator().next()).getId());
+
+        verify(platformParameterService, times(2)).getCloudNetworks(any());
+    }
+
+    @Test
+    @DisplayName("when retrieveSubnetMetadata has called with EnvironmentDto and the platform is Azure and no endpoint subnets are provided " +
+        "then an empty endpoint map should return")
+    void testRetrieveSubnetMetadataByEnvironmentDtoWhenPlatformIsAzureAndNoEndpointSubnetsAreProvided() {
+        AzureParams azureParams = NetworkTestUtils.getAzureParams();
+
+        CloudSubnet cloudSubnet = new CloudSubnet(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), "someSubnet");
+        CloudNetwork cloudNetwork = new CloudNetwork("someCloudNetwork", DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), Set.of(cloudSubnet),
+            Collections.emptyMap());
+        Map<String, Set<CloudNetwork>> cloudNetworksFromProvider = new LinkedHashMap<>();
+        cloudNetworksFromProvider.put(DEFAULT_TEST_REGION_NAME, Set.of(cloudNetwork));
+
+        when(testNetworkDto.getSubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(Set.of());
+        when(testNetworkDto.getAzure()).thenReturn(azureParams);
+        when(testEnvironmentDto.getCloudPlatform()).thenReturn(AZURE_CLOUD_PLATFORM);
+        when(cloudNetworks.getCloudNetworkResponses()).thenReturn(cloudNetworksFromProvider);
+
+        Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironmentDto, testNetworkDto);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
+
+        byte expectedAmountOfResultCloudSubnet = 1;
+        byte expectedAmountOfResultCloudEndpointSubnet = 0;
+
+        assertNotNull(result);
+        assertEquals(expectedAmountOfResultCloudSubnet, result.size(), "The amount of result CloudSubnet(s) must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), result.get(result.keySet().iterator().next()).getId());
+
+        assertNotNull(gatewayResult);
+        assertEquals(expectedAmountOfResultCloudEndpointSubnet, gatewayResult.size(),
+            "The amount of result CloudSubnet(s) for the gateway endpoint must be: " + expectedAmountOfResultCloudEndpointSubnet);
+
         verify(platformParameterService, times(1)).getCloudNetworks(any());
+    }
+
+    @Test
+    @DisplayName("when retrieveSubnetMetadata has called with EnvironmentDto and the platform is Azure and endpoint subnets are provided that " +
+        "do not match the environment subnets, then endpoint subnet information unique those subnets should be returned")
+    void testRetrieveSubnetMetadataByEnvironmentDtoWhenPlatformIsAzureAndDifferentEndpointSubnetsAreProvided() {
+        AzureParams azureParams = NetworkTestUtils.getAzureParams();
+
+        CloudSubnet cloudSubnet = new CloudSubnet(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), "someSubnet");
+        CloudNetwork cloudNetwork = new CloudNetwork("someCloudNetwork", DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), Set.of(cloudSubnet),
+            Collections.emptyMap());
+        Map<String, Set<CloudNetwork>> cloudNetworksFromProvider = new LinkedHashMap<>();
+        cloudNetworksFromProvider.put(DEFAULT_TEST_REGION_NAME, Set.of(cloudNetwork));
+
+        CloudSubnet publicCloudSubnet = new CloudSubnet(DEFAULT_TEST_PUBLIC_SUBNET_ID_SET.iterator().next(), "someSubnet");
+        CloudNetwork publicCloudNetwork = new CloudNetwork("someCloudNetwork", DEFAULT_TEST_PUBLIC_SUBNET_ID_SET.iterator().next(), Set.of(publicCloudSubnet),
+            Collections.emptyMap());
+        Map<String, Set<CloudNetwork>> publicCloudNetworksFromProvider = new LinkedHashMap<>();
+        publicCloudNetworksFromProvider.put(DEFAULT_TEST_REGION_NAME, Set.of(publicCloudNetwork));
+
+        when(testNetworkDto.getSubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(DEFAULT_TEST_PUBLIC_SUBNET_ID_SET);
+        when(testNetworkDto.getAzure()).thenReturn(azureParams);
+        when(testEnvironmentDto.getCloudPlatform()).thenReturn(AZURE_CLOUD_PLATFORM);
+        when(cloudNetworks.getCloudNetworkResponses()).thenReturn(cloudNetworksFromProvider);
+
+        Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironmentDto, testNetworkDto);
+
+        when(cloudNetworks.getCloudNetworkResponses()).thenReturn(publicCloudNetworksFromProvider);
+
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
+
+        byte expectedAmountOfResultCloudSubnet = 1;
+
+        assertNotNull(result);
+        assertEquals(expectedAmountOfResultCloudSubnet, result.size(), "The amount of result CloudSubnet(s) must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), result.get(result.keySet().iterator().next()).getId());
+
+        assertNotNull(gatewayResult);
+        assertEquals(expectedAmountOfResultCloudSubnet, gatewayResult.size(),
+            "The amount of result CloudSubnet(s) for the gateway endpoint must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_PUBLIC_SUBNET_ID_SET.iterator().next(), gatewayResult.get(gatewayResult.keySet().iterator().next()).getId());
+
+        verify(platformParameterService, times(2)).getCloudNetworks(any());
     }
 
     @Test
@@ -156,14 +338,21 @@ class CloudNetworkServiceTest {
             "from the network ids and no need for fetching anything from the provider")
     void testRetrieveSubnetMetadataByEnvironmentDtoWhenPlatformIsNeitherAzureOrAwsThenNoNeedForFetchingAnythingFromProvider() {
         when(testNetworkDto.getSubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(DEFAULT_TEST_PUBLIC_SUBNET_ID_SET);
 
         Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironmentDto, testNetworkDto);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
 
         byte expectedAmountOfResultCloudSubnet = 1;
 
         assertNotNull(result);
         assertEquals(expectedAmountOfResultCloudSubnet, result.size(), "The amount of result CloudSubnet(s) must be: " + expectedAmountOfResultCloudSubnet);
         assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), result.get(result.keySet().iterator().next()).getId());
+
+        assertNotNull(gatewayResult);
+        assertEquals(expectedAmountOfResultCloudSubnet, gatewayResult.size(),
+            "The amount of result CloudSubnet(s) for the gateway endpoint must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_PUBLIC_SUBNET_ID_SET.iterator().next(), gatewayResult.get(gatewayResult.keySet().iterator().next()).getId());
 
         verify(platformParameterService, times(0)).getCloudNetworks(any());
     }
@@ -172,19 +361,26 @@ class CloudNetworkServiceTest {
     @DisplayName("when retrieveSubnetMetadata has called with Environment and empty subnetIds, then empty map should return")
     void testRetrieveSubnetMetadataByEnvironmentWhenNetworkIsNotNullButSubnetIdSetIsEmptyThenEmptyMapReturns() {
         when(testNetworkDto.getSubnetIds()).thenReturn(Collections.emptySet());
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(Collections.emptySet());
         Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironment, testNetworkDto);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
+        assertNotNull(gatewayResult);
+        assertTrue(gatewayResult.isEmpty());
     }
 
     @Test
     @DisplayName("when retrieveSubnetMetadata has called with Environment and with a null NetworkDto then empty map should return")
     void retrieveSubnetMetadataByEnvironmentWhenNetworkIsNullThenEmptyMapReturns() {
         Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironment, null);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironment, null);
 
         assertNotNull(result);
         assertTrue(result.isEmpty());
+        assertNotNull(gatewayResult);
+        assertTrue(gatewayResult.isEmpty());
     }
 
     @Test
@@ -199,16 +395,24 @@ class CloudNetworkServiceTest {
         cloudNetworksFromProvider.put(DEFAULT_TEST_REGION_NAME, Set.of(cloudNetwork));
 
         when(testNetworkDto.getSubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
         when(testNetworkDto.getAws()).thenReturn(awsParams);
         when(testEnvironment.getCloudPlatform()).thenReturn(AWS_CLOUD_PLATFORM);
         when(cloudNetworks.getCloudNetworkResponses()).thenReturn(cloudNetworksFromProvider);
 
         Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironment, testNetworkDto);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
 
         byte expectedAmountOfResultCloudSubnet = 1;
+
         assertNotNull(result);
         assertEquals(expectedAmountOfResultCloudSubnet, result.size(), "The amount of result CloudSubnet(s) must be: " + expectedAmountOfResultCloudSubnet);
         assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), result.get(result.keySet().iterator().next()).getId());
+
+        assertNotNull(gatewayResult);
+        assertEquals(expectedAmountOfResultCloudSubnet, gatewayResult.size(),
+            "The amount of result CloudSubnet(s) for the gateway endpoint must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), gatewayResult.get(gatewayResult.keySet().iterator().next()).getId());
 
         verify(platformParameterService, times(1)).getCloudNetworks(any());
     }
@@ -226,16 +430,24 @@ class CloudNetworkServiceTest {
         cloudNetworksFromProvider.put(DEFAULT_TEST_REGION_NAME, Set.of(cloudNetwork));
 
         when(testNetworkDto.getSubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
         when(testNetworkDto.getAzure()).thenReturn(azureParams);
         when(testEnvironment.getCloudPlatform()).thenReturn(AZURE_CLOUD_PLATFORM);
         when(cloudNetworks.getCloudNetworkResponses()).thenReturn(cloudNetworksFromProvider);
 
         Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironment, testNetworkDto);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
 
         byte expectedAmountOfResultCloudSubnet = 1;
+
         assertNotNull(result);
         assertEquals(expectedAmountOfResultCloudSubnet, result.size(), "The amount of result CloudSubnet(s) must be: " + expectedAmountOfResultCloudSubnet);
         assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), result.get(result.keySet().iterator().next()).getId());
+
+        assertNotNull(gatewayResult);
+        assertEquals(expectedAmountOfResultCloudSubnet, gatewayResult.size(),
+            "The amount of result CloudSubnet(s) for the gateway endpoint must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), gatewayResult.get(gatewayResult.keySet().iterator().next()).getId());
 
         verify(platformParameterService, times(1)).getCloudNetworks(any());
     }
@@ -245,14 +457,21 @@ class CloudNetworkServiceTest {
             "from the network ids and no need for fetching anything from the provider")
     void testRetrieveSubnetMetadataByEnvironmentWhenPlatformIsNeitherAzureOrAwsThenNoNeedForFetchingAnythingFromProvider() {
         when(testNetworkDto.getSubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
+        when(testNetworkDto.getEndpointGatewaySubnetIds()).thenReturn(DEFAULT_TEST_SUBNET_ID_SET);
 
         Map<String, CloudSubnet> result = underTest.retrieveSubnetMetadata(testEnvironment, testNetworkDto);
+        Map<String, CloudSubnet> gatewayResult = underTest.retrieveEndpointGatewaySubnetMetadata(testEnvironmentDto, testNetworkDto);
 
         byte expectedAmountOfResultCloudSubnet = 1;
 
         assertNotNull(result);
         assertEquals(expectedAmountOfResultCloudSubnet, result.size(), "The amount of result CloudSubnet(s) must be: " + expectedAmountOfResultCloudSubnet);
         assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), result.get(result.keySet().iterator().next()).getId());
+
+        assertNotNull(gatewayResult);
+        assertEquals(expectedAmountOfResultCloudSubnet, gatewayResult.size(),
+            "The amount of result CloudSubnet(s) for the gateway endpoint must be: " + expectedAmountOfResultCloudSubnet);
+        assertEquals(DEFAULT_TEST_SUBNET_ID_SET.iterator().next(), gatewayResult.get(gatewayResult.keySet().iterator().next()).getId());
 
         verify(platformParameterService, times(0)).getCloudNetworks(any());
     }

--- a/environment/src/test/java/com/sequenceiq/environment/network/NetworkServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/network/NetworkServiceTest.java
@@ -71,10 +71,10 @@ public class NetworkServiceTest {
         environment.setCredential(credential);
 
         when(environmentNetworkConverterMap.get(any(CloudPlatform.class))).thenReturn(environmentNetworkConverter);
-        when(environmentNetworkConverter.convert(environment, networkDto, Collections.emptyMap())).thenReturn(baseNetwork);
+        when(environmentNetworkConverter.convert(environment, networkDto, Map.of(), Map.of())).thenReturn(baseNetwork);
         when(networkRepository.save(baseNetwork)).thenReturn(baseNetwork);
 
-        BaseNetwork result = underTest.saveNetwork(environment, networkDto, "accountId", Collections.emptyMap());
+        BaseNetwork result = underTest.saveNetwork(environment, networkDto, "accountId", Map.of(), Map.of());
 
         Assertions.assertNull(result.getNetworkCidr());
         verify(environmentNetworkService, times(0)).getNetworkCidr(eq(network), anyString(), eq(credential));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/environment/EnvironmentNetworkTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/environment/EnvironmentNetworkTestAssertion.java
@@ -1,9 +1,11 @@
 package com.sequenceiq.it.cloudbreak.assertion.environment;
 
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.api.v1.environment.model.base.PrivateSubnetCreation;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.it.cloudbreak.EnvironmentClient;
@@ -104,5 +106,27 @@ public class EnvironmentNetworkTestAssertion {
                 .filter(e -> e.getType().equals(type))
                 .collect(Collectors.toList())
                 .size();
+    }
+
+    public static Assertion<EnvironmentTestDto, EnvironmentClient> environmentWithEndpointGatewayContainsNeccessaryConfigs(Set<String> subnetIds) {
+        return (testContext, testDto, environmentClient) -> {
+            DetailedEnvironmentResponse environment = environmentClient.getEnvironmentClient().environmentV1Endpoint().getByName(testDto.getName());
+            isPublicEndpointAccessGatewayEnabled(environment);
+            subnetIdsWerePropagatedCorrectly(environment, subnetIds);
+            return testDto;
+        };
+    }
+
+    private static void isPublicEndpointAccessGatewayEnabled(DetailedEnvironmentResponse environment) {
+        if (environment.getNetwork() == null ||
+                environment.getNetwork().getPublicEndpointAccessGateway() != PublicEndpointAccessGateway.ENABLED) {
+            throw new IllegalArgumentException("Public endpoint access gateway should be enabled!");
+        }
+    }
+
+    private static void subnetIdsWerePropagatedCorrectly(DetailedEnvironmentResponse environment, Set<String> expectedSubnetIds) {
+        if (!expectedSubnetIds.equals(environment.getNetwork().getEndpointGatewaySubnetIds())) {
+            throw new IllegalArgumentException(String.format("Public endpoint access gateway subnet ids should be set to %s!", expectedSubnetIds));
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentNetworkTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentNetworkTestDto.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.it.cloudbreak.PrivateEndpointTest.PRIVATE_ENDPOINT_
 import java.util.Set;
 
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkGcpParams;
@@ -100,6 +101,16 @@ public class EnvironmentNetworkTestDto extends AbstractCloudbreakTestDto<Environ
 
     public EnvironmentNetworkTestDto withMock(EnvironmentNetworkMockParams mock) {
         getRequest().setMock(mock);
+        return this;
+    }
+
+    public EnvironmentNetworkTestDto withPublicEndpointAccessGateway(PublicEndpointAccessGateway publicEndpointAccessGateway) {
+        getRequest().setPublicEndpointAccessGateway(publicEndpointAccessGateway);
+        return this;
+    }
+
+    public EnvironmentNetworkTestDto withEndpointGatewaySubnetIds(Set<String> endpointGatewaySubnetIds) {
+        getRequest().setEndpointGatewaySubnetIds(endpointGatewaySubnetIds);
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentWithPublicEndpointAccessGatewayTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentWithPublicEndpointAccessGatewayTests.java
@@ -1,0 +1,72 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.environment;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.testng.annotations.Test;
+
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.it.cloudbreak.assertion.environment.EnvironmentNetworkTestAssertion;
+import com.sequenceiq.it.cloudbreak.client.CredentialTestClient;
+import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
+
+public class EnvironmentWithPublicEndpointAccessGatewayTests extends AbstractE2ETest {
+
+    @Inject
+    private EnvironmentTestClient environmentTestClient;
+
+    @Inject
+    private CredentialTestClient credentialTestClient;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        createDefaultUser(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(
+        given = "there is a running cloudbreak",
+        when = "create an Environment with public endpoint access gateway enabled and endpoint subnets provided",
+        then = "should persist the user settings to the environment response")
+    public void testCreateNewEnvironmentWithPublicEndpointAccessGatewayEnabled(TestContext testContext) {
+        String networkKey = "someOtherNetwork";
+        Set<String> subnetIds = Set.of("public-subnet-1", "public-subnet-2", "public-subnet-3");
+
+        testContext
+            .given(CredentialTestDto.class)
+            .when(credentialTestClient.create())
+            .given("telemetry", TelemetryTestDto.class)
+            .withLogging()
+            .withReportClusterLogs()
+
+            .given(EnvironmentTestDto.class)
+            .given(networkKey, EnvironmentNetworkTestDto.class)
+            .withNetworkCIDR("10.0.0.0/16")
+            .withPrivateSubnets()
+            .withMock(new EnvironmentNetworkMockParams())
+            .withPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED)
+            .withEndpointGatewaySubnetIds(subnetIds)
+            .given(EnvironmentTestDto.class)
+
+            .withNetwork(networkKey)
+            .withTelemetry("telemetry")
+            .withCreateFreeIpa(Boolean.FALSE)
+            .when(environmentTestClient.create())
+            .await(EnvironmentStatus.AVAILABLE)
+            .then((tc, testDto, cc) -> environmentTestClient.describe().action(tc, testDto, cc))
+            .then(EnvironmentNetworkTestAssertion.environmentWithEndpointGatewayContainsNeccessaryConfigs(subnetIds))
+            .validate();
+    }
+}

--- a/integration-test/src/main/resources/testsuites/e2e/network-endpoint-access-gateway-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/network-endpoint-access-gateway-tests.yaml
@@ -1,0 +1,5 @@
+name: "network-endpoint-access-gateway-tests"
+tests:
+  - name: "network_endpoint_access_gateway_tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentWithPublicEndpointAccessGatewayTests

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/NetworkDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/network/dto/NetworkDto.java
@@ -12,6 +12,7 @@ import org.apache.commons.collections4.MapUtils;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.api.v1.environment.model.base.PrivateSubnetCreation;
 import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.environment.network.dao.domain.RegistrationType;
@@ -42,6 +43,10 @@ public class NetworkDto {
 
     private Map<String, CloudSubnet> subnetMetas;
 
+    private PublicEndpointAccessGateway publicEndpointAccessGateway;
+
+    private Map<String, CloudSubnet> endpointGatewaySubnetMetas;
+
     private final Map<String, CloudSubnet> cbSubnets;
 
     private final Map<String, CloudSubnet> dwxSubnets;
@@ -69,6 +74,9 @@ public class NetworkDto {
         yarn = builder.yarn;
         mock = builder.mock;
         subnetMetas = MapUtils.isEmpty(builder.subnetMetas) ? new HashMap<>() : builder.subnetMetas;
+        publicEndpointAccessGateway = builder.publicEndpointAccessGateway;
+        endpointGatewaySubnetMetas = MapUtils.isEmpty(builder.endpointGatewaySubnetMetas) ?
+            new HashMap<>() : builder.endpointGatewaySubnetMetas;
         cbSubnets = builder.cbSubnets;
         dwxSubnets = builder.dwxSubnets;
         mlxSubnets = builder.mlxSubnets;
@@ -132,6 +140,10 @@ public class NetworkDto {
         return subnetMetas != null ? subnetMetas.keySet() : new HashSet<>();
     }
 
+    public Set<String> getEndpointGatewaySubnetIds() {
+        return endpointGatewaySubnetMetas != null ? endpointGatewaySubnetMetas.keySet() : new HashSet<>();
+    }
+
     public String getNetworkCidr() {
         return networkCidr;
     }
@@ -146,6 +158,22 @@ public class NetworkDto {
 
     public void setSubnetMetas(Map<String, CloudSubnet> subnetMetas) {
         this.subnetMetas = subnetMetas;
+    }
+
+    public PublicEndpointAccessGateway getPublicEndpointAccessGateway() {
+        return publicEndpointAccessGateway;
+    }
+
+    public void setPublicEndpointAccessGateway(PublicEndpointAccessGateway publicEndpointAccessGateway) {
+        this.publicEndpointAccessGateway = publicEndpointAccessGateway;
+    }
+
+    public Map<String, CloudSubnet> getEndpointGatewaySubnetMetas() {
+        return endpointGatewaySubnetMetas;
+    }
+
+    public void setEndpointGatewaySubnetMetas(Map<String, CloudSubnet> endpointGatewaySubnetMetas) {
+        this.endpointGatewaySubnetMetas = endpointGatewaySubnetMetas;
     }
 
     public Map<String, CloudSubnet> getCbSubnets() {
@@ -211,6 +239,8 @@ public class NetworkDto {
                 ", networkCidr='" + networkCidr + '\'' +
                 ", networkCidrs='" + networkCidrs + '\'' +
                 ", subnetMetas=" + subnetMetas +
+                ", publicEndpointAccessGateway=" + publicEndpointAccessGateway +
+                ", endpointGatewaySubnetMetas=" + endpointGatewaySubnetMetas +
                 ", privateSubnetCreation=" + privateSubnetCreation +
                 ", serviceEndpointCreation=" + serviceEndpointCreation +
                 ", outboundInternetTraffic=" + outboundInternetTraffic +
@@ -240,6 +270,10 @@ public class NetworkDto {
         private MockParams mock;
 
         private Map<String, CloudSubnet> subnetMetas;
+
+        private PublicEndpointAccessGateway publicEndpointAccessGateway;
+
+        private Map<String, CloudSubnet> endpointGatewaySubnetMetas;
 
         private Map<String, CloudSubnet> cbSubnets;
 
@@ -276,6 +310,8 @@ public class NetworkDto {
             yarn = networkDto.yarn;
             mock = networkDto.mock;
             subnetMetas = networkDto.subnetMetas;
+            publicEndpointAccessGateway = networkDto.publicEndpointAccessGateway;
+            endpointGatewaySubnetMetas = networkDto.endpointGatewaySubnetMetas;
             networkCidr = networkDto.networkCidr;
             privateSubnetCreation = networkDto.privateSubnetCreation;
             serviceEndpointCreation = networkDto.serviceEndpointCreation;
@@ -332,6 +368,16 @@ public class NetworkDto {
 
         public Builder withSubnetMetas(Map<String, CloudSubnet> subnetMetas) {
             this.subnetMetas = subnetMetas;
+            return this;
+        }
+
+        public Builder withUsePublicEndpointAccessGateway(PublicEndpointAccessGateway publicEndpointAccessGateway) {
+            this.publicEndpointAccessGateway = publicEndpointAccessGateway;
+            return this;
+        }
+
+        public Builder withEndpointGatewaySubnetMetas(Map<String, CloudSubnet> endpointGatewaySubnetMetas) {
+            this.endpointGatewaySubnetMetas = endpointGatewaySubnetMetas;
             return this;
         }
 


### PR DESCRIPTION
Adds new optional fields 'usePublicEndpointAccessGateway' and
'endpointGatewaySubnetIds' to the EnvironmentNetworkV1Request API object. These
fields are persisted to the EnvironmentNetwork and NetworkDto BaseNetwork
objects. Adds new columns for these fields to the environment_network table
and saves them to the database.

Tested with unit tests, and by manually setting the new fields in the IDE and
verifying they were converted/persisted in the database correctly.

See detailed description in the commit message.