### PR TITLE
CB-9711 - OS upgrade for datahubs should work

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDistroxFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDistroxFlowEventChainFactory.java
@@ -1,9 +1,16 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeEvent.CLUSTER_UPGRADE_INIT_EVENT;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
+
+import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,13 +21,23 @@ import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterUpgradeTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.DistroxUpgradeTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackImageUpdateTriggerEvent;
+import com.sequenceiq.cloudbreak.domain.stack.ManualClusterRepairMode;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.ClusterRepairTriggerEvent;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterRepairService;
+import com.sequenceiq.cloudbreak.service.cluster.model.HostGroupName;
+import com.sequenceiq.cloudbreak.service.cluster.model.RepairValidation;
+import com.sequenceiq.cloudbreak.service.cluster.model.Result;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 
 @Component
 public class UpgradeDistroxFlowEventChainFactory implements FlowEventChainFactory<DistroxUpgradeTriggerEvent> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeDistroxFlowEventChainFactory.class);
+
+    @Inject
+    private ClusterRepairService clusterRepairService;
 
     @Override
     public String initEvent() {
@@ -29,15 +46,33 @@ public class UpgradeDistroxFlowEventChainFactory implements FlowEventChainFactor
 
     @Override
     public Queue<Selectable> createFlowTriggerEventQueue(DistroxUpgradeTriggerEvent event) {
+        LOGGER.debug("Creating flow trigger event queue for distrox upgrade with event {}", event);
         Queue<Selectable> chain = new ConcurrentLinkedQueue<>();
         chain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
         chain.add(new ClusterUpgradeTriggerEvent(CLUSTER_UPGRADE_INIT_EVENT.event(), event.getResourceId(), event.accepted(),
                 event.getImageChangeDto().getImageId()));
         chain.add(new StackImageUpdateTriggerEvent(FlowChainTriggers.STACK_IMAGE_UPDATE_TRIGGER_EVENT, event.getImageChangeDto()));
         if (event.isReplaceVms()) {
-            // TODO
-            LOGGER.warn("Replace VMs for DistroX is not implemented!");
+            Map<String, List<String>> nodeMap = getReplaceableInstancesByHostgroup(event);
+            chain.add(new ClusterRepairTriggerEvent(FlowChainTriggers.CLUSTER_REPAIR_TRIGGER_EVENT, event.getResourceId(), nodeMap, false, true));
         }
         return chain;
+    }
+
+    private Map<String, List<String>> getReplaceableInstancesByHostgroup(DistroxUpgradeTriggerEvent event) {
+        Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> validationResult =
+                clusterRepairService.validateRepair(ManualClusterRepairMode.ALL, event.getResourceId(), Set.of(), false);
+        return toStringMap(validationResult.getSuccess());
+    }
+
+    private Map<String, List<String>> toStringMap(Map<HostGroupName, Set<InstanceMetaData>> repairableNodes) {
+        return repairableNodes
+                .entrySet()
+                .stream()
+                .collect(toMap(entry -> entry.getKey().value(),
+                        entry -> entry.getValue()
+                                .stream()
+                                .map(InstanceMetaData::getDiscoveryFQDN)
+                                .collect(toList())));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DistroxUpgradeTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DistroxUpgradeTriggerEvent.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.event;
 
+import java.util.StringJoiner;
+
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.service.image.ImageChangeDto;
 
@@ -21,5 +23,13 @@ public class DistroxUpgradeTriggerEvent extends StackEvent {
 
     public boolean isReplaceVms() {
         return replaceVms;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", DistroxUpgradeTriggerEvent.class.getSimpleName() + "[", "]")
+                .add("imageChangeDto=" + imageChangeDto)
+                .add("replaceVms=" + replaceVms)
+                .toString();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterRepairTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterRepairTriggerEvent.java
@@ -23,6 +23,14 @@ public class ClusterRepairTriggerEvent extends StackEvent {
         this.restartServices = restartServices;
     }
 
+    public ClusterRepairTriggerEvent(String event, Long stackId, Map<String, List<String>> failedNodesMap, boolean removeOnly, boolean restartServices) {
+        super(event, stackId);
+        this.failedNodesMap = failedNodesMap;
+        this.removeOnly = removeOnly;
+        this.stackId = stackId;
+        this.restartServices = restartServices;
+    }
+
     public Map<String, List<String>> getFailedNodesMap() {
         return failedNodesMap;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairService.java
@@ -138,7 +138,7 @@ public class ClusterRepairService {
         return repairStart;
     }
 
-    private Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> validateRepair(ManualClusterRepairMode repairMode, Long stackId,
+    public Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> validateRepair(ManualClusterRepairMode repairMode, Long stackId,
             Set<String> selectedParts, boolean deleteVolumes) {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         boolean reattach = !deleteVolumes;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageChangeDto.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageChangeDto.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.service.image;
 
+import java.util.StringJoiner;
+
 public class ImageChangeDto {
 
     private final Long stackId;
@@ -35,5 +37,15 @@ public class ImageChangeDto {
 
     public String getImageCatalogUrl() {
         return imageCatalogUrl;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ImageChangeDto.class.getSimpleName() + "[", "]")
+                .add("stackId=" + stackId)
+                .add("imageId='" + imageId + "'")
+                .add("imageCatalogName='" + imageCatalogName + "'")
+                .add("imageCatalogUrl='" + imageCatalogUrl + "'")
+                .toString();
     }
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/UpgradeConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/UpgradeConverter.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.distrox.v1.distrox.converter;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
@@ -22,8 +23,16 @@ public class UpgradeConverter {
         request.setLockComponents(source.getLockComponents());
         Optional.ofNullable(source.getShowAvailableImages())
                 .ifPresent(value -> request.setShowAvailableImages(UpgradeShowAvailableImages.valueOf(value.name())));
-        request.setReplaceVms(DistroxUpgradeReplaceVms.ENABLED == source.getReplaceVms());
+        request.setReplaceVms(convertReplaceVms(source));
         return request;
+    }
+
+    private boolean convertReplaceVms(DistroxUpgradeV1Request source) {
+        if (Objects.nonNull(source.getReplaceVms())) {
+            return DistroxUpgradeReplaceVms.ENABLED == source.getReplaceVms();
+        } else {
+            return Boolean.TRUE.equals(source.getLockComponents());
+        }
     }
 
     public DistroxUpgradeV1Response convert(UpgradeV4Response source) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroxUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroxUpgradeService.java
@@ -79,7 +79,7 @@ public class DistroxUpgradeService {
         ImageInfoV4Response image = imageSelector.determineImageId(request, upgradeCandidates);
         ImageChangeDto imageChangeDto = createImageChangeDto(cluster, workspaceId, image);
         Long stackId = stackService.getIdByNameOrCrnInWorkspace(cluster, workspaceId);
-        FlowIdentifier flowIdentifier = reactorFlowManager.triggerDistroxUpgrade(stackId, imageChangeDto, false);
+        FlowIdentifier flowIdentifier = reactorFlowManager.triggerDistroxUpgrade(stackId, imageChangeDto, request.getReplaceVms());
         return new UpgradeV4Response("Upgrade started with Image: " + image.getImageId(), flowIdentifier);
     }
 

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroxUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroxUpgradeServiceTest.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -132,7 +133,7 @@ class DistroxUpgradeServiceTest {
                 .thenReturn(imageChangeDto);
         when(stackService.getIdByNameOrCrnInWorkspace(CLUSTER, WS_ID)).thenReturn(STACK_ID);
         FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW_CHAIN, "asdf");
-        when(reactorFlowManager.triggerDistroxUpgrade(STACK_ID, imageChangeDto, false)).thenReturn(flowIdentifier);
+        when(reactorFlowManager.triggerDistroxUpgrade(eq(STACK_ID), eq(imageChangeDto), anyBoolean())).thenReturn(flowIdentifier);
 
         UpgradeV4Response result = underTest.triggerUpgrade(CLUSTER, WS_ID, USER_CRN, request);
 
@@ -161,7 +162,7 @@ class DistroxUpgradeServiceTest {
                 .thenReturn(imageChangeDto);
         when(stackService.getIdByNameOrCrnInWorkspace(CLUSTER, WS_ID)).thenReturn(STACK_ID);
         FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW_CHAIN, "asdf");
-        when(reactorFlowManager.triggerDistroxUpgrade(STACK_ID, imageChangeDto, false)).thenReturn(flowIdentifier);
+        when(reactorFlowManager.triggerDistroxUpgrade(eq(STACK_ID), eq(imageChangeDto), anyBoolean())).thenReturn(flowIdentifier);
 
         UpgradeV4Response result = underTest.triggerUpgrade(CLUSTER, WS_ID, USER_CRN, request);
 


### PR DESCRIPTION
Data Hub OS upgrades are supported via cli with " --lock-components --replace-vms ENABLED"