### PR TITLE
CB-10265: Only update the required CSDs with Data Hub upgrade

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/service/ClouderaManagerProductsProvider.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/service/ClouderaManagerProductsProvider.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.cloudbreak.cluster.service;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.component.StackType;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.type.ComponentType;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
+
+@Component
+public class ClouderaManagerProductsProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerProductsProvider.class);
+
+    public Set<ClouderaManagerProduct> getProducts(Set<ClusterComponent> components) {
+        return components.stream()
+                .filter(clusterComponent -> ComponentType.CDH_PRODUCT_DETAILS.equals(clusterComponent.getComponentType()))
+                .map(this::getClouderaManagerProduct)
+                .collect(Collectors.toSet());
+    }
+
+    public Optional<ClouderaManagerProduct> findCdhProduct(Set<ClusterComponent> components) {
+        return components.stream()
+                .filter(clusterComponent -> clusterComponent.getName().equals(StackType.CDH.name()))
+                .map(this::getClouderaManagerProduct)
+                .findFirst();
+    }
+
+    private ClouderaManagerProduct getClouderaManagerProduct(ClusterComponent clusterComponent) {
+        try {
+            return clusterComponent.getAttributes().get(ClouderaManagerProduct.class);
+        } catch (IOException e) {
+            LOGGER.error("Could not convert component {} into a ClouderaManagerProduct", clusterComponent.getName(), e);
+            throw new CloudbreakServiceException(e.getMessage(), e);
+        }
+    }
+}

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
@@ -55,6 +55,7 @@ import com.sequenceiq.cloudbreak.client.HttpClientConfig;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
+import com.sequenceiq.cloudbreak.cluster.service.ClouderaManagerProductsProvider;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
@@ -150,6 +151,9 @@ class ClouderaManagerModificationServiceTest {
 
     @Mock
     private PollingResultErrorHandler pollingResultErrorHandler;
+
+    @Spy
+    private ClouderaManagerProductsProvider clouderaManagerProductsProvider;
 
     private Cluster cluster;
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.cluster.service.ClouderaManagerProductsProvider;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
+import com.sequenceiq.cloudbreak.service.parcel.ParcelService;
+import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterParams;
+
+@Component
+class ImageFilterParamsFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageFilterParamsFactory.class);
+
+    @Inject
+    private ParcelService parcelService;
+
+    @Inject
+    private ClouderaManagerProductsProvider clouderaManagerProductsProvider;
+
+    ImageFilterParams create(Image image, boolean lockComponents, Stack stack) {
+        return new ImageFilterParams(image, lockComponents, getStackRelatedParcels(stack), stack.getType());
+    }
+
+    private Map<String, String> getStackRelatedParcels(Stack stack) {
+        Set<ClusterComponent> componentsByBlueprint = parcelService.getParcelComponentsByBlueprint(stack);
+        if (stack.isDatalake()) {
+            ClouderaManagerProduct stackProduct = getCdhProduct(componentsByBlueprint);
+            LOGGER.debug("For datalake clusters only the CDH parcel is related in CM: {}", stackProduct);
+            return Map.of(stackProduct.getName(), stackProduct.getVersion());
+        } else {
+            Set<ClouderaManagerProduct> products = clouderaManagerProductsProvider.getProducts(componentsByBlueprint);
+            LOGGER.debug("The following parcels are related for this datahub cluster: {}", products);
+            return products.stream().collect(Collectors.toMap(ClouderaManagerProduct::getName, ClouderaManagerProduct::getVersion));
+        }
+    }
+
+    private ClouderaManagerProduct getCdhProduct(Set<ClusterComponent> componentsByBlueprint) {
+        return clouderaManagerProductsProvider.findCdhProduct(componentsByBlueprint)
+                .orElseThrow(() -> new NotFoundException("Runtime component not found!"));
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/CdhPackageLocationFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/CdhPackageLocationFilter.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 
 @Component
 public class CdhPackageLocationFilter implements PackageLocationFilter {
@@ -14,7 +13,7 @@ public class CdhPackageLocationFilter implements PackageLocationFilter {
     private static final Logger LOGGER = LoggerFactory.getLogger(CdhPackageLocationFilter.class);
 
     @Override
-    public boolean filterImage(Image image, Image currentImage, StackType stackType) {
+    public boolean filterImage(Image image, Image currentImage, ImageFilterParams imageFilterParams) {
         if (isRelevantFieldNull(image, currentImage)) {
             LOGGER.debug("Image or some part of it is null: {}", image);
             return false;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClouderaManagerPackageLocationFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClouderaManagerPackageLocationFilter.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 
 @Component
 public class ClouderaManagerPackageLocationFilter implements PackageLocationFilter {
@@ -14,7 +13,7 @@ public class ClouderaManagerPackageLocationFilter implements PackageLocationFilt
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerPackageLocationFilter.class);
 
     @Override
-    public boolean filterImage(Image image, Image currentImage, StackType stackType) {
+    public boolean filterImage(Image image, Image currentImage, ImageFilterParams imageFilterParams) {
         if (image == null || image.getRepo() == null || currentImage == null || StringUtils.isBlank(currentImage.getOsType())) {
             LOGGER.debug("Image or repo is null: {}", image);
             return false;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilter.java
@@ -66,7 +66,7 @@ public class ClusterUpgradeImageFilter {
                 .filter(cmAndStackVersionFilter.filterCmAndStackVersion(imageFilterParams, reason))
                 .filter(validateCloudPlatform(cloudPlatform, reason))
                 .filter(validateOsVersion(currentImage, reason))
-                .filter(packageLocationFilter.filterImage(currentImage, imageFilterParams.getStackType()))
+                .filter(validatePackageLocation(imageFilterParams, currentImage, reason))
                 .collect(Collectors.toList());
 
         return new ImageFilterResult(new Images(null, images, null), getReason(images, reason));
@@ -109,6 +109,11 @@ public class ClusterUpgradeImageFilter {
             reason.setValue("There are no eligible images to upgrade with the same OS version.");
             return isOsVersionsMatch(currentImage, image);
         };
+    }
+
+    private Predicate<Image> validatePackageLocation(ImageFilterParams imageFilterParams, Image currentImage, Mutable<String> reason) {
+        reason.setValue("There are no eligible images to upgrade because the location of the packages are not appropriate.");
+        return packageLocationFilter.filterImage(currentImage, imageFilterParams);
     }
 
     private boolean isOsVersionsMatch(Image currentImage, Image newImage) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/CmAndStackVersionFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/CmAndStackVersionFilter.java
@@ -23,7 +23,7 @@ public class CmAndStackVersionFilter {
 
     public Predicate<Image> filterCmAndStackVersion(ImageFilterParams imageFilterParams, Mutable<String> reason) {
         return candidateImage -> {
-            updateReason(imageFilterParams.isLockComponents(), imageFilterParams.getActivatedParcels(), reason);
+            updateReason(imageFilterParams.isLockComponents(), imageFilterParams.getStackRelatedParcels(), reason);
             return isUpgradePermitted(imageFilterParams, candidateImage);
         };
     }
@@ -39,7 +39,7 @@ public class CmAndStackVersionFilter {
 
     private boolean isUpgradePermitted(ImageFilterParams imageFilterParams, Image candidateImage) {
         return imageFilterParams.isLockComponents()
-                ? lockedComponentChecker.isUpgradePermitted(imageFilterParams.getCurrentImage(), candidateImage, imageFilterParams.getActivatedParcels())
+                ? lockedComponentChecker.isUpgradePermitted(imageFilterParams.getCurrentImage(), candidateImage, imageFilterParams.getStackRelatedParcels())
                 : isUnlockedCmAndStackUpgradePermitted(imageFilterParams, candidateImage);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/CsdLocationFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/CsdLocationFilter.java
@@ -1,13 +1,20 @@
 package com.sequenceiq.cloudbreak.service.upgrade.image;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 
-import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 
 @Component
 public class CsdLocationFilter implements PackageLocationFilter {
@@ -15,19 +22,44 @@ public class CsdLocationFilter implements PackageLocationFilter {
     private static final Logger LOGGER = LoggerFactory.getLogger(CsdLocationFilter.class);
 
     @Override
-    public boolean filterImage(Image image, Image currentImage, StackType stackType) {
-        if (StackType.WORKLOAD.equals(stackType)) {
+    public boolean filterImage(Image image, Image currentImage, ImageFilterParams imageFilterParams) {
+        if (StackType.WORKLOAD.equals(imageFilterParams.getStackType())) {
             if (image == null || image.getPreWarmCsd() == null || image.getPreWarmCsd().isEmpty()) {
                 LOGGER.debug("Image or CSD parcels are not present. Image: {}", image);
                 return false;
             } else {
-                List<String> csdList = image.getPreWarmCsd();
+                List<String> csdList = getPreWarmCsdList(image, imageFilterParams);
                 LOGGER.debug("Matching URLs: [{}]", csdList);
-                return csdList.stream().allMatch(csdUrl -> URL_PATTERN.matcher(csdUrl).find());
+                return !csdList.isEmpty() && csdList.stream().allMatch(csdUrl -> URL_PATTERN.matcher(csdUrl).find());
             }
         } else {
-            LOGGER.debug("Skip filtering because the stack type is {}", stackType);
-            return false;
+            LOGGER.debug("Skip filtering because the stack type is {}", imageFilterParams.getStackType());
+            return true;
         }
     }
+
+    private List<String> getPreWarmCsdList(Image image, ImageFilterParams imageFilterParams) {
+        Set<String> relatedParcelNames = getParcelNames(imageFilterParams);
+        List<String> imagePreWarmCsd = image.getPreWarmCsd();
+        return CollectionUtils.isEmpty(relatedParcelNames) ? imagePreWarmCsd
+                : filterPreWarmCsdListByStackRelatedParcels(relatedParcelNames, imagePreWarmCsd);
+    }
+
+    private List<String> filterPreWarmCsdListByStackRelatedParcels(Set<String> stackRelatedParcelNames, List<String> imagePreWarmCsd) {
+        return imagePreWarmCsd.stream()
+                .filter(preWarmCsd -> stackRelatedParcelNames.stream().anyMatch(csdUrlContainsParcelName(preWarmCsd)))
+                .collect(Collectors.toList());
+    }
+
+    private Set<String> getParcelNames(ImageFilterParams imageFilterParams) {
+        return Optional.ofNullable(imageFilterParams)
+                .map(ImageFilterParams::getStackRelatedParcels)
+                .map(Map::keySet)
+                .orElse(Collections.emptySet());
+    }
+
+    private Predicate<String> csdUrlContainsParcelName(String preWarmCsd) {
+        return parcelName -> !"CDH".equals(parcelName) && preWarmCsd.toLowerCase().contains(parcelName.toLowerCase());
+    }
+
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/EntitlementDrivenPackageLocationFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/EntitlementDrivenPackageLocationFilter.java
@@ -7,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
@@ -26,13 +25,13 @@ public class EntitlementDrivenPackageLocationFilter {
         this.filters = filters;
     }
 
-    public Predicate<Image> filterImage(Image currentImage, StackType stackType) {
+    public Predicate<Image> filterImage(Image currentImage, ImageFilterParams imageFilterParams) {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         if (entitlementService.isInternalRepositoryForUpgradeAllowed(accountId)) {
             LOGGER.debug("Skipping image filtering based on repository url");
             return image -> true;
         } else {
-            return image -> filters.stream().allMatch(filter -> filter.filterImage(image, currentImage, stackType));
+            return image -> filters.stream().allMatch(filter -> filter.filterImage(image, currentImage, imageFilterParams));
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ImageFilterParams.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ImageFilterParams.java
@@ -12,14 +12,14 @@ public class ImageFilterParams {
 
     private final boolean lockComponents;
 
-    private final Map<String, String> activatedParcels;
+    private final Map<String, String> stackRelatedParcels;
 
     private final StackType stackType;
 
-    public ImageFilterParams(Image currentImage, boolean lockComponents, Map<String, String> activatedParcels, StackType stackType) {
+    public ImageFilterParams(Image currentImage, boolean lockComponents, Map<String, String> stackRelatedParcels, StackType stackType) {
         this.currentImage = currentImage;
         this.lockComponents = lockComponents;
-        this.activatedParcels = activatedParcels;
+        this.stackRelatedParcels = stackRelatedParcels;
         this.stackType = stackType;
     }
 
@@ -31,8 +31,8 @@ public class ImageFilterParams {
         return lockComponents;
     }
 
-    public Map<String, String> getActivatedParcels() {
-        return activatedParcels;
+    public Map<String, String> getStackRelatedParcels() {
+        return stackRelatedParcels;
     }
 
     public StackType getStackType() {
@@ -51,11 +51,11 @@ public class ImageFilterParams {
         return lockComponents == that.lockComponents &&
                 Objects.equals(currentImage, that.currentImage) &&
                 Objects.equals(stackType, that.stackType) &&
-                Objects.equals(activatedParcels, that.activatedParcels);
+                Objects.equals(stackRelatedParcels, that.stackRelatedParcels);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(currentImage, lockComponents, activatedParcels, stackType);
+        return Objects.hash(currentImage, lockComponents, stackRelatedParcels, stackType);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/PackageLocationFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/PackageLocationFilter.java
@@ -3,10 +3,9 @@ package com.sequenceiq.cloudbreak.service.upgrade.image;
 import java.util.regex.Pattern;
 
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 
 public interface PackageLocationFilter {
     Pattern URL_PATTERN = Pattern.compile("http[s]?://archive\\.cloudera\\.com.+");
 
-    boolean filterImage(Image image, Image currentImage, StackType stackType);
+    boolean filterImage(Image image, Image currentImage, ImageFilterParams imageFilterParams);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/PreWarmParcelLocationFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/PreWarmParcelLocationFilter.java
@@ -2,12 +2,16 @@ package com.sequenceiq.cloudbreak.service.upgrade.image;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
@@ -21,9 +25,9 @@ public class PreWarmParcelLocationFilter implements PackageLocationFilter {
     private static final String URL_PREFIX = "http";
 
     @Override
-    public boolean filterImage(Image image, Image currentImage, StackType stackType) {
-        if (StackType.WORKLOAD.equals(stackType)) {
-            List<String> parcelUrls = getUrls(image);
+    public boolean filterImage(Image image, Image currentImage, ImageFilterParams imageFilterParams) {
+        if (StackType.WORKLOAD.equals(imageFilterParams.getStackType())) {
+            List<String> parcelUrls = getUrls(image, imageFilterParams.getStackRelatedParcels());
             if (parcelUrls.isEmpty()) {
                 LOGGER.debug("Image or some part of it is null or not contains the parcel urls: {}", image);
                 return false;
@@ -32,17 +36,31 @@ public class PreWarmParcelLocationFilter implements PackageLocationFilter {
                 return parcelUrls.stream().allMatch(parcelUrl -> URL_PATTERN.matcher(parcelUrl).find());
             }
         } else {
-            LOGGER.debug("Skip filtering because the stack type is {}", stackType);
-            return false;
+            LOGGER.debug("Skip filtering because the stack type is {}", imageFilterParams.getStackType());
+            return true;
         }
     }
 
-    private List<String> getUrls(Image image) {
+    private List<String> getUrls(Image image, Map<String, String> stackRelatedParcels) {
         return Optional.ofNullable(image)
                 .map(Image::getPreWarmParcels).orElse(Collections.emptyList())
                 .stream()
+                .filter(filterByStackRelatedParcels(stackRelatedParcels))
                 .flatMap(List::stream)
                 .filter(parcel -> StringUtils.hasText(parcel) && parcel.startsWith(URL_PREFIX))
                 .collect(Collectors.toList());
+    }
+
+    private Predicate<List<String>> filterByStackRelatedParcels(Map<String, String> stackRelatedParcels) {
+        Set<String> stackRelatedParcelNames = getParcelNames(stackRelatedParcels);
+        return parcelList -> CollectionUtils.isEmpty(stackRelatedParcels) || parcelList.stream()
+                .anyMatch(parcel -> stackRelatedParcelNames.stream()
+                        .anyMatch(relatedParcel -> StringUtils.hasText(parcel) && parcel.startsWith(relatedParcel)));
+    }
+
+    private Set<String> getParcelNames(Map<String, String> parcels) {
+        return Optional.ofNullable(parcels)
+                .map(Map::keySet)
+                .orElse(Collections.emptySet());
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactoryTest.java
@@ -1,0 +1,119 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.cluster.service.ClouderaManagerProductsProvider;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
+import com.sequenceiq.cloudbreak.service.parcel.ParcelService;
+import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterParams;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ImageFilterParamsFactoryTest {
+
+    @InjectMocks
+    private ImageFilterParamsFactory underTest;
+
+    @Mock
+    private ParcelService parcelService;
+
+    @Mock
+    private ClouderaManagerProductsProvider clouderaManagerProductsProvider;
+
+    @Test
+    public void testCreateShouldReturnsANewImageFilterParamsInstanceWhenTheStackTypeIsDataLake() {
+        Image image = mock(Image.class);
+        Stack stack = createStack(StackType.DATALAKE);
+        Set<ClusterComponent> clusterComponents = createCdhClusterComponent();
+        String cdhName = com.sequenceiq.cloudbreak.cloud.model.component.StackType.CDH.name();
+        String cdhVersion = "7.2.0";
+
+        when(parcelService.getParcelComponentsByBlueprint(stack)).thenReturn(clusterComponents);
+        when(clouderaManagerProductsProvider.findCdhProduct(clusterComponents)).thenReturn(Optional.of(createCMProduct(cdhName, cdhVersion)));
+
+        ImageFilterParams actual = underTest.create(image, true, stack);
+
+        assertEquals(image, actual.getCurrentImage());
+        assertTrue(actual.isLockComponents());
+        assertEquals(cdhVersion, actual.getStackRelatedParcels().get(cdhName));
+        assertEquals(StackType.DATALAKE, actual.getStackType());
+        verify(parcelService).getParcelComponentsByBlueprint(stack);
+        verify(clouderaManagerProductsProvider).findCdhProduct(clusterComponents);
+    }
+
+    @Test
+    public void testCreateShouldReturnsANewImageFilterParamsInstanceWhenTheStackTypeIsDataHub() {
+        Image image = mock(Image.class);
+        Stack stack = createStack(StackType.WORKLOAD);
+        Set<ClusterComponent> cdhClusterComponent = createCdhClusterComponent();
+        String sparkName = "Spark";
+        String sparkVersion = "123";
+        ClouderaManagerProduct spark = createCMProduct(sparkName, sparkVersion);
+        String nifiName = "Nifi";
+        String nifiVersion = "456";
+        ClouderaManagerProduct nifi = createCMProduct(nifiName, nifiVersion);
+
+        when(parcelService.getParcelComponentsByBlueprint(stack)).thenReturn(cdhClusterComponent);
+        when(clouderaManagerProductsProvider.getProducts(cdhClusterComponent)).thenReturn(Set.of(spark, nifi));
+
+        ImageFilterParams actual = underTest.create(image, true, stack);
+
+        assertEquals(image, actual.getCurrentImage());
+        assertTrue(actual.isLockComponents());
+        assertEquals(sparkVersion, actual.getStackRelatedParcels().get(sparkName));
+        assertEquals(nifiVersion, actual.getStackRelatedParcels().get(nifiName));
+        assertEquals(StackType.WORKLOAD, actual.getStackType());
+        verify(parcelService).getParcelComponentsByBlueprint(stack);
+        verify(clouderaManagerProductsProvider).getProducts(cdhClusterComponent);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void testCreateShouldThrowExceptionThenThereIsNoCdhComponentAvailable() {
+        Image image = mock(Image.class);
+        Stack stack = createStack(StackType.DATALAKE);
+        ClusterComponent clusterComponent = new ClusterComponent();
+        clusterComponent.setName("CM");
+
+        when(parcelService.getParcelComponentsByBlueprint(stack)).thenReturn(Collections.singleton(clusterComponent));
+
+        underTest.create(image, true, stack);
+
+        verify(parcelService).getParcelComponentsByBlueprint(stack);
+    }
+
+    private Set<ClusterComponent> createCdhClusterComponent() {
+        return Collections.singleton(new ClusterComponent());
+    }
+
+    private Stack createStack(StackType stackType) {
+        Stack stack = new Stack();
+        stack.setType(stackType);
+        return stack;
+    }
+
+    private ClouderaManagerProduct createCMProduct(String name, String version) {
+        ClouderaManagerProduct clouderaManagerProduct = new ClouderaManagerProduct();
+        clouderaManagerProduct.setName(name);
+        clouderaManagerProduct.setVersion(version);
+        return clouderaManagerProduct;
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CdhPackageLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CdhPackageLocationFilterTest.java
@@ -9,27 +9,24 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.StackDetails;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.StackRepoDetails;
 
 class CdhPackageLocationFilterTest {
 
-    private static final StackType DATALAKE_STACK_TYPE = StackType.DATALAKE;
-
     private final CdhPackageLocationFilter underTest = new CdhPackageLocationFilter();
 
     @Test
     public void testImageNull() {
-        boolean result = underTest.filterImage(null, mock(Image.class), DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(null, mock(Image.class), null);
 
         assertFalse(result);
     }
 
     @Test
     public void testStackDetailIsNull() {
-        boolean result = underTest.filterImage(mock(Image.class), mock(Image.class), DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(mock(Image.class), mock(Image.class), null);
 
         assertFalse(result);
     }
@@ -39,7 +36,7 @@ class CdhPackageLocationFilterTest {
         Image image = mock(Image.class);
         when(image.getStackDetails()).thenReturn(new StackDetails("1", null, "1"));
 
-        boolean result = underTest.filterImage(image, mock(Image.class), DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, mock(Image.class), null);
 
         assertFalse(result);
     }
@@ -49,7 +46,7 @@ class CdhPackageLocationFilterTest {
         Image image = mock(Image.class);
         when(image.getStackDetails()).thenReturn(new StackDetails("1", new StackRepoDetails(null, null), "1"));
 
-        boolean result = underTest.filterImage(image, mock(Image.class), DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, mock(Image.class), null);
 
         assertFalse(result);
     }
@@ -59,7 +56,7 @@ class CdhPackageLocationFilterTest {
         Image image = mock(Image.class);
         when(image.getStackDetails()).thenReturn(new StackDetails("1", new StackRepoDetails(Map.of(), Map.of()), "1"));
 
-        boolean result = underTest.filterImage(image, null, DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, null, null);
 
         assertFalse(result);
     }
@@ -71,7 +68,7 @@ class CdhPackageLocationFilterTest {
         Image currentImage = mock(Image.class);
         when(currentImage.getOsType()).thenReturn(" ");
 
-        boolean result = underTest.filterImage(image, currentImage, DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, currentImage, null);
 
         assertFalse(result);
     }
@@ -83,7 +80,7 @@ class CdhPackageLocationFilterTest {
         Image currentImage = mock(Image.class);
         when(currentImage.getOsType()).thenReturn("redhat7");
 
-        boolean result = underTest.filterImage(image, currentImage, DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, currentImage, null);
 
         assertFalse(result);
     }
@@ -95,7 +92,7 @@ class CdhPackageLocationFilterTest {
         Image currentImage = mock(Image.class);
         when(currentImage.getOsType()).thenReturn("redhat7");
 
-        boolean result = underTest.filterImage(image, currentImage, DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, currentImage, null);
 
         assertFalse(result);
     }
@@ -108,7 +105,7 @@ class CdhPackageLocationFilterTest {
         Image currentImage = mock(Image.class);
         when(currentImage.getOsType()).thenReturn("redhat7");
 
-        boolean result = underTest.filterImage(image, currentImage, DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, currentImage, null);
 
         assertTrue(result);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClouderaManagerPackageLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClouderaManagerPackageLocationFilterTest.java
@@ -9,25 +9,22 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 
 class ClouderaManagerPackageLocationFilterTest {
-
-    private static final StackType DATALAKE_STACK_TYPE = StackType.DATALAKE;
 
     private final ClouderaManagerPackageLocationFilter underTest = new ClouderaManagerPackageLocationFilter();
 
     @Test
     public void testImageNull() {
-        boolean result = underTest.filterImage(null, mock(Image.class), DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(null, mock(Image.class), null);
 
         assertFalse(result);
     }
 
     @Test
     public void testRepoNull() {
-        boolean result = underTest.filterImage(mock(Image.class), mock(Image.class), DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(mock(Image.class), mock(Image.class), null);
 
         assertFalse(result);
     }
@@ -36,7 +33,7 @@ class ClouderaManagerPackageLocationFilterTest {
     public void testCurrentImageNull() {
         Image image = mock(Image.class);
         when(image.getRepo()).thenReturn(Map.of());
-        boolean result = underTest.filterImage(image, null, DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, null, null);
 
         assertFalse(result);
     }
@@ -47,7 +44,7 @@ class ClouderaManagerPackageLocationFilterTest {
         when(image.getRepo()).thenReturn(Map.of());
         Image currentImage = mock(Image.class);
         when(currentImage.getOsType()).thenReturn(" ");
-        boolean result = underTest.filterImage(image, currentImage, DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, currentImage, null);
 
         assertFalse(result);
     }
@@ -58,7 +55,7 @@ class ClouderaManagerPackageLocationFilterTest {
         when(image.getRepo()).thenReturn(Map.of());
         Image currentImage = mock(Image.class);
         when(currentImage.getOsType()).thenReturn("redhat7");
-        boolean result = underTest.filterImage(image, currentImage, DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, currentImage, null);
 
         assertFalse(result);
     }
@@ -69,7 +66,7 @@ class ClouderaManagerPackageLocationFilterTest {
         when(image.getRepo()).thenReturn(Map.of("redhat7", "http://random.org/asdf/"));
         Image currentImage = mock(Image.class);
         when(currentImage.getOsType()).thenReturn("redhat7");
-        boolean result = underTest.filterImage(image, currentImage, DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, currentImage, null);
 
         assertFalse(result);
     }
@@ -80,7 +77,7 @@ class ClouderaManagerPackageLocationFilterTest {
         when(image.getRepo()).thenReturn(Map.of("redhat7", "http://archive.cloudera.com/asdf/"));
         Image currentImage = mock(Image.class);
         when(currentImage.getOsType()).thenReturn("redhat7");
-        boolean result = underTest.filterImage(image, currentImage, DATALAKE_STACK_TYPE);
+        boolean result = underTest.filterImage(image, currentImage, null);
 
         assertTrue(result);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilterTest.java
@@ -97,7 +97,7 @@ public class ClusterUpgradeImageFilterTest {
         activatedParcels = Map.of("stack", V_7_0_3);
         Predicate<Image> predicate = mock(Predicate.class);
         when(predicate.test(any())).thenReturn(Boolean.TRUE);
-        when(entitlementDrivenPackageLocationFilter.filterImage(any(Image.class), any(StackType.class))).thenReturn(predicate);
+        when(entitlementDrivenPackageLocationFilter.filterImage(any(Image.class), any(ImageFilterParams.class))).thenReturn(predicate);
         when(imageCreationBasedFilter.filterPreviousImages(any(Image.class), any())).thenReturn(predicate);
         when(cmAndStackVersionFilter.filterCmAndStackVersion(any(ImageFilterParams.class), any())).thenReturn(predicate);
     }
@@ -123,7 +123,7 @@ public class ClusterUpgradeImageFilterTest {
 
         Predicate<Image> predicate = mock(Predicate.class);
         when(predicate.test(any())).thenReturn(Boolean.FALSE);
-        when(entitlementDrivenPackageLocationFilter.filterImage(any(Image.class), eq(imageFilterParams.getStackType()))).thenReturn(predicate);
+        when(entitlementDrivenPackageLocationFilter.filterImage(any(Image.class), eq(imageFilterParams))).thenReturn(predicate);
         when(versionBasedImageFilter.getCdhImagesForCbVersion(supportedCbVersions, properImages)).thenReturn(imageFilterResult);
 
         ImageFilterResult actual = underTest.filter(properImages, supportedCbVersions, CLOUD_PLATFORM, imageFilterParams);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/EntitlementDrivenPackageLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/EntitlementDrivenPackageLocationFilterTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -20,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
@@ -29,8 +27,6 @@ import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 class EntitlementDrivenPackageLocationFilterTest {
 
     private static final String USER_CRN = "crn:cdp:iam:us-west-1:123:user:321";
-
-    private static final StackType DATALAKE_STACK_TYPE = StackType.DATALAKE;
 
     private final EntitlementService entitlementService = mock(EntitlementService.class);
 
@@ -49,31 +45,34 @@ class EntitlementDrivenPackageLocationFilterTest {
         PackageLocationFilter filter = mock(PackageLocationFilter.class);
         when(entitlementService.isInternalRepositoryForUpgradeAllowed(anyString())).thenReturn(Boolean.TRUE);
         EntitlementDrivenPackageLocationFilter underTest = new EntitlementDrivenPackageLocationFilter(entitlementService, Set.of(filter));
-        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.filterImage(mock(Image.class), DATALAKE_STACK_TYPE));
+        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN,
+                () -> underTest.filterImage(mock(Image.class), mock(ImageFilterParams.class)));
 
         boolean result = imagePredicate.test(mock(Image.class));
 
         assertTrue(result);
-        verify(filter, never()).filterImage(any(Image.class), any(Image.class), eq(DATALAKE_STACK_TYPE));
+        verify(filter, never()).filterImage(any(Image.class), any(Image.class), any(ImageFilterParams.class));
     }
 
     @Test
     public void testAcceptedImageMultipleFilters() {
         Set<PackageLocationFilter> filters = Set.of(createAcceptingFilter(), createAcceptingFilter(), createAcceptingFilter(), createAcceptingFilter());
         EntitlementDrivenPackageLocationFilter underTest = new EntitlementDrivenPackageLocationFilter(entitlementService, filters);
-        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.filterImage(mock(Image.class), DATALAKE_STACK_TYPE));
+        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN,
+                () -> underTest.filterImage(mock(Image.class), mock(ImageFilterParams.class)));
 
         boolean result = imagePredicate.test(mock(Image.class));
 
         assertTrue(result);
-        filters.forEach(filter -> verify(filter).filterImage(any(Image.class), any(Image.class), eq(DATALAKE_STACK_TYPE)));
+        filters.forEach(filter -> verify(filter).filterImage(any(Image.class), any(Image.class), any(ImageFilterParams.class)));
     }
 
     @Test
     public void testRejectedImageMultipleFilters() {
         Set<PackageLocationFilter> filters = Set.of(createAcceptingFilter(), createAcceptingFilter(), createRejectingFilter(), createAcceptingFilter());
         EntitlementDrivenPackageLocationFilter underTest = new EntitlementDrivenPackageLocationFilter(entitlementService, filters);
-        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.filterImage(mock(Image.class), DATALAKE_STACK_TYPE));
+        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN,
+                () -> underTest.filterImage(mock(Image.class), mock(ImageFilterParams.class)));
 
         boolean result = imagePredicate.test(mock(Image.class));
 
@@ -84,7 +83,8 @@ class EntitlementDrivenPackageLocationFilterTest {
     public void testRejectedImageMultipleRejectingFilters() {
         Set<PackageLocationFilter> filters = Set.of(createRejectingFilter(), createRejectingFilter(), createRejectingFilter());
         EntitlementDrivenPackageLocationFilter underTest = new EntitlementDrivenPackageLocationFilter(entitlementService, filters);
-        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.filterImage(mock(Image.class), DATALAKE_STACK_TYPE));
+        Predicate<Image> imagePredicate = ThreadBasedUserCrnProvider.doAs(USER_CRN,
+                () -> underTest.filterImage(mock(Image.class), mock(ImageFilterParams.class)));
 
         boolean result = imagePredicate.test(mock(Image.class));
 
@@ -93,13 +93,13 @@ class EntitlementDrivenPackageLocationFilterTest {
 
     private PackageLocationFilter createAcceptingFilter() {
         PackageLocationFilter filter = mock(PackageLocationFilter.class);
-        lenient().when(filter.filterImage(any(Image.class), any(Image.class), eq(DATALAKE_STACK_TYPE))).thenReturn(Boolean.TRUE);
+        lenient().when(filter.filterImage(any(Image.class), any(Image.class), any(ImageFilterParams.class))).thenReturn(Boolean.TRUE);
         return filter;
     }
 
     private PackageLocationFilter createRejectingFilter() {
         PackageLocationFilter filter = mock(PackageLocationFilter.class);
-        lenient().when(filter.filterImage(any(Image.class), any(Image.class), eq(DATALAKE_STACK_TYPE))).thenReturn(Boolean.FALSE);
+        lenient().when(filter.filterImage(any(Image.class), any(Image.class), any(ImageFilterParams.class))).thenReturn(Boolean.FALSE);
         return filter;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ImageCreationBasedFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ImageCreationBasedFilterTest.java
@@ -15,7 +15,7 @@ import com.sequenceiq.cloudbreak.cloud.model.catalog.StackDetails;
 
 class ImageCreationBasedFilterTest {
 
-    private ImageCreationBasedFilter underTest = new ImageCreationBasedFilter();
+    private final ImageCreationBasedFilter underTest = new ImageCreationBasedFilter();
 
     @Test
     public void testImageIsNewer() {


### PR DESCRIPTION
When we send an upgrade request it's important to use only the required CSD files and pre warmed parcels to filter the images.
The second part of this change is during the upgrade we need only download the required CSD files.