### PR TITLE
CB-10617 Semi-private network: Datahub creation fails with Unable to configure load balancer

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AwsNetworkV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/network/AwsNetworkV4Parameters.java
@@ -27,6 +27,9 @@ public class AwsNetworkV4Parameters extends MappableBase implements JsonEntity {
     @ApiModelProperty
     private String subnetId;
 
+    @ApiModelProperty
+    private String endpointGatewaySubnetId;
+
     public String getVpcId() {
         return vpcId;
     }
@@ -51,12 +54,21 @@ public class AwsNetworkV4Parameters extends MappableBase implements JsonEntity {
         this.subnetId = subnetId;
     }
 
+    public String getEndpointGatewaySubnetId() {
+        return endpointGatewaySubnetId;
+    }
+
+    public void setEndpointGatewaySubnetId(String endpointGatewaySubnetId) {
+        this.endpointGatewaySubnetId = endpointGatewaySubnetId;
+    }
+
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
         putIfValueNotNull(map, "vpcId", vpcId);
         putIfValueNotNull(map, "internetGatewayId", internetGatewayId);
         putIfValueNotNull(map, "subnetId", subnetId);
+        putIfValueNotNull(map, "endpointGatewaySubnetId", endpointGatewaySubnetId);
         return map;
     }
 
