### PR TITLE
CB-10817 - Azure datahub scaling from 100 to 200 nodes fails with wei…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudResource.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudResource.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.cloud.model;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import com.google.common.base.Preconditions;
 import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
@@ -75,19 +76,6 @@ public class CloudResource extends DynamicModel {
         return stackAware;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder("CloudResource{");
-        sb.append("type=").append(type);
-        sb.append(", status=").append(status);
-        sb.append(", name='").append(name).append('\'');
-        sb.append(", reference='").append(reference).append('\'');
-        sb.append(", group='").append(group).append('\'');
-        sb.append(", persistent='").append(persistent).append('\'');
-        sb.append('}');
-        return sb.toString();
-    }
-
     public static Builder builder() {
         return new Builder();
     }
@@ -102,6 +90,20 @@ public class CloudResource extends DynamicModel {
 
     public void setInstanceId(String instanceId) {
         this.instanceId = instanceId;
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", CloudResource.class.getSimpleName() + "[", "]")
+                .add("type=" + type)
+                .add("status=" + status)
+                .add("name='" + name + "'")
+                .add("reference='" + reference + "'")
+                .add("group='" + group + "'")
+                .add("persistent=" + persistent)
+                .add("stackAware=" + stackAware)
+                .add("instanceId='" + instanceId + "'")
+                .toString();
     }
 
     public static class Builder {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureVirtualMachineService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureVirtualMachineService.java
@@ -45,7 +45,7 @@ public class AzureVirtualMachineService {
 
     @Retryable(backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 10000), maxAttempts = 5)
     public Map<String, VirtualMachine> getVirtualMachinesByName(AzureClient azureClient, String resourceGroup, Collection<String> privateInstanceIds) {
-        LOGGER.debug("Starting to retrieve vm metadata from Azure for ids: {}", privateInstanceIds);
+        LOGGER.debug("Starting to retrieve vm metadata from Azure for {} for ids: {}", resourceGroup, privateInstanceIds);
         PagedList<VirtualMachine> virtualMachines = azureClient.getVirtualMachines(resourceGroup);
         while (hasMissingVm(virtualMachines, privateInstanceIds) && virtualMachines.hasNextPage()) {
             virtualMachines.loadNextPage();
@@ -75,7 +75,7 @@ public class AzureVirtualMachineService {
 
     @Retryable(backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 10000), maxAttempts = 5)
     public void refreshInstanceViews(Map<String, VirtualMachine> virtualMachines) {
-        LOGGER.info("Parallel instanceviews refresh to download instance view fields from azure, like PowerState of the machines: {}",
+        LOGGER.info("Parallel instance views refresh to download instance view fields from azure, like PowerState of the machines: {}",
                 virtualMachines.keySet());
         List<Completable> refreshInstanceViewCompletables = new ArrayList<>();
         for (VirtualMachine virtualMachine : virtualMachines.values()) {
@@ -120,7 +120,7 @@ public class AzureVirtualMachineService {
 
         Map<String, VirtualMachine> virtualMachines = new HashMap<>();
         for (Map.Entry<String, Collection<String>> resourceGroupInstanceIdsMap : resourceGroupInstanceMultimap.asMap().entrySet()) {
-            LOGGER.info("Get vms for resource group and add to all virtualmachines: {}", resourceGroupInstanceIdsMap.getKey());
+            LOGGER.info("Get vms for resource group and add to all virtual machines: {}", resourceGroupInstanceIdsMap.getKey());
             try {
                 virtualMachines.putAll(getVirtualMachinesByName(azureClient,
                         resourceGroupInstanceIdsMap.getKey(), resourceGroupInstanceIdsMap.getValue()));

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -33,7 +33,6 @@ import com.microsoft.azure.management.compute.Disk;
 import com.microsoft.azure.management.compute.DiskSkuTypes;
 import com.microsoft.azure.management.compute.DiskStorageAccountTypes;
 import com.microsoft.azure.management.compute.OperatingSystemStateTypes;
-import com.microsoft.azure.management.compute.PowerState;
 import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.compute.VirtualMachineCustomImage;
 import com.microsoft.azure.management.compute.VirtualMachineDataDisk;
@@ -468,7 +467,7 @@ public class AzureClient {
         return handleAuthException(() -> azure.virtualMachines().listByResourceGroup(resourceGroup));
     }
 
-    public VirtualMachine getVirtualMachine(String resourceGroup, String vmName) {
+    public VirtualMachine getVirtualMachineByResourceGroup(String resourceGroup, String vmName) {
         return handleAuthException(() -> azure.virtualMachines().getByResourceGroup(resourceGroup, vmName));
     }
 
@@ -480,12 +479,8 @@ public class AzureClient {
         return handleAuthException(() -> azure.virtualMachines().getByResourceGroupAsync(resourceGroup, vmName));
     }
 
-    public PowerState getVirtualMachinePowerState(String resourceGroup, String vmName) {
-        return getVirtualMachine(resourceGroup, vmName).powerState();
-    }
-
     public VirtualMachineInstanceView getVirtualMachineInstanceView(String resourceGroup, String vmName) {
-        return getVirtualMachine(resourceGroup, vmName).instanceView();
+        return getVirtualMachineByResourceGroup(resourceGroup, vmName).instanceView();
     }
 
     public Set<AvailabilityZoneId> getAvailabilityZone(String resourceGroup, String vmName) {
@@ -517,15 +512,6 @@ public class AzureClient {
 
     public Completable deallocateVirtualMachineAsync(String resourceGroup, String vmName) {
         return handleAuthException(() -> azure.virtualMachines().deallocateAsync(resourceGroup, vmName));
-    }
-
-    public boolean isVirtualMachineExists(String resourceGroup, String vmName) {
-        return handleAuthException(() -> {
-            Optional<VirtualMachine> vm = azure.virtualMachines().listByResourceGroup(resourceGroup).stream()
-                    .filter(virtualMachine -> vmName.equals(virtualMachine.name()))
-                    .findFirst();
-            return vm.isPresent();
-        });
     }
 
     public Completable deleteVirtualMachine(String resourceGroup, String vmName) {

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
@@ -217,7 +217,7 @@ public class AzureVolumeResourceBuilderTest {
         ArgumentCaptor<Collection<String>> captor = ArgumentCaptor.forClass(Collection.class);
         underTest.delete(context, auth, volumeSetResource);
         verify(azureUtils, times(1)).deleteManagedDisks(any(), captor.capture());
-        verify(azureClient, times(0)).getVirtualMachine(any(), any());
+        verify(azureClient, times(0)).getVirtualMachineByResourceGroup(any(), any());
         verify(azureClient, times(0)).detachDiskFromVm(any(), any());
         Collection<String> deletedAzureManagedDisks = captor.getValue();
         assertThat(deletedAzureManagedDisks, containsInAnyOrder("vol1"));
@@ -252,12 +252,12 @@ public class AzureVolumeResourceBuilderTest {
         when(pagedList.stream()).thenAnswer(invocation -> diskList.stream());
         when(azureClient.listDisksByResourceGroup(eq("resource-group"))).thenReturn(pagedList);
         VirtualMachine virtualMachine = mock(VirtualMachine.class);
-        when(azureClient.getVirtualMachine(any(), eq("instance1"))).thenReturn(virtualMachine);
+        when(azureClient.getVirtualMachineByResourceGroup(any(), eq("instance1"))).thenReturn(virtualMachine);
         ArgumentCaptor<Collection<String>> captor = ArgumentCaptor.forClass(Collection.class);
         underTest.delete(context, auth, volumeSetResource);
 
         verify(azureUtils, times(1)).deleteManagedDisks(any(), captor.capture());
-        verify(azureClient, times(1)).getVirtualMachine(eq("resource-group"), eq("instance1"));
+        verify(azureClient, times(1)).getVirtualMachineByResourceGroup(eq("resource-group"), eq("instance1"));
         verify(azureClient, times(1)).detachDiskFromVm(eq("vol1"), eq(virtualMachine));
         Collection<String> deletedAzureManagedDisks = captor.getValue();
         assertThat(deletedAzureManagedDisks, containsInAnyOrder("vol1"));

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/CloudFailureHandler.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/CloudFailureHandler.java
@@ -58,13 +58,13 @@ public class CloudFailureHandler {
         AuthenticatedContext auth = cloudFailureContext.getAuth();
         ResourceBuilderContext ctx = cloudFailureContext.getCtx();
         if (stx.getAdjustmentType() == null && !failures.isEmpty()) {
-            LOGGER.info("Failure policy is null so error will throw");
+            LOGGER.info("Failure policy is null so error will be thrown");
             throwError(failuresList);
         }
         switch (stx.getAdjustmentType()) {
             case EXACT:
                 if (stx.getThreshold() > fullNodeCount - failures.size()) {
-                    LOGGER.info("Number of failures is more than the threshold so error will throw");
+                    LOGGER.info("Number of failures is more than the threshold ({}) so error will be thrown", stx.getThreshold());
                     failures = resourceStatuses.stream().map(CloudResourceStatus::getPrivateId).collect(Collectors.toSet());
                     doRollbackAndDecreaseNodeCount(auth, resourceStatuses, failures, group, ctx, resourceBuilders, stx.getUpscale());
                     throwError(failuresList);
@@ -128,7 +128,7 @@ public class CloudFailureHandler {
         Collection<Future<ResourceRequestResult<List<CloudResourceStatus>>>> futures = new ArrayList<>();
         LOGGER.info("InstanceGroup {} node count decreased with one so the new node size is: {}", group.getName(), group.getInstancesSize());
         if (getRemovableInstanceTemplates(group, ids).size() <= 0 && !upscale) {
-            LOGGER.info("InstanceGroup node count lower than 1 which is incorrect so error will throw");
+            LOGGER.info("InstanceGroup node count lower than 1 which is incorrect so error will be thrown");
             throwError(statuses);
         } else {
             for (int i = compute.size() - 1; i >= 0; i--) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -261,7 +261,7 @@ public class StackToCloudStackConverter {
                                         instanceGroup.getInstanceGroupType(),
                                         buildCloudInstances(stackAuthentication, deleteRequests, instanceGroup),
                                         buildSecurity(instanceGroup),
-                                        buildCloudInstanceSkeleton(stackAuthentication, instanceGroup, stack),
+                                        buildCloudInstanceSkeleton(stackAuthentication, instanceGroup),
                                         getFields(instanceGroup),
                                         instanceAuthentication,
                                         instanceAuthentication.getLoginUserName(),
@@ -341,7 +341,7 @@ public class StackToCloudStackConverter {
         return new Security(rules, ig.getSecurityGroup().getSecurityGroupIds(), true);
     }
 
-    private CloudInstance buildCloudInstanceSkeleton(StackAuthentication stackAuthentication, InstanceGroup instanceGroup, Stack stack) {
+    private CloudInstance buildCloudInstanceSkeleton(StackAuthentication stackAuthentication, InstanceGroup instanceGroup) {
         CloudInstance skeleton = null;
         if (instanceGroup.getNodeCount() == 0) {
             skeleton = buildInstance(null, instanceGroup, stackAuthentication, 0L,


### PR DESCRIPTION
…rd error

This PR solves 2 issues, for the use case of recovering from failed upscale:

- CloudInstance inherits cloudResource.getParameters() containing RG name in single RG mode. This solves that the VM-s were fetched from the default, incorrect RG

` INFO  c.m.a.m.c.VirtualMachines listByResourceGroup] <-- 404  https://management.azure.com/subscriptions/3ddda1c7-d1f5-4e7b-ac81-0523f483b3b3/resourceGroups/gk1prod-ha98430/providers/Microsoft.Compute/virtualMachines?api-version=2020-06-01 (136 ms, 107-byte body)`

- We do not query the VM for a given volume set if does not have the VM's name stored in cloudResource.getInstanceId(). This prevents like the following. 
I was not able to reproduce the cause why instanceId is missing for these volume sets, but those should be deleted independently

` doRollbackAndDecreaseNodeCount:148 DEBUG c.s.c.c.t.c.CloudFailureHandler  Resource can not be deleted. Reason: java.lang.IllegalArgumentException: Parameter vmName is required and cannot be null.`