### PR TITLE
CB-10788. Enhance flow service to be able to query flow state by flow type.

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
@@ -39,6 +39,9 @@ public interface FlowLogRepository extends CrudRepository<FlowLog, Long> {
     @Query("SELECT fl FROM FlowLog fl WHERE fl.cloudbreakNodeId IS NULL AND fl.stateStatus = 'PENDING'")
     Set<FlowLog> findAllUnassigned();
 
+    @Query("SELECT fl FROM FlowLog fl WHERE fl.flowType = :flowType AND fl.resourceId = :resourceId ORDER BY fl.created DESC")
+    List<FlowLog> findAllFlowByType(@Param("resourceId") Long resourceId, @Param("flowType") Class<?> clazz);
+
     @Query("SELECT fl.flowId FROM FlowLog fl WHERE fl.flowChainId IN (:chainIds)")
     Set<String> findAllFlowIdsByChainIds(@Param("chainIds") Set<String> chainIds);
 

--- a/flow/src/main/java/com/sequenceiq/flow/service/FlowService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/FlowService.java
@@ -25,6 +25,7 @@ import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.flow.api.model.FlowCheckResponse;
 import com.sequenceiq.flow.api.model.FlowLogResponse;
 import com.sequenceiq.flow.core.FlowConstants;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.domain.FlowChainLog;
 import com.sequenceiq.flow.domain.FlowLog;
 import com.sequenceiq.flow.domain.StateStatus;
@@ -82,6 +83,13 @@ public class FlowService {
         checkState(Crn.isCrn(resourceCrn));
         LOGGER.info("Getting flow logs by resource crn {}", resourceCrn);
         List<FlowLog> flowLogs = flowLogDBService.getFlowLogsByResourceCrnOrName(resourceCrn);
+        return flowLogs.stream().map(flowLog -> conversionService.convert(flowLog, FlowLogResponse.class)).collect(Collectors.toList());
+    }
+
+    public <T extends AbstractFlowConfiguration> List<FlowLogResponse> getFlowLogsByCrnAndType(String resourceCrn, Class<T> clazz) {
+        checkState(Crn.isCrn(resourceCrn));
+        LOGGER.info("Getting flow logs by resource crn {} and type {}", resourceCrn, clazz.getCanonicalName());
+        List<FlowLog> flowLogs = flowLogDBService.getFlowLogsByCrnAndType(resourceCrn, clazz);
         return flowLogs.stream().map(flowLog -> conversionService.convert(flowLog, FlowLogResponse.class)).collect(Collectors.toList());
     }
 

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
@@ -33,6 +33,7 @@ import com.sequenceiq.flow.core.FlowLogService;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.ResourceIdProvider;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.domain.FlowChainLog;
 import com.sequenceiq.flow.domain.FlowLog;
 import com.sequenceiq.flow.domain.FlowLogIdWithTypeAndTimestamp;
@@ -279,6 +280,11 @@ public class FlowLogDBService implements FlowLogService {
         LOGGER.debug("Checking if there is a pending flowEvent based on these flowLogs {}", Joiner.on(",")
                 .join(flowLogs.stream().map(flowLog -> flowLog.minimizedString()).collect(Collectors.toList())));
         return flowLogs.stream().anyMatch(pendingFlowLogPredicate());
+    }
+
+    public <T extends AbstractFlowConfiguration> List<FlowLog> getFlowLogsByCrnAndType(String resourceCrn, Class<T> clazz) {
+        Long resourceId = getResourceIdByCrnOrName(resourceCrn);
+        return flowLogRepository.findAllFlowByType(resourceId, clazz);
     }
 
     public Predicate<FlowLog> pendingFlowLogPredicate() {


### PR DESCRIPTION
detaails:
- Long term: provide different endpoints for diagnostics to follow progress of flows without providing the ids
- at first step, that can be done to query flows by type (only for flow logs for now, can be done for flow chains later)

See detailed description in the commit message.