### PR TITLE
CB-10180 Add the real response  types to the responses of the mock en…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/ClouderaManagerEndpoints.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/ClouderaManagerEndpoints.java
@@ -1,7 +1,24 @@
 package com.sequenceiq.it.cloudbreak.dto.mock.endpoint;
 
+import com.cloudera.api.swagger.model.ApiAuthRoleMetadataList;
 import com.cloudera.api.swagger.model.ApiClusterTemplate;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiCommandList;
+import com.cloudera.api.swagger.model.ApiConfigList;
+import com.cloudera.api.swagger.model.ApiEcho;
+import com.cloudera.api.swagger.model.ApiExternalUserMappingList;
+import com.cloudera.api.swagger.model.ApiHostList;
+import com.cloudera.api.swagger.model.ApiHostRef;
+import com.cloudera.api.swagger.model.ApiHostRefList;
+import com.cloudera.api.swagger.model.ApiHostTemplateList;
+import com.cloudera.api.swagger.model.ApiParcelList;
+import com.cloudera.api.swagger.model.ApiRole;
+import com.cloudera.api.swagger.model.ApiRoleList;
+import com.cloudera.api.swagger.model.ApiService;
+import com.cloudera.api.swagger.model.ApiServiceList;
 import com.cloudera.api.swagger.model.ApiUser2;
+import com.cloudera.api.swagger.model.ApiUser2List;
+import com.cloudera.api.swagger.model.ApiVersionInfo;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.mock.SparkUri;
@@ -67,155 +84,136 @@ public final class ClouderaManagerEndpoints<T extends CloudbreakTestDto> {
     public interface ClusterTemplateImport<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
 
         @Override
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, ApiCommand> post();
     }
 
     @SparkUri(url = API_ROOT + "/externalUserMappings")
     public interface ExternalUserMappings<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, ApiExternalUserMappingList> post();
     }
 
     @SparkUri(url = API_ROOT + "/tools/echo")
     public interface Echo<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiEcho> get();
     }
 
     @SparkUri(url = API_ROOT + "/cm/version")
     public interface Version<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiVersionInfo> get();
     }
 
     @SparkUri(url = API_ROOT + "/authRoles/metadata")
     public interface AuthRoles<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiAuthRoleMetadataList> get();
     }
 
     @SparkUri(url = API_ROOT + "/users", requestType = ApiUser2.class)
     public interface Users<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, Void> get();
 
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, ApiUser2List> post();
 
         @SparkUri(url = API_ROOT + "/users/{user}")
-        DefaultResponseConfigure<T> put();
+        DefaultResponseConfigure<T, ApiUser2> put();
     }
 
     public interface Admin<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
         @SparkUri(url = API_ROOT + "/users/admin")
-        DefaultResponseConfigure<T> put();
+        DefaultResponseConfigure<T, ApiUser2> put();
     }
 
     public interface CMCommands<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
         @SparkUri(url = API_ROOT + "/cm/commands/{command}")
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, ApiCommand> post();
 
         @SparkUri(url = API_ROOT + "/cm/commands")
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiCommand> get();
     }
 
     public interface Commands<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
         @SparkUri(url = API_ROOT + "/commands/{commandId}")
-        DefaultResponseConfigure<T> getById();
+        DefaultResponseConfigure<T, ApiCommand> getById();
     }
 
     @SparkUri(url = API_ROOT + "/cm/service")
     public interface Service<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> put();
+        DefaultResponseConfigure<T, ApiService> put();
 
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiService> get();
 
         @SparkUri(url = API_ROOT + "/cm/service/autoConfigure")
-        DefaultResponseConfigure<T> putAutoConfigure();
+        DefaultResponseConfigure<T, Void> putAutoConfigure();
     }
 
     @SparkUri(url = API_ROOT + "/cm/service/commands")
     public interface ServiceCommands<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
         @SparkUri(url = API_ROOT + "/cm/service/commands/{command}")
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, ApiCommand> post();
 
-        DefaultResponseConfigure<T> get();
-    }
-
-    @SparkUri(url = API_ROOT + "/cm/trial/begin")
-    public interface FreeTrial<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, ApiCommandList> get();
     }
 
     @SparkUri(url = API_ROOT + "/cm/config")
     public interface Config<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiConfigList> get();
 
