### PR TITLE
CB-9746: Adding LoadBalancer FQDN endpoints to the datalake services.

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancer.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancer.java
@@ -42,6 +42,8 @@ public class LoadBalancer implements ProvisionEntity  {
     @OneToMany(mappedBy = "loadBalancer", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private Set<TargetGroup> targetGroups = new HashSet<>();
 
+    private String fqdn;
+
     public Long getId() {
         return id;
     }
@@ -102,6 +104,14 @@ public class LoadBalancer implements ProvisionEntity  {
         this.targetGroups = targetGroups;
     }
 
+    public String getFqdn() {
+        return fqdn;
+    }
+
+    public void setFqdn(String fqdn) {
+        this.fqdn = fqdn;
+    }
+
     @Override
     public String toString() {
         return "LoadBalancer{" +
@@ -110,6 +120,7 @@ public class LoadBalancer implements ProvisionEntity  {
             ", hostedZoneId='" + hostedZoneId + '\'' +
             ", type='" + type + '\'' +
             ", endpoint='" + endpoint + '\'' +
+            ", fqdn='" + fqdn + '\'' +
             '}';
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementService.java
@@ -131,7 +131,13 @@ public class GatewayPublicEndpointManagementService extends BasePublicEndpointMa
                 } else {
                     LOGGER.warn("Could not find IP or cloud DNS info for load balancer with endpoint {} ." +
                         "DNS registration will be skipped.", loadBalancer.getEndpoint());
+                    continue;
                 }
+
+                loadBalancer.setFqdn(getDomainNameProvider().getFullyQualifiedEndpointName(
+                        endpoint.get(), environment.getName(), getWorkloadSubdomain(userCrn)));
+                loadBalancerPersistenceService.save(loadBalancer);
+                LOGGER.info("Set load balancer's FQDN to {}.", loadBalancer.getFqdn());
             }
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
@@ -29,8 +29,12 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.dto.credential.Credential;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialClientService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 @Service
 public class StackUtil {
@@ -46,6 +50,9 @@ public class StackUtil {
 
     @Inject
     private CredentialClientService credentialClientService;
+
+    @Inject
+    private LoadBalancerConfigService loadBalancerConfigService;
 
     public Set<Node> collectNodes(Stack stack) {
         Set<Node> agents = new HashSet<>();
@@ -164,7 +171,7 @@ public class StackUtil {
     }
 
     public String extractClusterManagerIp(Stack stack) {
-        if (!StringUtils.isEmpty(stack.getClusterManagerIp())) {
+        if (!isEmpty(stack.getClusterManagerIp())) {
             return stack.getClusterManagerIp();
         }
         return extractClusterManagerIp(stack.getId());
@@ -177,14 +184,19 @@ public class StackUtil {
     }
 
     public String extractClusterManagerAddress(Stack stack) {
-        String fqdn = stack.getFqdn();
-        if (fqdn != null) {
+        String fqdn = loadBalancerConfigService.getLoadBalancerUserFacingFQDN(stack.getId());
+        fqdn = isEmpty(fqdn) ? stack.getFqdn() : fqdn;
+
+        if (isNotEmpty(fqdn)) {
             return fqdn;
         }
+
         String clusterManagerIp = stack.getClusterManagerIp();
-        if (clusterManagerIp != null) {
+
+        if (isNotEmpty(clusterManagerIp)) {
             return clusterManagerIp;
         }
+
         return extractClusterManagerIp(stack.getId());
     }
 

--- a/core/src/main/resources/schema/app/20201221232206_CB-9746:_Use_new_loadbalancer_endpoints_for_DL_services.sql
+++ b/core/src/main/resources/schema/app/20201221232206_CB-9746:_Use_new_loadbalancer_endpoints_for_DL_services.sql
@@ -1,0 +1,9 @@
+-- // CB-9746: Use new loadbalancer endpoints for DL services
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE loadbalancer ADD COLUMN IF NOT EXISTS fqdn character varying(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE loadbalancer DROP COLUMN IF EXISTS fqdn;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementServiceTest.java
@@ -686,7 +686,7 @@ class GatewayPublicEndpointManagementServiceTest {
         boolean result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.generateCertAndSaveForStackAndUpdateDnsEntry(stack));
 
         verify(environmentClientService, times(3)).getByCrn(anyString());
-        verify(grpcUmsClient, times(2)).getAccountDetails(USER_CRN, "123", Optional.empty());
+        verify(grpcUmsClient, times(3)).getAccountDetails(USER_CRN, "123", Optional.empty());
         verify(domainNameProvider, times(1)).getCommonName(endpointName, envName, accountWorkloadSubdomain);
         verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain);
         verify(certificateCreationService, times(1))
@@ -746,7 +746,7 @@ class GatewayPublicEndpointManagementServiceTest {
         boolean result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.generateCertAndSaveForStackAndUpdateDnsEntry(stack));
 
         verify(environmentClientService, times(3)).getByCrn(anyString());
-        verify(grpcUmsClient, times(2)).getAccountDetails(USER_CRN, "123", Optional.empty());
+        verify(grpcUmsClient, times(3)).getAccountDetails(USER_CRN, "123", Optional.empty());
         verify(domainNameProvider, times(1)).getCommonName(endpointName, envName, accountWorkloadSubdomain);
         verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain);
         verify(certificateCreationService, times(1))


### PR DESCRIPTION
This PR addresses the following Jiras:
https://jira.cloudera.com/browse/CB-9746
https://jira.cloudera.com/browse/CB-10123

Specifically, I am attempting to change the endpoints assigned to all of the Datalake services from being constructed with a Knox URL to being constructed with the LoadBalancer URL.

The end-goal is for this change to be reflected across both the CDP UI and any other way of attempting to access the individual service endpoints