### PR TITLE
CB-10504. Make cloud storage logging configurable by a flag (API)

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/FeaturesBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/base/FeaturesBase.java
@@ -23,6 +23,10 @@ public abstract class FeaturesBase implements Serializable {
     @ApiModelProperty(TelemetryModelDescription.TELEMETRY_CLUSTER_MONITORING_ENABLED)
     private FeatureSetting monitoring;
 
+    @JsonProperty("cloudStorageLogging")
+    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_CLOUD_STORAGE_LOGGING_ENABLED)
+    private FeatureSetting cloudStorageLogging;
+
     public FeatureSetting getWorkloadAnalytics() {
         return workloadAnalytics;
     }
@@ -47,6 +51,14 @@ public abstract class FeaturesBase implements Serializable {
         this.monitoring = monitoring;
     }
 
+    public FeatureSetting getCloudStorageLogging() {
+        return cloudStorageLogging;
+    }
+
+    public void setCloudStorageLogging(FeatureSetting cloudStorageLogging) {
+        this.cloudStorageLogging = cloudStorageLogging;
+    }
+
     @JsonIgnore
     public void addWorkloadAnalytics(boolean enabled) {
         workloadAnalytics = new FeatureSetting();
@@ -63,5 +75,11 @@ public abstract class FeaturesBase implements Serializable {
     public void addMonitoring(boolean enabled) {
         monitoring = new FeatureSetting();
         monitoring.setEnabled(enabled);
+    }
+
+    @JsonIgnore
+    public void addCloudStorageLogging(boolean enabled) {
+        cloudStorageLogging = new FeatureSetting();
+        cloudStorageLogging.setEnabled(enabled);
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/TelemetryModelDescription.java
@@ -16,6 +16,8 @@ public class TelemetryModelDescription {
     public static final String TELEMETRY_LOGGING_STORAGE_LOCATION = "telemetry - logging storage location / container";
     public static final String TELEMETRY_CLUSTER_LOGS_COLLECTION_ENABLED = "enable cluster logs collection";
     public static final String TELEMETRY_CLUSTER_MONITORING_ENABLED = "enable monitoring for cluster services";
+    public static final String TELEMETRY_CLOUD_STORAGE_LOGGING_ENABLED = "enable uploading daemon service logs to cloud storage from the cluster nodes. " +
+            "(default: enabled)";
     public static final String TELEMETRY_CLOUDWATCH_PARAMS = "telemetry - CloudWatch releated parameters";
     public static final String TELEMETRY_CLOUDWATCH_PARAMS_REGION = "telemetry - CloudWatch related AWS region (should be used only outside of AWS platform)";
     public static final String TELEMETRY_USE_SHARED_ALTUS_CREDENTIAL_ENABLED = "enable shared Altus credential usage";

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/model/Telemetry.java
@@ -109,4 +109,10 @@ public class Telemetry implements Serializable {
                 && features.getUseSharedAltusCredential().isEnabled();
     }
 
+    @JsonIgnore
+    public boolean isCloudStorageLoggingEnabled() {
+        return features == null || (features.getCloudStorageLogging() != null
+                && features.getCloudStorageLogging().isEnabled());
+    }
+
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigService.java
@@ -125,6 +125,10 @@ public class FluentConfigService {
                 cloudLogServiceLoggingEnabled = true;
             }
         }
+        if (!telemetry.isCloudStorageLoggingEnabled()) {
+            LOGGER.debug("Disable (override) cloud storage logging as feature setting is disabled.");
+            cloudStorageLoggingEnabled = false;
+        }
         builder.withCloudStorageLoggingEnabled(cloudStorageLoggingEnabled)
                 .withCloudLoggingServiceEnabled(cloudLogServiceLoggingEnabled);
         boolean databusLogEnabled = fillDiagnosticsConfigs(telemetry, databusEnabled, meteringEnabled, builder);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -76,6 +76,7 @@ public class TelemetryConverterTest {
         FeaturesRequest featuresRequest = new FeaturesRequest();
         featuresRequest.addClusterLogsCollection(false);
         featuresRequest.addMonitoring(true);
+        featuresRequest.addCloudStorageLogging(false);
         telemetryRequest.setLogging(logging);
         telemetryRequest.setFeatures(featuresRequest);
         telemetryRequest.setWorkloadAnalytics(workloadAnalyticsRequest);
@@ -84,6 +85,7 @@ public class TelemetryConverterTest {
         // THEN
         assertNotNull(result.getFeatures().getWorkloadAnalytics());
         assertFalse(result.getFeatures().getClusterLogsCollection().isEnabled());
+        assertFalse(result.getFeatures().getCloudStorageLogging().isEnabled());
         assertTrue(result.getFeatures().getMetering().isEnabled());
         assertTrue(result.getFeatures().getMonitoring().isEnabled());
         assertTrue(result.getFeatures().getWorkloadAnalytics().isEnabled());
@@ -136,6 +138,7 @@ public class TelemetryConverterTest {
         // THEN
         assertFalse(result.getFeatures().getClusterLogsCollection().isEnabled());
         assertTrue(result.getFeatures().getMetering().isEnabled());
+        assertTrue(result.getFeatures().getCloudStorageLogging().isEnabled());
     }
 
     @Test

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -204,6 +204,11 @@ public class StackRequestManifester {
                 FeaturesRequest featuresRequest = new FeaturesRequest();
                 featuresRequest.setClusterLogsCollection(envTelemetry.getFeatures().getClusterLogsCollection());
                 featuresRequest.setMonitoring(envTelemetry.getFeatures().getMonitoring());
+                if (envTelemetry.getFeatures().getCloudStorageLogging() != null) {
+                    featuresRequest.setCloudStorageLogging(envTelemetry.getFeatures().getCloudStorageLogging());
+                } else {
+                    featuresRequest.addCloudStorageLogging(true);
+                }
                 telemetryRequest.setFeatures(featuresRequest);
             }
             if (envTelemetry.getFluentAttributes() != null) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverter.java
@@ -8,6 +8,7 @@ import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.base.FeaturesBase;
 import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
 import com.sequenceiq.common.api.telemetry.model.Features;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
@@ -94,6 +95,7 @@ public class TelemetryApiConverter {
             featuresRequest = new FeaturesRequest();
             featuresRequest.setClusterLogsCollection(features.getClusterLogsCollection());
             featuresRequest.setMonitoring(features.getMonitoring());
+            setCloudStorageLoggingOnFeaturesModel(features, featuresRequest);
         }
         return featuresRequest;
     }
@@ -106,6 +108,7 @@ public class TelemetryApiConverter {
             featuresResponse.setMonitoring(features.getMonitoring());
             featuresResponse.setWorkloadAnalytics(features.getWorkloadAnalytics());
             featuresResponse.setUseSharedAltusCredential(features.getUseSharedAltusCredential());
+            setCloudStorageLoggingOnFeaturesModel(features, featuresResponse);
         }
         return featuresResponse;
     }
@@ -132,6 +135,7 @@ public class TelemetryApiConverter {
             }
             setClusterLogsCollectionFromAccountAndRequest(featuresRequest, accountFeatures, features);
             setMonitoringFromAccountAndRequest(featuresRequest, accountFeatures, features);
+            setCloudStorageLoggingFromAccountAndRequest(featuresRequest, accountFeatures, features);
             if (accountFeatures.getWorkloadAnalytics() != null) {
                 features.setWorkloadAnalytics(accountFeatures.getWorkloadAnalytics());
             }
@@ -140,6 +144,17 @@ public class TelemetryApiConverter {
             }
         }
         return features;
+    }
+
+    private void setCloudStorageLoggingFromAccountAndRequest(FeaturesRequest featuresRequest, Features accountFeatures, EnvironmentFeatures features) {
+        if (accountFeatures.getCloudStorageLogging() != null) {
+            features.setCloudStorageLogging(accountFeatures.getCloudStorageLogging());
+        }
+        if (featuresRequest.getCloudStorageLogging() != null) {
+            features.setCloudStorageLogging(featuresRequest.getCloudStorageLogging());
+        } else {
+            features.addCloudStorageLogging(true);
+        }
     }
 
     private void setClusterLogsCollectionFromAccountAndRequest(FeaturesRequest featuresRequest, Features accountFeatures, EnvironmentFeatures features) {
@@ -165,6 +180,14 @@ public class TelemetryApiConverter {
             } else {
                 features.addMonitoring(false);
             }
+        }
+    }
+
+    private void setCloudStorageLoggingOnFeaturesModel(EnvironmentFeatures features, FeaturesBase featureModel) {
+        if (features.getCloudStorageLogging() != null) {
+            featureModel.setCloudStorageLogging(features.getCloudStorageLogging());
+        } else {
+            featureModel.addCloudStorageLogging(true);
         }
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/telemetry/service/AccountTelemetryService.java
@@ -79,6 +79,7 @@ public class AccountTelemetryService {
                 finalFeatures.setClusterLogsCollection(features.getClusterLogsCollection());
                 finalFeatures.setWorkloadAnalytics(features.getWorkloadAnalytics());
                 finalFeatures.setMonitoring(features.getMonitoring());
+                finalFeatures.setCloudStorageLogging(features.getCloudStorageLogging());
                 if (newFeatures.getClusterLogsCollection() != null) {
                     LOGGER.debug("Account telemetry feature request contains log collection feature " +
                             "for account {} (set: {})", accountId, newFeatures.getClusterLogsCollection().isEnabled());
@@ -93,6 +94,11 @@ public class AccountTelemetryService {
                     LOGGER.debug("Account telemetry feature request contains monitoring feature " +
                             "for account {} (set: {})", accountId, newFeatures.getMonitoring().isEnabled());
                     finalFeatures.setMonitoring(newFeatures.getMonitoring());
+                }
+                if (newFeatures.getCloudStorageLogging() != null) {
+                    LOGGER.debug("Account telemetry feature request contains cloud storage logging feature " +
+                            "for account {} (set: {})", accountId, newFeatures.getCloudStorageLogging().isEnabled());
+                    finalFeatures.setMonitoring(newFeatures.getCloudStorageLogging());
                 }
             }
             telemetry.setFeatures(finalFeatures);
@@ -114,6 +120,7 @@ public class AccountTelemetryService {
                 }).collect(Collectors.toList());
         Features defaultFeatures = new Features();
         defaultFeatures.addClusterLogsCollection(false);
+        defaultFeatures.addCloudStorageLogging(true);
         defaultTelemetry.setRules(defaultEncodedRules);
         defaultTelemetry.setFeatures(defaultFeatures);
         return defaultTelemetry;

--- a/environment/src/main/java/com/sequenceiq/environment/telemetry/v1/converter/AccountTelemetryConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/telemetry/v1/converter/AccountTelemetryConverter.java
@@ -39,6 +39,11 @@ public class AccountTelemetryConverter {
             response.setClusterLogsCollection(source.getClusterLogsCollection());
             response.setMonitoring(source.getMonitoring());
             response.setWorkloadAnalytics(source.getWorkloadAnalytics());
+            if (source.getCloudStorageLogging() != null) {
+                response.setCloudStorageLogging(source.getCloudStorageLogging());
+            } else {
+                response.addCloudStorageLogging(true);
+            }
         }
         return response;
     }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
