### PR TITLE
CB-10886 move the FreeIPA cluster availability status update after th…

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/action/FreeIpaProvisionActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/action/FreeIpaProvisionActions.java
@@ -140,10 +140,10 @@ public class FreeIpaProvisionActions {
 
             @Override
             protected void doExecute(StackContext context, PostInstallFreeIpaSuccess payload, Map<Object, Object> variables) {
-                stackUpdater.updateStackStatus(context.getStack().getId(), DetailedStackStatus.PROVISIONED, "FreeIPA installation finished");
                 configRegisters.forEach(configProvider -> configProvider.register(context.getStack().getId()));
                 metricService.incrementMetricCounter(MetricType.FREEIPA_CREATION_FINISHED, context.getStack());
                 freeipaJobService.schedule(context.getStack());
+                stackUpdater.updateStackStatus(context.getStack().getId(), DetailedStackStatus.PROVISIONED, "FreeIPA installation finished");
                 sendEvent(context);
             }
 


### PR DESCRIPTION
…e config providers

The last flow step in FreeIPA provisioning creates a few configs, LDAP, Kerveros, Root CA
which takes a few seconds after we already updated the provisioning status to AVAILABLE.
This adds a slight delay between the state update and the flow execution and can cause
issues in our E2E testing since the test only waits for the status update, but not for the
flow execution. As part of this PR I moved the status update to the very end and that
hopefully solve this timing issue in the tests. Otherwise, we will need to introduce the
flow-ids in the responses so the test can query them.
