### PR TITLE
CB-10555 Support wildcard hostname in requested DNS A records

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/dns/model/DnsRecordRegexpPatterns.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/dns/model/DnsRecordRegexpPatterns.java
@@ -10,7 +10,7 @@ public final class DnsRecordRegexpPatterns {
 
     public static final String DNS_CNAME_MSG = "CNAME must be valid. Might start with '*.' and can contain alphanumeric characters, dash and dot.";
 
-    public static final String DNS_HOSTNAME_PATTERN = "^[a-zA-Z0-9]+[a-zA-Z0-9-\\.]*[a-zA-Z0-9]+$";
+    public static final String DNS_HOSTNAME_PATTERN = "^(\\*\\.)?[a-zA-Z0-9]+[a-zA-Z0-9-\\.]*[a-zA-Z0-9]+$";
 
     public static final String DNS_HOSTNAME_MSG = "Hostname must be valid. Can contain alphanumeric characters, dash and dot.";
 

--- a/freeipa-api/src/test/java/com/sequenceiq/freeipa/api/v1/dns/model/DnsRecordRegexpPatternsTest.java
+++ b/freeipa-api/src/test/java/com/sequenceiq/freeipa/api/v1/dns/model/DnsRecordRegexpPatternsTest.java
@@ -51,6 +51,10 @@ class DnsRecordRegexpPatternsTest {
                 {"google.com-", false},
                 {"-google.com", false},
                 {"*.google.com", true},
+                {"ok*.google.com", false},
+                {".*.google.com", false},
+                {"*.", false},
+                {"*", false},
         };
     }
 
@@ -76,7 +80,12 @@ class DnsRecordRegexpPatternsTest {
                 {"www.goo-gle.com", true},
                 {"google.com-", false},
                 {"-google.com", false},
-                {"*.google.com", false},
+                {"*.google.com", true},
+                {"ok.*.google.com", false},
+                {"ok*.google.com", false},
+                {".*.google.com", false},
+                {"*.", false},
+                {"*", false},
         };
     }
 
@@ -103,6 +112,10 @@ class DnsRecordRegexpPatternsTest {
                 {"google.com-", false},
                 {"-google.com", false},
                 {"*.google.com", false},
+                {"ok*.google.com", false},
+                {".*.google.com", false},
+                {"*.", false},
+                {"*", false},
         };
     }
 


### PR DESCRIPTION
With this commit A records with wildcard characters will be supported.
Wildcard only supported in the beginning and must be followed by dot and other valid characters.
Accepted:
`*.test`
`*.test.name`
Not accepted:
`*`
`*.`
`test.*.`
`*test`
`test*`
etc

See detailed description in the commit message.