### PR TITLE
CB-10451: Perform salt update before performing datalake backup.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.cloudbreak.core.flow2.chain;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
+import com.sequenceiq.cloudbreak.core.flow2.event.DatabaseBackupTriggerEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.backup.DatabaseBackupEvent.DATABASE_BACKUP_EVENT;
+
+@Component
+public class BackupDatalakeDatabaseFlowEventChainFactory implements FlowEventChainFactory<DatabaseBackupTriggerEvent> {
+    @Override
+    public String initEvent() {
+        return FlowChainTriggers.DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT;
+    }
+
+    @Override
+    public Queue<Selectable> createFlowTriggerEventQueue(DatabaseBackupTriggerEvent event) {
+        Queue<Selectable> chain = new ConcurrentLinkedQueue<>();
+        chain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
+        chain.add(new DatabaseBackupTriggerEvent(DATABASE_BACKUP_EVENT.event(), event.getResourceId(),
+                event.getBackupLocation(), event.getBackupId()));
+        return chain;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/FlowChainTriggers.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/FlowChainTriggers.java
@@ -43,6 +43,8 @@ public class FlowChainTriggers {
 
     public static final String ROTATE_CLUSTER_CERTIFICATES_CHAIN_TRIGGER_EVENT = "ROTATE_CLUSTER_CERTIFICATES_CHAIN_TRIGGER_EVENT";
 
+    public static final String DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT = "DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT";
+
     private FlowChainTriggers() {
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -2,7 +2,6 @@ package com.sequenceiq.cloudbreak.core.flow2.service;
 
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.certrenew.ClusterCertificateRenewEvent.CLUSTER_CERTIFICATE_REISSUE_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.PillarConfigurationUpdateEvent.PILLAR_CONFIG_UPDATE_EVENT;
-import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.backup.DatabaseBackupEvent.DATABASE_BACKUP_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.restore.DatabaseRestoreEvent.DATABASE_RESTORE_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationEvent.CLUSTER_CREATION_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent.SALT_UPDATE_EVENT;
@@ -283,7 +282,7 @@ public class ReactorFlowManager {
     }
 
     public FlowIdentifier triggerDatalakeDatabaseBackup(Long stackId, String location, String backupId) {
-        String selector = DATABASE_BACKUP_EVENT.event();
+        String selector = FlowChainTriggers.DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT;
         return reactorNotifier.notify(stackId, selector, new DatabaseBackupTriggerEvent(selector, stackId, location, backupId));
     }
 


### PR DESCRIPTION
Create a flow chain using the flow for updating salt and also flow for database backup.

This flow chain should first trigger the flow to update the salt pillar and sates in the nodes before triggering the flow for database backup.

This is needed because data lake nodes setup using runtime 7.1.0 and 7.2.0 might not have the necessary salt pillar and salt states needed to perform a database backup.

Tested the changes by triggering the database backup using CBD. I made sure that salt update of triggered before database backup. Additionally, i deleted some of the salt scripts needed for database backup and made sure that database backup was successful and the salt scripts are restored.