### PR TITLE
CB-10756 - fix for NPE when one wants to obtain the value of a tag for an empty SdxClusterDetailResponse

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
@@ -33,7 +33,8 @@ public class SdxClusterDetailResponse extends SdxClusterResponse implements Tagg
 
     @Override
     public String getTagValue(String key) {
-        return Optional.ofNullable(stackV4Response.getTags())
+        return Optional.ofNullable(stackV4Response)
+                .map(stack -> stack.getTags())
                 .map(tags -> tags.getTagValue(key))
                 .orElse(null);
     }

--- a/datalake-api/src/test/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponseTest.java
+++ b/datalake-api/src/test/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponseTest.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.sdx.api.model;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+
+class SdxClusterDetailResponseTest {
+
+    private static final String TAG_KEY = "sometthing";
+
+    private SdxClusterDetailResponse underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new SdxClusterDetailResponse();
+    }
+
+    @Test
+    void testWhenInternalStackV4ResponseIsNullAndTheInputKeyIsAlsoNullThenNullShouldReturn() {
+        String result = underTest.getTagValue(null);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testWhenInternalStackV4ResponseIsNullAndTheInputKeyIsNotNullThenNullShouldReturn() {
+        String result = underTest.getTagValue(TAG_KEY);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testWhenInternalStackV4ResponseIsNotNullAndTheInputKeyIsNotNullThenNullShouldReturn() {
+        underTest = new SdxClusterDetailResponse(new SdxClusterDetailResponse(), new StackV4Response());
+        String result = underTest.getTagValue(TAG_KEY);
+
+        assertNull(result);
+    }
+
+    @Test
+    void testWhenInternalStackV4ResponseIsNotNullAndTheInputKeyIsNullThenNullShouldReturn() {
+        underTest = new SdxClusterDetailResponse(new SdxClusterDetailResponse(), new StackV4Response());
+        String result = underTest.getTagValue(null);
+
+        assertNull(result);
+    }
+
+}


### PR DESCRIPTION
fix for NPE when one wants to obtain the value of a tag for an empty SdxClusterDetailResponse