### PR TITLE
CB-10096 Expand Knox load balancer to data hubs

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
@@ -380,15 +380,22 @@ public class StackV4RequestToStackConverter extends AbstractConversionServiceAwa
     }
 
     private boolean shouldCreateInternalKnoxLoadBalancer(StackType type, EnvironmentNetworkResponse network) {
-        // TODO expand this to data hubs
+        return shouldCreateInternalKnoxLoadBalancerForDatalake(type, network) ||
+            shouldCreateInternalKnoxLoadBalancerForDatahub(type, network);
+    }
+
+    private boolean shouldCreateInternalKnoxLoadBalancerForDatalake(StackType type, EnvironmentNetworkResponse network) {
         return StackType.DATALAKE.equals(type) &&
             (entitlementService.datalakeLoadBalancerEnabled(ThreadBasedUserCrnProvider.getAccountId())
             || isEndpointGatewayEnabled(network));
     }
 
+    private boolean shouldCreateInternalKnoxLoadBalancerForDatahub(StackType type, EnvironmentNetworkResponse network) {
+        return  StackType.WORKLOAD.equals(type) && isEndpointGatewayEnabled(network);
+    }
+
     private boolean shouldCreateExternalKnoxLoadBalancer(StackType type, EnvironmentNetworkResponse network) {
-        // TODO expand this to data hubs
-        return StackType.DATALAKE.equals(type) && isEndpointGatewayEnabled(network);
+        return (StackType.DATALAKE.equals(type) || StackType.WORKLOAD.equals(type)) && isEndpointGatewayEnabled(network);
     }
 
     private boolean isEndpointGatewayEnabled(EnvironmentNetworkResponse network) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
@@ -38,7 +38,7 @@ public class LoadBalancerConfigService {
     private LoadBalancerPersistenceService loadBalancerPersistenceService;
 
     public Set<String> getKnoxGatewayGroups(Stack stack) {
-        LOGGER.info("Fetching list of instance groups with Knox gateway installed");
+        LOGGER.debug("Fetching list of instance groups with Knox gateway installed");
         Set<String> groupNames = new HashSet<>();
         Cluster cluster = stack.getCluster();
         if (cluster != null) {
@@ -48,7 +48,7 @@ public class LoadBalancerConfigService {
         }
 
         if (groupNames.isEmpty()) {
-            LOGGER.info("Knox gateway is not explicitly defined; searching for CM gateway hosts");
+            LOGGER.debug("Knox gateway is not explicitly defined; searching for CM gateway hosts");
             groupNames = stack.getInstanceGroups().stream()
                 .filter(i -> InstanceGroupType.isGateway(i.getInstanceGroupType()))
                 .map(InstanceGroup::getGroupName)


### PR DESCRIPTION
Added a new entitlement for the public / private load balancer to the datahubs. This is separate
entitlement than the datalake one to err on the consevative side.

See detailed description in the commit message.