### PR TITLE
CB-10475 [7.2.7][Flow Mgmt Light] Datahub creation failure. Enabled f…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-flow-management-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-flow-management-small.bp
@@ -260,11 +260,11 @@
               },
               {
                 "name": "xml.providers.flowPersistenceProvider.file-provider.enabled",
-                "value": "false"
+                "value": "true"
               },
               {
                 "name": "xml.providers.flowPersistenceProvider.database-provider.enabled",
-                "value": "true"
+                "value": "false"
               },
               {
                 "name": "nifi.registry.properties.ignored",

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-flow-management.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-flow-management.bp
@@ -260,11 +260,11 @@
               },
               {
                 "name": "xml.providers.flowPersistenceProvider.file-provider.enabled",
-                "value": "false"
+                "value": "true"
               },
               {
                 "name": "xml.providers.flowPersistenceProvider.database-provider.enabled",
-                "value": "true"
+                "value": "false"
               },
               {
                 "name": "nifi.registry.properties.ignored",


### PR DESCRIPTION
…ile provider to make NiFi Registry Workable, because database provider is not actual for current version.

See detailed description in the commit message.