### PR TITLE
CB-8906 Add FreeIPA backup support for GCP

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupFolderResolverService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupFolderResolverService.java
@@ -15,12 +15,16 @@ public class CloudBackupFolderResolverService {
 
     private final S3BackupConfigGenerator s3BackupConfigGenerator;
 
+    private final GCSBackupConfigGenerator gcsBackupConfigGenerator;
+
     private final AdlsGen2BackupConfigGenerator adlsGen2BackupConfigGenerator;
 
     public CloudBackupFolderResolverService(S3BackupConfigGenerator s3BackupConfigGenerator,
-            AdlsGen2BackupConfigGenerator adlsGen2BackupConfigGenerator) {
+            AdlsGen2BackupConfigGenerator adlsGen2BackupConfigGenerator,
+            GCSBackupConfigGenerator gcsBackupConfigGenerator) {
         this.s3BackupConfigGenerator = s3BackupConfigGenerator;
         this.adlsGen2BackupConfigGenerator = adlsGen2BackupConfigGenerator;
+        this.gcsBackupConfigGenerator = gcsBackupConfigGenerator;
     }
 
     public Backup updateStorageLocation(Backup backup, String clusterType,
@@ -33,6 +37,9 @@ public class CloudBackupFolderResolverService {
                         clusterType, clusterName, clusterCrn);
             } else if (backup.getAdlsGen2() != null) {
                 storageLocation = resolveAdlsGen2Location(storageLocation,
+                        clusterType, clusterName, clusterCrn);
+            } else if (backup.getGcs() != null) {
+                storageLocation = resolveGcsLocation(storageLocation,
                         clusterType, clusterName, clusterCrn);
             } else {
                 LOGGER.warn("None of the backup storage location was resolved, "
@@ -49,6 +56,13 @@ public class CloudBackupFolderResolverService {
             String clusterName, String clusterCrn) {
         LOGGER.debug("Start to resolve S3 storage location for telemetry (logging).");
         return s3BackupConfigGenerator.generateBackupLocation(location,
+                clusterType, clusterName, Crn.fromString(clusterCrn).getResource());
+    }
+
+    public String resolveGcsLocation(String location, String clusterType,
+            String clusterName, String clusterCrn) {
+        LOGGER.debug("Start to resolve GCS storage location for telemetry (logging).");
+        return gcsBackupConfigGenerator.generateBackupLocation(location,
                 clusterType, clusterName, Crn.fromString(clusterCrn).getResource());
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/GCSBackupConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/GCSBackupConfig.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+public class GCSBackupConfig extends CloudBackupStorageConfig {
+
+    private final String bucket;
+
+    public GCSBackupConfig(String folderPrefix, String bucket) {
+        super(folderPrefix);
+        this.bucket = bucket;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/GCSBackupConfigGenerator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/GCSBackupConfigGenerator.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Paths;
+
+@Component
+public class GCSBackupConfigGenerator extends CloudBackupConfigGenerator<GCSBackupConfig> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GCSBackupConfigGenerator.class);
+
+    private static final String[] GCS_SCHEME_PREFIXES = {"gs://"};
+
+    @Override
+    public String generateBackupLocation(String location, String clusterType, String clusterName, String clusterId) {
+        GCSBackupConfig gcsBackupConfig = generateBackupConfig(location);
+        String generatedGcsLocation = GCS_SCHEME_PREFIXES[0] + Paths.get(gcsBackupConfig.getBucket(),
+                resolveBackupFolder(gcsBackupConfig, clusterType, clusterName, clusterId));
+        LOGGER.debug("The following GCS base folder location is generated: {} (from {})",
+                generatedGcsLocation, location);
+        return generatedGcsLocation;
+    }
+
+    private GCSBackupConfig generateBackupConfig(String location) {
+        if (StringUtils.isNotEmpty(location)) {
+            String locationWithoutScheme = getLocationWithoutSchemePrefixes(location, GCS_SCHEME_PREFIXES);
+            String[] locationSplit = locationWithoutScheme.split("/", 2);
+            String folderPrefix = locationSplit.length < 2 ? "" :  locationSplit[1];
+            return new GCSBackupConfig(folderPrefix, locationSplit[0]);
+        }
+        throw new CloudbreakServiceException("Storage location parameter is missing for GCS");
+    }
+}

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
@@ -209,6 +209,24 @@ elif [[ "${config[backup_platform]}" = "AZURE" ]]; then
     /usr/local/bin/azcopy login --identity --identity-resource-id "${config[azure_instance_msi]}" >> "${LOGFILE}" 2>&1 || error_exit "Unable to login to Azure!"
     /usr/local/bin/azcopy copy "${config[backup_path]}/${BACKUPDIR}" "${BACKUP_LOCATION}" --recursive=true --check-length=false >> "${LOGFILE}" 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
     remove_local_backups
+elif [[ "${config[backup_platform]}" = "GCP" ]]; then
+    # To avoid storage.objects.list permission for logger we must sync backups to the bucket instead of the object
+    BACKUP_PATH="/${BACKUP_LOCATION#*://*/}"
+    BACKUP_BUCKET=$(echo "${BACKUP_LOCATION}" | cut -f-3 -d '/')
+    doLog "INFO Copy backup to ${BACKUP_PATH} before moving it to cloud storage"
+    if [[ "${BACKUP_PATH}" = / ]]; then
+      BACKUP_PATH="/cluster-backups/freeipa"
+    elif [[ "${BACKUP_PATH}" != /* ]]; then
+      BACKUP_PATH="/${BACKUP_PATH}"
+    fi
+    mkdir -p "${BACKUP_PATH}"
+    cp -r "${config[backup_path]}/${BACKUPDIR}" "${BACKUP_PATH}"
+    # shellcheck disable=SC2012
+    BACKUP_ROOT_FOLDER="/"$(ls -d "${BACKUP_PATH}" | cut -f 2 -d '/')
+    doLog "INFO Syncing backups to Google Cloud Storage"
+    /bin/gsutil -m mv "${BACKUP_ROOT_FOLDER}" "${BACKUP_BUCKET}" >> "${LOGFILE}" 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
+    rm -rf "${BACKUP_PATH}"
+    remove_local_backups
 fi
 
 doLog "INFO Backup completed."

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupFolderResolverServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/CloudBackupFolderResolverServiceTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,7 +20,8 @@ public class CloudBackupFolderResolverServiceTest {
     @Before
     public void setUp() {
         underTest = new CloudBackupFolderResolverService(new S3BackupConfigGenerator(),
-                new AdlsGen2BackupConfigGenerator());
+                new AdlsGen2BackupConfigGenerator(),
+                new GCSBackupConfigGenerator());
     }
 
     @Test
@@ -45,6 +47,20 @@ public class CloudBackupFolderResolverServiceTest {
                 "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
         // THEN
         assertEquals("https://someaccount.dfs.core.windows.net/mycontainer/cluster-backups/freeipa/mycluster_12345", backup.getStorageLocation());
+    }
+
+    @Test
+    public void testUpdateStorageLocationGcs() {
+        // GIVEN
+        Backup backup = createBackup();
+        backup.setS3(null);
+        backup.setGcs(new GcsCloudStorageV1Parameters());
+        backup.setStorageLocation("gs://mybucket");
+        // WHEN
+        underTest.updateStorageLocation(backup, FluentClusterType.FREEIPA.value(), "mycluster",
+                "crn:cdp:cloudbreak:us-west-1:someone:stack:12345");
+        // THEN
+        assertEquals("gs://mybucket/cluster-backups/freeipa/mycluster_12345", backup.getStorageLocation());
     }
 
     @Test

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/GCSBackupConfigGeneratorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/backup/cloud/GCSBackupConfigGeneratorTest.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.freeipa.service.freeipa.backup.cloud;
+
+import com.sequenceiq.cloudbreak.telemetry.fluent.FluentClusterType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ */
+public class GCSBackupConfigGeneratorTest {
+
+    @Test
+    public void testSimpleCaseLocation() {
+        GCSBackupConfigGenerator gcsBackupConfigGenerator = new GCSBackupConfigGenerator();
+        String location = gcsBackupConfigGenerator.generateBackupLocation(
+                "gs://mybucket",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("gs://mybucket/cluster-backups/freeipa/mycluster_12345", location);
+    }
+
+    @Test
+    public void testSuppliedFolderLocation() {
+        GCSBackupConfigGenerator gcsBackupConfigGenerator = new GCSBackupConfigGenerator();
+        String location = gcsBackupConfigGenerator.generateBackupLocation(
+                "gs://mybucket/something",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("gs://mybucket/something/cluster-backups/freeipa/mycluster_12345", location);
+    }
+
+    @Test
+    public void testNonPrefixedLocation() {
+        GCSBackupConfigGenerator gcsBackupConfigGenerator = new GCSBackupConfigGenerator();
+        String location = gcsBackupConfigGenerator.generateBackupLocation(
+                "mybucket",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("gs://mybucket/cluster-backups/freeipa/mycluster_12345", location);
+    }
+
+    @Test
+    public void testMultiFolderLocation() {
+        GCSBackupConfigGenerator gcsBackupConfigGenerator = new GCSBackupConfigGenerator();
+        String location = gcsBackupConfigGenerator.generateBackupLocation(
+                "mybucket/something/deeper",
+                FluentClusterType.FREEIPA.value(),
+                "mycluster",
+                "12345");
+        assertEquals("gs://mybucket/something/deeper/cluster-backups/freeipa/mycluster_12345", location);
+    }
+}


### PR DESCRIPTION
1. Setup the FreeIPA backup config folder appropriately.
2. The backup logic got convoluted because a normal gsutil cp operation needs storage.objects.get permission if the destination is an object instead of bucket.
3. To achieve the directory structure temporarily copied the backups to a folder with the appropriate structure then perform the move to the destination.
4. Tested the script in a live cluster.