### PR TITLE
CB-8677 Fix FreeIPA HA in GCP

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpProvisionSetup.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpProvisionSetup.java
@@ -9,7 +9,7 @@ import static com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil.getProjectId
 import static com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil.getTarName;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.http.HttpStatus;
@@ -86,8 +86,9 @@ public class GcpProvisionSetup implements Setup {
                 RawDisk rawDisk = new RawDisk();
                 rawDisk.setSource(String.format("http://storage.googleapis.com/%s/%s", bucket.getName(), tarName));
                 gcpApiImage.setRawDisk(rawDisk);
-                GuestOsFeature guestOsFeature = new GuestOsFeature().setType("UEFI_COMPATIBLE");
-                gcpApiImage.setGuestOsFeatures(Collections.singletonList(guestOsFeature));
+                GuestOsFeature uefiCompatible = new GuestOsFeature().setType("UEFI_COMPATIBLE");
+                GuestOsFeature multiIpSubnet = new GuestOsFeature().setType("MULTI_IP_SUBNET");
+                gcpApiImage.setGuestOsFeatures(List.of(uefiCompatible, multiIpSubnet));
                 Insert ins = compute.images().insert(projectId, gcpApiImage);
                 ins.execute();
             }


### PR DESCRIPTION
1. FreeIPA HA setup uses link-local IP address as a forwarder which does not work in GCP.
2. To make it work we need to enable MULTI_IP_SUBNET while creating the image https://cloud.google.com/vpc/docs/create-use-multiple-interfaces#i_am_having_connectivity_issues_when_using_a_netmask_that_is_not_32
3. This change will enable us to test the FreeIPA HA in GCP.