### PR TITLE
CB-10141 Missing Experience deletion entitlement from mock-thunderhead service

### DIFF
--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -239,6 +239,8 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     private static final String CDP_LOAD_BALANCER_ENABLEMENT = "CDP_DATA_LAKE_LOAD_BALANCER";
 
+    private static final String CDP_EXPERIENCE_DELETION_BY_ENVIRONMENT = "CDP_EXPERIENCE_DELETION_BY_ENVIRONMENT";
+
     private static final String MOCK_RESOURCE = "mock_resource";
 
     private static final String SSH_PUBLIC_KEY_PATTERN = "^ssh-(rsa|ed25519)\\s+AAAA(B|C)3NzaC1.*(|\\n)";
@@ -335,6 +337,9 @@ public class MockUserManagementService extends UserManagementImplBase {
 
     @Value("${auth.mock.datalake.loadbalancer.enable}")
     private boolean datalakeLoadBalancerEnabled;
+
+    @Value("${auth.mock.environment.experience.deletion.enable}")
+    private boolean enableExperienceDeletionByEnvironment;
 
     private String cbLicense;
 
@@ -651,6 +656,9 @@ public class MockUserManagementService extends UserManagementImplBase {
         }
         if (datalakeLoadBalancerEnabled) {
             builder.addEntitlements(createEntitlement(CDP_LOAD_BALANCER_ENABLEMENT));
+        }
+        if (enableExperienceDeletionByEnvironment) {
+            builder.addEntitlements(createEntitlement(CDP_EXPERIENCE_DELETION_BY_ENVIRONMENT));
         }
         responseObserver.onNext(
                 GetAccountResponse.newBuilder()

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -36,3 +36,4 @@ auth:
     embedded.database.on.attached.disk.enable: true
     datalake.loadbalancer.enable: false
     ccmv2.enable: false
+    environment.experience.deletion.enable: true


### PR DESCRIPTION
Added as enabled by default.