### PR TITLE
DISTX-559 DH Autoscaling Periscope Node Allocation.

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ha/LeaderElectionService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ha/LeaderElectionService.java
@@ -112,8 +112,8 @@ public class LeaderElectionService {
                         try {
                             long limit = clock.getCurrentTimeMillis() - heartbeatThresholdRate;
                             List<PeriscopeNode> activeNodes = periscopeNodeRepository.findAllByLastUpdatedIsGreaterThan(limit);
-                            reallocateOrphanClusters(activeNodes);
                             if (!activeNodes.isEmpty()) {
+                                reallocateOrphanClusters(activeNodes);
                                 cleanupInactiveNodesByActiveNodes(activeNodes);
                             }
                         } catch (RuntimeException e) {


### PR DESCRIPTION
Periscope Node has a heart beat service which updates heartbeat in DB every 30 seconds indicating its aliveness.
Also there is a LeaderElectionService which polls active nodes which have updated heart beat in last 60 seconds.
Under certain scenarios when DB is slow or Node is slow and a single Leader heartBeat is delayed, Leader assumes it is not leader even though it is still leader and stops the process of allocating new DH Clusters to one of the periscope node.

Hence code is updated so that allocating new DH clusters is stopped only if active nodes are not empty.

See detailed description in the commit message.