### PR TITLE
CB-10813. Handle/interrupt CM deployClientConfig timeout during upsca…

### DIFF
--- a/autoscale/src/main/resources/application.yml
+++ b/autoscale/src/main/resources/application.yml
@@ -64,6 +64,8 @@ cb:
       connect.timeout.seconds: 245
       read.timeout.seconds: 245
       write.timeout.seconds: 245
+      commands:
+        deployClientConfig.interrupt.timeout.seconds: 120
 
 rest:
   debug: false

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDeployClientConfigProvider.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDeployClientConfigProvider.java
@@ -1,0 +1,261 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.cloudera.api.swagger.ClustersResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.client.ApiResponse;
+import com.cloudera.api.swagger.client.Pair;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiCommandList;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import com.sequenceiq.cloudbreak.cm.model.CommandResource;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.squareup.okhttp.HttpUrl;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
+
+@Service
+public class ClouderaManagerDeployClientConfigProvider {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(ClouderaManagerDeployClientConfigProvider.class);
+
+    private static final String CMF_COMMANDS_COMMAND_TABLE_URI_PATH = "/cmf/commands/commandTable";
+
+    private static final String DEPLOY_CLIENT_CONFIG_COMMAND_NAME = "DeployClusterClientConfig";
+
+    private static final int INTERVAL_MINUTES = 30;
+
+    private static final int ERROR_CODES_FROM = 400;
+
+    private final Integer interruptTimeoutSeconds;
+
+    public ClouderaManagerDeployClientConfigProvider(
+            @Value("${cb.cm.client.commands.deployClientConfig.interrupt.timeout.seconds:}") Integer interruptTimeoutSeconds) {
+        this.interruptTimeoutSeconds = interruptTimeoutSeconds;
+    }
+
+    /**
+     * Obtain deploy cluster client config command ID with different strategies:
+     * - first run deployClusterClientConfig command on CM, if it returns successfully,
+     *   get the command ID of the command.
+     * - if deployClusterClientConfig CM command times out, use listActiveCommands against
+     *   CM API and find the command ID from that response.
+     * - if listActiveCommands is empty (in case of the command finishes during the
+     *   deployClusterClientConfig timeout), use /cmf/commands/commandTable call (with the
+     *   response cookie of listActiveCommands call)
+     */
+    public BigDecimal deployClientConfigAndGetCommandId(
+            ClustersResourceApi api, Stack stack) throws CloudbreakException, ApiException {
+        ExecutorService executor = createExecutor();
+        Future<BigDecimal> future = executor.submit(() -> {
+            ApiCommand deployCommand = api.deployClientConfig(stack.getName());
+            return deployCommand.getId();
+        });
+        try {
+            return future.get(interruptTimeoutSeconds, TimeUnit.SECONDS);
+        } catch (TimeoutException timeoutException) {
+            LOGGER.debug("Deploy client config command took too much time. Start command ID "
+                    + "query by listing active commands");
+            ApiResponse<ApiCommandList> commandListResponse =
+                    api.listActiveCommandsWithHttpInfo(stack.getName(), null);
+            BigDecimal commandIdFromActiveCommands = getCommandIdFromActiveCommands(commandListResponse);
+            if (commandIdFromActiveCommands != null) {
+                return commandIdFromActiveCommands;
+            }
+            LOGGER.debug("The last deploy client config command could not be found  "
+                    + "by listing active commands. Trying {} call", CMF_COMMANDS_COMMAND_TABLE_URI_PATH);
+            BigDecimal commandIdFromCommandsTable = getCommandIdFromCommandsTable(api, commandListResponse.getHeaders());
+            if (commandIdFromCommandsTable != null) {
+                return commandIdFromCommandsTable;
+            } else {
+                throw new CloudbreakException(
+                        String.format("Obtaining Cloudera Manager Deploy config command ID was not possible neither by"
+                                + " listing Cloudera Manager commands nor using commandTable [stack: %s]", stack.getName()));
+            }
+        } catch (ExecutionException ee) {
+            throw new ApiException(ee.getCause());
+        } catch (InterruptedException e) {
+            throw new CloudbreakException(
+                    "Obtaining Cloudera Manager Deploy config command ID interrupted", e);
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @VisibleForTesting
+    BigDecimal getCommandIdFromActiveCommands(ApiResponse<ApiCommandList> response) {
+        BigDecimal result = null;
+        if (response.getStatusCode() >= ERROR_CODES_FROM) {
+            return result;
+        }
+        ApiCommandList commandList = response.getData();
+        List<ApiCommand> commands = commandList.getItems();
+        long currentStartTime = Long.MIN_VALUE;
+        for (ApiCommand command : commands) {
+            if (command.getParent() == null && command.getStartTime() != null
+                    && DEPLOY_CLIENT_CONFIG_COMMAND_NAME.equals(command.getName())) {
+                long startTime = new DateTime(command.getStartTime())
+                        .toDate().toInstant().toEpochMilli();
+                if (startTime > currentStartTime) {
+                    LOGGER.debug("Found latest DeployClusterClientConfig command " +
+                            "with [command_id: {}, starTime: {}] by active commands]",
+                            command.getId(), command.getStartTime());
+                    currentStartTime = startTime;
+                    result = command.getId();
+                }
+            }
+        }
+        return result;
+    }
+
+    @VisibleForTesting
+    BigDecimal getCommandIdFromCommandsTable(ClustersResourceApi api,
+            Map<String, List<String>> headers) throws CloudbreakException, ApiException {
+        try {
+            OkHttpClient httpClient = api.getApiClient().getHttpClient();
+            Request request = createRequest(api.getApiClient(), headers);
+            Response response = httpClient
+                    .newCall(request)
+                    .execute();
+            if (response.code() >= ERROR_CODES_FROM) {
+                LOGGER.debug("{} request against Cloudera Manager API returned with status code: {}, response: {}",
+                        CMF_COMMANDS_COMMAND_TABLE_URI_PATH, response.toString(), response.code());
+                throw new CloudbreakException(
+                        String.format("%s request against CM API returned with status code: %d",
+                                CMF_COMMANDS_COMMAND_TABLE_URI_PATH, response.code()));
+            }
+            return getCommandIdFromCMResponse(response);
+        } catch (IOException e) {
+            throw new CloudbreakException(
+                    String.format("DeployClusterClientConfig - error during processing %s CM request",
+                            CMF_COMMANDS_COMMAND_TABLE_URI_PATH), e);
+        }
+    }
+
+    private BigDecimal getCommandIdFromCMResponse(Response response) throws IOException {
+        BigDecimal result = null;
+        try (ResponseBody responseBody = response.body()) {
+            String responseBodyStr = responseBody.string();
+            LOGGER.debug("Start processing commandTable response: {}", responseBodyStr);
+            List<CommandResource> commandList =
+                    new ObjectMapper().readValue(responseBodyStr, new TypeReference<>() {
+                    });
+            LOGGER.debug("Processing commandTable were successful.");
+            long currentStartTime = Long.MIN_VALUE;
+            for (CommandResource command : commandList) {
+                if (DEPLOY_CLIENT_CONFIG_COMMAND_NAME.equals(command.getName())) {
+                    LOGGER.debug("Found DeployClusterClientConfig command based on "
+                                    + "{} response [command_id: {}]", CMF_COMMANDS_COMMAND_TABLE_URI_PATH,
+                            command.getId());
+                    long startTime = command.getStart();
+                    if (startTime > currentStartTime) {
+                        LOGGER.debug("Found latest DeployClusterClientConfig command " +
+                                "with [command_id: {}, start: {}] by commandTable call",
+                                command.getId(), command.getStart());
+                        currentStartTime = startTime;
+                        result = new BigDecimal(command.getId());
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    // similar as apiClient#Call creator methods - so keep this in one place
+    private Request createRequest(ApiClient apiClient, Map<String, List<String>> headers)
+            throws ApiException {
+        List<Pair> queryParams = new ArrayList<>();
+        Map<String, String> headerParams = new HashMap<>();
+        String[] localVarAccepts = new String[]{"application/json"};
+        String localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            headerParams.put("Accept", localVarAccept);
+        }
+        String[] localVarContentTypes = new String[0];
+        String localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+        headerParams.put("Content-Type", localVarContentType);
+        String[] authNames = new String[]{"basic"};
+        enhanceRequestParams(headers, queryParams, headerParams);
+        Request defaultRequest = apiClient.buildRequest(CMF_COMMANDS_COMMAND_TABLE_URI_PATH, "GET", queryParams, null,
+                headerParams, new HashMap<>(), authNames, null);
+        return createRequestFromDefaultRequest(defaultRequest);
+    }
+
+    private Request createRequestFromDefaultRequest(Request defaultRequest) {
+        HttpUrl defaultHttpUrl = defaultRequest.httpUrl();
+        HttpUrl.Builder httpUrlBuilder = new HttpUrl.Builder()
+                .username(defaultHttpUrl.username())
+                .password(defaultHttpUrl.password())
+                .host(defaultHttpUrl.host())
+                .scheme(defaultHttpUrl.scheme())
+                .port(defaultHttpUrl.port());
+        List<String> pathSegments = Splitter.on("/")
+                .splitToList(CMF_COMMANDS_COMMAND_TABLE_URI_PATH.substring(1));
+        for (String pathSegment : pathSegments) {
+            httpUrlBuilder.addPathSegment(pathSegment);
+        }
+        for (String queryParamName : defaultHttpUrl.queryParameterNames()) {
+            httpUrlBuilder.addQueryParameter(queryParamName, defaultHttpUrl.queryParameter(queryParamName));
+        }
+        return new Request.Builder()
+                .headers(defaultRequest.headers())
+                .url(httpUrlBuilder.build())
+                .cacheControl(defaultRequest.cacheControl())
+                .tag(defaultRequest.tag())
+                .get()
+                .build();
+    }
+
+    /**
+     * Extends request that is created based on the ApiClient endpoint implementations
+     * with default query params + Cookie header from listActiveCommands call.
+     * Example query: /cmf/commands/commandTable?limit=501&startTime=1234&endTime1235
+     */
+    private void enhanceRequestParams(Map<String, List<String>> headers, List<Pair> queryParams, Map<String, String> headerParams) {
+        queryParams.add(new Pair("limit", "501"));
+        long startTime = new DateTime()
+                .minusMinutes(INTERVAL_MINUTES)
+                .toDate().toInstant().toEpochMilli();
+        long endTime = new DateTime()
+                .plusMinutes(INTERVAL_MINUTES)
+                .toDate().toInstant().toEpochMilli();
+        queryParams.add(new Pair("startTime", Long.toString(startTime)));
+        queryParams.add(new Pair("endTime", Long.toString(endTime)));
+        if (headers.containsKey("Set-Cookie")) {
+            LOGGER.debug("Copying Set-Cookie header from listActiveCommands "
+                    + "to commandTable request (as Cookie header)");
+            headerParams.put("Cookie", headers.get("Set-Cookie").get(0));
+        }
+    }
+
+    @VisibleForTesting
+    ExecutorService createExecutor() {
+        return Executors.newSingleThreadExecutor();
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosService.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.cm;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_1_0;
 
+import java.math.BigDecimal;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -49,6 +51,9 @@ public class ClouderaManagerKerberosService {
     @Inject
     private ClouderaManagerConfigService clouderaManagerConfigService;
 
+    @Inject
+    private ClouderaManagerDeployClientConfigProvider clouderaManagerDeployClientConfigProvider;
+
     public void configureKerberosViaApi(ApiClient client, HttpClientConfig clientConfig, Stack stack, KerberosConfig kerberosConfig)
             throws ApiException, CloudbreakException {
         Cluster cluster = stack.getCluster();
@@ -61,8 +66,9 @@ public class ClouderaManagerKerberosService {
             clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, configureForKerberos.getId());
             ApiCommand generateCredentials = clouderaManagerResourceApi.generateCredentialsCommand();
             clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, generateCredentials.getId());
-            ApiCommand deployClusterConfig = clustersResourceApi.deployClientConfig(cluster.getName());
-            clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, deployClusterConfig.getId());
+            BigDecimal deployClientConfigCommandId = clouderaManagerDeployClientConfigProvider
+                    .deployClientConfigAndGetCommandId(clustersResourceApi, stack);
+            clouderaManagerPollingServiceProvider.startPollingCmKerberosJob(stack, client, deployClientConfigCommandId);
             modificationService.startCluster();
         }
     }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/model/CommandResource.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/model/CommandResource.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.cloudbreak.cm.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CommandResource {
+
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("start")
+    private Long start;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Long getStart() {
+        return start;
+    }
+
+    public void setStart(Long start) {
+        this.start = start;
+    }
+}

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDeployClientConfigProviderTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDeployClientConfigProviderTest.java
@@ -1,0 +1,335 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.api.swagger.ClustersResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.client.ApiResponse;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiCommandList;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.squareup.okhttp.Call;
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Protocol;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import com.squareup.okhttp.ResponseBody;
+
+@ExtendWith(MockitoExtension.class)
+public class ClouderaManagerDeployClientConfigProviderTest {
+
+    private static final int INTERRUPT_TIMEOUT_SECONDS = 120;
+
+    private static final int SUCCESS_STATUS_CODE = 200;
+
+    private static final int NOT_FOUND_STATUS_CODE = 404;
+
+    @Mock
+    private ClustersResourceApi clustersResourceApi;
+
+    @Mock
+    private ExecutorService executorService;
+
+    @Mock
+    private Future<BigDecimal> future;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private OkHttpClient okHttpClient;
+
+    @Mock
+    private Call requestCall;
+
+    private ClouderaManagerDeployClientConfigProvider underTest;
+
+    private Stack stack;
+
+    private final Map<String, List<String>> emptyHeaders = new HashMap<>();
+
+    @BeforeEach
+    public void setUp() {
+        underTest = Mockito.spy(new ClouderaManagerDeployClientConfigProvider(INTERRUPT_TIMEOUT_SECONDS));
+        stack = new Stack();
+        stack.setName("mycluster");
+    }
+
+    @Test
+    public void testGetDeployClientConfigCommandId() throws ApiException, CloudbreakException {
+        // GIVEN
+        given(clustersResourceApi.deployClientConfig(stack.getName())).willReturn(createCommand());
+        // WHEN
+        BigDecimal result = underTest.deployClientConfigAndGetCommandId(clustersResourceApi, stack);
+        // THEN
+        assertEquals(7L, result.longValue());
+    }
+
+    @Test
+    public void testGetDeployClientConfigCommandIdApiException() throws ApiException, CloudbreakException {
+        // GIVEN
+        given(clustersResourceApi.deployClientConfig(stack.getName())).willThrow(new ApiException("my exc"));
+        // WHEN
+        ApiException executionException = assertThrows(ApiException.class,
+                () -> underTest.deployClientConfigAndGetCommandId(clustersResourceApi, stack)
+        );
+        // THEN
+        assertTrue(executionException.getMessage().contains("my exc"));
+    }
+
+    @Test
+    public void testGetDeployClientConfigCommandIdNullAnswers()
+            throws ApiException, CloudbreakException, InterruptedException,
+            ExecutionException, TimeoutException {
+        // GIVEN
+        ApiResponse<ApiCommandList> response = createApiCommandListResponse();
+        doReturn(executorService).when(underTest).createExecutor();
+        given(executorService.submit(any(Callable.class))).willReturn(future);
+        given(future.get(INTERRUPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)).willThrow(new TimeoutException());
+        given(clustersResourceApi.listActiveCommandsWithHttpInfo(anyString(), isNull()))
+                .willReturn(response);
+        doReturn(null).when(underTest).getCommandIdFromActiveCommands(response);
+        doReturn(null).when(underTest).getCommandIdFromCommandsTable(clustersResourceApi, emptyHeaders);
+        given(underTest.getCommandIdFromActiveCommands(response)).willReturn(null);
+        // WHEN
+        CloudbreakException exception = assertThrows(CloudbreakException.class,
+                () -> underTest.deployClientConfigAndGetCommandId(clustersResourceApi, stack));
+        // THEN
+        assertTrue(exception.getMessage().contains("Obtaining Cloudera Manager Deploy config command ID was not possible"));
+        verify(underTest, times(1)).getCommandIdFromActiveCommands(response);
+        verify(underTest, times(1)).getCommandIdFromCommandsTable(clustersResourceApi, emptyHeaders);
+        verify(executorService, times(1)).shutdown();
+    }
+
+    @Test
+    public void testGetDeployClientConfigCommandIdByListCommands()
+            throws ApiException, CloudbreakException, InterruptedException, ExecutionException, TimeoutException {
+        // GIVEN
+        doReturn(executorService).when(underTest).createExecutor();
+        given(executorService.submit(any(Callable.class))).willReturn(future);
+        given(future.get(INTERRUPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)).willThrow(new TimeoutException());
+        given(clustersResourceApi.listActiveCommandsWithHttpInfo(anyString(), isNull()))
+                .willReturn(createApiCommandListResponse());
+        // WHEN
+        BigDecimal result = underTest.deployClientConfigAndGetCommandId(clustersResourceApi, stack);
+        // THEN
+        assertEquals(5L, result.longValue());
+        verify(executorService, times(1)).shutdown();
+    }
+
+    @Test
+    public void testGetDeployClientConfigCommandIdByListCommandsApiException()
+            throws ApiException, InterruptedException, ExecutionException, TimeoutException {
+        // GIVEN
+        doReturn(executorService).when(underTest).createExecutor();
+        given(executorService.submit(any(Callable.class))).willReturn(future);
+        given(future.get(INTERRUPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)).willThrow(new TimeoutException());
+        given(clustersResourceApi.listActiveCommandsWithHttpInfo(anyString(), isNull()))
+                .willThrow(new ApiException("my exc"));
+        // WHEN
+        ApiException apiException = assertThrows(ApiException.class,
+                () -> underTest.deployClientConfigAndGetCommandId(clustersResourceApi, stack)
+        );
+        // THEN
+        assertTrue(apiException.getMessage().contains("my exc"));
+        verify(executorService, times(1)).shutdown();
+    }
+
+    @Test
+    public void testGetDeployClientConfigCommandIdByCommandTable()
+            throws ApiException, CloudbreakException, InterruptedException,
+            ExecutionException, TimeoutException, IOException {
+        // GIVEN
+        Map<String, List<String>> headers = new HashMap<>();
+        List<String> headerList = new ArrayList<>();
+        headerList.add("mycookie");
+        headers.put("Set-Cookie", headerList);
+        Request request = createDefaultRequest();
+        doReturn(executorService).when(underTest).createExecutor();
+        given(executorService.submit(any(Callable.class))).willReturn(future);
+        given(future.get(INTERRUPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)).willThrow(new TimeoutException());
+        given(clustersResourceApi.listActiveCommandsWithHttpInfo(anyString(), isNull()))
+                .willReturn(new ApiResponse<>(SUCCESS_STATUS_CODE, headers,
+                        new ApiCommandList().items(new ArrayList<>())));
+        given(clustersResourceApi.getApiClient()).willReturn(apiClient);
+        given(apiClient.getHttpClient()).willReturn(okHttpClient);
+        given(apiClient.buildRequest(any(), any(), any(), isNull(),
+                any(), any(), any(), isNull())).willReturn(request);
+        given(okHttpClient.newCall(any())).willReturn(requestCall);
+        given(requestCall.execute()).willReturn(
+                createResponse(SUCCESS_STATUS_CODE, createResponseDefaultString(), request));
+        // WHEN
+        BigDecimal result = underTest.deployClientConfigAndGetCommandId(clustersResourceApi, stack);
+        // THEN
+        assertEquals(3L, result.longValue());
+        verify(executorService, times(1)).shutdown();
+    }
+
+    @Test
+    public void testGetDeployClientConfigCommandIdByCommandTableWithListCommands()
+            throws ApiException, CloudbreakException, InterruptedException,
+            ExecutionException, TimeoutException, IOException {
+        // GIVEN
+        Request request = createDefaultRequest();
+        doReturn(executorService).when(underTest).createExecutor();
+        given(executorService.submit(any(Callable.class))).willReturn(future);
+        given(future.get(INTERRUPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)).willThrow(new TimeoutException());
+        given(clustersResourceApi.listActiveCommandsWithHttpInfo(anyString(), isNull()))
+                .willReturn(createApiCommandListResponse(NOT_FOUND_STATUS_CODE));
+        given(clustersResourceApi.getApiClient()).willReturn(apiClient);
+        given(apiClient.getHttpClient()).willReturn(okHttpClient);
+        given(apiClient.buildRequest(any(), any(), any(), isNull(),
+                any(), any(), any(), isNull())).willReturn(request);
+        given(okHttpClient.newCall(any())).willReturn(requestCall);
+        given(requestCall.execute()).willReturn(
+                createResponse(SUCCESS_STATUS_CODE, createResponseDefaultString(), request));
+        // WHEN
+        BigDecimal result = underTest.deployClientConfigAndGetCommandId(clustersResourceApi, stack);
+        // THEN
+        assertEquals(3L, result.longValue());
+        verify(executorService, times(1)).shutdown();
+    }
+
+    @Test
+    public void testGetDeployClientConfigCommandIdByCommandTableNotFound()
+            throws ApiException, InterruptedException, ExecutionException,
+            TimeoutException, IOException {
+        // GIVEN
+        Request request = createDefaultRequest();
+        doReturn(executorService).when(underTest).createExecutor();
+        given(executorService.submit(any(Callable.class))).willReturn(future);
+        given(future.get(INTERRUPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)).willThrow(new TimeoutException());
+        given(clustersResourceApi.listActiveCommandsWithHttpInfo(anyString(), isNull()))
+                .willReturn(createApiCommandListResponse(NOT_FOUND_STATUS_CODE));
+        given(clustersResourceApi.getApiClient()).willReturn(apiClient);
+        given(apiClient.getHttpClient()).willReturn(okHttpClient);
+        given(apiClient.buildRequest(any(), any(), any(), isNull(),
+                any(), any(), any(), isNull())).willReturn(request);
+        given(okHttpClient.newCall(any())).willReturn(requestCall);
+        given(requestCall.execute()).willReturn(
+                createResponse(NOT_FOUND_STATUS_CODE, createResponseDefaultString(), request));
+        // WHEN
+        CloudbreakException exception = assertThrows(CloudbreakException.class,
+                () -> underTest.deployClientConfigAndGetCommandId(clustersResourceApi, stack));
+        // THEN
+        assertTrue(exception.getMessage().contains("returned with status code: 404"));
+        verify(executorService, times(1)).shutdown();
+    }
+
+    @Test
+    public void testGetDeployClientConfigCommandIdByCommandTableInvalidResponse()
+            throws ApiException, InterruptedException, ExecutionException,
+            TimeoutException, IOException {
+        // GIVEN
+        Request request = createDefaultRequest();
+        doReturn(executorService).when(underTest).createExecutor();
+        given(executorService.submit(any(Callable.class))).willReturn(future);
+        given(future.get(INTERRUPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)).willThrow(new TimeoutException());
+        given(clustersResourceApi.listActiveCommandsWithHttpInfo(anyString(), isNull()))
+                .willReturn(createApiCommandListResponse(NOT_FOUND_STATUS_CODE));
+        given(clustersResourceApi.getApiClient()).willReturn(apiClient);
+        given(apiClient.getHttpClient()).willReturn(okHttpClient);
+        given(apiClient.buildRequest(any(), any(), any(), isNull(),
+                any(), any(), any(), isNull())).willReturn(request);
+        given(okHttpClient.newCall(any())).willReturn(requestCall);
+        given(requestCall.execute()).willReturn(
+                createResponse(SUCCESS_STATUS_CODE, "invalid", request));
+        // WHEN
+        CloudbreakException exception = assertThrows(CloudbreakException.class,
+                () -> underTest.deployClientConfigAndGetCommandId(clustersResourceApi, stack));
+        // THEN
+        assertTrue(exception.getMessage().contains("error during processing"));
+        verify(executorService, times(1)).shutdown();
+    }
+
+    private ApiCommand createCommand() {
+        ApiCommand command = new ApiCommand();
+        command.setId(new BigDecimal(7L));
+        return command;
+    }
+
+    private ApiResponse<ApiCommandList> createApiCommandListResponse() {
+        return createApiCommandListResponse(SUCCESS_STATUS_CODE);
+    }
+
+    private ApiResponse<ApiCommandList> createApiCommandListResponse(int statusCode) {
+        ApiCommandList commandList = new ApiCommandList();
+        ApiCommand command1 = new ApiCommand();
+        command1.setId(new BigDecimal(4L));
+        command1.setName("DeployClusterClientConfig");
+        command1.setStartTime(new DateTime(2000, 1, 1, 1, 1, 1).toString());
+        ApiCommand command2 = new ApiCommand();
+        command2.setId(new BigDecimal(5L));
+        command2.setName("DeployClusterClientConfig");
+        command2.setStartTime(new DateTime(2000, 1, 1, 1, 1, 2).toString());
+        ApiCommand command3 = new ApiCommand();
+        command3.setId(new BigDecimal(6L));
+        command3.setName("RestartServices");
+        command3.setStartTime(new DateTime(2000, 1, 1, 1, 1, 3).toString());
+        commandList.addItemsItem(command1);
+        commandList.addItemsItem(command2);
+        commandList.addItemsItem(command3);
+        return new ApiResponse<>(statusCode, emptyHeaders, commandList);
+    }
+
+    private Request createDefaultRequest() {
+        return new Request.Builder()
+                .url("https://localhost:9443/api/v1/cmf/commands/commandTable")
+                .get()
+                .build();
+    }
+
+    private Response createResponse(int statusCode, String body, Request request) {
+        return new Response.Builder()
+                .code(statusCode)
+                .request(request)
+                .body(createResponseBody(body))
+                .protocol(Protocol.HTTP_2)
+                .build();
+    }
+
+    private ResponseBody createResponseBody(String bodyString) {
+        return ResponseBody
+                .create(MediaType.parse("application/json"), bodyString);
+    }
+
+    private String createResponseDefaultString() {
+        return "[{\"id\": 1,\"name\": \"DeployClusterClientConfig\",\"start\": 1611513499011}, "
+                + "{\"id\": 2,\"name\": \"RestartServices\",\"start\": 1611513499013}, "
+                + "{\"id\": 3,\"name\": \"DeployClusterClientConfig\",\"start\": 1611513499021}]";
+    }
+
+}

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerKerberosServiceTest.java
@@ -71,6 +71,9 @@ public class ClouderaManagerKerberosServiceTest {
     @Mock
     private ClouderaManagerConfigService clouderaManagerConfigService;
 
+    @Mock
+    private ClouderaManagerDeployClientConfigProvider clouderaManagerDeployClientConfigProvider;
+
     @InjectMocks
     private ClouderaManagerKerberosService underTest;
 
@@ -112,7 +115,7 @@ public class ClouderaManagerKerberosServiceTest {
         when(clustersResourceApi.configureForKerberos(eq(cluster.getName()), any(ApiConfigureForKerberosArguments.class)))
                 .thenReturn(new ApiCommand().id(BigDecimal.TEN));
         when(clouderaManagerResourceApi.generateCredentialsCommand()).thenReturn(new ApiCommand().id(BigDecimal.ZERO));
-        when(clustersResourceApi.deployClientConfig(cluster.getName())).thenReturn(new ApiCommand().id(BigDecimal.valueOf(2L)));
+        when(clouderaManagerDeployClientConfigProvider.deployClientConfigAndGetCommandId(any(), any())).thenReturn(BigDecimal.valueOf(2L));
         when(kerberosDetailService.isAdJoinable(kerberosConfig)).thenReturn(Boolean.TRUE);
 
         underTest.configureKerberosViaApi(client, clientConfig, stack, kerberosConfig);
@@ -120,7 +123,7 @@ public class ClouderaManagerKerberosServiceTest {
         verify(modificationService).stopCluster(false);
         verify(clouderaManagerPollingServiceProvider).startPollingCmKerberosJob(stack, client, BigDecimal.TEN);
         verify(clouderaManagerPollingServiceProvider).startPollingCmKerberosJob(stack, client, BigDecimal.ZERO);
-        verify(clustersResourceApi).deployClientConfig(cluster.getName());
+        verify(clouderaManagerDeployClientConfigProvider).deployClientConfigAndGetCommandId(any(), any());
         verify(modificationService).startCluster();
     }
 

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
@@ -151,6 +151,9 @@ class ClouderaManagerModificationServiceTest {
     @Mock
     private PollingResultErrorHandler pollingResultErrorHandler;
 
+    @Mock
+    private ClouderaManagerDeployClientConfigProvider clouderaManagerDeployClientConfigProvider;
+
     private Cluster cluster;
 
     private HostGroup hostGroup;
@@ -383,7 +386,7 @@ class ClouderaManagerModificationServiceTest {
 
         when(servicesResourceApi.readServices(stack.getName(), "SUMMARY")).thenReturn(apiServiceList);
         when(clustersResourceApi.listActiveCommands(stack.getName(), "SUMMARY")).thenReturn(apiCommandList);
-        when(clustersResourceApi.deployClientConfig(stack.getName())).thenReturn(new ApiCommand().id(apiCommandId));
+        when(clouderaManagerDeployClientConfigProvider.deployClientConfigAndGetCommandId(clustersResourceApi, stack)).thenReturn(apiCommandId);
         when(clustersResourceApi.refresh(stack.getName())).thenReturn(new ApiCommand().id(apiCommandId));
         when(clouderaManagerPollingServiceProvider.startPollingCmClientConfigDeployment(stack, apiClientMock, apiCommandId))
                 .thenReturn(successPollingResult);
@@ -400,11 +403,11 @@ class ClouderaManagerModificationServiceTest {
         verify(clouderaManagerParcelManagementService, times(2)).distributeParcels(any(), eq(parcelResourceApi), eq(stack), eq(apiClientMock));
         verify(clouderaManagerUpgradeService, times(1)).callUpgradeCdhCommand(TestUtil.CDH_VERSION, clustersResourceApi, stack, apiClientMock);
         verify(clouderaManagerParcelManagementService).activateParcels(any(), eq(parcelResourceApi), eq(stack), eq(apiClientMock));
-        verify(clustersResourceApi, times(1)).deployClientConfig(stack.getName());
+        verify(clouderaManagerDeployClientConfigProvider, times(1)).deployClientConfigAndGetCommandId(clustersResourceApi, stack);
         verify(clustersResourceApi, times(1)).refresh(stack.getName());
 
         InOrder inOrder = Mockito.inOrder(clouderaManagerPollingServiceProvider, clouderaManagerParcelManagementService, clouderaManagerUpgradeService,
-                clustersResourceApi);
+                clustersResourceApi, clouderaManagerDeployClientConfigProvider);
         inOrder.verify(clouderaManagerPollingServiceProvider).startPollingCmStartup(stack, apiClientMock);
         inOrder.verify(clouderaManagerParcelManagementService).checkParcelApiAvailability(stack, apiClientMock);
         inOrder.verify(clouderaManagerParcelManagementService).setParcelRepos(any(), eq(clouderaManagerResourceApi));
@@ -413,7 +416,7 @@ class ClouderaManagerModificationServiceTest {
         inOrder.verify(clouderaManagerParcelManagementService).distributeParcels(any(), eq(parcelResourceApi), eq(stack), eq(apiClientMock));
         inOrder.verify(clouderaManagerParcelManagementService).activateParcels(any(), eq(parcelResourceApi), eq(stack), eq(apiClientMock));
         inOrder.verify(clouderaManagerUpgradeService).callUpgradeCdhCommand(TestUtil.CDH_VERSION, clustersResourceApi, stack, apiClientMock);
-        inOrder.verify(clustersResourceApi).deployClientConfig(stack.getName());
+        inOrder.verify(clouderaManagerDeployClientConfigProvider).deployClientConfigAndGetCommandId(clustersResourceApi, stack);
         inOrder.verify(clustersResourceApi).refresh(stack.getName());
     }
 
@@ -446,7 +449,7 @@ class ClouderaManagerModificationServiceTest {
         String expectedMessage = "Cluster was terminated while waiting for config deploy";
         when(clouderaManagerPollingServiceProvider.startPollingCmClientConfigDeployment(any(), any(), any())).thenReturn(pollingResult);
         doThrow(new CancellationException(expectedMessage)).when(pollingResultErrorHandler).handlePollingResult(eq(pollingResult), any(), any());
-        CancellationException actual = assertThrows(CancellationException.class, () -> underTest.pollDeployConfig(apiCommand));
+        CancellationException actual = assertThrows(CancellationException.class, () -> underTest.pollDeployConfig(apiCommand.getId()));
         assertEquals(expectedMessage, actual.getMessage());
     }
 
@@ -457,7 +460,7 @@ class ClouderaManagerModificationServiceTest {
         when(clouderaManagerPollingServiceProvider.startPollingCmClientConfigDeployment(any(), any(), any())).thenReturn(pollingResult);
         String expectedMessage = "Timeout while Cloudera Manager was config deploying services.";
         doThrow(new CloudbreakException(expectedMessage)).when(pollingResultErrorHandler).handlePollingResult(eq(pollingResult), any(), any());
-        CloudbreakException actual = assertThrows(CloudbreakException.class, () -> underTest.pollDeployConfig(apiCommand));
+        CloudbreakException actual = assertThrows(CloudbreakException.class, () -> underTest.pollDeployConfig(apiCommand.getId()));
         assertEquals(expectedMessage, actual.getMessage());
     }
 
@@ -541,9 +544,9 @@ class ClouderaManagerModificationServiceTest {
         when(clouderaManagerApiFactory.getHostsResourceApi(eq(apiClientMock))).thenReturn(hostResourceApi);
     }
 
-    private void setUpDeployClientConfigPolling(PollingResult success) throws ApiException {
+    private void setUpDeployClientConfigPolling(PollingResult success) throws ApiException, CloudbreakException {
         BigDecimal deployClientCommandId = new BigDecimal(100);
-        when(clustersResourceApi.deployClientConfig(eq(STACK_NAME))).thenReturn(new ApiCommand().id(deployClientCommandId));
+        when(clouderaManagerDeployClientConfigProvider.deployClientConfigAndGetCommandId(clustersResourceApi, stack)).thenReturn(deployClientCommandId);
 
         when(clouderaManagerPollingServiceProvider.startPollingCmClientConfigDeployment(eq(stack), eq(apiClientMock), eq(deployClientCommandId)))
                 .thenReturn(success);

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -540,6 +540,8 @@ cb:
       connect.timeout.seconds: 245
       read.timeout.seconds: 245
       write.timeout.seconds: 245
+      commands:
+        deployClientConfig.interrupt.timeout.seconds: 120
 
   workspace.service.cache.ttl: 15
 

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -129,6 +129,8 @@ cb:
       connect.timeout.seconds: 245
       read.timeout.seconds: 245
       write.timeout.seconds: 245
+      commands:
+        deployClientConfig.timeout.interrupt.seconds: 120
 
 notification:
   urls: http://localhost:3000/notifications


### PR DESCRIPTION
…le/downscale

details:
Until deployClientConfig call on CM side is not async (only partly, that means it starts running the deployClientConfig commands but the API call itself is not returning and times out...it's mostly around 3.5 min but can take 12 mins etc.)
Implementation:
- Interrupt deployClientConfig http call on CB side
- we need to know the commandId -> next step is try out listing the active commands in CM
- if active commands will be empty (could happen if it finishes around that 5 sec), try to use /cmf/commands/commandTable call (based on the UI), that contains all commands, which returns a JSON (by setting the right cookie from the list active commands api command)
- set the timeout for the interrupt -> 120 sec, as ~130 sec is the timeout for the cluster proxy, so do the interrupt before that times out (that one is the lowest at the moment)
- also handle invalid or not found responses + added UTs

See detailed description in the commit message.