### PR TITLE
CB-10363 Highstate must always correct the userid / group id

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,7 +322,7 @@ class BuildInfoTask extends DefaultTask {
       if (buildVersion.startsWith(latestVersionOnMaster)) {
         activeProfile = "dev"
       } else {
-        activeProfile = "rc"
+        activeProfile = "dev"
       }
     } catch(Exception ex) {
       println "Could not query version of master branch from http://release.infra.cloudera.com, falling back to 'dev' profile!"

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterPreCreationApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterPreCreationApi.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.cluster.api;
 
 import java.util.Map;
 
+import com.sequenceiq.cloudbreak.cluster.model.ServiceLocationMap;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 
@@ -26,4 +27,6 @@ public interface ClusterPreCreationApi {
     String getMasterKey(Cluster cluster);
 
     Map<String, Integer> getServicePorts(Blueprint blueprint, boolean tls);
+
+    ServiceLocationMap getServiceLocations();
 }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ServiceLocation.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ServiceLocation.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.cluster.model;
+
+public class ServiceLocation {
+    private final String service;
+
+    private final String volumePath;
+
+    public ServiceLocation(String service, String volumePath) {
+        this.service = service;
+        this.volumePath = volumePath;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public String getVolumePath() {
+        return volumePath;
+    }
+}

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ServiceLocationMap.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ServiceLocationMap.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.cloudbreak.cluster.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ServiceLocationMap {
+
+    private Map<String, ServiceLocation> serviceLocations = new HashMap<>();
+
+    public ServiceLocationMap add(ServiceLocation serviceLocation) {
+        serviceLocations.put(serviceLocation.getService(), serviceLocation);
+        return this;
+    }
+
+    public ServiceLocation getServiceLocationByService(String service) {
+        return serviceLocations.get(service);
+    }
+
+    public String getVolumePathByService(String service) {
+        Optional<ServiceLocation> serviceLocation = Optional.ofNullable(serviceLocations.get(service));
+        return serviceLocation.map(ServiceLocation::getVolumePath).orElse(null);
+    }
+
+    public Set<String> getAllVolumePath() {
+        return serviceLocations.values().stream().map(ServiceLocation::getVolumePath).collect(Collectors.toSet());
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerPreCreationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerPreCreationService.java
@@ -10,6 +10,8 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cluster.api.ClusterPreCreationApi;
+import com.sequenceiq.cloudbreak.cluster.model.ServiceLocationMap;
+import com.sequenceiq.cloudbreak.cm.config.CmMgmtVolumePathBuilder;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 
@@ -21,6 +23,9 @@ public class ClouderaManagerPreCreationService implements ClusterPreCreationApi 
 
     @Inject
     private ClouderaManagerBlueprintPortConfigCollector clouderaManagerBlueprintPortConfigCollector;
+
+    @Inject
+    private CmMgmtVolumePathBuilder volumePathBuilder;
 
     @Override
     public String getCloudbreakClusterUserName(Cluster cluster) {
@@ -70,5 +75,10 @@ public class ClouderaManagerPreCreationService implements ClusterPreCreationApi 
     @Override
     public Map<String, Integer> getServicePorts(Blueprint blueprint, boolean tls) {
         return clouderaManagerBlueprintPortConfigCollector.getServicePorts(blueprint, tls);
+    }
+
+    @Override
+    public ServiceLocationMap getServiceLocations() {
+        return volumePathBuilder.buildServiceLocationMap();
     }
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/config/CmMgmtServiceConfigLocationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/config/CmMgmtServiceConfigLocationService.java
@@ -1,36 +1,34 @@
 package com.sequenceiq.cloudbreak.cm.config;
 
-import static com.sequenceiq.cloudbreak.template.VolumeUtils.buildSingleVolumePath;
-
+import java.util.Arrays;
 import java.util.Optional;
+
+import javax.inject.Inject;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.stereotype.Service;
 
 import com.cloudera.api.swagger.model.ApiRole;
 import com.cloudera.api.swagger.model.ApiRoleList;
+import com.sequenceiq.cloudbreak.cluster.model.ServiceLocationMap;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 
 @Service
 class CmMgmtServiceConfigLocationService implements CmConfigServiceDelegate {
 
+    @Inject
+    private CmMgmtVolumePathBuilder volumePathBuilder;
+
     @Override
     public void setConfigs(Stack stack, ApiRoleList apiRoleList) {
-        Optional<ApiRole> eventServer = getApiRole("EVENTSERVER", apiRoleList);
-        eventServer.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("eventserver_index_dir",
-                buildSingleVolumePath(1, "cloudera-scm-eventserver"))));
+        ServiceLocationMap serviceLocationMap = volumePathBuilder.buildServiceLocationMap();
+        Arrays.stream(MgmtServices.values()).forEach(mgmtService -> addConfigIfRoleIsPresent(apiRoleList, serviceLocationMap, mgmtService));
+    }
 
-        Optional<ApiRole> hostMonitor = getApiRole("HOSTMONITOR", apiRoleList);
-        hostMonitor.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("firehose_storage_dir",
-                buildSingleVolumePath(1, "cloudera-host-monitor"))));
-
-        Optional<ApiRole> reportsManager = getApiRole("REPORTSMANAGER", apiRoleList);
-        reportsManager.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("headlamp_scratch_dir",
-                buildSingleVolumePath(1, "cloudera-scm-headlamp"))));
-
-        Optional<ApiRole> serviceMonitor = getApiRole("SERVICEMONITOR", apiRoleList);
-        serviceMonitor.ifPresent(apiRole -> addConfig(apiRole, createApiConfig("firehose_storage_dir",
-                buildSingleVolumePath(1, "cloudera-service-monitor"))));
+    private void addConfigIfRoleIsPresent(ApiRoleList apiRoleList, ServiceLocationMap serviceLocationMap, MgmtServices mgmtService) {
+        Optional<ApiRole> role = getApiRole(mgmtService.name(), apiRoleList);
+        role.ifPresent(apiRole -> addConfig(apiRole, createApiConfig(mgmtService.getConfigName(),
+                serviceLocationMap.getVolumePathByService(mgmtService.name()))));
     }
 
     private Optional<ApiRole> getApiRole(String roleName, ApiRoleList apiRoleList) {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/config/CmMgmtVolumePathBuilder.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/config/CmMgmtVolumePathBuilder.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.cm.config;
+
+import static com.sequenceiq.cloudbreak.template.VolumeUtils.buildSingleVolumePath;
+
+import java.util.Arrays;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cluster.model.ServiceLocation;
+import com.sequenceiq.cloudbreak.cluster.model.ServiceLocationMap;
+
+@Component
+public class CmMgmtVolumePathBuilder {
+
+    public ServiceLocationMap buildServiceLocationMap() {
+        ServiceLocationMap serviceLocations = new ServiceLocationMap();
+        Arrays.stream(MgmtServices.values()).forEach(service ->
+                serviceLocations.add(new ServiceLocation(service.name(), buildSingleVolumePath(1, service.getDirectory()))));
+        return serviceLocations;
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/config/MgmtServices.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/config/MgmtServices.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.cm.config;
+
+public enum MgmtServices {
+    EVENTSERVER("cloudera-scm-eventserver", "eventserver_index_dir"),
+    HOSTMONITOR("cloudera-host-monitor", "firehose_storage_dir"),
+    REPORTSMANAGER("cloudera-scm-headlamp", "headlamp_scratch_dir"),
+    SERVICEMONITOR("cloudera-service-monitor", "firehose_storage_dir");
+
+    private String directory;
+
+    private String configName;
+
+    MgmtServices(String directory, String configName) {
+        this.directory = directory;
+        this.configName = configName;
+    }
+
+    public String getDirectory() {
+        return directory;
+    }
+
+    public String getConfigName() {
+        return configName;
+    }
+}

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/config/CmMgmtServiceConfigLocationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/config/CmMgmtServiceConfigLocationServiceTest.java
@@ -6,7 +6,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.model.ApiConfig;
 import com.cloudera.api.swagger.model.ApiConfigList;
@@ -17,6 +21,7 @@ import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.common.api.type.ResourceType;
 
+@ExtendWith(MockitoExtension.class)
 public class CmMgmtServiceConfigLocationServiceTest {
 
     private static final String VOLUME_PREFIX = "/hadoopfs/fs1/";
@@ -35,7 +40,11 @@ public class CmMgmtServiceConfigLocationServiceTest {
 
     private static final String TEST_CONFIG_VALUE = "test_config_value";
 
-    private CmMgmtServiceConfigLocationService underTest = new CmMgmtServiceConfigLocationService();
+    @Spy
+    private CmMgmtVolumePathBuilder volumePathBuilder;
+
+    @InjectMocks
+    private CmMgmtServiceConfigLocationService underTest;
 
     @Test
     public void testSetConfigLocationsShouldSetLocationsWhenThereAreNoExistingConfig() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
@@ -87,7 +87,7 @@ public class ClusterManagerUpgradeService {
         GatewayConfig gatewayConfig = gatewayConfigService.getGatewayConfig(stack, gatewayInstance, cluster.getGateway() != null);
         Set<String> gatewayFQDN = Collections.singleton(gatewayInstance.getDiscoveryFQDN());
         ExitCriteriaModel exitCriteriaModel = clusterDeletionBasedModel(stack.getId(), cluster.getId());
-        SaltConfig pillar = createSaltConfig(stack.getId(), stack.getType(), cluster);
+        SaltConfig pillar = createSaltConfig(stack, stack.getType(), cluster);
         hostOrchestrator.upgradeClusterManager(gatewayConfig, gatewayFQDN, stackUtil.collectReachableNodes(stack), pillar, exitCriteriaModel);
     }
 
@@ -99,12 +99,12 @@ public class ClusterManagerUpgradeService {
         clusterApiConnectors.getConnector(stack).startCluster();
     }
 
-    private SaltConfig createSaltConfig(Long stackId, StackType stackType, Cluster cluster) {
+    private SaltConfig createSaltConfig(Stack stack, StackType stackType, Cluster cluster) {
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
         ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId());
-        Optional<String> license = clusterHostServiceRunner.decoratePillarWithClouderaManagerLicense(stackId, servicePillar);
+        Optional<String> license = clusterHostServiceRunner.decoratePillarWithClouderaManagerLicense(stack.getId(), servicePillar);
         clusterHostServiceRunner.decoratePillarWithClouderaManagerRepo(clouderaManagerRepo, servicePillar, license);
-        clusterHostServiceRunner.decoratePillarWithClouderaManagerSettings(servicePillar, clouderaManagerRepo);
+        clusterHostServiceRunner.decoratePillarWithClouderaManagerSettings(servicePillar, clouderaManagerRepo, stack);
         decorateWorkloadClusterPillarWithCsdDownloader(stackType, cluster, servicePillar);
         return new SaltConfig(servicePillar);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
@@ -82,7 +82,7 @@ public class ClusterManagerUpgradeServiceTest {
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
         verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any());
+        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any(), any());
         verify(clusterApi).startCluster();
     }
 
@@ -97,7 +97,7 @@ public class ClusterManagerUpgradeServiceTest {
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
         verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any());
+        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any(), any());
         verify(clusterApi, never()).startCluster();
     }
 
@@ -113,7 +113,7 @@ public class ClusterManagerUpgradeServiceTest {
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
         verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any());
+        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any(), any());
         verify(clusterApi).startCluster();
         verify(clusterHostServiceRunner, never()).decoratePillarWithClouderaManagerCsds(any(), any());
     }
