### PR TITLE
CB-10654 disable account level check for get operation status

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/OperationV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/OperationV1Controller.java
@@ -5,8 +5,7 @@ import javax.validation.constraints.NotNull;
 
 import org.springframework.stereotype.Controller;
 
-import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
-import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
+import com.sequenceiq.authorization.annotation.DisableCheckPermissions;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
@@ -23,7 +22,8 @@ public class OperationV1Controller implements OperationV1Endpoint {
     private OperationToOperationStatusConverter operationToOperationStatusConverter;
 
     @Override
-    @CheckPermissionByAccount(action = AuthorizationResourceAction.GET_OPERATION_STATUS)
+    // TODO this API method can be authorized only on account level, which doesn't fit into the resource sharing model
+    @DisableCheckPermissions
     public OperationStatus getOperationStatus(@NotNull String operationId) {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         return operationToOperationStatusConverter.convert(operationService.getOperationForAccountIdAndOperationId(accountId, operationId));

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
@@ -13,14 +13,14 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Controller;
 
 import com.google.common.collect.Iterables;
-import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.CustomPermissionCheck;
+import com.sequenceiq.authorization.annotation.DisableCheckPermissions;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
-import com.sequenceiq.cloudbreak.auth.altus.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.UserV1Endpoint;
@@ -113,7 +113,6 @@ public class UserV1Controller implements UserV1Endpoint {
 
     @Override
     @CustomPermissionCheck
-    @CheckPermissionByAccount(action = AuthorizationResourceAction.ENVIRONMENT_READ)
     public SyncOperationStatus setPassword(SetPasswordRequest request) {
         String userCrn = checkActorCrn();
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
@@ -125,7 +124,8 @@ public class UserV1Controller implements UserV1Endpoint {
     }
 
     @Override
-    @CheckPermissionByAccount(action = AuthorizationResourceAction.GET_OPERATION_STATUS)
+    // TODO this API method can be authorized only on account level, which doesn't fit into the resource sharing model
+    @DisableCheckPermissions
     public SyncOperationStatus getSyncOperationStatus(@NotNull String operationId) {
         checkActorCrn();
         String accountId = ThreadBasedUserCrnProvider.getAccountId();


### PR DESCRIPTION
- also removed old annotation from setPassword (that is skipped anyway because of the `@CustomPermissionCheck` annotation)
- long term we should introduce new APIs for these methods and make them authorizable on resource (environment) level