### PR TITLE
CB-10359 - increase cluster template related converter test coverage vol.1

### DIFF
--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
@@ -40,6 +40,9 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataTyp
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.RecoveryMode;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.SSOType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AwsNetworkV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.MockNetworkV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.network.NetworkV4Request;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.model.recipe.RecipeType;
@@ -445,6 +448,38 @@ public class TestUtil {
         cluster.setWorkspace(workspace);
         cluster.setDatabaseServerCrn("databaseCRN");
         return cluster;
+    }
+
+    public static NetworkV4Request networkV4RequestForMock() {
+        NetworkV4Request r = new NetworkV4Request();
+        r.setMock(mockNetworkV4Parameters());
+        r.setCloudPlatform(CloudPlatform.MOCK);
+        r.setSubnetCIDR("0.0.0.0/0");
+        return r;
+    }
+
+    public static MockNetworkV4Parameters mockNetworkV4Parameters() {
+        MockNetworkV4Parameters p = new MockNetworkV4Parameters();
+        p.setSubnetId("someMockSubnet");
+        p.setVpcId("someMockVpc");
+        p.setInternetGatewayId("someMockInternetGatewayId");
+        return p;
+    }
+
+    public static NetworkV4Request networkV4RequestForAws() {
+        NetworkV4Request r = new NetworkV4Request();
+        r.setAws(awsNetworkV4Parameters());
+        r.setCloudPlatform(CloudPlatform.AWS);
+        r.setSubnetCIDR("0.0.0.0/0");
+        return r;
+    }
+
+    public static AwsNetworkV4Parameters awsNetworkV4Parameters() {
+        AwsNetworkV4Parameters p = new AwsNetworkV4Parameters();
+        p.setSubnetId("someAwsSubnet");
+        p.setVpcId("someAwsVpc");
+        p.setInternetGatewayId("someAwsInternetGatewayId");
+        return p;
     }
 
     public static KerberosConfig kerberosConfigFreeipa() {

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/clustertemplate/ClusterTemplateTestUtil.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/clustertemplate/ClusterTemplateTestUtil.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.clustertemplate;
+
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.requests.ClusterTemplateV4Request;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
+
+public final class ClusterTemplateTestUtil {
+
+    private static final String TEST_ENVIRONMENT_NAME = "some-awesome-env";
+
+    private ClusterTemplateTestUtil() {
+    }
+
+    public static ClusterTemplateV4Request createClusterTemplateV4RequestForAws() {
+        return createClusterTemplateV4RequestFor(AWS);
+    }
+
+    public static ClusterTemplateV4Request createClusterTemplateV4RequestFor(CloudPlatform cloudPlatform) {
+        ClusterTemplateV4Request r = new ClusterTemplateV4Request();
+        r.setDistroXTemplate(createDistroXV1Request());
+        r.setCloudPlatform(cloudPlatform.name());
+        return r;
+    }
+
+    private static DistroXV1Request createDistroXV1Request() {
+        DistroXV1Request r = new DistroXV1Request();
+        r.setEnvironmentName(TEST_ENVIRONMENT_NAME);
+        return r;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverter.java
@@ -175,14 +175,14 @@ public class TelemetryConverter {
         WorkloadAnalyticsRequest workloadAnalyticsRequest = null;
         if (telemetryPublisherEnabled) {
             Map<String, Object> waDefaultAttributes = createWAAttributesFromEnvironmentResponse(response);
-            workloadAnalyticsRequest = fillWARequestFromEnvironmenResponse(response, sdxClusterResponse, waDefaultAttributes);
+            workloadAnalyticsRequest = fillWARequestFromEnvironmentResponse(response, sdxClusterResponse, waDefaultAttributes);
         } else {
             LOGGER.debug("Workload analytics feature is disabled (globally).");
         }
         return workloadAnalyticsRequest;
     }
 
-    private WorkloadAnalyticsRequest fillWARequestFromEnvironmenResponse(TelemetryResponse response,
+    private WorkloadAnalyticsRequest fillWARequestFromEnvironmentResponse(TelemetryResponse response,
             SdxClusterResponse sdxClusterResponse, Map<String, Object> waDefaultAttributes) {
         WorkloadAnalyticsRequest workloadAnalyticsRequest = null;
         if (response != null && response.getFeatures() != null

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXAuthenticationToStaAuthenticationConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXAuthenticationToStaAuthenticationConverter.java
@@ -15,4 +15,5 @@ public class DistroXAuthenticationToStaAuthenticationConverter {
         response.setPublicKeyId(source.getPublicKeyId());
         return response;
     }
+
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXClusterToClusterConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXClusterToClusterConverter.java
@@ -5,8 +5,6 @@ import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 
 import java.util.List;
 
-import javax.inject.Inject;
-
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ExecutorType;
@@ -20,17 +18,21 @@ import com.sequenceiq.environment.api.v1.proxy.endpoint.ProxyEndpoint;
 @Component
 public class DistroXClusterToClusterConverter {
 
-    @Inject
-    private ClouderaManagerV1ToClouderaManagerV4Converter cmConverter;
+    private final ClouderaManagerV1ToClouderaManagerV4Converter cmConverter;
 
-    @Inject
-    private CloudStorageDecorator cloudStorageDecorator;
+    private final GatewayV1ToGatewayV4Converter gatewayConverter;
 
-    @Inject
-    private GatewayV1ToGatewayV4Converter gatewayConverter;
+    private final CloudStorageDecorator cloudStorageDecorator;
 
-    @Inject
-    private ProxyEndpoint proxyEndpoint;
+    private final ProxyEndpoint proxyEndpoint;
+
+    public DistroXClusterToClusterConverter(ClouderaManagerV1ToClouderaManagerV4Converter cmConverter, CloudStorageDecorator cloudStorageDecorator,
+            GatewayV1ToGatewayV4Converter gatewayConverter, ProxyEndpoint proxyEndpoint) {
+        this.cmConverter = cmConverter;
+        this.cloudStorageDecorator = cloudStorageDecorator;
+        this.gatewayConverter = gatewayConverter;
+        this.proxyEndpoint = proxyEndpoint;
+    }
 
     public ClusterV4Request convert(DistroXV1Request request) {
         return convert(request, null);
@@ -79,4 +81,5 @@ public class DistroXClusterToClusterConverter {
     private String getProxyCrnByName(String accountId, String proxyName) {
         return ThreadBasedUserCrnProvider.doAsInternalActor(() -> proxyEndpoint.getCrnByAccountIdAndName(accountId, proxyName));
     }
+
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXDatabaseRequestToStackDatabaseRequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXDatabaseRequestToStackDatabaseRequestConverter.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.distrox.v1.distrox.converter;
 
+import static java.lang.String.format;
+
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
@@ -9,6 +11,8 @@ import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseReque
 
 @Component
 public class DistroXDatabaseRequestToStackDatabaseRequestConverter {
+
+    private static final String UNEXPECTED_AVAILABILITY_TYPE_MSG_FORMAT = "Unexpected database availability type: %s";
 
     public DatabaseRequest convert(DistroXDatabaseRequest source) {
         DatabaseRequest request = new DatabaseRequest();
@@ -23,6 +27,9 @@ public class DistroXDatabaseRequestToStackDatabaseRequestConverter {
     }
 
     private DatabaseAvailabilityType convertAvailabilityType(DistroXDatabaseAvailabilityType availabilityType) {
+        if (availabilityType == null) {
+            throw new IllegalArgumentException(format(UNEXPECTED_AVAILABILITY_TYPE_MSG_FORMAT, null));
+        }
         switch (availabilityType) {
             case NONE:
                 return DatabaseAvailabilityType.NONE;
@@ -31,11 +38,14 @@ public class DistroXDatabaseRequestToStackDatabaseRequestConverter {
             case HA:
                 return DatabaseAvailabilityType.HA;
             default:
-                throw new IllegalStateException("Unexpected value: " + availabilityType);
+                throw new IllegalStateException(format(UNEXPECTED_AVAILABILITY_TYPE_MSG_FORMAT, availabilityType.name()));
         }
     }
 
     private DistroXDatabaseAvailabilityType convertAvailabilityType(DatabaseAvailabilityType availabilityType) {
+        if (availabilityType == null) {
+            throw new IllegalArgumentException(format(UNEXPECTED_AVAILABILITY_TYPE_MSG_FORMAT, null));
+        }
         switch (availabilityType) {
             case NONE:
                 return DistroXDatabaseAvailabilityType.NONE;
@@ -44,7 +54,8 @@ public class DistroXDatabaseRequestToStackDatabaseRequestConverter {
             case HA:
                 return DistroXDatabaseAvailabilityType.HA;
             default:
-                throw new IllegalStateException("Unexpected value: " + availabilityType);
+                throw new IllegalStateException(format(UNEXPECTED_AVAILABILITY_TYPE_MSG_FORMAT, availabilityType.name()));
         }
     }
+
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXImageToImageSettingsConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXImageToImageSettingsConverter.java
@@ -21,4 +21,5 @@ public class DistroXImageToImageSettingsConverter {
         response.setId(source.getId());
         return response;
     }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/AbstractJsonConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/AbstractJsonConverterTest.java
@@ -47,4 +47,5 @@ public abstract class AbstractJsonConverterTest<S> extends AbstractConverterTest
             throw new TestException(e);
         }
     }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/clustertemplate/ClusterTemplateV4RequestToClusterTemplateConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/clustertemplate/ClusterTemplateV4RequestToClusterTemplateConverterTest.java
@@ -1,0 +1,244 @@
+package com.sequenceiq.cloudbreak.converter.v4.clustertemplate;
+
+import static com.sequenceiq.cloudbreak.TestUtil.awsCredential;
+import static com.sequenceiq.cloudbreak.TestUtil.blueprint;
+import static com.sequenceiq.cloudbreak.TestUtil.cluster;
+import static com.sequenceiq.cloudbreak.TestUtil.stack;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.ClusterTemplateV4Type;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.DatalakeRequired;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.requests.ClusterTemplateV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.FeatureState;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
+import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
+import com.sequenceiq.cloudbreak.clustertemplate.ClusterTemplateTestUtil;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplate;
+import com.sequenceiq.cloudbreak.dto.credential.Credential;
+import com.sequenceiq.cloudbreak.service.environment.credential.CredentialClientService;
+import com.sequenceiq.cloudbreak.service.user.UserService;
+import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
+import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
+import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
+import com.sequenceiq.distrox.v1.distrox.converter.DistroXV1RequestToStackV4RequestConverter;
+
+class ClusterTemplateV4RequestToClusterTemplateConverterTest {
+
+    private static final Long TEST_WORKSPACE_ID = 1L;
+
+    @Mock
+    private ConverterUtil converterUtil;
+
+    @Mock
+    private WorkspaceService workspaceService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
+
+    @Mock
+    private CredentialClientService credentialClientService;
+
+    @Mock
+    private DistroXV1RequestToStackV4RequestConverter stackV4RequestConverter;
+
+    private ClusterTemplateV4RequestToClusterTemplateConverter underTest;
+
+    @Mock
+    private CloudbreakUser testCloudbreakUser;
+
+    @Mock
+    private User testUser;
+
+    @Mock
+    private Workspace testWorkspace;
+
+    @Mock
+    private StackV4Request testStackV4Request;
+
+    private Stack testStack;
+
+    @BeforeEach
+    void setUp() {
+        testStack = createStack();
+
+        MockitoAnnotations.openMocks(this);
+        underTest = new ClusterTemplateV4RequestToClusterTemplateConverter(converterUtil, workspaceService, userService, restRequestThreadLocalService,
+                credentialClientService, stackV4RequestConverter);
+        when(restRequestThreadLocalService.getCloudbreakUser()).thenReturn(testCloudbreakUser);
+        when(userService.getOrCreate(testCloudbreakUser)).thenReturn(testUser);
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(TEST_WORKSPACE_ID);
+        when(workspaceService.get(TEST_WORKSPACE_ID, testUser)).thenReturn(testWorkspace);
+        when(stackV4RequestConverter.convert(any(DistroXV1Request.class))).thenReturn(testStackV4Request);
+        when(converterUtil.convert(testStackV4Request, Stack.class)).thenReturn(testStack);
+    }
+
+    @Test
+    void testWhenDistroXTemplateIsNullThenBadRequestExceptionComes() {
+        ClusterTemplateV4Request r = ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws();
+        r.setDistroXTemplate(null);
+
+        assertThrows(BadRequestException.class, () -> underTest.convert(r));
+    }
+
+    @Test
+    void testWhenDistroXTemplateEnvironmentNameIsNullThenBadRequestExceptionComes() {
+        ClusterTemplateV4Request r = ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws();
+        r.getDistroXTemplate().setEnvironmentName(null);
+
+        assertThrows(BadRequestException.class, () -> underTest.convert(r));
+    }
+
+    @Test
+    void testWhenDistroXTemplateEnvironmentNameIsEmptyThenBadRequestExceptionComes() {
+        ClusterTemplateV4Request r = ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws();
+        r.getDistroXTemplate().setEnvironmentName("");
+
+        assertThrows(BadRequestException.class, () -> underTest.convert(r));
+    }
+
+    @Test
+    void testFetchedWorkspaceShouldBeSet() {
+        ClusterTemplate result = underTest.convert(ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws());
+
+        assertNotNull(result);
+        assertEquals(testWorkspace, result.getWorkspace());
+
+        verify(restRequestThreadLocalService, times(1)).getCloudbreakUser();
+        verify(userService, times(1)).getOrCreate(any());
+        verify(userService, times(1)).getOrCreate(testCloudbreakUser);
+        verify(workspaceService, times(1)).get(any(), any());
+        verify(workspaceService, times(1)).get(TEST_WORKSPACE_ID, testUser);
+    }
+
+    @Test
+    void testGivenStackHasBeenSet() {
+        ClusterTemplate result = underTest.convert(ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws());
+
+        assertNotNull(result);
+        assertEquals(testStack, result.getStackTemplate());
+    }
+
+    @Test
+    void testWhenCloudPlatformIsNotNullThenItShouldBeSetFromTheGivenRequest() {
+        ClusterTemplateV4Request r = ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws();
+        ClusterTemplate result = underTest.convert(r);
+
+        assertNotNull(r);
+        assertEquals(r.getCloudPlatform(), result.getCloudPlatform());
+    }
+
+    @Test
+    void testWhenCloudPlatformIsNullThenItShouldBeSetFromTheCredentialClientService() {
+        ClusterTemplateV4Request r = ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws();
+        r.setCloudPlatform(null);
+
+        Credential testCredential = Credential.builder().cloudPlatform("AWS").build();
+        when(credentialClientService.getByEnvironmentCrn(testStack.getEnvironmentCrn())).thenReturn(testCredential);
+
+        ClusterTemplate result = underTest.convert(r);
+
+        assertNotNull(r);
+        assertEquals(testCredential.cloudPlatform(), result.getCloudPlatform());
+    }
+
+    @Test
+    void testDatalakeRequiredShouldBeSetToOptional() {
+        ClusterTemplate result = underTest.convert(ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws());
+
+        assertNotNull(result);
+        assertEquals(DatalakeRequired.OPTIONAL, result.getDatalakeRequired());
+    }
+
+    @Test
+    void testFeatureStateShouldBeSetToReleased() {
+        ClusterTemplate result = underTest.convert(ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws());
+
+        assertNotNull(result);
+        assertEquals(FeatureState.RELEASED, result.getFeatureState());
+    }
+
+    @Test
+    void testStatusShouldBeSetToUserManaged() {
+        ClusterTemplate result = underTest.convert(ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws());
+
+        assertNotNull(result);
+        assertEquals(ResourceStatus.USER_MANAGED, result.getStatus());
+    }
+
+    @Test
+    void testWhenClusterInStackIsNullThenIllegalStateExceptionComes() {
+        Stack invalidStack = createStack();
+        invalidStack.setCluster(null);
+        when(converterUtil.convert(testStackV4Request, Stack.class)).thenReturn(invalidStack);
+
+        assertThrows(IllegalStateException.class, () -> underTest.convert(ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws()));
+    }
+
+    @Test
+    void testWhenBlueprintInClusterIsNullThenIllegalStateExceptionComes() {
+        Stack invalidStack = createStack();
+        invalidStack.getCluster().setBlueprint(null);
+        when(converterUtil.convert(testStackV4Request, Stack.class)).thenReturn(invalidStack);
+
+        assertThrows(IllegalStateException.class, () -> underTest.convert(ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws()));
+    }
+
+    @Test
+    void testWhenCldrRuntimeVersionIsObtainableThenItShouldBeSet() {
+        ClusterTemplate result = underTest.convert(ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws());
+
+        assertNotNull(result);
+        assertEquals(testStack.getCluster().getBlueprint().getStackVersion(), result.getClouderaRuntimeVersion());
+    }
+
+    @Test
+    void testWhenSourceContainsTypeThenThatShouldBeSet() {
+        ClusterTemplateV4Request r = ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws();
+
+        ClusterTemplate result = underTest.convert(r);
+
+        assertNotNull(r);
+        assertEquals(r.getType(), result.getType());
+    }
+
+    @Test
+    void testWhenSourceDoesNotContainsTypeThenOtherShouldBeSet() {
+        ClusterTemplateV4Request r = ClusterTemplateTestUtil.createClusterTemplateV4RequestForAws();
+        r.setType(null);
+
+        ClusterTemplate result = underTest.convert(r);
+
+        assertNotNull(r);
+        assertEquals(ClusterTemplateV4Type.OTHER, result.getType());
+    }
+
+    private Stack createStack() {
+        Stack stack = stack(AVAILABLE, awsCredential());
+        Cluster cluster = cluster(blueprint(), stack, 1L);
+        stack.setCluster(cluster);
+        return stack;
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
@@ -1,6 +1,11 @@
 package com.sequenceiq.cloudbreak.converter.v4.stacks;
 
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.MOCK;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -10,21 +15,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
-
 import java.util.Set;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -32,15 +34,16 @@ import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.authentication.StackAuthenticationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.InstanceGroupV4Request;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.security.authentication.AuthenticatedUserService;
-import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
-import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.mappable.Mappable;
 import com.sequenceiq.cloudbreak.common.mappable.ProviderParameterCalculator;
@@ -58,9 +61,7 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
 import com.sequenceiq.cloudbreak.dto.credential.Credential;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.kerberos.KerberosConfigService;
-import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.account.PreferencesService;
 import com.sequenceiq.cloudbreak.service.datalake.DatalakeResourcesService;
@@ -69,6 +70,7 @@ import com.sequenceiq.cloudbreak.service.environment.credential.CredentialClient
 import com.sequenceiq.cloudbreak.service.stack.GatewaySecurityGroupDecorator;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
+import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
 import com.sequenceiq.cloudbreak.tag.request.CDPTagMergeRequest;
 import com.sequenceiq.cloudbreak.workspace.model.User;
@@ -76,6 +78,7 @@ import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.LoadBalancerType;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.common.api.type.TargetGroupType;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
@@ -83,12 +86,15 @@ import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvi
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.TagResponse;
 
-public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<StackV4Request> {
+class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<StackV4Request> {
 
     private static final String TEST_USER_CRN = "crn:cdp:iam:us-west-1:accid:user:mockuser@cloudera.com";
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
+    private static final Map<CloudPlatform, String> TEST_REGIONS = Map.of(
+            AWS, "eu-west-2",
+            MOCK, "some-mock-region-1");
+
+    private static final String DEFAULT_REGIONS_FIELD_NAME = "defaultRegions";
 
     @InjectMocks
     private StackV4RequestToStackConverter underTest;
@@ -154,6 +160,9 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
     private CredentialResponse credentialResponse;
 
     @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
     private CostTagging costTagging;
 
     @Mock
@@ -161,15 +170,15 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
 
     private Credential credential;
 
-    @BeforeClass
-    public static void setupUserCrn() {
+    @BeforeAll
+    static void beforeAll() {
         if (ThreadBasedUserCrnProvider.getUserCrn() == null) {
             ThreadBasedUserCrnProvider.setUserCrn(TEST_USER_CRN);
         }
     }
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         MockitoAnnotations.initMocks(this);
         when(restRequestThreadLocalService.getCloudbreakUser()).thenReturn(cloudbreakUser);
         when(cloudbreakUser.getUsername()).thenReturn("username");
@@ -184,6 +193,7 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
         when(environmentClientService.getByName(anyString())).thenReturn(environmentResponse);
         when(environmentClientService.getByCrn(anyString())).thenReturn(environmentResponse);
         when(kerberosConfigService.get(anyString(), anyString())).thenReturn(Optional.empty());
+        when(entitlementService.internalTenant(anyString())).thenReturn(true);
         when(costTagging.mergeTags(any(CDPTagMergeRequest.class))).thenReturn(new HashMap<>());
         credential = Credential.builder()
                 .cloudPlatform("AWS")
@@ -193,7 +203,7 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
     @Test
     public void testConvert() {
         initMocks();
-        ReflectionTestUtils.setField(underTest, "defaultRegions", "AWS:eu-west-2");
+        setDefaultRegions(AWS);
         StackV4Request request = getRequest("stack.json");
 
         given(credentialClientService.getByCrn(anyString())).willReturn(credential);
@@ -221,9 +231,9 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
     }
 
     @Test
-    public void testConvertShouldHaveDefaultTags() throws IOException {
+    public void testConvertShouldHaveDefaultTags() {
         initMocks();
-        ReflectionTestUtils.setField(underTest, "defaultRegions", "AWS:eu-west-2");
+        setDefaultRegions(AWS);
         StackV4Request request = getRequest("stack-without-tags.json");
 
         given(credentialClientService.getByName(anyString())).willReturn(credential);
@@ -262,24 +272,63 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
     @Test
     public void testConvertWithLoginUserName() {
         initMocks();
-        ReflectionTestUtils.setField(underTest, "defaultRegions", "AWS:eu-west-2");
-        thrown.expect(BadRequestException.class);
-        thrown.expectMessage("You can not modify the default user!");
+        setDefaultRegions(AWS);
         // WHEN
-        Stack stack = underTest.convert(getRequest("stack-with-loginusername.json"));
+        BadRequestException expectedException = Assertions.assertThrows(BadRequestException.class,
+                () -> underTest.convert(getRequest("stack-with-loginusername.json")));
+
         // THEN
-        assertAllFieldsNotNull(
-                stack,
-                Arrays.asList("description", "statusReason", "cluster", "credential", "environmentCrn", "gatewayPort", "template", "network", "securityConfig",
-                        "securityGroup", "version", "created", "platformVariant", "cloudPlatform", "saltPassword", "stackTemplate", "datalakeId",
-                        "customHostname", "customDomain", "clusterNameAsSubdomain", "hostgroupNameAsHostname", "loginUserName", "rootVolumeSize"));
-        assertEquals("eu-west-1", stack.getRegion());
+        assertEquals("You can not modify the default user!", expectedException.getMessage());
     }
 
     @Test
-    public void testConvertSharedServicePreparateWhenSharedServiceIsNullThenDatalakeNameShouldNotBeSet() {
+    public void testWhenRegionIsEmptyButDefaultRegionsAreEmptyThenBadRequestExceptionComes() {
+        setDefaultRegions(null);
         StackV4Request request = getRequest("stack.json");
-        request.setCloudPlatform(CloudPlatform.MOCK);
+        request.setCloudPlatform(MOCK);
+        request.getPlacement().setRegion(null);
+
+        BadRequestException resultException = assertThrows(BadRequestException.class, () -> underTest.convert(request));
+        assertEquals("No default region is specified. Region cannot be empty.", resultException.getMessage());
+    }
+
+    @Test
+    void testWhenProvidedRegionIsEmptyButDefaultOnesAreNotAndPlatformRegionIsNullThenBadRequestExceptionComes() {
+        setDefaultRegions(AWS);
+        StackV4Request request = getRequest("stack.json");
+        request.setCloudPlatform(MOCK);
+        request.getPlacement().setRegion(null);
+
+        BadRequestException resultException = assertThrows(BadRequestException.class, () -> underTest.convert(request));
+        assertEquals(String.format("No default region specified for: %s. Region cannot be empty.",
+                request.getCloudPlatform().name()), resultException.getMessage());
+    }
+
+    @Test
+    void testWhenProvidedRegionIsEmptyAndDefaultOnesAreNotAndPlatformRegionExistsForPlatformThenItShouldBeSet() {
+        setDefaultRegions(MOCK);
+        StackV4Request request = getRequest("stack.json");
+        request.setCloudPlatform(MOCK);
+        request.getPlacement().setRegion(null);
+        InstanceGroup instanceGroup = mock(InstanceGroup.class);
+
+        when(instanceGroup.getInstanceGroupType()).thenReturn(InstanceGroupType.GATEWAY);
+        given(credentialClientService.getByName(anyString())).willReturn(credential);
+        given(credentialClientService.getByCrn(anyString())).willReturn(credential);
+        given(conversionService.convert(any(InstanceGroupV4Request.class), eq(InstanceGroup.class))).willReturn(instanceGroup);
+        given(providerParameterCalculator.get(request)).willReturn(getMappable());
+        given(conversionService.convert(any(ClusterV4Request.class), eq(Cluster.class))).willReturn(new Cluster());
+
+        Stack result = underTest.convert(request);
+
+        assertEquals(TEST_REGIONS.get(MOCK), result.getRegion());
+    }
+
+    @Test
+    public void testConvertSharedServicePreparedWhenSharedServiceIsNullThenDatabaseNameShouldNotBeSet() {
+        StackV4Request request = getRequest("stack.json");
+        request.setCloudPlatform(MOCK);
+        request.setNetwork(TestUtil.networkV4RequestForMock());
         InstanceGroup instanceGroup = mock(InstanceGroup.class);
         when(instanceGroup.getInstanceGroupType()).thenReturn(InstanceGroupType.GATEWAY);
 
@@ -294,7 +343,30 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
         Stack result = underTest.convert(request);
 
         //THEN
-        Assert.assertNull(result.getDatalakeResourceId());
+        assertNull(result.getDatalakeResourceId());
+    }
+
+    @Test
+    public void testWhenSourceIsTemplate() {
+        StackV4Request request = getRequest("stack.json");
+        request.setCloudPlatform(MOCK);
+        request.setType(StackType.TEMPLATE);
+        request.setNetwork(TestUtil.networkV4RequestForMock());
+        InstanceGroup instanceGroup = mock(InstanceGroup.class);
+        when(instanceGroup.getInstanceGroupType()).thenReturn(InstanceGroupType.GATEWAY);
+
+        //GIVEN
+        given(credentialClientService.getByName(anyString())).willReturn(credential);
+        given(credentialClientService.getByCrn(anyString())).willReturn(credential);
+        given(conversionService.convert(any(InstanceGroupV4Request.class), eq(InstanceGroup.class))).willReturn(instanceGroup);
+        given(providerParameterCalculator.get(request)).willReturn(getMappable());
+        given(conversionService.convert(any(ClusterV4Request.class), eq(Cluster.class))).willReturn(new Cluster());
+
+        //WHEN
+        Stack result = underTest.convert(request);
+
+        //THEN
+        assertNull(result.getDatalakeResourceId());
     }
 
     @Test
@@ -321,8 +393,10 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
     @Test
     public void testConvertWithKnoxLoadBalancer() {
         initMocks();
+        setDefaultRegions(AWS);
+        StackV4Request request = getRequest("stack-datalake-with-instancegroups.json");
         ReflectionTestUtils.setField(underTest, "defaultRegions", "AWS:eu-west-2");
-        StackV4Request request = setupRequestWithNetwork();
+        //StackV4Request request = setupRequestWithNetwork();
         TargetGroup targetGroup = new TargetGroup();
         targetGroup.setType(TargetGroupType.KNOX);
         LoadBalancer loadBalancer = new LoadBalancer();
@@ -341,6 +415,44 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
         assertEquals(1, stack.getLoadBalancers().size());
         assertEquals(1, stack.getLoadBalancers().iterator().next().getTargetGroupSet().size());
         assertEquals(TargetGroupType.KNOX, stack.getLoadBalancers().iterator().next().getTargetGroupSet().iterator().next().getType());
+    }
+
+    @Test
+    public void testNoLoadBalancersCreatedWhenEntitlementIsDisabled() {
+        initMocks();
+        setDefaultRegions(AWS);
+        StackV4Request request = getRequest("stack-datalake-with-instancegroups.json");
+
+        given(credentialClientService.getByCrn(anyString())).willReturn(credential);
+        given(credentialClientService.getByName(anyString())).willReturn(credential);
+        given(providerParameterCalculator.get(request)).willReturn(getMappable());
+        given(conversionService.convert(any(ClusterV4Request.class), eq(Cluster.class))).willReturn(new Cluster());
+        given(telemetryConverter.convert(null, StackType.DATALAKE)).willReturn(new Telemetry());
+        given(loadBalancerConfigService.getKnoxGatewayGroups(any(Stack.class))).willReturn(Set.of("master"));
+        // WHEN
+        Stack stack = underTest.convert(request);
+        // THEN
+        assertEquals(0, stack.getLoadBalancers().size());
+    }
+
+    @Test
+    public void testNoEndpointGatewayLoadBalancerWhenEntitlementIsDisabled() {
+        StackV4Request request = setupForEndpointGateway(true);
+        when(entitlementService.publicEndpointAccessGatewayEnabled(anyString())).thenReturn(false);
+        // WHEN
+        Stack stack = underTest.convert(request);
+        // THEN
+        assertTrue(stack.getLoadBalancers().isEmpty());
+    }
+
+    @Test
+    public void testNoEndpointGatewayLoadBalancerWhenFlagIsDisabled() {
+        StackV4Request request = setupForEndpointGateway(false);
+        when(entitlementService.publicEndpointAccessGatewayEnabled(anyString())).thenReturn(true);
+        // WHEN
+        Stack stack = underTest.convert(request);
+        // THEN
+        assertTrue(stack.getLoadBalancers().isEmpty());
     }
 
     @Override
@@ -364,14 +476,13 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
         given(conversionService.convert(any(InstanceGroupV4Request.class), eq(InstanceGroup.class))).willReturn(instanceGroup);
     }
 
-    private StackV4Request setupRequestWithNetwork() {
+    private StackV4Request setupForEndpointGateway(boolean enabled) {
         initMocks();
         ReflectionTestUtils.setField(underTest, "defaultRegions", "AWS:eu-west-2");
         StackV4Request request = getRequest("stack-datalake-with-instancegroups.json");
 
         EnvironmentNetworkResponse networkResponse = new EnvironmentNetworkResponse();
-        networkResponse.setSubnetMetas(Map.of("key", new CloudSubnet("private-id", "name", "az-1", "cidr", true, false, false, SubnetType.PRIVATE)));
-
+        networkResponse.setPublicEndpointAccessGateway(enabled ? PublicEndpointAccessGateway.ENABLED : PublicEndpointAccessGateway.DISABLED);
         DetailedEnvironmentResponse environmentResponse = new DetailedEnvironmentResponse();
         environmentResponse.setCredential(credentialResponse);
         environmentResponse.setCloudPlatform("AWS");
@@ -390,4 +501,17 @@ public class StackV4RequestToStackConverterTest extends AbstractJsonConverterTes
 
         return request;
     }
+
+    private void setDefaultRegions(CloudPlatform platform) {
+        ReflectionTestUtils.setField(underTest, DEFAULT_REGIONS_FIELD_NAME, platform != null ? getTestRegion(platform) : null);
+    }
+
+    private String getTestRegion(CloudPlatform platform) {
+        String region = TEST_REGIONS.get(platform);
+        if (region != null) {
+            return platform.name() + ":" + region;
+        }
+        throw new IllegalArgumentException("No region has found for platform: " + platform);
+    }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/BaseDnsEntryServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/BaseDnsEntryServiceTest.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -87,11 +86,6 @@ class BaseDnsEntryServiceTest {
     @InjectMocks
     private NifiHostPublicDnsEntryService underTest;
 
-    @BeforeAll
-    static void setupAll() {
-        ThreadBasedUserCrnProvider.setUserCrn(USER_CRN);
-    }
-
     @BeforeEach
     void setupEach() {
         underTest.setCertGenerationEnabled(true);
@@ -103,7 +97,7 @@ class BaseDnsEntryServiceTest {
         Cluster cluster = new Cluster();
         stack.setCluster(cluster);
 
-        underTest.getComponentLocation(stack);
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.getComponentLocation(stack));
 
         verify(componentLocatorService).getComponentLocation(cluster, nifiConfigProvider.getRoleTypes());
     }
@@ -127,7 +121,7 @@ class BaseDnsEntryServiceTest {
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(USER_CRN, ACCOUNT_ID, FQDN_2, ENVIRONMENT_NAME, false, List.of(PUBLIC_IP_2))).thenReturn(true);
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(USER_CRN, ACCOUNT_ID, FQDN_3, ENVIRONMENT_NAME, false, List.of(PUBLIC_IP_3))).thenReturn(true);
 
-        Map<String, String> result = underTest.createOrUpdate(stack);
+        Map<String, String> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createOrUpdate(stack));
 
         assertEquals(3, result.size());
         assertTrue(result.containsKey(FQDN_1));
@@ -155,7 +149,7 @@ class BaseDnsEntryServiceTest {
                 .thenReturn(componentLocation);
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(USER_CRN, ACCOUNT_ID, FQDN_1, ENVIRONMENT_NAME, false, List.of(PUBLIC_IP_1))).thenReturn(true);
 
-        Map<String, String> result = underTest.createOrUpdateCandidates(stack, Map.of(FQDN_1, PUBLIC_IP_1));
+        Map<String, String> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createOrUpdateCandidates(stack, Map.of(FQDN_1, PUBLIC_IP_1)));
 
         assertEquals(1, result.size());
         assertTrue(result.containsKey(FQDN_1));
@@ -181,7 +175,7 @@ class BaseDnsEntryServiceTest {
         when(dnsManagementService.deleteDnsEntryWithIp(USER_CRN, ACCOUNT_ID, FQDN_2, ENVIRONMENT_NAME, false, List.of(PUBLIC_IP_2))).thenReturn(true);
         when(dnsManagementService.deleteDnsEntryWithIp(USER_CRN, ACCOUNT_ID, FQDN_3, ENVIRONMENT_NAME, false, List.of(PUBLIC_IP_3))).thenReturn(true);
 
-        Map<String, String> result = underTest.deregister(stack);
+        Map<String, String> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.deregister(stack));
 
         assertEquals(3, result.size());
         assertTrue(result.containsKey(FQDN_1));
@@ -209,7 +203,7 @@ class BaseDnsEntryServiceTest {
                 .thenReturn(componentLocation);
         when(dnsManagementService.deleteDnsEntryWithIp(USER_CRN, ACCOUNT_ID, FQDN_1, ENVIRONMENT_NAME, false, List.of(PUBLIC_IP_1))).thenReturn(true);
 
-        Map<String, String> result = underTest.deregister(stack, Map.of(FQDN_1, PUBLIC_IP_1));
+        Map<String, String> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.deregister(stack, Map.of(FQDN_1, PUBLIC_IP_1)));
 
         assertEquals(1, result.size());
         assertTrue(result.containsKey(FQDN_1));

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXAuthenticationToStaAuthenticationConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXAuthenticationToStaAuthenticationConverterTest.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.distrox.v1.distrox.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.authentication.StackAuthenticationV4Request;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentAuthenticationResponse;
+
+class DistroXAuthenticationToStaAuthenticationConverterTest {
+
+    private DistroXAuthenticationToStaAuthenticationConverter underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new DistroXAuthenticationToStaAuthenticationConverter();
+    }
+
+    @Test
+    void testConvertEnvironmentAuthenticationResponseToStackAuthenticationV4Request() {
+        EnvironmentAuthenticationResponse input = new EnvironmentAuthenticationResponse();
+        input.setPublicKey("somePublicKey");
+        input.setPublicKeyId("somePublicKeyId");
+        input.setLoginUserName("someLoginUserName");
+
+        StackAuthenticationV4Request result = underTest.convert(input);
+
+        assertNotNull(result);
+        assertNull(result.getLoginUserName());
+        assertEquals(input.getPublicKey(), result.getPublicKey());
+        assertEquals(input.getPublicKeyId(), result.getPublicKeyId());
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXClusterToClusterConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXClusterToClusterConverterTest.java
@@ -1,0 +1,555 @@
+package com.sequenceiq.distrox.v1.distrox.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ExecutorType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.ClusterV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.cm.ClouderaManagerV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.cluster.gateway.GatewayV4Request;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.common.api.cloudstorage.CloudStorageRequest;
+import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.cluster.DistroXClusterV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.cluster.cm.ClouderaManagerV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.cluster.cm.product.ClouderaManagerProductV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.cluster.cm.repository.ClouderaManagerRepositoryV1Request;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.environment.api.v1.proxy.endpoint.ProxyEndpoint;
+
+class DistroXClusterToClusterConverterTest {
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:accid:user:mockuser@cloudera.com";
+
+    @Mock
+    private ClouderaManagerV1ToClouderaManagerV4Converter cmConverter;
+
+    @Mock
+    private GatewayV1ToGatewayV4Converter gatewayConverter;
+
+    @Mock
+    private CloudStorageDecorator cloudStorageDecorator;
+
+    @Mock
+    private ProxyEndpoint proxyEndpoint;
+
+    private DistroXClusterToClusterConverter underTest;
+
+    private DistroXV1Request distroXV1RequestInput;
+
+    private ClusterV4Request clusterV4RequestInput;
+
+    private DetailedEnvironmentResponse env;
+
+    @BeforeAll
+    static void beforeAll() {
+        if (ThreadBasedUserCrnProvider.getUserCrn() == null) {
+            ThreadBasedUserCrnProvider.setUserCrn(USER_CRN);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        underTest = new DistroXClusterToClusterConverter(cmConverter, cloudStorageDecorator, gatewayConverter, proxyEndpoint);
+        env = new DetailedEnvironmentResponse();
+        clusterV4RequestInput = createClusterV4Request();
+        distroXV1RequestInput = createDistroXV1Request();
+    }
+
+    @Test
+    void testConvertWithoutEnvWhenExposedServiceIsEmptyThenAllShouldBeConverted() {
+        distroXV1RequestInput.getCluster().setExposedServices(new ArrayList<>(0));
+        GatewayV4Request gr = new GatewayV4Request();
+
+        when(gatewayConverter.convert(List.of("ALL"))).thenReturn(gr);
+
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertEquals(gr, result.getGateway());
+        verify(gatewayConverter, times(1)).convert(anyList());
+        verify(gatewayConverter, times(1)).convert(List.of("ALL"));
+    }
+
+    @Test
+    void testConvertWithoutEnvWhenExposedServiceIsNotEmptyThenItShouldBeConverted() {
+        GatewayV4Request gr = new GatewayV4Request();
+        when(gatewayConverter.convert(distroXV1RequestInput.getCluster().getExposedServices())).thenReturn(gr);
+
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertEquals(gr, result.getGateway());
+        verify(gatewayConverter, times(1)).convert(anyList());
+        verify(gatewayConverter, times(1)).convert(distroXV1RequestInput.getCluster().getExposedServices());
+    }
+
+    @Test
+    void testConvertWithoutEnvTheNameShouldBeSetToNull() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertNull(result.getName());
+    }
+
+    @Test
+    void testConvertWithoutEnvTheCustomContainerShouldBeSetToNull() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertNull(result.getCustomContainer());
+    }
+
+    @Test
+    void testConvertWithoutEnvTheCustomQueueShouldBeSetToNull() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertNull(result.getCustomQueue());
+    }
+
+    @Test
+    void testConvertWithoutEnvTheUsernameShouldBeSet() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertEquals(distroXV1RequestInput.getCluster().getUserName(), result.getUserName());
+    }
+
+    @Test
+    void testConvertWithoutEnvThePasswordShouldBeSet() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertEquals(distroXV1RequestInput.getCluster().getPassword(), result.getPassword());
+    }
+
+    @Test
+    void testConvertWithoutEnvTheValidateBlueprintShouldBeSet() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertEquals(distroXV1RequestInput.getCluster().getValidateBlueprint(), result.getValidateBlueprint());
+    }
+
+    @Test
+    void testConvertWithoutEnvTheBlueprintNameShouldBeSet() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertEquals(distroXV1RequestInput.getCluster().getBlueprintName(), result.getBlueprintName());
+    }
+
+    @Test
+    void testConvertWithoutEnvTheDatabasesShouldBeSet() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertEquals(distroXV1RequestInput.getCluster().getDatabases(), result.getDatabases());
+    }
+
+    @Test
+    void testConvertWithoutEnvCmConversionShouldHappenIfInputCmIsNotNull() {
+        ClouderaManagerV4Request cmConversionResult = new ClouderaManagerV4Request();
+        when(cmConverter.convert(distroXV1RequestInput.getCluster().getCm())).thenReturn(cmConversionResult);
+
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertEquals(cmConversionResult, result.getCm());
+
+        verify(cmConverter, times(1)).convert(any(ClouderaManagerV1Request.class));
+        verify(cmConverter, times(1)).convert(distroXV1RequestInput.getCluster().getCm());
+    }
+
+    @Test
+    void testConvertWithoutEnvCmConversionShouldNotHappenIfInputCmIsNull() {
+        distroXV1RequestInput.getCluster().setCm(null);
+        when(cmConverter.convert(any(ClouderaManagerV1Request.class))).thenReturn(new ClouderaManagerV4Request());
+
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertNull(result.getCm());
+
+        verify(cmConverter, never()).convert(any(ClouderaManagerV1Request.class));
+    }
+
+    @Test
+    void testConvertWithoutEnvTheExecutionTypeShouldBeSetToDefault() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertEquals(ExecutorType.DEFAULT, result.getExecutorType());
+    }
+
+    @Test
+    void testConvertWithoutEnvTheCloudStorageShouldBeSetBasedOnTheInputs() {
+        CloudStorageRequest decoratorResult = new CloudStorageRequest();
+        when(cloudStorageDecorator.decorate(
+                distroXV1RequestInput.getCluster().getBlueprintName(),
+                distroXV1RequestInput.getName(),
+                distroXV1RequestInput.getCluster().getCloudStorage(),
+                null
+        )).thenReturn(decoratorResult);
+
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput);
+
+        assertNotNull(result);
+        assertEquals(decoratorResult, result.getCloudStorage());
+
+        verify(cloudStorageDecorator, times(1)).decorate(any(), any(), any(), any());
+        verify(cloudStorageDecorator, times(1)).decorate(
+                distroXV1RequestInput.getCluster().getBlueprintName(),
+                distroXV1RequestInput.getName(),
+                distroXV1RequestInput.getCluster().getCloudStorage(),
+                null
+        );
+    }
+
+    @Test
+    void testConvertWithEnvWhenExposedServiceIsEmptyThenAllShouldBeConverted() {
+        distroXV1RequestInput.getCluster().setExposedServices(new ArrayList<>(0));
+        GatewayV4Request gr = new GatewayV4Request();
+
+        when(gatewayConverter.convert(List.of("ALL"))).thenReturn(gr);
+
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertEquals(gr, result.getGateway());
+        verify(gatewayConverter, times(1)).convert(anyList());
+        verify(gatewayConverter, times(1)).convert(List.of("ALL"));
+    }
+
+    @Test
+    void testConvertWithEnvWhenExposedServiceIsNotEmptyThenItShouldBeConverted() {
+        GatewayV4Request gr = new GatewayV4Request();
+        when(gatewayConverter.convert(distroXV1RequestInput.getCluster().getExposedServices())).thenReturn(gr);
+
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertEquals(gr, result.getGateway());
+        verify(gatewayConverter, times(1)).convert(anyList());
+        verify(gatewayConverter, times(1)).convert(distroXV1RequestInput.getCluster().getExposedServices());
+    }
+
+    @Test
+    void testConvertWithEnvTheNameShouldBeSetToNull() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertNull(result.getName());
+    }
+
+    @Test
+    void testConvertWithEnvTheCustomContainerShouldBeSetToNull() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertNull(result.getCustomContainer());
+    }
+
+    @Test
+    void testConvertWithEnvTheCustomQueueShouldBeSetToNull() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertNull(result.getCustomQueue());
+    }
+
+    @Test
+    void testConvertWithEnvTheUsernameShouldBeSet() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertEquals(distroXV1RequestInput.getCluster().getUserName(), result.getUserName());
+    }
+
+    @Test
+    void testConvertWithEnvThePasswordShouldBeSet() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertEquals(distroXV1RequestInput.getCluster().getPassword(), result.getPassword());
+    }
+
+    @Test
+    void testConvertWithEnvTheValidateBlueprintShouldBeSet() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertEquals(distroXV1RequestInput.getCluster().getValidateBlueprint(), result.getValidateBlueprint());
+    }
+
+    @Test
+    void testConvertWithEnvTheBlueprintNameShouldBeSet() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertEquals(distroXV1RequestInput.getCluster().getBlueprintName(), result.getBlueprintName());
+    }
+
+    @Test
+    void testConvertWithEnvTheDatabasesShouldBeSet() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertEquals(distroXV1RequestInput.getCluster().getDatabases(), result.getDatabases());
+    }
+
+    @Test
+    void testConvertWithEnvCmConversionShouldHappenIfInputCmIsNotNull() {
+        ClouderaManagerV4Request cmConversionResult = new ClouderaManagerV4Request();
+        when(cmConverter.convert(distroXV1RequestInput.getCluster().getCm())).thenReturn(cmConversionResult);
+
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertEquals(cmConversionResult, result.getCm());
+
+        verify(cmConverter, times(1)).convert(any(ClouderaManagerV1Request.class));
+        verify(cmConverter, times(1)).convert(distroXV1RequestInput.getCluster().getCm());
+    }
+
+    @Test
+    void testConvertWithEnvCmConversionShouldNotHappenIfInputCmIsNull() {
+        distroXV1RequestInput.getCluster().setCm(null);
+        when(cmConverter.convert(any(ClouderaManagerV1Request.class))).thenReturn(new ClouderaManagerV4Request());
+
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertNull(result.getCm());
+
+        verify(cmConverter, never()).convert(any(ClouderaManagerV1Request.class));
+    }
+
+    @Test
+    void testConvertWithEnvTheExecutionTypeShouldBeSetToDefault() {
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertEquals(ExecutorType.DEFAULT, result.getExecutorType());
+    }
+
+    @Test
+    void testConvertWithEnvTheCloudStorageShouldBeSetBasedOnTheInputs() {
+        CloudStorageRequest decoratorResult = new CloudStorageRequest();
+        when(cloudStorageDecorator.decorate(
+                distroXV1RequestInput.getCluster().getBlueprintName(),
+                distroXV1RequestInput.getName(),
+                distroXV1RequestInput.getCluster().getCloudStorage(),
+                env
+        )).thenReturn(decoratorResult);
+
+        ClusterV4Request result = underTest.convert(distroXV1RequestInput, env);
+
+        assertNotNull(result);
+        assertEquals(decoratorResult, result.getCloudStorage());
+
+        verify(cloudStorageDecorator, times(1)).decorate(any(), any(), any(), any());
+        verify(cloudStorageDecorator, times(1)).decorate(
+                distroXV1RequestInput.getCluster().getBlueprintName(),
+                distroXV1RequestInput.getName(),
+                distroXV1RequestInput.getCluster().getCloudStorage(),
+                env
+        );
+    }
+
+    @Test
+    void testConvertClusterV4RequestToDistroXClusterV1RequestWhenExposedServicesAreNullThenItShouldNotBeSet() {
+        clusterV4RequestInput.setGateway(null);
+
+        when(gatewayConverter.exposedService(any())).thenReturn(new ArrayList<>());
+
+        DistroXClusterV1Request result = underTest.convert(clusterV4RequestInput);
+
+        assertNotNull(result);
+        assertNull(result.getExposedServices());
+
+        verify(gatewayConverter, never()).exposedService(any());
+    }
+
+    @Test
+    void testConvertClusterV4RequestToDistroXClusterV1RequestWhenExposedServicesAreNotNullThenItShouldBeConverted() {
+        List<String> gatewayConversionResult = new ArrayList<>();
+
+        when(gatewayConverter.exposedService(any())).thenReturn(gatewayConversionResult);
+
+        DistroXClusterV1Request result = underTest.convert(clusterV4RequestInput);
+
+        assertNotNull(result);
+        assertEquals(gatewayConversionResult, result.getExposedServices());
+
+        verify(gatewayConverter, times(1)).exposedService(any());
+        verify(gatewayConverter, times(1)).exposedService(clusterV4RequestInput.getGateway());
+    }
+
+    @Test
+    void testConvertClusterV4RequestToDistroXClusterV1RequestThenDatabasesShouldBeSet() {
+        DistroXClusterV1Request result = underTest.convert(clusterV4RequestInput);
+
+        assertNotNull(result);
+        assertEquals(clusterV4RequestInput.getDatabases(), result.getDatabases());
+    }
+
+    @Test
+    void testConvertClusterV4RequestToDistroXClusterV1RequestThenBlueprintNameShouldBeSet() {
+        DistroXClusterV1Request result = underTest.convert(clusterV4RequestInput);
+
+        assertNotNull(result);
+        assertEquals(clusterV4RequestInput.getBlueprintName(), result.getBlueprintName());
+    }
+
+    @Test
+    void testConvertClusterV4RequestToDistroXClusterV1RequestThenCloudStorageShouldBeSet() {
+        DistroXClusterV1Request result = underTest.convert(clusterV4RequestInput);
+
+        assertNotNull(result);
+        assertEquals(clusterV4RequestInput.getCloudStorage(), result.getCloudStorage());
+    }
+
+    @Test
+    void testConvertClusterV4RequestToDistroXClusterV1RequestThenProxyShouldBeSet() {
+        DistroXClusterV1Request result = underTest.convert(clusterV4RequestInput);
+
+        assertNotNull(result);
+        assertEquals(clusterV4RequestInput.getProxyConfigCrn(), result.getProxy());
+    }
+
+    @Test
+    void testConvertClusterV4RequestToDistroXClusterV1RequestThenUserNameShouldNotBeSet() {
+        DistroXClusterV1Request result = underTest.convert(clusterV4RequestInput);
+
+        assertNotNull(result);
+        assertNotEquals(clusterV4RequestInput.getUserName(), result.getUserName());
+        assertNull(result.getUserName());
+    }
+
+    @Test
+    void testConvertClusterV4RequestToDistroXClusterV1RequestThenPasswordShouldNotBeSet() {
+        DistroXClusterV1Request result = underTest.convert(clusterV4RequestInput);
+
+        assertNotNull(result);
+        assertNotEquals(clusterV4RequestInput.getPassword(), result.getPassword());
+        assertNull(result.getPassword());
+    }
+
+    @Test
+    void testConvertClusterV4RequestToDistroXClusterV1RequestWhenCmIsNullThenItShouldNotBeSet() {
+        clusterV4RequestInput.setCm(null);
+
+        DistroXClusterV1Request result = underTest.convert(clusterV4RequestInput);
+
+        assertNotNull(result);
+        assertNull(result.getCm());
+
+        verify(cmConverter, never()).convert(any(ClouderaManagerV4Request.class));
+    }
+
+    @Test
+    void testConvertClusterV4RequestToDistroXClusterV1RequestWhenCmIsNotNullThenItShouldBeSet() {
+        ClouderaManagerV1Request cmConverterResult = new ClouderaManagerV1Request();
+        when(cmConverter.convert(clusterV4RequestInput.getCm())).thenReturn(cmConverterResult);
+        DistroXClusterV1Request result = underTest.convert(clusterV4RequestInput);
+
+        assertNotNull(result);
+        assertEquals(cmConverterResult, result.getCm());
+
+        verify(cmConverter, times(1)).convert(any(ClouderaManagerV4Request.class));
+        verify(cmConverter, times(1)).convert(clusterV4RequestInput.getCm());
+    }
+
+    private DistroXV1Request createDistroXV1Request() {
+        DistroXV1Request r = new DistroXV1Request();
+        r.setCluster(createDistroXClusterV1Request());
+        r.setName("SomeDistroX");
+        return r;
+    }
+
+    private DistroXClusterV1Request createDistroXClusterV1Request() {
+        DistroXClusterV1Request r = new DistroXClusterV1Request();
+        r.setBlueprintName("someBP");
+        r.setValidateBlueprint(true);
+        r.setDatabases(Set.of("DB1"));
+        r.setExposedServices(List.of("service1", "service2", "service3"));
+        r.setPassword("somePW");
+        r.setProxy("someProxy");
+        r.setUserName("someUserName");
+        r.setCm(createClouderaManagerV1Request());
+        r.setCloudStorage(createCloudStorageRequest());
+        return r;
+    }
+
+    private ClouderaManagerV1Request createClouderaManagerV1Request() {
+        ClouderaManagerV1Request r = new ClouderaManagerV1Request();
+        r.setRepository(createClouderaManagerRepositoryV1Request());
+        r.setProducts(List.of(createClouderaManagerProductV1Request()));
+        r.setEnableAutoTls(true);
+        return r;
+    }
+
+    private ClouderaManagerRepositoryV1Request createClouderaManagerRepositoryV1Request() {
+        ClouderaManagerRepositoryV1Request r = new ClouderaManagerRepositoryV1Request();
+        r.setBaseUrl("someBaeUrl");
+        r.setGpgKeyUrl("someGpgKeyUrl");
+        r.setVersion("someVersion");
+        return r;
+    }
+
+    private ClouderaManagerProductV1Request createClouderaManagerProductV1Request() {
+        ClouderaManagerProductV1Request r = new ClouderaManagerProductV1Request();
+        r.setName("someName");
+        r.setCsd(List.of("someCsd"));
+        r.setParcel("someParcel");
+        r.setVersion("someVersion");
+        return r;
+    }
+
+    private ClusterV4Request createClusterV4Request() {
+        ClusterV4Request r = new ClusterV4Request();
+        r.setBlueprintName("someBlueprint");
+        r.setGateway(createGatewayV4Request());
+        r.setDatabases(Set.of("DB1", "DB2"));
+        r.setUserName("someUserName");
+        r.setPassword("somePassword");
+        r.setCm(createClouderaManagerV4Request());
+        r.setCloudStorage(createCloudStorageRequest());
+        r.setProxyConfigCrn("someProxyConfigCrn");
+        return r;
+    }
+
+    private CloudStorageRequest createCloudStorageRequest() {
+        return new CloudStorageRequest();
+    }
+
+    private ClouderaManagerV4Request createClouderaManagerV4Request() {
+        return new ClouderaManagerV4Request();
+    }
+
+    private GatewayV4Request createGatewayV4Request() {
+        return new GatewayV4Request();
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXDatabaseRequestToStackDatabaseRequestConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXDatabaseRequestToStackDatabaseRequestConverterTest.java
@@ -1,7 +1,11 @@
 package com.sequenceiq.distrox.v1.distrox.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -31,4 +35,25 @@ class DistroXDatabaseRequestToStackDatabaseRequestConverterTest {
         DatabaseRequest result = underTest.convert(source);
         assertThat(result.getAvailabilityType().name()).isEqualTo(daType.name());
     }
+
+    @Test
+    void testConvertDistroXDatabaseRequestToDatabaseRequestWhenNullAvailabilityTypeProvidedThenIllegalArgumentExceptionHappens() {
+        DistroXDatabaseRequest input = new DistroXDatabaseRequest();
+
+        IllegalArgumentException expectedException = Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.convert(input));
+
+        assertNotNull(expectedException);
+        assertEquals("Unexpected database availability type: null", expectedException.getMessage());
+    }
+
+    @Test
+    void testConvertDatabaseRequestToDistroXDatabaseRequestWhenNullAvailabilityTypeProvidedThenIllegalArgumentExceptionHappens() {
+        DatabaseRequest input = new DatabaseRequest();
+
+        IllegalArgumentException expectedException = Assertions.assertThrows(IllegalArgumentException.class, () -> underTest.convert(input));
+
+        assertNotNull(expectedException);
+        assertEquals("Unexpected database availability type: null", expectedException.getMessage());
+    }
+
 }

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXImageToImageSettingsConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXImageToImageSettingsConverterTest.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.distrox.v1.distrox.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.image.DistroXImageV1Request;
+
+class DistroXImageToImageSettingsConverterTest {
+
+    private DistroXImageToImageSettingsConverter underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new DistroXImageToImageSettingsConverter();
+    }
+
+    @Test
+    void testConvertDistroXImageV1RequestToImageSettingsV4Request() {
+        DistroXImageV1Request input = new DistroXImageV1Request();
+        input.setCatalog("someCatalog");
+        input.setId("someId");
+
+        ImageSettingsV4Request result = underTest.convert(input);
+
+        assertNotNull(result);
+        assertEquals(input.getCatalog(), result.getCatalog());
+        assertEquals(input.getId(), result.getId());
+    }
+
+    @Test
+    void testConvertImageSettingsV4RequestToDistroXImageV1Request() {
+        ImageSettingsV4Request input = new ImageSettingsV4Request();
+        input.setCatalog("someCatalog");
+        input.setId("someId");
+
+        DistroXImageV1Request result = underTest.convert(input);
+
+        assertNotNull(result);
+        assertEquals(input.getCatalog(), result.getCatalog());
+        assertEquals(input.getId(), result.getId());
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXParameterConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXParameterConverterTest.java
@@ -1,0 +1,129 @@
+package com.sequenceiq.distrox.v1.distrox.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.AwsStackV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.AzureStackV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.GcpStackV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.YarnStackV4Parameters;
+import com.sequenceiq.distrox.api.v1.distrox.model.AwsDistroXV1Parameters;
+import com.sequenceiq.distrox.api.v1.distrox.model.AzureDistroXV1Parameters;
+import com.sequenceiq.distrox.api.v1.distrox.model.GcpDistroXV1Parameters;
+import com.sequenceiq.distrox.api.v1.distrox.model.YarnDistroXV1Parameters;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkYarnParams;
+
+class DistroXParameterConverterTest {
+
+    private DistroXParameterConverter underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new DistroXParameterConverter();
+    }
+
+    @Test
+    void testAzureStackV4ParametersToAzureDistroXV1Parameters() {
+        AzureStackV4Parameters input = new AzureStackV4Parameters();
+        input.setEncryptStorage(true);
+        input.setResourceGroupName("resourceGroupName");
+
+        AzureDistroXV1Parameters result = underTest.convert(input);
+
+        assertNotNull(result);
+        assertEquals(input.isEncryptStorage(), result.isEncryptStorage());
+        assertEquals(input.getResourceGroupName(), result.getResourceGroupName());
+    }
+
+    @Test
+    void testAzureDistroXV1ParametersToAzureStackV4Parameters() {
+        AzureDistroXV1Parameters input = new AzureDistroXV1Parameters();
+        input.setEncryptStorage(true);
+        input.setResourceGroupName("resourceGroupName");
+
+        AzureStackV4Parameters result = underTest.convert(input);
+
+        assertNotNull(result);
+        assertEquals(input.isEncryptStorage(), result.isEncryptStorage());
+        assertEquals(input.getResourceGroupName(), result.getResourceGroupName());
+    }
+
+    @Test
+    void testAwsDistroXV1ParametersToAwsStackV4Parameters() {
+        AwsDistroXV1Parameters input = new AwsDistroXV1Parameters();
+
+        AwsStackV4Parameters result = underTest.convert(input);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void testAwsStackV4ParametersToAwsDistroXV1Parameters() {
+        AwsStackV4Parameters input = new AwsStackV4Parameters();
+
+        AwsDistroXV1Parameters result = underTest.convert(input);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void testGcpDistroXV1ParametersToGcpStackV4Parameters() {
+        GcpDistroXV1Parameters input = new GcpDistroXV1Parameters();
+
+        GcpStackV4Parameters result = underTest.convert(input);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void testGcpStackV4ParametersToGcpDistroXV1Parameters() {
+        GcpStackV4Parameters input = new GcpStackV4Parameters();
+
+        GcpDistroXV1Parameters result = underTest.convert(input);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void testYarnDistroXV1ParametersToYarnStackV4Parameters() {
+        YarnDistroXV1Parameters input = new YarnDistroXV1Parameters();
+        input.setYarnQueue("queue");
+        input.setLifetime(10);
+
+        YarnStackV4Parameters result = underTest.convert(input);
+
+        assertNotNull(result);
+        assertEquals(input.getLifetime(), result.getLifetime());
+        assertEquals(input.getYarnQueue(), result.getYarnQueue());
+    }
+
+    @Test
+    void testYarnStackV4ParametersToYarnDistroXV1Parameters() {
+        YarnStackV4Parameters input = new YarnStackV4Parameters();
+        input.setYarnQueue("queue");
+        input.setLifetime(10);
+
+        YarnDistroXV1Parameters result = underTest.convert(input);
+
+        assertNotNull(result);
+        assertEquals(input.getLifetime(), result.getLifetime());
+        assertEquals(input.getYarnQueue(), result.getYarnQueue());
+    }
+
+    @Test
+    void testEnvironmentNetworkYarnParamsToYarnStackV4Parameters() {
+        EnvironmentNetworkYarnParams input = new EnvironmentNetworkYarnParams();
+        input.setLifetime(10);
+        input.setQueue("queue");
+
+        YarnStackV4Parameters result = underTest.convert(input);
+
+        assertNotNull(result);
+        assertEquals(input.getLifetime(), result.getLifetime());
+        assertEquals(input.getQueue(), result.getYarnQueue());
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXV1RequestToStackV4RequestConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXV1RequestToStackV4RequestConverterTest.java
@@ -2,6 +2,10 @@ package com.sequenceiq.distrox.v1.distrox.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
@@ -10,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Assertions;
@@ -22,17 +27,26 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AwsNetworkV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AzureNetworkV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.GcpNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.network.NetworkV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.TagsV4Request;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.TelemetryConverter;
 import com.sequenceiq.cloudbreak.service.datalake.SdxClientService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseAvailabilityType;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseRequest;
+import com.sequenceiq.distrox.api.v1.distrox.model.tags.TagsV1Request;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkGcpParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.CompactRegionResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
@@ -79,8 +93,8 @@ class DistroXV1RequestToStackV4RequestConverterTest {
 
     @Test
     void convert() {
-        when(environmentClientService.getByName(anyString())).thenReturn(createEnvironment());
-        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createNetworkV4Request());
+        when(environmentClientService.getByName(anyString())).thenReturn(createAwsEnvironment());
+        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createAwsNetworkV4Request());
         when(databaseRequestConverter.convert(any(DistroXDatabaseRequest.class))).thenReturn(createDatabaseRequest());
 
         DistroXV1Request source = new DistroXV1Request();
@@ -94,9 +108,30 @@ class DistroXV1RequestToStackV4RequestConverterTest {
     }
 
     @Test
+    void convertAvailabilityZoneComesFromEnv() {
+        DistroXV1Request source = new DistroXV1Request();
+        source.setEnvironmentName("envname");
+        DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
+        databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
+        source.setExternalDatabase(databaseRequest);
+
+        DetailedEnvironmentResponse env = createAwsEnvironment();
+        env.getNetwork().setSubnetMetas(Map.of("SubnetMeta", createCloudSubnet()));
+
+        when(environmentClientService.getByName(source.getEnvironmentName())).thenReturn(env);
+        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createAwsNetworkV4Request());
+        when(databaseRequestConverter.convert(any(DistroXDatabaseRequest.class))).thenReturn(createDatabaseRequest());
+
+        StackV4Request convert = underTest.convert(source);
+
+        assertThat(convert.getExternalDatabase()).isNotNull();
+        assertThat(convert.getExternalDatabase().getAvailabilityType()).isEqualTo(DatabaseAvailabilityType.HA);
+    }
+
+    @Test
     void convertAsTemplate() {
-        when(environmentClientService.getByName(anyString())).thenReturn(createEnvironment());
-        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createNetworkV4Request());
+        when(environmentClientService.getByName(anyString())).thenReturn(createAwsEnvironment());
+        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createAwsNetworkV4Request());
         when(databaseRequestConverter.convert(any(DistroXDatabaseRequest.class))).thenReturn(createDatabaseRequest());
 
         DistroXV1Request source = new DistroXV1Request();
@@ -104,7 +139,9 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
         databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
         source.setExternalDatabase(databaseRequest);
+
         StackV4Request convert = underTest.convertAsTemplate(source);
+
         assertThat(convert.getExternalDatabase()).isNotNull();
         assertThat(convert.getExternalDatabase().getAvailabilityType()).isEqualTo(DatabaseAvailabilityType.HA);
     }
@@ -116,7 +153,7 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         source.setName("SomeStack");
         source.setEnvironmentCrn("SomeEnvCrn");
 
-        DetailedEnvironmentResponse env = createEnvironment();
+        DetailedEnvironmentResponse env = createAwsEnvironment();
         env.setCrn(source.getEnvironmentCrn());
         env.setEnvironmentStatus(status);
 
@@ -128,6 +165,79 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         verify(environmentClientService, times(1)).getByCrn(source.getEnvironmentCrn());
 
         Assertions.assertEquals(env.getName(), result.getEnvironmentName());
+    }
+
+    @Test
+    void testWhenEnvironmentStatusIsNotAvailableThenBadRequestExceptionComes() {
+        DistroXV1Request source = new DistroXV1Request();
+        source.setEnvironmentName("envname");
+        DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
+        databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
+        source.setExternalDatabase(databaseRequest);
+
+        DetailedEnvironmentResponse env = createAwsEnvironment();
+        env.setEnvironmentStatus(EnvironmentStatus.ENV_STOPPED);
+
+        when(environmentClientService.getByName(source.getEnvironmentName())).thenReturn(env);
+
+        assertThrows(BadRequestException.class, () -> underTest.convertAsTemplate(source));
+    }
+
+    @Test
+    void convertAsTemplateForAzure() {
+        DistroXV1Request source = new DistroXV1Request();
+        source.setEnvironmentName("envname");
+        DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
+        databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
+        source.setExternalDatabase(databaseRequest);
+
+        when(environmentClientService.getByName(source.getEnvironmentName())).thenReturn(createAzureEnvironment());
+        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createAzureNetworkV4Request());
+        when(databaseRequestConverter.convert(any(DistroXDatabaseRequest.class))).thenReturn(createDatabaseRequest());
+
+        StackV4Request result = underTest.convertAsTemplate(source);
+
+        assertNotNull(result.getExternalDatabase());
+        assertEquals(DatabaseAvailabilityType.HA, result.getExternalDatabase().getAvailabilityType());
+    }
+
+    @Test
+    void convertAsTemplateForGcp() {
+        DistroXV1Request source = new DistroXV1Request();
+        source.setEnvironmentName("envname");
+        DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
+        databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
+        source.setExternalDatabase(databaseRequest);
+
+        when(environmentClientService.getByName(source.getEnvironmentName())).thenReturn(createGcpEnvironment());
+        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createGcpNetworkV4Request());
+        when(databaseRequestConverter.convert(any(DistroXDatabaseRequest.class))).thenReturn(createDatabaseRequest());
+
+        StackV4Request result = underTest.convertAsTemplate(source);
+
+        assertNotNull(result.getExternalDatabase());
+        assertEquals(DatabaseAvailabilityType.HA, result.getExternalDatabase().getAvailabilityType());
+    }
+
+    @Test
+    void testWhenTagsProvidedForDistroxConversionTheyWillBePassed() {
+        DistroXV1Request source = new DistroXV1Request();
+        source.setEnvironmentName("envname");
+        DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
+        databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
+        source.setExternalDatabase(databaseRequest);
+        TagsV1Request tags = createTagsV1Request();
+        source.setTags(tags);
+
+        when(environmentClientService.getByName(source.getEnvironmentName())).thenReturn(createGcpEnvironment());
+        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createGcpNetworkV4Request());
+        when(databaseRequestConverter.convert(any(DistroXDatabaseRequest.class))).thenReturn(createDatabaseRequest());
+
+        StackV4Request result = underTest.convertAsTemplate(source);
+
+        assertNotNull(result.getExternalDatabase());
+        assertEquals(DatabaseAvailabilityType.HA, result.getExternalDatabase().getAvailabilityType());
+        checkTagsV1WithV4(tags, result.getTags());
     }
 
     @Test
