### PR TITLE
CB-10468 Add missing SRM to 7.2.8 Streams Messaging blueprints

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-streaming-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-streaming-small.bp
@@ -68,6 +68,22 @@
             "base": true
           }
         ]
+      },
+      {
+        "refName" : "streams_replication_manager",
+        "serviceType" : "STREAMS_REPLICATION_MANAGER",
+        "roleConfigGroups" : [
+          {
+            "refName" : "streams_replication_manager-STREAMS_REPLICATION_MANAGER_SERVICE-BASE",
+            "roleType" : "STREAMS_REPLICATION_MANAGER_SERVICE",
+            "base" : true
+          },
+          {
+            "refName" : "streams_replication_manager-STREAMS_REPLICATION_MANAGER_DRIVER-BASE",
+            "roleType" : "STREAMS_REPLICATION_MANAGER_DRIVER",
+            "base" : true
+          }
+        ]
       }
     ],
     "hostTemplates": [
@@ -76,6 +92,7 @@
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "core_settings-STORAGEOPERATIONS-BASE",
+          "streams_replication_manager-STREAMS_REPLICATION_MANAGER_SERVICE-BASE",
           "schemaregistry-SCHEMA_REGISTRY_SERVER-BASE",
           "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_SERVER-BASE",
           "streams_messaging_manager-STREAMS_MESSAGING_MANAGER_UI-BASE"
@@ -85,9 +102,10 @@
         "refName": "broker",
         "cardinality": 3,
         "roleConfigGroupsRefNames": [
+          "zookeeper-SERVER-BASE",
+          "streams_replication_manager-STREAMS_REPLICATION_MANAGER_DRIVER-BASE",
           "kafka-GATEWAY-BASE",
-          "kafka-KAFKA_BROKER-BASE",
-          "zookeeper-SERVER-BASE"
+          "kafka-KAFKA_BROKER-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-streaming.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-streaming.bp
@@ -68,6 +68,22 @@
             "base": true
           }
         ]
+      },
+      {
+        "refName" : "streams_replication_manager",
+        "serviceType" : "STREAMS_REPLICATION_MANAGER",
+        "roleConfigGroups" : [
+          {
+            "refName" : "streams_replication_manager-STREAMS_REPLICATION_MANAGER_SERVICE-BASE",
+            "roleType" : "STREAMS_REPLICATION_MANAGER_SERVICE",
+            "base" : true
+          },
+          {
+            "refName" : "streams_replication_manager-STREAMS_REPLICATION_MANAGER_DRIVER-BASE",
+            "roleType" : "STREAMS_REPLICATION_MANAGER_DRIVER",
+            "base" : true
+          }
+        ]
       }
     ],
     "hostTemplates": [
@@ -103,6 +119,14 @@
         "roleConfigGroupsRefNames": [
           "kafka-GATEWAY-BASE",
           "kafka-KAFKA_BROKER-BASE"
+        ]
+      },
+      {
+        "refName": "srm",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "streams_replication_manager-STREAMS_REPLICATION_MANAGER_SERVICE-BASE",
+          "streams_replication_manager-STREAMS_REPLICATION_MANAGER_DRIVER-BASE"
         ]
       }
     ]


### PR DESCRIPTION
SRM (released in 7.2.6) is missing from the 7.2.8 Streams Messaging blueprints. This PR fixes it.