### PR TITLE
CB-9745 Enabling Knox sticky sessions for ui and api requests.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -258,11 +258,11 @@
              {% if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>RANGER</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
              </param>
              <param>
                  <name>RANGERUI</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enableStickySession=true;noFallback=true;enableLoadBalancing=true</value>
              </param>
              {%- endif %}
              {% if 'YARNUIV2' in exposed and 'RESOURCEMANAGER' in salt['pillar.get']('gateway:location') -%}
@@ -278,7 +278,7 @@
              {% if 'SOLR' in exposed and 'SOLR_SERVER' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>SOLR</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enableStickySession=true;noFallback=true;enableLoadBalancing=true</value>
              </param>
              {%- endif %}
              {% if 'JOBHISTORYUI' in exposed and 'JOBHISTORY' in salt['pillar.get']('gateway:location') -%}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -165,7 +165,7 @@
             {% if 'HIVE' in exposed and 'HIVESERVER2' in salt['pillar.get']('gateway:location') -%}
             <param>
                 <name>HIVE</name>
-                <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                <value>enableStickySession=true;noFallback=true;enableLoadBalancing=true</value>
             </param>
             {%- endif %}
             {% if 'LIVYSERVER_API' in exposed and 'LIVY_SERVER' in salt['pillar.get']('gateway:location') -%}
@@ -195,7 +195,7 @@
             {% if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}
             <param>
                 <name>RANGER</name>
-                <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                <value>enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
             </param>
             {%- endif %}
             {% if 'YARNUIV2' in exposed and 'RESOURCEMANAGER' in salt['pillar.get']('gateway:location') -%}
@@ -219,7 +219,7 @@
             {% if 'SOLR' in exposed and 'SOLR_SERVER' in salt['pillar.get']('gateway:location') -%}
             <param>
                 <name>SOLR</name>
-                <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                <value>enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
             </param>
             {%- endif %}
             {% if 'IMPALA' in exposed and 'IMPALAD' in salt['pillar.get']('gateway:location') -%}
@@ -237,7 +237,7 @@
             {% if 'AVATICA' in exposed and 'PHOENIX_QUERY_SERVER' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>AVATICA</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enableStickySession=true;noFallback=true;enableLoadBalancing=true</value>
              </param>
              {%- endif %}
             {% if 'NIFI-REGISTRY-REST' in exposed and 'NIFI_REGISTRY_SERVER' in salt['pillar.get']('gateway:location') -%}


### PR DESCRIPTION
This also enables round robining to all the hosts in the topology,
and should not affect Knox services that do not have this enabled.

See detailed description in the commit message.