### PR TITLE
CB-10411: Add FreeIPA backup debug to logs

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backups.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backups.sls
@@ -13,6 +13,14 @@
     - group: root
     - mode: 640
 
+/usr/local/bin/backup-log-filter.sh:
+  file.managed:
+    - makedirs: True
+    - user: root
+    - group: root
+    - mode: 700
+    - source: salt://freeipa/scripts/backup-log-filter.sh
+
 {% if salt['pillar.get']('freeipa:backup:enabled') %}
 {% if salt['pillar.get']('freeipa:backup:initial_full_enabled') %}
 freeipa_initial_full_backup:
@@ -21,6 +29,7 @@ freeipa_initial_full_backup:
     - unless: test -f /var/log/freeipa_initial_backup-executed
     - require:
         - file: /usr/local/bin/freeipa_backup
+        - file: /usr/local/bin/backup-log-filter.sh
         - file: /etc/freeipa_backup.conf
 {% endif %}
 

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/backup-log-filter.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/backup-log-filter.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+while read line; do
+  echo "$line" | sed -u -E 's/(x-amz-security-token:)([A-Za-z0-9/+]*[=]*)/\1[FILTERED]/g'
+done

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
@@ -149,15 +149,15 @@ remove_local_backups() {
 upload_aws_backup() {
     echo "try to upload with AES256 encryption"
     # shellcheck disable=SC2086
-    /usr/bin/aws ${REGION_OPTION} s3 cp --recursive --sse AES256 --no-progress "${config[backup_path]}/${BACKUPDIR}" "${BACKUP_LOCATION}/${BACKUPDIR}" >> "${LOGFILE}" 2>&1
-    ret_code=$?
+    /usr/bin/aws ${REGION_OPTION} s3 cp --debug --recursive --sse AES256 --no-progress "${config[backup_path]}/${BACKUPDIR}" "${BACKUP_LOCATION}/${BACKUPDIR}" 2>&1 | /usr/local/bin/backup-log-filter.sh | tee -a "${LOGFILE}"
+    ret_code=${PIPESTATUS[0]}
 
     if [[ "$ret_code" -ne "0" ]]
     then
         echo "try to upload with aws:kms encryption"
         # shellcheck disable=SC2086
-        /usr/bin/aws ${REGION_OPTION} s3 cp --recursive --sse aws:kms --no-progress "${config[backup_path]}/${BACKUPDIR}" "${BACKUP_LOCATION}/${BACKUPDIR}" >> "${LOGFILE}" 2>&1
-        ret_code=$?
+        /usr/bin/aws ${REGION_OPTION} s3 cp --debug --recursive --sse aws:kms --no-progress "${config[backup_path]}/${BACKUPDIR}" "${BACKUP_LOCATION}/${BACKUPDIR}" 2>&1 | /usr/local/bin/backup-log-filter.sh | tee -a "${LOGFILE}"
+        ret_code=${PIPESTATUS[0]}
     fi
 
     if [[ "$ret_code" -ne "0" ]]

--- a/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/ipabackup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/ipabackup
@@ -1,0 +1,6 @@
+/var/log/ipabackup.log {
+    missingok
+    notifempty
+    size 128M
+    rotate 6
+}

--- a/freeipa/src/main/resources/freeipa-salt/salt/logrotate/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/logrotate/init.sls
@@ -5,3 +5,11 @@ logrotate-krb5kdc:
     - user: root
     - group: root
     - mode: 644
+
+logrotate-ipabackup:
+  file.managed:
+    - name: /etc/logrotate.d/ipabackup
+    - source: salt://logrotate/conf/ipabackup
+    - user: root
+    - group: root
+    - mode: 644


### PR DESCRIPTION
Add FreeIPA backup debug to salt output and /var/log/ipabackup.log.
Include redaction of the x-amz-security-token.

This was tested using a local deployment of cloudbreak.

See detailed description in the commit message.