### PR TITLE
CB-10580 authorizeDefaultOrElseCompute throws NPE if authorizationResourceType is null

### DIFF
--- a/authorization-common/src/main/java/com/sequenceiq/authorization/service/DefaultResourceAuthorizationProvider.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/service/DefaultResourceAuthorizationProvider.java
@@ -28,7 +28,11 @@ public class DefaultResourceAuthorizationProvider {
 
     public Optional<AuthorizationRule> authorizeDefaultOrElseCompute(String resourceCrn, AuthorizationResourceAction action,
             Supplier<Optional<AuthorizationRule>> supplier) {
-        DefaultResourceChecker defaultResourceChecker = defaultResourceCheckerMap.get(action.getAuthorizationResourceType());
+        AuthorizationResourceType authorizationResourceType = action.getAuthorizationResourceType();
+        DefaultResourceChecker defaultResourceChecker = null;
+        if (authorizationResourceType != null) {
+            defaultResourceChecker = defaultResourceCheckerMap.get(authorizationResourceType);
+        }
         if (defaultResourceChecker != null && defaultResourceChecker.isDefault(resourceCrn)) {
             commonPermissionCheckingUtils.throwAccessDeniedIfActionNotAllowed(action, List.of(resourceCrn), defaultResourceChecker);
             return Optional.empty();


### PR DESCRIPTION
In case of LIST_ASSIGNED_ROLES the authorizationResourceType is null (2nd param) -> LIST_ASSIGNED_ROLES("iam/listAssignedResourceRoles", null),