### PR TITLE
CB-10867 While we try to validate the Azure credential, we get a Runt…

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/exception/mapper/DefaultExceptionMapper.java
+++ b/environment/src/main/java/com/sequenceiq/environment/exception/mapper/DefaultExceptionMapper.java
@@ -5,7 +5,7 @@ import javax.ws.rs.core.Response.Status;
 import org.springframework.stereotype.Component;
 
 @Component
-public class DefaultExceptionMapper extends BaseExceptionMapper<Exception> {
+public class DefaultExceptionMapper extends SearchCauseExceptionMapper<Exception> {
 
     @Override
     Status getResponseStatus(Exception exception) {

--- a/environment/src/main/java/com/sequenceiq/environment/exception/mapper/SearchCauseExceptionMapper.java
+++ b/environment/src/main/java/com/sequenceiq/environment/exception/mapper/SearchCauseExceptionMapper.java
@@ -4,6 +4,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Providers;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 public abstract class SearchCauseExceptionMapper<T extends Throwable> extends BaseExceptionMapper<T> {
 
     @Context
@@ -12,13 +14,28 @@ public abstract class SearchCauseExceptionMapper<T extends Throwable> extends Ba
     @Override
     Response.Status getResponseStatus(T exception) {
         Response.Status defaultResponse = Response.Status.BAD_REQUEST;
-        if (exception.getCause() != null && Exception.class == exception.getCause().getClass()) {
-            return defaultResponse;
+        if (exception != null) {
+            Pair<BaseExceptionMapper, ? extends Throwable> pair = searchRecursively(exception);
+            if (pair.getKey() != null && pair.getKey() != this && !(pair.getKey() instanceof DefaultExceptionMapper)) {
+                defaultResponse = pair.getKey().getResponseStatus(pair.getValue());
+            }
         }
-        BaseExceptionMapper exceptionMapper = (BaseExceptionMapper<? extends Throwable>) providers.getExceptionMapper(exception.getCause().getClass());
-        if (exceptionMapper == null) {
-            return defaultResponse;
+        return defaultResponse;
+    }
+
+    private Pair<BaseExceptionMapper, Throwable> searchRecursively(Throwable exception) {
+        if (exception.getCause() == null) {
+            BaseExceptionMapper exceptionMapper = getExceptionMapper(exception);
+            return Pair.of(exceptionMapper, exception);
         }
-        return exceptionMapper.getResponseStatus(exception.getCause());
+        BaseExceptionMapper<? extends Throwable> exceptionMapper = getExceptionMapper(exception.getCause());
+        if (exceptionMapper == null || exceptionMapper instanceof DefaultExceptionMapper) {
+            return searchRecursively(exception.getCause());
+        }
+        return Pair.of(exceptionMapper, exception.getCause());
+    }
+
+    private BaseExceptionMapper<? extends Throwable> getExceptionMapper(Throwable exception) {
+        return (BaseExceptionMapper<? extends Throwable>) providers.getExceptionMapper(exception.getClass());
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/exception/mapper/SearchCauseExceptionMapperTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/exception/mapper/SearchCauseExceptionMapperTest.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.environment.exception.mapper;
+
+import static java.util.Collections.emptySet;
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Providers;
+
+import org.glassfish.jersey.internal.ExceptionMapperFactory;
+import org.glassfish.jersey.internal.JaxrsProviders;
+import org.glassfish.jersey.internal.inject.InjectionManager;
+import org.glassfish.jersey.internal.inject.ServiceHolder;
+import org.glassfish.jersey.internal.inject.ServiceHolderImpl;
+import org.glassfish.jersey.spi.ExceptionMappers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.environment.credential.exception.CredentialVerificationException;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = TestExceptionMapperConfiguration.class)
+public class SearchCauseExceptionMapperTest {
+
+    @Inject
+    private CredentialVerificationExceptionMapper underTest;
+
+    @MockBean
+    private InjectionManager injectionManager;
+
+    @Inject
+    private List<ExceptionMapper> exceptionMappers;
+
+    @BeforeEach
+    public void setup() {
+        List<ServiceHolder<ExceptionMapper>> ret = exceptionMappers.stream().map(em -> new ServiceHolderImpl<>(em, emptySet())).collect(toList());
+        Mockito.when(injectionManager.getAllServiceHolders(ExceptionMapper.class)).thenReturn(ret);
+        Provider<ExceptionMappers> mappers = () -> new ExceptionMapperFactory(injectionManager);
+
+        Providers providers = new JaxrsProviders();
+
+        ReflectionTestUtils.setField(providers, "mappers", mappers);
+        ReflectionTestUtils.setField(underTest, "providers", providers);
+    }
+
+    @Test
+    public void testGetResponseStatusWhenNoCause() {
+        Response.Status actual = underTest.getResponseStatus(new CredentialVerificationException(""));
+        Assertions.assertEquals(Response.Status.BAD_REQUEST, actual);
+    }
+
+    @Test
+    public void testGetResponseStatusWhenHasOnlyOneCause() {
+        Response.Status actual = underTest.getResponseStatus(new CredentialVerificationException("", new NotFoundException()));
+        Assertions.assertEquals(Response.Status.NOT_FOUND, actual);
+    }
+
+    @Test
+    public void testGetResponseStatusWhenHasTwoDepthsCause() {
+        Response.Status actual = underTest.getResponseStatus(new CredentialVerificationException("", new RuntimeException(new NotFoundException())));
+        Assertions.assertEquals(Response.Status.NOT_FOUND, actual);
+    }
+
+    @Test
+    public void testGetResponseStatusWhenHasTwoDepthsCauseWithDefaultMapper() {
+        Response.Status actual = underTest.getResponseStatus(new CredentialVerificationException("", new Exception(new Exception())));
+        Assertions.assertEquals(Response.Status.BAD_REQUEST, actual);
+    }
+
+    @Test
+    public void testGetResponseStatusWhenHasOneDepthsCauseWithDefaultMapper() {
+        Response.Status actual = underTest.getResponseStatus(new CredentialVerificationException("", new Exception()));
+        Assertions.assertEquals(Response.Status.BAD_REQUEST, actual);
+    }
+
+    @Test
+    public void testGetResponseStatusWhenTheExceptionIsTheFirstCause() {
+        Response.Status actual = underTest.getResponseStatus(new CredentialVerificationException("", new Exception(new NotFoundException())));
+        Assertions.assertEquals(Response.Status.NOT_FOUND, actual);
+    }
+
+    @Test
+    public void testGetResponseStatusWhenTheCauseIsTheRealException() {
+        Response.Status actual = underTest.getResponseStatus(new CredentialVerificationException("", new NotFoundException(new Exception())));
+        Assertions.assertEquals(Response.Status.NOT_FOUND, actual);
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/exception/mapper/TestExceptionMapperConfiguration.java
+++ b/environment/src/test/java/com/sequenceiq/environment/exception/mapper/TestExceptionMapperConfiguration.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.environment.exception.mapper;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = {"com.sequenceiq.environment.exception"})
+public class TestExceptionMapperConfiguration {
+
+}


### PR DESCRIPTION
…imeException. However, the AuthenticatedException can be found in the tree of causes. Now we search recursively the cause exception. Rules:

* if cause is null, get the closest mapper for the exception
if cannot find a mapper or the mapper is the default, we search the next cause mapper
any other case, use the found mapper

With this test, we can test the real mapper finder

See detailed description in the commit message.