### PR TITLE
CB-10265: Fixing the Csd and PreWarmPackage location filter

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CsdLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/CsdLocationFilterTest.java
@@ -71,10 +71,31 @@ public class CsdLocationFilterTest {
     }
 
     @Test
-    public void testFilterImageShouldReturnTrueWhenThereAreNoInstalledParcelInfoAvailable() {
+    public void testFilterImageShouldReturnTrueWhenTheStackRelatedParcelsAreNull() {
         List<String> preWarmCsd = List.of(ARCHIVE_URL);
         Image image = createImage(preWarmCsd);
         assertTrue(underTest.filterImage(image, null, createImageFilterParams(null)));
+    }
+
+    @Test
+    public void testFilterImageShouldReturnTrueWhenTheStackRelatedParcelsAreEmpty() {
+        List<String> preWarmCsd = List.of(ARCHIVE_URL);
+        Image image = createImage(preWarmCsd);
+        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Collections.emptyMap())));
+    }
+
+    @Test
+    public void testFilterImageShouldReturnTrueWhenTheStackRelatedParcelsContainsOnlyTheIgnoredParcel() {
+        List<String> preWarmCsd = List.of(ARCHIVE_URL);
+        Image image = createImage(preWarmCsd);
+        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Map.of("CDH", ""))));
+    }
+
+    @Test
+    public void testFilterImageShouldReturnFalseWhenThereAreNoCsdAvailableForAllRequiresParcels() {
+        List<String> preWarmCsd = List.of(ARCHIVE_URL);
+        Image image = createImage(preWarmCsd);
+        assertFalse(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel1", "", "spark", ""))));
     }
 
     private Image createImage(List<String> preWarmCsd) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/PreWarmParcelLocationFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/PreWarmParcelLocationFilterTest.java
@@ -61,14 +61,14 @@ public class PreWarmParcelLocationFilterTest {
     public void testFilterImageShouldReturnTrueWhenThePreWarmParcelsAreEligibleForUpgrade() {
         List<List<String>> preWarmParcels = List.of(List.of("parcel", ARCHIVE_URL));
         Image image = createImage(preWarmParcels);
-        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel", "", "parcel1", ""))));
+        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel", ""))));
     }
 
     @Test
-    public void testFilterImageShouldReturnTrueWhenThePreWarmParcelsContainsCorruptedAndProperElementAsWell() {
+    public void testFilterImageShouldReturnFalseWhenThePreWarmParcelsContainsCorruptedAndProperElementAsWell() {
         List<List<String>> preWarmParcels = List.of(List.of("parcel1", ARCHIVE_URL), Arrays.asList("parcel2", null));
         Image image = createImage(preWarmParcels);
-        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel1", "", "parcel2", ""))));
+        assertFalse(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel1", "", "parcel2", ""))));
     }
 
     @Test
@@ -93,10 +93,31 @@ public class PreWarmParcelLocationFilterTest {
     }
 
     @Test
+    public void testFilterImageShouldReturnTrueWhenThereAreNoStackRelatedParcels() {
+        List<List<String>> preWarmParcels = List.of(List.of("parcel1", RANDOM_URL), List.of("parcel2", ARCHIVE_URL));
+        Image image = createImage(preWarmParcels);
+        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Collections.emptyMap())));
+    }
+
+    @Test
     public void testFilterImageShouldReturnTrueWhenThereAreNoInstalledParcelInfoAvailable() {
         List<List<String>> preWarmParcels = List.of(List.of("parcel2", ARCHIVE_URL));
         Image image = createImage(preWarmParcels);
         assertTrue(underTest.filterImage(image, null, createImageFilterParams(null)));
+    }
+
+    @Test
+    public void testFilterImageShouldReturnTrueWhenTheStackRelatedParcelsContainsOnlyTheIgnoredParcel() {
+        List<List<String>> preWarmParcels = List.of(List.of("parcel", ARCHIVE_URL));
+        Image image = createImage(preWarmParcels);
+        assertTrue(underTest.filterImage(image, null, createImageFilterParams(Map.of("CDH", ""))));
+    }
+
+    @Test
+    public void testFilterImageShouldReturnFalseWhenThereAreNoPreWarmParcelAvailableForAllRequiresParcels() {
+        List<List<String>> preWarmParcels = List.of(List.of("parcel", ARCHIVE_URL));
+        Image image = createImage(preWarmParcels);
+        assertFalse(underTest.filterImage(image, null, createImageFilterParams(Map.of("parcel", "", "spark", ""))));
     }
 
     private Image createImage(List<List<String>> preWarmParcels) {


### PR DESCRIPTION
CB-10265: Fixing the Csd and PreWarmPackage location filter when the cluster using only the CDH parcels and the stackRelated parcels are empty