### PR TITLE
CB-10484 add SRM versions to 7.2.7 and 7.2.8 version infos

### DIFF
--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.2.7.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.2.7.json
@@ -135,6 +135,10 @@
     {
       "name": "LIVY_FOR_SPARK3",
       "version": "0.6.0"
+    },
+    {
+      "name": "STREAMS_REPLICATION_MANAGER",
+      "version": "1.0.0"
     }
   ],
   "version": "7.2.7",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.2.8.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.2.8.json
@@ -135,6 +135,10 @@
     {
       "name": "LIVY_FOR_SPARK3",
       "version": "0.6.0"
+    },
+    {
+      "name": "STREAMS_REPLICATION_MANAGER",
+      "version": "1.0.0"
     }
   ],
   "version": "7.2.8",


### PR DESCRIPTION
Porting "CB-10484 add SRM versions to 7.2.7 and 7.2.8 version infos" from master.

This issue causes SRM not appearing on streams messaging cluster creation page on the UI 