### PR TITLE
CB-9462 [E2E] Enable Private Link creation in CB E2E test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/PrivateEndpointTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/PrivateEndpointTest.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.it.cloudbreak;
+
+public class PrivateEndpointTest extends GherkinTest {
+
+    public static final String PRIVATE_ENDPOINT_USAGE = "PRIVATE_ENDPOINT_USAGE";
+
+    public static final String PRIVATE_ENDPOINT_ENABLED = "enabled";
+
+    public static final String PRIVATE_ENDPOINT_DISABLED = "disabled";
+
+    private PrivateEndpointTest() {
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/ResourceGroupTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/ResourceGroupTest.java
@@ -1,14 +1,21 @@
 package com.sequenceiq.it.cloudbreak;
 
-public class ResourceGroupTest {
+public class ResourceGroupTest extends GherkinTest {
     public static final String AZURE_RESOURCE_GROUP_USAGE = "AZURE_RESOURCE_GROUP_USAGE";
 
     public static final String AZURE_RESOURCE_GROUP_USAGE_SINGLE = "SINGLE";
+
+    public static final String AZURE_RESOURCE_GROUP_USAGE_SINGLE_DEDICATED = "SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT";
 
     public static final String AZURE_RESOURCE_GROUP_USAGE_MULTIPLE = "MULTIPLE";
 
     public static final String AZURE_RESOURCE_GROUP_NAME = "AZURE_RESOURCE_GROUP_NAME";
 
     private ResourceGroupTest() {
+    }
+
+    public static boolean isSingleResourceGroup(String resourceGroupUsage) {
+        return AZURE_RESOURCE_GROUP_USAGE_SINGLE.equals(resourceGroupUsage) ||
+                AZURE_RESOURCE_GROUP_USAGE_SINGLE_DEDICATED.equals(resourceGroupUsage);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.BaseImageV4Response;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.environment.api.v1.environment.model.request.AttachedFreeIpaRequest;
 import com.sequenceiq.it.TestParameter;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
@@ -83,6 +84,11 @@ public abstract class AbstractCloudProvider implements CloudProvider {
     public DistroXImageTestDto imageSettings(DistroXImageTestDto imageSettings) {
         imageSettings.withImageCatalog(commonCloudProperties.getImageCatalogName());
         return imageSettings;
+    }
+
+    @Override
+    public ServiceEndpointCreation serviceEndpoint() {
+        return ServiceEndpointCreation.DISABLED;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.StackV4ParameterBase;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
@@ -64,6 +65,8 @@ public interface CloudProvider {
     DistroXVolumeTestDto attachedVolume(DistroXVolumeTestDto volume);
 
     NetworkV4TestDto network(NetworkV4TestDto network);
+
+    ServiceEndpointCreation serviceEndpoint();
 
     DistroXNetworkTestDto network(DistroXNetworkTestDto network);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.StackV4ParameterBase;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
@@ -182,6 +183,11 @@ public class CloudProviderProxy implements CloudProvider {
     @Override
     public NetworkV4TestDto network(NetworkV4TestDto network) {
         return getDelegate(network).network(network);
+    }
+
+    @Override
+    public ServiceEndpointCreation serviceEndpoint() {
+        return delegate.serviceEndpoint();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.common.api.type.EncryptionType;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.distrox.api.v1.distrox.model.AwsDistroXV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsEncryptionV1Parameters;
@@ -158,6 +159,11 @@ public class AwsCloudProvider extends AbstractCloudProvider {
     @Override
     public NetworkV4TestDto network(NetworkV4TestDto network) {
         return network.withAws(networkParameters());
+    }
+
+    @Override
+    public ServiceEndpointCreation serviceEndpoint() {
+        return ServiceEndpointCreation.ENABLED;
     }
 
     public AwsNetworkV4Parameters networkParameters() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsCloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.WasbCloudStorageV1Parameters;
+import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.distrox.api.v1.distrox.model.AzureDistroXV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
@@ -31,6 +32,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEn
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.ResourceGroupUsage;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.ResourceGroupTest;
 import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProvider;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
@@ -182,6 +184,16 @@ public class AzureCloudProvider extends AbstractCloudProvider {
         parameters.setResourceGroupName(azureProperties.getNetwork().getResourceGroupName());
         return network.withAzure(parameters)
                 .withSubnetCIDR(getSubnetCIDR());
+    }
+
+    @Override
+    public ServiceEndpointCreation serviceEndpoint() {
+        ServiceEndpointCreation serviceEndpointCreation =
+                ResourceGroupTest.isSingleResourceGroup(getTestParameter().get(ResourceGroupTest.AZURE_RESOURCE_GROUP_USAGE))
+                ? ServiceEndpointCreation.ENABLED_PRIVATE_ENDPOINT
+                : ServiceEndpointCreation.DISABLED;
+        LOGGER.debug("Azure service endpoint creation: {}", serviceEndpointCreation);
+        return serviceEndpointCreation;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/PrivateEndpointProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/PrivateEndpointProperties.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.it.cloudbreak.config;
+
+import static com.sequenceiq.it.cloudbreak.PrivateEndpointTest.PRIVATE_ENDPOINT_DISABLED;
+import static com.sequenceiq.it.cloudbreak.PrivateEndpointTest.PRIVATE_ENDPOINT_ENABLED;
+import static com.sequenceiq.it.cloudbreak.PrivateEndpointTest.PRIVATE_ENDPOINT_USAGE;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.it.TestParameter;
+
+@Component
+public class PrivateEndpointProperties {
+
+    @Value("${integrationtest.privateEndpointEnabled}")
+    private boolean enabled;
+
+    @Inject
+    private TestParameter testParameter;
+
+    @PostConstruct
+    private void init() {
+        testParameter.put(PRIVATE_ENDPOINT_USAGE, enabled ? PRIVATE_ENDPOINT_ENABLED : PRIVATE_ENDPOINT_DISABLED);
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentNetworkTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentNetworkTestDto.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.it.cloudbreak.dto.environment;
 
+import static com.sequenceiq.it.cloudbreak.PrivateEndpointTest.PRIVATE_ENDPOINT_ENABLED;
+import static com.sequenceiq.it.cloudbreak.PrivateEndpointTest.PRIVATE_ENDPOINT_USAGE;
+
 import java.util.Set;
 
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
@@ -9,7 +12,6 @@ import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkGcp
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkYarnParams;
 import com.sequenceiq.environment.api.v1.environment.model.base.PrivateSubnetCreation;
-import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentNetworkRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 import com.sequenceiq.it.cloudbreak.Prototype;
@@ -33,7 +35,9 @@ public class EnvironmentNetworkTestDto extends AbstractCloudbreakTestDto<Environ
     }
 
     public EnvironmentNetworkTestDto valid() {
-        return getCloudProvider().network(this);
+        return getCloudProvider()
+                .network(this)
+                .withTryUseServiceEndpoints();
     }
 
     public EnvironmentNetworkTestDto withAzure(EnvironmentNetworkAzureParams azure) {
@@ -71,8 +75,16 @@ public class EnvironmentNetworkTestDto extends AbstractCloudbreakTestDto<Environ
         return this;
     }
 
+    public EnvironmentNetworkTestDto withTryUseServiceEndpoints() {
+        if (PRIVATE_ENDPOINT_ENABLED.equals(getTestParameter().get(PRIVATE_ENDPOINT_USAGE))) {
+            LOGGER.debug("Private endpoints enabled via environment parameters");
+            withServiceEndpoints();
+        }
+        return this;
+    }
+
     public EnvironmentNetworkTestDto withServiceEndpoints() {
-        getRequest().setServiceEndpointCreation(ServiceEndpointCreation.ENABLED);
+        getRequest().setServiceEndpointCreation(getCloudProvider().serviceEndpoint());
         return this;
     }
 

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -69,6 +69,7 @@ integrationtest:
   upgrade:
     currentRuntimeVersion: 7.2.0
     targetRuntimeVersion: 7.2.6
+  privateEndpointEnabled: false
 
   spot:
     enabledCloudPlatforms:


### PR DESCRIPTION
This commit enabled to test postgres via private endpoint on azure as well. It can be turned on for AWS and AZURE via environment variable 'integrationtest.privateendpoint.enabled'. For other platforms it is disabled for now.

For AZURE it also needs to be used together with single rg option. If it is a multiple rg deployment, then private endpoints are automatically turned off in int-test.

See detailed description in the commit message.