### PR TITLE
CB-10766 Handle multiple subnet with same id in FMS NetworkService

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudNetwork.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudNetwork.java
@@ -12,7 +12,7 @@ public class CloudNetwork {
 
     private String id;
 
-    private Set<CloudSubnet> subnets;
+    private final Set<CloudSubnet> subnets;
 
     private Map<String, Object> properties;
 
@@ -40,7 +40,7 @@ public class CloudNetwork {
     }
 
     public Map<String, String> getSubnets() {
-        return subnets.stream().collect(Collectors.toMap(s -> s.getId(), s -> s.getName()));
+        return subnets.stream().collect(Collectors.toMap(CloudSubnet::getId, CloudSubnet::getName));
     }
 
     public Map<String, CloudSubnet> getSubnetsWithMetadata() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.freeipa.service.freeipa.config;
 
-import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -10,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
+import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.dto.ProxyConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
@@ -51,7 +51,7 @@ public class FreeIpaConfigService {
         final FreeIpaConfigView.Builder builder = new FreeIpaConfigView.Builder();
 
         FreeIpa freeIpa = freeIpaService.findByStack(stack);
-        Map<String, String> subnetWithCidr = networkService.getFilteredSubnetWithCidr(stack);
+        Multimap<String, String> subnetWithCidr = networkService.getFilteredSubnetWithCidr(stack);
         LOGGER.debug("Subnets for reverse zone calculation : {}", subnetWithCidr);
         String reverseZones = reverseDnsZoneCalculator.reverseDnsZoneForCidrs(subnetWithCidr.values());
         LOGGER.debug("Reverse zones : {}", reverseZones);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/NetworkService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/NetworkService.java
@@ -2,11 +2,9 @@ package com.sequenceiq.freeipa.service.stack;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -15,6 +13,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import com.sequenceiq.cloudbreak.cloud.model.CloudNetworks;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
@@ -43,7 +44,7 @@ public class NetworkService {
     @Inject
     private Map<CloudPlatform, NetworkFilterProvider> networkFilterProviderMap;
 
-    public Map<String, String> getFilteredSubnetWithCidr(Stack stack) {
+    public Multimap<String, String> getFilteredSubnetWithCidr(Stack stack) {
         Map<String, Object> attributes = stack.getNetwork().getAttributes().getMap();
         String networkId = (String) attributes.getOrDefault("networkId", attributes.get("vpcId"));
         String subnetId = (String) attributes.get("subnetId");
@@ -52,32 +53,54 @@ public class NetworkService {
         return getFilteredSubnetWithCidr(stack.getEnvironmentCrn(), stack, networkId, Set.of(subnetId));
     }
 
-    public Map<String, String> getFilteredSubnetWithCidr(String environmentCrn, Stack stack, String networkId, Collection<String> subnetIds) {
-        Credential credential = credentialService.getCredentialByEnvCrn(environmentCrn);
-        ExtendedCloudCredential cloudCredential = extendedCloudCredentialConverter.convert(credential);
-        Map<String, String> filter = getFilter(stack, networkId, subnetIds);
-        CloudNetworks cloudNetworks =
-                cloudParameterService.getCloudNetworks(cloudCredential, stack.getRegion(), stack.getPlatformvariant(), filter);
-        LOGGER.debug("Received Cloud networks for region [{}]: {}", stack.getRegion(), cloudNetworks.getCloudNetworkResponses().get(stack.getRegion()));
-        return cloudNetworks.getCloudNetworkResponses().getOrDefault(stack.getRegion(), Collections.emptySet()).stream()
-                .filter(cloudNetwork -> {
-                    // support for azure
-                    String[] splittedNetworkId = cloudNetwork.getId().split("/");
-                    String cloudNetworkId = splittedNetworkId[splittedNetworkId.length - 1];
-                    return networkId.equals(cloudNetworkId) || networkId.equals(cloudNetwork.getName());
-                })
+    public Multimap<String, String> getFilteredSubnetWithCidr(String environmentCrn, Stack stack, String networkId, Collection<String> subnetIds) {
+        LOGGER.debug("NetworkId: [{}] SubnetIds: {}", networkId, subnetIds);
+        CloudNetworks cloudNetworks = fetchCloudNetworks(environmentCrn, stack, networkId, subnetIds);
+        ArrayListMultimap<String, String> filteredSubnetsWithCidr = filterNetworkResponse(stack, networkId, subnetIds, cloudNetworks);
+        LOGGER.debug("Filtering result: {}", filteredSubnetsWithCidr);
+        return filteredSubnetsWithCidr;
+    }
+
+    private ArrayListMultimap<String, String> filterNetworkResponse(Stack stack, String networkId, Collection<String> subnetIds, CloudNetworks cloudNetworks) {
+        return cloudNetworks.getCloudNetworkResponses()
+                .getOrDefault(stack.getRegion(), Collections.emptySet()).stream()
+                .filter(cloudNetwork -> filterNetwork(networkId, cloudNetwork))
+                .peek(cloudNetwork -> LOGGER.debug("CloudNetwork passed filtering name: [{}] id: [{}]", cloudNetwork.getName(), cloudNetwork.getId()))
                 .flatMap(cloudNetwork -> cloudNetwork.getSubnetsMeta().stream())
                 .filter(cloudSubnet -> StringUtils.isNoneBlank(cloudSubnet.getId(), cloudSubnet.getCidr()))
                 .filter(cloudSubnet -> subnetIds.contains(cloudSubnet.getId()) || subnetIds.contains(cloudSubnet.getName()))
-                .collect(Collectors.toMap(CloudSubnet::getId, CloudSubnet::getCidr));
+                .collect(Multimaps.toMultimap(CloudSubnet::getId, CloudSubnet::getCidr, ArrayListMultimap::create));
     }
 
-    public Map<String, String> getFilter(Stack stack, String networkId, Collection<String> subnetIds) {
-        Map<String, String> filter = new HashMap<>();
+    private CloudNetworks fetchCloudNetworks(String environmentCrn, Stack stack, String networkId, Collection<String> subnetIds) {
+        Credential credential = credentialService.getCredentialByEnvCrn(environmentCrn);
+        ExtendedCloudCredential cloudCredential = extendedCloudCredentialConverter.convert(credential);
+        Map<String, String> filter = getCloudNetworkFilter(stack, networkId, subnetIds);
+        CloudNetworks cloudNetworks = cloudParameterService.getCloudNetworks(cloudCredential, stack.getRegion(), stack.getPlatformvariant(), filter);
+        LOGGER.debug("Received Cloud networks for region [{}]: {}", stack.getRegion(), cloudNetworks.getCloudNetworkResponses().get(stack.getRegion()));
+        return cloudNetworks;
+    }
+
+    private boolean filterNetwork(String networkId, com.sequenceiq.cloudbreak.cloud.model.CloudNetwork cloudNetwork) {
+        String cloudNetworkId = transformAzureNetworkId(cloudNetwork);
+        return networkId.equals(cloudNetworkId) || networkId.equals(cloudNetwork.getName());
+    }
+
+    private String transformAzureNetworkId(com.sequenceiq.cloudbreak.cloud.model.CloudNetwork cloudNetwork) {
+        String[] splittedNetworkId = cloudNetwork.getId().split("/");
+        return splittedNetworkId[splittedNetworkId.length - 1];
+    }
+
+    private Map<String, String> getCloudNetworkFilter(Stack stack, String networkId, Collection<String> subnetIds) {
         NetworkFilterProvider networkFilterProvider = networkFilterProviderMap.get(CloudPlatform.valueOf(stack.getCloudPlatform()));
-        if (networkFilterProvider != null) {
-            filter = networkFilterProvider.provide(stack.getNetwork(), networkId, subnetIds);
+        if (networkFilterProvider == null) {
+            LOGGER.debug("networkFilterProvider is null for [{}]", stack.getCloudPlatform());
+            return Map.of();
+        } else {
+            LOGGER.debug("NetworkFilterProvider found for [{}]", stack.getCloudPlatform());
+            Map<String, String> networkFilter = networkFilterProvider.provide(stack.getNetwork(), networkId, subnetIds);
+            LOGGER.debug("NetworkFilter: {}", networkFilter);
+            return networkFilter;
         }
-        return filter;
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/NetworkServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/NetworkServiceTest.java
@@ -1,0 +1,127 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.common.collect.Multimap;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudNetwork;
+import com.sequenceiq.cloudbreak.cloud.model.CloudNetworks;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.cloud.model.ExtendedCloudCredential;
+import com.sequenceiq.cloudbreak.cloud.service.CloudParameterService;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.freeipa.converter.cloud.CredentialToExtendedCloudCredentialConverter;
+import com.sequenceiq.freeipa.dto.Credential;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.CredentialService;
+import com.sequenceiq.freeipa.service.filter.NetworkFilterProvider;
+
+@ExtendWith(MockitoExtension.class)
+class NetworkServiceTest {
+
+    public static final String ENV_CRN = "ENV_CRN";
+
+    public static final String NETWORK_ID = "networkId";
+
+    public static final String SUBNET_1 = "subnet1";
+
+    public static final String SUBNET_2 = "subnet2";
+
+    public static final String REGION = "region";
+
+    public static final String PLATFORM = "AWS";
+
+    @Mock
+    private CloudParameterService cloudParameterService;
+
+    @Mock
+    private CredentialService credentialService;
+
+    @Mock
+    private CredentialToExtendedCloudCredentialConverter extendedCloudCredentialConverter;
+
+    @Mock
+    private Map<CloudPlatform, NetworkFilterProvider> networkFilterProviderMap;
+
+    @InjectMocks
+    private NetworkService underTest;
+
+    @Test
+    public void testFiltering() {
+        Stack stack = new Stack();
+        stack.setCloudPlatform(PLATFORM);
+        stack.setRegion(REGION);
+        stack.setPlatformvariant(PLATFORM);
+        Credential credential = new Credential(PLATFORM, "", "", "");
+        ExtendedCloudCredential extendedCred = new ExtendedCloudCredential(new CloudCredential(), PLATFORM, "", "", "");
+        CloudSubnet subnet1 = new CloudSubnet(SUBNET_1, SUBNET_1, "", "10.1.0.0/24");
+        CloudSubnet subnet2 = new CloudSubnet(SUBNET_2, SUBNET_2, "", "10.1.1.0/24");
+        CloudSubnet subnet3 = new CloudSubnet("indifferent", "indifferent", "", "10.1.2.0/24");
+        CloudNetwork cloudNetwork1 = new CloudNetwork(NETWORK_ID, NETWORK_ID, Set.of(subnet1, subnet2, subnet3), Map.of());
+        CloudNetwork cloudNetwork2 = new CloudNetwork("other", "other",
+                Set.of(new CloudSubnet(SUBNET_1, SUBNET_1), new CloudSubnet("test", "test")), Map.of());
+        Map<String, Set<CloudNetwork>> cloudNets = Map.of(REGION, Set.of(cloudNetwork1, cloudNetwork2));
+        CloudNetworks cloudNetworks = new CloudNetworks(cloudNets);
+
+        when(credentialService.getCredentialByEnvCrn(ENV_CRN)).thenReturn(credential);
+        when(extendedCloudCredentialConverter.convert(credential)).thenReturn(extendedCred);
+        when(cloudParameterService.getCloudNetworks(eq(extendedCred), eq(REGION), eq(PLATFORM), any())).thenReturn(cloudNetworks);
+        when(networkFilterProviderMap.get(any())).thenReturn(null);
+
+        Multimap<String, String> filteredSubnetWithCidr = underTest.getFilteredSubnetWithCidr(ENV_CRN, stack, NETWORK_ID, List.of(SUBNET_1, SUBNET_2));
+
+        assertEquals(2, filteredSubnetWithCidr.size());
+        assertEquals(1, filteredSubnetWithCidr.get(subnet1.getId()).size());
+        assertEquals(subnet1.getCidr(), filteredSubnetWithCidr.get(subnet1.getId()).stream().findFirst().get());
+        assertEquals(1, filteredSubnetWithCidr.get(subnet2.getId()).size());
+        assertEquals(subnet2.getCidr(), filteredSubnetWithCidr.get(subnet2.getId()).stream().findFirst().get());
+    }
+
+    @Test
+    public void testAzureMultipleNetworkWithSameId() {
+        Stack stack = new Stack();
+        stack.setCloudPlatform(PLATFORM);
+        stack.setRegion(REGION);
+        stack.setPlatformvariant(PLATFORM);
+        Credential credential = new Credential(PLATFORM, "", "", "");
+        ExtendedCloudCredential extendedCred = new ExtendedCloudCredential(new CloudCredential(), PLATFORM, "", "", "");
+        CloudSubnet subnet1 = new CloudSubnet(SUBNET_1, SUBNET_1, "", "10.1.0.0/24");
+        CloudSubnet subnet2 = new CloudSubnet(SUBNET_2, SUBNET_2, "", "10.1.1.0/24");
+        CloudSubnet subnet3 = new CloudSubnet("indifferent", "indifferent", "", "10.1.2.0/24");
+        CloudNetwork cloudNetwork1 = new CloudNetwork("/rg1/" + NETWORK_ID, "/rg1/" + NETWORK_ID, Set.of(subnet1, subnet2, subnet3), Map.of());
+        CloudNetwork cloudNetwork2 = new CloudNetwork("/rg2/" + NETWORK_ID, "/rg2/" + NETWORK_ID,
+                Set.of(new CloudSubnet(SUBNET_1, SUBNET_1, "", "10.2.0.0/24"),
+                        new CloudSubnet("test", "test")), Map.of());
+        Map<String, Set<CloudNetwork>> cloudNets = Map.of(REGION, Set.of(cloudNetwork1, cloudNetwork2));
+        CloudNetworks cloudNetworks = new CloudNetworks(cloudNets);
+
+        when(credentialService.getCredentialByEnvCrn(ENV_CRN)).thenReturn(credential);
+        when(extendedCloudCredentialConverter.convert(credential)).thenReturn(extendedCred);
+        when(cloudParameterService.getCloudNetworks(eq(extendedCred), eq(REGION), eq(PLATFORM), any())).thenReturn(cloudNetworks);
+        when(networkFilterProviderMap.get(any())).thenReturn(null);
+
+        Multimap<String, String> filteredSubnetWithCidr = underTest.getFilteredSubnetWithCidr(ENV_CRN, stack, NETWORK_ID, List.of(SUBNET_1, SUBNET_2));
+
+        assertEquals(3, filteredSubnetWithCidr.size());
+        assertEquals(2, filteredSubnetWithCidr.get(subnet1.getId()).size());
+        assertTrue(filteredSubnetWithCidr.get(subnet1.getId()).contains(subnet1.getCidr()));
+        assertTrue(filteredSubnetWithCidr.get(subnet1.getId()).contains("10.2.0.0/24"));
+        assertEquals(1, filteredSubnetWithCidr.get(subnet2.getId()).size());
+        assertEquals(subnet2.getCidr(), filteredSubnetWithCidr.get(subnet2.getId()).stream().findFirst().get());
+    }
+
+}


### PR DESCRIPTION
Current implementation doesn't filter Azure networks by resource group.
Different resource groups can have networks and subnets with the same name/id.
This could cause an issue in `NetworkService` as it tried to create a map and create multiple entry with the same key.
For a quick fix we switch to `MultiMap` so we can avoid customer issues with as little code change as possible.
The final solution requires a bigger refactor where resource group name also included in filtering.

See detailed description in the commit message.