@@ -157,6 +267,51 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         assertThat(convert.getExternalDatabase().getAvailabilityType()).isEqualTo(DistroXDatabaseAvailabilityType.HA);
     }
 
+    @Test
+    void testWhenTagsProvidedTheyWillBePassedForStackConversion() {
+        when(databaseRequestConverter.convert(any(DatabaseRequest.class))).thenReturn(createDistroXDatabaseRequest());
+
+        StackV4Request source = new StackV4Request();
+        source.setName("stackname");
+        DatabaseRequest databaseRequest = new DatabaseRequest();
+        databaseRequest.setAvailabilityType(DatabaseAvailabilityType.HA);
+        source.setExternalDatabase(databaseRequest);
+        TagsV4Request tags = createTagsV4Request();
+        source.setTags(tags);
+
+        DistroXV1Request result = underTest.convert(source);
+        assertThat(result.getExternalDatabase()).isNotNull();
+        assertThat(result.getExternalDatabase().getAvailabilityType()).isEqualTo(DistroXDatabaseAvailabilityType.HA);
+        checkTagsV4WithV1(tags, result.getTags());
+    }
+
+    private void checkTagsV1WithV4(TagsV1Request input, TagsV4Request result) {
+        assertEquals(input.getUserDefined().size(), result.getUserDefined().size());
+        assertEquals(input.getApplication().size(), result.getApplication().size());
+        assertEquals(input.getDefaults().size(), result.getDefaults().size());
+
+        checkTagMap(input.getUserDefined(), result.getUserDefined());
+        checkTagMap(input.getApplication(), result.getApplication());
+        checkTagMap(input.getDefaults(), result.getDefaults());
+    }
+
+    private void checkTagsV4WithV1(TagsV4Request input, TagsV1Request result) {
+        assertEquals(input.getUserDefined().size(), result.getUserDefined().size());
+        assertEquals(input.getApplication().size(), result.getApplication().size());
+        assertEquals(input.getDefaults().size(), result.getDefaults().size());
+
+        checkTagMap(input.getUserDefined(), result.getUserDefined());
+        checkTagMap(input.getApplication(), result.getApplication());
+        checkTagMap(input.getDefaults(), result.getDefaults());
+    }
+
+    private void checkTagMap(Map<String, String> input, Map<String, String> result) {
+        input.forEach((k, v) -> {
+            assertTrue(result.containsKey(k));
+            assertEquals(v, result.get(k));
+        });
+    }
+
     private DatabaseRequest createDatabaseRequest() {
         DatabaseRequest request = new DatabaseRequest();
         request.setAvailabilityType(DatabaseAvailabilityType.HA);
@@ -169,10 +324,38 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         return request;
     }
 
