### PR TITLE
CB-10519 Modify directories' owner only if directory exists

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/start.sls
@@ -44,17 +44,18 @@ restart_cm_after_fronted_url_change:
 {% endif %}
 
 {% if salt['pillar.get']('cloudera-manager:mgmt_service_directories') is defined and salt['pillar.get']('cloudera-manager:mgmt_service_directories')|length > 0 %}
-ensure_owners:
-  file.directory:
-    - names:
 {%- for dir in salt['pillar.get']('cloudera-manager:mgmt_service_directories') %}
-        - {{ dir }}
-{%- endfor %}
+ensure_owners_{{ dir }}:
+  file.directory:
+    - name: {{ dir }}
     - user: cloudera-scm
     - group: cloudera-scm
     - recurse:
-        - user
-        - group
+      - user
+      - group
+    - onlyif: test -d {{ dir }}
+
+{%- endfor %}
 {% endif %}
 
 start_server:


### PR DESCRIPTION
CM MGMT services use some directories under /hadoopfs which owners must be ensured. This has been added with a previous commit.
With this commit we won't create the directories if they don't exist to avoid some issues on ycloud and creating directories when not used.