### PR TITLE
CB-10290: Fix the FreeIPA log message for the old instance's status

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/ProviderChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/ProviderChecker.java
@@ -124,13 +124,14 @@ public class ProviderChecker {
     }
 
     private void setStatusIfNotTheSame(InstanceMetaData instanceMetaData, InstanceStatus newStatus) {
-        if (instanceMetaData.getInstanceStatus() != newStatus) {
+        InstanceStatus oldStatus = instanceMetaData.getInstanceStatus();
+        if (oldStatus != newStatus) {
             if (updateStatus) {
                 instanceMetaData.setInstanceStatus(newStatus);
-                LOGGER.info(":::Auto sync::: The instance status updated from {} to {}", instanceMetaData.getInstanceStatus(), newStatus);
+                LOGGER.info(":::Auto sync::: The instance status updated from {} to {}", oldStatus, newStatus);
             } else {
                 LOGGER.info(":::Auto sync::: The instance status would be had to update from {} to {}",
-                        instanceMetaData.getInstanceStatus(), newStatus);
+                        oldStatus, newStatus);
             }
         }
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
@@ -186,13 +186,14 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     }
 
     private void setStatusIfNotTheSame(InstanceMetaData instanceMetaData, InstanceStatus newStatus) {
-        if (instanceMetaData.getInstanceStatus() != newStatus) {
+        InstanceStatus oldStatus = instanceMetaData.getInstanceStatus();
+        if (oldStatus != newStatus) {
             if (updateStatus) {
                 instanceMetaData.setInstanceStatus(newStatus);
-                LOGGER.info(":::Auto sync::: The instance status updated from {} to {}", instanceMetaData.getInstanceStatus(), newStatus);
+                LOGGER.info(":::Auto sync::: The instance status updated from {} to {}", oldStatus, newStatus);
             } else {
                 LOGGER.info(":::Auto sync::: The instance status would be had to update from {} to {}",
-                        instanceMetaData.getInstanceStatus(), newStatus);
+                        oldStatus, newStatus);
             }
         }
     }


### PR DESCRIPTION
Fix the FreeIPA log message for the old instance's status.

This was manually tested with a local deployment of cloudbreak.

See detailed description in the commit message.