### PR TITLE
CB-10511: Changing RAZ deployment location in DHs to the Gateway and keeping it to master nodes for DLs.

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazBaseConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazBaseConfigProvider.java
@@ -4,9 +4,6 @@ import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.raz.RangerRaz
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.raz.RangerRazRoles.RANGER_RAZ_SERVER;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.cloudera.api.swagger.model.ApiClusterTemplateRoleConfigGroup;
@@ -14,26 +11,12 @@ import com.cloudera.api.swagger.model.ApiClusterTemplateService;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
-import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 
 public abstract class RangerRazBaseConfigProvider extends AbstractRoleConfigProvider {
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
         return List.of();
-    }
-
-    @Override
-    public Map<String, ApiClusterTemplateService> getAdditionalServices(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
-        if (isConfigurationNeeded(cmTemplateProcessor, source)) {
-            ApiClusterTemplateService coreSettings = createTemplate();
-            Set<HostgroupView> hostgroupViews = source.getHostgroupViews();
-
-            return hostgroupViews.stream()
-                    .filter(hg -> hg.getName().toLowerCase().equals("master"))
-                    .collect(Collectors.toMap(HostgroupView::getName, v -> coreSettings));
-        }
-        return Map.of();
     }
 
     @Override
@@ -51,7 +34,7 @@ public abstract class RangerRazBaseConfigProvider extends AbstractRoleConfigProv
         return List.of();
     }
 
-    private ApiClusterTemplateService createTemplate() {
+    protected ApiClusterTemplateService createTemplate() {
         ApiClusterTemplateService coreSettings = new ApiClusterTemplateService()
                 .serviceType(RANGER_RAZ)
                 .refName("ranger-RANGER_RAZ");

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatahubConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatahubConfigProvider.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.raz;
 
+import com.cloudera.api.swagger.model.ApiClusterTemplateService;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
@@ -7,6 +10,10 @@ import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Enables the Ranger Raz service.
@@ -25,4 +32,16 @@ public class RangerRazDatahubConfigProvider extends RangerRazBaseConfigProvider 
                 && source.getDatalakeView().get().isRazEnabled();
     }
 
+    @Override
+    public Map<String, ApiClusterTemplateService> getAdditionalServices(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        if (isConfigurationNeeded(cmTemplateProcessor, source)) {
+            ApiClusterTemplateService coreSettings = createTemplate();
+            Set<HostgroupView> hostgroupViews = source.getHostgroupViews();
+
+            return hostgroupViews.stream()
+                    .filter(hg -> InstanceGroupType.GATEWAY.equals(hg.getInstanceGroupType()))
+                    .collect(Collectors.toMap(HostgroupView::getName, v -> coreSettings));
+        }
+        return Map.of();
+    }
 }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatalakeConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazDatalakeConfigProvider.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.raz;
 
+import com.cloudera.api.swagger.model.ApiClusterTemplateService;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
@@ -7,6 +9,10 @@ import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Enables the Ranger Raz service.
@@ -22,4 +28,16 @@ public class RangerRazDatalakeConfigProvider extends RangerRazBaseConfigProvider
                 && source.getGeneralClusterConfigs().isEnableRangerRaz();
     }
 
+    @Override
+    public Map<String, ApiClusterTemplateService> getAdditionalServices(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        if (isConfigurationNeeded(cmTemplateProcessor, source)) {
+            ApiClusterTemplateService coreSettings = createTemplate();
+            Set<HostgroupView> hostgroupViews = source.getHostgroupViews();
+
+            return hostgroupViews.stream()
+                    .filter(hg -> hg.getName().toLowerCase().equals("master"))
+                    .collect(Collectors.toMap(HostgroupView::getName, v -> coreSettings));
+        }
+        return Map.of();
+    }
 }


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-10511

Specifically just wanted to make it so that DataHubs have RAZ deployed on their Gateway nodes, while Datalakes have it deployed on the nodes with the name "master".

Have not tested yet but will do so soon.