### PR TITLE
CB-10553 enable pre-warmed based image test for SDX on GCP, that was disabled accidentally

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxImagesTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxImagesTests.java
@@ -35,7 +35,7 @@ public class SdxImagesTests extends PreconditionSdxE2ETest {
     @Inject
     private SdxTestClient sdxTestClient;
 
-    @Test(dataProvider = TEST_CONTEXT, enabled = false)
+    @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(
             given = "there is a running Cloudbreak",


### PR DESCRIPTION


See detailed description in the commit message.