### PR TITLE
CB-10598 Azure network resource group is not deleted when "Create new…

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/network/EnvironmentNetworkService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/EnvironmentNetworkService.java
@@ -31,10 +31,10 @@ import com.sequenceiq.environment.network.dto.AzureParams;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.environment.network.service.NetworkCreationRequestFactory;
 import com.sequenceiq.environment.network.v1.converter.EnvironmentNetworkConverter;
-import com.sequenceiq.environment.parameter.dto.ResourceGroupUsagePattern;
 import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceGroupDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
+import com.sequenceiq.environment.parameter.dto.ResourceGroupUsagePattern;
 
 @Component
 public class EnvironmentNetworkService {
@@ -116,11 +116,18 @@ public class EnvironmentNetworkService {
     }
 
     private Optional<String> getResourceGroupName(EnvironmentDto environmentDto) {
-        return Optional.of(environmentDto)
-                .map(EnvironmentDto::getParameters)
-                .map(ParametersDto::getAzureParametersDto)
-                .map(AzureParametersDto::getAzureResourceGroupDto)
-                .map(AzureResourceGroupDto::getName);
+        if (isSingleResourceGroup(environmentDto)) {
+            return Optional.of(environmentDto)
+                    .map(EnvironmentDto::getParameters)
+                    .map(ParametersDto::getAzureParametersDto)
+                    .map(AzureParametersDto::getAzureResourceGroupDto)
+                    .map(AzureResourceGroupDto::getName);
+        } else {
+            return Optional.of(environmentDto)
+                    .map(EnvironmentDto::getNetwork)
+                    .map(NetworkDto::getAzure)
+                    .map(AzureParams::getResourceGroupName);
+        }
     }
 
     private String getNetworkId(NetworkDto networkDto, String envName) {

--- a/environment/src/test/java/com/sequenceiq/environment/network/EnvironmentNetworkServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/network/EnvironmentNetworkServiceTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.environment.network;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -177,7 +178,7 @@ class EnvironmentNetworkServiceTest {
     }
 
     @Test
-    void testDeleteNetworkShouldDeleteTheNetworkWithResourceGroup() {
+    void testDeleteNetworkShouldDeleteTheNetworkWithResourceGroupWhenUsagePatternMultiple() {
         CloudCredential cloudCredential = new CloudCredential("1", "credName");
         EnvironmentDto environmentDto = createEnvironmentDto("resourceGroup");
 
@@ -194,7 +195,8 @@ class EnvironmentNetworkServiceTest {
         assertEquals(STACK_NAME, argumentCaptor.getValue().getStackName());
         assertEquals(cloudCredential, argumentCaptor.getValue().getCloudCredential());
         assertEquals(environmentDto.getLocation().getName(), argumentCaptor.getValue().getRegion());
-        assertEquals(environmentDto.getParameters().getAzureParametersDto().getAzureResourceGroupDto().getName(), argumentCaptor.getValue().getResourceGroup());
+        assertEquals(environmentDto.getNetwork().getAzure().getResourceGroupName(), argumentCaptor.getValue().getResourceGroup());
+        assertFalse(argumentCaptor.getValue().isSingleResourceGroup());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
… RG" is used

When you create a new Azure environment using the create RG option (multiple RGs) the control plane creates 4 RGs. One of them is only for the VNet and when you delete the environment it should delete the network RG as well. The problem is that currently only the single RG name is fetched during deletion.

See detailed description in the commit message.