### PR TITLE
CB-10740 LB doesn't failover when Knox instance is stopped

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancer.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancer.java
@@ -10,22 +10,22 @@ public class CloudLoadBalancer {
 
     private final LoadBalancerType type;
 
-    private final Map<Integer, Set<Group>> portToTargetGroupMapping;
+    private final Map<TargetGroupPortPair, Set<Group>> portToTargetGroupMapping;
 
     public CloudLoadBalancer(LoadBalancerType type) {
         this.type = type;
         portToTargetGroupMapping = new HashMap<>();
     }
 
-    public void addPortToTargetGroupMapping(Integer port, Set<Group> targetGroups) {
-        if (portToTargetGroupMapping.containsKey(port)) {
-            portToTargetGroupMapping.get(port).addAll(targetGroups);
+    public void addPortToTargetGroupMapping(TargetGroupPortPair portPair, Set<Group> targetGroups) {
+        if (portToTargetGroupMapping.containsKey(portPair)) {
+            portToTargetGroupMapping.get(portPair).addAll(targetGroups);
         } else {
-            portToTargetGroupMapping.put(port, targetGroups);
+            portToTargetGroupMapping.put(portPair, targetGroups);
         }
     }
 
-    public Map<Integer, Set<Group>> getPortToTargetGroupMapping() {
+    public Map<TargetGroupPortPair, Set<Group>> getPortToTargetGroupMapping() {
         return portToTargetGroupMapping;
     }
 

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/TargetGroupPortPair.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/TargetGroupPortPair.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import java.util.Objects;
+
+/**
+ * A joining of ports related to target groups. Target groups are groups of instances that a load balancer routes traffic
+ * to. The instances in the target group have a port on which they receive traffic from the load balancer (trafficPort),
+ * and a port on which the load balancer runs its health checks (healthCheckPort). If the health check responses from
+ * the healthCheckPort ever go into an unhealthy state, the load balancer will stop forwarding traffic to the trafficPort
+ * for the unhealthy instance.
+ */
+public class TargetGroupPortPair {
+
+    private final int trafficPort;
+
+    private final int healthCheckPort;
+
+    public TargetGroupPortPair(int trafficPort, int healthCheckPort) {
+        this.trafficPort = trafficPort;
+        this.healthCheckPort = healthCheckPort;
+    }
+
+    public Integer getTrafficPort() {
+        return trafficPort;
+    }
+
+    public Integer getHealthCheckPort() {
+        return healthCheckPort;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TargetGroupPortPair portPair = (TargetGroupPortPair) o;
+        return trafficPort == portPair.trafficPort &&
+            healthCheckPort == portPair.healthCheckPort;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(trafficPort, healthCheckPort);
+    }
+
+    @Override
+    public String toString() {
+        return "TargetGroupPortPair{" +
+            "trafficPort=" + trafficPort +
+            ", healthCheckPort=" + healthCheckPort +
+            '}';
+    }
+}

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/TargetGroupPortPairTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/TargetGroupPortPairTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class TargetGroupPortPairTest {
+
+    private static final int TRAFFIC_PORT = 443;
+
+    private static final int HEALTH_PORT = 8443;
+
+    @Test
+    public void testEquals() {
+        TargetGroupPortPair a = new TargetGroupPortPair(TRAFFIC_PORT, HEALTH_PORT);
+        TargetGroupPortPair b = new TargetGroupPortPair(TRAFFIC_PORT, HEALTH_PORT);
+        assert a.equals(b);
+        assert b.equals(a);
+    }
+
+    @Test
+    public void testHashCode() {
+        TargetGroupPortPair a = new TargetGroupPortPair(TRAFFIC_PORT, HEALTH_PORT);
+        TargetGroupPortPair b = new TargetGroupPortPair(TRAFFIC_PORT, HEALTH_PORT);
+        assertEquals(a.hashCode(), b.hashCode());
+    }
+
+    @Test
+    public void testSetKey() {
+        TargetGroupPortPair a = new TargetGroupPortPair(TRAFFIC_PORT, HEALTH_PORT);
+        TargetGroupPortPair b = new TargetGroupPortPair(TRAFFIC_PORT, HEALTH_PORT);
+        Set<TargetGroupPortPair> set = new HashSet<>();
+        set.add(a);
+        set.add(b);
+        assertEquals(1, set.size());
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationStackUtil.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationStackUtil.java
@@ -54,6 +54,7 @@ import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
 
@@ -194,13 +195,13 @@ public class CloudFormationStackUtil {
         AmazonElasticLoadBalancingClient amazonElbClient =
             awsClient.createElasticLoadBalancingClient(new AwsCredentialView(ac.getCloudCredential()), region);
 
-        for (Map.Entry<Integer, Set<Group>> entry : loadBalancer.getPortToTargetGroupMapping().entrySet()) {
+        for (Map.Entry<TargetGroupPortPair, Set<Group>> entry : loadBalancer.getPortToTargetGroupMapping().entrySet()) {
             // Get a list of the new instances in the target groups
             Set<String> updatedInstanceIds = getInstanceIdsForGroups(resourcesToAdd, entry.getValue());
 
             // Find target group ARN
             AwsLoadBalancerScheme scheme = loadBalancerTypeConverter.convert(loadBalancer.getType());
-            String targetGroupArn = getResourceArnByLogicalId(ac, AwsTargetGroup.getTargetGroupName(entry.getKey(), scheme), region);
+            String targetGroupArn = getResourceArnByLogicalId(ac, AwsTargetGroup.getTargetGroupName(entry.getKey().getTrafficPort(), scheme), region);
 
             // Use ARN to fetch a list of current targets
             DescribeTargetHealthResult targetHealthResult = amazonElbClient.describeTargetHealth(new DescribeTargetHealthRequest()
@@ -232,13 +233,13 @@ public class CloudFormationStackUtil {
         AmazonElasticLoadBalancingClient amazonElbClient =
             awsClient.createElasticLoadBalancingClient(new AwsCredentialView(ac.getCloudCredential()), region);
 
-        for (Map.Entry<Integer, Set<Group>> entry : loadBalancer.getPortToTargetGroupMapping().entrySet()) {
+        for (Map.Entry<TargetGroupPortPair, Set<Group>> entry : loadBalancer.getPortToTargetGroupMapping().entrySet()) {
             // Get a list of the instance ids to remove
             Set<String> instancesToRemove = getInstanceIdsForGroups(resourcesToRemove, entry.getValue());
 
             // Find target group ARN
             AwsLoadBalancerScheme scheme = loadBalancerTypeConverter.convert(loadBalancer.getType());
-            String targetGroupArn = getResourceArnByLogicalId(ac, AwsTargetGroup.getTargetGroupName(entry.getKey(), scheme), region);
+            String targetGroupArn = getResourceArnByLogicalId(ac, AwsTargetGroup.getTargetGroupName(entry.getKey().getTrafficPort(), scheme), region);
 
             // Deregister any instances that no longer exist
             if (!instancesToRemove.isEmpty()) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchService.java
@@ -64,6 +64,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.common.api.type.AdjustmentType;
 import com.sequenceiq.common.api.type.LoadBalancerType;
@@ -387,8 +388,8 @@ public class AwsLaunchService {
 
     private void setupLoadBalancer(CloudLoadBalancer cloudLoadBalancer, List<CloudResource> instances,
             AwsLoadBalancer awsLoadBalancer) {
-        for (Map.Entry<Integer, Set<Group>> entry : cloudLoadBalancer.getPortToTargetGroupMapping().entrySet()) {
-            AwsListener listener = awsLoadBalancer.getOrCreateListener(entry.getKey());
+        for (Map.Entry<TargetGroupPortPair, Set<Group>> entry : cloudLoadBalancer.getPortToTargetGroupMapping().entrySet()) {
+            AwsListener listener = awsLoadBalancer.getOrCreateListener(entry.getKey().getTrafficPort(), entry.getKey().getHealthCheckPort());
             List<CloudResource> lbTargetInstances = instances.stream()
                 .filter(instance -> entry.getValue().stream().anyMatch(tg -> tg.getName().equals(instance.getGroup())))
                 .collect(Collectors.toList());

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/loadbalancer/AwsListener.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/loadbalancer/AwsListener.java
@@ -12,10 +12,10 @@ public class AwsListener {
 
     private final String name;
 
-    public AwsListener(AwsLoadBalancerScheme scheme, int port) {
+    public AwsListener(AwsLoadBalancerScheme scheme, int port, int healthCheckPort) {
         this.port = port;
         this.name = getListenerName(port, scheme);
-        this.targetGroup = new AwsTargetGroup(scheme, port);
+        this.targetGroup = new AwsTargetGroup(scheme, port, healthCheckPort);
     }
 
     public int getPort() {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/loadbalancer/AwsLoadBalancer.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/loadbalancer/AwsLoadBalancer.java
@@ -40,14 +40,14 @@ public class AwsLoadBalancer {
         return listeners;
     }
 
-    public AwsListener getOrCreateListener(int port) {
+    public AwsListener getOrCreateListener(int port, int healthCheckPort) {
         return listeners.stream()
             .filter(l -> l.getPort() == port)
-            .findFirst().orElseGet(() -> createListener(port));
+            .findFirst().orElseGet(() -> createListener(port, healthCheckPort));
     }
 
-    private AwsListener createListener(int port) {
-        AwsListener listener = new AwsListener(scheme, port);
+    private AwsListener createListener(int port, int healthCheckPort) {
+        AwsListener listener = new AwsListener(scheme, port, healthCheckPort);
         listeners.add(listener);
         return listener;
     }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/loadbalancer/AwsTargetGroup.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/loadbalancer/AwsTargetGroup.java
@@ -13,10 +13,13 @@ public class AwsTargetGroup {
 
     private final String name;
 
+    private final String healthCheckPort;
+
     private String arn;
 
-    public AwsTargetGroup(AwsLoadBalancerScheme scheme, int port) {
+    public AwsTargetGroup(AwsLoadBalancerScheme scheme, int port, int healthCheckPort) {
         this.port = port;
+        this.healthCheckPort = String.valueOf(healthCheckPort);
         this.name = getTargetGroupName(port, scheme);
     }
 
@@ -42,6 +45,10 @@ public class AwsTargetGroup {
 
     public void addInstanceIds(Set<String> newInstanceIds) {
         instanceIds.addAll(newInstanceIds);
+    }
+
+    public String getHealthCheckPort() {
+        return healthCheckPort;
     }
 
     public static String getTargetGroupName(int port, AwsLoadBalancerScheme scheme) {

--- a/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
@@ -313,6 +313,7 @@
           "Port" : ${listener.targetGroup.port},
           "Protocol" : "TCP",
           "TargetType" : "instance",
+          "HealthCheckPort" : "${listener.targetGroup.healthCheckPort}",
           <#if existingVPC>
           "VpcId" : { "Ref" : "VPCId" }
           <#else>

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
@@ -21,8 +21,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import java.util.Set;
+
 import org.assertj.core.api.Assertions;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -1399,6 +1399,7 @@ public class CloudFormationTemplateBuilderTest {
 
         //THEN
         Assertions.assertThat(templateString)
+            .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
             .contains("\"LoadBalancerInternal\" : {\"Type\" : \"AWS::ElasticLoadBalancingV2::LoadBalancer\"")
             .contains("\"Scheme\" : \"internal\"")
             .contains("\"TargetGroupPort443Internal\" : {\"Type\" : \"AWS::ElasticLoadBalancingV2::TargetGroup\"")
@@ -1430,6 +1431,7 @@ public class CloudFormationTemplateBuilderTest {
 
         //THEN
         Assertions.assertThat(templateString)
+            .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
             .contains("\"LoadBalancerInternal\" : {\"Type\" : \"AWS::ElasticLoadBalancingV2::LoadBalancer\"")
             .contains("\"Scheme\" : \"internal\"")
             .contains("\"TargetGroupPort443Internal\" : {\"Type\" : \"AWS::ElasticLoadBalancingV2::TargetGroup\"")
@@ -1464,6 +1466,7 @@ public class CloudFormationTemplateBuilderTest {
 
         //THEN
         Assertions.assertThat(templateString)
+            .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
             .contains("\"LoadBalancerInternal\" : {\"Type\" : \"AWS::ElasticLoadBalancingV2::LoadBalancer\"")
             .contains("\"Scheme\" : \"internal\"")
             .contains("\"TargetGroupPort443Internal\" : {\"Type\" : \"AWS::ElasticLoadBalancingV2::TargetGroup\"")
@@ -1478,6 +1481,34 @@ public class CloudFormationTemplateBuilderTest {
             templateString.contains("\"Targets\" : [{ \"Id\" : \"instance2-888\" },{ \"Id\" : \"instance1-888\" }]}}");
     }
 
+    public void buildTestHealthCheckPortDifferentFromTrafficPort() {
+        //GIVEN
+        AwsLoadBalancer awsLoadBalancer = setupLoadBalancer(AwsLoadBalancerScheme.INTERNAL, 443, true);
+
+        //WHEN
+        modelContext = new ModelContext()
+            .withAuthenticatedContext(authenticatedContext)
+            .withStack(cloudStack)
+            .withExistingVpc(true)
+            .withExistingIGW(true)
+            .withExistingSubnetCidr(singletonList(existingSubnetCidr))
+            .withExistinVpcCidr(List.of(existingSubnetCidr))
+            .mapPublicIpOnLaunch(true)
+            .withEnableInstanceProfile(true)
+            .withInstanceProfileAvailable(true)
+            .withOutboundInternetTraffic(OutboundInternetTraffic.ENABLED)
+            .withTemplate(awsCloudFormationTemplate)
+            .withLoadBalancers(List.of(awsLoadBalancer));
+
+        String templateString = cloudFormationTemplateBuilder.build(modelContext);
+
+        //THEN
+        Assertions.assertThat(templateString)
+            .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
+            .contains("\"Port\" : 443")
+            .contains("\"HealthCheckPort\" : \"8443\"");
+    }
+
     @Test
     public void buildTestEfsNullFields() {
         //GIVEN
@@ -1485,29 +1516,29 @@ public class CloudFormationTemplateBuilderTest {
 
         //WHEN
         modelContext = new ModelContext()
-                .withAuthenticatedContext(authenticatedContext)
-                .withStack(cloudStack)
-                .withExistingVpc(true)
-                .withExistingIGW(true)
-                .withExistingSubnetCidr(singletonList(existingSubnetCidr))
-                .withExistinVpcCidr(List.of(existingSubnetCidr))
-                .mapPublicIpOnLaunch(true)
-                .withEnableInstanceProfile(true)
-                .withInstanceProfileAvailable(true)
-                .withOutboundInternetTraffic(OutboundInternetTraffic.ENABLED)
-                .withTemplate(awsCloudFormationTemplate)
-                .withEnableEfs(true)
-                .withEfsFileSystem(awsEfsFileSystem);
+            .withAuthenticatedContext(authenticatedContext)
+            .withStack(cloudStack)
+            .withExistingVpc(true)
+            .withExistingIGW(true)
+            .withExistingSubnetCidr(singletonList(existingSubnetCidr))
+            .withExistinVpcCidr(List.of(existingSubnetCidr))
+            .mapPublicIpOnLaunch(true)
+            .withEnableInstanceProfile(true)
+            .withInstanceProfileAvailable(true)
+            .withOutboundInternetTraffic(OutboundInternetTraffic.ENABLED)
+            .withTemplate(awsCloudFormationTemplate)
+            .withEnableEfs(true)
+            .withEfsFileSystem(awsEfsFileSystem);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
 
         //THEN
         Assertions.assertThat(templateString)
-                .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
-                .contains("AWS::EFS::FileSystem")
-                .contains("\"Encrypted\" : \"true\"")
-                .contains("\"PerformanceMode\": \"generalPurpose\"")
-                .contains("\"ThroughputMode\": \"bursting\"");
+            .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
+            .contains("AWS::EFS::FileSystem")
+            .contains("\"Encrypted\" : \"true\"")
+            .contains("\"PerformanceMode\": \"generalPurpose\"")
+            .contains("\"ThroughputMode\": \"bursting\"");
     }
 
     @Test
@@ -1517,34 +1548,34 @@ public class CloudFormationTemplateBuilderTest {
 
         //WHEN
         modelContext = new ModelContext()
-                .withAuthenticatedContext(authenticatedContext)
-                .withStack(cloudStack)
-                .withExistingVpc(true)
-                .withExistingIGW(true)
-                .withExistingSubnetCidr(singletonList(existingSubnetCidr))
-                .withExistinVpcCidr(List.of(existingSubnetCidr))
-                .mapPublicIpOnLaunch(true)
-                .withEnableInstanceProfile(true)
-                .withInstanceProfileAvailable(true)
-                .withOutboundInternetTraffic(OutboundInternetTraffic.ENABLED)
-                .withTemplate(awsCloudFormationTemplate)
-                .withEnableEfs(true)
-                .withEfsFileSystem(awsEfsFileSystem);
+            .withAuthenticatedContext(authenticatedContext)
+            .withStack(cloudStack)
+            .withExistingVpc(true)
+            .withExistingIGW(true)
+            .withExistingSubnetCidr(singletonList(existingSubnetCidr))
+            .withExistinVpcCidr(List.of(existingSubnetCidr))
+            .mapPublicIpOnLaunch(true)
+            .withEnableInstanceProfile(true)
+            .withInstanceProfileAvailable(true)
+            .withOutboundInternetTraffic(OutboundInternetTraffic.ENABLED)
+            .withTemplate(awsCloudFormationTemplate)
+            .withEnableEfs(true)
+            .withEfsFileSystem(awsEfsFileSystem);
 
         String templateString = cloudFormationTemplateBuilder.build(modelContext);
 
         //THEN
         Assertions.assertThat(templateString)
-                .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
-                .contains("AWS::EFS::FileSystem")
-                .contains("\"Encrypted\" : \"false\"")
-                .contains("\"PerformanceMode\": \"maxIO\"")
-                .contains("\"ThroughputMode\": \"provisioned\"");
+            .matches(JsonUtil::isValid, "Invalid JSON: " + templateString)
+            .contains("AWS::EFS::FileSystem")
+            .contains("\"Encrypted\" : \"false\"")
+            .contains("\"PerformanceMode\": \"maxIO\"")
+            .contains("\"ThroughputMode\": \"provisioned\"");
     }
 
     private AwsEfsFileSystem setupEfsFileSystemNullFields() {
         return new AwsEfsFileSystem(null, true, null, null, null, null,
-                null, null, null);
+            null, null, null);
     }
 
     private AwsEfsFileSystem setupEfsFileSystemValidSet() {
@@ -1555,7 +1586,7 @@ public class CloudFormationTemplateBuilderTest {
         JSONObject fileSystemPolicy = null;
         try {
             fileSystemPolicy = new JSONObject("{\"Version\": \"2012-10-17\",\"Statement\": [{\"Effect\": \"Allow\",\"Action\": " +
-                    "[\"elasticfilesystem:ClientMount\"],\"Principal\":  {\"AWS\": \"arn:aws:iam::111122223333:root\"}}]}");
+                "[\"elasticfilesystem:ClientMount\"],\"Principal\":  {\"AWS\": \"arn:aws:iam::111122223333:root\"}}]}");
         } catch (JSONException e) {
         }
 
@@ -1565,13 +1596,13 @@ public class CloudFormationTemplateBuilderTest {
         lifeCyclePolicies.add("{\"TransitionToIA\" : \"AFTER_7_DAYS\"}");
 
         return new AwsEfsFileSystem("DISABLED", false, fileSystemPolicy != null ? fileSystemPolicy.toString() : null, fileSystemTags,
-                "sdx-key", lifeCyclePolicies, "maxIO", 1.0, "provisioned");
+            "sdx-key", lifeCyclePolicies, "maxIO", 1.0, "provisioned");
     }
 
     private AwsLoadBalancer setupLoadBalancer(AwsLoadBalancerScheme scheme, int port, boolean setArn) {
         AwsLoadBalancer loadBalancer = new AwsLoadBalancer(scheme);
         loadBalancer.addSubnets(Set.of("subnet1"));
-        AwsListener listener = loadBalancer.getOrCreateListener(port);
+        AwsListener listener = loadBalancer.getOrCreateListener(port, 8443);
         listener.addInstancesToTargetGroup(Set.of("instance1-" + port, "instance2-" + port));
 
         if (setArn) {

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchServiceLoadBalancerTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchServiceLoadBalancerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -476,7 +477,7 @@ public class AwsLaunchServiceLoadBalancerTest {
     @Test
     public void testSetLoadBalancerMetadata() {
         AwsLoadBalancer loadBalancer = new AwsLoadBalancer(AwsLoadBalancerScheme.INTERNAL);
-        loadBalancer.getOrCreateListener(PORT);
+        loadBalancer.getOrCreateListener(PORT, PORT);
         when(result.getStackResourceSummaries()).thenReturn(createSummaries(Set.of(LoadBalancerType.PRIVATE), false));
 
         underTest.setLoadBalancerMetadata(List.of(loadBalancer), result);
@@ -521,7 +522,7 @@ public class AwsLaunchServiceLoadBalancerTest {
     private CloudLoadBalancer createCloudLoadBalancer(LoadBalancerType type) {
         Group group = new Group(INSTANCE_NAME, GATEWAY, List.of(), null, null, null, null, null, null, 100, null);
         CloudLoadBalancer cloudLoadBalancer = new CloudLoadBalancer(type);
-        cloudLoadBalancer.addPortToTargetGroupMapping(PORT, Set.of(group));
+        cloudLoadBalancer.addPortToTargetGroupMapping(new TargetGroupPortPair(PORT, PORT), Set.of(group));
         return cloudLoadBalancer;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -43,6 +43,7 @@ import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
 import com.sequenceiq.cloudbreak.cloud.model.StackTags;
 import com.sequenceiq.cloudbreak.cloud.model.StackTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Subnet;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudFileSystemView;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
@@ -265,12 +266,13 @@ public class StackToCloudStackConverter {
         for (LoadBalancer loadBalancer : loadBalancerPersistenceService.findByStackId(stack.getId())) {
             CloudLoadBalancer cloudLoadBalancer = new CloudLoadBalancer(loadBalancer.getType());
             for (TargetGroup targetGroup : targetGroupPersistenceService.findByLoadBalancerId(loadBalancer.getId())) {
-                Set<Integer> ports = loadBalancerConfigService.getPortsForTargetGroup(targetGroup);
+                Set<TargetGroupPortPair> portPairs = loadBalancerConfigService.getTargetGroupPortPairs(targetGroup);
                 Set<String> targetInstanceGroupName = instanceGroupService.findByTargetGroupId(targetGroup.getId()).stream()
                     .map(InstanceGroup::getGroupName)
                     .collect(Collectors.toSet());
-                for (Integer port : ports) {
-                    cloudLoadBalancer.addPortToTargetGroupMapping(port, instanceGroups.stream()
+
+                for (TargetGroupPortPair portPair : portPairs) {
+                    cloudLoadBalancer.addPortToTargetGroupMapping(portPair, instanceGroups.stream()
                         .filter(ig -> targetInstanceGroupName.contains(ig.getName()))
                         .collect(Collectors.toSet()));
                 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
@@ -12,6 +12,7 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.google.common.base.Preconditions;
@@ -19,10 +20,11 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
-import com.sequenceiq.cloudbreak.converter.v4.environment.network.SubnetSelector;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox.KnoxRoles;
 import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.converter.v4.environment.network.SubnetSelector;
 import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -48,6 +50,12 @@ public class LoadBalancerConfigService {
     private static final String SUBNET_ID = "subnetId";
 
     private static final Set<Integer> DEFAULT_KNOX_PORTS = Set.of(443);
+
+    @Value("${cb.https.port:443}")
+    private String httpsPort;
+
+    @Value("${cb.knox.port:8443}")
+    private String knoxServicePort;
 
     @Inject
     private LoadBalancerPersistenceService loadBalancerPersistenceService;
@@ -95,12 +103,12 @@ public class LoadBalancerConfigService {
         return name.toString();
     }
 
-    public Set<Integer> getPortsForTargetGroup(TargetGroup targetGroup) {
+    public Set<TargetGroupPortPair> getTargetGroupPortPairs(TargetGroup targetGroup) {
         switch (targetGroup.getType()) {
             case KNOX:
-                return DEFAULT_KNOX_PORTS;
+                return Set.of(new TargetGroupPortPair(Integer.parseInt(httpsPort), Integer.parseInt(knoxServicePort)));
             default:
-                return Collections.emptySet();
+                return null;
         }
     }
 

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -539,6 +539,8 @@ cb:
 
   nginx:
     port: 9443
+  knox:
+    port: 8443
   https:
     port: 443
   ssh:

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
@@ -50,6 +50,7 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
 import com.sequenceiq.cloudbreak.cloud.model.StackTags;
 import com.sequenceiq.cloudbreak.cloud.model.StackTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.common.json.Json;
@@ -969,14 +970,15 @@ public class StackToCloudStackConverterTest {
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(loadBalancer));
         when(targetGroupPersistenceService.findByLoadBalancerId(anyLong())).thenReturn(Set.of(targetGroup));
         when(instanceGroupService.findByTargetGroupId(anyLong())).thenReturn(Set.of(instanceGroup1, instanceGroup2));
-        when(loadBalancerConfigService.getPortsForTargetGroup(any(TargetGroup.class))).thenReturn(Set.of(443));
+        TargetGroupPortPair targetGroupPortPair = new TargetGroupPortPair(443, 8443);
+        when(loadBalancerConfigService.getTargetGroupPortPairs(any(TargetGroup.class))).thenReturn(Set.of(targetGroupPortPair));
 
         CloudStack result = underTest.convert(stack);
 
         assertEquals(1, result.getLoadBalancers().size());
         CloudLoadBalancer cloudLoadBalancer = result.getLoadBalancers().iterator().next();
         assertEquals(LoadBalancerType.PRIVATE, cloudLoadBalancer.getType());
-        assertEquals(Set.of(443), cloudLoadBalancer.getPortToTargetGroupMapping().keySet());
+        assertEquals(Set.of(targetGroupPortPair), cloudLoadBalancer.getPortToTargetGroupMapping().keySet());
         Set<String> groupNames = cloudLoadBalancer.getPortToTargetGroupMapping().values().stream()
             .flatMap(Collection::stream)
             .collect(Collectors.toSet())
@@ -1015,7 +1017,7 @@ public class StackToCloudStackConverterTest {
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(internalLoadBalancer, externalLoadBalancer));
         when(targetGroupPersistenceService.findByLoadBalancerId(anyLong())).thenReturn(Set.of(targetGroup));
         when(instanceGroupService.findByTargetGroupId(anyLong())).thenReturn(Set.of(instanceGroup1, instanceGroup2));
-        when(loadBalancerConfigService.getPortsForTargetGroup(any(TargetGroup.class))).thenReturn(Set.of(443));
+        when(loadBalancerConfigService.getTargetGroupPortPairs(any(TargetGroup.class))).thenReturn(Set.of(new TargetGroupPortPair(443, 8443)));
 
         CloudStack result = underTest.convert(stack);
 


### PR DESCRIPTION
Replaced the single port being used for load balancer config with TargetGroupPortPair.
This contains a port to direct traffic to, and a port to use for health checks.
Previous LB logic was using health the of nginx port to determine Knox instance health.
The new logic allows different ports to be used for traffic forwarding and health
checks. For the Knox LB, traffic will be forwarded to the nginx port, but health checks
will be done on the Knox port. So if Knox goes down, the LB will be able to detect it
and fail over to the second node.

Tested via unit tests and by creating a data lake and verifying LB configuration and
failover logic.

See detailed description in the commit message.