### PR TITLE
CB-10452: Database backup should support hdfs location as well.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/dr/BackupRestoreV4RequestValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/dr/BackupRestoreV4RequestValidator.java
@@ -39,6 +39,10 @@ public class BackupRestoreV4RequestValidator {
     private void validateCloudLocationScheme(String cloudPlatform, String location, ValidationResult.ValidationResultBuilder resultBuilder) {
         try {
             URI uri = new URI(location);
+            if (!Strings.isNullOrEmpty(uri.getScheme()) &&
+                    uri.getScheme().equalsIgnoreCase("hdfs")) {
+                return;
+            }
             if (AWS.equalsIgnoreCase(cloudPlatform)) {
                 if (uri.getScheme() != null) {
                     Matcher matcher = AWS_PATTERN.matcher(uri.getScheme());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
@@ -9,6 +9,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.base.Strings;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -47,7 +48,10 @@ public class BackupRestoreSaltConfigGenerator {
         URI uri = new URI(location);
         String suffix = '/' + backupId + DATABASE_BACKUP_POSTFIX;
         String fullLocation;
-        if (AWS.equalsIgnoreCase(cloudPlatform)) {
+        if (!Strings.isNullOrEmpty(uri.getScheme()) &&
+                uri.getScheme().equalsIgnoreCase("hdfs")) {
+            fullLocation = uri.toString();
+        } else if (AWS.equalsIgnoreCase(cloudPlatform)) {
             fullLocation = "s3a://" + uri.getSchemeSpecificPart().replaceAll("^/+", "");
         } else if (AZURE.equalsIgnoreCase(cloudPlatform)) {
             fullLocation = "abfs://" + uri.getSchemeSpecificPart().replaceAll("^/+", "");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/dr/BackupRestoreV4RequestValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/dr/BackupRestoreV4RequestValidatorTest.java
@@ -58,6 +58,9 @@ public class BackupRestoreV4RequestValidatorTest {
 
         validationResult = requestValidator.validate(stack, LOCATION, BACKUP_ID);
         assertFalse(validationResult.hasError());
+
+        validationResult = requestValidator.validate(stack, "hdfs://" + LOCATION, BACKUP_ID);
+        assertFalse(validationResult.hasError());
     }
 
     @Test
@@ -81,6 +84,9 @@ public class BackupRestoreV4RequestValidatorTest {
         assertFalse(validationResult.hasError());
 
         validationResult = requestValidator.validate(stack, LOCATION, BACKUP_ID);
+        assertFalse(validationResult.hasError());
+
+        validationResult = requestValidator.validate(stack, "hdfs://" + LOCATION, BACKUP_ID);
         assertFalse(validationResult.hasError());
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
@@ -47,6 +47,35 @@ public class BackupRestoreSaltConfigGeneratorTest {
     }
 
     @Test
+    public void testCreateSaltConfigWithHdfsLocation() throws URISyntaxException {
+        // AWS platform
+        String cloudPlatform = "aws";
+        String location = "hdfs://test/backups";
+        Stack placeholderStack = new Stack();
+        placeholderStack.setCloudPlatform(cloudPlatform);
+
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, placeholderStack);
+
+        Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
+        Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
+
+        assertEquals("hdfs://test/backups/backupId_database_backup", disasterRecoveryKeyValuePairs.get(OBJECT_STORAGE_URL_KEY));
+        assertEquals(RANGER_ADMIN_GROUP, disasterRecoveryKeyValuePairs.get(RANGER_ADMIN_GROUP_KEY));
+
+        // Azure platform
+        cloudPlatform = "azure";
+        placeholderStack = new Stack();
+        placeholderStack.setCloudPlatform(cloudPlatform);
+
+        saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, placeholderStack);
+
+        disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
+        disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
+
+        assertEquals("hdfs://test/backups/backupId_database_backup", disasterRecoveryKeyValuePairs.get(OBJECT_STORAGE_URL_KEY));
+    }
+
+    @Test
     public void testObjectStorageUrlIsPrefixedWithS3aForAwsCloudplatform() throws URISyntaxException {
         String cloudPlatform = "aws";
         String location = "/test/backups";


### PR DESCRIPTION
As runtime 7.1.0 and 7.2.0 do not support backup to object stores, we should support backup to HDFS location as well.
This is needed to support backup for data lake that are using runtime 7.1.0 and 7.20.