### PR TITLE
Cherry pick of Gcp image promoter E2E test fixes from 2.36 line

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpLabelUtil.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpLabelUtil.java
@@ -11,9 +11,9 @@ import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 
 public final class GcpLabelUtil {
-    private static final Logger LOGGER = LoggerFactory.getLogger(GcpLabelUtil.class);
+    static final int GCP_MAX_TAG_LEN = 63;
 
-    private static final int GCP_MAX_TAG_LEN = 63;
+    private static final Logger LOGGER = LoggerFactory.getLogger(GcpLabelUtil.class);
 
     private GcpLabelUtil() {
     }
@@ -26,12 +26,12 @@ public final class GcpLabelUtil {
     public static Map<String, String> createLabelsFromTagsMap(Map<String, String> tags) {
         Map<String, String> result = new HashMap<>();
         if (tags != null) {
-            tags.forEach((key, value) -> result.put(transform(key), transform(value)));
+            tags.forEach((key, value) -> result.put(transformValue(key), transformValue(value)));
         }
         return result;
     }
 
-    private static String transform(String value) {
+    public static String transformValue(String value) {
         // GCP labels have strict rules https://cloud.google.com/compute/docs/labeling-resources
         LOGGER.debug("Transforming tag key/value for GCP.");
         if (Crn.isCrn(value)) {

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpLabelUtilTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpLabelUtilTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.gcp.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,5 +32,34 @@ class GcpLabelUtilTest {
         assertEquals("12474ddc-6e44-4f4c-806a-b197ef12cbb8", result.get(ENVIRONMENT_CRN.toLowerCase()));
         assertEquals("5d7-b645-7ccf9edbb73d-user-05ca1026-c028-466b-8943-b04f765fa3f6", result.get(CREATOR_CRN.toLowerCase()));
         assertEquals("-b645-7ccf9edbb73d-freeipa-8111d534-8c7e-4a68-a8ba-7ebb389a3a20", result.get(RESOURCE_CRN.toLowerCase()));
+    }
+
+    @Test
+    void transformValueWhenItsLengthLessThan63Chars() {
+        String originalValue = "gpc-test-value-which-is-short";
+
+        String result = GcpLabelUtil.transformValue(originalValue);
+
+        assertEquals(originalValue, result);
+    }
+
+    @Test
+    void transformValueWhenItsLengthMoreThan63Chars() {
+        String originalValue = "gcp-dev-cloudbreak-gcp-test-9257bdae358342cca05e674b3893563-387";
+
+        String result = GcpLabelUtil.transformValue(originalValue);
+
+        assertEquals(GcpLabelUtil.GCP_MAX_TAG_LEN, result.length());
+        assertEquals(originalValue.substring(originalValue.length() - GcpLabelUtil.GCP_MAX_TAG_LEN), result);
+    }
+
+    @Test
+    void transformValueWhenItsLengthMoreThan63CharsAndItIsACrn() {
+        String originalValue = "crn:cdp:environments:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:environment:12474ddc-6e44-4f4c-806a-b197ef12cbb8";
+
+        String result = GcpLabelUtil.transformValue(originalValue);
+
+        assertTrue(result.length() < GcpLabelUtil.GCP_MAX_TAG_LEN);
+        assertEquals("12474ddc-6e44-4f4c-806a-b197ef12cbb8", result);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/imagevalidation/BaseImageValidatorE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/imagevalidation/BaseImageValidatorE2ETest.java
@@ -1,5 +1,17 @@
 package com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation;
 
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.IDBROKER;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.inject.Inject;
+
+import org.testng.annotations.Test;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
@@ -14,17 +26,6 @@ import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
-import org.testng.annotations.Test;
-
-import javax.inject.Inject;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.IDBROKER;
-import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
 public class BaseImageValidatorE2ETest extends AbstractImageValidatorE2ETest {
 
@@ -70,6 +71,7 @@ public class BaseImageValidatorE2ETest extends AbstractImageValidatorE2ETest {
                 .given(masterInstanceGroup, InstanceGroupTestDto.class).withHostGroup(MASTER).withNodeCount(1)
                 .given(idbrokerInstanceGroup, InstanceGroupTestDto.class).withHostGroup(IDBROKER).withNodeCount(1)
                 .given(stack, StackTestDto.class).withCluster(cluster).withImageSettings(imageSettings)
+                .withEmptyNetwork()
                 .withInstanceGroups(masterInstanceGroup, idbrokerInstanceGroup)
                 .given(sdxInternal, SdxInternalTestDto.class)
                 .withCloudStorage(getCloudStorageRequest(testContext))


### PR DESCRIPTION
**Changes:**
 - not to create new newtork for Datalake with internal call in BaseImageValidatorE2ETest 
 - limit the length of the GCP bucket name as it could not be longer than 63 characters