### PR TITLE
CB-10348 Fix misleading cluster definition errors

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clustertemplate/ClusterTemplateV4Base.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/clustertemplate/ClusterTemplateV4Base.java
@@ -15,9 +15,9 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel
 public abstract class ClusterTemplateV4Base implements JsonEntity {
 
-    @Size(max = 40, min = 5, message = "The length of the cluster's name has to be in range of 5 to 40")
+    @Size(max = 40, min = 5, message = "The length of name has to be in range of 5 to 40")
     @Pattern(regexp = "^[^;\\/%]*$",
-            message = "The length of the cluster template's name has to be in range of 1 to 100 and should not contain semicolon")
+            message = "Name should not contain semicolon, forward slash or percentage characters")
     @NotNull
     @ApiModelProperty(value = ModelDescriptions.NAME, required = true)
     private String name;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -251,7 +251,7 @@ public class ClusterTemplateTest extends AbstractMockTest {
                 .withName(ILLEGAL_CT_NAME)
                 .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
                 .expect(BadRequestException.class, RunningParameter.key(generatedKey)
-                        .withExpectedMessage("The length of the cluster template's name has to be in range of 1 to 100 and should not contain semicolon"))
+                        .withExpectedMessage("Name should not contain semicolon, forward slash or percentage characters"))
                 .validate();
     }
 
@@ -291,7 +291,7 @@ public class ClusterTemplateTest extends AbstractMockTest {
                 .withName(getLongNameGenerator().stringGenerator(2))
                 .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
                 .expect(BadRequestException.class, RunningParameter.key(generatedKey)
-                        .withExpectedMessage("The length of the cluster's name has to be in range of 5 to 40")
+                        .withExpectedMessage("The length of name has to be in range of 5 to 40")
                 )
                 .validate();
     }
@@ -433,7 +433,7 @@ public class ClusterTemplateTest extends AbstractMockTest {
                         .withSkipOnFail(false))
                 .expect(BadRequestException.class, RunningParameter.key(generatedKey1).withExpectedMessage("must not be null"))
                 .expect(BadRequestException.class, RunningParameter.key(generatedKey2)
-                        .withExpectedMessage("The length of the cluster's name has to be in range of 5 to 40"))
+                        .withExpectedMessage("The length of name has to be in range of 5 to 40"))
                 .validate();
     }
 


### PR DESCRIPTION
Also, I have omitted "Template" from the messages as it is being used for Definitions. 