### PR TITLE
CB-9579 Attach an extra disk preserved for Postgres data only

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParameters.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParameters.java
@@ -94,6 +94,7 @@ public interface PlatformParameters {
         specialParameters.put(PlatformParametersConsts.DOWNSCALING_SUPPORTED, Boolean.TRUE);
         specialParameters.put(PlatformParametersConsts.STARTSTOP_SUPPORTED, Boolean.TRUE);
         specialParameters.put(PlatformParametersConsts.REGIONS_SUPPORTED, Boolean.TRUE);
+        specialParameters.put(PlatformParametersConsts.VOLUME_ATTACHMENT_SUPPORTED, Boolean.TRUE);
         return new SpecialParameters(specialParameters);
     }
 

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersConsts.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersConsts.java
@@ -20,6 +20,8 @@ public class PlatformParametersConsts {
 
     public static final String REGIONS_SUPPORTED = "regionsSupported";
 
+    public static final String VOLUME_ATTACHMENT_SUPPORTED = "volumeAttachmentSupported";
+
     public static final String FREEIPA_STACK_TYPE = "freeipa";
 
     public static final String CLOUD_STACK_TYPE_PARAMETER = "cloudStackType";

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudVolumeUsageType.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudVolumeUsageType.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+public enum CloudVolumeUsageType {
+    GENERAL,
+    DATABASE
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Volume.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Volume.java
@@ -4,20 +4,23 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Volume {
-
     private final String mount;
 
     private final String type;
 
     private final int size;
 
+    private final CloudVolumeUsageType volumeUsageType;
+
     @JsonCreator
     public Volume(@JsonProperty("mount") String mount,
             @JsonProperty("type") String type,
-            @JsonProperty("size") int size) {
+            @JsonProperty("size") int size,
+            @JsonProperty("volumeUsageType") CloudVolumeUsageType volumeUsageType) {
         this.mount = mount;
         this.type = type;
         this.size = size;
+        this.volumeUsageType = volumeUsageType;
     }
 
     public String getMount() {
@@ -32,12 +35,17 @@ public class Volume {
         return size;
     }
 
+    public CloudVolumeUsageType getVolumeUsageType() {
+        return volumeUsageType == null ? CloudVolumeUsageType.GENERAL : volumeUsageType;
+    }
+
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("Volume{");
+        final StringBuilder sb = new StringBuilder("Volume{");
         sb.append("mount='").append(mount).append('\'');
         sb.append(", type='").append(type).append('\'');
         sb.append(", size=").append(size);
+        sb.append(", volumeUsageType=").append(volumeUsageType);
         sb.append('}');
         return sb.toString();
     }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VolumeSetAttributes.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VolumeSetAttributes.java
@@ -108,15 +108,18 @@ public class VolumeSetAttributes {
 
         private String type;
 
+        private CloudVolumeUsageType cloudVolumeUsageType;
+
         public Volume(@JsonProperty("id") String id,
                 @JsonProperty("device") String device,
                 @JsonProperty("size") Integer size,
-                @JsonProperty("type") String type) {
+                @JsonProperty("type") String type,
+                @JsonProperty("usageType") CloudVolumeUsageType cloudVolumeUsageType) {
             this.id = id;
             this.device = device;
             this.type = type;
             this.size = size;
-
+            this.cloudVolumeUsageType = cloudVolumeUsageType;
         }
 
         public String getId() {
@@ -149,6 +152,14 @@ public class VolumeSetAttributes {
 
         public void setType(String type) {
             this.type = type;
+        }
+
+        public CloudVolumeUsageType getCloudVolumeUsageType() {
+            return cloudVolumeUsageType == null ? CloudVolumeUsageType.GENERAL : cloudVolumeUsageType;
+        }
+
+        public void setCloudVolumeUsageType(CloudVolumeUsageType cloudVolumeUsageType) {
+            this.cloudVolumeUsageType = cloudVolumeUsageType;
         }
     }
 

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
@@ -48,6 +48,7 @@ import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
@@ -1593,7 +1594,8 @@ public class CloudFormationTemplateBuilderTest {
     }
 
     private InstanceTemplate createDefaultInstanceTemplate() {
-        List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1), new Volume("/hadoop/fs2", "HDD", 1));
+        List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
+                new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         return new InstanceTemplate("m1.medium", "master", 0L, volumes, InstanceStatus.CREATE_REQUESTED, new HashMap<>(), 0L,
                 "cb-centos66-amb200-2015-05-25");
     }

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
@@ -82,6 +82,7 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
@@ -463,7 +464,7 @@ public class AwsRepairTest {
                 .withAvailabilityZone(AVAILABILITY_ZONE)
                 .withDeleteOnTermination(Boolean.FALSE)
                 .withFstab(fstab)
-                .withVolumes(List.of(new VolumeSetAttributes.Volume(volumeId, DEVICE, sizeDisk, VOLUME_TYPE)))
+                .withVolumes(List.of(new VolumeSetAttributes.Volume(volumeId, DEVICE, sizeDisk, VOLUME_TYPE, CloudVolumeUsageType.GENERAL)))
                 .build());
         return CloudResource.builder()
                 .group(WORKER_GROUP)

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/ComponentTestUtil.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/ComponentTestUtil.java
@@ -26,6 +26,7 @@ import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
@@ -151,8 +152,8 @@ public class ComponentTestUtil {
     private CloudInstance getCloudInstance(InstanceAuthentication instanceAuthentication,
             String groupName, InstanceStatus instanceStatus, long privateId, String instanceId) {
         List<Volume> volumes = Arrays.asList(
-                new Volume("/hadoop/fs1", "HDD", SIZE_DISK_1),
-                new Volume("/hadoop/fs2", "HDD", SIZE_DISK_2)
+                new Volume("/hadoop/fs1", "HDD", SIZE_DISK_1, CloudVolumeUsageType.GENERAL),
+                new Volume("/hadoop/fs2", "HDD", SIZE_DISK_2, CloudVolumeUsageType.GENERAL)
         );
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", groupName, privateId, volumes, instanceStatus,
                 new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25");

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilderTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilderTest.java
@@ -40,6 +40,7 @@ import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
@@ -244,7 +245,7 @@ class AwsVolumeResourceBuilderTest {
     }
 
     private Volume createVolume(String type) {
-        return new Volume(MOUNT_PREFIX + type, type, VOLUME_SIZE);
+        return new Volume(MOUNT_PREFIX + type, type, VOLUME_SIZE, CloudVolumeUsageType.GENERAL);
     }
 
     private Group createGroup(List<Volume> volumes, Map<String, Object> templateParameters) {
@@ -255,7 +256,7 @@ class AwsVolumeResourceBuilderTest {
     }
 
     private VolumeSetAttributes.Volume createVolumeForVolumeSet(String type) {
-        return new VolumeSetAttributes.Volume(null, null, VOLUME_SIZE, type);
+        return new VolumeSetAttributes.Volume(null, null, VOLUME_SIZE, type, CloudVolumeUsageType.GENERAL);
     }
 
     private CloudResource createVolumeSet(List<VolumeSetAttributes.Volume> volumes) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilder.java
@@ -113,7 +113,8 @@ public class AzureVolumeResourceBuilder extends AbstractAzureComputeBuilder {
                                     template.getVolumes().stream()
                                             .map(volume -> new VolumeSetAttributes.Volume(
                                                     resourceNameService.resourceName(ResourceType.AZURE_DISK, stackName, groupName, privateId,
-                                                            template.getVolumes().indexOf(volume), stackCrn), null, volume.getSize(), volume.getType()))
+                                                            template.getVolumes().indexOf(volume), stackCrn),
+                                                    null, volume.getSize(), volume.getType(), volume.getVolumeUsageType()))
                                             .collect(Collectors.toList()))
                             .build()))
                     .build();
@@ -164,7 +165,8 @@ public class AzureVolumeResourceBuilder extends AbstractAzureComputeBuilder {
                             LOGGER.debug("Managed disk for resourcegroup: {}, name: {} already exists: {}", resourceGroupName, volume.getId(), result);
                         }
                         String volumeId = result.id();
-                        volumeSetMap.get(resource.getName()).add(new VolumeSetAttributes.Volume(volumeId, generator.next(), volume.getSize(), volume.getType()));
+                        volumeSetMap.get(resource.getName()).add(new VolumeSetAttributes.Volume(volumeId, generator.next(), volume.getSize(), volume.getType(),
+                                volume.getCloudVolumeUsageType()));
                     }))
                     .collect(Collectors.toList()));
         }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -52,6 +52,7 @@ import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
