### PR TITLE
CB-10482 Knox signing keys should not be world readable

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/knox.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/knox.sls
@@ -67,13 +67,25 @@
   file.managed:
     - contents_pillar: gateway:signkey
     - makedirs: True
+{% if salt['pillar.get']('cloudera-manager:settings:deterministic_uid_gid') == True %}
+    - user: knox
+    - group: knox
+    - mode: 640
+{% else %}
     - mode: 644
+{% endif %}
 
 {{ gateway.knox_data_root }}/security/keystores/signcert.pem:
   file.managed:
     - contents_pillar: gateway:signcert
     - makedirs: True
+{% if salt['pillar.get']('cloudera-manager:settings:deterministic_uid_gid') == True %}
+    - user: knox
+    - group: knox
+    - mode: 640
+{% else %}
     - mode: 644
+{% endif %}
 
   # openssl pkcs12 -export -in cert.pem -inkey key.pem -out signing.p12 -name signing-identity -password pass:admin
   # keytool -importkeystore -deststorepass admin1 -destkeypass admin1 -destkeystore signing.jks -srckeystore signing.p12 -srcstoretype PKCS12 -srcstorepass admin -alias signing-identity
@@ -86,7 +98,13 @@ knox-create-sign-pkcs12:
 
 {{ gateway.knox_data_root }}/security/keystores/signing.p12:
   file.managed:
+{% if salt['pillar.get']('cloudera-manager:settings:deterministic_uid_gid') == True %}
+    - user: knox
+    - group: knox
+    - mode: 640
+{% else %}
     - mode: 644
+{% endif %}
     - replace: False
 
 knox-create-sign-jks:
@@ -97,7 +115,13 @@ knox-create-sign-jks:
 
 {{ gateway.knox_data_root }}/security/keystores/signing.jks:
   file.managed:
+{% if salt['pillar.get']('cloudera-manager:settings:deterministic_uid_gid') == True %}
+    - user: knox
+    - group: knox
+    - mode: 640
+{% else %}
     - mode: 644
+{% endif %}
     - replace: False
 
 {% if salt['pillar.get']('gateway:saml') %}


### PR DESCRIPTION
When CM introduced Knox it didn't have a way to generate the signing
keys and topologies so we used our existing Salt states to generate them.
However, at the time of generation of these files the Knox user does not
exist, because it will be created later during the template installation.
For this reason we had to make the files world readable. Since CDP 7.2.1
CM introduced a script that CB calls to make all the user and group IDs
deterministic. After the invocation of this script the Knox user and group
becomes available when we generate the Knox files.

This PR is making the Knox user as the owner of these files intead of having
a world readable permission. This is only possible from 7.2.1 onwards at
the moment. The new permissions will look like the following:

ls -la /var/lib/knox/cloudbreak_resources/security/keystores/
-rw-r----- 1 knox knox  969 Jan  7 16:15 signcert.pem
-rw-r----- 1 knox knox 2036 Jan  7 16:15 signing.jks
-rw-r----- 1 knox knox 2374 Jan  7 16:15 signing.p12
-rw-r----- 1 knox knox 1679 Jan  7 16:15 signkey.pem

See detailed description in the commit message.