### PR TITLE
CB-10634: Allow 100 seconds for initial cluster proxy health check

### DIFF
--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -255,7 +255,7 @@ clusterProxy:
   registerConfigPath: /rpc/forceRegisterConfig
   updateConfigPath: /rpc/updateConfig
   removeConfigPath: /rpc/removeConfig
-  maxAttempts: 10
+  maxAttempts: 20
   maxFailure: 1
   healthCheckV1:
     # the login page returns a 400


### PR DESCRIPTION
Now that cluster proxy has circuit breakers, allow enough time for the
FreeIPA health check (run from cluster proxy) to run again after the
inital ciruit breakers opens the cirucit. Allowing 20 attempts at 5
seconds, provides sufficient time.

See detailed description in the commit message.