### PR TITLE
CB-10269 remove change image notification as it is not really useful

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -233,7 +233,6 @@ public enum ResourceEvent {
     CLUSTER_PRIMARY_GATEWAY_UNHEALTHY_SYNC_STARTED("cluster.pgw.unhealthy.sync.started"),
     CLUSTER_PACKAGES_ON_INSTANCES_ARE_DIFFERENT("cluster.sync.instance.different.packages"),
     CLUSTER_PACKAGE_VERSIONS_ON_INSTANCES_ARE_MISSING("cluster.sync.instance.missing.package.versions"),
-    CLUSTER_PACKAGE_VERSIONS_ARE_CHANGED("cluster.sync.instance.changed.packages"),
     CLUSTER_PACKAGE_VERSION_CANNOT_BE_QUERIED("cluster.sync.instance.failedquery.packages"),
     CLUSTER_UPLOAD_RECIPES("cluster.recipes.upload"),
     CLUSTER_BOOTSTRAPPER_ERROR_BOOTSTRAP_FAILED_ON_NODES("cluster.bootstrapper.error.nodes.failed"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -193,7 +193,6 @@ cluster.ambari.cluster.could.not.sync=Cluster can''t be synchronized. [ stack st
 cluster.ambari.cluster.synchronized=The cluster state synchronized with Cloudera Manager: {0}
 cluster.sync.instance.different.packages=The following packages are installed with different versions on hosts: {0}
 cluster.sync.instance.missing.package.versions=There are missing package versions on hosts: {0}
-cluster.sync.instance.changed.packages=The following package versions have been changed on hosts: {0}
 cluster.sync.instance.failedquery.packages=Query of package versions has been failed on hosts: {0}
 
 stack.stop.ignored=Stop request ignored; cluster infrastructure is already stopped.

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/InstanceMetadataUpdaterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/InstanceMetadataUpdaterTest.java
@@ -152,8 +152,6 @@ public class InstanceMetadataUpdaterTest {
 
         verify(cloudbreakEventService, times(1)).fireCloudbreakEvent(anyLong(), anyString(),
                 eq(ResourceEvent.CLUSTER_PACKAGE_VERSIONS_ON_INSTANCES_ARE_MISSING), anyCollection());
-        verify(cloudbreakEventService, times(1)).fireCloudbreakEvent(anyLong(), anyString(),
-                eq(ResourceEvent.CLUSTER_PACKAGE_VERSIONS_ARE_CHANGED), anyCollection());
     }
 
     @Test
@@ -170,8 +168,6 @@ public class InstanceMetadataUpdaterTest {
 
         verify(cloudbreakEventService, times(1)).fireCloudbreakEvent(anyLong(), anyString(),
                 eq(ResourceEvent.CLUSTER_PACKAGES_ON_INSTANCES_ARE_DIFFERENT), anyCollection());
-        verify(cloudbreakEventService, times(1)).fireCloudbreakEvent(anyLong(), anyString(),
-                eq(ResourceEvent.CLUSTER_PACKAGE_VERSIONS_ARE_CHANGED), anyCollection());
     }
 
     private Map<String, String> packageMap() {


### PR DESCRIPTION
As part of the upgrade flow we replace the instances with new ones using
the new cloud image. This process is called change image. The images
contain different versions of certain packages which we send a
notification about that they have changed. However, there are many
packages and most of them are not relevant to customers. As part of
this PR this notification is removed.