### PR TITLE
CB-10731 Load balancer type not being converted correctly in CloudFormationStackUtil

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationStackUtil.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationStackUtil.java
@@ -43,6 +43,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonAutoScalingRetryClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationRetryClient;
 import com.sequenceiq.cloudbreak.cloud.aws.loadbalancer.AwsLoadBalancerScheme;
 import com.sequenceiq.cloudbreak.cloud.aws.loadbalancer.AwsTargetGroup;
+import com.sequenceiq.cloudbreak.cloud.aws.loadbalancer.converter.LoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
@@ -62,6 +63,9 @@ public class CloudFormationStackUtil {
 
     @Inject
     private AwsClient awsClient;
+
+    @Inject
+    private LoadBalancerTypeConverter loadBalancerTypeConverter;
 
     @Retryable(
             value = SdkClientException.class,
@@ -191,7 +195,7 @@ public class CloudFormationStackUtil {
             Set<String> updatedInstanceIds = getInstanceIdsForGroups(resourcesToAdd, entry.getValue());
 
             // Find target group ARN
-            AwsLoadBalancerScheme scheme = AwsLoadBalancerScheme.valueOf(loadBalancer.getType().name());
+            AwsLoadBalancerScheme scheme = loadBalancerTypeConverter.convert(loadBalancer.getType());
             String targetGroupArn = getResourceArnByLogicalId(ac, AwsTargetGroup.getTargetGroupName(entry.getKey(), scheme), region);
 
             // Use ARN to fetch a list of current targets
@@ -229,7 +233,7 @@ public class CloudFormationStackUtil {
             Set<String> instancesToRemove = getInstanceIdsForGroups(resourcesToRemove, entry.getValue());
 
             // Find target group ARN
-            AwsLoadBalancerScheme scheme = AwsLoadBalancerScheme.valueOf(loadBalancer.getType().name());
+            AwsLoadBalancerScheme scheme = loadBalancerTypeConverter.convert(loadBalancer.getType());
             String targetGroupArn = getResourceArnByLogicalId(ac, AwsTargetGroup.getTargetGroupName(entry.getKey(), scheme), region);
 
             // Deregister any instances that no longer exist

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
@@ -37,6 +37,7 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationRetryClient;
 import com.sequenceiq.cloudbreak.cloud.aws.conf.AwsConfig;
+import com.sequenceiq.cloudbreak.cloud.aws.loadbalancer.converter.LoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
@@ -197,7 +198,8 @@ public class AwsValidatorsTest {
             AwsEnvironmentVariableChecker.class,
             RetryService.class,
             AwsStackValidator.class,
-            CloudFormationStackUtil.class
+            CloudFormationStackUtil.class,
+            LoadBalancerTypeConverter.class
     })
     static class Config {
 


### PR DESCRIPTION
Replaces the AwsLoadBalancerScheme.valueOf() conversion with a call to LoadBalancerTypeConverter.convert().