### PR TITLE
DISTX-556 Optimize Periscope Cluster Monitors

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
@@ -97,6 +97,10 @@ public class Cluster implements Monitored, Clustered {
     public Cluster() {
     }
 
+    public Cluster(Long clusterId) {
+        this.id = clusterId;
+    }
+
     public Cluster(MonitoredStack monitoredStack) {
         setStackCrn(monitoredStack.getStackCrn());
         clusterManager = monitoredStack.getClusterManager();

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterStatusMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterStatusMonitor.java
@@ -1,10 +1,12 @@
 package com.sequenceiq.periscope.monitor;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.monitor.evaluator.ClusterStateEvaluator;
 
@@ -29,6 +31,8 @@ public class ClusterStatusMonitor extends ClusterMonitor {
 
     @Override
     protected List<Cluster> getMonitored() {
-        return getClusterService().findAllByPeriscopeNodeId(getPeriscopeNodeConfig().getId());
+        return getClusterService().findClusterIdsByStackTypeAndPeriscopeNodeId(StackType.WORKLOAD, getPeriscopeNodeConfig().getId())
+                .stream().map(clusterId -> new Cluster(clusterId))
+                .collect(Collectors.toList());
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/LoadMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/LoadMonitor.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.periscope.monitor;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -32,8 +33,8 @@ public class LoadMonitor extends ClusterMonitor {
 
     @Override
     protected List<Cluster> getMonitored() {
-        List<Long> clusterIds = getClusterService().findLoadAlertClustersForNode(StackType.WORKLOAD,
-                ClusterState.RUNNING, true, getPeriscopeNodeConfig().getId());
-        return clusterIds.isEmpty() ? List.of() : getClusterService().findClustersByClusterIds(clusterIds);
+        return getClusterService().findLoadAlertClusterIdsForPeriscopeNodeId(StackType.WORKLOAD, ClusterState.RUNNING, true, getPeriscopeNodeConfig().getId())
+                .stream().map(clusterId -> new Cluster(clusterId))
+                .collect(Collectors.toList());
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/TimeMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/TimeMonitor.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.periscope.monitor;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
@@ -30,8 +31,8 @@ public class TimeMonitor extends ClusterMonitor {
 
     @Override
     protected List<Cluster> getMonitored() {
-        List<Long> clusterIds = getClusterService().findTimeAlertClustersForNode(StackType.WORKLOAD,
-                true, getPeriscopeNodeConfig().getId());
-        return clusterIds.isEmpty() ? List.of() : getClusterService().findClustersByClusterIds(clusterIds);
+        return getClusterService().findTimeAlertClusterIdsForPeriscopeNodeId(StackType.WORKLOAD, true, getPeriscopeNodeConfig().getId())
+                .stream().map(clusterId -> new Cluster(clusterId))
+                .collect(Collectors.toList());
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
@@ -57,6 +57,11 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
             @Param("autoScalingEnabled") Boolean autoScalingEnabled,
             @Param("periscopeNodeId") String periscopeNodeId);
 
+    @Query("SELECT distinct c.id FROM Cluster c WHERE c.stackType = :stackType " +
+            " and (:periscopeNodeId IS NULL or c.periscopeNodeId = :periscopeNodeId) ")
+    List<Long> findClusterIdsByStackTypeAndPeriscopeNodeId(@Param("stackType") StackType stackType,
+            @Param("periscopeNodeId") String periscopeNodeId);
+
     List<Cluster> findByStateAndPeriscopeNodeId(ClusterState state, String nodeId);
 
     List<Cluster> findAllByPeriscopeNodeId(String nodeId);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -225,13 +225,17 @@ public class ClusterService {
         return clusterRepository.findClustersByClusterIds(clusterIds);
     }
 
-    public List<Long> findLoadAlertClustersForNode(StackType stackType, ClusterState state,
+    public List<Long> findLoadAlertClusterIdsForPeriscopeNodeId(StackType stackType, ClusterState state,
             boolean autoscalingEnabled, String nodeId) {
         return clusterRepository.findByLoadAlertAndStackTypeAndClusterStateAndAutoscaling(stackType, state, autoscalingEnabled, nodeId);
     }
 
-    public List<Long> findTimeAlertClustersForNode(StackType stackType, boolean autoscalingEnabled, String nodeId) {
+    public List<Long> findTimeAlertClusterIdsForPeriscopeNodeId(StackType stackType, boolean autoscalingEnabled, String nodeId) {
         return clusterRepository.findByTimeAlertAndStackTypeAndAutoscaling(stackType, autoscalingEnabled, nodeId);
+    }
+
+    public List<Long> findClusterIdsByStackTypeAndPeriscopeNodeId(StackType stackType, String nodeId) {
+        return clusterRepository.findClusterIdsByStackTypeAndPeriscopeNodeId(stackType, nodeId);
     }
 
     public void validateClusterUniqueness(MonitoredStack stack) {


### PR DESCRIPTION
Periscope Cluster Monitors while loading clusters for evaluation load entire Cluster Object. But in Monitor Evaulation Context, only ClusterId is required. So ClusterStatusMonitor, LoadMonitor, TimeMonitor are  enhanced to initialize only ClusterId in this context.

Since these monitors are run very frequently, load on PersicopeDB is also reduced.
Also stops hibernate warnings about 500 queries in single transaction.

See detailed description in the commit message.