### PR TITLE
CB-9973 checks removable nodes to available nodes in order to avoid c…

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissioner.java
@@ -97,7 +97,12 @@ public class ClouderaManagerDecomissioner {
                 if (!removableHostsInHostGroup.isEmpty()) {
                     String hostGroupName = hostGroup.getName();
                     int replication = hostGroupNodesAreDataNodes(hostTemplates, hostGroupName) ? getReplicationFactor(client, stack.getName()) : 0;
-                    verifyNodeCount(replication, removableHostsInHostGroup.size(), hostGroup.getInstanceGroup().getRunningInstanceMetaDataSet().size(),
+
+                    Set<InstanceMetaData> runningInstances = hostGroup.getInstanceGroup().getRunningInstanceMetaDataSet();
+                    int removableSizeFromTheRunning = Math.toIntExact(removableHostsInHostGroup.stream()
+                            .filter(instance -> runningInstances.contains(instance))
+                            .count());
+                    verifyNodeCount(replication, removableSizeFromTheRunning, runningInstances.size(),
                             0, stack);
                 }
             }


### PR DESCRIPTION
…alculating unavailable nodes when remove (downscale). before this removing unavaiable nodes could cause exception about replication factor

See detailed description in the commit message.