### PR TITLE
CB-9972 If freeipa is in unreachable state, badgateway http status code will return instead of internal server error in the freeipa endpoint responses

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/InvalidFreeIpaStateException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/InvalidFreeIpaStateException.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.freeipa.client;
+
+public class InvalidFreeIpaStateException extends RuntimeException {
+    public InvalidFreeIpaStateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/mapper/FreeipaClientExceptionWrapperMapper.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/mapper/FreeipaClientExceptionWrapperMapper.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.freeipa.controller.mapper;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.exception.ExceptionResponse;
+import com.sequenceiq.freeipa.client.FreeIpaClientExceptionWrapper;
+
+@Component
+public class FreeipaClientExceptionWrapperMapper extends BaseExceptionMapper<FreeIpaClientExceptionWrapper> {
+
+    @Override
+    protected Object getEntity(FreeIpaClientExceptionWrapper exception) {
+        return new ExceptionResponse("Error during interaction with FreeIPA: " + exception.getWrappedException().getMessage());
+    }
+
+    @Override
+    Status getResponseStatus() {
+        return Status.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    Class<FreeIpaClientExceptionWrapper> getExceptionType() {
+        return FreeIpaClientExceptionWrapper.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/mapper/InvalidFreeIpaStateExceptionMapper.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/mapper/InvalidFreeIpaStateExceptionMapper.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.freeipa.controller.mapper;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.exception.ExceptionResponse;
+import com.sequenceiq.freeipa.client.InvalidFreeIpaStateException;
+
+@Component
+public class InvalidFreeIpaStateExceptionMapper extends BaseExceptionMapper<InvalidFreeIpaStateException> {
+
+    @Override
+    protected Object getEntity(InvalidFreeIpaStateException exception) {
+        return new ExceptionResponse("Error during interaction with FreeIPA: " + exception.getMessage());
+    }
+
+    @Override
+    Status getResponseStatus() {
+        return Status.BAD_GATEWAY;
+    }
+
+    @Override
+    Class<InvalidFreeIpaStateException> getExceptionType() {
+        return InvalidFreeIpaStateException.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/CertRevokeHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/CertRevokeHandler.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.cert.RevokeCertsRequest;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.cert.RevokeCertsResponse;
 import com.sequenceiq.freeipa.service.freeipa.cleanup.CleanupService;
@@ -46,7 +45,7 @@ public class CertRevokeHandler implements EventHandler<RevokeCertsRequest> {
             eventBus.notify(response.getCertCleanupFailed().isEmpty()
                             ? EventSelectorUtil.selector(RevokeCertsResponse.class) : EventSelectorUtil.failureSelector(RevokeCertsResponse.class),
                     new Event<>(event.getHeaders(), response));
-        } catch (FreeIpaClientException e) {
+        } catch (Exception e) {
             LOGGER.error("Revoking of certificates failed for hosts: [{}]", request.getHosts(), e);
             Map<String, String> failureResult = request.getHosts().stream().collect(Collectors.toMap(h -> h, h -> e.getMessage()));
             RevokeCertsResponse response = new RevokeCertsResponse(request, Collections.emptySet(), failureResult);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/DnsRemoveHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/DnsRemoveHandler.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.dns.RemoveDnsRequest;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.dns.RemoveDnsResponse;
@@ -53,7 +52,7 @@ public class DnsRemoveHandler implements EventHandler<RemoveDnsRequest> {
             eventBus.notify(response.getDnsCleanupFailed().isEmpty()
                             ? EventSelectorUtil.selector(RemoveDnsResponse.class) : EventSelectorUtil.failureSelector(RemoveDnsResponse.class),
                     new Event<>(event.getHeaders(), response));
-        } catch (FreeIpaClientException e) {
+        } catch (Exception e) {
             LOGGER.error("Removing DNS entries failed for hosts: [{}]", request.getHosts(), e);
             Map<String, String> failureResult = request.getHosts().stream().collect(Collectors.toMap(h -> h, h -> e.getMessage()));
             RemoveDnsResponse response = new RemoveDnsResponse(request, Collections.emptySet(), failureResult);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/HostRemoveHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/HostRemoveHandler.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.host.RemoveHostsRequest;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.host.RemoveHostsResponse;
 import com.sequenceiq.freeipa.service.freeipa.cleanup.CleanupService;
@@ -47,7 +46,7 @@ public class HostRemoveHandler implements EventHandler<RemoveHostsRequest> {
             eventBus.notify(response.getHostCleanupFailed().isEmpty()
                             ? EventSelectorUtil.selector(RemoveHostsResponse.class) : EventSelectorUtil.failureSelector(RemoveHostsResponse.class),
                     new Event<>(event.getHeaders(), response));
-        } catch (FreeIpaClientException e) {
+        } catch (Exception e) {
             LOGGER.error("Removing failed for hosts: [{}]", request.getHosts(), e);
             Map<String, String> failureResult = request.getHosts().stream().collect(Collectors.toMap(h -> h, h -> e.getMessage()));
             RemoveHostsResponse response = new RemoveHostsResponse(request, Collections.emptySet(), failureResult);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/RoleRemoveHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/RoleRemoveHandler.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.roles.RemoveRolesRequest;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.roles.RemoveRolesResponse;
 import com.sequenceiq.freeipa.service.freeipa.cleanup.CleanupService;
@@ -47,7 +46,7 @@ public class RoleRemoveHandler implements EventHandler<RemoveRolesRequest> {
             eventBus.notify(response.getRoleCleanupFailed().isEmpty()
                             ? EventSelectorUtil.selector(RemoveRolesResponse.class) : EventSelectorUtil.failureSelector(RemoveRolesResponse.class),
                     new Event<>(event.getHeaders(), response));
-        } catch (FreeIpaClientException e) {
+        } catch (Exception e) {
             LOGGER.error("Removing roles failed: [{}]", request.getRoles(), e);
             Map<String, String> failureResult = request.getRoles().stream().collect(Collectors.toMap(h -> h, h -> e.getMessage()));
             RemoveRolesResponse response = new RemoveRolesResponse(request, Collections.emptySet(), failureResult);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/UserRemoveHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/UserRemoveHandler.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.users.RemoveUsersRequest;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.users.RemoveUsersResponse;
 import com.sequenceiq.freeipa.service.freeipa.cleanup.CleanupService;
@@ -47,7 +46,7 @@ public class UserRemoveHandler implements EventHandler<RemoveUsersRequest> {
             eventBus.notify(response.getUserCleanupFailed().isEmpty()
                             ? EventSelectorUtil.selector(RemoveUsersResponse.class) : EventSelectorUtil.failureSelector(RemoveUsersResponse.class),
                     new Event<>(event.getHeaders(), response));
-        } catch (FreeIpaClientException e) {
+        } catch (Exception e) {
             LOGGER.error("Removing users failed: [{}]", request.getUsers(), e);
             Map<String, String> failureResult = request.getUsers().stream().collect(Collectors.toMap(h -> h, h -> e.getMessage()));
             RemoveUsersResponse response = new RemoveUsersResponse(request, Collections.emptySet(), failureResult);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/VaultRemoveHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/handler/VaultRemoveHandler.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.vault.RemoveVaultEntriesRequest;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.vault.RemoveVaultEntriesResponse;
 import com.sequenceiq.freeipa.service.freeipa.cleanup.CleanupService;
@@ -47,7 +46,7 @@ public class VaultRemoveHandler implements EventHandler<RemoveVaultEntriesReques
             eventBus.notify(response.getVaultCleanupFailed().isEmpty()
                             ? EventSelectorUtil.selector(RemoveVaultEntriesResponse.class) : EventSelectorUtil.failureSelector(RemoveVaultEntriesResponse.class),
                     new Event<>(event.getHeaders(), response));
-        } catch (FreeIpaClientException e) {
+        } catch (Exception e) {
             LOGGER.error("Removing vault entries for hosts failed: [{}]", request.getHosts(), e);
             Map<String, String> failureResult = request.getHosts().stream().collect(Collectors.toMap(h -> h, h -> e.getMessage()));
             RemoveVaultEntriesResponse response = new RemoveVaultEntriesResponse(request, Collections.emptySet(), failureResult);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/ServerRemoveHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/ServerRemoveHandler.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.event.removeserver.RemoveServersRequest;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.event.removeserver.RemoveServersResponse;
 import com.sequenceiq.freeipa.service.freeipa.cleanup.CleanupService;
@@ -49,7 +48,7 @@ public class ServerRemoveHandler implements EventHandler<RemoveServersRequest> {
             eventBus.notify(response.getServerCleanupFailed().isEmpty()
                             ? EventSelectorUtil.selector(RemoveServersResponse.class) : EventSelectorUtil.failureSelector(RemoveServersResponse.class),
                     new Event<>(event.getHeaders(), response));
-        } catch (FreeIpaClientException e) {
+        } catch (Exception e) {
             LOGGER.error("Removing failed for servers: [{}]", request.getHosts(), e);
             Map<String, String> failureResult = request.getHosts().stream().collect(Collectors.toMap(h -> h, h -> e.getMessage()));
             RemoveServersResponse response = new RemoveServersResponse(request, Collections.emptySet(), failureResult);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactory.java
@@ -27,6 +27,7 @@ import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientBuilder;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.FreeIpaHostNotAvailableException;
+import com.sequenceiq.freeipa.client.InvalidFreeIpaStateException;
 import com.sequenceiq.freeipa.client.RetryableFreeIpaClientException;
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
@@ -131,7 +132,7 @@ public class FreeIpaClientFactory {
                         client = getFreeIpaClientForDirectConnect(stack, instanceMetaData, withPing, !instanceIterator.hasNext());
                     }
                 }
-                return client.orElseThrow(() -> createFreeIpaUnableToBuildClient(new FreeIpaHostNotAvailableException("No FreeIPA client was available")));
+                return client.orElseThrow(() -> new FreeIpaHostNotAvailableException("No FreeIPA client was available"));
             } catch (RetryableFreeIpaClientException e) {
                 throw createFreeIpaUnableToBuildClient(e);
             } catch (Exception e) {
@@ -228,10 +229,10 @@ public class FreeIpaClientFactory {
         return new FreeIpaClientBuilder(ADMIN_USER, freeIpa.getAdminPassword(), httpClientConfig, gatewayPort, instanceMetaData.getDiscoveryFQDN(), tracer);
     }
 
-    private FreeIpaClientException createFreeIpaStateIsInvalidException(Status stackStatus) {
+    private InvalidFreeIpaStateException createFreeIpaStateIsInvalidException(Status stackStatus) {
         String message = String.format("Couldn't build FreeIPA client. Because FreeIPA is in invalid state: '%s'", stackStatus);
         LOGGER.warn(message);
-        return new FreeIpaClientException(message, new FreeIpaHostNotAvailableException(message));
+        return new InvalidFreeIpaStateException(message, new FreeIpaHostNotAvailableException(message));
     }
 
     private FreeIpaClientException createFreeIpaUnableToBuildClient(Exception e) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactoryTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaClientFactoryTest.java
@@ -23,6 +23,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.FreeIpaHostNotAvailableException;
+import com.sequenceiq.freeipa.client.InvalidFreeIpaStateException;
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.InstanceGroup;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
@@ -75,7 +76,7 @@ class FreeIpaClientFactoryTest {
         StackStatus stackStatus = new StackStatus(stack, unreachableState, "The FreeIPA instance is unreachable.", DetailedStackStatus.UNREACHABLE);
         stack.setStackStatus(stackStatus);
 
-        Assertions.assertThrows(FreeIpaClientException.class, () -> underTest.getFreeIpaClientForStack(stack));
+        Assertions.assertThrows(InvalidFreeIpaStateException.class, () -> underTest.getFreeIpaClientForStack(stack));
     }
 
     @Test


### PR DESCRIPTION
Whenever the FreeIPA instance is not reachable and we know it's not reachable because the status indicates it, we're going to return 502 Bad Gateway.

According to the official explanation of the status code:
The server was acting as a gateway or proxy and received an invalid response from the upstream server.

If we don't know that the IPA server is not reachable, because we think it's available, that will remain an Internal Server Error.

See detailed description in the commit message.