### PR TITLE
CB-10875 Redbeams termination flow fix

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsContext.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/RedbeamsContext.java
@@ -41,4 +41,8 @@ public class RedbeamsContext extends CommonContext {
     public DBStack getDBStack() {
         return dbStack;
     }
+
+    public boolean doesDBStackExist() {
+        return dbStack != null;
+    }
 }


### PR DESCRIPTION
Handle the case when the dbstack is already deleted from the database, but the termination flow has not finished.
After redbeams process restart the flow will continue its execution:
* The termination flow will handle when dbstack is not found in database during flowcontext creation.
* The termination finsished and failed action will handle if dbstack is missing from the context.
