### PR TITLE
CB-10401: Modify the e2e test configuration to use CDH 7.2.6

### DIFF
--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -68,7 +68,7 @@ integrationtest:
   runtimeVersion: 7.2.7
   upgrade:
     currentRuntimeVersion: 7.2.0
-    targetRuntimeVersion: 7.2.7
+    targetRuntimeVersion: 7.2.6
   privateEndpointEnabled: false
 
   spot:


### PR DESCRIPTION
Modify the e2e test configuration to use CDH 7.2.6 for target version instead of CDH 7.2.7 because currently, the upgrade is not working for CDH 7.2.7