### PR TITLE
CB-10663 Azure PrivateEndpoint Subnet Selection Issue

### DIFF
--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/AzureEnvironmentNetworkValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/network/AzureEnvironmentNetworkValidatorTest.java
@@ -111,8 +111,9 @@ class AzureEnvironmentNetworkValidatorTest {
 
         assertTrue(validationResultBuilder.build().hasError());
         NetworkTestUtils.checkErrorsPresent(validationResultBuilder, List.of(
-                "It is not possible to create private endpoints: existing network with id 'networkId' in resource group 'networkResourceGroupName' " +
-                        "has no subnet with privateEndpointNetworkPolicies disabled."));
+                "It is not possible to create private endpoints for existing network with id 'networkId' in resource group 'networkResourceGroupName': " +
+                        "Azure requires at least one subnet with private endpoint network policies (eg. NSGs) disabled.  Please disable private endpoint " +
+                        "network policies in at least one of the following subnets and retry: 'subnet-one'."));
     }
 
     @Test
@@ -371,6 +372,7 @@ class AzureEnvironmentNetworkValidatorTest {
     private Map<String, CloudSubnet> getCloudSubnets(boolean privateEndpointNetworkPoliciesEnabled) {
         CloudSubnet cloudSubnetOne = new CloudSubnet();
         cloudSubnetOne.putParameter("privateEndpointNetworkPolicies", privateEndpointNetworkPoliciesEnabled ? "enabled" : "disabled");
+        cloudSubnetOne.setName("subnet-one");
         return Map.of("subnet-one", cloudSubnetOne);
     }
 


### PR DESCRIPTION
Validation during environment creation with private endpoint fails if there are no subnet with networkSecurityGroupPolicies disabled. The error message, however, was not clear enough. This commit improves the error message.

See detailed description in the commit message.