### PR TITLE
CB-10904 remove unused authz annotation from setPassword

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
@@ -115,7 +115,6 @@ public class UserV1Controller implements UserV1Endpoint {
 
     @Override
     @CustomPermissionCheck
-    @CheckPermissionByAccount(action = AuthorizationResourceAction.ENVIRONMENT_READ)
     public SyncOperationStatus setPassword(SetPasswordRequest request) {
         String userCrn = checkActorCrn();
         String accountId = ThreadBasedUserCrnProvider.getAccountId();


### PR DESCRIPTION
- since permission check is custom for setPassword, other annotations are ignored

See detailed description in the commit message.