### PR TITLE
CB-10679 Place empty hostattrs.sls pillar file to support salt 2017 version

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/pillar/nodes/hostattrs.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/nodes/hostattrs.sls
@@ -1,0 +1,1 @@
+hostattrs:

--- a/orchestrator-salt/src/main/resources/salt/pillar/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/top.sls
@@ -1,6 +1,9 @@
 base:
   '*':
-    - nodes.*
+    - nodes.hosts
+{%- if salt['file.file_exists']('/srv/pillar/nodes/hostattrs.sls') %}
+    - nodes.hostattrs
+{%- endif %}
     - discovery.init
     - recipes.init
     - unbound.forwarders


### PR DESCRIPTION
Using wildcard `*` char for including pillars in top file doesn't work in saltstack 2017.
To avoid the issue when the file is not present and causing issue in the top file and also
support the old saltstack version we are placing an empty version of this file in the
orchestrator-salt modul pillar directory. This will result in `hostattrs.sls` being on the
filesystem when salt states are updated but somehow the pillars are missing.