### PR TITLE
CB-10520 - DL creation failed 'Data Lake creation failed: null' due t…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudResource.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudResource.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.cloud.model;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import com.google.common.base.Preconditions;
 import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
@@ -29,10 +30,12 @@ public class CloudResource extends DynamicModel {
 
     private final boolean persistent;
 
+    private final boolean stackAware;
+
     private String instanceId;
 
     private CloudResource(ResourceType type, CommonStatus status, String name, String reference, String group, boolean persistent, Map<String, Object> params,
-            String instanceId) {
+            String instanceId, boolean stackAware) {
         super(params);
         this.type = type;
         this.status = status;
@@ -41,6 +44,7 @@ public class CloudResource extends DynamicModel {
         this.group = group;
         this.persistent = persistent;
         this.instanceId = instanceId;
+        this.stackAware = stackAware;
     }
 
     public ResourceType getType() {
@@ -65,6 +69,10 @@ public class CloudResource extends DynamicModel {
 
     public boolean isPersistent() {
         return persistent;
+    }
+
+    public boolean isStackAware() {
+        return stackAware;
     }
 
     @Override
@@ -113,6 +121,8 @@ public class CloudResource extends DynamicModel {
 
         private Map<String, Object> parameters = new HashMap<>();
 
+        private Boolean stackAware;
+
         public Builder cloudResource(CloudResource cloudResource) {
             type = cloudResource.getType();
             status = cloudResource.getStatus();
@@ -121,6 +131,7 @@ public class CloudResource extends DynamicModel {
             persistent = cloudResource.isPersistent();
             group = cloudResource.getGroup();
             instanceId = cloudResource.getInstanceId();
+            stackAware = cloudResource.isStackAware();
             return this;
         }
 
@@ -164,12 +175,21 @@ public class CloudResource extends DynamicModel {
             return this;
         }
 
+        public Builder stackAware(boolean stackAware) {
+            this.stackAware = stackAware;
+            return this;
+        }
+
         public CloudResource build() {
             Preconditions.checkNotNull(type);
             Preconditions.checkNotNull(status);
             Preconditions.checkNotNull(name);
             Preconditions.checkNotNull(parameters);
-            return new CloudResource(type, status, name, reference, group, persistent, parameters, instanceId);
+            if (Objects.isNull(stackAware)) {
+                return new CloudResource(type, status, name, reference, group, persistent, parameters, instanceId, true);
+            } else {
+                return new CloudResource(type, status, name, reference, group, persistent, parameters, instanceId, stackAware);
+            }
         }
     }
 }

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/CloudResourceTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/CloudResourceTest.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.ResourceType;
+
+public class CloudResourceTest {
+
+    @Test
+    void isStackAwareWhenDefault() {
+        CloudResource cloudResource = generateCloudResourceStub().build();
+
+        assertThat(cloudResource).isNotNull();
+        assertThat(cloudResource.isStackAware()).isTrue();
+    }
+
+    @Test
+    void isStackAwareWhenTrueIsSet() {
+        CloudResource cloudResource = generateCloudResourceStub().stackAware(true).build();
+
+        assertThat(cloudResource).isNotNull();
+        assertThat(cloudResource.isStackAware()).isTrue();
+    }
+
+    @Test
+    void isNonStackAwareWhenFalseIsSet() {
+        CloudResource cloudResource = generateCloudResourceStub().stackAware(false).build();
+
+        assertThat(cloudResource).isNotNull();
+        assertThat(cloudResource.isStackAware()).isFalse();
+    }
+
+    private CloudResource.Builder generateCloudResourceStub() {
+        return CloudResource.builder()
+                .type(ResourceType.AZURE_MANAGED_IMAGE)
+                .name("test-image")
+                .status(CommonStatus.REQUESTED)
+                .params(Map.of());
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ResourceRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ResourceRepository.java
@@ -36,4 +36,8 @@ public interface ResourceRepository extends CrudRepository<Resource, Long> {
     Optional<Resource> findByResourceReferenceAndStatusAndType(@Param("resourceReference") String resourceReference, @Param("status") CommonStatus status,
             @Param("type") ResourceType type);
 
+    @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceType = :type")
+    Optional<Resource> findByResourceReferenceAndType(@Param("resourceReference") String resourceReference,
+            @Param("type") ResourceType type);
+
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/resource/ResourceService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/resource/ResourceService.java
@@ -72,4 +72,8 @@ public class ResourceService {
     public Optional<Resource> findByResourceReferenceAndStatusAndType(String resourceReference, CommonStatus status, ResourceType resourceType) {
         return repository.findByResourceReferenceAndStatusAndType(resourceReference, status, resourceType);
     }
+
+    public Optional<Resource> findByResourceReferenceAndType(String resourceReference, ResourceType resourceType) {
+        return repository.findByResourceReferenceAndType(resourceReference, resourceType);
+    }
 }

--- a/core/src/main/resources/schema/app/20210107113616_CB-10520-missing-unique-constraint.sql
+++ b/core/src/main/resources/schema/app/20210107113616_CB-10520-missing-unique-constraint.sql
@@ -1,0 +1,10 @@
+-- // CB-10520-missing-unique-constraint
+-- Migration SQL that makes the change goes here.
+ALTER TABLE resource DROP CONSTRAINT IF EXISTS uk_namebytypebystack;
+
+ALTER TABLE resource ADD CONSTRAINT uk_namebytypebystack UNIQUE (resourcename, resourcetype, resourcereference, resource_stack);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE resource DROP CONSTRAINT IF EXISTS uk_namebytypebystack;

--- a/environment/src/main/java/com/sequenceiq/environment/resourcepersister/CloudResourcePersisterService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/resourcepersister/CloudResourcePersisterService.java
@@ -39,8 +39,7 @@ public class CloudResourcePersisterService implements Persister<ResourceNotifica
         CloudResource cloudResource = notification.getCloudResource();
         Resource resource = conversionService.convert(cloudResource, Resource.class);
         Optional<Resource> persistedResource =
-                resourceService.findByResourceReferencAndType(cloudResource.getReference(),
-                        ResourceType.valueOf(cloudResource.getType().name()));
+                resourceService.findByResourceReferenceAndType(cloudResource.getReference(), cloudResource.getType());
         if (persistedResource.isPresent()) {
             LOGGER.debug("Trying to persist a resource (name: {}, type: {}, environmentId: {}) that is already persisted, skipping..",
                     cloudResource.getName(), cloudResource.getType().name(), envId);
@@ -56,7 +55,7 @@ public class CloudResourcePersisterService implements Persister<ResourceNotifica
         LOGGER.debug("Resource update notification received: {}", notification);
         Long envId = notification.getCloudContext().getId();
         CloudResource cloudResource = notification.getCloudResource();
-        Resource persistedResource = resourceService.findByResourceReferencAndType(cloudResource.getReference(),
+        Resource persistedResource = resourceService.findByResourceReferenceAndType(cloudResource.getReference(),
                 ResourceType.valueOf(cloudResource.getType().name())).orElseThrow(NotFoundException.notFound("resource", cloudResource.getName()));
         Resource resource = conversionService.convert(cloudResource, Resource.class);
         updateWithPersistedFields(resource, persistedResource);
@@ -69,7 +68,7 @@ public class CloudResourcePersisterService implements Persister<ResourceNotifica
     public ResourceNotification delete(ResourceNotification notification) {
         LOGGER.debug("Resource deletion notification received: {}", notification);
         CloudResource cloudResource = notification.getCloudResource();
-        resourceService.findByResourceReferencAndType(cloudResource.getReference(),
+        resourceService.findByResourceReferenceAndType(cloudResource.getReference(),
                 ResourceType.valueOf(cloudResource.getType().name())).ifPresent(value -> resourceService.delete(value));
         return notification;
     }

--- a/environment/src/main/java/com/sequenceiq/environment/resourcepersister/ResourceService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/resourcepersister/ResourceService.java
@@ -41,7 +41,7 @@ public class ResourceService {
         return repository.findByResourceReferenceAndStatusAndType(resourceReference, status, resourceType);
     }
 
-    public Optional<Resource> findByResourceReferencAndType(String resourceReference, ResourceType resourceType) {
+    public Optional<Resource> findByResourceReferenceAndType(String resourceReference, ResourceType resourceType) {
         return repository.findByResourceReferenceAndType(resourceReference, resourceType);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/ResourceRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/ResourceRepository.java
@@ -27,4 +27,8 @@ public interface ResourceRepository extends CrudRepository<Resource, Long> {
     @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceStatus = :status AND r.resourceType = :type")
     Optional<Resource> findByResourceReferenceAndStatusAndType(@Param("resourceReference") String resourceReference, @Param("status") CommonStatus status,
             @Param("type") ResourceType type);
+
+    @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceType = :type")
+    Optional<Resource> findByResourceReferenceAndType(@Param("resourceReference") String resourceReference,
+            @Param("type") ResourceType type);
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/resource/ResourceService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/resource/ResourceService.java
@@ -63,4 +63,8 @@ public class ResourceService {
         return repository.findByResourceReferenceAndStatusAndType(resourceReference, status, resourceType);
     }
 
+    public Optional<Resource> findByResourceReferenceAndType(String resourceReference, ResourceType resourceType) {
+        return repository.findByResourceReferenceAndType(resourceReference, resourceType);
+    }
+
 }

--- a/freeipa/src/main/resources/schema/app/20210107113616_CB-10520-missing-unique-constraint.sql
+++ b/freeipa/src/main/resources/schema/app/20210107113616_CB-10520-missing-unique-constraint.sql
@@ -1,0 +1,10 @@
+-- // CB-10520-missing-unique-constraint
+-- Migration SQL that makes the change goes here.
+ALTER TABLE resource DROP CONSTRAINT IF EXISTS uk_namebytypebystack;
+
+ALTER TABLE resource ADD CONSTRAINT uk_namebytypebystack UNIQUE (resourcename, resourcetype, resourcereference, resource_stack);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE resource DROP CONSTRAINT IF EXISTS uk_namebytypebystack;


### PR DESCRIPTION
…o managed image race condition

The original issue was caused by a race condition between 2 cluster launches trying to create the same managed image object because there was no unique constraint in the table and the time difference on the creation was tiny. The finder method caused the cluster to fail as it expected a single Optional but received 2 items.


To fix this, the PR includes the following:

1. StackAware vs nonStackAware resources -> the latter being the managed image, as it is not connected to any stack directly
2. CloudResourcePersisterService rewrite to use correct DB methods for non-stack aware reources 
3. unique constraint to prevent race conditions on multiple concurrent managed image resource DB insertion


These were the events related to the original issue

`2021-01-06 17:16:36,649 [reactorDispatcher-18] updateImageStatus:111 DEBUG c.s.c.c.a.i.AzureImageService - [type:STACK] [crn:crn:cdp:datalake:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:datalake:db3fbd5b-7501-4745-9b49-574d6a002cb2] [name:e2e-8573395-mbb-dl] [flow:14bd6e64-36bc-4e1b-bb62-7d31c1db946e] [requestid:] [tenant:c6d5116e-75f2-42d9-8049-8c2976fd7ae0] [userCrn:crn:altus:iam:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:user:e99fd494-299a-4ed7-9ae8-15662edb1946] [environment:crn:cdp:environments:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:environment:38de51b9-c4f4-4489-ada6-bce38e1d3c8c] [traceId:999dfab07214697c] [spanId:80595650253eeec] Updating image status to CREATED: /subscriptions/39b27430-905d-48b2-b018-982ee2860521/resourceGroups/cloudbreak-images/providers/Microsoft.Compute/images/cb-cdh-72-2101052208.vhd-westus2`

`2021-01-06 17:16:14,342 [reactorDispatcher-33] updateImageStatus:111 DEBUG c.s.c.c.a.i.AzureImageService - [type:STACK] [crn:crn:cdp:datalake:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:datalake:f677b1b0-e8e3-4a29-a644-c8af41e0634f] [name:e2e-8573395-6hy-dl] [flow:4cc89800-1a15-49f4-a8f0-914c59c2d837] [requestid:] [tenant:c6d5116e-75f2-42d9-8049-8c2976fd7ae0] [userCrn:crn:altus:iam:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:user:e99fd494-299a-4ed7-9ae8-15662edb1946] [environment:crn:cdp:environments:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:environment:2b8763c4-ac08-484b-ae57-827df9a929c6] [traceId:86af9f714a536af6] [spanId:8bff7466a7d2865e] Updating image status to CREATED: /subscriptions/39b27430-905d-48b2-b018-982ee2860521/resourceGroups/cloudbreak-images/providers/Microsoft.Compute/images/cb-cdh-72-2101052208.vhd-westus2`

`2021-01-06 17:16:08,305 [reactorDispatcher-8] lambda$reactor$1:128 ERROR c.s.f.r.c.EventBusConfig - [type:springLog] [crn:] [name:] [flow:] [requestid:] [tenant:] [userCrn:] [environment:] [traceId:19b1e06547b83532] [spanId:19b1e06547b83532] Exception happened in dispatcher
org.springframework.dao.IncorrectResultSizeDataAccessException: query did not return a unique result: 2; nested exception is javax.persistence.NonUniqueResultException: query did not return a unique result: 2`

`2021-01-06 17:16:00,141 [reactorDispatcher-18] saveImage:106 DEBUG c.s.c.c.a.i.AzureImageService - [type:STACK] [crn:crn:cdp:datalake:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:datalake:db3fbd5b-7501-4745-9b49-574d6a002cb2] [name:e2e-8573395-mbb-dl] [flow:14bd6e64-36bc-4e1b-bb62-7d31c1db946e] [requestid:] [tenant:c6d5116e-75f2-42d9-8049-8c2976fd7ae0] [userCrn:crn:altus:iam:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:user:e99fd494-299a-4ed7-9ae8-15662edb1946] [environment:crn:cdp:environments:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:environment:38de51b9-c4f4-4489-ada6-bce38e1d3c8c] [traceId:999dfab07214697c] [spanId:80595650253eeec] Persisting image with REQUESTED status: /subscriptions/39b27430-905d-48b2-b018-982ee2860521/resourceGroups/cloudbreak-images/providers/Microsoft.Compute/images/cb-cdh-72-2101052208.vhd-westus2`

`2021-01-06 17:16:00,115 [reactorDispatcher-33] saveImage:106 DEBUG c.s.c.c.a.i.AzureImageService - [type:STACK] [crn:crn:cdp:datalake:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:datalake:f677b1b0-e8e3-4a29-a644-c8af41e0634f] [name:e2e-8573395-6hy-dl] [flow:4cc89800-1a15-49f4-a8f0-914c59c2d837] [requestid:] [tenant:c6d5116e-75f2-42d9-8049-8c2976fd7ae0] [userCrn:crn:altus:iam:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:user:e99fd494-299a-4ed7-9ae8-15662edb1946] [environment:crn:cdp:environments:us-west-1:c6d5116e-75f2-42d9-8049-8c2976fd7ae0:environment:2b8763c4-ac08-484b-ae57-827df9a929c6] [traceId:86af9f714a536af6] [spanId:8bff7466a7d2865e] Persisting image with REQUESTED status: /subscriptions/39b27430-905d-48b2-b018-982ee2860521/resourceGroups/cloudbreak-images/providers/Microsoft.Compute/images/cb-cdh-72-2101052208.vhd-westus2`