### PR TITLE
CB-10510. Create new cluster service: CDP nodestatus monitor (on mast…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryClusterDetails.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryClusterDetails.java
@@ -25,6 +25,10 @@ public class TelemetryClusterDetails {
 
     private final String version;
 
+    private final String databusEndpoint;
+
+    private final boolean databusEndpointValidation;
+
     private TelemetryClusterDetails(Builder builder) {
         this.name = builder.name;
         this.type = builder.type;
@@ -32,6 +36,8 @@ public class TelemetryClusterDetails {
         this.owner = builder.owner;
         this.platform = builder.platform;
         this.version = builder.version;
+        this.databusEndpoint = builder.databusEndpoint;
+        this.databusEndpointValidation = builder.databusEndpointValidation;
     }
 
     public String getName() {
@@ -58,6 +64,14 @@ public class TelemetryClusterDetails {
         return version;
     }
 
+    public String getDatabusEndpoint() {
+        return databusEndpoint;
+    }
+
+    public boolean isDatabusEndpointValidation() {
+        return databusEndpointValidation;
+    }
+
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
         map.put("platform", ObjectUtils.defaultIfNull(this.platform, EMPTY_CONFIG_DEFAULT));
@@ -66,6 +80,8 @@ public class TelemetryClusterDetails {
         map.put(CLUSTER_CRN_KEY, this.crn);
         map.put("clusterOwner", this.owner);
         map.put("clusterVersion", this.version);
+        map.put("databusEndpoint", this.databusEndpoint);
+        map.put("databusEndpointValidation", this.databusEndpointValidation);
         return map;
     }
 
@@ -82,6 +98,10 @@ public class TelemetryClusterDetails {
         private String platform;
 
         private String version;
+
+        private String databusEndpoint;
+
+        private boolean databusEndpointValidation;
 
         private Builder() {
         }
@@ -121,6 +141,16 @@ public class TelemetryClusterDetails {
 
         public Builder withVersion(String version) {
             this.version = version;
+            return this;
+        }
+
+        public Builder withDatabusEndpoint(String databusEndpoint) {
+            this.databusEndpoint = databusEndpoint;
+            return this;
+        }
+
+        public Builder withDatabusEndpointValidation(boolean databusEndpointValidation) {
+            this.databusEndpointValidation = databusEndpointValidation;
             return this;
         }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigService.java
@@ -27,16 +27,22 @@ public class TelemetryCommonConfigService {
 
     private final String version;
 
+    private final boolean databusEndpointValidation;
+
     private final AnonymizationRuleResolver anonymizationRuleResolver;
 
     public TelemetryCommonConfigService(AnonymizationRuleResolver anonymizationRuleResolver,
+            @Value("${altus.databus.endpoint.validation:false}") boolean databusEndpointValidation,
             @Value("${info.app.version:}") String version) {
         this.anonymizationRuleResolver = anonymizationRuleResolver;
+        this.databusEndpointValidation = databusEndpointValidation;
         this.version = version;
     }
-
+    // CHECKSTYLE:OFF
+    // TODO: refactor parameters to 1 object
     public TelemetryCommonConfigView createTelemetryCommonConfigs(Telemetry telemetry, List<VmLog> logs,
-            String clusterType, String clusterCrn, String clusterName, String clusterOwner, String platform) {
+            String clusterType, String clusterCrn, String clusterName, String clusterOwner, String platform,
+            String databusEndpoint) {
         final TelemetryClusterDetails clusterDetails = TelemetryClusterDetails.Builder.builder()
                 .withOwner(clusterOwner)
                 .withName(clusterName)
@@ -44,6 +50,8 @@ public class TelemetryCommonConfigService {
                 .withCrn(clusterCrn)
                 .withPlatform(platform)
                 .withVersion(version)
+                .withDatabusEndpoint(databusEndpoint)
+                .withDatabusEndpointValidation(databusEndpointValidation)
                 .build();
         resolveLogPathReferences(telemetry, logs);
         return new TelemetryCommonConfigView.Builder()
@@ -52,6 +60,7 @@ public class TelemetryCommonConfigService {
                 .withVmLogs(logs)
                 .build();
     }
+    // CHECKSTYLE:ON
 
     @VisibleForTesting
     void resolveLogPathReferences(Telemetry telemetry, List<VmLog> logs) {

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigServiceTest.java
@@ -22,7 +22,7 @@ public class TelemetryCommonConfigServiceTest {
 
     @Before
     public void setUp() {
-        underTest = new TelemetryCommonConfigService(null, null);
+        underTest = new TelemetryCommonConfigService(null, false, null);
     }
 
     @Test

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
@@ -160,7 +160,8 @@ public class TelemetryDecorator {
                 .withVersion(version)
                 .build();
         final TelemetryCommonConfigView telemetryCommonConfigs = telemetryCommonConfigService.createTelemetryCommonConfigs(
-                telemetry, vmLogsService.getVmLogs(), clusterType, clusterCrn, stack.getName(), stack.getCreator().getUserCrn(), stack.getCloudPlatform());
+                telemetry, vmLogsService.getVmLogs(), clusterType, clusterCrn, stack.getName(), stack.getCreator().getUserCrn(), stack.getCloudPlatform(),
+                databusEndpoint);
         servicePillar.put("telemetry",
                 new SaltPillarProperties("/telemetry/init.sls", Collections.singletonMap("telemetry", telemetryCommonConfigs.toMap())));
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -286,7 +286,8 @@ public class TelemetryDecoratorTest {
     private void mockConfigServiceResults(DatabusConfigView databusConfigView, FluentConfigView fluentConfigView,
             MeteringConfigView meteringConfigView, MonitoringConfigView monitoringConfigView,
             TelemetryCommonConfigView telemetryCommonConfigView) {
-        given(databusConfigService.createDatabusConfigs(anyString(), any(), isNull(), isNull()))
+        given(dataBusEndpointProvider.getDataBusEndpoint(isNull(), anyBoolean())).willReturn("https://dbusapi.us-west-1.sigma.altus.cloudera.com");
+        given(databusConfigService.createDatabusConfigs(anyString(), any(), isNull(), anyString()))
                 .willReturn(databusConfigView);
         given(fluentConfigService.createFluentConfigs(any(TelemetryClusterDetails.class),
                 anyBoolean(), anyBoolean(), any(Telemetry.class)))
@@ -296,10 +297,9 @@ public class TelemetryDecoratorTest {
         given(monitoringConfigService.createMonitoringConfig(any(), any()))
                 .willReturn(monitoringConfigView);
         given(telemetryCommonConfigService.createTelemetryCommonConfigs(any(), anyList(), anyString(), anyString(),
-                anyString(), anyString(), anyString()))
+                anyString(), anyString(), anyString(), anyString()))
                 .willReturn(telemetryCommonConfigView);
         given(entitlementService.useDataBusCNameEndpointEnabled(anyString())).willReturn(false);
-        given(dataBusEndpointProvider.getDataBusEndpoint(anyString(), anyBoolean())).willReturn("https://dbusapi.us-west-1.sigma.altus.cloudera.com");
     }
 
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaInstallService.java
@@ -148,6 +148,8 @@ public class FreeIpaInstallService {
         Telemetry telemetry = stack.getTelemetry();
         if (telemetry != null) {
             boolean databusEnabled = telemetry.isClusterLogsCollectionEnabled();
+            boolean useDbusCnameEndpoint = entitlementService.useDataBusCNameEndpointEnabled(stack.getAccountId());
+            String databusEndpoint = dataBusEndpointProvider.getDataBusEndpoint(telemetry.getDatabusEndpoint(), useDbusCnameEndpoint);
             final TelemetryClusterDetails clusterDetails = TelemetryClusterDetails.Builder.builder()
                     .withOwner(stack.getOwner())
                     .withName(stack.getName())
@@ -157,10 +159,9 @@ public class FreeIpaInstallService {
                     .withVersion(version)
                     .build();
 
-
             final TelemetryCommonConfigView telemetryCommonConfigs = telemetryCommonConfigService.createTelemetryCommonConfigs(
                     telemetry, vmLogsService.getVmLogs(), FluentClusterType.FREEIPA.value(), stack.getResourceCrn(),
-                    stack.getName(), stack.getOwner(), stack.getCloudPlatform());
+                    stack.getName(), stack.getOwner(), stack.getCloudPlatform(), databusEndpoint);
             servicePillarConfig.put("telemetry",
                     new SaltPillarProperties("/telemetry/init.sls", Collections.singletonMap("telemetry", telemetryCommonConfigs.toMap())));
 
@@ -173,8 +174,6 @@ public class FreeIpaInstallService {
                     DataBusCredential dbusCredential = altusMachineUserService.getOrCreateDataBusCredentialIfNeeded(stack);
                     String accessKey = dbusCredential.getAccessKey();
                     char[] privateKey = dbusCredential.getPrivateKey().toCharArray();
-                    boolean useDbusCnameEndpoint = entitlementService.useDataBusCNameEndpointEnabled(stack.getAccountId());
-                    String databusEndpoint = dataBusEndpointProvider.getDataBusEndpoint(telemetry.getDatabusEndpoint(), useDbusCnameEndpoint);
                     DatabusConfigView databusConfigView = databusConfigService.createDatabusConfigs(accessKey, privateKey,
                             null, databusEndpoint);
                     servicePillarConfig.put("databus", new SaltPillarProperties("/databus/init.sls",

--- a/freeipa/src/main/resources/freeipa-salt/salt/nginx/conf/ssl-locations.d/nodestatus.conf
+++ b/freeipa/src/main/resources/freeipa-salt/salt/nginx/conf/ssl-locations.d/nodestatus.conf
@@ -1,0 +1,7 @@
+location /nodestatus {
+  proxy_pass         https://{{ salt['grains.get']('fqdn') }}:61888;
+  proxy_read_timeout 300;
+  proxy_redirect     off;
+  proxy_set_header   Host $host;
+  rewrite /nodestatus(.*) /$1 break;
+}

--- a/freeipa/src/main/resources/freeipa-salt/salt/nginx/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/nginx/init.sls
@@ -27,6 +27,12 @@
     - source: salt://nginx/conf/ssl-locations.d/freeipahealthcheck.conf
     - template: jinja
 
+/etc/nginx/sites-enabled/ssl-locations.d/nodestatus.conf:
+  file.managed:
+    - makedirs: True
+    - source: salt://nginx/conf/ssl-locations.d/nodestatus.conf
+    - template: jinja
+
 restart_nginx_after_ssl_reconfig:
   service.running:
     - name: nginx

--- a/freeipa/src/main/resources/freeipa-salt/salt/top.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/top.sls
@@ -2,6 +2,7 @@ base:
            '*':
              - nginx
              - tags
+             - telemetry
              - fluent
              - ntp
              - freeipa
@@ -16,6 +17,7 @@ base:
              - freeipa.common-install
              - freeipa.backups
              - freeipa.healthagent
+             - nodestatus
 
            'roles:freeipa_replica':
              - match: grain
@@ -23,6 +25,7 @@ base:
              - freeipa.common-install
              - freeipa.backups
              - freeipa.healthagent
+             - nodestatus
 
            'roles:freeipa_primary_replacement':
              - match: grain
@@ -31,3 +34,4 @@ base:
              - freeipa.promote-replica-to-master
              - freeipa.backups
              - freeipa.healthagent
+             - nodestatus

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/init.sls
@@ -3,7 +3,7 @@
 {%- from 'fluent/settings.sls' import fluent with context %}
 {%- from 'databus/settings.sls' import databus with context %}
 
-{% set cdp_telemetry_version = '0.2.4' %}
+{% set cdp_telemetry_version = '0.3.3' %}
 {% set cdp_telemetry_rpm_location = 'https://cloudera-service-delivery-cache.s3.amazonaws.com/telemetry/cdp-telemetry/'%}
 {% set cdp_telemetry_rpm_repo_url = cdp_telemetry_rpm_location + 'cdp_telemetry-' + cdp_telemetry_version + '.x86_64.rpm' %}
 {% set cdp_telemetry_package_name = 'cdp-telemetry' %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
@@ -109,18 +109,6 @@
    {% set cluster_version = '' %}
 {% endif %}
 
-{% set version_data = namespace(entities=[]) %}
-{% for role in grains.get('roles', []) %}
-{% if role.startswith("cdp_telemetry_prewarmed") %}
-  {% set version_data.entities = version_data.entities + [role.split("cdp_telemetry_prewarmed_v")[1]]%}
-{% endif %}
-{% endfor %}
-{% if version_data.entities|length > 0 %}
-{% set cdp_telemetry_version = version_data.entities[0] | int %}
-{% else %}
-{% set cdp_telemetry_version = 0 %}
-{% endif %}
-
 {% do filecollector.update({
     "destination": destination,
     "cloudStorageUploadParams": cloud_storage_upload_params,
@@ -144,7 +132,6 @@
     "clusterVersion": cluster_version,
     "uuid": uuid,
     "accountId": account_id,
-    "cdpTelemetryVersion": cdp_telemetry_version,
     "supportBundleDbusStreamName": support_bundle_dbus_stream_name,
     "supportBundleDbusHeaders": support_bundle_dbus_headers,
     "supportBundleDbusAccessKey": support_bundle_dbus_access_key,

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/cdp-doctor-commands.yaml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/cdp-doctor-commands.yaml.j2
@@ -1,3 +1,4 @@
+{%- from 'telemetry/settings.sls' import telemetry with context %}
 {%- from 'filecollector/settings.sls' import filecollector with context %}
 commands:
     - command: ps aux
@@ -16,7 +17,7 @@ commands:
     - command: cdp-doctor recipe results
       output: /tmp/doctor_recipes.txt
     - command: cdp-doctor scm list-commands
-      output: /tmp/doctor_scm_agent_commands.txt{% endif %}{% if filecollector.clusterType == "DATAHUB" and filecollector.cdpTelemetryVersion > 0 %}
+      output: /tmp/doctor_scm_agent_commands.txt{% endif %}{% if filecollector.clusterType == "DATAHUB" and telemetry.cdpTelemetryVersion > 0 %}
     - command: cdp-doctor metering status
       output: /tmp/doctor_metering.txt{% endif %}
 report:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/nodestatus/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/nodestatus/init.sls
@@ -1,0 +1,17 @@
+{%- from 'telemetry/settings.sls' import telemetry with context %}
+{% if telemetry.cdpTelemetryVersion > 1 %}
+/opt/cdp-telemetry/conf/nodestatus-monitor.yaml:
+   file.managed:
+    - source: salt://nodestatus/template/nodestatus-monitor.yaml.j2
+    - template: jinja
+    - user: "root"
+    - group: "root"
+    - mode: 600
+
+start_nodestatus_monitor:
+  service.running:
+    - enable: True
+    - name: cdp-nodestatus-monitor
+    - watch:
+       - file: /opt/cdp-telemetry/conf/nodestatus-monitor.yaml
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/nodestatus/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/nodestatus/settings.sls
@@ -1,0 +1,8 @@
+{% set nodestatus = {} %}
+{% set server_username = salt['pillar.get']('nodestatus:serverUsername') %}
+{% set server_password = salt['pillar.get']('nodestatus:serverPassword') %}
+
+{% do nodestatus.update({
+    "serverUsername": server_username,
+    "serverPassword": server_password
+}) %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/nodestatus/template/nodestatus-monitor.yaml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/nodestatus/template/nodestatus-monitor.yaml.j2
@@ -1,0 +1,14 @@
+{%- from 'telemetry/settings.sls' import telemetry with context %}
+{%- from 'nodestatus/settings.sls' import nodestatus with context %}
+server:
+  port: 61888
+  folder: /var/lib/cdp-nodestatus/report
+{% if nodestatus.serverUsername and nodestatus.serverPassword %}
+  auth:
+    username: {{ nodestatus.serverUsername }}
+    password: {{ nodestatus.serverPassword }}
+    hash: sha256{% endif %}
+commands:
+  - "cdp-nodestatus collect --databus-url {{ telemetry.databusEndpoint }}"
+firstSleep: 660
+sleepTime: 3600

--- a/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/init.sls
@@ -1,0 +1,10 @@
+{%- from 'telemetry/settings.sls' import telemetry with context %}
+{% if telemetry.databusEndpointValidation and telemetry.databusEndpoint and telemetry.cdpTelemetryVersion > 1 %}
+check_databus_network_connectivity:
+  cmd.run:
+    - name: "cdp-telemetry utils check-connection --url {{ telemetry.databusEndpoint }}"
+    - failhard: True{% if telemetry.proxyUrl %}
+    - env: {% if telemetry.proxyProtocol == "https" %}
+       - HTTPS_PROXY: {{ telemetry.proxyUrl }}{% else %}
+       - HTTP_PROXY: {{ telemetry.proxyUrl }}{% endif %}{% endif %}
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/settings.sls
@@ -7,6 +7,13 @@
 {% set cluster_version = salt['pillar.get']('telemetry:clusterVersion') %}
 {% set cluster_type = salt['pillar.get']('telemetry:clusterType') %}
 {% set cluster_owner = salt['pillar.get']('telemetry:clusterOwner') %}
+{% set databus_endpoint = salt['pillar.get']('telemetry:databusEndpoint') %}
+
+{% if salt['pillar.get']('telemetry:databusEndpointValidation') %}
+    {% set databus_endpoint_validation = True %}
+{% else %}
+    {% set databus_endpoint_validation = False %}
+{% endif %}
 
 {% set anonymization_rules=[] %}
 {% if salt['pillar.get']('telemetry:anonymizationRules') %}
@@ -18,6 +25,34 @@
 {%   set logs = salt['pillar.get']('telemetry:logs') %}
 {% endif %}
 
+{% set proxy_full_url = None %}
+{% set proxy_protocol = None %}
+{% if salt['pillar.get']('proxy:host') %}
+  {% set proxy_host = salt['pillar.get']('proxy:host') %}
+  {% set proxy_port = salt['pillar.get']('proxy:port')|string %}
+  {% set proxy_protocol = salt['pillar.get']('proxy:protocol') %}
+  {% set proxy_url = proxy_protocol + "://" + proxy_host + ":" + proxy_port %}
+  {% if salt['pillar.get']('proxy:user') and salt['pillar.get']('proxy:password') %}
+    {% set proxy_user = salt['pillar.get']('proxy:user') %}
+    {% set proxy_password = salt['pillar.get']('proxy:password') %}
+    {% set proxy_full_url =  proxy_protocol + "://" + proxy_user + ":"+ proxy_password + "@" + proxy_host + ":" + proxy_port %}
+  {% else %}
+    {% set proxy_full_url = proxy_url %}
+  {% endif %}
+{% endif %}
+
+{% set version_data = namespace(entities=[]) %}
+{% for role in grains.get('roles', []) %}
+{% if role.startswith("cdp_telemetry_prewarmed") %}
+  {% set version_data.entities = version_data.entities + [role.split("cdp_telemetry_prewarmed_v")[1]]%}
+{% endif %}
+{% endfor %}
+{% if version_data.entities|length > 0 %}
+{% set cdp_telemetry_version = version_data.entities[0] | int %}
+{% else %}
+{% set cdp_telemetry_version = 0 %}
+{% endif %}
+
 {% do telemetry.update({
     "platform": platform,
     "clusterCrn": cluster_crn,
@@ -26,5 +61,10 @@
     "clusterType": cluster_type,
     "clusterOwner": cluster_owner,
     "anonymizationRules": anonymization_rules,
+    "databusEndpoint": databus_endpoint,
+    "databusEndpointValidation": databus_endpoint_validation,
+    "cdpTelemetryVersion": cdp_telemetry_version,
+    "proxyUrl": proxy_full_url,
+    "proxyProtocol": proxy_protocol,
     "logs": logs
 }) %}

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/nodestatus.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl-locations.d/nodestatus.conf
@@ -1,0 +1,7 @@
+location /nodestatus {
+  proxy_pass         https://{{ salt['grains.get']('fqdn') }}:61888;
+  proxy_read_timeout 300;
+  proxy_redirect     off;
+  proxy_set_header   Host $host;
+  rewrite /nodestatus(.*) /$1 break;
+}

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/init.sls
@@ -16,6 +16,11 @@
     - makedirs: True
     - source: salt://nginx/conf/ssl-locations.d/prometheus.conf
 
+/etc/nginx/sites-enabled/ssl-locations.d/nodestatus.conf:
+  file.managed:
+    - makedirs: True
+    - source: salt://nginx/conf/ssl-locations.d/nodestatus.conf
+
 /etc/nginx/sites-enabled/ssl-locations.d/saltapi.conf:
   file.managed:
     - makedirs: True

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -7,6 +7,7 @@ base:
     - tags
     - docker
     - recipes.runner
+    - telemetry
     - fluent
     - metering
     - ntp
@@ -35,6 +36,7 @@ base:
     - cloudera.manager
     - cloudera.agent
     - gateway.cm
+    - nodestatus
 
   'G@roles:manager_agent':
     - cloudera.repo


### PR DESCRIPTION
…er node)

details:
- create a new service on the salt master nodes as cdp-nodestatus-monitor
- add network connectivity check agaainst databus for salt highstate (disabled by default)
- cdp-nodestatus-monitor should run around every hour and refresh the states based on cdp-doctor outputs
- expose nodestatus app through nginx (both for DL/DH and FreeIPA clusters)

See detailed description in the commit message.