-        DefaultResponseConfigure<T> put();
-    }
-
-    public interface CdpRemoteContext<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        @SparkUri(url = "/api/cdp/remoteContext/byCluster/{clusterName}")
-        DefaultResponseConfigure<T> get();
-
-        @SparkUri(url = "/api/cdp/remoteContext")
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, ApiConfigList> put();
     }
 
     public interface ClouderaManagerHosts<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
         @SparkUri(url = API_ROOT + "/hosts")
-        DefaultResponseConfigure<T> get();
-
-        @SparkUri(url = API_ROOT + "/hosts/{hostId}")
-        DefaultResponseConfigure<T> getById();
-
-        @SparkUri(url = API_ROOT + "/hosts/{hostId}")
-        DefaultResponseConfigure<T> deleteById();
+        DefaultResponseConfigure<T, ApiHostList> get();
     }
 
     public interface ClusterCommands<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
         @SparkUri(url = API_ROOT + "/clusters/{clusterName}/commands")
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiCommandList> get();
 
         @SparkUri(url = API_ROOT + "/clusters/{clusterName}/commands/{command}")
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, ApiCommand> post();
 
         @SparkUri(url = API_ROOT + "/clusters/{clusterName}/commands/deployClientConfig")
         interface DeployConfig<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-            DefaultResponseConfigure<T> post();
+            DefaultResponseConfigure<T, ApiCommand> post();
         }
     }
 
     @SparkUri(url = API_ROOT + "/clusters/{clusterName}/services")
     public interface ClusterServices<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiServiceList> get();
     }
 
     @SparkUri(url = API_ROOT + "/clusters/{clusterName}/hosts")
     public interface ClusterHosts<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiHostRefList> get();
 
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, ApiHostRefList> post();
 
         @SparkUri(url = API_ROOT + "/clusters/{clusterName}/hosts/{hostId}")
-        DefaultResponseConfigure<T> delete();
+        DefaultResponseConfigure<T, ApiHostRef> delete();
     }
 
     @SparkUri(url = API_ROOT + "/clusters/{clusterName}/hostTemplates")
     public interface ClusterHostTemplates<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiHostTemplateList> get();
 
         @SparkUri(url = API_ROOT + "/clusters/{clusterName}/hostTemplates/{hostTemplateName}/commands/applyHostTemplate")
         interface CommandsApplyHostTemplate<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-            DefaultResponseConfigure<T> post();
+            DefaultResponseConfigure<T, ApiCommand> post();
         }
     }
 
     public interface ClusterServiceRoles<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
         @SparkUri(url = API_ROOT + "/clusters/{clusterName}/services/{serviceName}/roles")
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiRoleList> get();
 
         @SparkUri(url = API_ROOT + "/clusters/{clusterName}/services/{serviceName}/roles/{roleName}")
-        DefaultResponseConfigure<T> delete();
+        DefaultResponseConfigure<T, ApiRole> delete();
     }
 
     //API_ROOT + "/clusters/{clusterName}/parcels"
     public interface ClusterParcel<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
         @SparkUri(url = API_ROOT + "/clusters/{clusterName}/parcels")
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, ApiParcelList> get();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/FreeIPAEndpoints.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/FreeIPAEndpoints.java
@@ -22,6 +22,6 @@ public class FreeIPAEndpoints<T extends CloudbreakTestDto> {
 
     @SparkUri(url = "/{mockUuid}/ipa/session/json")
     public interface Session<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, Object> post();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/SaltEndpoints.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/SaltEndpoints.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.dto.mock.endpoint;
 
+import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponse;
+import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponses;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.mock.SparkUri;
@@ -34,29 +36,29 @@ public final class SaltEndpoints<T extends CloudbreakTestDto> {
 
     @SparkUri(url = SALT_BOOT_ROOT + "/health")
     public interface SaltHealth<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, Void> post();
 
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, GenericResponse> get();
     }
 
     @SparkUri(url = SALT_API_ROOT + "/run")
     public interface Run<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, Object> post();
     }
 
     @SparkUri(url = SALT_BOOT_ROOT + "/file/distribute")
     public interface SaltFileDistribute<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, GenericResponses> post();
     }
 
     @SparkUri(url = SALT_BOOT_ROOT + "/salt/action/distribute")
     public interface SaltActionDistribute<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, GenericResponses> post();
     }
 
     // SALT_BOOT_ROOT + "/salt/server/pillar/distribute"
     @SparkUri(url = SALT_BOOT_ROOT + "/salt/server/pillar/distribute")
     public interface SaltPillar<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, GenericResponses> post();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/SpiEndpoints.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/SpiEndpoints.java