@@ -68,6 +68,7 @@ public class TelemetryApiConverterTest {
         assertTrue(result.getFeatures().getWorkloadAnalytics().isEnabled());
         assertTrue(result.getFeatures().getUseSharedAltusCredential().isEnabled());
         assertTrue(result.getFeatures().getMonitoring().isEnabled());
+        assertTrue(result.getFeatures().getCloudStorageLogging().isEnabled());
     }
 
     @Test

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverter.java
@@ -134,6 +134,11 @@ public class TelemetryConverter {
         if (useSharedAltusCredential) {
             features.addUseSharedAltusCredential(true);
         }
+        if (featuresRequest != null && featuresRequest.getCloudStorageLogging() != null) {
+            features.setCloudStorageLogging(featuresRequest.getCloudStorageLogging());
+        } else {
+            features.addCloudStorageLogging(true);
+        }
         return features;
     }
 
@@ -143,6 +148,11 @@ public class TelemetryConverter {
             featuresResponse = new FeaturesResponse();
             featuresResponse.setClusterLogsCollection(features.getClusterLogsCollection());
             featuresResponse.setUseSharedAltusCredential(features.getUseSharedAltusCredential());
+            if (features.getCloudStorageLogging() != null) {
+                featuresResponse.setCloudStorageLogging(features.getCloudStorageLogging());
+            } else {
+                featuresResponse.addCloudStorageLogging(true);
+            }
         }
         return featuresResponse;
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
@@ -58,6 +58,7 @@ public class TelemetryConverterTest {
         // THEN
         assertThat(result.getFeatures().getWorkloadAnalytics(), nullValue());
         assertThat(result.getFeatures().getClusterLogsCollection().isEnabled(), is(false));
+        assertThat(result.getFeatures().getCloudStorageLogging().isEnabled(), is(true));
         assertThat(result.getDatabusEndpoint(), is(DATABUS_ENDPOINT));
     }
 

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentFeatures.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/environment/dto/telemetry/EnvironmentFeatures.java
@@ -19,6 +19,8 @@ public class EnvironmentFeatures implements Serializable {
 
     private FeatureSetting monitoring;
 
+    private FeatureSetting cloudStorageLogging;
+
     public FeatureSetting getClusterLogsCollection() {
         return clusterLogsCollection;
     }
@@ -51,6 +53,14 @@ public class EnvironmentFeatures implements Serializable {
         this.monitoring = monitoring;
     }
 
+    public FeatureSetting getCloudStorageLogging() {
+        return cloudStorageLogging;
+    }
+
+    public void setCloudStorageLogging(FeatureSetting cloudStorageLogging) {
+        this.cloudStorageLogging = cloudStorageLogging;
+    }
+
     @JsonIgnore
     public void addWorkloadAnalytics(boolean enabled) {
         workloadAnalytics = new FeatureSetting();
@@ -73,5 +83,11 @@ public class EnvironmentFeatures implements Serializable {
     public void addUseSharedAltusredential(boolean enabled) {
         useSharedAltusCredential = new FeatureSetting();
         useSharedAltusCredential.setEnabled(enabled);
+    }
+
+    @JsonIgnore
+    public void addCloudStorageLogging(boolean enabled) {
+        cloudStorageLogging = new FeatureSetting();
+        cloudStorageLogging.setEnabled(enabled);
     }
 }


### PR DESCRIPTION
details:
create a new flag on the api (in telemetry request/response) to be able to disable/enable cloud storage logging (even if s3 related details are provided in the telemetry settings)
provide this flag for account level telemetry + freeipa/datalake/datahub telemetry

See detailed description in the commit message.