### PR TITLE
CB-10911 E2E test cases fails, created resources are persisted for cleanup job in case of timeout

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
@@ -47,6 +47,7 @@ import com.sequenceiq.it.cloudbreak.listener.ThreadLocalTestListener;
 import com.sequenceiq.it.cloudbreak.search.CustomHTMLReporter;
 import com.sequenceiq.it.cloudbreak.search.CustomJUnitXMLReporter;
 import com.sequenceiq.it.config.ITProps;
+import com.sequenceiq.it.cloudbreak.listener.TestCaseTimeoutListener;
 import com.sequenceiq.it.util.cleanup.CleanupUtil;
 
 @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class,
@@ -126,6 +127,7 @@ public class IntegrationTestApp implements CommandLineRunner {
         testng.addListener(new TestInvocationListener());
         testng.addListener(new CustomHTMLReporter());
         testng.addListener(new CustomJUnitXMLReporter());
+        testng.addListener(new TestCaseTimeoutListener());
         setupSuites(testng);
         if (!CLEANUP_COMMAND.equals(itCommand)) {
             testng.run();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestCaseTimeoutListener.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestCaseTimeoutListener.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.it.cloudbreak.listener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+
+public class TestCaseTimeoutListener implements ITestListener {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestCaseTimeoutListener.class);
+
+    @Override
+    public void onTestFailedWithTimeout(ITestResult result) {
+        long testRunInMs = result.getEndMillis() - result.getStartMillis();
+        LOGGER.error("Test timed out: '{}' it took: '{}' ms", result.getName(), testRunInMs);
+        LOGGER.info("Invoking TestInvocationListener to persist created resources in a JSON output file for clean up job.");
+        TestInvocationListener testInvocationListener = new TestInvocationListener();
+        testInvocationListener.afterInvocation(null, result);
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestInvocationListener.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestInvocationListener.java
@@ -45,11 +45,13 @@ public class TestInvocationListener implements IInvokedMethodListener {
         JSONObject jsonObject = new JSONObject();
         Object[] parameters = testResult.getParameters();
         if (parameters == null || parameters.length == 0) {
+            LOGGER.warn("Test context could not be found because parameters array is empty in test result.");
             return;
         }
         try {
             testContext = (TestContext) parameters[0];
         } catch (ClassCastException e) {
+            LOGGER.warn("Test context could not be casted from test result parameters.");
             return;
         }
 
@@ -94,6 +96,8 @@ public class TestInvocationListener implements IInvokedMethodListener {
             } catch (Exception e) {
                 LOGGER.info("Creating/Appending resource file is failing, because of: {}", e.getMessage(), e);
             }
+        } else {
+            LOGGER.info("No resources found, no output file needs to be created.");
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
@@ -4,6 +4,8 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
@@ -24,6 +26,7 @@ import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class EnvironmentStopStartTests extends AbstractE2ETest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentStopStartTests.class);
 
     private static final Map<String, String> ENV_TAGS = Map.of("envTagKey", "envTagValue");
 
@@ -52,12 +55,13 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
         initializeDefaultBlueprints(testContext);
     }
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT, timeOut =  7200000)
     @Description(
             given = "there is a running cloudbreak",
             when = "create an attached SDX and Datahub",
             then = "should be stopped first and started after it")
     public void testCreateStopStartEnvironment(TestContext testContext) {
+        LOGGER.info("Environment stop-start test execution has been started....");
         testContext
                 .given(CredentialTestDto.class)
                 .when(credentialTestClient.create())
@@ -95,5 +99,7 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
                 .when(environmentTestClient.start())
                 .await(EnvironmentStatus.AVAILABLE)
                 .validate();
+
+        LOGGER.info("Environment stop-start test execution has been finished....");
     }
 }


### PR DESCRIPTION
CB-10911  - In case of E2E test case timeout the created resources are persisted into a JSON file by a new TestNG listener. Increase the timeout for Environment stop/start test case. In case of timeout the test case should be marked failed.
Also some log enhancements has been added to the changes.
