### PR TITLE
CB-10406. Diagnostics: Support destination for DL/DH fails with clust…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/altus/AltusMachineUserService.java
@@ -100,7 +100,7 @@ public class AltusMachineUserService {
     public DataBusCredential getOrCreateDataBusCredentialIfNeeded(Long stackId) throws IOException {
         LOGGER.debug("Get or create databus credential for stack");
         Stack stack = stackService.get(stackId);
-        Cluster cluster = clusterService.getById(stack.getId());
+        Cluster cluster = clusterService.getCluster(stack);
         cluster.getDatabusCredential();
         Telemetry telemetry = componentConfigProviderService.getTelemetry(stack.getId());
         if (cluster.getDatabusCredential() != null) {


### PR DESCRIPTION
…er not found error.

details:
- this happens if the cluster id is not the same as the stack id

See detailed description in the commit message.