-    private NetworkV4Request createNetworkV4Request() {
+    private NetworkV4Request createAwsNetworkV4Request() {
         NetworkV4Request network = new NetworkV4Request();
         network.setAws(createAwsNetworkV4Parameters());
         return network;
+    }
+
+    private NetworkV4Request createAzureNetworkV4Request() {
+        NetworkV4Request network = new NetworkV4Request();
+        network.setAzure(createAzureNetworkV4Parameters());
+        return network;
+    }
+
+    private NetworkV4Request createGcpNetworkV4Request() {
+        NetworkV4Request network = new NetworkV4Request();
+        network.setGcp(createGcpNetworkV4Parameters());
+        return network;
+    }
+
+    private TagsV1Request createTagsV1Request() {
+        TagsV1Request r = new TagsV1Request();
+        r.setUserDefined(Map.of("apple", "tree"));
+        r.setDefaults(Map.of("default", "fruit"));
+        r.setApplication(Map.of("peach", "tree"));
+        return r;
+    }
+
+    private TagsV4Request createTagsV4Request() {
+        TagsV4Request r = new TagsV4Request();
+        r.setUserDefined(Map.of("apple", "tree"));
+        r.setDefaults(Map.of("default", "fruit"));
+        r.setApplication(Map.of("peach", "tree"));
+        return r;
     }
 
     private AwsNetworkV4Parameters createAwsNetworkV4Parameters() {
@@ -182,11 +365,49 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         return awsNetwork;
     }
 
-    private DetailedEnvironmentResponse createEnvironment() {
+    private AzureNetworkV4Parameters createAzureNetworkV4Parameters() {
+        AzureNetworkV4Parameters params = new AzureNetworkV4Parameters();
+        params.setSubnetId("mysubnetid");
+        params.setNetworkId("networkId");
+        params.setNoPublicIp(false);
+        params.setResourceGroupName("resourceGroup");
+        return params;
+    }
+
+    private GcpNetworkV4Parameters createGcpNetworkV4Parameters() {
+        GcpNetworkV4Parameters params = new GcpNetworkV4Parameters();
+        params.setSubnetId("mysubnetid");
+        params.setNoFirewallRules(true);
+        params.setNoPublicIp(false);
+        params.setSharedProjectId("projectId");
+        return params;
+    }
+
+    private DetailedEnvironmentResponse createAzureEnvironment() {
+        DetailedEnvironmentResponse env = new DetailedEnvironmentResponse();
+        env.setEnvironmentStatus(EnvironmentStatus.AVAILABLE);
+        env.setCloudPlatform("AZURE");
+        env.setNetwork(createAzureNetwork());
+        env.setName("SomeAwesomeEnv");
+        env.setRegions(createCompactRegionResponse());
+        return env;
+    }
+
+    private DetailedEnvironmentResponse createGcpEnvironment() {
+        DetailedEnvironmentResponse env = new DetailedEnvironmentResponse();
+        env.setEnvironmentStatus(EnvironmentStatus.AVAILABLE);
+        env.setCloudPlatform("GCP");
+        env.setNetwork(createGcpNetwork());
+        env.setName("SomeAwesomeEnv");
+        env.setRegions(createCompactRegionResponse());
+        return env;
+    }
+
+    private DetailedEnvironmentResponse createAwsEnvironment() {
         DetailedEnvironmentResponse env = new DetailedEnvironmentResponse();
         env.setEnvironmentStatus(EnvironmentStatus.AVAILABLE);
         env.setCloudPlatform("AWS");
-        env.setNetwork(createNetwork());
+        env.setNetwork(createAwsNetwork());
         env.setName("SomeAwesomeEnv");
         env.setRegions(createCompactRegionResponse());
         return env;
@@ -198,16 +419,60 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         return regionResponse;
     }
 
-    private EnvironmentNetworkResponse createNetwork() {
+    private EnvironmentNetworkResponse createAzureNetwork() {
         EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
-        network.setAws(createAwsNetwork());
+        network.setAzure(createAzureNetworkParams());
         network.setSubnetIds(Set.of("mysubnetid"));
         return network;
     }
 
-    private EnvironmentNetworkAwsParams createAwsNetwork() {
+    private EnvironmentNetworkAzureParams createAzureNetworkParams() {
+        EnvironmentNetworkAzureParams azureParams = new EnvironmentNetworkAzureParams();
+        azureParams.setNetworkId("someNetworkId");
+        azureParams.setResourceGroupName("someResourceGroup");
+        azureParams.setNoPublicIp(false);
+        return azureParams;
+    }
+
+    private EnvironmentNetworkResponse createGcpNetwork() {
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setGcp(createGcpNetworkParams());
+        network.setSubnetIds(Set.of("mysubnetid"));
+        return network;
+    }
+
+    private EnvironmentNetworkGcpParams createGcpNetworkParams() {
+        EnvironmentNetworkGcpParams gcpParams = new EnvironmentNetworkGcpParams();
+        gcpParams.setNetworkId("someNetworkId");
+        gcpParams.setNoPublicIp(false);
+        gcpParams.setNoFirewallRules(true);
+        gcpParams.setSharedProjectId("someSharedProjectId");
+        return gcpParams;
+    }
+
+    private EnvironmentNetworkResponse createAwsNetwork() {
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setAws(createAwsNetworkParams());
+        network.setSubnetIds(Set.of("mysubnetid"));
+        return network;
+    }
+
+    private CloudSubnet createCloudSubnet() {
+        CloudSubnet cs = new CloudSubnet();
+        cs.setType(SubnetType.PUBLIC);
+        cs.setName("someCloudSubnet");
+        cs.setId("123");
+        cs.setIgwAvailable(true);
+        cs.setMapPublicIpOnLaunch(false);
+        cs.setPrivateSubnet(false);
+        cs.setCidr("0.0.0.0/0");
+        return cs;
+    }
+
+    private EnvironmentNetworkAwsParams createAwsNetworkParams() {
         EnvironmentNetworkAwsParams awsNetwork = new EnvironmentNetworkAwsParams();
         awsNetwork.setVpcId("myvpc");
         return awsNetwork;
     }
+
 }

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4ConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4ConverterTest.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.distrox.v1.distrox.converter;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -9,8 +12,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,24 +23,31 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AwsNetworkV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AzureNetworkV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.GcpNetworkV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.MockNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.network.NetworkV4Request;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
-import com.sequenceiq.cloudbreak.converter.v4.environment.network.SubnetSelector;
-import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.cloudbreak.controller.validation.loadbalancer.EndpointGatewayNetworkValidator;
+import com.sequenceiq.cloudbreak.converter.v4.environment.network.SubnetSelector;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.AwsNetworkV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.AzureNetworkV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.NetworkV1Request;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkGcpParams;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkYarnParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 
 @ExtendWith(MockitoExtension.class)
 public class NetworkV1ToNetworkV4ConverterTest {
@@ -69,14 +81,56 @@ public class NetworkV1ToNetworkV4ConverterTest {
         NetworkV1Request networkV1Request = awsNetworkV1Request();
         DetailedEnvironmentResponse environmentNetworkResponse = awsEnvironmentNetwork();
 
+
         NetworkV4Request[] networkV4Request = new NetworkV4Request[1];
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
             networkV4Request[0] = underTest
-                .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
+                    .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
         });
 
-        Assert.assertEquals(networkV4Request[0].createAws().getVpcId(), VPC_ID);
-        Assert.assertEquals(networkV4Request[0].createAws().getSubnetId(), SUBNET_ID);
+        assertEquals(networkV4Request[0].createAws().getVpcId(), VPC_ID);
+        assertEquals(networkV4Request[0].createAws().getSubnetId(), SUBNET_ID);
+    }
+
+    @Test
+    void testWhenEnvironmentResponseHasNoCloudPlatformSetThenIllegalStateExceptionShouldCome() {
+        DetailedEnvironmentResponse input = createGcpEnvironment();
+        input.setCloudPlatform(null);
+
+        IllegalStateException expectedException = Assertions.assertThrows(IllegalStateException.class, () ->
+                underTest.convertToNetworkV4Request(new ImmutablePair<>(null, input)));
+
+        assertEquals("Unable to determine cloud platform for network since it has not been set!", expectedException.getMessage());
+    }
+
+    @Test
+    void testConvertToNetworkV4RequestWhenGcpNetworkKeyIsNullThenBasicSettingShouldHappen() {
+        DetailedEnvironmentResponse input = createGcpEnvironment();
+        NetworkV4Request result = underTest
+                .convertToNetworkV4Request(new ImmutablePair<>(null, input));
+
+        Assertions.assertNotNull(result);
+        GcpNetworkV4Parameters gcpNetworkResult = result.getGcp();
+        EnvironmentNetworkGcpParams inputGcpNetwork = input.getNetwork().getGcp();
+        Assertions.assertNotNull(gcpNetworkResult);
+        assertEquals(inputGcpNetwork.getNetworkId(), gcpNetworkResult.getNetworkId());
+        assertEquals(inputGcpNetwork.getNoPublicIp(), gcpNetworkResult.getNoPublicIp());
+        assertEquals(inputGcpNetwork.getSharedProjectId(), gcpNetworkResult.getSharedProjectId());
+        assertEquals(inputGcpNetwork.getNoFirewallRules(), gcpNetworkResult.getNoFirewallRules());
+    }
+
+    @Test
+    void testConvertToNetworkV4RequestWhenMockNetworkKeyIsNullThenBasicSettingShouldHappen() {
+        DetailedEnvironmentResponse input = createMockEnvironment();
+        NetworkV4Request result = underTest
+                .convertToNetworkV4Request(new ImmutablePair<>(null, input));
+
+        Assertions.assertNotNull(result);
+        MockNetworkV4Parameters mockNetworkResult = result.getMock();
+        Assertions.assertNotNull(mockNetworkResult);
+        Assertions.assertNull(mockNetworkResult.getVpcId());
+        Assertions.assertNull(mockNetworkResult.getInternetGatewayId());
+        assertTrue(StringUtils.isNotEmpty(mockNetworkResult.getSubnetId()));
     }
 
     @Test
@@ -87,11 +141,57 @@ public class NetworkV1ToNetworkV4ConverterTest {
         NetworkV4Request[] networkV4Request = new NetworkV4Request[1];
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
             networkV4Request[0] = underTest
-                .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
+                    .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
         });
 
-        Assert.assertEquals(networkV4Request[0].createAws().getVpcId(), VPC_ID);
-        Assert.assertTrue(SUBNET_IDS.contains(networkV4Request[0].createAws().getSubnetId()));
+
+
+        assertEquals(networkV4Request[0].createAws().getVpcId(), VPC_ID);
+        assertTrue(SUBNET_IDS.contains(networkV4Request[0].createAws().getSubnetId()));
+    }
+
+    @Test
+    void testConvertToNetworkV1RequestWhenAwsNetworkParamIsNullThenItShouldNotBeSet() {
+        NetworkV4Request input = createNetworkV4Request();
+        input.setAws(null);
+
+        NetworkV1Request result = underTest.convertToNetworkV1Request(input);
+
+        assertNotNull(result);
+        assertNull(result.getAws());
+    }
+
+    @Test
+    void testConvertToNetworkV1RequestWhenAwsNetworkParamIsNotNullThenItShouldBeSet() {
+        NetworkV4Request input = createNetworkV4Request();
+
+        NetworkV1Request result = underTest.convertToNetworkV1Request(input);
+
+        assertNotNull(result);
+        assertNotNull(result.getAws());
+        assertEquals(input.getAws().getSubnetId(), result.getAws().getSubnetId());
+    }
+
+    @Test
+    void testConvertToNetworkV1RequestWhenAzureNetworkParamIsNullThenItShouldNotBeSet() {
+        NetworkV4Request input = createNetworkV4Request();
+        input.setAzure(null);
+
+        NetworkV1Request result = underTest.convertToNetworkV1Request(input);
+
+        assertNotNull(result);
+        assertNull(result.getAzure());
+    }
+
+    @Test
+    void testConvertToNetworkV1RequestWhenAzureNetworkParamIsNotNullThenItShouldBeSet() {
+        NetworkV4Request input = createNetworkV4Request();
+
+        NetworkV1Request result = underTest.convertToNetworkV1Request(input);
+
+        assertNotNull(result);
+        assertNotNull(result.getAzure());
+        assertEquals(input.getAzure().getSubnetId(), result.getAzure().getSubnetId());
     }
 
     @Test