@@ -72,5 +84,6 @@ public class AwsNetworkV4Parameters extends MappableBase implements JsonEntity {
         vpcId = getParameterOrNull(parameters, "vpcId");
         internetGatewayId = getParameterOrNull(parameters, "internetGatewayId");
         subnetId = getParameterOrNull(parameters, "subnetId");
+        endpointGatewaySubnetId = getParameterOrNull(parameters, "endpointGatewaySubnetId");
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/loadbalancer/EndpointGatewayNetworkValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/loadbalancer/EndpointGatewayNetworkValidator.java
@@ -1,0 +1,73 @@
+package com.sequenceiq.cloudbreak.controller.validation.loadbalancer;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.converter.v4.environment.network.SubnetSelector;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+import com.sequenceiq.cloudbreak.validation.Validator;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+
+@Component
+public class EndpointGatewayNetworkValidator implements Validator<Pair<String, EnvironmentNetworkResponse>> {
+
+    static final String NO_BASE_SUBNET = "No cluster subnet id specified. Endpoint gateway subnet cannot be determined.";
+
+    static final String NO_BASE_SUBNET_META = "Could not determine availability zone of cluster subnet %s";
+
+    static final String NO_USABLE_SUBNET_IN_ENDPOINT_GATEWAY = "Unable to find public subnet in availability zone %s in " +
+        "provided endoint gateway subnet list.";
+
+    static final String NO_USABLE_SUBNET_IN_CLUSTER = "Unable to find public subnet in availability zone %s in cluster subnets.";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EndpointGatewayNetworkValidator.class);
+
+    @Inject
+    private SubnetSelector subnetSelector;
+
+    @Override
+    public ValidationResult validate(Pair<String, EnvironmentNetworkResponse> subject) {
+        String baseSubnetId = subject.getLeft();
+        EnvironmentNetworkResponse network = subject.getRight();
+
+        ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        if (network == null) {
+            LOGGER.debug("No network provided; public endpoint access gateway is disabled.");
+        } else {
+            if (PublicEndpointAccessGateway.ENABLED.equals(network.getPublicEndpointAccessGateway())) {
+                if (Strings.isNullOrEmpty(baseSubnetId)) {
+                    resultBuilder.error(NO_BASE_SUBNET);
+                } else {
+                    Optional<CloudSubnet> baseSubnet = subnetSelector.findSubnetById(network.getSubnetMetas(), baseSubnetId);
+                    if (baseSubnet.isEmpty()) {
+                        resultBuilder.error(String.format(NO_BASE_SUBNET_META, baseSubnetId));
+                    } else {
+                        String error;
+                        if (!MapUtils.isEmpty(network.getGatewayEndpointSubnetMetas())) {
+                            LOGGER.debug("Attempting to validate endpoint gateway subnet using provided endpoint subnets.");
+                            error = NO_USABLE_SUBNET_IN_ENDPOINT_GATEWAY;
+                        } else {
+                            LOGGER.debug("Attempting to validate endpoint gateway subnet using cluster subnets.");
+                            error = NO_USABLE_SUBNET_IN_CLUSTER;
+                        }
+                        Optional<CloudSubnet> endpointGatewaySubnet = subnetSelector.chooseSubnetForEndpointGateway(network, baseSubnetId);
+                        resultBuilder.ifError(endpointGatewaySubnet::isEmpty,
+                            String.format(error, baseSubnet.get().getAvailabilityZone()));
+                    }
+                }
+            }
+        }
+        return resultBuilder.build();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverter.java
@@ -3,12 +3,10 @@ package com.sequenceiq.cloudbreak.converter.v4.environment.network;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,7 +17,6 @@ import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.type.APIResourceType;
 import com.sequenceiq.cloudbreak.domain.Network;
-import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 
 public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetworkConverter {
@@ -31,6 +28,9 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
     @Inject
     private EntitlementService entitlementService;
 
+    @Inject
+    private SubnetSelector subnetSelector;
+
     @Override
     public Network convertToLegacyNetwork(EnvironmentNetworkResponse source, String availabilityZone) {
         Network result = new Network();
@@ -39,7 +39,7 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
         result.setOutboundInternetTraffic(source.getOutboundInternetTraffic());
         result.setNetworkCidrs(source.getNetworkCidrs());
         Map<String, Object> attributes = new HashMap<>();
-        Optional<CloudSubnet> cloudSubnet = chooseSubnet(source.getPreferedSubnetId(), source.getSubnetMetas(), availabilityZone, true);
+        Optional<CloudSubnet> cloudSubnet = subnetSelector.chooseSubnet(source.getPreferedSubnetId(), source.getSubnetMetas(), availabilityZone, true);
         if (cloudSubnet.isEmpty()) {
             throw new BadRequestException("No subnet for the given availability zone: " + availabilityZone);
         }
@@ -49,7 +49,12 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
         attributes.put("cloudPlatform", getCloudPlatform().name());
         attributes.putAll(getAttributesForLegacyNetwork(source));
         if (entitlementService.publicEndpointAccessGatewayEnabled(ThreadBasedUserCrnProvider.getAccountId())) {
-            chooseSubnetForEndpointGateway(source, cloudSubnet.get(), attributes);
+            Optional<CloudSubnet> endpointGatewaySubnet = subnetSelector.chooseSubnetForEndpointGateway(source, cloudSubnet.get().getId());
+            if (endpointGatewaySubnet.isPresent()) {
+                attributes.put("endpointGatewaySubnetId", endpointGatewaySubnet.get().getId());
+            } else {
+                throw new BadRequestException("Could not find public subnet in availability zone: " + cloudSubnet.get().getAvailabilityZone());
+            }
         }
 
         try {
@@ -58,57 +63,6 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
             LOGGER.debug("Environment's network could not be converted to network.", e);
         }
         return result;
-    }
-
-    private Optional<CloudSubnet> chooseSubnet(String preferredSubnetId, Map<String, CloudSubnet> subnetMetas,
-            String availabilityZone, boolean allowRandom) {
-        Optional<CloudSubnet> cloudSubnet;
-        if (StringUtils.isNotEmpty(preferredSubnetId)) {
-            LOGGER.debug("Choosing subnet by prefered subnet Id {}", preferredSubnetId);
-            CloudSubnet cloudSubnetById = subnetMetas.get(preferredSubnetId);
-            if (cloudSubnetById == null) {
-                cloudSubnetById = subnetMetas.values()
-                    .stream()
-                    .filter(e -> e.getId().equals(preferredSubnetId))
-                    .findFirst().orElse(null);
-            }
-            cloudSubnet = Optional.ofNullable(cloudSubnetById);
-        } else if (StringUtils.isNotEmpty(availabilityZone)) {
-            LOGGER.debug("Choosing subnet by availability zone {}", availabilityZone);
-            cloudSubnet = subnetMetas.values().stream()
-                .filter(s -> StringUtils.isNotEmpty(s.getAvailabilityZone()) &&
-                    s.getAvailabilityZone().equals(availabilityZone))
-                .findFirst();
-        } else if (allowRandom) {
-            LOGGER.debug("Fallback to choose random subnet");
-            cloudSubnet = subnetMetas.values().stream().findFirst();
-        } else {
-            cloudSubnet = Optional.empty();
-        }
-        return cloudSubnet;
-    }
-
-    private void chooseSubnetForEndpointGateway(EnvironmentNetworkResponse source, CloudSubnet cloudSubnet, Map<String, Object> attributes) {
-        if (source.getPublicEndpointAccessGateway() == PublicEndpointAccessGateway.ENABLED) {
-            String selectedAZ = cloudSubnet.getAvailabilityZone();
-            Map<String, CloudSubnet> subnetsToParse;
-            if (source.getGatewayEndpointSubnetMetas() == null || source.getGatewayEndpointSubnetMetas().isEmpty()) {
-                subnetsToParse = source.getSubnetMetas();
-            } else {
-                subnetsToParse = source.getGatewayEndpointSubnetMetas();
-            }
-            Map<String, CloudSubnet> publicSubnetMetas = subnetsToParse.entrySet().stream()
-                .filter(entry -> !entry.getValue().isPrivateSubnet())
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-            Optional<CloudSubnet> endpointGatewayCloudSubnet = chooseSubnet(null,
-                publicSubnetMetas, selectedAZ, false);
-            if (endpointGatewayCloudSubnet.isEmpty()) {
-                throw new BadRequestException("Could not find public subnet in availability zone: " + selectedAZ);
-            }
-            LOGGER.debug("Chosen endpoint gateway subnet: {}", endpointGatewayCloudSubnet.get());
-            attributes.put("endpointGatewaySubnetId", endpointGatewayCloudSubnet.get().getId());
-        }
     }
 
     abstract Map<String, Object> getAttributesForLegacyNetwork(EnvironmentNetworkResponse source);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/SubnetSelector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/SubnetSelector.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.cloudbreak.converter.v4.environment.network;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+
+@Component
+public class SubnetSelector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubnetSelector.class);
+
+    public Optional<CloudSubnet> chooseSubnet(String preferredSubnetId, Map<String, CloudSubnet> subnetMetas, String availabilityZone, boolean allowRandom) {
+        Optional<CloudSubnet> cloudSubnet;
+        if (StringUtils.isNotEmpty(preferredSubnetId)) {
+            cloudSubnet = findSubnetById(subnetMetas, preferredSubnetId);
+        } else if (StringUtils.isNotEmpty(availabilityZone)) {
+            LOGGER.debug("Choosing subnet by availability zone {}", availabilityZone);
+            cloudSubnet = subnetMetas.values().stream()
+                .filter(s -> StringUtils.isNotEmpty(s.getAvailabilityZone()) &&
+                    s.getAvailabilityZone().equals(availabilityZone))
+                .findFirst();
+        } else if (allowRandom) {
+            LOGGER.debug("Fallback to choose random subnet");
+            cloudSubnet = subnetMetas.values().stream().findFirst();
+        } else {
+            cloudSubnet = Optional.empty();
+        }
+        return cloudSubnet;
+    }
+
+    public Optional<CloudSubnet> chooseSubnetForEndpointGateway(EnvironmentNetworkResponse source, String baseSubnetId) {
+        Optional<CloudSubnet> endpointGatewayCloudSubnet = Optional.empty();
+        if (source.getPublicEndpointAccessGateway() == PublicEndpointAccessGateway.ENABLED) {
+            Optional<CloudSubnet> baseSubnet = findSubnetById(source.getSubnetMetas(), baseSubnetId);
+            if (baseSubnet.isEmpty()) {
+                LOGGER.error("Unable to find subnet with id {}", baseSubnet);
+            } else {
+                String selectedAZ = baseSubnet.get().getAvailabilityZone();
+                Map<String, CloudSubnet> subnetsToParse;
+                if (source.getGatewayEndpointSubnetMetas() == null || source.getGatewayEndpointSubnetMetas().isEmpty()) {
+                    subnetsToParse = source.getSubnetMetas();
+                } else {
+                    subnetsToParse = source.getGatewayEndpointSubnetMetas();
+                }
+                Map<String, CloudSubnet> publicSubnetMetas = subnetsToParse.entrySet().stream()
+                    .filter(entry -> !entry.getValue().isPrivateSubnet())
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+                endpointGatewayCloudSubnet = chooseSubnet(null, publicSubnetMetas, selectedAZ, false);
+                if (endpointGatewayCloudSubnet.isPresent()) {
+                    LOGGER.debug("Chosen endpoint gateway subnet: {}", endpointGatewayCloudSubnet.get());
+                } else {
+                    LOGGER.debug("Could not find public subnet in availability zone {}", selectedAZ);
+                }
+            }
+        }
+        return endpointGatewayCloudSubnet;
+    }
+
+    public Optional<CloudSubnet> findSubnetById(Map<String, CloudSubnet> subnetMetas, String id) {
+        CloudSubnet cloudSubnetById = subnetMetas.get(id);
+        if (cloudSubnetById == null) {
+            cloudSubnetById = subnetMetas.values()
+                .stream()
+                .filter(e -> e.getId().equals(id))
+                .findFirst().orElse(null);
+        }
+        return Optional.ofNullable(cloudSubnetById);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/loadbalancer/EndpointGatewayNetworkValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/loadbalancer/EndpointGatewayNetworkValidatorTest.java
@@ -1,0 +1,149 @@
+package com.sequenceiq.cloudbreak.controller.validation.loadbalancer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static com.sequenceiq.cloudbreak.controller.validation.loadbalancer.EndpointGatewayNetworkValidator.NO_BASE_SUBNET;
+import static com.sequenceiq.cloudbreak.controller.validation.loadbalancer.EndpointGatewayNetworkValidator.NO_BASE_SUBNET_META;
+import static com.sequenceiq.cloudbreak.controller.validation.loadbalancer.EndpointGatewayNetworkValidator.NO_USABLE_SUBNET_IN_CLUSTER;
+import static com.sequenceiq.cloudbreak.controller.validation.loadbalancer.EndpointGatewayNetworkValidator.NO_USABLE_SUBNET_IN_ENDPOINT_GATEWAY;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.converter.v4.environment.network.SubnetSelector;
+import com.sequenceiq.cloudbreak.core.network.SubnetTest;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EndpointGatewayNetworkValidatorTest extends SubnetTest {
+
+    private static final String KEY = "key";
+
+    @InjectMocks
+    private EndpointGatewayNetworkValidator underTest;
+
+    @Mock
+    private SubnetSelector subnetSelector;
+
+    @Test
+    public void validateNoNetworkProvided() {
+        ValidationResult result = underTest.validate(new ImmutablePair<>("", null));
+
+        assertNoError(result);
+    }
+
+    @Test
+    public void validateEndpointGatewayDisabled() {
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.DISABLED);
+
+        ValidationResult result = underTest.validate(new ImmutablePair<>("", network));
+
+        assertNoError(result);
+    }
+
+    @Test
+    public void validateNoBaseSubnetId() {
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+
+        ValidationResult result = underTest.validate(new ImmutablePair<>("", network));
+
+        assert result.hasError();
+        assertEquals(NO_BASE_SUBNET, result.getErrors().get(0));
+    }
+
+    @Test
+    public void validateNoBaseSubnetMeta() {
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+
+        when(subnetSelector.findSubnetById(any(), anyString())).thenReturn(Optional.empty());
+
+        ValidationResult result = underTest.validate(new ImmutablePair<>(PRIVATE_ID_1, network));
+
+        assert result.hasError();
+        assertEquals(String.format(NO_BASE_SUBNET_META, PRIVATE_ID_1), result.getErrors().get(0));
+    }
+
+    @Test
+    public void validateProvidedEndpointGatwaySubnets() {
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+        CloudSubnet publicSubnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
+        network.setGatewayEndpointSubnetMetas(Map.of(KEY, publicSubnet));
+
+        when(subnetSelector.findSubnetById(any(), anyString())).thenReturn(Optional.of(getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1)));
+        when(subnetSelector.chooseSubnetForEndpointGateway(any(), anyString())).thenReturn(Optional.of(publicSubnet));
+
+        ValidationResult result = underTest.validate(new ImmutablePair<>(PRIVATE_ID_1, network));
+
+        assertNoError(result);
+    }
+
+    @Test
+    public void validateWhenEndpointGatewaySubnetsAreInvalid() {
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+        CloudSubnet publicSubnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
+        network.setGatewayEndpointSubnetMetas(Map.of(KEY, publicSubnet));
+
+        when(subnetSelector.findSubnetById(any(), anyString())).thenReturn(Optional.of(getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1)));
+        when(subnetSelector.chooseSubnetForEndpointGateway(any(), anyString())).thenReturn(Optional.empty());
+
+        ValidationResult result = underTest.validate(new ImmutablePair<>(PRIVATE_ID_1, network));
+
+        assert result.hasError();
+        assertEquals(String.format(NO_USABLE_SUBNET_IN_ENDPOINT_GATEWAY, AZ_1), result.getErrors().get(0));
+    }
+
+    @Test
+    public void validateProvidedClusterSubnets() {
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+        CloudSubnet publicSubnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
+        CloudSubnet privateSubnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
+        network.setSubnetMetas(Map.of(KEY, privateSubnet, KEY + '2', publicSubnet));
+
+        when(subnetSelector.findSubnetById(anyMap(), anyString())).thenReturn(Optional.of(privateSubnet));
+        when(subnetSelector.chooseSubnetForEndpointGateway(any(), anyString())).thenReturn(Optional.of(publicSubnet));
+
+        ValidationResult result = underTest.validate(new ImmutablePair<>(PRIVATE_ID_1, network));
+
+        assertNoError(result);
+    }
+
+    @Test
+    public void validateWhenClusterSubnetsAreInvalid() {
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+        CloudSubnet privateSubnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
+        network.setSubnetMetas(Map.of(KEY, privateSubnet));
+
+        when(subnetSelector.findSubnetById(any(), anyString())).thenReturn(Optional.of(privateSubnet));
+        when(subnetSelector.chooseSubnetForEndpointGateway(any(), anyString())).thenReturn(Optional.empty());
+
+        ValidationResult result = underTest.validate(new ImmutablePair<>(PRIVATE_ID_1, network));
+
+        assert result.hasError();
+        assertEquals(String.format(NO_USABLE_SUBNET_IN_CLUSTER, AZ_1), result.getErrors().get(0));
+    }
+
+    private void assertNoError(ValidationResult result) {
+        assert result.getState() != ValidationResult.State.ERROR;
+        assert !result.hasError();
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverterTest.java
@@ -5,10 +5,15 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -23,28 +28,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
-import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.core.network.SubnetTest;
 import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.common.api.type.OutboundInternetTraffic;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 
 @ExtendWith(MockitoExtension.class)
-public class EnvironmentBaseNetworkConverterTest {
+public class EnvironmentBaseNetworkConverterTest extends SubnetTest {
 
     private static final String USER_CRN = "crn:cdp:iam:us-west-1:" + UUID.randomUUID() + ":user:" + UUID.randomUUID();
 
     private static final Set<String> NETWORK_CIDRS = Set.of("1.2.3.4/32", "0.0.0.0/0");
 
-    private static final String AZ_1 = "AZ-1";
-
-    private static final String PRIVATE_ID_1 = "private-id-1";
-
-    private static final String PUBLIC_ID_1 = "public-id-1";
-
-    private static final String ENDPOINT_ID = "endpointGatewaySubnetId";
+    private static final String EU_AZ = "eu-west-1a";
 
     @InjectMocks
     private TestEnvironmentBaseNetworkConverter underTest;
@@ -55,23 +54,33 @@ public class EnvironmentBaseNetworkConverterTest {
     @Mock
     private EntitlementService entitlementService;
 
+    @Mock
+    private SubnetSelector subnetSelector;
+
     @Test
     public void testConvertToLegacyNetworkWhenSubnetNotFound() {
         EnvironmentNetworkResponse source = new EnvironmentNetworkResponse();
         source.setSubnetMetas(Map.of("key", getCloudSubnet("any")));
+        when(subnetSelector.chooseSubnet(any(), anyMap(), anyString(), anyBoolean())).thenReturn(Optional.empty());
+
         BadRequestException badRequestException = assertThrows(BadRequestException.class, () ->
-            ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.convertToLegacyNetwork(source, "eu-west-1a"))
+            ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.convertToLegacyNetwork(source, EU_AZ))
         );
         assertEquals(badRequestException.getMessage(), "No subnet for the given availability zone: eu-west-1a");
     }
 
     @Test
     public void testConvertToLegacyNetworkWhenSubnetFound() {
+        CloudSubnet subnet = getCloudSubnet(EU_AZ);
+        Map<String, CloudSubnet> metas = Map.of("key", subnet);
         EnvironmentNetworkResponse source = setupResponse();
-        source.setSubnetMetas(Map.of("key", getCloudSubnet("eu-west-1a")));
+        source.setSubnetMetas(metas);
+
+        when(subnetSelector.chooseSubnet(any(), eq(metas), eq(EU_AZ), eq(true))).thenReturn(Optional.of(subnet));
+
         Network[] network = new Network[1];
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
-            network[0] = underTest.convertToLegacyNetwork(source, "eu-west-1a");
+            network[0] = underTest.convertToLegacyNetwork(source, EU_AZ);
         });
         assertEquals(network[0].getAttributes().getValue("subnetId"), "eu-west-1");
         assertTrue(network[0].getNetworkCidrs().containsAll(NETWORK_CIDRS));
@@ -79,12 +88,16 @@ public class EnvironmentBaseNetworkConverterTest {
     }
 
     @Test
-    public void testConvertToLegacyNetworkWithEndpointAccessGatewayAndProvidedSubnets() {
+    public void testConvertToLegacyNetworkWithEndpointAccessGateway() {
+        CloudSubnet privateSubnet = getCloudSubnet(AZ_1);
+        CloudSubnet publicSubnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
         EnvironmentNetworkResponse source = setupResponse();
-        source.setSubnetMetas(Map.of("key", getCloudSubnet(AZ_1)));
+        source.setSubnetMetas(Map.of("key", privateSubnet));
         source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
-        source.setGatewayEndpointSubnetMetas(Map.of("public-key", getPublicCloudSubnet(PUBLIC_ID_1, AZ_1)));
+        source.setGatewayEndpointSubnetMetas(Map.of("public-key", publicSubnet));
 
+        when(subnetSelector.chooseSubnet(any(), eq(source.getSubnetMetas()), eq(AZ_1), eq(true))).thenReturn(Optional.of(privateSubnet));
+        when(subnetSelector.chooseSubnetForEndpointGateway(eq(source), eq(privateSubnet.getId()))).thenReturn(Optional.of(publicSubnet));
         when(entitlementService.publicEndpointAccessGatewayEnabled(any())).thenReturn(true);
 
         Network[] network = new Network[1];
@@ -96,45 +109,15 @@ public class EnvironmentBaseNetworkConverterTest {
     }
 
     @Test
-    public void testConvertToLegacyNetworkWithEndpointAccessGatewayAndEnvironmentSubnets() {
+    public void testConvertToLegacyNetworkWithEndpointAccessGatewayNoPublicSubnets() {
+        CloudSubnet privateSubnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
         EnvironmentNetworkResponse source = setupResponse();
-        source.setSubnetMetas(Map.of(
-            "key1", getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1),
-            "key2", getPublicCloudSubnet(PUBLIC_ID_1, AZ_1)
-        ));
+        source.setSubnetMetas(Map.of("key", privateSubnet));
         source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+        source.setGatewayEndpointSubnetMetas(Map.of("private-key", privateSubnet));
 
-        when(entitlementService.publicEndpointAccessGatewayEnabled(any())).thenReturn(true);
-
-        Network[] network = new Network[1];
-        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
-            network[0] = underTest.convertToLegacyNetwork(source, AZ_1);
-        });
-
-        assertEquals(PUBLIC_ID_1, network[0].getAttributes().getValue(ENDPOINT_ID));
-    }
-
-    @Test
-    public void testConvertToLegacyNetworkWithEndpointAccessGatewayProvidedSubnetsNoPublicSubnets() {
-        EnvironmentNetworkResponse source = setupResponse();
-        source.setSubnetMetas(Map.of("key", getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1)));
-        source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
-        source.setGatewayEndpointSubnetMetas(Map.of("private-key", getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1)));
-
-        when(entitlementService.publicEndpointAccessGatewayEnabled(any())).thenReturn(true);
-
-        Exception exception = assertThrows(BadRequestException.class, () ->
-            ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.convertToLegacyNetwork(source, AZ_1))
-        );
-        assertEquals("Could not find public subnet in availability zone: AZ-1", exception.getMessage());
-    }
-
-    @Test
-    public void testConvertToLegacyNetworkWithEndpointAccessGatewayEnvironmentSubnetsNoPublicSubnets() {
-        EnvironmentNetworkResponse source = setupResponse();
-        source.setSubnetMetas(Map.of("key", getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1)));
-        source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
-
+        when(subnetSelector.chooseSubnet(any(), anyMap(), anyString(), anyBoolean())).thenReturn(Optional.of(privateSubnet));
+        when(subnetSelector.chooseSubnetForEndpointGateway(any(), anyString())).thenReturn(Optional.empty());
         when(entitlementService.publicEndpointAccessGatewayEnabled(any())).thenReturn(true);
 
         Exception exception = assertThrows(BadRequestException.class, () ->
@@ -145,11 +128,14 @@ public class EnvironmentBaseNetworkConverterTest {
 
     @Test
     public void testEndpointGatewaySubnetNotSetWhenEntitlementIsDisabled() {
+        CloudSubnet privateSubnet = getCloudSubnet(AZ_1);
+        CloudSubnet publicSubnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
         EnvironmentNetworkResponse source = setupResponse();
-        source.setSubnetMetas(Map.of("key", getCloudSubnet(AZ_1)));
+        source.setSubnetMetas(Map.of("key", privateSubnet));
         source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
-        source.setGatewayEndpointSubnetMetas(Map.of("public-key", getPublicCloudSubnet(PUBLIC_ID_1, AZ_1)));
+        source.setGatewayEndpointSubnetMetas(Map.of("public-key", publicSubnet));
 
+        when(subnetSelector.chooseSubnet(any(), anyMap(), anyString(), anyBoolean())).thenReturn(Optional.of(privateSubnet));
         when(entitlementService.publicEndpointAccessGatewayEnabled(any())).thenReturn(false);
 
         Network[] network = new Network[1];
@@ -162,14 +148,6 @@ public class EnvironmentBaseNetworkConverterTest {
 
     private CloudSubnet getCloudSubnet(String availabilityZone) {
         return new CloudSubnet("eu-west-1", "name", availabilityZone, "cidr");
-    }
-
-    private CloudSubnet getPublicCloudSubnet(String id, String availabilityZone) {
-        return new CloudSubnet(id, "name", availabilityZone, "cidr", false, true, true, SubnetType.PUBLIC);
-    }
-
-    private CloudSubnet getPrivateCloudSubnet(String id, String availabilityZone) {
-        return new CloudSubnet(id, "name", availabilityZone, "cidr", true, false, false, SubnetType.PRIVATE);
     }
 
     private EnvironmentNetworkResponse setupResponse() {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/SubnetSelectorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/SubnetSelectorTest.java
@@ -1,0 +1,117 @@
+package com.sequenceiq.cloudbreak.converter.v4.environment.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.core.network.SubnetTest;
+import com.sequenceiq.common.api.type.OutboundInternetTraffic;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class SubnetSelectorTest extends SubnetTest {
+
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:" + UUID.randomUUID() + ":user:" + UUID.randomUUID();
+
+    private static final Set<String> NETWORK_CIDRS = Set.of("1.2.3.4/32", "0.0.0.0/0");
+
+    @InjectMocks
+    private SubnetSelector underTest;
+
+    @Test
+    public void testNoSubnetInAvailabilityZone() {
+        EnvironmentNetworkResponse source = new EnvironmentNetworkResponse();
+        source.setSubnetMetas(Map.of("key", getCloudSubnet("any")));
+
+        Optional<CloudSubnet> subnet = underTest.chooseSubnet(source.getPreferedSubnetId(), source.getSubnetMetas(), AZ_1, true);
+
+        assert subnet.isEmpty();
+    }
+
+    @Test
+    public void testSubnetFoundInAvailabilityZone() {
+        EnvironmentNetworkResponse source = setupResponse();
+        source.setSubnetMetas(Map.of("key", getCloudSubnet(AZ_1)));
+
+        Optional<CloudSubnet> subnet = underTest.chooseSubnet(source.getPreferedSubnetId(), source.getSubnetMetas(), AZ_1, true);
+
+        assert subnet.isPresent();
+        assertEquals(PRIVATE_ID_1, subnet.get().getId());
+    }
+
+    @Test
+    public void testChooseEndpointGatewaySubnetFromEndpointSubnetst() {
+        EnvironmentNetworkResponse source = setupResponse();
+        source.setSubnetMetas(Map.of("key", getCloudSubnet(AZ_1)));
+        source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+        source.setGatewayEndpointSubnetMetas(Map.of("public-key", getPublicCloudSubnet(PUBLIC_ID_1, AZ_1)));
+
+        Optional<CloudSubnet> subnet =
+            underTest.chooseSubnetForEndpointGateway(source, PRIVATE_ID_1);
+
+        assert subnet.isPresent();
+        assertEquals(PUBLIC_ID_1, subnet.get().getId());
+    }
+
+    @Test
+    public void testChooseEndpointGatewaySubnetFromEnvironmentSubnetst() {
+        EnvironmentNetworkResponse source = setupResponse();
+        source.setSubnetMetas(Map.of(
+            "key1", getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1),
+            "key2", getPublicCloudSubnet(PUBLIC_ID_1, AZ_1)
+        ));
+        source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+
+        Optional<CloudSubnet> subnet =
+            underTest.chooseSubnetForEndpointGateway(source, PRIVATE_ID_1);
+
+        assert subnet.isPresent();
+        assertEquals(PUBLIC_ID_1, subnet.get().getId());
+    }
+
+    @Test
+    public void testChooseEndpointGatewaySubnetNoPublicEndpointSubnets() {
+        EnvironmentNetworkResponse source = setupResponse();
+        source.setSubnetMetas(Map.of("key", getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1)));
+        source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+        source.setGatewayEndpointSubnetMetas(Map.of("private-key", getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1)));
+
+        Optional<CloudSubnet> subnet =
+            underTest.chooseSubnetForEndpointGateway(source, PRIVATE_ID_1);
+
+        assert subnet.isEmpty();
+    }
+
+    @Test
+    public void testChooseEndpointGatewaySubnetNoPublicEnvironmentSubnets() {
+        EnvironmentNetworkResponse source = setupResponse();
+        source.setSubnetMetas(Map.of("key", getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1)));
+        source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+
+        Optional<CloudSubnet> subnet =
+            underTest.chooseSubnetForEndpointGateway(source, PRIVATE_ID_1);
+
+        assert subnet.isEmpty();
+    }
+
+    private CloudSubnet getCloudSubnet(String availabilityZone) {
+        return new CloudSubnet(PRIVATE_ID_1, "name", availabilityZone, "cidr");
+    }
+
+    private EnvironmentNetworkResponse setupResponse() {
+        EnvironmentNetworkResponse source = new EnvironmentNetworkResponse();
+        source.setNetworkCidrs(NETWORK_CIDRS);
+        source.setOutboundInternetTraffic(OutboundInternetTraffic.DISABLED);
+        return source;
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/network/SubnetTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/network/SubnetTest.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.core.network;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
+
+public class SubnetTest {
+
+    protected static final String AZ_1 = "AZ-1";
+
+    protected static final String AZ_2 = "AZ-2";
+
+    protected static final String PRIVATE_ID_1 = "private-id-1";
+
+    protected static final String PUBLIC_ID_1 = "public-id-1";
+
+    protected static final String ENDPOINT_ID = "endpointGatewaySubnetId";
+
+    protected CloudSubnet getPublicCloudSubnet(String id, String availabilityZone) {
+        return new CloudSubnet(id, "name", availabilityZone, "cidr", false, true, true, SubnetType.PUBLIC);
+    }
+
+    protected CloudSubnet getPrivateCloudSubnet(String id, String availabilityZone) {
+        return new CloudSubnet(id, "name", availabilityZone, "cidr", true, false, false, SubnetType.PRIVATE);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4ConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/NetworkV1ToNetworkV4ConverterTest.java
@@ -1,16 +1,33 @@
 package com.sequenceiq.distrox.v1.distrox.converter;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.network.NetworkV4Request;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.converter.v4.environment.network.SubnetSelector;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.cloudbreak.controller.validation.loadbalancer.EndpointGatewayNetworkValidator;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.AwsNetworkV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.AzureNetworkV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.NetworkV1Request;
@@ -23,6 +40,8 @@ import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentN
 @ExtendWith(MockitoExtension.class)
 public class NetworkV1ToNetworkV4ConverterTest {
 
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:" + UUID.randomUUID() + ":user:" + UUID.randomUUID();
+
     private static final String VPC_ID = "vpc-123";
 
     private static final String GROUP_NAME = "group-123";
@@ -31,20 +50,33 @@ public class NetworkV1ToNetworkV4ConverterTest {
 
     private static final Set<String> SUBNET_IDS = Sets.newHashSet("subnet-123", "subnet-456");
 
+    private static final String PUBLIC_SUBNET_ID = "public-subnet-123";
+
     @InjectMocks
     private NetworkV1ToNetworkV4Converter underTest;
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @Mock
+    private SubnetSelector subnetSelector;
+
+    @Mock
+    private EndpointGatewayNetworkValidator endpointGatewayNetworkValidator;
 
     @Test
     public void testConvertToStackRequestWhenAwsPresentedWithSubnet() {
         NetworkV1Request networkV1Request = awsNetworkV1Request();
         DetailedEnvironmentResponse environmentNetworkResponse = awsEnvironmentNetwork();
 
-
-        NetworkV4Request networkV4Request = underTest
+        NetworkV4Request[] networkV4Request = new NetworkV4Request[1];
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
+            networkV4Request[0] = underTest
                 .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
+        });
 
-        Assert.assertEquals(networkV4Request.createAws().getVpcId(), VPC_ID);
-        Assert.assertEquals(networkV4Request.createAws().getSubnetId(), SUBNET_ID);
+        Assert.assertEquals(networkV4Request[0].createAws().getVpcId(), VPC_ID);
+        Assert.assertEquals(networkV4Request[0].createAws().getSubnetId(), SUBNET_ID);
     }
 
     @Test
@@ -52,12 +84,14 @@ public class NetworkV1ToNetworkV4ConverterTest {
         NetworkV1Request networkV1Request = awsEmptyNetworkV1Request();
         DetailedEnvironmentResponse environmentNetworkResponse = awsEnvironmentNetwork();
 
-
-        NetworkV4Request networkV4Request = underTest
+        NetworkV4Request[] networkV4Request = new NetworkV4Request[1];
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
+            networkV4Request[0] = underTest
                 .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
+        });
 
-        Assert.assertEquals(networkV4Request.createAws().getVpcId(), VPC_ID);
-        Assert.assertTrue(SUBNET_IDS.contains(networkV4Request.createAws().getSubnetId()));
+        Assert.assertEquals(networkV4Request[0].createAws().getVpcId(), VPC_ID);
+        Assert.assertTrue(SUBNET_IDS.contains(networkV4Request[0].createAws().getSubnetId()));
     }
 
     @Test
@@ -98,6 +132,66 @@ public class NetworkV1ToNetworkV4ConverterTest {
                 .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
 
         Assert.assertTrue(networkV4Request.createYarn().asMap().size() == 1);
+    }
+
+    @Test
+    public void testConvertToStackRequestWhenAwsPresentedWithEndpointGateway() {
+        NetworkV1Request networkV1Request = awsNetworkV1Request();
+        DetailedEnvironmentResponse environmentNetworkResponse = awsEnvironmentNetwork();
+        EnvironmentNetworkResponse network = environmentNetworkResponse.getNetwork();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+        CloudSubnet publicSubnet = new CloudSubnet(PUBLIC_SUBNET_ID, "name", "az-1", "cidr", false, true, true, SubnetType.PUBLIC);
+
+        when(subnetSelector.chooseSubnetForEndpointGateway(any(), any())).thenReturn(Optional.of(publicSubnet));
+        when(entitlementService.publicEndpointAccessGatewayEnabled(any())).thenReturn(true);
+        when(endpointGatewayNetworkValidator.validate(any())).thenReturn(ValidationResult.empty());
+
+        NetworkV4Request[] networkV4Request = new NetworkV4Request[1];
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
+            networkV4Request[0] = underTest
+                .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
+        });
+
+        Assert.assertEquals(networkV4Request[0].createAws().getVpcId(), VPC_ID);
+        Assert.assertEquals(networkV4Request[0].createAws().getSubnetId(), SUBNET_ID);
+        Assert.assertEquals(networkV4Request[0].createAws().getEndpointGatewaySubnetId(), PUBLIC_SUBNET_ID);
+    }
+
+    @Test
+    public void testConvertToStackRequestWhenAwsPresentedWithEndpointGatewayMissingSubnet() {
+        NetworkV1Request networkV1Request = awsNetworkV1Request();
+        DetailedEnvironmentResponse environmentNetworkResponse = awsEnvironmentNetwork();
+        EnvironmentNetworkResponse network = environmentNetworkResponse.getNetwork();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+
+        when(entitlementService.publicEndpointAccessGatewayEnabled(any())).thenReturn(true);
+        when(endpointGatewayNetworkValidator.validate(any())).thenReturn(ValidationResult.builder().error("error").build());
+
+        Exception exception = assertThrows(BadRequestException.class, () -> {
+            ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
+                underTest.convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
+            });
+        });
+
+        assert exception.getMessage().startsWith("Endpoint gateway subnet validation failed:");
+    }
+
+    @Test
+    public void testConvertToStackRequestWhenEndpointGatewayEnabledAndEntitlementDisabled() {
+        NetworkV1Request networkV1Request = awsNetworkV1Request();
+        DetailedEnvironmentResponse environmentNetworkResponse = awsEnvironmentNetwork();
+        EnvironmentNetworkResponse network = environmentNetworkResponse.getNetwork();
+        network.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+
+        when(entitlementService.publicEndpointAccessGatewayEnabled(any())).thenReturn(false);
+
+        NetworkV4Request[] networkV4Request = new NetworkV4Request[1];
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
+            networkV4Request[0] = underTest
+                .convertToNetworkV4Request(new ImmutablePair<>(networkV1Request, environmentNetworkResponse));
+        });
+
+        assertNull(networkV4Request[0].createAws().getEndpointGatewaySubnetId());
     }
 
     private DetailedEnvironmentResponse awsEnvironmentNetwork() {


### PR DESCRIPTION
Adds new logic to the NetworkV1ToNetworkV4Converter to detect the public endpoint gateway
is enabled for the environment, and if so selects and adds the subnet for the endpoint to
the AWS network object. The logic for selecting a subnet has been moved out of
EnvironmentBaseNetworkConverter where it originally lived and into a separate SubnetSelector.
Support for other cloud providers will be added as this feature is extended to new cloud
providers.

Tested with unit tests and by creating data hub and verifying LB creation was successful.
