### PR TITLE
CB-6600 Azure msi validation fails with identity not found

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidator.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/validator/AzureIDBrokerObjectStorageValidator.java
@@ -124,6 +124,9 @@ public class AzureIDBrokerObjectStorageValidator {
             Set<String> mappedIdentityIds = new HashSet<>();
             mappedIdentityIds.addAll(accountMappings.getUserMappings().values());
             mappedIdentityIds.addAll(accountMappings.getGroupMappings().values());
+            mappedIdentityIds = mappedIdentityIds.stream()
+                    .map(id -> id.replaceFirst("(?i)/resourceGroups/", "/resourcegroups/"))
+                    .collect(Collectors.toSet());
             PagedList<Identity> existingIdentities = client.listIdentities();
 
             Set<String> existingIdentityIds = existingIdentities.stream().map(Identity::id).collect(Collectors.toSet());


### PR DESCRIPTION
Fixes a case sensitivity issue in the azure object storage validation.