### PR TITLE
CB-9284 We don't handle correctly the consecutiveFailures in PollingS…

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/PollingService.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/PollingService.java
@@ -43,6 +43,7 @@ public class PollingService<T> {
             LOGGER.debug("Polling attempt {}.", attempts);
             try {
                 success = statusCheckerTask.checkStatus(t);
+                consecutiveFailures = 0;
             } catch (Exception ex) {
                 consecutiveFailures++;
                 actual = ex;
@@ -57,7 +58,6 @@ public class PollingService<T> {
                 LOGGER.debug(statusCheckerTask.successMessage(t));
                 LOGGER.debug("Set the number of consecutive failures to 0, since we received a positve answer. Original number of consecutiveFailures: {}",
                         consecutiveFailures);
-                consecutiveFailures = 0;
                 return new ImmutablePair<>(PollingResult.SUCCESS, actual);
             }
             sleep(interval);


### PR DESCRIPTION
…ervice class. We reset the value if success but we should reset in case of success is either false or true and exception does not occur.

See detailed description in the commit message.