### PR TITLE
CB-8677 Fix FreeIPA HA in GCP

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_install.sh
@@ -3,7 +3,12 @@
 set -e
 
 FQDN=$(hostname -f)
-IPADDR=$(hostname -i)
+# Get the ipaddresses of the host
+IPADDRS=$(hostname -i)
+echo "The ipaddresses of the host are $IPADDRS"
+# Get the first ipaddress. %% removes longest matching pattern in the end. ' *' pattern matches all but the first ipaddress.
+IPADDR="${IPADDRS%% *}"
+echo "The first ipaddress of the host is $IPADDR"
 
 ipa-server-install --unattended --uninstall
 

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
@@ -3,7 +3,12 @@
 set -e
 
 FQDN=$(hostname -f)
-IPADDR=$(hostname -i)
+# Get the ipaddresses of the host
+IPADDRS=$(hostname -i)
+echo "The ipaddresses of the host are $IPADDRS"
+# Get the first ipaddress. %% removes longest matching pattern in the end. ' *' pattern matches all but the first ipaddress.
+IPADDR="${IPADDRS%% *}"
+echo "The first ipaddress of the host is $IPADDR"
 
 if [ ! -f /etc/resolv.conf.orig ]; then
   cp /etc/resolv.conf /etc/resolv.conf.orig


### PR DESCRIPTION
1. If FreeIPA is installed in multiple hosts then the `hostname -i` gives the same IP address many times in a space-separated form.
2. It somehow happens only in GCP, and without the MULTI_IP_SUBNET guest OS feature.
3. This makes the ipa-client-install fail.
4. The fix here removes all but one IP address from `hostname -i` output.
5. Tested the script manually with 1, 2, and 3 IP addresses.