### PR TITLE
CB-10592 Trim user name from leading and trailing spaces before sync

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverter.java
@@ -1,13 +1,13 @@
 package com.sequenceiq.freeipa.service.freeipa.user.conversion;
 
-import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
-import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
+import static com.google.common.base.Preconditions.checkArgument;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.freeipa.service.freeipa.user.model.FmsUser;
 
 @Component
 public class FmsUserConverter {
@@ -36,11 +36,11 @@ public class FmsUserConverter {
     }
 
     private FmsUser createFmsUser(String workloadUsername, String firstName, String lastName) {
-        checkArgument(!Strings.isNullOrEmpty(workloadUsername));
+        checkArgument(StringUtils.isNotBlank(workloadUsername));
         FmsUser fmsUser = new FmsUser();
         fmsUser.withName(workloadUsername);
-        fmsUser.withFirstName(StringUtils.defaultIfBlank(firstName, NONE_STRING));
-        fmsUser.withLastName(StringUtils.defaultIfBlank(lastName, NONE_STRING));
+        fmsUser.withFirstName(StringUtils.defaultIfBlank(StringUtils.strip(firstName), NONE_STRING));
+        fmsUser.withLastName(StringUtils.defaultIfBlank(StringUtils.strip(lastName), NONE_STRING));
         return fmsUser;
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverterTest.java
@@ -29,6 +29,24 @@ class FmsUserConverterTest {
     }
 
     @Test
+    public void testUserToFmsUserWithSpaces() {
+        String firstName = " Foo ";
+        String lastName = " Bar ";
+        String workloadUsername = "foobar";
+        UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
+                .setFirstName(firstName)
+                .setLastName(lastName)
+                .setWorkloadUsername(workloadUsername)
+                .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(umsUser);
+
+        assertEquals("foobar", fmsUser.getName());
+        assertEquals("Foo", fmsUser.getFirstName());
+        assertEquals("Bar", fmsUser.getLastName());
+    }
+
+    @Test
     public void testUserToFmsUserMissingNames() {
         String workloadUsername = "foobar";
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
@@ -70,6 +88,24 @@ class FmsUserConverterTest {
         assertEquals(workloadUsername, fmsUser.getName());
         assertEquals(name, fmsUser.getFirstName());
         assertEquals(id, fmsUser.getLastName());
+    }
+
+    @Test
+    public void testMachineUserToFmsUserWithSpaces() {
+        String name = " Foo ";
+        String id = " Bar ";
+        String workloadUsername = "foobar";
+        UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
+                .setMachineUserName(name)
+                .setMachineUserId(id)
+                .setWorkloadUsername(workloadUsername)
+                .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
+
+        assertEquals("foobar", fmsUser.getName());
+        assertEquals("Foo", fmsUser.getFirstName());
+        assertEquals("Bar", fmsUser.getLastName());
     }
 
     @Test
@@ -118,6 +154,25 @@ class FmsUserConverterTest {
     }
 
     @Test
+    public void testUserSyncActorDetailsToFmsUserWithSpaces() {
+        String firstName = " Foo ";
+        String lastName = " Bar ";
+        String workloadUsername = "foobar";
+        UserManagementProto.UserSyncActorDetails actorDetails =
+                UserManagementProto.UserSyncActorDetails.newBuilder()
+                        .setFirstName(firstName)
+                        .setLastName(lastName)
+                        .setWorkloadUsername(workloadUsername)
+                        .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(actorDetails);
+
+        assertEquals("foobar", fmsUser.getName());
+        assertEquals("Foo", fmsUser.getFirstName());
+        assertEquals("Bar", fmsUser.getLastName());
+    }
+
+    @Test
     public void testUserSyncActorDetailsToFmsUserMissingNames() {
         String workloadUsername = "foobar";
         UserManagementProto.UserSyncActorDetails actorDetails =
@@ -140,6 +195,21 @@ class FmsUserConverterTest {
                 UserManagementProto.UserSyncActorDetails.newBuilder()
                         .setFirstName(firstName)
                         .setLastName(lastName)
+                        .build();
+
+        assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(actorDetails));
+    }
+
+    @Test
+    public void testUserSyncActorDetailsToFmsUserBlankWorkloadUsername() {
+        String firstName = "Foo";
+        String lastName = "Bar";
+        String workloadUserName = " ";
+        UserManagementProto.UserSyncActorDetails actorDetails =
+                UserManagementProto.UserSyncActorDetails.newBuilder()
+                        .setFirstName(firstName)
+                        .setLastName(lastName)
+                        .setWorkloadUsername(workloadUserName)
                         .build();
 
         assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(actorDetails));


### PR DESCRIPTION
If user first or last name starts or ends with spaces the sync for that user would fail on FreeIPA side.
To avoid such issues we have to trim these spaces during user sync.
Workloadusername also stripped from spaces and now checked against if it's blank isntead of empty.

Please wait for @handavid approval before merging