### PR TITLE
CB-8937: ipa-custodia and ipa-dnskeysyncd restart after 60 seconds

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/services.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/services.sls
@@ -1,3 +1,31 @@
+ipadnskeysyncdRestart:
+   file.replace:
+    - name: /usr/lib/systemd/system/ipa-dnskeysyncd.service
+    - pattern: '^Restart=.*'
+    - repl: 'Restart=always'
+    - backup: False
+
+ipadnskeysyncdRestartSec:
+   file.replace:
+     - name: /usr/lib/systemd/system/ipa-dnskeysyncd.service
+     - pattern: '^RestartSec=.*'
+     - repl: 'RestartSec=3'
+     - backup: False
+
+ipacustodiaRestart:
+   file.replace:
+    - name: /usr/lib/systemd/system/ipa-custodia.service
+    - pattern: '^Restart=.*'
+    - repl: 'Restart=always'
+    - backup: False
+
+ipacustodiaRestartSec:
+   file.replace:
+     - name: /usr/lib/systemd/system/ipa-custodia.service
+     - pattern: '^RestartSec=.*'
+     - repl: 'RestartSec=3'
+     - backup: False
+
 {%- if grains['init'] == 'systemd' %}
 {%- for service in pillar['freeipa']['services'] %}
 {%- set command = 'systemctl show -p FragmentPath ' + service %}


### PR DESCRIPTION
ipa-custodia and ipa-dnskeysyncd now will automatically restart after 60 seconds with failure exit code. We change it to 3 seconds and always to be consistent with all other services.

See detailed description in the commit message.