### PR TITLE
ENGESC-6221 Autoscale optimistic locking issue second fix

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -10,7 +10,6 @@ Cloudbreak uses [Semantic Version numbers](http://semver.org):
 - `pre-release` is a postfix that signals whether the artifact was built locally, or if it is a development or a release candidate.
 - `build-metadata` is only used in locally built artifacts and contains the git hash of the latest commit. 
 
-
 ### Example 1: Local development versions
 
 Local development should be done on feature branches, branched from `master`. Locally built artifacts will have a version like this:

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
@@ -70,7 +70,7 @@ public class Cluster implements Monitored {
     @Column(name = "cb_stack_id")
     private Long stackId;
 
-    @Column(name = "last_scaling_activity")
+    @Column(name = "last_scaling_activity", updatable = false)
     private volatile long lastScalingActivity;
 
     @Column(name = "autoscaling_enabled")

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ScalingHandlerUtil.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ScalingHandlerUtil.java
@@ -51,7 +51,7 @@ public class ScalingHandlerUtil {
         if (totalNodes != desiredNodeCount) {
             LOGGER.info("{} cluster id will be scaled up with {} policy", cluster.getId(), policy.getName());
             cluster.setLastScalingActivityCurrent();
-            clusterService.save(cluster);
+            clusterService.updateLastScalingActivity(cluster);
             scale(cluster, policy);
         } else {
             LOGGER.info("No scaling activity required for '{}' policy", policy.getName());

--- a/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/repository/ClusterRepository.java
@@ -44,7 +44,10 @@ public interface ClusterRepository extends BaseRepository<Cluster, Long> {
     void deallocateClustersOfNode(@Param("periscopeNodeId") String periscopeNodeId);
 
     @Modifying
-    @Query("UPDATE Cluster c SET c.lastEvaluated = :lastEvaluated WHERE c.id = :id")
-    void updateLastEvaluated(@Param("id") long id, @Param("lastEvaluated") long lastEvaluated);
+    @Query("UPDATE Cluster c SET c.lastEvaluated = :lastEvaluated WHERE c.id = :clusterId")
+    void updateLastEvaluated(@Param("clusterId") long clusterId, @Param("lastEvaluated") long lastEvaluated);
 
+    @Modifying
+    @Query("UPDATE Cluster c SET c.lastScalingActivity = :lastScalingActivity WHERE c.id = :clusterId")
+    void updateClusterLastScalingActivity(@Param("clusterId") long clusterId, @Param("lastScalingActivity") long lastScalingActivity);
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -148,6 +148,21 @@ public class ClusterService {
         }
     }
 
+    public void updateLastScalingActivity(Cluster cluster) {
+        try {
+            transactionService.required(() -> {
+                LOGGER.debug("Updating last scaling activity timestamp for cluster (id: {}) with value {}",
+                        cluster.getId(), cluster.getLastScalingActivity());
+                clusterRepository.updateClusterLastScalingActivity(cluster.getId(), cluster.getLastScalingActivity());
+                LOGGER.debug("Update last scaling activity timestamp for cluster (id: {}) with value {} finished successfully",
+                        cluster.getId(), cluster.getLastScalingActivity());
+                return null;
+            });
+        } catch (TransactionExecutionException e) {
+            LOGGER.error("Unable to set lastScalingActivity column", e);
+        }
+    }
+
     public Cluster findById(Long clusterId) {
         return clusterRepository.findById(clusterId).orElseThrow(notFound("Cluster", clusterId));
     }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/ScalingHandlerUtilTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/ScalingHandlerUtilTest.java
@@ -131,7 +131,7 @@ public class ScalingHandlerUtilTest {
         when(autoscaleEndpoint.getHostMetadataCountForAutoscale(10L, "hg")).thenReturn(1L);
         when(applicationContext.getBean("ScalingRequest", cluster, policy, 1, 2)).thenReturn(runnable);
         underTest.scaleIfNeed(cluster, alert);
-        verify(clusterService, times(1)).save(cluster);
+        verify(clusterService, times(1)).updateLastScalingActivity(cluster);
         verify(loggedExecutorService, times(1)).submit("ScalingHandler", runnable);
     }
 


### PR DESCRIPTION
Similar fix to the ClusterMonitor fix earlier but this time the
scaling handler had to be modified, instead of saving the whole Cluster record
only the lastScalingActivity column is updated.