### PR TITLE
CB-10320: Do not enable HBase on S3 for 7.2.6 when Raz is enabled

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -32,6 +32,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_2_6 = () -> "7.2.6";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_2_7 = () -> "7.2.7";
+
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CMRepositoryVersionUtil.class);

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hbase;
 
-import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_2;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_7;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
@@ -54,13 +54,13 @@ public class HbaseCloudStorageServiceConfigProvider implements CmTemplateCompone
                 .map(SharedServiceConfigsView::isDatalakeCluster)
                 .orElse(false);
         String cdhVersion = getCdhVersion(source);
-        boolean is722OrNewer = isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_2);
+        boolean is727OrNewer = isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_7);
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         boolean sdxHbaseCloudStorageEnabled =
                 entitlementService.sdxHbaseCloudStorageEnabled(accountId);
         return source.getFileSystemConfigurationView().isPresent()
                 && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes())
-                && (!datalakeCluster || (is722OrNewer && sdxHbaseCloudStorageEnabled));
+                && (!datalakeCluster || (is727OrNewer && sdxHbaseCloudStorageEnabled));
     }
 
     private String getCdhVersion(TemplatePreparationObject source) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProviderTest.java
@@ -121,8 +121,18 @@ public class HbaseCloudStorageServiceConfigProviderTest {
     }
 
     @Test
-    public void testConfigurationNeededWhenDatalake722() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.2");
+    public void testConfigurationNotNeededWhenDataLake726() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.6");
+        String inputJson = getBlueprintText("input/clouderamanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+
+        boolean configurationNeeded = underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject);
+        assertFalse(configurationNeeded);
+    }
+
+    @Test
+    public void testConfigurationNeededWhenDatalake727() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.7");
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 
@@ -131,8 +141,8 @@ public class HbaseCloudStorageServiceConfigProviderTest {
     }
 
     @Test
-    public void testConfigurationNeededWhenDatalake723() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.3");
+    public void testConfigurationNeededWhenDatalake728() {
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.8");
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 


### PR DESCRIPTION
RAZ is enabled on 7.2.6, but the code change for HBase feature supporting RAZ is only on 7.2.7. Therefore, only enable HBase cloud storage feature on 7.2.7+.