### PR TITLE
CB-10815 Refactor SaltStack sync all call to async

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/Glob.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/Glob.java
@@ -19,4 +19,11 @@ public class Glob implements Target<String> {
     public String getType() {
         return "glob";
     }
+
+    @Override
+    public String toString() {
+        return "Glob{" +
+                "glob='" + glob + '\'' +
+                '}';
+    }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/GrainTarget.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/GrainTarget.java
@@ -17,4 +17,11 @@ public class GrainTarget implements Target<String> {
     public String getType() {
         return "grain";
     }
+
+    @Override
+    public String toString() {
+        return "GrainTarget{" +
+                "target='" + target + '\'' +
+                '}';
+    }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/HostList.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/HostList.java
@@ -19,4 +19,11 @@ public class HostList implements Target<String> {
     public String getType() {
         return "list";
     }
+
+    @Override
+    public String toString() {
+        return "HostList{" +
+                "targets=" + targets == null ? "null" : String.join(", ", targets) +
+                '}';
+    }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/RoleTarget.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/RoleTarget.java
@@ -8,4 +8,10 @@ public class RoleTarget extends GrainTarget {
         super(ROLE_PREFIX + target);
     }
 
+    @Override
+    public String toString() {
+        return "RoleTarget{" +
+                "targets=" + getTarget() +
+                '}';
+    }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/checker/SyncAllRunner.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/checker/SyncAllRunner.java
@@ -19,7 +19,7 @@ public class SyncAllRunner extends BaseSaltJobRunner {
         ApplyResponse grainsResult = SaltStates.syncAll(saltConnector);
         Set<String> strings = collectMissingHostnames(collectSucceededNodes(grainsResult));
         setTargetHostnames(strings);
-        return strings.toString();
+        return grainsResult.getJid();
     }
 
     @Override

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
@@ -218,7 +218,7 @@ public class SaltOrchestratorTest {
         verifyNew(HighStateAllRunner.class, atLeastOnce()).withArguments(eq(allNodes),
                 eq(targets));
         verifyNew(SaltJobIdTracker.class, atLeastOnce()).withArguments(eq(saltConnector), eq(highStateAllRunner), eq(true));
-        verify(saltCommandRunner, times(2)).runSaltCommand(any(SaltConnector.class), any(BaseSaltJobRunner.class),
+        verify(saltCommandRunner, times(1)).runSaltCommand(any(SaltConnector.class), any(BaseSaltJobRunner.class),
                 any(ExitCriteriaModel.class), any(ExitCriteria.class));
         verify(saltCommandRunner, times(2)).runModifyGrainCommand(any(SaltConnector.class), any(ModifyGrainBase.class),
                 any(ExitCriteriaModel.class), any(ExitCriteria.class));

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/checker/SyncAllRunnerTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/checker/SyncAllRunnerTest.java
@@ -48,6 +48,7 @@ public class SyncAllRunnerTest {
         ObjectMapper objectMapper = new ObjectMapper();
         nodes.put("10-0-0-1.example.com", objectMapper.valueToTree("something"));
         nodes.put("10-0-0-2.example.com", objectMapper.valueToTree("something"));
+        nodes.put("jid", objectMapper.valueToTree("1234"));
         result.add(nodes);
         applyResponse.setResult(result);
         PowerMockito.when(SaltStates.syncAll(any())).thenReturn(applyResponse);
@@ -55,8 +56,8 @@ public class SyncAllRunnerTest {
         SyncAllRunner syncAllRunner = new SyncAllRunner(targets, allNode);
 
         SaltConnector saltConnector = Mockito.mock(SaltConnector.class);
-        String missingIps = syncAllRunner.submit(saltConnector);
+        String jid = syncAllRunner.submit(saltConnector);
         assertThat(syncAllRunner.getTargetHostnames(), hasItems("10-0-0-3.example.com"));
-        assertEquals("[10-0-0-3.example.com]", missingIps);
+        assertEquals("1234", jid);
     }
 }

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStatesTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStatesTest.java
@@ -92,7 +92,7 @@ public class SaltStatesTest {
     @Test
     public void syncAllTest() {
         SaltStates.syncAll(saltConnector);
-        verify(saltConnector, times(1)).run(eq(Glob.ALL), eq("saltutil.sync_all"), eq(LOCAL), eq(ApplyResponse.class));
+        verify(saltConnector, times(1)).run(eq(Glob.ALL), eq("saltutil.sync_all"), eq(LOCAL_ASYNC), eq(ApplyResponse.class));
     }
 
     @Test


### PR DESCRIPTION
`saltutil.sync_all` call was a sync call which doesn't cause any issue if the size is under 200 nodes.
Over 200 nodes it takes too much time and caused timeout. Moving it to async solved the issue. It's handled similarly to highstate call.
Also measurements has been added to salt calls, so we will be able to check which salt calls are taking long time.