### PR TITLE
CB-10327 Fixes:

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.it.cloudbreak;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
@@ -10,6 +11,7 @@ import com.sequenceiq.flow.api.FlowPublicEndpoint;
 import com.sequenceiq.it.IntegrationTestContext;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.WaitService;
@@ -60,5 +62,10 @@ public class UmsClient extends MicroserviceClient {
 
     public GrpcUmsClient getUmsClient() {
         return umsClient;
+    }
+
+    @Override
+    public Set<String> supportedTestDtos() {
+        return Set.of(UmsTestDto.class.getSimpleName());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -654,7 +654,7 @@ public abstract class TestContext implements ApplicationContextAware {
 
     public <U extends MicroserviceClient> U getMicroserviceClient(Class<? extends CloudbreakTestDto> testDtoClass, String who) {
 
-        if (clients.get(who).isEmpty()) {
+        if (clients.get(who) == null || clients.get(who).isEmpty()) {
             throw new IllegalStateException("Should create a client for this user: " + who);
         }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxSecurityTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxSecurityTests.java
@@ -73,7 +73,7 @@ public class SdxSecurityTests extends PreconditionSdxE2ETest {
                     return testDto;
                 })
                 .when(sdxTestClient.rotateAutotlsCertificates(), key(sdx))
-                .await(SdxClusterStatusResponse.CERT_ROTATION_IN_PROGRESS, key(sdx))
+                .await(SdxClusterStatusResponse.CERT_ROTATION_IN_PROGRESS, key(sdx).withWaitForFlow(false))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForInstance(getSdxInstancesHealthyState())
                 .then((tc, testDto, client) -> {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceWaitObject.java
@@ -124,8 +124,8 @@ public class InstanceWaitObject implements WaitObject {
 
     @Override
     public boolean isDeletionCheck() {
-        Set<InstanceStatus> failedStatuses = Set.of(FAILED, ORCHESTRATION_FAILED, DECOMMISSION_FAILED);
-        return failedStatuses.contains(desiredStatus);
+        Set<InstanceStatus> deletedStatuses = Set.of(DELETED_ON_PROVIDER_SIDE, DELETED_BY_PROVIDER, DECOMMISSIONED, TERMINATED);
+        return deletedStatuses.contains(desiredStatus);
     }
 
     @Override


### PR DESCRIPTION
CB-10327 Fixes:
* wrong deletion check in instance wait object
* we don't need to wait to the flow in case of CERT_ROTATION_IN_PROGRESS
* missing supported dto in UmsClient: UmsTestDto
missing null check at clients

See detailed description in the commit message.