### PR TITLE
CB-10708 looks like the IT is faling with PKIX error because the mock…

### DIFF
--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -13,7 +13,7 @@ mock:
     address: localhost
 
 integrationtest:
-  threadCount: 8
+  threadCount: 6
   parallel: methods
   timeOut: 6000000
   command: suiteurls


### PR DESCRIPTION
…-infrastructure cannot serve the requests in time. We need to reduce the load on the service. Reduce the thread count from 8 to 6.

See detailed description in the commit message.