### PR TITLE
CB-10862: Use a consistent FreeIPA backup path on Azure

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
@@ -175,9 +175,9 @@ upload_aws_backup() {
 
 if [[ -n "$PERMISSIONS_CHECK" ]]; then
     doLog "INFO Running backup upload permissions check."
-    BACKUPDIR="ipa-backup-test-$(date "+%Y-%m-%dT%H-%M-%S")"
-    mkdir -p "${config[backup_path]}/${BACKUPDIR}"
-    echo "Backup upload test" > "${config[backup_path]}/${BACKUPDIR}/upload-test.txt"
+    BACKUP_TEST_DIR="ipa-backup-test-$(date "+%Y-%m-%dT%H-%M-%S")"
+    mkdir -p "${config[backup_path]}/${BACKUP_TEST_DIR}"
+    echo "Backup upload test" > "${config[backup_path]}/${BACKUP_TEST_DIR}/upload-test.txt"
     BACKUP_LOCATION="${config[backup_location]}/$(hostname -f)/.upload-test"
 else
     # ON START
@@ -199,11 +199,12 @@ else
     # shellcheck disable=SC2086
     /sbin/ipa-backup ${BACKUP_OPTIONS} >> "${LOGFILE}" 2>&1 || error_exit "ipa-backup failed! Aborting!"
 
-    # shellcheck disable=SC2012
-    BACKUPDIR=$(basename "$(ls -td "${config[backup_path]}/ipa-*" | head -1)")
-
     BACKUP_LOCATION="${config[backup_location]}/${BACKUP_PATH_POSTFIX}"
 fi
+
+# shellcheck disable=SC2012
+BACKUPDIR=$(basename "$(ls -td "${config[backup_path]}"/ipa-* | head -1)")
+
 doLog "DEBUG Uploading backup to ${BACKUP_LOCATION} on ${config[backup_platform]}"
 
 if [[ "${config[backup_platform]}" = "AWS" ]]; then


### PR DESCRIPTION
Use a consistent FreeIPA backup path on Azure.

Old path: cluster-backups/freeipa/FREEIPA_CRN/FQDN/full/backup/
ipa-full-YYYY-MM-DD-hh-mm-ss
New path: cluster-backups/freeipa/FREEIPA_CRN/FQDN/full/
ipa-full-YYYY-MM-DD-hh-mm-ss

This was tested using a local deployment of cloudbreak.

See detailed description in the commit message.