### PR TITLE
CB-10668: Fix retries when ClusterProxyException is thrown

### DIFF
--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyError.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyError.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.client;
+package com.sequenceiq.cloudbreak.clusterproxy;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyException.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyException.java
@@ -1,11 +1,22 @@
 package com.sequenceiq.cloudbreak.clusterproxy;
 
+import java.util.Optional;
+
 public class ClusterProxyException extends RuntimeException {
-    public ClusterProxyException(String message) {
+
+    private final Optional<ClusterProxyError> clusterProxyError;
+
+    public ClusterProxyException(String message, Optional<ClusterProxyError> clusterProxyError) {
         super(message);
+        this.clusterProxyError = clusterProxyError;
     }
 
     public ClusterProxyException(String message, Throwable cause) {
         super(message, cause);
+        clusterProxyError = Optional.empty();
+    }
+
+    public Optional<ClusterProxyError> getClusterProxyError() {
+        return clusterProxyError;
     }
 }

--- a/freeipa-client/build.gradle
+++ b/freeipa-client/build.gradle
@@ -26,6 +26,8 @@ dependencies {
   compile            group: 'org.glassfish.jersey.core',        name: 'jersey-common',               version: jerseyCoreVersion
   testImplementation group: 'org.mockito',                      name: 'mockito-core',                version: mockitoVersion
   testImplementation group: 'org.hamcrest',                     name: 'hamcrest',                    version: hamcrestVersion
+  compile            group: 'org.springframework.boot',         name: 'spring-boot-starter-web',     version: springBootVersion
 
   implementation project(':common')
+  implementation project(':cluster-proxy')
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/ClusterProxyErrorRpcListener.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/ClusterProxyErrorRpcListener.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.googlecode.jsonrpc4j.JsonRpcClient;
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyError;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyException;
 
 import java.util.Optional;
@@ -26,7 +27,7 @@ public class ClusterProxyErrorRpcListener implements JsonRpcClient.RequestListen
     private void throwIfClusterProxyError(ObjectNode node) {
         Optional<ClusterProxyError> clusterProxyError = deserializeAsClusterProxyError(node);
         if (clusterProxyError.isPresent()) {
-            throw new ClusterProxyException(String.format("Cluster proxy service returned error: %s", clusterProxyError.get()));
+            throw new ClusterProxyException(String.format("Cluster proxy service returned error: %s", clusterProxyError.get()), clusterProxyError);
         }
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClusterProxyErrorRpcListener.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClusterProxyErrorRpcListener.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import javax.ws.rs.core.Response;
 
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyError;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyException;
 
 public class FreeIpaHealthCheckClusterProxyErrorRpcListener implements FreeIpaHealthCheckRpcListener {
@@ -24,7 +25,7 @@ public class FreeIpaHealthCheckClusterProxyErrorRpcListener implements FreeIpaHe
     private void throwIfClusterProxyError(Response response) {
         Optional<ClusterProxyError> clusterProxyError = deserializeAsClusterProxyError(response);
         if (clusterProxyError.isPresent()) {
-            throw new ClusterProxyException(String.format("Cluster proxy service returned error: %s", clusterProxyError.get()));
+            throw new ClusterProxyException(String.format("Cluster proxy service returned error: %s", clusterProxyError.get()), clusterProxyError);
         }
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClusterProxyErrorRpcListenerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClusterProxyErrorRpcListenerTest.java
@@ -12,6 +12,7 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Test;
 
+import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyError;
 import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyException;
 
 public class FreeIpaHealthCheckClusterProxyErrorRpcListenerTest {


### PR DESCRIPTION
The FreeIPA management service was fix so that when a
ClusterProxyExcpetion is thrown, the HTTP response status code can be
decoded and it can be converted into a retryable exception.

This was tested on a local deployment of cloudbreak.

See detailed description in the commit message.