### PR TITLE
CB-10704 transform the CCM connectivity error message to an understan…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/message/StackStatusMessageTransformator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/message/StackStatusMessageTransformator.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.cloudbreak.message;
+
+import static org.apache.commons.lang3.StringUtils.isNoneBlank;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+
+@Component
+public class StackStatusMessageTransformator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackStatusMessageTransformator.class);
+
+    private Map<String, String> statusMessagePatterns;
+
+    @PostConstruct
+    public void init() {
+        try {
+            String file = FileReaderUtils.readFileFromClasspath("messages/stack-status-messages.yaml");
+            statusMessagePatterns = new Yaml().load(file);
+            LOGGER.info("Status messages loaded for stack: {}", statusMessagePatterns);
+        } catch (IOException e) {
+            throw new RuntimeException("Can't load stack status messsages", e);
+        }
+    }
+
+    public String transformMessage(String rawMessage) {
+        String result = rawMessage;
+        if (isNoneBlank(rawMessage)) {
+            Optional<String> patternKey = statusMessagePatterns.keySet().stream().filter(rawMessage::contains).findFirst();
+            if (patternKey.isPresent()) {
+                result = statusMessagePatterns.get(patternKey.get());
+                LOGGER.info("Status message was transformed from '{}' to '{}'", rawMessage, result);
+            }
+        }
+        return result;
+    }
+}

--- a/common/src/main/resources/messages/stack-status-messages.yaml
+++ b/common/src/main/resources/messages/stack-status-messages.yaml
@@ -1,0 +1,1 @@
+'cluster-proxy.ccm.endpoint-unavailable': 'The Control Plane was not able to establish the connection with the gateway instance. This means that the reverse SSH tunnel (autossh process) running on this instance could not connect to the Cloudera server. Please check your connection and proxy settings and make sure the instance can reach *.ccm.cdp.cloudera.com'

--- a/common/src/test/java/com/sequenceiq/cloudbreak/message/StackStatusMessageTransformatorTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/message/StackStatusMessageTransformatorTest.java
@@ -1,0 +1,61 @@
+package com.sequenceiq.cloudbreak.message;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class StackStatusMessageTransformatorTest {
+
+    private StackStatusMessageTransformator underTest;
+
+    @BeforeEach
+    public void init() {
+        underTest = new StackStatusMessageTransformator();
+        underTest.init();
+    }
+
+    @Test
+    void transformMessageWithCCMIssue() {
+        String result = underTest.transformMessage("com.sequenceiq.environment.exception.FreeIpaOperationFailedException: "
+                + "FreeIpa creation operation failed. FreeIpa creation failed. Status: 'CREATE_FAILED' statusReason: 'Status: 502 Bad Gateway Response: "
+                + "{\"status\":502,\"code\":\"cluster-proxy.ccm.endpoint-unavailable\",\"message\":\"Unable to get endpoint from CCM for key "
+                + "(i-0ff60b23ff3845f39, GATEWAY)\"}'");
+
+        String expected = "The Control Plane was not able to establish the connection with the gateway instance. This means that the reverse SSH tunnel "
+                + "(autossh process) running on this instance could not connect to the Cloudera server. Please check your connection and proxy settings and "
+                + "make sure the instance can reach *.ccm.cdp.cloudera.com";
+        Assertions.assertEquals(expected, result);
+    }
+
+    @Test
+    void transformMessageWhenNoPatternFound() {
+        String result = underTest.transformMessage("com.sequenceiq.environment.exception.FreeIpaOperationFailedException: Random error happened");
+
+        String expected = "com.sequenceiq.environment.exception.FreeIpaOperationFailedException: Random error happened";
+        Assertions.assertEquals(expected, result);
+    }
+
+    @Test
+    void transformMessageWithEmptyMessage() {
+        String result = underTest.transformMessage("");
+
+        String expected = "";
+        Assertions.assertEquals(expected, result);
+    }
+
+    @Test
+    void transformMessageWithSpaceMessage() {
+        String result = underTest.transformMessage(" ");
+
+        String expected = " ";
+        Assertions.assertEquals(expected, result);
+    }
+
+    @Test
+    void transformMessageWithNullMessage() {
+        String result = underTest.transformMessage(null);
+
+        String expected = null;
+        Assertions.assertEquals(expected, result);
+    }
+}

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -307,7 +307,7 @@ SaltOrchestrator implements HostOrchestrator {
             saltBootstrapRunner.call();
         } catch (Exception e) {
             LOGGER.info("Error occurred during salt upscale", e);
-            throw new CloudbreakOrchestratorFailedException(e);
+            throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
         }
     }
 
@@ -1118,7 +1118,7 @@ SaltOrchestrator implements HostOrchestrator {
             saltUploadRunner.call();
         } catch (Exception e) {
             LOGGER.info("Error occurred during file distribute to gateway nodes", e);
-            throw new CloudbreakOrchestratorFailedException(e);
+            throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
…dable by the end user

It is a common case when customers launch clusters with CCM enabled and it fails due to different
networking issues. The error message that we prompt back to the user is not really understandable
by them. If developers are looking at the error message they immediatelly know that the customer
has connectivity issues, but it is not trivial to the customers. If we would provide a more clear
message to them where the issue is they might can debug and fix the error themselves.

A typical error message look like this:
com.sequenceiq.environment.exception.FreeIpaOperationFailedException: FreeIpa creation operation failed. FreeIpa creation failed. Status: 'CREATE_FAILED' statusReason: 'Status: 502 Bad Gateway Response: {"status":502,"code":"cluster-proxy.ccm.endpoint-unavailable","message":"Unable to get endpoint from CCM for key (i-nstanceid, GATEWAY)"}'

Not to mention that we also expose Cloudera internal details. This error message is changed as part of this PR to:
The Control Plane was not able to establish the connection with the CM server instance. This means that the reverse SSH tunnel (autossh process) running on the instance could not connect to the Cloudera server. Please check your connection and proxy settings and make sure the instance can reach *.ccm.cdp.cloudera.com'

As part of this PR, the Salt bootstrap phase is also fixed in FreeIPA to make the flow step fail upon
failure and do not ignore it.
