### PR TITLE
CB-10419: [CCMv2] New route for knox from nginx on port 9443

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/knox.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/knox.conf
@@ -1,0 +1,22 @@
+location /knox/ {
+  rewrite /knox/(.*) /$1  break;
+  proxy_pass         https://knox;
+  proxy_connect_timeout       300;
+  proxy_send_timeout          300;
+  proxy_read_timeout          300;
+  send_timeout                300;
+  proxy_buffer_size  32k;
+  proxy_buffers      8 32k;
+  proxy_redirect     off;
+  proxy_set_header   Host $host;
+  proxy_set_header   Referer https://$host/;
+  proxy_set_header   X-Forwarded-Host $server_name;
+  proxy_set_header   X-Forwarded-Proto $scheme;
+  proxy_set_header   Expect $http_expect;
+  # Ensure that websockets work
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "upgrade";
+  # Enable large uploads
+  client_max_body_size 0;
+}

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/init.sls
@@ -11,6 +11,11 @@
     - makedirs: True
     - source: salt://nginx/conf/ssl-locations.d/consul.conf
 
+/etc/nginx/sites-enabled/ssl-locations.d/knox.conf:
+  file.managed:
+    - makedirs: True
+    - source: salt://nginx/conf/ssl-locations.d/knox.conf
+
 /etc/nginx/sites-enabled/ssl-locations.d/prometheus.conf:
   file.managed:
     - makedirs: True


### PR DESCRIPTION
CcmV2 agent currently forwards requests only to nginx on port 9443.

Control Plane requests to cluster's /resourcemanager and similar api need to be routed to knox for features like DH autoscaling to succeed.

Hence nginx on port 9443 should be configured with a new rule which routes all requests with path prefix "/knox/<clustername>" to knox running on the node. The re-route rule to knox should not include path prefix "/knox" and should only include /<clustername>.