### PR TITLE
CB-10536. Add internal API to get usersync status

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/UserV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/UserV1Endpoint.java
@@ -10,6 +10,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserNotes;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.doc.UserOperationDescriptions;
@@ -54,6 +55,14 @@ public interface UserV1Endpoint {
     @ApiOperation(value = UserOperationDescriptions.SYNC_OPERATION_STATUS, notes = UserNotes.USER_NOTES, produces = MediaType.APPLICATION_JSON,
             nickname = "getSyncOperationStatusV1")
     SyncOperationStatus getSyncOperationStatus(@QueryParam("operationId") @NotNull String operationId);
+
+    @GET
+    @Path("internal/status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UserOperationDescriptions.INTERNAL_SYNC_OPERATION_STATUS, notes = UserNotes.USER_NOTES,
+            produces = MediaType.APPLICATION_JSON, nickname = "internalGetSyncOperationStatusV1")
+    SyncOperationStatus getSyncOperationStatusInternal(
+            @QueryParam("accountId") @AccountId String accountId, @QueryParam("operationId") @NotNull String operationId);
 
     @GET
     @Path("lastStatus")

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserOperationDescriptions.java
@@ -5,6 +5,8 @@ public final class UserOperationDescriptions {
     public static final String SYNC_ALL = "Synchronizes Groups and Users to the FreeIPA servers";
     public static final String SET_PASSWORD = "Sets the user's password in the FreeIPA servers";
     public static final String SYNC_OPERATION_STATUS = "Gets the status of a sync operation";
+    public static final String INTERNAL_SYNC_OPERATION_STATUS =
+            "Gets the status of a sync operation by account and id. Used by internal actors.";
     public static final String LAST_SYNC_OPERATION_STATUS = "Gets the status of the last environment sync operation";
     public static final String ENVIRONMENT_USERSYNC_STATE = "Gets the synchronization status of an environment";
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
@@ -7,6 +7,8 @@ import javax.inject.Inject;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
+import com.sequenceiq.authorization.annotation.InternalOnly;
+import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
@@ -130,6 +132,12 @@ public class UserV1Controller implements UserV1Endpoint {
         checkActorCrn();
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         LOGGER.debug("getSyncOperationStatus() requested for operation '{}' in account '{}'", operationId, accountId);
+        return getSyncOperationStatusInternal(accountId, operationId);
+    }
+
+    @Override
+    @InternalOnly
+    public SyncOperationStatus getSyncOperationStatusInternal(@AccountId String accountId, @NotNull String operationId) {
         return operationToSyncOperationStatus.convert(
                 operationService.getOperationForAccountIdAndOperationId(accountId, operationId));
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
@@ -230,6 +230,21 @@ public class UserV1ControllerTest {
     }
 
     @Test
+    void getStatusInternal() {
+        String operationId = "testId";
+
+        Operation operation = mock(Operation.class);
+        when(operationService.getOperationForAccountIdAndOperationId(ACCOUNT_ID, operationId)).thenReturn(operation);
+        SyncOperationStatus status = mock(SyncOperationStatus.class);
+        when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
+
+        assertEquals(status, ThreadBasedUserCrnProvider.doAsInternalActor(() ->
+                underTest.getSyncOperationStatusInternal(ACCOUNT_ID, operationId)));
+
+        verify(operationService, times(1)).getOperationForAccountIdAndOperationId(ACCOUNT_ID, operationId);
+    }
+
+    @Test
     void setPassword() {
         String password = "password";
         SetPasswordRequest request = mock(SetPasswordRequest.class);


### PR DESCRIPTION
This is similar to my previous pull request. I identified one more API that we'll need to call internally.

See detailed description in the commit message.

An internal usersync status API is added to the FMS
to allow internal actors to retrieve status of usersync
operations.
