### PR TITLE
CB-10520 create partial unique indexes to achieve true NULL constrain…

### DIFF
--- a/core/src/main/resources/schema/app/20210110091020_CB-10520_crate_unique_index_for_resources_instead_of_constraint.sql
+++ b/core/src/main/resources/schema/app/20210110091020_CB-10520_crate_unique_index_for_resources_instead_of_constraint.sql
@@ -1,0 +1,21 @@
+-- // CB-10520 crate unique index for resources instead of constraint
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE resource DROP CONSTRAINT IF EXISTS uk_namebytypebystack;
+
+DROP INDEX IF EXISTS uk_resource_where_stack_id_is_not_null;
+DROP INDEX IF EXISTS uk_resource_where_stack_id_is_null;
+
+CREATE UNIQUE INDEX uk_resource_where_stack_id_is_not_null ON resource (resourcename, resourcetype, resourcereference, resource_stack)
+WHERE resource_stack IS NOT NULL;
+
+CREATE UNIQUE INDEX uk_resource_where_stack_id_is_null ON resource (resourcename, resourcetype, resourcereference)
+WHERE resource_stack IS NULL;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS uk_resource_where_stack_id_is_not_null;
+DROP INDEX IF EXISTS uk_resource_where_stack_id_is_null;
+
+ALTER TABLE resource ADD CONSTRAINT uk_namebytypebystack UNIQUE (resourcename, resourcetype, resourcereference, resource_stack);

--- a/freeipa/src/main/resources/schema/app/20210110091020_CB-10520_crate_unique_index_for_resources_instead_of_constraint.sql
+++ b/freeipa/src/main/resources/schema/app/20210110091020_CB-10520_crate_unique_index_for_resources_instead_of_constraint.sql
@@ -1,0 +1,21 @@
+-- // CB-10520 crate unique index for resources instead of constraint
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE resource DROP CONSTRAINT IF EXISTS uk_namebytypebystack;
+
+DROP INDEX IF EXISTS uk_resource_where_stack_id_is_not_null;
+DROP INDEX IF EXISTS uk_resource_where_stack_id_is_null;
+
+CREATE UNIQUE INDEX uk_resource_where_stack_id_is_not_null ON resource (resourcename, resourcetype, resourcereference, resource_stack)
+WHERE resource_stack IS NOT NULL;
+
+CREATE UNIQUE INDEX uk_resource_where_stack_id_is_null ON resource (resourcename, resourcetype, resourcereference)
+WHERE resource_stack IS NULL;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS uk_resource_where_stack_id_is_not_null;
+DROP INDEX IF EXISTS uk_resource_where_stack_id_is_null;
+
+ALTER TABLE resource ADD CONSTRAINT uk_namebytypebystack UNIQUE (resourcename, resourcetype, resourcereference, resource_stack);


### PR DESCRIPTION
…t on stack id

When multiple Azure environments are requested at the same time
and each would need to copy and create a managed image there is
a race condition on which one to create the managed image itself.
To fix this race condition we save a REQUESTED resource in the database
to know which environment is doing the work and the rest of them are
waiting for the image to be ready. To do this we have created a unique
constraint on the resource table with the "resourcename", "resourcetype",
"resourcereference" and "resource_stack" columns where the "resource_stack"
can be "null". It can be "null" since this resource is not stack dependent.
However, the unique constraint does not compare the values when there is a "null"
in any of the before mentioned columns and multiple resources with the same fields
can be inserted into the database.

To overcome this problem, instead of a unique constraint, we can create partial unique indexes.
When you create a unique constraint Postgres automatically creates the corresponding unique
index as well so there is not much difference, but for constraints, you cannot define conditions.
More on this:
https://www.enterprisedb.com/postgres-tutorials/postgresql-unique-constraint-null-allowing-only-one-null
https://stackoverflow.com/questions/8289100/create-unique-constraint-with-null-columns

See detailed description in the commit message.