### PR TITLE
ENGESC-5190 Make Hue follow the HDFS failovers using WebHDFS

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.0.2/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.0.2/cdp-data-engineering-ha.bp
@@ -81,6 +81,11 @@
                 "value": "true"
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },
@@ -351,6 +356,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.1.0/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.1.0/cdp-data-engineering-ha.bp
@@ -85,6 +85,11 @@
                 "value": "true"
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },
@@ -407,6 +412,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.0/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.0/cdp-data-engineering-ha.bp
@@ -109,6 +109,11 @@
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },
@@ -471,6 +476,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.1/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.1/cdp-data-engineering-ha.bp
@@ -109,6 +109,11 @@
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },
@@ -471,6 +476,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-ha.bp
@@ -109,6 +109,11 @@
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },
@@ -471,6 +476,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-ha.bp
@@ -109,6 +109,11 @@
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },
@@ -471,6 +476,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-ha.bp
@@ -109,6 +109,11 @@
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },
@@ -471,6 +476,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",


### PR DESCRIPTION
1. In the tagged engineering escalation we saw a scenario Hue did not follow the HDFS failover.
2. The suggested approach was to use HTTPFS role for hue_webhdfs.
3. Used this template as a custom template to create a cluster and verify that hue_webhdfs indeed points to HTTPFS role.