### PR TITLE
CB-10504. Make environment cloud storage logging environment telemetr…

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
@@ -159,6 +159,11 @@ public class EnvironmentModificationService {
                     LOGGER.debug("Updating workload analytics (environment telemetry feature): {}.",
                             features.getWorkloadAnalytics().isEnabled());
                 }
+                if (features.getCloudStorageLogging() != null) {
+                    actualFeatures.setCloudStorageLogging(features.getCloudStorageLogging());
+                    LOGGER.debug("Updating cloud storage logging (environment telemetry feature): {}.",
+                            features.getCloudStorageLogging().isEnabled());
+                }
                 telemetry.setFeatures(actualFeatures);
                 // required to re-set as telemetry is saved as a JSON string
                 environment.setTelemetry(telemetry);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentModificationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentModificationServiceTest.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.cloudbreak.util.TestConstants.CRN;
 import static com.sequenceiq.common.model.CredentialType.ENVIRONMENT;
 import static com.sequenceiq.environment.environment.service.EnvironmentTestData.ENVIRONMENT_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -565,6 +566,7 @@ class EnvironmentModificationServiceTest {
         String accountId = "myAccountId";
         String envCrn = "myEnvCrn";
         EnvironmentFeatures featuresInput = new EnvironmentFeatures();
+        featuresInput.addCloudStorageLogging(false);
         featuresInput.addClusterLogsCollection(true);
         Environment environment = new Environment();
         environment.setTelemetry(new EnvironmentTelemetry());
@@ -576,6 +578,7 @@ class EnvironmentModificationServiceTest {
         environmentModificationServiceUnderTest.changeTelemetryFeaturesByEnvironmentCrn(accountId, envCrn, featuresInput);
 
         verify(environmentService).save(any());
+        assertFalse(environment.getTelemetry().getFeatures().getCloudStorageLogging().isEnabled());
         assertTrue(environment.getTelemetry().getFeatures().getClusterLogsCollection().isEnabled());
     }
 


### PR DESCRIPTION
…y feature editable

details:
- aat the moment, cloud storage logging telemetry feature only can be enabled by accoutn telemetry not by environment level telemetry

See detailed description in the commit message.