### PR TITLE
CB-10423 7.1.0 -> 7.2.6 upgrade fix: if the restartNeeded flag is set  but salt-bootstrap does not support this flag, then we change the salt master ip address to an another one, so minions will be restarted

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
@@ -111,7 +111,7 @@ public class ClusterBootstrapper {
     private ComponentConfigProviderService componentConfigProviderService;
 
     @Inject
-    private SaltBootstrapFingerprintVersionChecker fingerprintVersionChecker;
+    private SaltBootstrapVersionChecker saltBootstrapVersionChecker;
 
     @Inject
     private InstanceMetaDataService instanceMetaDataService;
@@ -222,15 +222,23 @@ public class ClusterBootstrapper {
             LOGGER.warn("Image not found for stack {}", stack.getName(), e);
         }
         boolean saltBootstrapFpSupported = isSaltBootstrapFpSupported(stack);
+        boolean saltBootstrapRestartNeededSupported = isSaltBootstrapRestartNeededSupported(stack);
         params.setSaltBootstrapFpSupported(saltBootstrapFpSupported);
+        params.setRestartNeededFlagSupported(saltBootstrapRestartNeededSupported);
         LOGGER.debug("Created bootstrap params: {}", params);
         return params;
+    }
+
+    private boolean isSaltBootstrapRestartNeededSupported(Stack stack) {
+        return stack.getNotDeletedInstanceMetaDataSet().stream()
+                .map(InstanceMetaData::getImage)
+                .allMatch(i -> saltBootstrapVersionChecker.isRestartNeededFlagSupported(i));
     }
 
     private boolean isSaltBootstrapFpSupported(Stack stack) {
         return stack.getNotDeletedInstanceMetaDataSet().stream()
                 .map(InstanceMetaData::getImage)
-                .allMatch(i -> fingerprintVersionChecker.isFingerprintingSupported(i));
+                .allMatch(i -> saltBootstrapVersionChecker.isFingerprintingSupported(i));
     }
 
     private List<GatewayConfig> collectAndCheckGateways(Stack stack) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/SaltBootstrapVersionChecker.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/SaltBootstrapVersionChecker.java
@@ -15,13 +15,23 @@ import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.cloudbreak.core.flow2.stack.image.update.PackageVersionChecker;
 
 @Component
