### PR TITLE
CB-10487: Manually revert CB-7306, fix dfs replication values.

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.0/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.0/cdp-sdx.bp
@@ -224,6 +224,14 @@
             {
                 "name": "enable_ranger_authorization",
                 "value": "true"
+            },
+            {
+                "name": "dfs_replication",
+                "value": "1"
+            },
+            {
+                "name": "service_health_suppression_hdfs_verify_ec_with_topology",
+                "value": "true"
             }
         ],
         "serviceType": "HDFS"

--- a/core/src/main/resources/defaults/blueprints/7.2.1/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.1/cdp-sdx.bp
@@ -280,6 +280,10 @@
             {
               "name": "service_config_suppression_datanode_count_validator",
               "value": "true"
+            },
+            {
+              "name": "dfs_replication",
+              "value": "1"
             }
         ],
         "serviceType": "HDFS"

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx.bp
@@ -278,6 +278,10 @@
               "value": "true"
             },
             {
+              "name": "dfs_replication",
+              "value": "1"
+            },
+            {
               "name": "service_config_suppression_datanode_count_validator",
               "value": "true"
             }

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx.bp
@@ -278,6 +278,10 @@
               "value": "true"
             },
             {
+              "name": "dfs_replication",
+              "value": "1"
+            },
+            {
               "name": "service_config_suppression_datanode_count_validator",
               "value": "true"
             }

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
@@ -344,6 +344,10 @@
             "value": "true"
           },
           {
+            "name": "dfs_replication",
+            "value": "3"
+          },
+          {
             "name": "service_config_suppression_datanode_count_validator",
             "value": "true"
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx.bp
@@ -278,6 +278,10 @@
               "value": "true"
             },
             {
+              "name": "dfs_replication",
+              "value": "1"
+            },
+            {
               "name": "service_config_suppression_datanode_count_validator",
               "value": "true"
             }

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx-medium-ha.bp
@@ -344,6 +344,10 @@
             "value": "true"
           },
           {
+            "name": "dfs_replication",
+            "value": "3"
+          },
+          {
             "name": "service_config_suppression_datanode_count_validator",
             "value": "true"
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx.bp
@@ -278,6 +278,10 @@
               "value": "true"
             },
             {
+              "name": "dfs_replication",
+              "value": "1"
+            },
+            {
               "name": "service_config_suppression_datanode_count_validator",
               "value": "true"
             }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsConfigProvider.java
@@ -1,20 +1,14 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs;
 
-import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0;
-import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3guard.S3GuardConfigProvider;
@@ -34,20 +28,8 @@ public class HdfsConfigProvider implements CmTemplateComponentConfigProvider {
 
         s3GuardConfigProvider.getServiceConfigs(templatePreparationObject, hdfsCoreSiteSafetyValveValue);
 
-        List<ApiClusterTemplateConfig> list = new ArrayList<>();
-        if (StringUtils.isNotEmpty(hdfsCoreSiteSafetyValveValue.toString())) {
-            list.add(config(CORE_SITE_SAFETY_VALVE, hdfsCoreSiteSafetyValveValue.toString()));
-        }
-        if (templatePreparationObject.getProductDetailsView() != null &&
-                templatePreparationObject.getProductDetailsView().getCm() != null &&
-                templatePreparationObject.getProductDetailsView().getCm().getVersion() != null) {
-            String cmVersion = templatePreparationObject.getProductDetailsView().getCm().getVersion();
-            if (templatePreparationObject.getStackType() == StackType.DATALAKE && isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_2_0)) {
-                list.add(config("dfs_replication", "1"));
-                list.add(config("service_health_suppression_hdfs_verify_ec_with_topology", "true"));
-            }
-        }
-        return Collections.unmodifiableList(list);
+        return hdfsCoreSiteSafetyValveValue.toString().isEmpty() ? List.of()
+                : List.of(config(CORE_SITE_SAFETY_VALVE, hdfsCoreSiteSafetyValveValue.toString()));
     }
 
     @Override

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsConfigProviderTest.java
@@ -73,23 +73,6 @@ public class HdfsConfigProviderTest {
         assertEquals(0, serviceConfigs.size());
     }
 
-    @Test
-    public void testGetHdsfServiceConfigsFor720() {
-        doNothing().when(s3GuardConfigProvider).getServiceConfigs(any(TemplatePreparationObject.class), any(StringBuilder.class));
-
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, false, false);
-        ClouderaManagerRepo cmRepo = new ClouderaManagerRepo();
-        cmRepo.setVersion("7.2.0");
-        preparationObject.getProductDetailsView().setCm(cmRepo);
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
-        assertEquals(2, serviceConfigs.size());
-        assertEquals("dfs_replication", serviceConfigs.get(0).getName());
-        assertEquals("service_health_suppression_hdfs_verify_ec_with_topology", serviceConfigs.get(1).getName());
-    }
-
     private TemplatePreparationObject getTemplatePreparationObject(boolean useS3FileSystem, boolean fillDynamoTableName, boolean includeLocations) {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);


### PR DESCRIPTION
Closes [CB-10487](https://jira.cloudera.com/browse/CB-10487)

* Remove code that added dfs_replication to hdfs service configs
* Add `dfs_replication` values to templates:
  * 7.2.0
  * 7.2.1
  * 7.2.2
  * 7.2.6
  * 7.2.7
  * 7.2.7 HA
  * 7.2.8
  * 7.2.8 HA

Tested by setting up Data Lakes using `cbd` tool locally.