### PR TITLE
ENGESC-6221 Autoscale optimistic locking issue fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,11 @@ ID             Applied At          Description
 
 ------------------------------------------------------------------------
 ```
-
+If you would like to log out all Hibernate-generated queries and show query parameter values as well, add this export to your Profile file, or from the IDE 
+just add the following flag:
+```
+export CB_JAVA_OPTS="-Dperiscope.hibernate.debug=true"
+```
 ## Building
 
 Gradle is used for build and dependency management. Gradle wrapper is added to Cloudbreak git repository, therefore building can be done with:

--- a/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/config/DatabaseConfig.java
@@ -1,16 +1,22 @@
 package com.sequenceiq.periscope.config;
 
+import static ch.qos.logback.classic.Level.TRACE;
+
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
 
+import org.hibernate.type.descriptor.sql.BasicBinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -65,6 +71,18 @@ public class DatabaseConfig {
 
     @Inject
     private PeriscopeNodeConfig periscopeNodeConfig;
+
+    @PostConstruct
+    public void setupQueryParameterLogging() {
+        if (debug) {
+            final Logger logger = LoggerFactory.getLogger(BasicBinder.class.getName());
+            if (!(logger instanceof ch.qos.logback.classic.Logger)) {
+                return;
+            }
+            ch.qos.logback.classic.Logger logbackLogger = (ch.qos.logback.classic.Logger) logger;
+            logbackLogger.setLevel(TRACE);
+        }
+    }
 
     @Bean
     public DataSource dataSource() throws SQLException {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
@@ -136,8 +136,13 @@ public class AutoScaleClusterCommonService {
                 cluster = clusterService.create(cluster, user, ambariStack, PENDING);
             } else {
                 AmbariStack resolvedAmbari = clusterSecurityService.tryResolve(ambari);
-                cluster = clusterId == null ? clusterService.create(cluster, user, resolvedAmbari, RUNNING)
-                        : clusterService.update(clusterId, resolvedAmbari, cluster.isAutoscalingEnabled());
+                if (clusterId == null) {
+                    LOGGER.info("Creating cluster as clusterId is null for user [id: {}]: {}", user.getId(), cluster);
+                    clusterService.create(cluster, user, resolvedAmbari, RUNNING);
+                } else {
+                    LOGGER.info("Updating cluster [id: {}] for user [id: {}]: {}", clusterId, user.getId(), cluster);
+                    clusterService.update(clusterId, resolvedAmbari, cluster.isAutoscalingEnabled());
+                }
             }
             createHistoryAndNotification(cluster);
             return createClusterJsonResponse(cluster);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
@@ -78,7 +78,7 @@ public class Cluster implements Monitored {
 
     private String periscopeNodeId;
 
-    @Column(name = "lastevaulated")
+    @Column(name = "lastevaulated", updatable = false)
     private long lastEvaluated;
 
     public Cluster() {
@@ -261,6 +261,23 @@ public class Cluster implements Monitored {
     public void setLastEvaluated(long lastEvaluated) {
         this.lastEvaluated = lastEvaluated;
     }
+
+    @Override
+    public String toString() {
+        return "Cluster{"
+                + "id=" + id
+                + ", state=" + state
+                + ", minSize=" + minSize
+                + ", maxSize=" + maxSize
+                + ", coolDown=" + coolDown
+                + ", stackId=" + stackId
+                + ", lastScalingActivity=" + lastScalingActivity
+                + ", autoscalingEnabled=" + autoscalingEnabled
+                + ", periscopeNodeId='" + periscopeNodeId + '\''
+                + ", lastEvaluated=" + lastEvaluated
+                + '}';
+    }
+
 }
 
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/model/RejectedThread.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/model/RejectedThread.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.periscope.model;
 
+import java.util.StringJoiner;
+
 import com.sequenceiq.periscope.monitor.Monitored;
 
 public class RejectedThread implements Monitored {
@@ -47,5 +49,14 @@ public class RejectedThread implements Monitored {
     @Override
     public void setLastEvaluated(long lastEvaluated) {
 
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", RejectedThread.class.getSimpleName() + "[", "]")
+                .add("id=" + id)
+                .add("rejectedCount=" + rejectedCount)
+                .add("type='" + type + "'")
+                .toString();
     }
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/AbstractMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/AbstractMonitor.java
@@ -40,11 +40,12 @@ public abstract class AbstractMonitor<M extends Monitored> implements Monitor<M>
                 LOGGER.info("Succesfully submitted {} for cluster {}.", evaluatorExecutor.getName(), evaluatorContext.getData());
                 rejectedThreadService.remove(evaluatorContext.getData());
                 monitored.setLastEvaluated(System.currentTimeMillis());
-                save(monitored);
-            } catch (RejectedExecutionException ignore) {
-
+                updateLastEvaluated(monitored);
+            } catch (RejectedExecutionException e) {
+                LOGGER.warn("Execution rejected", e);
             }
         }
+        LOGGER.info("Job finished: {}, monitored: {}", context.getJobDetail().getKey(), monitoredData.size());
     }
 
     void evalContext(JobExecutionContext context) {
@@ -64,7 +65,7 @@ public abstract class AbstractMonitor<M extends Monitored> implements Monitor<M>
 
     protected abstract List<M> getMonitored();
 
-    protected abstract M save(M monitored);
+    protected abstract void updateLastEvaluated(M monitored);
 
     protected RejectedThreadService getRejectedThreadService() {
         return rejectedThreadService;

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterMonitor.java
@@ -31,8 +31,8 @@ public abstract class ClusterMonitor extends AbstractMonitor<Cluster> {
     }
 
     @Override
-    protected Cluster save(Cluster monitored) {
-        return clusterService.save(monitored);
+    protected void updateLastEvaluated(Cluster monitored) {
+        clusterService.updateLastEvaluated(monitored);
     }
 
     PeriscopeNodeConfig getPeriscopeNodeConfig() {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/RejectedThreadMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/RejectedThreadMonitor.java
@@ -63,8 +63,8 @@ public class RejectedThreadMonitor extends AbstractMonitor<RejectedThread> {
     }
 
     @Override
-    protected RejectedThread save(RejectedThread monitored) {
-        return getRejectedThreadService().save(monitored);
+    protected void updateLastEvaluated(RejectedThread monitored) {
+        getRejectedThreadService().save(monitored);
     }
 
     private int compareRejectedThreadsByCount(RejectedThread o1, RejectedThread o2) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
@@ -42,4 +42,9 @@ public interface ClusterRepository extends BaseRepository<Cluster, Long> {
     @Modifying
     @Query("UPDATE Cluster c SET c.periscopeNodeId = NULL WHERE c.periscopeNodeId = :periscopeNodeId")
     void deallocateClustersOfNode(@Param("periscopeNodeId") String periscopeNodeId);
+
+    @Modifying
+    @Query("UPDATE Cluster c SET c.lastEvaluated = :lastEvaluated WHERE c.id = :id")
+    void updateLastEvaluated(@Param("id") long id, @Param("lastEvaluated") long lastEvaluated);
+
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -17,6 +17,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.service.TransactionService;
+import com.sequenceiq.cloudbreak.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.periscope.api.model.ClusterState;
 import com.sequenceiq.periscope.api.model.ScalingConfigurationRequest;
 import com.sequenceiq.periscope.domain.Ambari;
@@ -57,6 +59,9 @@ public class ClusterService {
 
     @Inject
     private FailedNodeRepository failedNodeRepository;
+
+    @Inject
+    private TransactionService transactionService;
 
     public Cluster create(PeriscopeUser user, AmbariStack stack, ClusterState clusterState) {
         return create(new Cluster(), user, stack, clusterState);
@@ -128,6 +133,21 @@ public class ClusterService {
         return clusterRepository.save(cluster);
     }
 
+    public void updateLastEvaluated(Cluster cluster) {
+        try {
+            transactionService.required(() -> {
+                LOGGER.debug("Updating last evaluated for cluster (id: {}) with value {}",
+                        cluster.getId(), cluster.getLastEvaluated());
+                clusterRepository.updateLastEvaluated(cluster.getId(), cluster.getLastEvaluated());
+                LOGGER.debug("Update last evaluated for cluster (id: {}) with value {} finished successfully",
+                        cluster.getId(), cluster.getLastEvaluated());
+                return null;
+            });
+        } catch (TransactionExecutionException e) {
+            LOGGER.error("Unable to set lastEvaluated column", e);
+        }
+    }
+
     public Cluster findById(Long clusterId) {
         return clusterRepository.findById(clusterId).orElseThrow(notFound("Cluster", clusterId));
     }
@@ -141,11 +161,18 @@ public class ClusterService {
     }
 
     public Cluster updateScalingConfiguration(Long clusterId, ScalingConfigurationRequest scalingConfiguration) {
+        LOGGER.info("Update scaling configuration operation has been triggered for cluster with id {} "
+                        + "- min: {}, max: {}, coolDown: {}", clusterId, scalingConfiguration.getMinSize(),
+                scalingConfiguration.getMaxSize(), scalingConfiguration.getCoolDown());
         Cluster cluster = findById(clusterId);
         cluster.setMinSize(scalingConfiguration.getMinSize());
         cluster.setMaxSize(scalingConfiguration.getMaxSize());
         cluster.setCoolDown(scalingConfiguration.getCoolDown());
-        return save(cluster);
+        save(cluster);
+        LOGGER.info("Update scaling configuration operation has been finished for cluster with id {} "
+                        + "- min: {}, max: {}, coolDown: {}", clusterId, scalingConfiguration.getMinSize(),
+                scalingConfiguration.getMaxSize(), scalingConfiguration.getCoolDown());
+        return cluster;
     }
 
     public ScalingConfigurationRequest getScalingConfiguration(Long clusterId) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/RejectedThreadService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/RejectedThreadService.java
@@ -24,6 +24,7 @@ public class RejectedThreadService {
     private final Map<Long, RejectedThread> rejectedThreads = new ConcurrentHashMap<>();
 
     public RejectedThread save(RejectedThread rejectedThread) {
+        LOGGER.warn("Thread was rejected: {}", rejectedThread);
         rejectedThreads.put(rejectedThread.getId(), rejectedThread);
         return rejectedThread;
     }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ScalingService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ScalingService.java
@@ -30,19 +30,20 @@ public class ScalingService {
         ScalingPolicy scalingPolicy = policyRepository.save(policy);
         alert.setScalingPolicy(scalingPolicy);
         alertService.save(alert);
-        LOGGER.info("Scaling policiy [name: {}] was created for cluster [id: {}] attached to the alert [id: {}, name: {}]: {}",
+        LOGGER.info("Scaling policy [name: {}] was created for cluster [id: {}] attached to the alert [id: {}, name: {}]: {}",
                 scalingPolicy.getName(), clusterId, alertId, alert.getName(), scalingPolicy);
         return scalingPolicy;
     }
 
     public ScalingPolicy updatePolicy(Long clusterId, Long policyId, ScalingPolicy scalingPolicy) {
+        LOGGER.info("Updating scaling policy [id: {}] operation has been triggered for cluster [id: {}]", policyId, clusterId);
         ScalingPolicy policy = getScalingPolicy(clusterId, policyId);
         policy.setName(scalingPolicy.getName());
         policy.setHostGroup(scalingPolicy.getHostGroup());
         policy.setAdjustmentType(scalingPolicy.getAdjustmentType());
         policy.setScalingAdjustment(scalingPolicy.getScalingAdjustment());
         policy = policyRepository.save(policy);
-        LOGGER.info("Scaling policiy [name: {}] was updated for cluster [id: {}] attached to the alert [id: {}, name: {}]: {}",
+        LOGGER.info("Scaling policy [name: {}] was updated for cluster [id: {}] attached to the alert [id: {}, name: {}]: {}",
                 scalingPolicy.getName(), clusterId, policy.getAlertId(), policy.getAlert().getName(), scalingPolicy);
         return policy;
     }
@@ -54,7 +55,7 @@ public class ScalingService {
         policy.setAlert(null);
         policyRepository.delete(policy);
         alertService.save(alert);
-        LOGGER.info("Scaling policiy [name: {}] was deleted for cluster [id: {}] and detached from the alert [id: {}, name: {}]: {}",
+        LOGGER.info("Scaling policy [name: {}] was deleted for cluster [id: {}] and detached from the alert [id: {}, name: {}]: {}",
                 policy.getName(), clusterId, alert.getId(), alert.getName(), policy);
     }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/StackCollectorService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/StackCollectorService.java
@@ -57,8 +57,8 @@ public class StackCollectorService {
                                 executorServiceWithRegistry.submitIfAbsent(clusterCreationEvaluator, stack.getStackId());
                                 LOGGER.info("Succesfully submitted, the stack id: {}.", stack.getStackId());
                                 rejectedThreadService.remove(stack);
-                            } catch (RejectedExecutionException ignore) {
-
+                            } catch (RejectedExecutionException e) {
+                                LOGGER.warn("Execution rejected", e);
                             }
                         } else {
                             LOGGER.info("Could not find Ambari for stack: {} (ID:{})", stack.getName(), stack.getStackId());

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/security/ClusterSecurityService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/security/ClusterSecurityService.java
@@ -2,6 +2,8 @@ package com.sequenceiq.periscope.service.security;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.model.AmbariAddressJson;
@@ -16,6 +18,8 @@ import com.sequenceiq.periscope.model.AmbariStack;
 @Service
 public class ClusterSecurityService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterSecurityService.class);
+
     @Inject
     private CloudbreakClient cloudbreakClient;
 
@@ -25,9 +29,10 @@ public class ClusterSecurityService {
     public boolean hasAccess(PeriscopeUser user, Ambari ambari, Long stackId) {
         try {
             return hasAccess(user.getId(), user.getAccount(), ambari.getHost(), stackId);
-        } catch (RuntimeException ignored) {
+        } catch (RuntimeException e) {
             // if the cluster is unknown for cloudbreak
             // it should allow it to monitor
+            LOGGER.debug("hasAccess request failed, falling back to 'true'", e);
             return true;
         }
     }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/security/TlsSecurityService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/security/TlsSecurityService.java
@@ -4,6 +4,8 @@ package com.sequenceiq.periscope.service.security;
 import javax.inject.Inject;
 
 import org.bouncycastle.util.encoders.Base64;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +18,8 @@ import com.sequenceiq.periscope.repository.SecurityConfigRepository;
 
 @Service
 public class TlsSecurityService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TlsSecurityService.class);
 
     @Inject
     private CloudbreakClient cloudbreakClient;
@@ -46,7 +50,8 @@ public class TlsSecurityService {
     private SecurityConfig getSecurityConfigSilently(Cluster cluster) {
         try {
             return securityConfigRepository.findByClusterId(cluster.getId());
-        } catch (AccessDeniedException ignore) {
+        } catch (AccessDeniedException e) {
+            LOGGER.warn("Access is denied during securityConfigRepository.findByClusterId call", e);
             return null;
         }
     }

--- a/autoscale/src/main/resources/logback.xml
+++ b/autoscale/src/main/resources/logback.xml
@@ -35,7 +35,7 @@
         </sift>
     </appender>
 
-    <root level="${PERISCOPE_LOG_LEVEL:-INFO}">
+    <root level="INFO">
         <appender-ref ref="PERISCOPE_NODEID_BASED"/>
         <appender-ref ref="STDOUT"/>
     </root>

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/AbstractMonitorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/AbstractMonitorTest.java
@@ -110,8 +110,7 @@ public class AbstractMonitorTest {
             }
 
             @Override
-            protected Monitored save(Monitored monitored) {
-                return null;
+            protected void updateLastEvaluated(Monitored monitored) {
             }
 
             @Override


### PR DESCRIPTION
The issue was that scheduled Monitoring tasks were updating the records in
the Cluster table without real locking. This caused updates from Cloudbreak UI
to be overwritten peridically, rendering the autoscale feature practically
unusable.
The solution was updating only the lastEvaluated column in the Monitoring tasks.
Added extra logging and modified debug flag to print out Hibernate-generated SQL
and bound parameter values.