### PR TITLE
CB-9483 Connect timeout on FreeIPA client won't translate to Forbidde…

### DIFF
--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -151,7 +151,7 @@ cluster.externaldatabase.stop.commenced=External database stop commenced.
 cluster.externaldatabase.stop.failed=External database stop failed.
 cluster.externaldatabase.stop.finished=External database stop finished.
 
-cluster.kerberosconfig.validation.failed=Kerberos config validation failed.
+cluster.kerberosconfig.validation.failed=Kerberos config validation failed with: {0}
 
 cluster.cloudconfig.validation.failed=Cloud config validation failed with the following errors: {0}
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/kerberosconfig/KerberosConfigValidationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/kerberosconfig/KerberosConfigValidationActions.java
@@ -104,8 +104,8 @@ public class KerberosConfigValidationActions {
 
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
-                stackUpdaterService.updateStatus(context.getStackView().getId(), DetailedStackStatus.PROVISION_FAILED,
-                        ResourceEvent.KERBEROS_CONFIG_VALIDATION_FAILED, payload.getException().getMessage());
+                stackUpdaterService.updateStatusAndSendEventWithArgs(context.getStackView().getId(), DetailedStackStatus.PROVISION_FAILED,
+                        ResourceEvent.KERBEROS_CONFIG_VALIDATION_FAILED, payload.getException().getMessage(), payload.getException().getMessage());
                 sendEvent(context);
             }
 

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberos/KerberosConfigV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/kerberos/KerberosConfigV1Endpoint.java
@@ -44,7 +44,7 @@ public interface KerberosConfigV1Endpoint {
     @ApiOperation(value = KerberosConfigOperationDescription.GET_BY_ENV_FOR_CLUSTER, produces = MediaType.APPLICATION_JSON, notes = KERBEROS_CONFIG_NOTES,
             nickname = "getKerberosConfigForClusterV1")
     DescribeKerberosConfigResponse getForCluster(@QueryParam("environmentCrn") @NotEmpty String environmentCrn,
-            @QueryParam("clusterName") @NotEmpty String clusterName) throws Exception;
+            @QueryParam("clusterName") @NotEmpty String clusterName);
 
     @POST
     @Path("")

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/ldap/LdapConfigV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/ldap/LdapConfigV1Endpoint.java
@@ -43,7 +43,7 @@ public interface LdapConfigV1Endpoint {
     @ApiOperation(value = LdapConfigOpDescription.GET_BY_ENV_FOR_CLUSTER, produces = MediaType.APPLICATION_JSON, notes = LDAP_CONFIG_NOTES,
             nickname = "getLdapConfigForClusterV1")
     DescribeLdapConfigResponse getForCluster(@QueryParam("environmentCrn") @NotEmpty String environmentCrn,
-            @QueryParam("clusterName") @NotEmpty String clusterName) throws Exception;
+            @QueryParam("clusterName") @NotEmpty String clusterName);
 
     @POST
     @Path("")

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigV1Controller.java
@@ -9,20 +9,19 @@ import javax.transaction.Transactional.TxType;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Controller;
 
-import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.CheckPermissionByRequestProperty;
-import com.sequenceiq.authorization.annotation.ResourceCrn;
+import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.RequestObject;
+import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
 import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberos.model.create.CreateKerberosConfigRequest;
 import com.sequenceiq.freeipa.api.v1.kerberos.model.describe.DescribeKerberosConfigResponse;
-import com.sequenceiq.freeipa.client.RetryableFreeIpaClientException;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.FreeIpaClientExceptionWrapper;
 import com.sequenceiq.freeipa.util.CrnService;
 import com.sequenceiq.notification.NotificationController;
 
@@ -37,20 +36,20 @@ public class KerberosConfigV1Controller extends NotificationController implement
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)
-    public DescribeKerberosConfigResponse describe(@ResourceCrn String environmentCrn) {
+    public DescribeKerberosConfigResponse describe(@TenantAwareParam @ResourceCrn String environmentCrn) {
         return kerberosConfigV1Service.describe(environmentCrn);
     }
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)
-    @Retryable(value = RetryableFreeIpaClientException.class,
-            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
-            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
-                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public DescribeKerberosConfigResponse getForCluster(@ResourceCrn @NotEmpty @TenantAwareParam String environmentCrn,
-            @NotEmpty String clusterName) throws Exception {
+            @NotEmpty String clusterName) {
         String accountId = crnService.getCurrentAccountId();
-        return kerberosConfigV1Service.getForCluster(environmentCrn, accountId, clusterName);
+        try {
+            return kerberosConfigV1Service.getForCluster(environmentCrn, accountId, clusterName);
+        } catch (FreeIpaClientException e) {
+            throw new FreeIpaClientExceptionWrapper(e);
+        }
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigV1Service.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigV1Service.java
@@ -7,6 +7,8 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
@@ -93,6 +95,10 @@ public class KerberosConfigV1Service {
         return describeKerberosConfigResponse;
     }
 
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public DescribeKerberosConfigResponse getForCluster(String environmentCrn, String accountId, String clusterName) throws FreeIpaClientException {
         Optional<Stack> stack = stackService.findByEnvironmentCrnAndAccountId(environmentCrn, accountId);
         if (stack.isPresent()) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/v1/LdapConfigV1Service.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/v1/LdapConfigV1Service.java
@@ -6,6 +6,8 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import com.google.common.base.Strings;
@@ -175,6 +177,10 @@ public class LdapConfigV1Service {
         return createLdapConfigRequest;
     }
 
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public DescribeLdapConfigResponse getForCluster(String environmentCrn, String accountId, String clusterName) throws FreeIpaClientException {
         Optional<Stack> stack = stackService.findByEnvironmentCrnAndAccountId(environmentCrn, accountId);
         if (stack.isPresent()) {


### PR DESCRIPTION
…n exception

In this commit:
- [FMS] LDAP and Kerberos endpoint calls won't return Forbidden anymore when FreeIPA is unreachable
- [CB] Kerberos config fetching code won't handle forbidden differently than other exceptions. Only not found will be handled as if there is no FreeIPA present
- [CB] Calls FMS as internal actor to get Kerberos and LDAP configuration so it won't be tied to user role
- [FMS] For future use describe methods for LDAP and Kerberos endpoints are ready for internal calls
- [CB] After Kerberos validation state failure notification will display the exception message too instead of the simple `Kerberos validation failed.`

Tested locally with SDX creation:
- with unreachable FreeIPA while it is AVAILABLE in FMS
- with unreachable FreeIPA when it's UNREACHABLE in FMS
- with working FreeIPA

See detailed description in the commit message.