@@ -103,9 +203,9 @@ public class NetworkV1ToNetworkV4ConverterTest {
         NetworkV4Request networkV4Request = underTest
                 .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
 
-        Assert.assertEquals(networkV4Request.createAzure().getNetworkId(), VPC_ID);
-        Assert.assertEquals(networkV4Request.createAzure().getResourceGroupName(), GROUP_NAME);
-        Assert.assertEquals(networkV4Request.createAzure().getSubnetId(), SUBNET_ID);
+        assertEquals(networkV4Request.createAzure().getNetworkId(), VPC_ID);
+        assertEquals(networkV4Request.createAzure().getResourceGroupName(), GROUP_NAME);
+        assertEquals(networkV4Request.createAzure().getSubnetId(), SUBNET_ID);
     }
 
     @Test
@@ -117,9 +217,9 @@ public class NetworkV1ToNetworkV4ConverterTest {
         NetworkV4Request networkV4Request = underTest
                 .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
 
-        Assert.assertEquals(networkV4Request.createAzure().getNetworkId(), VPC_ID);
-        Assert.assertEquals(networkV4Request.createAzure().getResourceGroupName(), GROUP_NAME);
-        Assert.assertTrue(SUBNET_IDS.contains(networkV4Request.createAzure().getSubnetId()));
+        assertEquals(networkV4Request.createAzure().getNetworkId(), VPC_ID);
+        assertEquals(networkV4Request.createAzure().getResourceGroupName(), GROUP_NAME);
+        assertTrue(SUBNET_IDS.contains(networkV4Request.createAzure().getSubnetId()));
     }
 
     @Test