@@ -179,7 +180,8 @@ public class AzureTemplateBuilderTest {
         groups = new ArrayList<>();
         stackName = "testStack";
         name = "master";
-        List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1), new Volume("/hadoop/fs2", "HDD", 1));
+        List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
+                new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", name, 0L, volumes, InstanceStatus.CREATE_REQUESTED,
                 new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25");
         Map<String, Object> params = new HashMap<>();

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
@@ -41,6 +41,7 @@ import com.sequenceiq.cloudbreak.cloud.azure.service.AzureResourceNameService;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
@@ -179,7 +180,7 @@ public class AzureVolumeResourceBuilderTest {
         CloudResource mock = CloudResource.builder().type(ResourceType.AZURE_RESOURCE_GROUP).name("resource-group").build();
         when(context.getNetworkResources()).thenReturn(List.of(mock));
         ArrayList<VolumeSetAttributes.Volume> volumes = new ArrayList<>();
-        volumes.add(new VolumeSetAttributes.Volume("volume-1", "device", 100, "ssd"));
+        volumes.add(new VolumeSetAttributes.Volume("volume-1", "device", 100, "ssd", CloudVolumeUsageType.GENERAL));
         CloudResource volumeSetResource = CloudResource.builder().type(ResourceType.AZURE_VOLUMESET).status(CommonStatus.CREATED)
                 .params(Map.of(CloudResource.ATTRIBUTES, new VolumeSetAttributes("az", true, "", volumes, 100, "ssd")))
                 .name("volume").build();
@@ -194,7 +195,7 @@ public class AzureVolumeResourceBuilderTest {
         CloudResource mock = CloudResource.builder().type(ResourceType.AZURE_RESOURCE_GROUP).name("resource-group").build();
         when(context.getNetworkResources()).thenReturn(List.of(mock));
         ArrayList<VolumeSetAttributes.Volume> volumes = new ArrayList<>();
-        volumes.add(new VolumeSetAttributes.Volume("vol1", "device", 100, "ssd"));
+        volumes.add(new VolumeSetAttributes.Volume("vol1", "device", 100, "ssd", CloudVolumeUsageType.GENERAL));
         CloudResource volumeSetResource = CloudResource.builder().type(ResourceType.AZURE_VOLUMESET).status(CommonStatus.CREATED)
                 .params(Map.of(
                         CloudResource.ATTRIBUTES, new VolumeSetAttributes("az", true, "", volumes, 100, "ssd")
@@ -227,7 +228,7 @@ public class AzureVolumeResourceBuilderTest {
         CloudResource mock = CloudResource.builder().type(ResourceType.AZURE_RESOURCE_GROUP).name("resource-group").build();
         when(context.getNetworkResources()).thenReturn(List.of(mock));
         ArrayList<VolumeSetAttributes.Volume> volumes = new ArrayList<>();
-        volumes.add(new VolumeSetAttributes.Volume("vol1", "device", 100, "ssd"));
+        volumes.add(new VolumeSetAttributes.Volume("vol1", "device", 100, "ssd", CloudVolumeUsageType.GENERAL));
         CloudResource volumeSetResource = CloudResource.builder().type(ResourceType.AZURE_VOLUMESET).status(CommonStatus.CREATED)
                 .params(Map.of(
                         CloudResource.ATTRIBUTES, new VolumeSetAttributes("az", true, "", volumes, 100, "ssd")

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilder.java
@@ -93,7 +93,7 @@ public class GcpAttachedDiskResourceBuilder extends AbstractGcpComputeBuilder {
         for (int i = 0; i < template.getVolumes().size(); i++) {
             String volumeName = resourceNameService.resourceName(resourceType(), stackName, groupName, privateId, i);
             Volume volume = template.getVolumes().get(i);
-            volumes.add(new VolumeSetAttributes.Volume(volumeName, generator.next(), volume.getSize(), volume.getType()));
+            volumes.add(new VolumeSetAttributes.Volume(volumeName, generator.next(), volume.getSize(), volume.getType(), volume.getVolumeUsageType()));
         }
         String resourceName = resourceNameService.resourceName(resourceType(), stackName, groupName, privateId, 0);
         Map<String, Object> attributes = new HashMap<>(Map.of(CloudResource.ATTRIBUTES, new VolumeSetAttributes.Builder()

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilderTest.java
@@ -45,6 +45,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
@@ -137,7 +138,8 @@ class GcpAttachedDiskResourceBuilderTest {
         auth = new AuthenticatedContext(cloudContext, cloudCredential);
 
         params = Map.of();
-        volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1), new Volume("/hadoop/fs2", "HDD", 1));
+        volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
+                new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
 
         List<SecurityRule> rules = Collections.singletonList(new SecurityRule("0.0.0.0/0",
                 new PortDefinition[]{new PortDefinition("22", "22"), new PortDefinition("443", "443")}, "tcp"));
@@ -151,7 +153,7 @@ class GcpAttachedDiskResourceBuilderTest {
                 instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), 50, Optional.empty());
 
         List<VolumeSetAttributes.Volume> volumes = new ArrayList<>();
-        volumes.add(new VolumeSetAttributes.Volume("1234", "noop", 0, "eph"));
+        volumes.add(new VolumeSetAttributes.Volume("1234", "noop", 0, "eph", CloudVolumeUsageType.GENERAL));
 
         VolumeSetAttributes attributes = new VolumeSetAttributes("Ireland", true, "", volumes, 0, "eph");
         Map<String, Object> params = new HashMap<>();

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilderTest.java
@@ -45,6 +45,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
@@ -129,7 +130,8 @@ class GcpDiskResourceBuilderTest {
         auth = new AuthenticatedContext(cloudContext, cloudCredential);
 
         Map<String, Object> params = Map.of();
-        List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1), new Volume("/hadoop/fs2", "HDD", 1));
+        List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
+                new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
 
         List<SecurityRule> rules = Collections.singletonList(new SecurityRule("0.0.0.0/0",
                 new PortDefinition[]{new PortDefinition("22", "22"), new PortDefinition("443", "443")}, "tcp"));

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
@@ -65,6 +65,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
@@ -143,7 +144,8 @@ public class GcpInstanceResourceBuilderTest {
         name = "master";
         flavor = "m1.medium";
         instanceId = "SOME_ID";
-        volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1), new Volume("/hadoop/fs2", "HDD", 1));
+        volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
+                new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         List<SecurityRule> rules = Collections.singletonList(new SecurityRule("0.0.0.0/0",
                 new PortDefinition[]{new PortDefinition("22", "22"), new PortDefinition("443", "443")}, "tcp"));
         security = new Security(rules, emptyList());

--- a/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/HeatTemplateBuilderTest.java
+++ b/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/HeatTemplateBuilderTest.java
@@ -37,6 +37,7 @@ import org.springframework.ui.freemarker.FreeMarkerConfigurationFactoryBean;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
@@ -115,7 +116,8 @@ public class HeatTemplateBuilderTest {
         stackName = "testStack";
         groups = new ArrayList<>(1);
         String name = "master";
-        List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1), new Volume("/hadoop/fs2", "HDD", 1));
+        List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
+                new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", name, 0L, volumes, InstanceStatus.CREATE_REQUESTED,
                 new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25");
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ParameterGenerator.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ParameterGenerator.java
@@ -25,6 +25,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
@@ -70,7 +71,8 @@ public class ParameterGenerator {
         List<Group> groups = new ArrayList<>();
 
         String name = "master";
-        List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1), new Volume("/hadoop/fs2", "HDD", 1));
+        List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
+                new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", name, 0L, volumes, InstanceStatus.CREATE_REQUESTED,
                 new HashMap<>(), 0L, "default-id");
 

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnPlatformParameters.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnPlatformParameters.java
@@ -97,6 +97,7 @@ public class YarnPlatformParameters implements PlatformParameters {
         specialParameters.put(PlatformParametersConsts.DOWNSCALING_SUPPORTED, Boolean.FALSE);
         specialParameters.put(PlatformParametersConsts.STARTSTOP_SUPPORTED, Boolean.FALSE);
         specialParameters.put(PlatformParametersConsts.REGIONS_SUPPORTED, Boolean.FALSE);
+        specialParameters.put(PlatformParametersConsts.VOLUME_ATTACHMENT_SUPPORTED, Boolean.FALSE);
         return new SpecialParameters(specialParameters);
     }
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/instancegroup/template/InstanceTemplateV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/instancegroup/template/InstanceTemplateV4Response.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceTemplateV4Base;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.template.volume.DatabaseVolumeV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.template.volume.RootVolumeV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.template.volume.VolumeV4Response;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
@@ -26,6 +27,8 @@ public class InstanceTemplateV4Response extends InstanceTemplateV4Base {
     private VolumeV4Response ephemeralVolume;
 
     private Set<VolumeV4Response> attachedVolumes;
+
+    private DatabaseVolumeV4Response databaseVolume;
 
     public Long getId() {
         return id;
@@ -57,5 +60,13 @@ public class InstanceTemplateV4Response extends InstanceTemplateV4Base {
 
     public void setAttachedVolumes(Set<VolumeV4Response> attachedVolumes) {
         this.attachedVolumes = attachedVolumes;
+    }
+
+    public DatabaseVolumeV4Response getDatabaseVolume() {
+        return databaseVolume;
+    }
+
+    public void setDatabaseVolume(DatabaseVolumeV4Response databaseVolume) {
+        this.databaseVolume = databaseVolume;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/instancegroup/template/volume/DatabaseVolumeV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/instancegroup/template/volume/DatabaseVolumeV4Response.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.template.volume;
+
+import static com.sequenceiq.cloudbreak.doc.ModelDescriptions.TemplateModelDescription.DATABASE_VOLUME_SIZE;
+import static com.sequenceiq.cloudbreak.doc.ModelDescriptions.TemplateModelDescription.DATABASE_VOLUME_TYPE;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.common.model.JsonEntity;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class DatabaseVolumeV4Response implements JsonEntity {
+
+    @ApiModelProperty(DATABASE_VOLUME_TYPE)
+    private String type;
+
+    @ApiModelProperty(DATABASE_VOLUME_SIZE)
+    private Integer size;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -62,6 +62,8 @@ public class ModelDescriptions {
         public static final String VOLUME_SIZE = "size of volume";
         public static final String ROOT_VOLUME_SIZE = "size of the root volume";
         public static final String VOLUME_TYPE = "type of the volumes";
+        public static final String DATABASE_VOLUME_SIZE = "size of the database volume";
+        public static final String DATABASE_VOLUME_TYPE = "type of the database volume";
         public static final String INSTANCE_TYPE = "type of the instance";
         public static final String CUSTOM_INSTANCE_TYPE = "custom instancetype definition";
         public static final String PARAMETERS = "cloud specific parameters for template";

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/VolumeTemplate.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/VolumeTemplate.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.domain;
 
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -7,6 +8,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 
+import com.sequenceiq.cloudbreak.domain.converter.VolumeUsageTypeConverter;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.cloudbreak.workspace.model.WorkspaceAwareResource;
 
@@ -23,6 +25,9 @@ public class VolumeTemplate implements ProvisionEntity, WorkspaceAwareResource {
     private Integer volumeSize;
 
     private String volumeType;
+
+    @Convert(converter = VolumeUsageTypeConverter.class)
+    private VolumeUsageType usageType = VolumeUsageType.GENERAL;
 
     @ManyToOne
     private Template template;
@@ -57,6 +62,14 @@ public class VolumeTemplate implements ProvisionEntity, WorkspaceAwareResource {
 
     public void setVolumeType(String volumeType) {
         this.volumeType = volumeType;
+    }
+
+    public VolumeUsageType getUsageType() {
+        return usageType == null ? VolumeUsageType.GENERAL : usageType;
+    }
+
+    public void setUsageType(VolumeUsageType usageType) {
+        this.usageType = usageType;
     }
 
     public Template getTemplate() {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/VolumeUsageType.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/VolumeUsageType.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.domain;
+
+public enum VolumeUsageType {
+    GENERAL,
+    DATABASE
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/VolumeUsageTypeConverter.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/VolumeUsageTypeConverter.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.domain.converter;
+
+import com.sequenceiq.cloudbreak.converter.DefaultEnumConverter;
+import com.sequenceiq.cloudbreak.domain.VolumeUsageType;
+
+public class VolumeUsageTypeConverter extends DefaultEnumConverter<VolumeUsageType> {
+    @Override
+    public VolumeUsageType getDefault() {
+        return VolumeUsageType.GENERAL;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/EmbeddedDatabaseConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/EmbeddedDatabaseConfig.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.conf;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "cb.db.env.embedded.volume")
+public class EmbeddedDatabaseConfig {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedDatabaseConfig.class);
+
+    private Integer size;
+
+    private Map<String, String> platformVolumeTypeMap;
+
+    @PostConstruct
+    public void log() {
+        LOGGER.info("Configuration of embedded database: {}", toString());
+    }
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+
+    public Map<String, String> getPlatformVolumeTypeMap() {
+        return platformVolumeTypeMap;
+    }
+
+    public void setPlatformVolumeTypeMap(Map<String, String> platformVolumeTypeMap) {
+        this.platformVolumeTypeMap = platformVolumeTypeMap;
+    }
+
+    public Optional<String> getPlatformVolumeType(String cloudPlatform) {
+        return Optional.ofNullable(platformVolumeTypeMap.get(cloudPlatform));
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", EmbeddedDatabaseConfig.class.getSimpleName() + "[", "]")
+                .add("size=" + size)
+                .add("platformVolumeTypeMap=" + platformVolumeTypeMap)
+                .toString();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/template/InstanceTemplateV4RequestToTemplateConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/template/InstanceTemplateV4RequestToTemplateConverter.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.common.type.APIResourceType;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.domain.VolumeUsageType;
 import com.sequenceiq.cloudbreak.service.stack.DefaultRootVolumeSizeProvider;
 
 @Component
@@ -77,6 +78,7 @@ public class InstanceTemplateV4RequestToTemplateConverter extends AbstractConver
                 volumeTemplate.setVolumeCount(volumeCount == null ? Integer.valueOf(0) : volumeCount);
                 volumeTemplate.setVolumeType(volumeType == null ? "HDD" : volumeType);
                 volumeTemplate.setVolumeSize(volumeSize == null ? Integer.valueOf(0) : volumeSize);
+                volumeTemplate.setUsageType(VolumeUsageType.GENERAL);
                 volumeTemplate.setTemplate(template);
                 template.getVolumeTemplates().add(volumeTemplate);
             });

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/template/TemplateToInstanceTemplateV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/template/TemplateToInstanceTemplateV4ResponseConverter.java
@@ -3,12 +3,14 @@ package com.sequenceiq.cloudbreak.converter.v4.stacks.instancegroup.template;
 import static java.util.Optional.ofNullable;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.template.volume.DatabaseVolumeV4Response;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.mappable.ProviderParameterCalculator;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.template.InstanceTemplateV4Response;
@@ -17,6 +19,8 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.t
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
 import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.domain.VolumeUsageType;
 
 @Component
 public class TemplateToInstanceTemplateV4ResponseConverter extends AbstractConversionServiceAwareConverter<Template, InstanceTemplateV4Response> {
@@ -30,8 +34,10 @@ public class TemplateToInstanceTemplateV4ResponseConverter extends AbstractConve
         response.setId(source.getId());
         response.setRootVolume(rootVolume(source));
         response.setAttachedVolumes(source.getVolumeTemplates().stream()
+                .filter(volume -> volume.getUsageType() == VolumeUsageType.GENERAL)
                 .map(volume -> getConversionService().convert(volume, VolumeV4Response.class))
                 .collect(Collectors.toSet()));
+        response.setDatabaseVolume(databaseVolume(source));
         response.setInstanceType(source.getInstanceType());
         Json attributes = source.getAttributes();
         if (attributes != null) {
@@ -47,5 +53,16 @@ public class TemplateToInstanceTemplateV4ResponseConverter extends AbstractConve
         RootVolumeV4Response response = new RootVolumeV4Response();
         response.setSize(source.getRootVolumeSize());
         return response;
+    }
+
+    private DatabaseVolumeV4Response databaseVolume(Template source) {
+        Optional<VolumeTemplate> databaseVolume = source.getVolumeTemplates().stream()
+                .filter(volumeTemplate -> volumeTemplate.getUsageType() == VolumeUsageType.DATABASE).findFirst();
+        return databaseVolume.map(volume -> {
+            DatabaseVolumeV4Response volumeResponse = new DatabaseVolumeV4Response();
+            volumeResponse.setType(volume.getVolumeType());
+            volumeResponse.setSize(volume.getVolumeSize());
+            return volumeResponse;
+        }).orElse(null);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/EmbeddedDatabaseConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/EmbeddedDatabaseConfigProvider.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.auth.altus.model.Entitlement;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.service.cluster.EmbeddedDatabaseInfo;
 import com.sequenceiq.cloudbreak.service.cluster.EmbeddedDatabaseService;
 import com.sequenceiq.cloudbreak.template.VolumeUtils;
 
@@ -37,11 +36,10 @@ public class EmbeddedDatabaseConfigProvider {
 
     public Map<String, Object> collectEmbeddedDatabaseConfigs(Stack stack) {
         Map<String, Object> result;
-        EmbeddedDatabaseInfo embeddedDatabaseInfo = embeddedDatabaseService.getEmbeddedDatabaseInfo(stack);
-        if (embeddedDatabaseInfo.isEmbeddedDatabaseOnAttachedDiskEnabled()) {
+        if (embeddedDatabaseService.isAttachedDiskForEmbeddedDatabaseCreated(stack)) {
             LOGGER.info("Attached disk will be used to store data for postgres sql server, as '{}' entitlement is enabled",
                     Entitlement.CDP_EMBEDDED_DATABASE_ON_ATTACHED_DISK);
-            result = createEmbeddedDbOnAttachedDiskConfig(embeddedDatabaseInfo.getAttachedDisksCount());
+            result = createEmbeddedDbOnAttachedDiskConfig();
         } else {
             LOGGER.info("Default settings for data storage will be used for postgres sql server, as '{}' entitlement is disabled or no disks attached",
                     Entitlement.CDP_EMBEDDED_DATABASE_ON_ATTACHED_DISK);
@@ -54,10 +52,10 @@ public class EmbeddedDatabaseConfigProvider {
         return result;
     }
 
-    private Map<String, Object> createEmbeddedDbOnAttachedDiskConfig(int volumeCount) {
+    private Map<String, Object> createEmbeddedDbOnAttachedDiskConfig() {
         return Map.of(
-            POSTGRES_DIRECTORY_KEY, VolumeUtils.buildSingleVolumePath(volumeCount, POSTGRES_SUBDIRECTORY_ON_ATTACHED_DISK),
-            POSTGRES_LOG_DIRECTORY_KEY, VolumeUtils.buildSingleVolumePath(volumeCount, POSTGRES_LOG_SUBDIRECTORY_ON_ATTACHED_DISK),
+            POSTGRES_DIRECTORY_KEY, VolumeUtils.DATABASE_VOLUME + "/" + POSTGRES_SUBDIRECTORY_ON_ATTACHED_DISK,
+            POSTGRES_LOG_DIRECTORY_KEY, VolumeUtils.DATABASE_VOLUME + "/" + POSTGRES_LOG_SUBDIRECTORY_ON_ATTACHED_DISK,
             POSTGRES_DATA_ON_ATTACHED_DISK_KEY, true);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/ClusterDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/ClusterDecorator.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.service.decorator;
 
-import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
-
 import java.util.HashSet;
 import java.util.Optional;
 
@@ -22,10 +20,10 @@ import com.sequenceiq.cloudbreak.cloud.PlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Variant;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintValidatorFactory;
 import com.sequenceiq.cloudbreak.service.cluster.EmbeddedDatabaseService;
@@ -113,7 +111,7 @@ public class ClusterDecorator {
     }
 
     private void setupEmbeddedDatabase(Cluster cluster, Stack stack) {
-        cluster.setEmbeddedDatabaseOnAttachedDisk(embeddedDatabaseService.getEmbeddedDatabaseInfo(
-                INTERNAL_ACTOR_CRN, ThreadBasedUserCrnProvider.getAccountId(), stack, cluster).isEmbeddedDatabaseOnAttachedDiskEnabled());
+        cluster.setEmbeddedDatabaseOnAttachedDisk(embeddedDatabaseService
+                .isEmbeddedDatabaseOnAttachedDiskEnabled(ThreadBasedUserCrnProvider.getAccountId(), stack, cluster));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/CloudParameterCache.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/CloudParameterCache.java
@@ -55,6 +55,10 @@ public class CloudParameterCache {
         return getSpecialParameters(Platform.platform(platform)).get(PlatformParametersConsts.REGIONS_SUPPORTED);
     }
 
+    public boolean isVolumeAttachmentSupported(String platform) {
+        return getSpecialParameters(Platform.platform(platform)).get(PlatformParametersConsts.VOLUME_ATTACHMENT_SUPPORTED);
+    }
+
     private Map<String, Boolean> getSpecialParameters(Platform platform) {
         PlatformParameters platformParameters = getPlatformParameters().get(platform);
         if (platformParameters == null) {

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -151,6 +151,13 @@ cb:
     schema: public
     cert.file: database.crt
     ssl: false
+    embedded.volume:
+      size: 100
+      platformVolumeTypeMap:
+        AWS: standard
+        AZURE: StandardSSD_LRS
+        GCP: pd-standard
+        MOCK: magnetic
 
   externaldatabase.ssl.rootcerts.path: /hadoopfs/fs1/database-cacerts/certs.pem
 

--- a/core/src/main/resources/schema/app/20210118111635_CB-9579_Extend_Volume_domain_object_to_store_the_usage_type_of_the_attached_volumes_(general_or_database).sql
+++ b/core/src/main/resources/schema/app/20210118111635_CB-9579_Extend_Volume_domain_object_to_store_the_usage_type_of_the_attached_volumes_(general_or_database).sql
@@ -1,0 +1,12 @@
+-- // CB-9579 Extend Volume domain object to store the usage type of the attached volumes (general or database)
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE volumetemplate ADD COLUMN IF NOT EXISTS usagetype VARCHAR(255);
+ALTER TABLE volumetemplate ALTER COLUMN usagetype SET DEFAULT 'GENERAL';
+UPDATE volumetemplate SET usagetype = 'GENERAL' WHERE usagetype IS NULL;
+ALTER TABLE volumetemplate ALTER COLUMN usagetype SET NOT NULL;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE volumetemplate DROP COLUMN IF EXISTS usagetype;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/EmbeddedDatabaseConfigProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/EmbeddedDatabaseConfigProviderTest.java
@@ -10,91 +10,52 @@ import static com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgre
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
-import com.sequenceiq.cloudbreak.domain.Template;
-import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
-import com.sequenceiq.cloudbreak.service.cluster.EmbeddedDatabaseInfo;
 import com.sequenceiq.cloudbreak.service.cluster.EmbeddedDatabaseService;
 import com.sequenceiq.cloudbreak.template.VolumeUtils;
-import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @ExtendWith(MockitoExtension.class)
 public class EmbeddedDatabaseConfigProviderTest {
-    private static final String ACCOUNT_ID = "cloudera";
-
-    private static final String USER_CRN = "crn:cdp:iam:us-west-1:" + ACCOUNT_ID + ":user:test@cloudera.com";
-
     @Mock
     private EmbeddedDatabaseService embeddedDatabaseService;
 
     @InjectMocks
     private EmbeddedDatabaseConfigProvider underTest;
 
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("volumeCounts")
-    public void collectEmbeddedDatabaseConfigsWhenDbOnAttachedDiskEnabled(String testName, int volumeCount) {
+    @Test
+    public void testIsEmbeddedDatabaseOnAttachedDiskEnabled() {
         // GIVEN
-        Stack stack = createStack(volumeCount);
-        when(embeddedDatabaseService.getEmbeddedDatabaseInfo(stack)).thenReturn(new EmbeddedDatabaseInfo(volumeCount));
+        Stack stack = new Stack();
+        when(embeddedDatabaseService.isAttachedDiskForEmbeddedDatabaseCreated(any())).thenReturn(true);
         // WHEN
         Map<String, Object> actualResult = underTest.collectEmbeddedDatabaseConfigs(stack);
         // THEN
         assertTrue((Boolean) actualResult.get(POSTGRES_DATA_ON_ATTACHED_DISK_KEY));
-        assertEquals(VolumeUtils.buildSingleVolumePath(volumeCount, POSTGRES_SUBDIRECTORY_ON_ATTACHED_DISK), actualResult.get(POSTGRES_DIRECTORY_KEY));
-        assertEquals(VolumeUtils.buildSingleVolumePath(volumeCount, POSTGRES_LOG_SUBDIRECTORY_ON_ATTACHED_DISK), actualResult.get(POSTGRES_LOG_DIRECTORY_KEY));
+        assertEquals(VolumeUtils.DATABASE_VOLUME + "/" + POSTGRES_SUBDIRECTORY_ON_ATTACHED_DISK, actualResult.get(POSTGRES_DIRECTORY_KEY));
+        assertEquals(VolumeUtils.DATABASE_VOLUME + "/" + POSTGRES_LOG_SUBDIRECTORY_ON_ATTACHED_DISK, actualResult.get(POSTGRES_LOG_DIRECTORY_KEY));
     }
 
     @Test
     public void collectEmbeddedDatabaseConfigsWhenDbOnAttachedDiskDisabledOrNoAttachedVolumes() {
         // GIVEN
-        Stack stack = createStack(0);
-        when(embeddedDatabaseService.getEmbeddedDatabaseInfo(stack)).thenReturn(new EmbeddedDatabaseInfo(0));
+        Stack stack = new Stack();
+        when(embeddedDatabaseService.isAttachedDiskForEmbeddedDatabaseCreated(any())).thenReturn(false);
         // WHEN
         Map<String, Object> actualResult = underTest.collectEmbeddedDatabaseConfigs(stack);
         // THEN
         assertFalse((Boolean) actualResult.get(POSTGRES_DATA_ON_ATTACHED_DISK_KEY));
         assertEquals(POSTGRES_DEFAULT_DIRECTORY, actualResult.get(POSTGRES_DIRECTORY_KEY));
         assertEquals(POSTGRES_DEFAULT_LOG_DIRECTORY, actualResult.get(POSTGRES_LOG_DIRECTORY_KEY));
-    }
-
-    private static Stream<Arguments> volumeCounts() {
-        return Stream.of(
-                Arguments.arguments("One attached volume", 1),
-                Arguments.arguments("Five attached volume", 5));
-    }
-
-    private Stack createStack(int volumeCount) {
-        Stack stack = new Stack();
-        InstanceGroup masterGroup = new InstanceGroup();
-        masterGroup.setInstanceGroupType(InstanceGroupType.GATEWAY);
-        InstanceMetaData instanceMetaData = new InstanceMetaData();
-        instanceMetaData.setInstanceGroup(masterGroup);
-        instanceMetaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
-        masterGroup.setInstanceMetaData(Set.of(instanceMetaData));
-        Template template = new Template();
-        VolumeTemplate volumeTemplate = new VolumeTemplate();
-        volumeTemplate.setVolumeCount(volumeCount);
-        template.setVolumeTemplates(Set.of(volumeTemplate));
-        masterGroup.setTemplate(template);
-        stack.setInstanceGroups(Set.of(masterGroup));
-        return stack;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/EmbeddedDatabaseServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/EmbeddedDatabaseServiceTest.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.service.cluster;
 
-import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -15,77 +13,130 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
-import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.domain.VolumeUsageType;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.service.stack.CloudParameterCache;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @ExtendWith(MockitoExtension.class)
 public class EmbeddedDatabaseServiceTest {
     private static final String ACCOUNT_ID = "cloudera";
 
-    private static final String USER_CRN = "crn:cdp:iam:us-west-1:" + ACCOUNT_ID + ":user:test@cloudera.com";
+    private static final String CLOUDPLATFORM = "cloudplatform";
 
     @Mock
     private EntitlementService entitlementService;
+
+    @Mock
+    private CloudParameterCache cloudParameterCache;
 
     @InjectMocks
     private EmbeddedDatabaseService underTest;
 
     @Test
-    public void testGetEmbeddedDatabaseInfoWithAttachmentEnabled() {
+    public void testIsEmbeddedDatabaseOnAttachedDiskEnabled() {
         // GIVEN
-        Stack stack = createStack(5);
+        Stack stack = createStack(1);
         Mockito.when(entitlementService.embeddedDatabaseOnAttachedDiskEnabled(ACCOUNT_ID)).thenReturn(true);
+        Mockito.when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(true);
         // WHEN
-        EmbeddedDatabaseInfo actualResult = ThreadBasedUserCrnProvider.doAs(USER_CRN,
-                () -> underTest.getEmbeddedDatabaseInfo(INTERNAL_ACTOR_CRN, ACCOUNT_ID, stack, null));
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabled(ACCOUNT_ID, stack, null);
         // THEN
-        assertTrue(actualResult.isEmbeddedDatabaseOnAttachedDiskEnabled());
-        assertEquals(5, actualResult.getAttachedDisksCount());
+        assertTrue(actualResult);
     }
 
     @Test
-    public void testGetEmbeddedDatabaseInfoWithAttachmentEnabledWhenAttachedDiskEntitlementIsEnabledButNoDisksAttached() {
+    public void testIsEmbeddedDatabaseOnAttachedDiskEnabledWhenAttachedDiskEntitlementIsEnabledButNoDisksAttachedSupported() {
         // GIVEN
         Stack stack = createStack(0);
         Mockito.when(entitlementService.embeddedDatabaseOnAttachedDiskEnabled(ACCOUNT_ID)).thenReturn(true);
+        Mockito.when(cloudParameterCache.isVolumeAttachmentSupported(CLOUDPLATFORM)).thenReturn(false);
         // WHEN
-        EmbeddedDatabaseInfo actualResult = ThreadBasedUserCrnProvider.doAs(USER_CRN,
-                () -> underTest.getEmbeddedDatabaseInfo(INTERNAL_ACTOR_CRN, ACCOUNT_ID, stack, null));
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabled(ACCOUNT_ID, stack, null);
         // THEN
-        assertFalse(actualResult.isEmbeddedDatabaseOnAttachedDiskEnabled());
-        assertEquals(0, actualResult.getAttachedDisksCount());
+        assertFalse(actualResult);
     }
 
     @Test
-    public void testGetEmbeddedDatabaseInfoWithAttachmentEnabledWhenAttachedDiskEntitlementIsEnabledButNoTemplateProvided() {
+    public void testIsEmbeddedDatabaseOnAttachedDiskEnabledWhenExternalDBUsed() {
+        // GIVEN
+        Stack stack = createStack(0);
+        stack.setExternalDatabaseCreationType(DatabaseAvailabilityType.NON_HA);
+        // WHEN
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabled(ACCOUNT_ID, stack, null);
+        // THEN
+        assertFalse(actualResult);
+    }
+
+    @Test
+    public void testIsEmbeddedDatabaseOnAttachedDiskEnabledWhenExternalDBCrnSet() {
+        // GIVEN
+        Stack stack = createStack(0);
+        Cluster cluster = new Cluster();
+        cluster.setDatabaseServerCrn("dbcrn");
+        // WHEN
+        boolean actualResult = underTest.isEmbeddedDatabaseOnAttachedDiskEnabled(ACCOUNT_ID, stack, cluster);
+        // THEN
+        assertFalse(actualResult);
+    }
+
+    @Test
+    public void testIsAttachedDiskForEmbeddedDatabaseCreated() {
+        // GIVEN
+        Stack stack = createStack(1);
+        Cluster cluster = new Cluster();
+        cluster.setEmbeddedDatabaseOnAttachedDisk(true);
+        stack.setCluster(cluster);
+        // WHEN
+        boolean actualResult = underTest.isAttachedDiskForEmbeddedDatabaseCreated(stack);
+        // THEN
+        assertTrue(actualResult);
+    }
+
+    @Test
+    public void testIsAttachedDiskForEmbeddedDatabaseCreatedWhenNoVolumeAttached() {
+        // GIVEN
+        Stack stack = createStack(0);
+        Cluster cluster = new Cluster();
+        cluster.setEmbeddedDatabaseOnAttachedDisk(true);
+        stack.setCluster(cluster);
+        // WHEN
+        boolean actualResult = underTest.isAttachedDiskForEmbeddedDatabaseCreated(stack);
+        // THEN
+        assertFalse(actualResult);
+    }
+
+    @Test
+    public void testIsAttachedDiskForEmbeddedDatabaseCreatedWhenNoTemplate() {
         // GIVEN
         Stack stack = createStackWithoutTemplate();
-        Mockito.when(entitlementService.embeddedDatabaseOnAttachedDiskEnabled(ACCOUNT_ID)).thenReturn(true);
+        Cluster cluster = new Cluster();
+        cluster.setEmbeddedDatabaseOnAttachedDisk(true);
+        stack.setCluster(cluster);
         // WHEN
-        EmbeddedDatabaseInfo actualResult = ThreadBasedUserCrnProvider.doAs(USER_CRN,
-                () -> underTest.getEmbeddedDatabaseInfo(INTERNAL_ACTOR_CRN, ACCOUNT_ID, stack, null));
+        boolean actualResult = underTest.isAttachedDiskForEmbeddedDatabaseCreated(stack);
         // THEN
-        assertFalse(actualResult.isEmbeddedDatabaseOnAttachedDiskEnabled());
-        assertEquals(0, actualResult.getAttachedDisksCount());
+        assertFalse(actualResult);
     }
 
     @Test
-    public void testGetEmbeddedDatabaseInfoWithAttachmentEnabledWhenAttachedDiskEntitlementIsDisabled() {
+    public void testIsAttachedDiskForEmbeddedDatabaseCreatedWhenDbOnAttachedDisIsDisabled() {
         // GIVEN
-        Stack stack = createStack(5);
-        Mockito.when(entitlementService.embeddedDatabaseOnAttachedDiskEnabled(ACCOUNT_ID)).thenReturn(false);
+        Stack stack = createStack(1);
+        Cluster cluster = new Cluster();
+        cluster.setEmbeddedDatabaseOnAttachedDisk(false);
+        stack.setCluster(cluster);
         // WHEN
-        EmbeddedDatabaseInfo actualResult = ThreadBasedUserCrnProvider.doAs(USER_CRN,
-                () -> underTest.getEmbeddedDatabaseInfo(INTERNAL_ACTOR_CRN, ACCOUNT_ID, stack, null));
+        boolean actualResult = underTest.isAttachedDiskForEmbeddedDatabaseCreated(stack);
         // THEN
-        assertFalse(actualResult.isEmbeddedDatabaseOnAttachedDiskEnabled());
-        assertEquals(0, actualResult.getAttachedDisksCount());
+        assertFalse(actualResult);
     }
 
     private Stack createStack(int volumeCount) {
@@ -99,9 +150,11 @@ public class EmbeddedDatabaseServiceTest {
         Template template = new Template();
         VolumeTemplate volumeTemplate = new VolumeTemplate();
         volumeTemplate.setVolumeCount(volumeCount);
+        volumeTemplate.setUsageType(VolumeUsageType.DATABASE);
         template.setVolumeTemplates(Set.of(volumeTemplate));
         masterGroup.setTemplate(template);
         stack.setInstanceGroups(Set.of(masterGroup));
+        stack.setCloudPlatform(CLOUDPLATFORM);
         return stack;
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/decorator/ClusterDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/decorator/ClusterDecoratorTest.java
@@ -31,7 +31,6 @@ import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintValidatorFactory;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
-import com.sequenceiq.cloudbreak.service.cluster.EmbeddedDatabaseInfo;
 import com.sequenceiq.cloudbreak.service.cluster.EmbeddedDatabaseService;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 import com.sequenceiq.cloudbreak.service.sharedservice.SharedServiceConfigProvider;
@@ -100,8 +99,7 @@ class ClusterDecoratorTest {
         Blueprint blueprint = getBlueprint();
         when(sharedServiceConfigProvider.configureCluster(any(Cluster.class), any(User.class), any(Workspace.class)))
                 .thenReturn(expectedClusterInstance);
-        when(embeddedDatabaseService.getEmbeddedDatabaseInfo(ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN, ACCOUNT_ID, stack, expectedClusterInstance))
-                .thenReturn(new EmbeddedDatabaseInfo(0));
+        when(embeddedDatabaseService.isEmbeddedDatabaseOnAttachedDiskEnabled(ACCOUNT_ID, stack, expectedClusterInstance)).thenReturn(false);
         Cluster result = ThreadBasedUserCrnProvider.doAs(USER_CRN,
                 () -> underTest.decorate(expectedClusterInstance, createClusterV4Request(), blueprint, user, new Workspace(), stack, null));
 
@@ -118,8 +116,7 @@ class ClusterDecoratorTest {
         when(sharedServiceConfigProvider.configureCluster(any(Cluster.class), any(User.class), any(Workspace.class)))
                 .thenReturn(expectedClusterInstance);
         when(platformParameters.isAutoTlsSupported()).thenReturn(useAutoTls);
-        when(embeddedDatabaseService.getEmbeddedDatabaseInfo(ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN, ACCOUNT_ID, stack, expectedClusterInstance))
-                .thenReturn(new EmbeddedDatabaseInfo(0));
+        when(embeddedDatabaseService.isEmbeddedDatabaseOnAttachedDiskEnabled(ACCOUNT_ID, stack, expectedClusterInstance)).thenReturn(false);
 
         Cluster result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.decorate(expectedClusterInstance, createClusterV4Request(), blueprint, user, new Workspace(), stack, null));
@@ -135,8 +132,7 @@ class ClusterDecoratorTest {
                 .thenReturn(expectedClusterInstance);
         ArgumentCaptor<Platform> platformArgumentCaptor = ArgumentCaptor.forClass(Platform.class);
         when(cloudPlatformConnectors.get(platformArgumentCaptor.capture(), any())).thenReturn(connector);
-        when(embeddedDatabaseService.getEmbeddedDatabaseInfo(ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN, ACCOUNT_ID, stack, expectedClusterInstance))
-                .thenReturn(new EmbeddedDatabaseInfo(0));
+        when(embeddedDatabaseService.isEmbeddedDatabaseOnAttachedDiskEnabled(ACCOUNT_ID, stack, expectedClusterInstance)).thenReturn(false);
 
         String platform = CloudPlatform.YARN.name();
         ThreadBasedUserCrnProvider.doAs(USER_CRN,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudGcsView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.converter.Converter;
@@ -33,6 +32,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
@@ -47,6 +47,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Subnet;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudAdlsGen2View;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudFileSystemView;
+import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudGcsView;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
@@ -162,7 +163,7 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
         List<Volume> volumes = new ArrayList<>();
         for (int i = 0; i < template.getVolumeCount(); i++) {
             //FIXME figure out volume mounting
-            Volume volume = new Volume("/mnt/vol" + (i + 1), template.getVolumeType(), template.getVolumeSize());
+            Volume volume = new Volume("/mnt/vol" + (i + 1), template.getVolumeType(), template.getVolumeSize(), CloudVolumeUsageType.GENERAL);
             volumes.add(volume);
         }
         return new InstanceTemplate(template.getInstanceType(), name, privateId, volumes, status, fields, template.getId(), instanceImageId);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigServiceTest.java
@@ -115,7 +115,7 @@ public class FreeIpaConfigServiceTest {
         when(gatewayConfigService.getPrimaryGatewayConfig(any())).thenReturn(gatewayConfig);
         when(proxyConfigDtoService.getByEnvironmentCrn(anyString())).thenReturn(Optional.empty());
 
-        Node node = new Node(PRIVATE_IP, null, null, null, HOSTNAME, DOMAIN, null);
+        Node node = new Node(PRIVATE_IP, null, null, null, HOSTNAME, DOMAIN, (String) null);
         Map<String, String> expectedHost = Map.of("ip", PRIVATE_IP, "fqdn", HOSTNAME);
         Set<Object> expectedHosts = ImmutableSet.of(expectedHost);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
@@ -55,10 +55,10 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "there is a running Cloudbreak",
-            when = "start an sdx cluster with embedded database on root disk",
-            then = "Upgrade criteria is not met"
+            when = "start an sdx cluster without attached disk on gateway, but disk attachment is supported on cloud provider side",
+            then = "Upgrade option should be presented"
     )
-    public void testSdxUpgradeCriteriaNotMetTestWhenEmbeddedDatabaseIsOnRootDisk(MockedTestContext testContext) {
+    public void testSdxUpgradeWhenNoAttachedDisksButEmbeddedDBShouldHaveBeenOnSelfConfiguredAttachedDisk(MockedTestContext testContext) {
         String upgradeImageCatalogName = resourcePropertyProvider().getName();
         createImageCatalogForOsUpgrade(testContext, upgradeImageCatalogName);
         String sdxInternal = resourcePropertyProvider().getName();
@@ -92,8 +92,7 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
                 .withStackRequest(key(cluster), key(stack))
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .await(SdxClusterStatusResponse.RUNNING)
-                .then(SdxUpgradeTestAssertion.validateUnsuccessfulUpgrade(
-                        "Action is only supported if Cloudera Manager state is stored in external Database or in embedded database on attached disk."))
+                .then(SdxUpgradeTestAssertion.validateSuccessfulUpgrade())
                 .validate();
     }
 

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/Node.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/Node.java
@@ -15,25 +15,15 @@ public class Node {
 
     private String hostGroup;
 
-    private String dataVolumes;
-
-    private String serialIds;
-
-    private String fstab;
-
-    private String uuids;
+    private NodeVolumes nodeVolumes;
 
     public Node(String privateIp, String publicIp, String instanceId, String instanceType, String fqdn, String hostGroup) {
         this(privateIp, publicIp, instanceId, instanceType, fqdn, null, hostGroup);
     }
 
-    public Node(String privateIp, String publicIp, String instanceId, String instanceType, String fqdn, String hostGroup, String dataVolumes,
-            String serialIds, String fstab, String uuids) {
+    public Node(String privateIp, String publicIp, String instanceId, String instanceType, String fqdn, String hostGroup, NodeVolumes nodeVolumes) {
         this(privateIp, publicIp, instanceId, instanceType, fqdn, null, hostGroup);
-        this.dataVolumes = dataVolumes;
-        this.serialIds = serialIds;
-        this.fstab = fstab;
-        this.uuids = uuids;
+        this.nodeVolumes = nodeVolumes;
     }
 
     public Node(String privateIp, String publicIp, String instanceId, String instanceType, String fqdn, String domain, String hostGroup) {
@@ -66,28 +56,12 @@ public class Node {
         this.hostname = hostname;
     }
 
-    public String getDataVolumes() {
-        return dataVolumes;
-    }
-
-    public String getSerialIds() {
-        return serialIds;
-    }
-
     public String getHostGroup() {
         return hostGroup;
     }
 
     public String getDomain() {
         return domain;
-    }
-
-    public String getFstab() {
-        return fstab;
-    }
-
-    public String getUuids() {
-        return uuids;
     }
 
     public String getInstanceId() {
@@ -98,20 +72,21 @@ public class Node {
         return instanceType;
     }
 
+    public NodeVolumes getNodeVolumes() {
+        return nodeVolumes;
+    }
+
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("Node{");
+        final StringBuilder sb = new StringBuilder("Node{");
         sb.append("privateIp='").append(privateIp).append('\'');
         sb.append(", publicIp='").append(publicIp).append('\'');
+        sb.append(", instanceId='").append(instanceId).append('\'');
+        sb.append(", instanceType='").append(instanceType).append('\'');
         sb.append(", hostname='").append(hostname).append('\'');
         sb.append(", domain='").append(domain).append('\'');
         sb.append(", hostGroup='").append(hostGroup).append('\'');
-        sb.append(", dataVolumes='").append(dataVolumes).append('\'');
-        sb.append(", serialIds='").append(serialIds).append('\'');
-        sb.append(", fstab='").append(fstab).append('\'');
-        sb.append(", uuids='").append(uuids).append('\'');
-        sb.append(", instanceId='").append(instanceId).append('\'');
-        sb.append(", instanceType='").append(instanceType).append('\'');
+        sb.append(", nodeVolumes=").append(nodeVolumes);
         sb.append('}');
         return sb.toString();
     }

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/NodeVolumes.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/NodeVolumes.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.cloudbreak.orchestrator.model;
+
+public class NodeVolumes {
+    private final int dataBaseVolumeIndex;
+
+    private final String dataVolumes;
+
+    private final String serialIds;
+
+    private final String fstab;
+
+    private final String uuids;
+
+    public NodeVolumes(int databaseVolumeIndex, String dataVolumes, String serialIds, String fstab, String uuids) {
+        this.dataBaseVolumeIndex = databaseVolumeIndex;
+        this.dataVolumes = dataVolumes;
+        this.serialIds = serialIds;
+        this.fstab = fstab;
+        this.uuids = uuids;
+    }
+
+    public int getDatabaseVolumeIndex() {
+        return dataBaseVolumeIndex;
+    }
+
+    public String getDataVolumes() {
+        return dataVolumes;
+    }
+
+    public String getSerialIds() {
+        return serialIds;
+    }
+
+    public String getFstab() {
+        return fstab;
+    }
+
+    public String getUuids() {
+        return uuids;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("NodeVolumes{");
+        sb.append("dataBaseVolumeIndex=").append(dataBaseVolumeIndex);
+        sb.append(", dataVolumes='").append(dataVolumes).append('\'');
+        sb.append(", serialIds='").append(serialIds).append('\'');
+        sb.append(", fstab='").append(fstab).append('\'');
+        sb.append(", uuids='").append(uuids).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/orchestrator-salt/src/main/resources/salt/salt/disks/mount/scripts/mount-disks.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/disks/mount/scripts/mount-disks.j2
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+DATABASE_VOLUME_INDEX="{{ (salt['pillar.get']('mount_data')[salt['grains.get']('fqdn')])['database_volume_index'] }}"
 ATTACHED_VOLUME_NAME_LIST="{{ (salt['pillar.get']('mount_data')[salt['grains.get']('fqdn')])['attached_volume_name_list'] }}"
 ATTACHED_VOLUME_SERIAL_LIST="{{ (salt['pillar.get']('mount_data')[salt['grains.get']('fqdn')])['attached_volume_serial_list'] }}"
 CLOUD_PLATFORM={{ (salt['pillar.get']('mount_data')[salt['grains.get']('fqdn')])['cloud_platform'] }}
@@ -72,13 +73,17 @@ mount_all_from_fstab() {
 
 mount_all_sequential() {
       local return_value=0
-      log $LOG_FILE mounting for first time, no previous fstab information present
+      log $LOG_FILE mounting for first time, no previous fstab information present $DATABASE_VOLUME_UUID
       local hadoop_fs_dir_counter=1
       for uuid in $ATTACHED_VOLUME_UUID_LIST; do
-          mount_one "UUID=$uuid /hadoopfs/fs${hadoop_fs_dir_counter} $FS_TYPE defaults,noatime,nofail 0 2"
+          if [[ $uuid == $DATABASE_VOLUME_UUID ]]; then
+              mount_one "UUID=$uuid /dbfs $FS_TYPE defaults,noatime,nofail 0 2"
+          else
+              mount_one "UUID=$uuid /hadoopfs/fs${hadoop_fs_dir_counter} $FS_TYPE defaults,noatime,nofail 0 2"
+              ((hadoop_fs_dir_counter++))
+          fi
           return_value=$(($? || return_value ))
           log $LOG_FILE result of all mounting: $return_value
-          ((hadoop_fs_dir_counter++))
       done
 
       mount_remaining $hadoop_fs_dir_counter
@@ -110,6 +115,9 @@ mount_one() {
 mount_common() {
     local return_value
     mkdir /hadoopfs
+    if [[ $DATABASE_VOLUME_INDEX != -1 ]]; then
+      mkdir /dbfs
+    fi
     if [[ -z $PREVIOUS_FSTAB  ]]; then
         mount_all_sequential
         return_value=$?
@@ -155,6 +163,7 @@ grow_mount_partition() {
 save_env_vars_to_log_file() {
     log $LOG_FILE environment variables:
     log $LOG_FILE ATTACHED_VOLUME_UUID_LIST=$ATTACHED_VOLUME_UUID_LIST
+    log $LOG_FILE DATABASE_VOLUME_UUID=$DATABASE_VOLUME_UUID
     log $LOG_FILE CLOUD_PLATFORM=$CLOUD_PLATFORM
     log $LOG_FILE PREVIOUS_FSTAB=$PREVIOUS_FSTAB
 }
@@ -163,7 +172,14 @@ main() {
     log $LOG_FILE "started, version: $VERSION"
     device_name_list=$(get_device_names $LOG_FILE)
     export ATTACHED_VOLUME_UUID_LIST=$(get_uuid_list $LOG_FILE "$device_name_list") # ephemeral devices' uuid should not be returned
-
+    local attached_volume_uuid_array=($ATTACHED_VOLUME_UUID_LIST)
+    if [[ $DATABASE_VOLUME_INDEX != -1 ]]; then
+        export DATABASE_VOLUME_UUID=${attached_volume_uuid_array[DATABASE_VOLUME_INDEX]}
+        log $LOG_FILE "database volume index is: $DATABASE_VOLUME_INDEX"
+        log $LOG_FILE "database volume uuid based on its index: $DATABASE_VOLUME_UUID"
+    else
+        log $LOG_FILE "database volume uuid is not set as its index is -1."
+    fi
     save_env_vars_to_log_file
     local script_name="mount-disk"
     can_start $script_name $LOG_FILE

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/TemplatePreparationObject.java
@@ -22,6 +22,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.domain.VolumeUsageType;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.IdBroker;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
@@ -293,8 +294,10 @@ public class TemplatePreparationObject {
                 InstanceGroup instanceGroup = hostGroup.getInstanceGroup();
                 if (instanceGroup != null) {
                     Template template = instanceGroup.getTemplate();
-                    int volumeCount = template == null ? 1 : template.getVolumeTemplates().stream()
-                            .mapToInt(volume -> volume.getVolumeCount()).sum();
+                    int volumeCount = template == null ? 1 : template.getVolumeTemplates().stream().
+                            filter(volumeTemplate -> volumeTemplate.getUsageType() == VolumeUsageType.GENERAL)
+                            .mapToInt(volume -> volume.getVolumeCount())
+                            .sum();
                     Set<VolumeTemplate> volumeTemplates = template == null ? Collections.EMPTY_SET
                             : template.getVolumeTemplates();
                     Set<String> fqdns = instanceGroup.getAllInstanceMetaData().stream()

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/VolumeUtils.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/VolumeUtils.java
@@ -6,6 +6,8 @@ public final class VolumeUtils {
 
     public static final String ROOT_VOLUME_PREFIX = "/hadoopfs/root";
 
+    public static final String DATABASE_VOLUME = "/dbfs";
+
     private static final int FIRST_VOLUME = 1;
 
     private static final long GB_TO_BYTES = 1024 * 1024 * 1024;


### PR DESCRIPTION
CB-9579 Attach an extra disk preserved for Postgres data only

* Extend Volume domain, cloud Volume and VolumeResponse with usage type: GENERAL / DATABASE
* Store the usage type in VolumeSet cloudresource as well (the pillar parameters are generated from this)
* Extend pillar parameters of mount_disks state with the database attached volume index in the attached disks list
* change the mount_disks.j2 script to mount the db volume to the database path
* change the db configuration sls to configure the postgres database to use this attached volume to store its data

If CDP_EMBEDDED_DATABASE_ON_ATTACHED_DISK entitlement is enabled and no external database is defined and disk attachment is supported by the cloud provider
a new volume will be attached to the gateway instance of the cluster and the embedded database will be configured to store its data there.
