### PR TITLE
CB-10029 Azure managed image creation error can potentially lock user out from using its single RG or subscription

### DIFF
--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageServiceTest.java
@@ -89,7 +89,7 @@ public class AzureImageServiceTest {
     }
 
     @Test
-    public void testFindCustomImageWhenImageExistsOnAzure() {
+    public void testFindCustomImageWhenImageExistsOnAzure() throws Exception {
         imagePresent(true);
 
         Optional<AzureImage> azureImageOptional = underTest.findImage(azureImageInfo, azureClient, authenticatedContext);
@@ -99,7 +99,7 @@ public class AzureImageServiceTest {
     }
 
     @Test
-    public void testFindCustomImageWhenImageIsRequested() {
+    public void testFindCustomImageWhenImageIsRequested() throws Exception {
         imagePresent(false);
         imageRequested(true);
 
@@ -110,7 +110,7 @@ public class AzureImageServiceTest {
     }
 
     @Test
-    public void testFindCustomImageWhenImageWasNotRequested() {
+    public void testFindCustomImageWhenImageWasNotRequested() throws Exception {
         imagePresent(false);
         imageRequested(false);
 
@@ -181,7 +181,7 @@ public class AzureImageServiceTest {
 
     }
 
-    private void verifyPollingStarted() {
+    private void verifyPollingStarted() throws Exception {
         ArgumentCaptor<AzureManagedImageCreationCheckerContext> captor = ArgumentCaptor.forClass(AzureManagedImageCreationCheckerContext.class);
         verify(azureManagedImageCreationPoller).startPolling(any(), captor.capture());
         assertEquals(CUSTOM_IMAGE_NAME_WITH_REGION, captor.getValue().getAzureImageInfo().getImageNameWithRegion());


### PR DESCRIPTION
The problem: when a user wants to use a new image, it needs to be copied to its storage account and then a managed image is created from it. The first step in image creation is to persist an image resource to database with status REQUESTED. If an exception comes during image creation then a polling is done. If after the polling the image is still not present then the exception is re-thrown and the user is notified.
However, unbeknownst to the developers, the poller throws an exception on timeout - the code that would set image status to FAILED is not run any more. An image in REQUESTED state would then block the usage of that image forever, it is a trap state.

Solution: the poller after image creation does not throw an exception on any error but lets the calling code decide what to do.