@@ -127,11 +227,82 @@ public class NetworkV1ToNetworkV4ConverterTest {
         NetworkV1Request networkV1Request = yarnNetworkV1Request();
         DetailedEnvironmentResponse environmentNetworkResponse = yarnEnvironmentNetwork();
 
-
         NetworkV4Request networkV4Request = underTest
                 .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
 
-        Assert.assertTrue(networkV4Request.createYarn().asMap().size() == 1);
+        assertTrue(networkV4Request.createYarn().asMap().size() == 1);
+    }
+
+    private NetworkV4Request createNetworkV4Request() {
+        NetworkV4Request r = new NetworkV4Request();
+        r.setAws(createAwsNetworkV4Parameters());
+        r.setAzure(createAzureNetworkV4Parameters());
+        return r;
+    }
+
+    private AzureNetworkV4Parameters createAzureNetworkV4Parameters() {
+        AzureNetworkV4Parameters p = new AzureNetworkV4Parameters();
+        p.setNetworkId("someNetworkId");
+        p.setNoPublicIp(true);
+        p.setSubnetId(SUBNET_ID);
+        p.setResourceGroupName("someResourceGroupName");
+        return p;
+    }
+
+    private AwsNetworkV4Parameters createAwsNetworkV4Parameters() {
+        AwsNetworkV4Parameters p = new AwsNetworkV4Parameters();
+        p.setSubnetId(SUBNET_ID);
+        p.setVpcId(VPC_ID);
+        p.setInternetGatewayId("someInternetGatewayId");
+        return p;
+    }
+
+    private DetailedEnvironmentResponse createGcpEnvironment() {
+        DetailedEnvironmentResponse r = new DetailedEnvironmentResponse();
+        r.setEnvironmentStatus(EnvironmentStatus.AVAILABLE);
+        r.setNetwork(createEnvironmentNetworkResponseForGcp());
+        r.setCloudPlatform("GCP");
+        return r;
+    }
+
+    private DetailedEnvironmentResponse createMockEnvironment() {
+        DetailedEnvironmentResponse r = new DetailedEnvironmentResponse();
+        r.setEnvironmentStatus(EnvironmentStatus.AVAILABLE);
+        r.setNetwork(createEnvironmentNetworkResponseForMock());
+        r.setCloudPlatform("MOCK");
+        return r;
+    }
+
+    private EnvironmentNetworkResponse createEnvironmentNetworkResponseForMock() {
+        EnvironmentNetworkResponse environmentNetworkResponse = new EnvironmentNetworkResponse();
+        environmentNetworkResponse.setSubnetIds(SUBNET_IDS);
+        environmentNetworkResponse.setPreferedSubnetId(SUBNET_ID);
+        environmentNetworkResponse.setMock(createEnvironmentNetworkMockParams());
+        return environmentNetworkResponse;
+    }
+
+    private EnvironmentNetworkMockParams createEnvironmentNetworkMockParams() {
+        EnvironmentNetworkMockParams mockParams = new EnvironmentNetworkMockParams();
+        mockParams.setVpcId("someVpcId");
+        mockParams.setInternetGatewayId("someInternetGatewayId");
+        return mockParams;
+    }
+
+    private EnvironmentNetworkResponse createEnvironmentNetworkResponseForGcp() {
+        EnvironmentNetworkResponse environmentNetworkResponse = new EnvironmentNetworkResponse();
+        environmentNetworkResponse.setSubnetIds(SUBNET_IDS);
+        environmentNetworkResponse.setPreferedSubnetId(SUBNET_ID);
+        environmentNetworkResponse.setGcp(createEnvironmentNetworkGcpParams());
+        return environmentNetworkResponse;
+    }
+
+    private EnvironmentNetworkGcpParams createEnvironmentNetworkGcpParams() {
+        EnvironmentNetworkGcpParams gcpParams = new EnvironmentNetworkGcpParams();
+        gcpParams.setSharedProjectId("someSharedProjectId");
+        gcpParams.setNoPublicIp(true);
+        gcpParams.setNoFirewallRules(true);
+        gcpParams.setNetworkId("someNetworkId");
+        return gcpParams;
     }
 
     @Test

