### PR TITLE
Gcp e2e sdx repair

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpStackUtil.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpStackUtil.java
@@ -316,7 +316,6 @@ public final class GcpStackUtil {
                 httpRequest.setReadTimeout(MINUTES * ONE_MINUTE_IN_MILISECOND);
             }
         };
-
     }
 
     public static SQLAdmin buildSQLAdmin(CloudCredential gcpCredential, String name) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/freeipa/FreeIpaTests.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.waitForFlow;
 
 import javax.inject.Inject;
 
@@ -52,10 +53,10 @@ public class FreeIpaTests extends AbstractE2ETest {
                 .when(freeIpaTestClient.start())
                 .await(Status.AVAILABLE)
                 .when(freeIpaTestClient.repair(InstanceMetadataType.GATEWAY_PRIMARY))
-                .await(Status.UPDATE_IN_PROGRESS)
+                .await(Status.UPDATE_IN_PROGRESS, waitForFlow().withWaitForFlow(Boolean.FALSE))
                 .await(FREEIPA_AVAILABLE)
                 .when(freeIpaTestClient.repair(InstanceMetadataType.GATEWAY))
-                .await(Status.UPDATE_IN_PROGRESS)
+                .await(Status.UPDATE_IN_PROGRESS, waitForFlow().withWaitForFlow(Boolean.FALSE))
                 .await(FREEIPA_AVAILABLE)
                 .then((tc, testDto, client) -> freeIpaTestClient.delete().action(tc, testDto, client))
                 .await(FREEIPA_DELETE_COMPLETED)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/InternalSdxRepairWithRecipeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/InternalSdxRepairWithRecipeTest.java
@@ -91,7 +91,7 @@ public class InternalSdxRepairWithRecipeTest extends PreconditionSdxE2ETest {
                 })
                 .awaitForInstance(getSdxInstancesStoppedState())
                 .when(sdxTestClient.repairInternal(), key(sdxInternal))
-                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, key(sdxInternal))
+                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, key(sdxInternal).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
                 .awaitForInstance(getSdxInstancesHealthyState())
                 .then((tc, testDto, client) -> {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
@@ -75,7 +75,7 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                 })
                 .awaitForInstance(getSdxInstancesDeletedOnProviderSideState())
                 .when(sdxTestClient.repair(), key(sdx))
-                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, key(sdx))
+                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, key(sdx).withWaitForFlow(false))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForInstance(getSdxInstancesHealthyState())
                 .then((tc, testDto, client) -> {
@@ -137,7 +137,7 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                 })
                 .awaitForInstance(Map.of(hostGroupType.getName(), InstanceStatus.STOPPED))
                 .when(sdxTestClient.repair(), key(sdx))
-                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, key(sdx))
+                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForInstance(getSdxInstancesHealthyState())
                 .then((tc, testDto, client) -> {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeTests.java
@@ -61,7 +61,7 @@ public class SdxUpgradeTests extends PreconditionSdxE2ETest {
                     return testDto;
                 })
                 .when(sdxTestClient.upgrade(), key(sdx))
-                .await(SdxClusterStatusResponse.DATALAKE_UPGRADE_IN_PROGRESS, key(sdx))
+                .await(SdxClusterStatusResponse.DATALAKE_UPGRADE_IN_PROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForInstance(getSdxInstancesHealthyState())
                 .then((tc, testDto, client) -> {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -51,22 +50,22 @@ public class GcpCloudFunctionality implements CloudFunctionality {
 
     @Override
     public void cloudStorageListContainer(String baseLocation) {
-        throw new NotImplementedException(GCP_IMPLEMENTATION_MISSING);
+        gcpUtil.cloudStorageListContainer(baseLocation);
     }
 
     @Override
     public void cloudStorageListContainerFreeIpa(String baseLocation, String clusterName, String crn) {
-        throw new NotImplementedException(GCP_IMPLEMENTATION_MISSING);
+        gcpUtil.cloudStorageListContainerFreeIpa(baseLocation, clusterName, crn);
     }
 
     @Override
     public void cloudStorageListContainerDataLake(String baseLocation, String clusterName, String crn) {
-        throw new NotImplementedException(GCP_IMPLEMENTATION_MISSING);
+        gcpUtil.cloudStorageListContainerDataLake(baseLocation, clusterName, crn);
     }
 
     @Override
     public void cloudStorageDeleteContainer(String baseLocation) {
-        throw new NotImplementedException(GCP_IMPLEMENTATION_MISSING);
+        gcpUtil.cloudStorageDeleteContainer(baseLocation);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
@@ -7,10 +7,12 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
 import com.sequenceiq.it.cloudbreak.util.gcp.action.GcpClientActions;
 
 @Component
 public class GcpUtil {
+
     @Inject
     private GcpClientActions gcpClientActions;
 
@@ -31,5 +33,31 @@ public class GcpUtil {
 
     public void stopHostGroupInstances(List<String> instanceIds) {
         gcpClientActions.stopHostGroupInstances(instanceIds);
+    }
+
+    public void cloudStorageListContainer(String baseLocation) {
+        listSelectedObject(baseLocation);
+    }
+
+    public void cloudStorageListContainerFreeIpa(String baseLocation, String clusterName, String crn) {
+        listSelectedObject(baseLocation);
+    }
+
+    public void cloudStorageListContainerDataLake(String baseLocation, String clusterName, String crn) {
+        listSelectedObject(baseLocation);
+    }
+
+    public void cloudStorageDeleteContainer(String baseLocation) {
+        String bucketName = GcpStackUtil.getBucketName(baseLocation);
+        gcpClientActions.deleteNonVersionedBucket(bucketName);
+    }
+
+    private void listSelectedObject(String baseLocation) {
+        String bucketName = GcpStackUtil.getBucketName(baseLocation);
+        String objectPath = GcpStackUtil
+                .getPath(baseLocation)
+                .replace(bucketName + "/", "")
+                + "/";
+        gcpClientActions.listBucketSelectedObject(bucketName, objectPath, false);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
@@ -81,6 +81,7 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
                 return true;
             }
             if (waitObject.isCreateFailed()) {
+                LOGGER.info("'{}' the polled resource entered into creation failed state. Exit waiting!", name);
                 return true;
             }
             return waitObject.isFailed();

--- a/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
@@ -6,4 +6,4 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
-#      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests


### PR DESCRIPTION
**Changes:**
 - Enable SDXRepair test on GCP side
 - Fix the validation of volumes on GCP side as only the original attached volumes needs to be re-attached and validated
 - Fix several E2E test case not to use flow based polling for a cluster status causing unhandled test timeouts on E2E engine side