### PR TITLE
CB-9681 We cannot fetch the deletion's flow identifier. The deletion …

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.withoutLogError;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -119,8 +118,10 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
                 .await(STACK_AVAILABLE)
                 .then(DistroXClusterCreationTest::distroxServiceTypeTagExists)
                 .then(auditGrpcServiceAssertion::create)
-                .when(distroXClient.forceDelete(), withoutLogError())
-                .await(STACK_DELETED)
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.delete())
+                .await(EnvironmentStatus.ARCHIVED)
+                .given(DistroXTestDto.class)
                 .then(auditGrpcServiceAssertion::delete)
                 .validate();
     }


### PR DESCRIPTION
…operation does not give back the identifier and we don't have any endpoint to fetch the last/current flow. The FlowEnpoint is internal only and this endpoint is callable by the internal user. This is the problem, the internal user and acting user workspaces are different and cannot access the distrox.

See detailed description in the commit message.