### PR TITLE
CB-10358: Changes to user-data-helper script to support one way TLS between inverting proxy agent and nginx

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl.conf
@@ -1,6 +1,10 @@
 #curl --verbose --key ./key.pem --cert ./cert.pem -k --user "user:password" -H "Accept: application/json" https://104.155.27.67:9443/saltboot/health
 server {
-    listen       9443;
+    {%- if salt['pillar.get']('gateway:enable_ccmv2', 'False') %}
+        listen       localhost:9443;
+    {%- else %}
+        listen       9443;
+    {%- endif %}
 
     client_max_body_size 64M;
     large_client_header_buffers 4 128k;
@@ -9,7 +13,11 @@ server {
     ssl_certificate      /etc/certs/cluster.pem;
     ssl_certificate_key  /etc/certs/cluster-key.pem;
     ssl_client_certificate /etc/certs/cb-client.pem;
-    ssl_verify_client on;
+    {%- if salt['pillar.get']('gateway:enable_ccmv2', 'False') %}
+        ssl_verify_client off;
+    {%- else %}
+        ssl_verify_client on;
+    {%- endif %}
     ssl_protocols TLSv1.2 TLSv1.3;
     include /etc/nginx/sites-enabled/ssl-locations.d/*.conf;
 }


### PR DESCRIPTION
We need to turn off ssl_verify_client in the ssl configuration, and should use localhost:9443.