-public class SaltBootstrapFingerprintVersionChecker {
+public class SaltBootstrapVersionChecker {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SaltBootstrapFingerprintVersionChecker.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaltBootstrapVersionChecker.class);
 
-    private static final Versioned MIN_VERSION = () -> "0.13.2";
+    private static final Versioned FINGERPRINT_SUPPORT_MIN_VERSION = () -> "0.13.2";
+
+    private static final Versioned RESTART_NEEDED_FLAG_SUPPORT_MIN_VERSION = () -> "0.13.4";
 
     public boolean isFingerprintingSupported(Json image) {
+        return isSupported(FINGERPRINT_SUPPORT_MIN_VERSION, image);
+    }
+
+    public boolean isRestartNeededFlagSupported(Json image) {
+        return isSupported(RESTART_NEEDED_FLAG_SUPPORT_MIN_VERSION, image);
+    }
+
+    private boolean isSupported(Versioned version, Json image) {
         if (image == null) {
             LOGGER.info("Image is null, couldn't verify salt-bootstrap version");
             return false;
@@ -33,7 +43,7 @@ public class SaltBootstrapFingerprintVersionChecker {
                     String saltBootstrapVersion = packageVersions.getOrDefault(PackageVersionChecker.SALT_BOOTSTRAP, "0.0.0");
                     Versioned currentVersion = () -> StringUtils.substringBefore(saltBootstrapVersion, "-");
                     LOGGER.debug("Saltboot version in image: {}", currentVersion.getVersion());
-                    return -1 < new VersionComparator().compare(currentVersion, MIN_VERSION);
+                    return -1 < new VersionComparator().compare(currentVersion, version);
                 } else {
                     LOGGER.info("PackageVersions is null in image {} {}", instanceImage.getImageId(), instanceImage.getImageName());
                     return false;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/SaltBootstrapVersionCheckerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/SaltBootstrapVersionCheckerTest.java
@@ -12,9 +12,32 @@ import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.core.flow2.stack.image.update.PackageVersionChecker;
 
-class SaltBootstrapFingerprintVersionCheckerTest {
+class SaltBootstrapVersionCheckerTest {
 
-    private SaltBootstrapFingerprintVersionChecker underTest = new SaltBootstrapFingerprintVersionChecker();
+    private SaltBootstrapVersionChecker underTest = new SaltBootstrapVersionChecker();
+
+    @Test
+    public void testRestartNeededFlagSupported() {
+        assertTrue(underTest.isRestartNeededFlagSupported(getJsonImage("0.13.4")));
+        assertTrue(underTest.isRestartNeededFlagSupported(getJsonImage("0.13.4-134")));
+        assertTrue(underTest.isRestartNeededFlagSupported(getJsonImage("0.13.5")));
+        assertTrue(underTest.isRestartNeededFlagSupported(getJsonImage("0.13.5-3245")));
+        assertTrue(underTest.isRestartNeededFlagSupported(getJsonImage("0.14")));
+        assertTrue(underTest.isRestartNeededFlagSupported(getJsonImage("0.14.0")));
+        assertTrue(underTest.isRestartNeededFlagSupported(getJsonImage("1.0.0")));
+    }
+
+    @Test
+    public void testRestartNeededFlagNotSupported() {
+        assertFalse(underTest.isRestartNeededFlagSupported(getJsonImage("0.13.2")));
+        assertFalse(underTest.isRestartNeededFlagSupported(getJsonImage("0.13.2-134")));
+        assertFalse(underTest.isRestartNeededFlagSupported(getJsonImage("0.13.1")));
+        assertFalse(underTest.isRestartNeededFlagSupported(getJsonImage("0.13.0")));
+        assertFalse(underTest.isRestartNeededFlagSupported(getJsonImage("0.13.1.1")));
+        assertFalse(underTest.isRestartNeededFlagSupported(getJsonImage("0.13.1-134")));
+        assertFalse(underTest.isRestartNeededFlagSupported(getJsonImage("0.12.3")));
+        assertFalse(underTest.isRestartNeededFlagSupported(getJsonImage("0.12.3-3245")));
+    }
 
     @Test
     public void testFingerPrintSupported() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/BootstrapService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/BootstrapService.java
@@ -80,6 +80,7 @@ public class BootstrapService {
         ImageEntity image = imageService.getByStack(stack);
         params.setOs(image.getOs());
         params.setSaltBootstrapFpSupported(true);
+        params.setRestartNeededFlagSupported(true);
         try {
             byte[] stateConfigZip = getStateConfigZip();
             hostOrchestrator.bootstrapNewNodes(gatewayConfigs, allNodes, allNodes,

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/BootstrapParams.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/BootstrapParams.java
@@ -7,6 +7,8 @@ public class BootstrapParams {
 
     private boolean saltBootstrapFpSupported;
 
+    private boolean restartNeededFlagSupported;
+
     private boolean restartNeeded;
 
     public String getCloud() {
@@ -31,6 +33,14 @@ public class BootstrapParams {
 
     public void setSaltBootstrapFpSupported(boolean saltBootstrapFpSupported) {
         this.saltBootstrapFpSupported = saltBootstrapFpSupported;
+    }
+
+    public boolean isRestartNeededFlagSupported() {
+        return restartNeededFlagSupported;
+    }
+
+    public void setRestartNeededFlagSupported(boolean restartNeededFlagSupported) {
+        this.restartNeededFlagSupported = restartNeededFlagSupported;
     }
 
     public boolean isRestartNeeded() {

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrapTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrapTest.java
@@ -3,12 +3,16 @@ package com.sequenceiq.cloudbreak.orchestrator.salt.poller;
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -22,6 +26,7 @@ import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.springframework.http.HttpStatus;
 
@@ -34,6 +39,7 @@ import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponse;
 import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponses;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
 import com.sequenceiq.cloudbreak.orchestrator.salt.client.SaltConnector;
+import com.sequenceiq.cloudbreak.orchestrator.salt.domain.Minion;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.MinionIpAddressesResponse;
 import com.sequenceiq.cloudbreak.orchestrator.salt.domain.SaltAction;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.join.MinionAcceptor;
@@ -114,6 +120,154 @@ public class SaltBootstrapTest {
             assertThat(e.getMessage(), not(containsString("10.0.0.2")));
             assertThat(e.getMessage(), not(containsString("10.0.0.1")));
         }
+    }
+
+    @Test
+    public void restartNeededTrueButFlagNotSupportedBySaltBootstrap() throws Exception {
+        List<Map<String, JsonNode>> result = new ArrayList<>();
+        Map<String, JsonNode> ipAddressesForMinions = new HashMap<>();
+        ipAddressesForMinions.put("10-0-0-1.example.com", JsonUtil.readTree("[\"10.0.0.1\"]"));
+        ipAddressesForMinions.put("10-0-0-2.example.com", JsonUtil.readTree("[\"10.0.0.2\"]"));
+        ipAddressesForMinions.put("10-0-0-3.example.com", JsonUtil.readTree("[\"10.0.0.3\"]"));
+        result.add(ipAddressesForMinions);
+        minionIpAddressesResponse.setResult(result);
+
+        Set<Node> targets = new HashSet<>();
+        targets.add(new Node("10.0.0.1", null, null, "hg"));
+        targets.add(new Node("10.0.0.2", null, null, "hg"));
+        targets.add(new Node("10.0.0.3", null, null, "hg"));
+
+        BootstrapParams params = new BootstrapParams();
+        params.setRestartNeeded(true);
+        params.setRestartNeededFlagSupported(false);
+        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, Collections.singletonList(gatewayConfig), targets, params);
+        saltBootstrap = spy(saltBootstrap);
+        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor(any(SaltAction.class));
+
+        saltBootstrap.call();
+
+        ArgumentCaptor<SaltAction> captor = ArgumentCaptor.forClass(SaltAction.class);
+        verify(saltConnector, times(1)).action(captor.capture());
+        SaltAction saltAction = captor.getValue();
+        List<Minion> minions = saltAction.getMinions();
+        assertEquals(3, minions.size());
+        assertEquals(Collections.singletonList("127.0.0.1"), minions.get(0).getServers());
+        assertEquals(Collections.singletonList("127.0.0.1"), minions.get(1).getServers());
+        assertEquals(Collections.singletonList("127.0.0.1"), minions.get(2).getServers());
+        assertTrue(minions.get(0).isRestartNeeded());
+        assertTrue(minions.get(1).isRestartNeeded());
+        assertTrue(minions.get(2).isRestartNeeded());
+    }
+
+    @Test
+    public void restartNeededTrueAndFlagSupportedBySaltBootstrap() throws Exception {
+        List<Map<String, JsonNode>> result = new ArrayList<>();
+        Map<String, JsonNode> ipAddressesForMinions = new HashMap<>();
+        ipAddressesForMinions.put("10-0-0-1.example.com", JsonUtil.readTree("[\"10.0.0.1\"]"));
+        ipAddressesForMinions.put("10-0-0-2.example.com", JsonUtil.readTree("[\"10.0.0.2\"]"));
+        ipAddressesForMinions.put("10-0-0-3.example.com", JsonUtil.readTree("[\"10.0.0.3\"]"));
+        result.add(ipAddressesForMinions);
+        minionIpAddressesResponse.setResult(result);
+
+        Set<Node> targets = new HashSet<>();
+        targets.add(new Node("10.0.0.1", null, null, "hg"));
+        targets.add(new Node("10.0.0.2", null, null, "hg"));
+        targets.add(new Node("10.0.0.3", null, null, "hg"));
+
+        BootstrapParams params = new BootstrapParams();
+        params.setRestartNeeded(true);
+        params.setRestartNeededFlagSupported(true);
+        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, Collections.singletonList(gatewayConfig), targets, params);
+        saltBootstrap = spy(saltBootstrap);
+        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor(any(SaltAction.class));
+
+        saltBootstrap.call();
+
+        ArgumentCaptor<SaltAction> captor = ArgumentCaptor.forClass(SaltAction.class);
+        verify(saltConnector, times(1)).action(captor.capture());
+        SaltAction saltAction = captor.getValue();
+        List<Minion> minions = saltAction.getMinions();
+        assertEquals(3, minions.size());
+        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(0).getServers());
+        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(1).getServers());
+        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(2).getServers());
+        assertTrue(minions.get(0).isRestartNeeded());
+        assertTrue(minions.get(1).isRestartNeeded());
+        assertTrue(minions.get(2).isRestartNeeded());
+    }
+
+    @Test
+    public void restartNeededFalseAndFlagSupportedBySaltBootstrap() throws Exception {
+        List<Map<String, JsonNode>> result = new ArrayList<>();
+        Map<String, JsonNode> ipAddressesForMinions = new HashMap<>();
+        ipAddressesForMinions.put("10-0-0-1.example.com", JsonUtil.readTree("[\"10.0.0.1\"]"));
+        ipAddressesForMinions.put("10-0-0-2.example.com", JsonUtil.readTree("[\"10.0.0.2\"]"));
+        ipAddressesForMinions.put("10-0-0-3.example.com", JsonUtil.readTree("[\"10.0.0.3\"]"));
+        result.add(ipAddressesForMinions);
+        minionIpAddressesResponse.setResult(result);
+
+        Set<Node> targets = new HashSet<>();
+        targets.add(new Node("10.0.0.1", null, null, "hg"));
+        targets.add(new Node("10.0.0.2", null, null, "hg"));
+        targets.add(new Node("10.0.0.3", null, null, "hg"));
+
+        BootstrapParams params = new BootstrapParams();
+        params.setRestartNeeded(false);
+        params.setRestartNeededFlagSupported(true);
+        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, Collections.singletonList(gatewayConfig), targets, params);
+        saltBootstrap = spy(saltBootstrap);
+        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor(any(SaltAction.class));
+
+        saltBootstrap.call();
+
+        ArgumentCaptor<SaltAction> captor = ArgumentCaptor.forClass(SaltAction.class);
+        verify(saltConnector, times(1)).action(captor.capture());
+        SaltAction saltAction = captor.getValue();
+        List<Minion> minions = saltAction.getMinions();
+        assertEquals(3, minions.size());
+        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(0).getServers());
+        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(1).getServers());
+        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(2).getServers());
+        assertFalse(minions.get(0).isRestartNeeded());
+        assertFalse(minions.get(1).isRestartNeeded());
+        assertFalse(minions.get(2).isRestartNeeded());
+    }
+
+    @Test
+    public void restartNeededFalseAndFlagNotSupportedBySaltBootstrap() throws Exception {
+        List<Map<String, JsonNode>> result = new ArrayList<>();
+        Map<String, JsonNode> ipAddressesForMinions = new HashMap<>();
+        ipAddressesForMinions.put("10-0-0-1.example.com", JsonUtil.readTree("[\"10.0.0.1\"]"));
+        ipAddressesForMinions.put("10-0-0-2.example.com", JsonUtil.readTree("[\"10.0.0.2\"]"));
+        ipAddressesForMinions.put("10-0-0-3.example.com", JsonUtil.readTree("[\"10.0.0.3\"]"));
+        result.add(ipAddressesForMinions);
+        minionIpAddressesResponse.setResult(result);
+
+        Set<Node> targets = new HashSet<>();
+        targets.add(new Node("10.0.0.1", null, null, "hg"));
+        targets.add(new Node("10.0.0.2", null, null, "hg"));
+        targets.add(new Node("10.0.0.3", null, null, "hg"));
+
+        BootstrapParams params = new BootstrapParams();
+        params.setRestartNeeded(false);
+        params.setRestartNeededFlagSupported(false);
+        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, Collections.singletonList(gatewayConfig), targets, params);
+        saltBootstrap = spy(saltBootstrap);
+        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor(any(SaltAction.class));
+
+        saltBootstrap.call();
+
+        ArgumentCaptor<SaltAction> captor = ArgumentCaptor.forClass(SaltAction.class);
+        verify(saltConnector, times(1)).action(captor.capture());
+        SaltAction saltAction = captor.getValue();
+        List<Minion> minions = saltAction.getMinions();
+        assertEquals(3, minions.size());
+        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(0).getServers());
+        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(1).getServers());
+        assertEquals(Collections.singletonList("172.16.252.43"), minions.get(2).getServers());
+        assertFalse(minions.get(0).isRestartNeeded());
+        assertFalse(minions.get(1).isRestartNeeded());
+        assertFalse(minions.get(2).isRestartNeeded());
     }
 
 }


### PR DESCRIPTION
Restart needed flag was introduced for the following use case:

In a repair scenario where salt master has the same IP address as before, the minions on other instances are not restarted by salt-bootstrap.
Salt minion does not try to communicate with master by itself for a long time (30mins or sthg like this).
So when we are waiting for the minions' keys on salt-master then timeout can happen if all the minions haven't tried to communicate with master during this time frame.

Timeout error message in this scenario: There are missing nodes from salt network response.
Solution was to introduce a restartNeeded flag in salt-bootstrap and we restart salt minions every time we do a salt-master replacement. (it used to be restarted only in case when salt-master IP address changed)

In case of older salt-bootsrap ( pre 0.13.4 ) the restartNeeded flag is not interpreted. So in an upgrade scenario (it has a repair flow in itself) where the upgrade starts from a 7.1.0 image, the minions are not restarted so the above mentioned timeout could happen.

It is a dirty fix but if the restartNeeded flag is set but salt-bootstrap does not support this flag, then we change the salt master ip address to an another one (1.2.3.4), so salt-minion will be restarted by older salt-bootstrap also.

The original IP will be set in the next iteration because restartNeeded flag will be false.