--- a/resource_names_testWhenEnvIsStoppedUnableToCreateDistroX.json
+++ b/resource_names_testWhenEnvIsStoppedUnableToCreateDistroX.json
@@ -1,0 +1,1 @@
+{"distroxImageName":["mock-test-bfa1d9263844457da28665557455ac","mock-test-54437d0889654920814b74f68dd98a"],"blueprintName":"mock-test-5de8ffbf33f74fbcbbe6aa5b2f6248","imagecatalogName":"mock-test-b11ef8bd31bc488e9a53179c3215b3","environmentName":"mock-test-85ef5066834440b583","distroxName":"mock-test-83e7b","credentialName":"mock-test-3861178ba37740baa652d6f2fbe6cc"}


### PR DESCRIPTION
Increasing line and decision test coverage for:
- ClusterTemplateV4RequestToClusterTemplateConverter
- DistroXAuthenticationToStaAuthenticationConverter
- DistroXClusterToClusterConverter
- DistroXDatabaseRequestToStackDatabaseRequestConverter
- DistroXImageToImageSettingsConverter
- InstanceGroupV1ToInstanceGroupV4Converter
- DistroXParameterConverter
- StackV4RequestToStackConverter
- DistroXV1RequestToStackV4RequestConverter
- ClusterTemplateV4RequestToClusterTemplateConverter
- NetworkV1ToNetworkV4Converter
- TelemetryConverter