@@ -1,5 +1,10 @@
 package com.sequenceiq.it.cloudbreak.dto.mock.endpoint;
 
+import java.util.List;
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmMetaDataStatus;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.mock.SparkUri;
@@ -52,31 +57,31 @@ public final class SpiEndpoints<T extends CloudbreakTestDto> {
 
     @SparkUri(url = SPI_ROOT + REGISTER_PUBLIC_KEY)
     public interface RegisterPublicKey<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, Void> post();
     }
 
     @SparkUri(url = SPI_ROOT + UNREGISTER_PUBLIC_KEY)
     public interface UnregisterPublicKey<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, Void> post();
     }
 
     @SparkUri(url = SPI_ROOT + GET_PUBLIC_KEY_BY_ID)
     public interface GetPublicKey<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> get();
+        DefaultResponseConfigure<T, Map<String, String>> get();
     }
 
     @SparkUri(url = SPI_WITH_MOCK_ROOT + "/cloud_instance_statuses")
     public interface CloudInstanceStatuses<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, List<CloudVmInstanceStatus>> post();
     }
 
     @SparkUri(url = SPI_WITH_MOCK_ROOT + "/cloud_metadata_statuses")
     public interface CloudMetadataStatuses<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, List<CloudVmMetaDataStatus>> post();
     }
 
     @SparkUri(url = SPI_WITH_MOCK_ROOT + "/launch")
     public interface Launch<T extends CloudbreakTestDto> extends VerificationEndpoint<T> {
-        DefaultResponseConfigure<T> post();
+        DefaultResponseConfigure<T, List<CloudVmInstanceStatus>> post();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/VerificationEndpoint.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/mock/endpoint/VerificationEndpoint.java
@@ -6,23 +6,23 @@ import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 
 public interface VerificationEndpoint<T extends CloudbreakTestDto> {
 
-    default DefaultResponseConfigure<T> post() {
+    default <R> DefaultResponseConfigure<T, R> post() {
         throw new TestFailException("This endpoint does not support the POST method");
     }
 
-    default DefaultResponseConfigure<T> get() {
+    default <R> DefaultResponseConfigure<T, R> get() {
         throw new TestFailException("This endpoint does not support the GET method");
     }
 
-    default DefaultResponseConfigure<T> head() {
+    default <R> DefaultResponseConfigure<T, R> head() {
         throw new TestFailException("This endpoint does not support the HEAD method");
     }
 
-    default DefaultResponseConfigure<T> put() {
+    default <R> DefaultResponseConfigure<T, R> put() {
         throw new TestFailException("This endpoint does not support the PUT method");
     }
 
-    default DefaultResponseConfigure<T> delete() {
+    default <R> DefaultResponseConfigure<T, R> delete() {
         throw new TestFailException("This endpoint does not support the DELETE method");
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/response/MockResponse.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/response/MockResponse.java
@@ -14,17 +14,20 @@ public class MockResponse {
 
     private int statusCode;
 
-    public MockResponse(Object response, String httpMethod, String path) {
-        this(response, null, httpMethod, path, 0, 200);
+    private String clss;
+
+    public MockResponse(Object response, String httpMethod, String path, String clss) {
+        this(response, null, httpMethod, path, 0, 200, clss);
     }
 
-    public MockResponse(Object response, String message, String httpMethod, String path, int times, int statusCode) {
+    public MockResponse(Object response, String message, String httpMethod, String path, int times, int statusCode, String clss) {
         this.response = response;
         this.message = message;
         this.httpMethod = httpMethod;
         this.path = path;
         this.times = times;
         this.statusCode = statusCode;
+        this.clss = clss;
     }
 
     public String getPath() {
@@ -73,5 +76,13 @@ public class MockResponse {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getClss() {
+        return clss;
+    }
+
+    public void setClss(String clss) {
+        this.clss = clss;
     }
 }

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/spi/MockResponse.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/spi/MockResponse.java
@@ -14,6 +14,8 @@ public class MockResponse {
 
     private int statusCode;
 
+    private String clss;
+
     public String getPath() {
         return path;
     }
@@ -60,5 +62,13 @@ public class MockResponse {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getClss() {
+        return clss;
+    }
+
+    public void setClss(String clss) {
+        this.clss = clss;
     }
 }


### PR DESCRIPTION
…dpoints. If we want to override the response of the mock we can do it type-safe. Now we don't accept the response as Object just the defined result type.

See detailed description in the commit message.