@@ -130,7 +130,7 @@ public class ClusterManagerUpgradeServiceTest {
         verify(hostOrchestrator, times(1)).upgradeClusterManager(any(), any(), any(), any(), any());
         verify(clusterApi).stopCluster(true);
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerRepo(any(), any(), any());
-        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any());
+        verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerSettings(any(), any(), any());
         verify(clusterApi).startCluster();
         verify(clusterHostServiceRunner, times(1)).decoratePillarWithClouderaManagerCsds(any(), any());
     }

--- a/orchestrator-salt/src/main/resources/salt/pillar/cloudera-manager/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/cloudera-manager/settings.sls
@@ -1,0 +1,3 @@
+cloudera-manager:
+  mgmt_service_directories: []
+  settings:

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/start.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/start.sls
@@ -12,7 +12,7 @@ start_agent:
   service.running:
     - enable: True
     - name: cloudera-scm-agent
-{% if cloudera_manager.communication.autotls_enabled == True %}
+  {% if cloudera_manager.communication.autotls_enabled == True %}
     - require:
-        - file: check_token
+      - file: check_token
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
@@ -43,6 +43,20 @@ restart_cm_after_fronted_url_change:
       - file: update_frontend_url_of_cm
 {% endif %}
 
+{% if salt['pillar.get']('cloudera-manager:mgmt_service_directories') is defined and salt['pillar.get']('cloudera-manager:mgmt_service_directories')|length > 0 %}
+ensure_owners:
+  file.directory:
+    - names:
+{%- for dir in salt['pillar.get']('cloudera-manager:mgmt_service_directories') %}
+        - {{ dir }}
+{%- endfor %}
+    - user: cloudera-scm
+    - group: cloudera-scm
+    - recurse:
+        - user
+        - group
+{% endif %}
+
 start_server:
   service.running:
     - enable: True


### PR DESCRIPTION
It's possible during upgrade different images has cloudera-scm user and group with different UID/GID.
Cloudera Manager server can use 4 directories. With this change we ensure before starting the server these directories has the right owner. As a side effect we create these directories even if CM doesn't need some of them.
The list of the directories is coming from JAVA side where we create the configuration for CM itself, this way it's ensured we'll set the owners if a new directory introduced.

See detailed description in the commit message.