### PR TITLE
CB-7195. Add cluster-logs prefix even if there is a provided path pre…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageConfigGenerator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageConfigGenerator.java
@@ -28,7 +28,8 @@ public abstract class CloudStorageConfigGenerator<T extends CloudStorageConfig> 
     String resolveLogFolder(CloudStorageConfig cloudStorageConfig, String clusterType,
             String clusterName, String clusterId) {
         String folderPrefix = StringUtils.isNotEmpty(cloudStorageConfig.getFolderPrefix())
-                ? cloudStorageConfig.getFolderPrefix() : CLUSTER_LOG_PREFIX;
+                ? Paths.get(cloudStorageConfig.getFolderPrefix(), CLUSTER_LOG_PREFIX).toString()
+                : CLUSTER_LOG_PREFIX;
         return Paths.get(folderPrefix, clusterType, String.format("%s_%s", clusterName, clusterId)).toString();
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageFolderResolverServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/cloud/CloudStorageFolderResolverServiceTest.java
@@ -35,6 +35,18 @@ public class CloudStorageFolderResolverServiceTest {
     }
 
     @Test
+    public void testUpdateStorageLocationS3WithPrefix() {
+        // GIVEN
+        Telemetry telemetry = createTelemetry();
+        telemetry.getLogging().setStorageLocation("s3://mybucket/prefix");
+        // WHEN
+        underTest.updateStorageLocation(telemetry, FluentClusterType.DATAHUB.value(), "mycluster",
+                "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertEquals("s3://mybucket/prefix/cluster-logs/datahub/mycluster_12345", telemetry.getLogging().getStorageLocation());
+    }
+
+    @Test
     public void testUpdateStorageLocationAdlsGen2() {
         // GIVEN
         Telemetry telemetry = createTelemetry();
@@ -46,6 +58,20 @@ public class CloudStorageFolderResolverServiceTest {
                 "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
         // THEN
         assertEquals("abfs://mycontainer@null.dfs.core.windows.net/cluster-logs/datahub/mycluster_12345", telemetry.getLogging().getStorageLocation());
+    }
+
+    @Test
+    public void testUpdateStorageLocationAdlsGen2WithPrefix() {
+        // GIVEN
+        Telemetry telemetry = createTelemetry();
+        telemetry.getLogging().setS3(null);
+        telemetry.getLogging().setAdlsGen2(new AdlsGen2CloudStorageV1Parameters());
+        telemetry.getLogging().setStorageLocation("abfs://mycontainer/prefix");
+        // WHEN
+        underTest.updateStorageLocation(telemetry, FluentClusterType.DATAHUB.value(), "mycluster",
+                "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertEquals("abfs://mycontainer@null.dfs.core.windows.net/prefix/cluster-logs/datahub/mycluster_12345", telemetry.getLogging().getStorageLocation());
     }
 
     @Test


### PR DESCRIPTION
…fix.

details:
- at the moment if path prefix for the cloud storage bucket is not provided, cluster-logs is not appended to the path, only if no prefix for the bucket.
e.g.:
s3://mybucket  -> s3://mybucket/cluster-logs
s3://mybucket/prefix ->  s3://mybucket/prefix
after the change:
s3://mybucket -> s3://mybucket/cluster-logs
s3://mybucket/prefix -> s3://mybucket/prefix/cluster-logs

See detailed description in the commit message.