### PR TITLE
CB-10536. Add internal list APIs to environments and FMS

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
@@ -5,6 +5,7 @@ public class EnvironmentOpDescription {
     public static final String GET_BY_NAME = "Get an environment by name.";
     public static final String GET_BY_CRN = "Get an environment by CRN.";
     public static final String LIST = "List all environments.";
+    public static final String INTERNAL_LIST = "List all environments by account ID using the internal actor.";
     public static final String DELETE_BY_NAME = "Delete an environment by name. Only possible if no cluster is running in the environment.";
     public static final String DELETE_BY_CRN = "Delete an environment by CRN. Only possible if no cluster is running in the environment.";
     public static final String DELETE_MULTIPLE_BY_NAME = "Delete multiple environment by names. Only possible if no cluster is running in the environments.";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
@@ -19,6 +19,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
+import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
 import com.sequenceiq.cloudbreak.validation.ValidCrn;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
@@ -92,6 +93,13 @@ public interface EnvironmentEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = EnvironmentOpDescription.LIST, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES, nickname = "listEnvironmentV1")
     SimpleEnvironmentResponses list();
+
+    @GET
+    @Path("internal")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.INTERNAL_LIST, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+            nickname = "internalListEnvironmentV1")
+    SimpleEnvironmentResponses listInternal(@QueryParam("accountId") @AccountId String accountId);
 
     @PUT
     @Path("/name/{name}/change_credential")

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
@@ -13,6 +13,7 @@ import javax.transaction.Transactional.TxType;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
+import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
@@ -227,6 +228,16 @@ public class EnvironmentController implements EnvironmentEndpoint {
     @DisableCheckPermissions
     public SimpleEnvironmentResponses list() {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        return listAllEnvironmentsForAccount(accountId);
+    }
+
+    @Override
+    @InternalOnly
+    public SimpleEnvironmentResponses listInternal(@AccountId String accountId) {
+        return listAllEnvironmentsForAccount(accountId);
+    }
+
+    private SimpleEnvironmentResponses listAllEnvironmentsForAccount(String accountId) {
         List<EnvironmentDto> environmentDtos = environmentService.listByAccountId(accountId);
         List<SimpleEnvironmentResponse> responses = environmentDtos.stream().map(environmentResponseConverter::dtoToSimpleResponse)
                 .collect(Collectors.toList());

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -81,6 +81,13 @@ public interface FreeIpaV1Endpoint {
     List<ListFreeIpaResponse> list();
 
     @GET
+    @Path("internal/list")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = FreeIpaOperationDescriptions.INTERNAL_LIST_BY_ACCOUNT, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
+            nickname = "internalListFreeIpaClustersByAccountV1")
+    List<ListFreeIpaResponse> listInternal(@QueryParam("accountId") @AccountId String accountId);
+
+    @GET
     @Path("health")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = FreeIpaOperationDescriptions.HEALTH, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -7,6 +7,7 @@ public final class FreeIpaOperationDescriptions {
     public static final String GET_BY_ENVID = "Get FreeIPA stack by envid";
     public static final String INTERNAL_GET_BY_ENVID_AND_ACCOUNTID = "Get FreeIPA stack by envid and account id";
     public static final String LIST_BY_ACCOUNT = "List all FreeIPA stacks by account";
+    public static final String INTERNAL_LIST_BY_ACCOUNT = "List all FreeIPA stacks by account using the internal actor";
     public static final String GET_ROOTCERTIFICATE_BY_ENVID = "Get FreeIPA root certificate by envid";
     public static final String DELETE_BY_ENVID = "Delete FreeIPA stack by envid";
     public static final String CLEANUP = "Cleans out users, hosts and related DNS entries";

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -157,6 +157,12 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
     @DisableCheckPermissions
     public List<ListFreeIpaResponse> list() {
         String accountId = crnService.getCurrentAccountId();
+        return listInternal(accountId);
+    }
+
+    @Override
+    @InternalOnly
+    public List<ListFreeIpaResponse> listInternal(@AccountId String accountId) {
         return freeIpaListService.list(accountId);
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
@@ -170,6 +170,17 @@ class FreeIpaV1ControllerTest {
     }
 
     @Test
+    void listInternal() {
+        List<ListFreeIpaResponse> responseList = Collections.singletonList(new ListFreeIpaResponse());
+        when(freeIpaListService.list(ACCOUNT_ID)).thenReturn(responseList);
+
+        List<ListFreeIpaResponse> actual = underTest.listInternal(ACCOUNT_ID);
+
+        assertEquals(responseList, actual);
+        verify(freeIpaListService).list(ACCOUNT_ID);
+    }
+
+    @Test
     void getRootCertificate() throws Exception {
         underTest.getRootCertificate(ENVIRONMENT_CRN);
         verify(rootCertificateService, times(1)).getRootCertificate(ENVIRONMENT_CRN, ACCOUNT_ID);


### PR DESCRIPTION
This commit supports the use case where an internal service needs to
list environments or list FreeIPA stacks. This follows the pattern
of the FMS describeInternal API where a parallel API is added that
includes the accountId as a query parameter. Authorization for these
APIs is limited to the internal actor only through the @InternalOnly
annotation.

See detailed description in the commit message.