### PR TITLE
CB-10869 - [azure] Failed to create environment with error message: '…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/ResourceRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/ResourceRepository.java
@@ -32,11 +32,12 @@ public interface ResourceRepository extends CrudRepository<Resource, Long> {
     @Query("SELECT r FROM Resource r WHERE r.stack.id = :stackId AND (r.resourceType NOT LIKE '%INSTANCE%' OR r.resourceType NOT LIKE '%DISK%')")
     Set<Resource> findAllByStackIdNotInstanceOrDisk(@Param("stackId") Long stackId);
 
-    @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceStatus = :status AND r.resourceType = :type")
+    @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceStatus = :status AND r.resourceType = :type "
+            + "AND r.stack.id is null")
     Optional<Resource> findByResourceReferenceAndStatusAndType(@Param("resourceReference") String resourceReference, @Param("status") CommonStatus status,
             @Param("type") ResourceType type);
 
-    @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceType = :type")
+    @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceType = :type AND r.stack.id is null")
     Optional<Resource> findByResourceReferenceAndType(@Param("resourceReference") String resourceReference,
             @Param("type") ResourceType type);
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/ResourceRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/ResourceRepository.java
@@ -24,11 +24,12 @@ public interface ResourceRepository extends CrudRepository<Resource, Long> {
     @Query("SELECT r FROM Resource r WHERE r.stack.id = :stackId")
     List<Resource> findAllByStackId(@Param("stackId") long stackId);
 
-    @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceStatus = :status AND r.resourceType = :type")
+    @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceStatus = :status AND r.resourceType = :type "
+            + "AND r.stack.id is null")
     Optional<Resource> findByResourceReferenceAndStatusAndType(@Param("resourceReference") String resourceReference, @Param("status") CommonStatus status,
             @Param("type") ResourceType type);
 
-    @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceType = :type")
+    @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceType = :type AND r.stack.id is null")
     Optional<Resource> findByResourceReferenceAndType(@Param("resourceReference") String resourceReference,
             @Param("type") ResourceType type);
 }


### PR DESCRIPTION
…query did not return a unique result: 9'

**Background**:
There was a fix some weeks ago which made the following changes: 

- managed image resource does not save stack_id, meaning it is a non-stack aware resource
- queries are distinguished for stack aware and non-stack aware resources

**Issue**:
As managed image resources saved before this change still had stack_id, there might be cases where our findByResourceReferenceAndType queries return multiple rows.

**Solution**:
We just fetch resources with stack_id = null 

