### PR TITLE
CB-10747 remove the CM license log message when we decorate the Salt …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -472,7 +472,6 @@ public class ClusterHostServiceRunner {
         Optional<String> licenseOpt = Optional.ofNullable(account.getClouderaManagerLicenseKey());
         if (licenseOpt.isPresent() && isNotEmpty(licenseOpt.get())) {
             String license = licenseOpt.get();
-            LOGGER.debug("Got license key from UMS: {}", license);
             servicePillar.put("cloudera-manager-license",
                     new SaltPillarProperties("/cloudera-manager/license.sls",
                             singletonMap("cloudera-manager",


### PR DESCRIPTION
…pillars

When we started to integrate with archive.cloudera.com we introduced a message
that would show the used CM license so we can check it is properly used. This
log message is no necessary and it exposes the customers' licenses as well.

