### PR TITLE
CB-10735 Semi-private network entitlement check incorrect

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverter.java
@@ -17,6 +17,7 @@ import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.type.APIResourceType;
 import com.sequenceiq.cloudbreak.domain.Network;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 
 public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetworkConverter {
@@ -48,7 +49,8 @@ public abstract class EnvironmentBaseNetworkConverter implements EnvironmentNetw
         attributes.put("subnetId", cloudSubnet.get().getId());
         attributes.put("cloudPlatform", getCloudPlatform().name());
         attributes.putAll(getAttributesForLegacyNetwork(source));
-        if (entitlementService.publicEndpointAccessGatewayEnabled(ThreadBasedUserCrnProvider.getAccountId())) {
+        if (PublicEndpointAccessGateway.ENABLED.equals(source.getPublicEndpointAccessGateway())
+            && entitlementService.publicEndpointAccessGatewayEnabled(ThreadBasedUserCrnProvider.getAccountId())) {
             Optional<CloudSubnet> endpointGatewaySubnet = subnetSelector.chooseSubnetForEndpointGateway(source, cloudSubnet.get().getId());
             if (endpointGatewaySubnet.isPresent()) {
                 attributes.put("endpointGatewaySubnetId", endpointGatewaySubnet.get().getId());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/EnvironmentBaseNetworkConverterTest.java
@@ -146,6 +146,25 @@ public class EnvironmentBaseNetworkConverterTest extends SubnetTest {
         assertNull(network[0].getAttributes().getValue(ENDPOINT_ID));
     }
 
+    @Test
+    public void testEndpointGatewayIsDisabledd() {
+        CloudSubnet privateSubnet = getCloudSubnet(AZ_1);
+        CloudSubnet publicSubnet = getPublicCloudSubnet(PUBLIC_ID_1, AZ_1);
+        EnvironmentNetworkResponse source = setupResponse();
+        source.setSubnetMetas(Map.of("key", privateSubnet));
+        source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.DISABLED);
+        source.setGatewayEndpointSubnetMetas(Map.of("public-key", publicSubnet));
+
+        when(subnetSelector.chooseSubnet(any(), anyMap(), anyString(), anyBoolean())).thenReturn(Optional.of(privateSubnet));
+
+        Network[] network = new Network[1];
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
+            network[0] = underTest.convertToLegacyNetwork(source, AZ_1);
+        });
+
+        assertNull(network[0].getAttributes().getValue(ENDPOINT_ID));
+    }
+
     private CloudSubnet getCloudSubnet(String availabilityZone) {
         return new CloudSubnet("eu-west-1", "name", availabilityZone, "cidr");
     }


### PR DESCRIPTION
Adds a check in EnvironmentBaseNetworkConverter to only trigger the semi-private
network logic if the feature is enabled for the environment.

Tested with a new unit test.