### PR TITLE
CB-10572 [2.9] downscale does not work with custom resource group name

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/InstanceMetaDataToCloudInstanceConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/InstanceMetaDataToCloudInstanceConverter.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.cloudbreak.converter.spi;
 
+import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AZURE;
+
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -21,6 +24,8 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 @Component
 public class InstanceMetaDataToCloudInstanceConverter extends AbstractConversionServiceAwareConverter<InstanceMetaData, CloudInstance> {
 
+    private static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+
     @Inject
     private StackToCloudStackConverter stackToCloudStackConverter;
 
@@ -28,22 +33,24 @@ public class InstanceMetaDataToCloudInstanceConverter extends AbstractConversion
     private InstanceMetadataToImageIdConverter instanceMetadataToImageIdConverter;
 
     @Override
-    public CloudInstance convert(InstanceMetaData metaDataEnity) {
-        InstanceGroup group = metaDataEnity.getInstanceGroup();
-        Template template = metaDataEnity.getInstanceGroup().getTemplate();
+    public CloudInstance convert(InstanceMetaData metaDataEntity) {
+        InstanceGroup group = metaDataEntity.getInstanceGroup();
+        Template template = metaDataEntity.getInstanceGroup().getTemplate();
         StackAuthentication stackAuthentication = group.getStack().getStackAuthentication();
-        InstanceStatus status = getInstanceStatus(metaDataEnity);
-        String imageId = instanceMetadataToImageIdConverter.convert(metaDataEnity);
-        InstanceTemplate instanceTemplate = stackToCloudStackConverter.buildInstanceTemplate(template, group.getGroupName(), metaDataEnity.getPrivateId(),
+        InstanceStatus status = getInstanceStatus(metaDataEntity);
+        String imageId = instanceMetadataToImageIdConverter.convert(metaDataEntity);
+        InstanceTemplate instanceTemplate = stackToCloudStackConverter.buildInstanceTemplate(template, group.getGroupName(), metaDataEntity.getPrivateId(),
                 status, imageId);
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication(
                 stackAuthentication.getPublicKey(),
                 stackAuthentication.getPublicKeyId(),
                 stackAuthentication.getLoginUserName());
         Map<String, Object> params = new HashMap<>();
-        params.put(CloudInstance.SUBNET_ID, metaDataEnity.getSubnetId());
-        params.put(CloudInstance.INSTANCE_NAME, metaDataEnity.getInstanceName());
-        return new CloudInstance(metaDataEnity.getInstanceId(), instanceTemplate, instanceAuthentication, params);
+        params.put(CloudInstance.SUBNET_ID, metaDataEntity.getSubnetId());
+        params.put(CloudInstance.INSTANCE_NAME, metaDataEntity.getInstanceName());
+        fillCloudSpecificParameters(group.getStack().getPlatformVariant(), params, metaDataEntity);
+
+        return new CloudInstance(metaDataEntity.getInstanceId(), instanceTemplate, instanceAuthentication, params);
     }
 
     private InstanceStatus getInstanceStatus(InstanceMetaData metaData) {
@@ -62,6 +69,14 @@ public class InstanceMetaDataToCloudInstanceConverter extends AbstractConversion
                 return InstanceStatus.TERMINATED;
             default:
                 return InstanceStatus.UNKNOWN;
+        }
+    }
+
+    private void fillCloudSpecificParameters(String cloudPlatform, Map<String, Object> parameters, InstanceMetaData instanceMetaData) {
+        if (AZURE.equals(cloudPlatform)) {
+            Optional.ofNullable(instanceMetaData.getInstanceGroup().getStack().getParameters())
+                    .map(params -> params.get(RESOURCE_GROUP_NAME))
+                    .ifPresent(rgName -> parameters.put(RESOURCE_GROUP_NAME, rgName));
         }
     }
 


### PR DESCRIPTION
On azure, customer created a cluster with specifying a custom resource group name on the UI. In this scenario downscale did not work, it failed at downscale stack step. Reason: cloudbreak was looking for virtual machines not in the resource group specified by the customer but the one cloudbreak would have generated.

See detailed description in the commit message.