### PR TITLE
CB-10521 Refactor expected exception

### DIFF
--- a/integration-test/.gitignore
+++ b/integration-test/.gitignore
@@ -26,4 +26,4 @@ integcb/docker-compose.yml
 integcb/uaa.yml
 test.out
 ImageId*
-/src/main/resources/ums-users/api-credentials.json
+/src/main/resources/ums-users/

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/RunningParameter.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/RunningParameter.java
@@ -36,8 +36,8 @@ public class RunningParameter {
         return who;
     }
 
-    public RunningParameter withWho(Actor who) {
-        this.who = who;
+    public RunningParameter withWho(Actor actor) {
+        who = actor;
         return this;
     }
 
@@ -134,9 +134,9 @@ public class RunningParameter {
                 .withSkipOnFail(false);
     }
 
-    public static RunningParameter who(Actor who) {
+    public static RunningParameter who(Actor actor) {
         return new RunningParameter()
-                .withWho(who);
+                .withWho(actor);
     }
 
     public static RunningParameter key(String key) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractCloudbreakTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractCloudbreakTestDto.java
@@ -57,6 +57,27 @@ public abstract class AbstractCloudbreakTestDto<R, S, T extends CloudbreakTestDt
     }
 
     @Override
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, CloudbreakClient> action, Class<E> expectedException) {
+        return getTestContext().whenException(entityClass, CloudbreakClient.class, action, expectedException, emptyRunningParameter());
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Action<T, CloudbreakClient> action, Class<E> expectedException) {
+        return getTestContext().whenException((T) this, CloudbreakClient.class, action, expectedException, emptyRunningParameter());
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, CloudbreakClient> action, Class<E> expectedException,
+            RunningParameter runningParameter) {
+        return getTestContext().whenException(entityClass, CloudbreakClient.class, action, expectedException, runningParameter);
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Action<T, CloudbreakClient> action, Class<E> expectedException, RunningParameter runningParameter) {
+        return getTestContext().whenException((T) this, CloudbreakClient.class, action, expectedException, runningParameter);
+    }
+
+    @Override
     public T then(Assertion<T, CloudbreakClient> assertion) {
         return then(assertion, emptyRunningParameter());
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractEnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractEnvironmentTestDto.java
@@ -67,6 +67,27 @@ public abstract class AbstractEnvironmentTestDto<R, S, T extends CloudbreakTestD
     }
 
     @Override
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, EnvironmentClient> action, Class<E> expectedException) {
+        return getTestContext().whenException(entityClass, EnvironmentClient.class, action, expectedException, emptyRunningParameter());
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Action<T, EnvironmentClient> action, Class<E> expectedException) {
+        return getTestContext().whenException((T) this, EnvironmentClient.class, action, expectedException, emptyRunningParameter());
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, EnvironmentClient> action, Class<E> expectedException,
+            RunningParameter runningParameter) {
+        return getTestContext().whenException(entityClass, EnvironmentClient.class, action, expectedException, runningParameter);
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Action<T, EnvironmentClient> action, Class<E> expectedException, RunningParameter runningParameter) {
+        return getTestContext().whenException((T) this, EnvironmentClient.class, action, expectedException, runningParameter);
+    }
+
+    @Override
     public T then(Assertion<T, EnvironmentClient> assertion) {
         return then(assertion, emptyRunningParameter());
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractFreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractFreeIpaTestDto.java
@@ -62,6 +62,27 @@ public abstract class AbstractFreeIpaTestDto<R, S, T extends CloudbreakTestDto> 
     }
 
     @Override
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, FreeIpaClient> action, Class<E> expectedException) {
+        return getTestContext().whenException(entityClass, FreeIpaClient.class, action, expectedException, emptyRunningParameter());
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Action<T, FreeIpaClient> action, Class<E> expectedException) {
+        return getTestContext().whenException((T) this, FreeIpaClient.class, action, expectedException, emptyRunningParameter());
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, FreeIpaClient> action, Class<E> expectedException,
+            RunningParameter runningParameter) {
+        return getTestContext().whenException(entityClass, FreeIpaClient.class, action, expectedException, runningParameter);
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Action<T, FreeIpaClient> action, Class<E> expectedException, RunningParameter runningParameter) {
+        return getTestContext().whenException((T) this, FreeIpaClient.class, action, expectedException, runningParameter);
+    }
+
+    @Override
     public T then(Assertion<T, FreeIpaClient> assertion) {
         return then(assertion, emptyRunningParameter());
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractRedbeamsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractRedbeamsTestDto.java
@@ -46,6 +46,27 @@ public abstract class AbstractRedbeamsTestDto<R, S, T extends CloudbreakTestDto>
     }
 
     @Override
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, RedbeamsClient> action, Class<E> expectedException) {
+        return getTestContext().whenException(entityClass, RedbeamsClient.class, action, expectedException, emptyRunningParameter());
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Action<T, RedbeamsClient> action, Class<E> expectedException) {
+        return getTestContext().whenException((T) this, RedbeamsClient.class, action, expectedException, emptyRunningParameter());
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, RedbeamsClient> action, Class<E> expectedException,
+            RunningParameter runningParameter) {
+        return getTestContext().whenException(entityClass, RedbeamsClient.class, action, expectedException, runningParameter);
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Action<T, RedbeamsClient> action, Class<E> expectedException, RunningParameter runningParameter) {
+        return getTestContext().whenException((T) this, RedbeamsClient.class, action, expectedException, runningParameter);
+    }
+
+    @Override
     public T then(Assertion<T, RedbeamsClient> assertion) {
         return then(assertion, emptyRunningParameter());
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractSdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractSdxTestDto.java
@@ -62,6 +62,27 @@ public abstract class AbstractSdxTestDto<R, S, T extends CloudbreakTestDto> exte
     }
 
     @Override
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, SdxClient> action, Class<E> expectedException) {
+        return getTestContext().whenException(entityClass, SdxClient.class, action, expectedException, emptyRunningParameter());
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Action<T, SdxClient> action, Class<E> expectedException) {
+        return getTestContext().whenException((T) this, SdxClient.class, action, expectedException, emptyRunningParameter());
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, SdxClient> action, Class<E> expectedException,
+            RunningParameter runningParameter) {
+        return getTestContext().whenException(entityClass, SdxClient.class, action, expectedException, runningParameter);
+    }
+
+    @Override
+    public <E extends Exception> T whenException(Action<T, SdxClient> action, Class<E> expectedException, RunningParameter runningParameter) {
+        return getTestContext().whenException((T) this, SdxClient.class, action, expectedException, runningParameter);
+    }
+
+    @Override
     public T then(Assertion<T, SdxClient> assertion) {
         return then(assertion, emptyRunningParameter());
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
@@ -285,6 +285,26 @@ public abstract class AbstractTestDto<R, S, T extends CloudbreakTestDto, U exten
         throw new NotImplementedException(String.format("The entity(%s) must be implement the valid() method.", getClass()));
     }
 
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, U> action, Class<E> expectedException) {
+        throw new NotImplementedException(String.format("The entity(%s) must be implement the whenException(Class<T>, Action<T, U>, Class<E>) method.",
+                getClass()));
+    }
+
+    public <E extends Exception> T whenException(Action<T, U> action, Class<E> expectedException) {
+        throw new NotImplementedException(String.format("The entity(%s) must be implement the when(Action<T, U>, Class<E>) method.", getClass()));
+    }
+
+    public <E extends Exception> T whenException(Class<T> entityClass, Action<T, U> action, Class<E> expectedException,
+            RunningParameter runningParameter) {
+        throw new NotImplementedException(
+                String.format("The entity(%s) must be implement the when(Class<T>, Action<T, U>, Class<E>, RunningParameter) method.", getClass()));
+    }
+
+    public <E extends Exception> T whenException(Action<T, U> action, Class<E> expectedException, RunningParameter runningParameter) {
+        throw new NotImplementedException(String.format("The entity(%s) must be implement the when(Action<T, U>, Class<E>, RunningParameter) method.",
+                getClass()));
+    }
+
     @Override
     public String toString() {
         return getClass().getSimpleName() + "[name: " + getName() + ']';

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/log/Log.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/log/Log.java
@@ -81,6 +81,10 @@ public class Log<T extends CloudbreakTestDto> {
         log(logger, "When", message);
     }
 
+    public static void whenException(Logger logger, String message) {
+        log(logger, "WhenException", message);
+    }
+
     public static void then(Logger logger, String message) {
         log(logger, "Then", message);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/CredentialCreateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/CredentialCreateTest.java
@@ -1,8 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.authorization;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 
 import javax.inject.Inject;
 import javax.ws.rs.ForbiddenException;
@@ -13,14 +11,11 @@ import com.sequenceiq.it.cloudbreak.actor.Actor;
 import com.sequenceiq.it.cloudbreak.client.CredentialTestClient;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
-import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 
 public class CredentialCreateTest extends AbstractIntegrationTest {
-
-    private static final Set<String> INVALID_REGION = new HashSet<>(Collections.singletonList("MockRegion"));
 
     @Inject
     private EnvironmentTestClient environmentTestClient;
@@ -58,11 +53,9 @@ public class CredentialCreateTest extends AbstractIntegrationTest {
         testContext
                 .given(CredentialTestDto.class)
                 .when(credentialTestClient.create())
-                .when(credentialTestClient.get(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
-                .expect(ForbiddenException.class, RunningParameter.key("CredentialGetAction")
-                        .withExpectedMessage("Doesn't have 'environments/describeCredential' right on 'credential' " +
-                                String.format("[\\[]name='%s', crn='crn:cdp:environments:us-west-1:.*:credential:.*'[]]\\.",
-                                        testContext.get(CredentialTestDto.class).getName())))
+                .whenException(credentialTestClient.get(), ForbiddenException.class, expectedMessage("Doesn't have 'environments/describeCredential'" +
+                        " right on 'credential' " + String.format("[\\[]name='%s', crn='crn:cdp:environments:us-west-1:.*:credential:.*'[]]\\.",
+                        testContext.get(CredentialTestDto.class).getName())).withWho(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .validate();
     }
 
@@ -75,11 +68,8 @@ public class CredentialCreateTest extends AbstractIntegrationTest {
         useRealUmsUser(testContext, AuthUserKeys.ZERO_RIGHTS);
         testContext
                 .given(CredentialTestDto.class)
-                .when(credentialTestClient.create(), RunningParameter.key("Unauthorized"))
-                .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("You have no right to perform " +
-                                "environments/createCredential in account 460c0d8f-ae8e-4dce-9cd7-2351762eb9ac")
-                                .withKey("Unauthorized"))
+                .whenException(credentialTestClient.create(), ForbiddenException.class, expectedMessage("You have no right to perform" +
+                        " environments/createCredential in account 460c0d8f-ae8e-4dce-9cd7-2351762eb9ac"))
                 .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DatalakeDatahubCreateAuthTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DatalakeDatahubCreateAuthTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.authorization;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
 import javax.inject.Inject;
@@ -81,23 +82,15 @@ public class DatalakeDatahubCreateAuthTest extends AbstractIntegrationTest {
                 .await(SdxClusterStatusResponse.RUNNING)
                 .when(sdxTestClient.detailedDescribeInternal(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_A)))
                 .when(sdxTestClient.detailedDescribeInternal(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
-                .when(sdxTestClient.detailedDescribeInternal(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
-                .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("Doesn't have 'datalake/describeDetailedDatalake' right on any of the " +
-                                "'environment'[(]-s[)] [\\[]crn='crn:cdp:environments:us-west-1:.*:environment:.*[]]" +
-                                " or on " +
-                                datalakePattern(testContext.get(sdxInternal).getName()))
-                                .withKey("SdxDetailedDescribeInternalAction"))
+                .whenException(sdxTestClient.detailedDescribeInternal(), ForbiddenException.class, expectedMessage("Doesn't have " +
+                        "'datalake/describeDetailedDatalake' right on any of the 'environment'[(]-s[)] " +
+                        "[\\[]crn='crn:cdp:environments:us-west-1:.*:environment:.*[]] or on " + datalakePattern(testContext.get(sdxInternal).getName()))
+                        .withWho(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .given(RenewDatalakeCertificateTestDto.class)
                 .withStackCrn(testContext.get(sdxInternal).getCrn())
-                .when(sdxTestClient.renewDatalakeCertificateV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
-                .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("Doesn't have 'datalake/repairDatalake' right on any of the " +
-                                "'environment'[(]-s[)] [\\[]crn='crn:cdp:environments:us-west-1:.*:environment:.*[]]" +
-                                " or on " +
-                                datalakePattern(testContext.get(sdxInternal).getName()))
-                                .withKey("RenewDatalakeCertificateAction"))
-
+                .whenException(sdxTestClient.renewDatalakeCertificateV4(), ForbiddenException.class, expectedMessage("Doesn't have 'datalake/repairDatalake'" +
+                        " right on any of the 'environment'[(]-s[)] [\\[]crn='crn:cdp:environments:us-west-1:.*:environment:.*[]] or on " +
+                        datalakePattern(testContext.get(sdxInternal).getName())).withWho(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/RecipeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/RecipeTest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.testcase.authorization;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
+
 import javax.inject.Inject;
 import javax.ws.rs.ForbiddenException;
 
@@ -9,7 +11,6 @@ import org.testng.annotations.Test;
 import com.sequenceiq.it.cloudbreak.actor.Actor;
 import com.sequenceiq.it.cloudbreak.client.RecipeTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
-import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.recipe.RecipeTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
@@ -47,34 +48,28 @@ public class RecipeTest extends AbstractIntegrationTest {
                     Assertions.assertThat(dto.getSimpleResponses().getResponses()).isNotEmpty();
                     return dto;
                 })
-                .when(recipeTestClient.getV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
-                .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("Doesn't have 'environments/useSharedResource' right on 'recipe' " +
-                                patternWithName(testContext.get(RecipeTestDto.class).getName()))
-                                .withKey("RecipeGetAction"))
-                .when(recipeTestClient.getV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
-                .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("Doesn't have 'environments/useSharedResource' right on 'recipe' " +
-                                patternWithName(testContext.get(RecipeTestDto.class).getName()))
-                                .withKey("RecipeGetAction"))
-                .when(recipeTestClient.deleteV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
-                .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("Doesn't have 'environments/deleteRecipe' right on 'recipe' " +
-                                patternWithName(testContext.get(RecipeTestDto.class).getName()))
-                                .withKey("RecipeDeleteAction"))
-                .when(recipeTestClient.deleteV4(), RunningParameter.who(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
-                .expect(ForbiddenException.class,
-                        RunningParameter.expectedMessage("Doesn't have 'environments/deleteRecipe' right on 'recipe' " +
-                                patternWithName(testContext.get(RecipeTestDto.class).getName()))
-                                .withKey("RecipeDeleteAction"))
+                .whenException(recipeTestClient.getV4(), ForbiddenException.class,
+                        expectedMessage("Doesn't have 'environments/useSharedResource' right on 'recipe' " +
+                                patternWithName(testContext.get(RecipeTestDto.class).getName())).withWho(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
+                .whenException(recipeTestClient.getV4(), ForbiddenException.class,
+                        expectedMessage("Doesn't have 'environments/useSharedResource' right on 'recipe' " +
+                                        patternWithName(testContext.get(RecipeTestDto.class).getName()))
+                                .withWho(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
+                .whenException(recipeTestClient.deleteV4(), ForbiddenException.class,
+                        expectedMessage("Doesn't have 'environments/deleteRecipe' right on 'recipe' " +
+                                        patternWithName(testContext.get(RecipeTestDto.class).getName()))
+                                .withWho(Actor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
+                .whenException(recipeTestClient.deleteV4(), ForbiddenException.class,
+                        expectedMessage("Doesn't have 'environments/deleteRecipe' right on 'recipe' " +
+                                        patternWithName(testContext.get(RecipeTestDto.class).getName()))
+                                .withWho(Actor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .when(recipeTestClient.deleteV4())
                 .when(recipeTestClient.listV4())
                 .then((context, dto, client) -> {
                     Assertions.assertThat(
                             dto.getSimpleResponses().getResponses()
                                     .stream()
-                                    .filter(response -> response.getName()
-                                            .equals(dto.getName())).findFirst().isPresent()).isFalse();
+                                    .anyMatch(response -> response.getName().equals(dto.getName()))).isFalse();
                     return dto;
                 })
                 .validate();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterCreationTest.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 
 import javax.ws.rs.BadRequestException;
 
@@ -29,9 +29,7 @@ public class ClusterCreationTest extends AbstractMockTest {
                 .given(StackTestDto.class)
                 .withEmptyNetwork()
                 .withEmptyPlacement()
-                .when(StackTestAction::create, key("error"))
-                .expect(BadRequestException.class, key("error")
-                        .withExpectedMessage("Network must be specified!"))
+                .whenException(StackTestAction::create, BadRequestException.class, expectedMessage("Network must be specified!"))
                 .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -142,15 +143,11 @@ public class ClusterTemplateTest extends AbstractMockTest {
             then = "the cluster template is cannot be created"
     )
     public void testCreateClusterTemplateWithoutEnvironmentName(MockedTestContext testContext) {
-        String generatedKey = resourcePropertyProvider().getName();
-
         testContext.given(DistroXTemplateTestDto.class)
                 .withEnvironmentName(null)
                 .given(ClusterTemplateTestDto.class)
                 .withDistroXTemplate()
-                .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .expect(BadRequestException.class, RunningParameter.key(generatedKey)
-                        .withExpectedMessage("The environmentName cannot be null."))
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class, expectedMessage("The environmentName cannot be null."))
                 .validate();
     }
 
@@ -176,52 +173,6 @@ public class ClusterTemplateTest extends AbstractMockTest {
                 .validate();
     }
 
-    /*@Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
-    @Description(
-            given = "a prepared cluster template with many properties",
-            when = "a stack is created from the prepared cluster template",
-            then = "the stack starts properly and can be deleted"
-    )
-    public void testLaunchClusterFromTemplateWithProperties(MockedTestContext testContext) {
-        testContext
-                .given(LdapTestDto.class)
-                .withName("mock-test-ldap")
-                .when(ldapTestClient.createV1())
-
-                .given(RecipeTestDto.class)
-                .withName("mock-test-recipe")
-                .when(recipeTestClient.createV4())
-
-                .given(DatabaseTestDto.class)
-                .withName("mock-test-rds")
-                .when(new DatabaseCreateIfNotExistsAction())
-
-                .given("mpack", MPackTestDto.class)
-                .withName("mock-test-mpack")
-                .when(mpackTestClient.createV4())
-
-                .given(StackTemplateTestDto.class)
-                .withEnvironment(EnvironmentTestDto.class)
-                .withEveryProperties()
-
-                .given(ClusterTemplateTestDto.class)
-                .withName(resourcePropertyProvider().getName())
-                .when(clusterTemplateTestClient.createV4())
-                .when(clusterTemplateTestClient.getV4())
-                .then(ClusterTemplateTestAssertion.checkStackTemplateAfterClusterTemplateCreationWithProperties())
-
-                .when(clusterTemplateTestClient.launchCluster(StackTemplateTestDto.class))
-                .given(StackTemplateTestDto.class)
-                .await(STACK_AVAILABLE)
-
-                .given(ClusterTemplateTestDto.class)
-                .withName(resourcePropertyProvider().getName())
-                .when(clusterTemplateTestClient.deleteCluster(StackTemplateTestDto.class), RunningParameter.force())
-                .given(StackTemplateTestDto.class)
-                .await(STACK_DELETED, RunningParameter.force())
-                .validate();
-    }*/
-
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
             given = "a cluster template list request",
@@ -244,14 +195,11 @@ public class ClusterTemplateTest extends AbstractMockTest {
             then = "the cluster template cannot be created"
     )
     public void testCreateInvalidNameClusterTemplate(MockedTestContext testContext) {
-        String generatedKey = resourcePropertyProvider().getName();
-
         testContext
                 .given(ClusterTemplateTestDto.class)
                 .withName(ILLEGAL_CT_NAME)
-                .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .expect(BadRequestException.class, RunningParameter.key(generatedKey)
-                        .withExpectedMessage("Name should not contain semicolon, forward slash or percentage characters"))
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class, expectedMessage("Name should not contain semicolon," +
+                        " forward slash or percentage characters"))
                 .validate();
     }
 
@@ -284,15 +232,11 @@ public class ClusterTemplateTest extends AbstractMockTest {
             then = "the cluster template cannot be created"
     )
     public void testCreateInvalidShortNameClusterTemplate(MockedTestContext testContext) {
-        String generatedKey = resourcePropertyProvider().getName();
-
         testContext
                 .given(ClusterTemplateTestDto.class)
                 .withName(getLongNameGenerator().stringGenerator(2))
-                .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .expect(BadRequestException.class, RunningParameter.key(generatedKey)
-                        .withExpectedMessage("The length of name has to be in range of 5 to 40")
-                )
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class, expectedMessage("The length of name has to be in range" +
+                        " of 5 to 40"))
                 .validate();
     }
 
@@ -303,15 +247,12 @@ public class ClusterTemplateTest extends AbstractMockTest {
             then = "the cluster definition cannot be created"
     )
     public void testCreateWithoutBlueprintInCluster(MockedTestContext testContext) {
-        String generatedKey = resourcePropertyProvider().getName();
-
         testContext
                 .given("dixTemplate", DistroXTemplateTestDto.class)
                 .withBlueprintName(null)
                 .given(ClusterTemplateTestDto.class)
                 .withDistroXTemplateKey("dixTemplate")
-                .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .expect(BadRequestException.class, RunningParameter.key(generatedKey))
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class)
                 .validate();
     }
 
@@ -322,15 +263,12 @@ public class ClusterTemplateTest extends AbstractMockTest {
             then = "the cluster definition cannot be created"
     )
     public void testCreateWithEmptyBlueprintInCluster(MockedTestContext testContext) {
-        String generatedKey = resourcePropertyProvider().getName();
-
         testContext
                 .given("dixTemplate", DistroXTemplateTestDto.class)
                 .withBlueprintName("")
                 .given(ClusterTemplateTestDto.class)
                 .withDistroXTemplateKey("dixTemplate")
-                .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .expect(BadRequestException.class, RunningParameter.key(generatedKey))
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class)
                 .validate();
     }
 
@@ -341,15 +279,12 @@ public class ClusterTemplateTest extends AbstractMockTest {
             then = "the cluster definition cannot be created"
     )
     public void testCreateWithNotExistingBlueprintInCluster(MockedTestContext testContext) {
-        String generatedKey = resourcePropertyProvider().getName();
-
         testContext
                 .given("dixTemplate", DistroXTemplateTestDto.class)
                 .withBlueprintName("thisBlueprintDoesNotExistsForSure")
                 .given(ClusterTemplateTestDto.class)
                 .withDistroXTemplateKey("dixTemplate")
-                .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .expect(BadRequestException.class, RunningParameter.key(generatedKey))
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class)
                 .validate();
     }
 
@@ -371,9 +306,7 @@ public class ClusterTemplateTest extends AbstractMockTest {
                 .given(ClusterTemplateTestDto.class)
                 .withName(resourcePropertyProvider().getName())
                 .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .expect(BadRequestException.class, RunningParameter.key(generatedKey)
-                        .withExpectedMessage("^clustertemplate already exists with name.*"))
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class, expectedMessage("^clustertemplate already exists with name.*"))
                 .validate();
     }
 
@@ -384,15 +317,12 @@ public class ClusterTemplateTest extends AbstractMockTest {
             then = "the a cluster template should not be created"
     )
     public void testCreateLongDescriptionClusterTemplate(MockedTestContext testContext) {
-        String generatedKey = resourcePropertyProvider().getName();
         String invalidLongDescripton = getLongNameGenerator().stringGenerator(1001);
         testContext
                 .given(ClusterTemplateTestDto.class)
                 .withName(resourcePropertyProvider().getName())
                 .withDescription(invalidLongDescripton)
-                .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .expect(BadRequestException.class, RunningParameter.key(generatedKey)
-                        .withExpectedMessage("size must be between 0 and 1000"))
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class, expectedMessage("size must be between 0 and 1000"))
                 .validate();
     }
 
@@ -403,13 +333,9 @@ public class ClusterTemplateTest extends AbstractMockTest {
             then = "the a cluster template should not be created"
     )
     public void testCreateEmptyStackTemplateClusterTemplateException(MockedTestContext testContext) {
-        String generatedKey = resourcePropertyProvider().getName();
-
         testContext.given(ClusterTemplateTestDto.class)
                 .withDistroXTemplate(null)
-                .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .expect(BadRequestException.class, RunningParameter.key(generatedKey)
-                        .withExpectedMessage("must not be null"))
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class, expectedMessage("must not be null"))
                 .validate();
     }
 
@@ -420,20 +346,14 @@ public class ClusterTemplateTest extends AbstractMockTest {
             then = "the a cluster template should not be created"
     )
     public void testCreateEmptyClusterTemplateNameException(MockedTestContext testContext) {
-        String generatedKey1 = resourcePropertyProvider().getName();
-        String generatedKey2 = resourcePropertyProvider().getName();
-
         testContext
                 .given(ClusterTemplateTestDto.class)
                 .withName(null)
-                .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey1))
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class, expectedMessage("must not be null").withSkipOnFail(false))
                 .given(ClusterTemplateTestDto.class)
                 .withName("")
-                .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey2)
-                        .withSkipOnFail(false))
-                .expect(BadRequestException.class, RunningParameter.key(generatedKey1).withExpectedMessage("must not be null"))
-                .expect(BadRequestException.class, RunningParameter.key(generatedKey2)
-                        .withExpectedMessage("The length of name has to be in range of 5 to 40"))
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class, expectedMessage("The length of name has to be in range" +
+                        " of 5 to 40"))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DatabaseTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DatabaseTest.java
@@ -83,61 +83,9 @@ public class DatabaseTest extends AbstractMockTest {
                 .when(databaseTestClient.createV4(), RunningParameter.key(databaseName))
                 .when(databaseTestClient.listV4(), RunningParameter.key(databaseName))
                 .then(RedbeamsDatabaseTestAssertion.containsDatabaseName(databaseName, 1), RunningParameter.key(databaseName))
-                .when(databaseTestClient.createV4(), RunningParameter.key(databaseName))
-                .expect(BadRequestException.class, RunningParameter.key(databaseName))
+                .whenException(databaseTestClient.createV4(), BadRequestException.class)
                 .validate();
     }
-
-    /*
-    @Test(dataProvider = INVALID_ATTRIBUTE_PROVIDER)
-    public void testCreateDatabaseWithInvalidAttribute(
-            TestContext testContext,
-            String databaseName,
-            String username,
-            String password,
-            String connectionUrl,
-            String expectedErrorMessage,
-            @Description TestCaseDescription testCaseDescription) {
-        String generatedKey = resourcePropertyProvider().getName();
-        testContext
-                .given(DatabaseTestDto.class)
-                .withName(databaseName)
-                .withConnectionUserName(username)
-                .withConnectionPassword(password)
-                .withConnectionURL(connectionUrl)
-                .when(databaseTestClient.createV4(), RunningParameter.key(generatedKey))
-                .expect(BadRequestException.class,
-                        RunningParameter.expectedMessage(expectedErrorMessage)
-                                .withKey(generatedKey))
-                .validate();
-    }
-
-    @Test(dataProvider = INVALID_ATTRIBUTE_PROVIDER)
-    public void testDatabaseTestConnectionWithInvalidAttribute(
-            TestContext testContext,
-            String databaseName,
-            String username,
-            String password,
-            String connectionUrl,
-            String expectedErrorMessage,
-            @Description TestCaseDescription testCaseDescription) {
-        String generatedKey = resourcePropertyProvider().getName();
-
-        testContext
-                .given(DatabaseTestTestDto.class)
-                .withRequest(new DatabaseV4Request())
-                .withName(databaseName)
-                .withConnectionUserName(username)
-                .withConnectionPassword(password)
-                .withConnectionURL(connectionUrl)
-                .withType("HIVE")
-                .when(databaseTestClient.testV4(), RunningParameter.key(generatedKey))
-                .expect(BadRequestException.class,
-                        RunningParameter.expectedMessage(expectedErrorMessage)
-                                .withKey(generatedKey))
-                .validate();
-    }
-    */
 
     @DataProvider(name = DB_TYPE_PROVIDER)
     public Object[][] provideTypes() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterCreationTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
 import java.time.Duration;
@@ -144,8 +145,7 @@ public class DistroXClusterCreationTest extends AbstractClouderaManagerTest {
                 .withCluster(CLUSTER_KEY)
                 .withImageSettings(DIX_IMG_KEY)
                 .withNetwork(DIX_NET_KEY)
-                .when(distroXClient.create(), key("error"))
-                .expect(BadRequestException.class, key("error").withExpectedMessage("Environment state is ENV_STOPPED instead of AVAILABLE"))
+                .whenException(distroXClient.create(), BadRequestException.class, expectedMessage("Environment state is ENV_STOPPED instead of AVAILABLE"))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentChildTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentChildTest.java
@@ -70,7 +70,6 @@ public class EnvironmentChildTest extends AbstractMockTest {
             when = "child create request is sent but parent environment is a child environment",
             then = "a BadRequestException should be returned")
     public void testCreateChildEnvironmentWhereParentIsAChild(MockedTestContext testContext) {
-        String forbiddenKey = resourcePropertyProvider().getName();
         testContext
                 .given(CHILD_ENVIRONMENT, EnvironmentTestDto.class)
                 .withParentEnvironment()
@@ -78,8 +77,7 @@ public class EnvironmentChildTest extends AbstractMockTest {
                 .await(EnvironmentStatus.AVAILABLE)
                 .given(EnvironmentTestDto.class)
                 .withParentEnvironment()
-                .when(environmentTestClient.create(), RunningParameter.key(forbiddenKey))
-                .expect(BadRequestException.class, RunningParameter.key(forbiddenKey))
+                .whenException(environmentTestClient.create(), BadRequestException.class)
                 .validate();
     }
 
@@ -89,13 +87,11 @@ public class EnvironmentChildTest extends AbstractMockTest {
             when = "child create request is sent but parent is not created yet",
             then = "a BadRequestException should be returned")
     public void testCreateChildWithoutParentEnvironment(MockedTestContext testContext) {
-        String forbiddenKey = resourcePropertyProvider().getName();
         testContext
                 .given(PARENT_ENVIRONMENT, EnvironmentTestDto.class)
                 .given(CHILD_ENVIRONMENT, EnvironmentTestDto.class)
                 .withParentEnvironment(RunningParameter.key(PARENT_ENVIRONMENT))
-                .when(environmentTestClient.create(), RunningParameter.key(forbiddenKey))
-                .expect(BadRequestException.class, RunningParameter.key(forbiddenKey))
+                .whenException(environmentTestClient.create(), BadRequestException.class)
                 .validate();
     }
 
@@ -105,15 +101,13 @@ public class EnvironmentChildTest extends AbstractMockTest {
             when = "a delete request is sent for the parent environment without cascading",
             then = "a BadRequestException should be returned")
     public void testDeleteParentEnvironmentWithExistingChild(MockedTestContext testContext) {
-        String forbiddenKey = resourcePropertyProvider().getName();
         testContext
                 .given(CHILD_ENVIRONMENT, EnvironmentTestDto.class)
                 .withParentEnvironment()
                 .when(environmentTestClient.create())
                 .await(EnvironmentStatus.AVAILABLE)
                 .given(EnvironmentTestDto.class)
-                .when(environmentTestClient.deleteByName(false), RunningParameter.key(forbiddenKey))
-                .expect(BadRequestException.class, RunningParameter.key(forbiddenKey))
+                .whenException(environmentTestClient.deleteByName(false), BadRequestException.class)
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentClusterTest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
+
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 
@@ -126,9 +128,7 @@ public class EnvironmentClusterTest extends AbstractMockTest {
                 .when(environmentTestClient.describe())
                 .given(StackTestDto.class)
                 .withEnvironmentCrn("")
-                .when(stackTestClient.createV4(), RunningParameter.key("badRequest"))
-                .expect(BadRequestException.class, RunningParameter.key("badRequest")
-                        .withExpectedMessage("Environment CRN cannot be null or empty."))
+                .whenException(stackTestClient.createV4(), BadRequestException.class, expectedMessage("Environment CRN cannot be null or empty."))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentEditTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentEditTest.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
-import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 
 import java.util.Map;
 import java.util.UUID;
@@ -143,17 +143,13 @@ public class EnvironmentEditTest extends AbstractMockTest {
                 .withPublicKeyId(value)
                 .withPublicKey(INVALID_PUBLIC_KEY)
                 .given(EnvironmentTestDto.class)
-                .when(environmentTestClient.changeAuthentication(), key("all-defined"))
-                .expect(BadRequestException.class, key("all-defined")
-                        .withExpectedMessage(errorPattern))
-
+                .whenException(environmentTestClient.changeAuthentication(), BadRequestException.class, expectedMessage(errorPattern))
                 .given(EnvironmentAuthenticationTestDto.class)
                 .withPublicKeyId(null)
                 .withPublicKey(null)
                 .given(EnvironmentTestDto.class)
-                .when(environmentTestClient.changeAuthentication(), key("non-defined"))
-                .expect(BadRequestException.class, key("non-defined")
-                        .withExpectedMessage("1. You should define either the publicKey or the publicKeyId."))
+                .whenException(environmentTestClient.changeAuthentication(), BadRequestException.class,
+                        expectedMessage("1. You should define either the publicKey or the publicKeyId."))
                 .validate();
     }
 
@@ -173,9 +169,9 @@ public class EnvironmentEditTest extends AbstractMockTest {
                 .withCidr("cidr")
                 .given(EnvironmentTestDto.class)
                 .withSecurityAccess()
-                .when(environmentTestClient.changeSecurityAccess(), key("cidr-defined"))
-                .expect(BadRequestException.class, key("cidr-defined")
-                        .withExpectedMessage("1. Please add the default or knox security groups, we cannot edit with empty value.\n" +
+                .whenException(environmentTestClient.changeSecurityAccess(), BadRequestException.class,
+                        expectedMessage(
+                                "1. Please add the default or knox security groups, we cannot edit with empty value.\n" +
                                 "2. The CIDR can be replaced with the default and knox security groups, please add to the request\n" +
                                 "3. The CIDR could not be updated in the environment"))
                 .validate();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentTest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -23,7 +25,6 @@ import com.sequenceiq.it.cloudbreak.client.CredentialTestClient;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
@@ -67,12 +68,10 @@ public class EnvironmentTest extends AbstractMockTest {
             when = "a create environment request with reference to a non-existing credential is sent",
             then = "a BadRequestException should be returned")
     public void testCreateEnvironmentNotExistCredential(MockedTestContext testContext) {
-        String forbiddenKey = resourcePropertyProvider().getName();
         testContext
                 .given(CredentialTestDto.class)
                 .init(EnvironmentTestDto.class)
-                .when(environmentTestClient.create(), RunningParameter.key(forbiddenKey))
-                .expect(BadRequestException.class, RunningParameter.key(forbiddenKey))
+                .whenException(environmentTestClient.create(), BadRequestException.class)
                 .validate();
     }
 
@@ -111,18 +110,14 @@ public class EnvironmentTest extends AbstractMockTest {
                 .getResponse().setCrn(invalidCrn);
         testContext
                 .given(EnvironmentTestDto.class)
-                .when(environmentTestClient.describeByCrn())
-                .expect(BadRequestException.class,
-                        RunningParameter.expectedMessage(".*Crn provided: " +
+                .whenException(environmentTestClient.describeByCrn(), BadRequestException.class,
+                        expectedMessage(".*Crn provided: " +
                                 "crn:cdp:datalake:us-west-1:acc:datalake:dl has invalid resource type or service type. " +
-                                "Accepted service type / resource type pairs: [(]environments,environment[)].*")
-                                .withKey("EnvironmentGetByCrnAction"))
-                .when(environmentTestClient.deleteMultipleByCrns(invalidCrn, otherInvalidCrn))
-                .expect(BadRequestException.class,
-                        RunningParameter.expectedMessage(".*Crns provided: \\[crn:cdp:datalake:us-west-1:acc:datalake:dl," +
+                                "Accepted service type / resource type pairs: [(]environments,environment[)].*"))
+                .whenException(environmentTestClient.deleteMultipleByCrns(invalidCrn, otherInvalidCrn), BadRequestException.class,
+                        expectedMessage(".*Crns provided: \\[crn:cdp:datalake:us-west-1:acc:datalake:dl," +
                                 "crn:cdp:datahub:us-west-1:acc:cluster:dh\\] have invalid resource type or service type. " +
-                                "Accepted service type / resource type pairs: [(]environments,environment[)].*")
-                                .withKey("EnvironmentDeleteMultipleByCrnsAction"))
+                                "Accepted service type / resource type pairs: [(]environments,environment[)].*"))
                 .validate();
     }
 
@@ -132,12 +127,10 @@ public class EnvironmentTest extends AbstractMockTest {
             when = "a delete request is sent for a non-existing environment",
             then = "a NotFoundException should be returned")
     public void testDeleteEnvironmentNotExist(MockedTestContext testContext) {
-        String forbiddenKey = resourcePropertyProvider().getName();
         testContext
                 .given(CredentialTestDto.class)
                 .init(EnvironmentTestDto.class)
-                .when(environmentTestClient.deleteByName(), RunningParameter.key(forbiddenKey))
-                .expect(NotFoundException.class, RunningParameter.key(forbiddenKey))
+                .whenException(environmentTestClient.deleteByName(), NotFoundException.class)
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaAttachDetachChildEnvironmentTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaAttachDetachChildEnvironmentTest.java
@@ -12,7 +12,6 @@ import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaChildEnvironmentTestDto;
@@ -62,7 +61,6 @@ public class FreeIpaAttachDetachChildEnvironmentTest extends AbstractMockTest {
             when = "calling a freeipa delete on parent environment",
             then = "it should fail")
     public void testParentFreeIpaDeleteFailure(MockedTestContext testContext) {
-        String key = resourcePropertyProvider().getName();
         testContext
                 .given(FreeIpaTestDto.class)
                     .withCatalog(getImageCatalogMockServerSetup().getFreeIpaImageCatalogUrl())
@@ -76,8 +74,7 @@ public class FreeIpaAttachDetachChildEnvironmentTest extends AbstractMockTest {
                 .given(FreeIpaChildEnvironmentTestDto.class)
                 .when(freeIpaTestClient.attachChildEnvironment())
                 .given(FreeIpaTestDto.class)
-                .when(freeIpaTestClient.delete(), RunningParameter.key(key))
-                .expect(BadRequestException.class, RunningParameter.key(key))
+                .whenException(freeIpaTestClient.delete(), BadRequestException.class)
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ImageCatalogTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ImageCatalogTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
 import javax.inject.Inject;
@@ -77,9 +78,8 @@ public class ImageCatalogTest extends AbstractMockTest {
                 .given(imgCatalogName, ImageCatalogTestDto.class)
                 .withName(imgCatalogName)
                 .withUrl(IMG_CATALOG_URL)
-                .when(imageCatalogTestClient.createV4(), key(imgCatalogName))
-                .expect(BadRequestException.class, key(imgCatalogName)
-                        .withExpectedMessage(".*The length of the credential's name has to be in range of 5 to 100"))
+                .whenException(imageCatalogTestClient.createV4(), BadRequestException.class,
+                        expectedMessage(".*The length of the credential's name has to be in range of 5 to 100"))
                 .validate();
     }
 
@@ -95,9 +95,8 @@ public class ImageCatalogTest extends AbstractMockTest {
                 .given(imgCatalogName, ImageCatalogTestDto.class)
                 .withName(imgCatalogName)
                 .withUrl(IMG_CATALOG_URL)
-                .when(imageCatalogTestClient.createV4(), key(imgCatalogName))
-                .expect(BadRequestException.class, key(imgCatalogName)
-                        .withExpectedMessage(".*The length of the credential's name has to be in range of 5 to 100"))
+                .whenException(imageCatalogTestClient.createV4(), BadRequestException.class,
+                        expectedMessage(".*The length of the credential's name has to be in range of 5 to 100"))
                 .validate();
     }
 
@@ -113,8 +112,7 @@ public class ImageCatalogTest extends AbstractMockTest {
                 .given(imgCatalogName, ImageCatalogTestDto.class)
                 .withName(imgCatalogName)
                 .withUrl(IMG_CATALOG_URL)
-                .when(imageCatalogTestClient.createWithoutNameV4(), key(imgCatalogName))
-                .expect(BadRequestException.class, key(imgCatalogName))
+                .whenException(imageCatalogTestClient.createWithoutNameV4(), BadRequestException.class)
                 .validate();
     }
 
@@ -131,9 +129,8 @@ public class ImageCatalogTest extends AbstractMockTest {
                 .given(imgCatalogName, ImageCatalogTestDto.class)
                 .withName(imgCatalogName)
                 .withUrl(invalidURL)
-                .when(imageCatalogTestClient.createV4(), key(imgCatalogName))
-                .expect(BadRequestException.class, key(imgCatalogName)
-                        .withExpectedMessage("A valid image catalog must be available on the given URL"))
+                .whenException(imageCatalogTestClient.createV4(), BadRequestException.class,
+                        expectedMessage("A valid image catalog must be available on the given URL"))
                 .validate();
     }
 
@@ -149,9 +146,8 @@ public class ImageCatalogTest extends AbstractMockTest {
                 .given(imgCatalogName, ImageCatalogTestDto.class)
                 .withName(imgCatalogName)
                 .withUrl(IMG_CATALOG_URL + "/notanimagecatalog")
-                .when(imageCatalogTestClient.createV4(), key(imgCatalogName))
-                .expect(BadRequestException.class, key(imgCatalogName)
-                        .withExpectedMessage(".*A valid image catalog must be available on the given URL.*"))
+                .whenException(imageCatalogTestClient.createV4(), BadRequestException.class,
+                        expectedMessage(".*A valid image catalog must be available on the given URL.*"))
                 .validate();
     }
 
@@ -167,38 +163,10 @@ public class ImageCatalogTest extends AbstractMockTest {
                 .given(imgCatalogName, ImageCatalogTestDto.class)
                 .withName(imgCatalogName)
                 .withUrl(INVALID_IMAGECATALOG_JSON_URL)
-                .when(imageCatalogTestClient.createV4(), key(imgCatalogName))
-                .expect(BadRequestException.class, key(imgCatalogName)
-                        .withExpectedMessage("A valid image catalog must be available on the given URL"))
+                .whenException(imageCatalogTestClient.createV4(), BadRequestException.class,
+                        expectedMessage("A valid image catalog must be available on the given URL"))
                 .validate();
     }
-
-    /*@Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
-    @Description(
-            given = "image catalog in the database",
-            when = "calling delete on the existing one and create a new one with the same name",
-            then = "getting an image catalog response so the request was valid")
-    public void testImageCatalogCreationWhenCatalogWithTheSameNameDeletedRightBeforeCreation(MockedTestContext testContext) {
-        String imgCatalogName = resourcePropertyProvider().getName();
-
-        testContext
-                .given(imgCatalogName, ImageCatalogTestDto.class)
-                .withName(imgCatalogName)
-                .withUrl(getImageCatalogMockServerSetup().getImageCatalogUrl())
-                .when(imageCatalogTestClient.createV4(), key(imgCatalogName))
-                .select(imgCatalog -> imgCatalog.getResponse().getId(), key(imgCatalogName))
-                .when(imageCatalogTestClient.deleteV4(), key(imgCatalogName))
-                .when(imageCatalogTestClient.createV4(), key(imgCatalogName))
-                .when(imageCatalogTestClient.getV4(Boolean.FALSE), key(imgCatalogName))
-                .then((testContext1, entity, cloudbreakClient) -> {
-                    Long firstPostEntityId = testContext1.getSelected(imgCatalogName);
-                    if (entity.getResponse().getId().equals(firstPostEntityId)) {
-                        throw new IllegalArgumentException("The re-created ImageCatalog should have a different id.");
-                    }
-                    return entity;
-                })
-                .validate();
-    }*/
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
@@ -215,9 +183,7 @@ public class ImageCatalogTest extends AbstractMockTest {
                 .withUrl(getImageCatalogMockServerSetup().getImageCatalogUrl())
                 .when(imageCatalogTestClient.createV4(), key(catalogKey))
                 .when(imageCatalogTestClient.deleteV4(), key(catalogKey))
-                .when(imageCatalogTestClient.getImagesByNameV4(), key(imgCatalogName))
-                .expect(NotFoundException.class, key(imgCatalogName)
-                        .withExpectedMessage("not found"))
+                .whenException(imageCatalogTestClient.getImagesByNameV4(), NotFoundException.class, expectedMessage("not found"))
                 .validate();
     }
 
@@ -281,8 +247,7 @@ public class ImageCatalogTest extends AbstractMockTest {
                 .given(imgCatalogName, ImageCatalogTestDto.class)
                 .withName(imgCatalogName)
                 .withUrl(getImageCatalogMockServerSetup().getImageCatalogUrl())
-                .when(imageCatalogTestClient.getImagesByNameV4(), key(imgCatalogName))
-                .expect(NotFoundException.class, key(imgCatalogName))
+                .whenException(imageCatalogTestClient.getImagesByNameV4(), NotFoundException.class)
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/LdapClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/LdapClusterTest.java
@@ -35,29 +35,4 @@ public class LdapClusterTest extends AbstractMockTest {
                 .mockCm().externalUserMappings().post().times(1).verify()
                 .validate();
     }
-
-    // TODO: Delete the test or improve the validation!
-//    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, enabled = false)
-//    @Description(
-//            given = "a valid cluster request with ldap configuration",
-//            when = "calling create cluster and then delete the attached ldap",
-//            then = "the ldap should be configured on the cluster but the ldap delete throw BadRequestException because the ldap attached to the cluster")
-//    public void testTryToDeleteAttachedLdap(MockedTestContext testContext) {
-//        String stackName = resourcePropertyProvider().getName();
-//        String deleteFail = resourcePropertyProvider().getName();
-//        String ldapName = resourcePropertyProvider().getName();
-//
-//        testContext.given(LdapTestDto.class).withName(ldapName)
-//                .when(ldapTestClient.createV1())
-//                .given(ClusterTestDto.class)
-//                .given(StackTestDto.class)
-//                .withCluster()
-//                .withName(stackName)
-//                .when(stackTestClient.createV4())
-//                .given(LdapTestDto.class)
-//                .when(ldapTestClient.deleteV1(), RunningParameter.key(deleteFail))
-//                .expect(BadRequestException.class, RunningParameter.expectedMessage(String.format("LDAP config '%s' cannot be deleted "
-//                        + "because there are clusters associated with it: \\[%s\\].", ldapName, stackName)).withKey(deleteFail))
-//                .validate();
-//    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/LdapConfigTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/LdapConfigTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 import static org.junit.Assert.assertNotNull;
 
 import javax.inject.Inject;
@@ -91,15 +92,12 @@ public class LdapConfigTest extends AbstractMockTest {
             when = "calling create ldap",
             then = "getting BadRequestException because ldap needs a valid name")
     public void testCreateLdapWithMissingName(MockedTestContext testContext) {
-        String key = resourcePropertyProvider().getName();
         testContext
                 .given(LdapTestDto.class)
                 .valid()
                 .withName("")
-                .when(ldapTestClient.createV1(), RunningParameter.key(key))
-                .expect(BadRequestException.class,
-                        RunningParameter.expectedMessage("The length of the ldap config's name has to be in range of 1 to 100")
-                                .withKey(key))
+                .whenException(ldapTestClient.createV1(), BadRequestException.class,
+                        expectedMessage("The length of the ldap config's name has to be in range of 1 to 100"))
                 .validate();
     }
 
@@ -109,15 +107,11 @@ public class LdapConfigTest extends AbstractMockTest {
             when = "calling create ldap",
             then = "getting BadRequestException because ldap needs a valid environmentCrn")
     public void testCreateLdapWithMissingEnvironmentCrn(MockedTestContext testContext) {
-        String key = resourcePropertyProvider().getName();
         testContext
                 .given(LdapTestDto.class)
                 .valid()
                 .withEnvironmentCrn("")
-                .when(ldapTestClient.createV1(), RunningParameter.key(key))
-                .expect(BadRequestException.class,
-                        RunningParameter.expectedMessage(".*environmentCrn.*must not be empty.*")
-                                .withKey(key))
+                .whenException(ldapTestClient.createV1(), BadRequestException.class, expectedMessage(".*environmentCrn.*must not be empty.*"))
                 .validate();
     }
 
@@ -131,10 +125,9 @@ public class LdapConfigTest extends AbstractMockTest {
                 .given(LdapTestDto.class)
                 .valid()
                 .withName(INVALID_LDAP_NAME)
-                .when(ldapTestClient.createV1(), RunningParameter.key(INVALID_LDAP_NAME))
-                .expect(BadRequestException.class, RunningParameter.expectedMessage(
-                        "The name can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character")
-                                .withKey(INVALID_LDAP_NAME))
+                .whenException(ldapTestClient.createV1(), BadRequestException.class,
+                        expectedMessage("The name can only contain lowercase alphanumeric characters" +
+                                " and hyphens and has start with an alphanumeric character"))
                 .validate();
     }
 
@@ -149,10 +142,8 @@ public class LdapConfigTest extends AbstractMockTest {
                 .given(LdapTestDto.class)
                 .valid()
                 .withName(longName)
-                .when(ldapTestClient.createV1(), RunningParameter.key(longName))
-                .expect(BadRequestException.class,
-                        RunningParameter.expectedMessage("The length of the ldap config's name has to be in range of 1 to 100")
-                                .withKey(longName))
+                .whenException(ldapTestClient.createV1(), BadRequestException.class,
+                        expectedMessage("The length of the ldap config's name has to be in range of 1 to 100"))
                 .validate();
     }
 
@@ -169,10 +160,8 @@ public class LdapConfigTest extends AbstractMockTest {
                 .valid()
                 .withName(name)
                 .withDescription(longDesc)
-                .when(ldapTestClient.createV1(), RunningParameter.key(longDesc))
-                .expect(BadRequestException.class,
-                        RunningParameter.expectedMessage("The length of the ldap config's description has to be in range of 0 to 1000")
-                                .withKey(longDesc))
+                .whenException(ldapTestClient.createV1(), BadRequestException.class,
+                        expectedMessage("The length of the ldap config's description has to be in range of 0 to 1000"))
                 .validate();
     }
 
@@ -220,10 +209,7 @@ public class LdapConfigTest extends AbstractMockTest {
                 .given(name, LdapTestDto.class)
                 .valid()
                 .withEnvironmentCrn(envCrn)
-                .when(ldapTestClient.createV1(), RunningParameter.key(name))
-                .expect(BadRequestException.class,
-                        RunningParameter.expectedMessage("environment is already exists")
-                                .withKey(name))
+                .whenException(ldapTestClient.createV1(), BadRequestException.class, expectedMessage("environment is already exists"))
                 .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockStackCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockStackCreationTest.java
@@ -8,7 +8,6 @@ import org.testng.annotations.Test;
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
 
 public class MockStackCreationTest extends AbstractMockTest {
@@ -22,11 +21,9 @@ public class MockStackCreationTest extends AbstractMockTest {
             when = "create stack twice",
             then = "getting BadRequestException in the second time because the names are same")
     public void testAttemptToCreateTwoRegularClusterWithTheSameName(MockedTestContext testContext) {
-        String badRequest = resourcePropertyProvider().getName();
         testContext.given(StackTestDto.class)
                 .when(stackTestClient.createV4())
-                .when(stackTestClient.createV4(), RunningParameter.key(badRequest))
-                .expect(BadRequestException.class, RunningParameter.key(badRequest))
+                .whenException(stackTestClient.createV4(), BadRequestException.class)
                 .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ProxyConfigTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ProxyConfigTest.java
@@ -104,10 +104,7 @@ public class ProxyConfigTest extends AbstractMockTest {
                 .withServerUser(PROXY_USER)
                 .withPassword(PROXY_PASSWORD)
                 .withProtocol(HTTP)
-                .when(proxyTestClient.create(), key(name))
-                .expect(BadRequestException.class,
-                        expectedMessage("The length of the name has to be in range of 4 to 100")
-                                .withKey(name))
+                .whenException(proxyTestClient.create(), BadRequestException.class, expectedMessage("The length of the name has to be in range of 4 to 100"))
                 .validate();
     }
 
@@ -117,7 +114,6 @@ public class ProxyConfigTest extends AbstractMockTest {
             when = "calling create proxy",
             then = "getting back a BadRequestException")
     public void testCreateProxyWithShortName(MockedTestContext testContext) {
-        String name = resourcePropertyProvider().getName();
         testContext
                 .given(ProxyTestDto.class)
                 .withName(SHORT_PROXY_NAME)
@@ -127,9 +123,7 @@ public class ProxyConfigTest extends AbstractMockTest {
                 .withServerUser(PROXY_USER)
                 .withPassword(PROXY_PASSWORD)
                 .withProtocol(HTTP)
-                .when(proxyTestClient.create(), key(name))
-                .expect(BadRequestException.class,
-                        expectedMessage("The length of the name has to be in range of 4 to 100").withKey(name))
+                .whenException(proxyTestClient.create(), BadRequestException.class, expectedMessage("The length of the name has to be in range of 4 to 100"))
                 .validate();
     }
 
@@ -148,10 +142,8 @@ public class ProxyConfigTest extends AbstractMockTest {
                 .withServerUser(PROXY_USER)
                 .withPassword(PROXY_PASSWORD)
                 .withProtocol(HTTP)
-                .when(proxyTestClient.create(), key(INVALID_PROXY_NAME))
-                .expect(BadRequestException.class,
-                        expectedMessage("The name can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character")
-                                .withKey(INVALID_PROXY_NAME))
+                .whenException(proxyTestClient.create(), BadRequestException.class, expectedMessage("The name can only contain lowercase alphanumeric" +
+                        " characters and hyphens and has start with an alphanumeric character"))
                 .validate();
     }
 
@@ -171,10 +163,7 @@ public class ProxyConfigTest extends AbstractMockTest {
                 .withServerUser(PROXY_USER)
                 .withPassword(PROXY_PASSWORD)
                 .withProtocol(HTTP)
-                .when(proxyTestClient.create(), key(key))
-                .expect(BadRequestException.class,
-                        expectedMessage("The length of the name has to be in range of 4 to 100")
-                                .withKey(key))
+                .whenException(proxyTestClient.create(), BadRequestException.class, expectedMessage("The length of the name has to be in range of 4 to 100"))
                 .validate();
     }
 
@@ -195,10 +184,8 @@ public class ProxyConfigTest extends AbstractMockTest {
                 .withServerUser(PROXY_USER)
                 .withPassword(PROXY_PASSWORD)
                 .withProtocol(HTTPS)
-                .when(proxyTestClient.create(), key(name))
-                .expect(BadRequestException.class,
-                        expectedMessage("The length of the description cannot be longer than 1000 character")
-                                .withKey(name))
+                .whenException(proxyTestClient.create(), BadRequestException.class, expectedMessage("The length of the description cannot" +
+                        " be longer than 1000 character"))
                 .validate();
     }
 
@@ -219,10 +206,8 @@ public class ProxyConfigTest extends AbstractMockTest {
                 .withServerUser(PROXY_USER)
                 .withPassword(PROXY_PASSWORD)
                 .withProtocol(HTTP)
-                .when(proxyTestClient.create(), key(key))
-                .expect(BadRequestException.class,
-                        expectedMessage("The length of the server host has to be in range of 1 to 255")
-                                .withKey(key))
+                .whenException(proxyTestClient.create(), BadRequestException.class, expectedMessage("The length of the server host" +
+                        " has to be in range of 1 to 255"))
                 .validate();
     }
 
@@ -243,10 +228,7 @@ public class ProxyConfigTest extends AbstractMockTest {
                 .withServerUser(PROXY_USER)
                 .withPassword(PROXY_PASSWORD)
                 .withProtocol(HTTP)
-                .when(proxyTestClient.create(), key(key))
-                .expect(BadRequestException.class,
-                        expectedMessage("Server port is required")
-                                .withKey(key))
+                .whenException(proxyTestClient.create(), BadRequestException.class, expectedMessage("Server port is required"))
                 .validate();
     }
 
@@ -309,9 +291,7 @@ public class ProxyConfigTest extends AbstractMockTest {
                 .withServerUser(PROXY_USER)
                 .withPassword(PROXY_PASSWORD)
                 .withProtocol(HTTP)
-                .when(proxyTestClient.create(),
-                        key(name))
-                .expect(ForbiddenException.class, key(name))
+                .whenException(proxyTestClient.create(), ForbiddenException.class)
                 .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeClusterTest.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.requests.RecipeV
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.requests.RecipeV4Type.POST_CLUSTER_INSTALL;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.requests.RecipeV4Type.PRE_CLOUDERA_MANAGER_START;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.requests.RecipeV4Type.PRE_TERMINATION;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -125,10 +126,8 @@ public class RecipeClusterTest extends AbstractMockTest {
                 .withRecipes(recipeName)
                 .given(stackName, StackTestDto.class)
                 .replaceInstanceGroups(instanceGroupName)
-                .when(stackTestClient.createV4(), RunningParameter.key(stackName))
-                .expect(BadRequestException.class, RunningParameter.key(stackName)
-                        .withExpectedMessage(String.format("The given recipe does not exist for the instance group \"%s\": %s",
-                                hostGroupTypeForRecipe.getName(), recipeName)))
+                .whenException(stackTestClient.createV4(), BadRequestException.class, expectedMessage(String.format("The given recipe does not exist" +
+                        " for the instance group \"%s\": %s", hostGroupTypeForRecipe.getName(), recipeName)))
                 .validate();
     }
 
@@ -248,7 +247,6 @@ public class RecipeClusterTest extends AbstractMockTest {
             then = "getting BadRequestException")
     public void testTryToDeleteAttachedRecipe(MockedTestContext testContext) {
         String recipeName = resourcePropertyProvider().getName();
-        String key = resourcePropertyProvider().getName();
 
         testContext
                 .given(RecipeTestDto.class).withName(recipeName).withContent(RECIPE_CONTENT).withRecipeType(POST_CLOUDERA_MANAGER_START)
@@ -258,10 +256,8 @@ public class RecipeClusterTest extends AbstractMockTest {
                 .when(stackTestClient.createV4())
                 .await(STACK_AVAILABLE)
                 .given(RecipeTestDto.class)
-                .when(recipeTestClient.deleteV4(), RunningParameter.key(key))
-                .expect(BadRequestException.class, RunningParameter.key(key)
-                        .withExpectedMessage("There is a cluster \\['.*'\\] which uses recipe '.*'. "
-                                + "Please remove this cluster before deleting the recipe"))
+                .whenException(recipeTestClient.deleteV4(), BadRequestException.class, expectedMessage("There is a cluster \\['.*'\\] which uses recipe" +
+                        " '.*'. Please remove this cluster before deleting the recipe"))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RecipeTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.not;
@@ -18,7 +19,6 @@ import com.sequenceiq.it.cloudbreak.assertion.audit.RecipeAuditGrpcServiceAssert
 import com.sequenceiq.it.cloudbreak.client.RecipeTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.recipe.RecipeTestDto;
 
@@ -70,14 +70,11 @@ public class RecipeTest extends AbstractMockTest {
             when = "create recipe",
             then = "getting a BadRequestException")
     public void testCreateSpecialNameRecipe(MockedTestContext testContext) {
-        String spacialName = resourcePropertyProvider().getName();
         testContext
                 .given(RecipeTestDto.class)
                 .withName(resourcePropertyProvider().getInvalidName())
-                .when(recipeTestClient.createV4(), RunningParameter.key(spacialName))
-                .expect(BadRequestException.class, RunningParameter.key(spacialName)
-                        .withExpectedMessage("The recipe's name can only contain lowercase alphanumeric characters and hyphens and has start "
-                                + "with an alphanumeric character"))
+                .whenException(recipeTestClient.createV4(), BadRequestException.class, expectedMessage("The recipe's name can only contain lowercase" +
+                        " alphanumeric characters and hyphens and has start with an alphanumeric character"))
                 .validate();
     }
 
@@ -87,12 +84,9 @@ public class RecipeTest extends AbstractMockTest {
             when = "create recipe twice",
             then = "getting a BadRequestException")
     public void testCreateAgainRecipe(MockedTestContext testContext) {
-        String againName = resourcePropertyProvider().getName();
         testContext.given(RecipeTestDto.class)
                 .when(recipeTestClient.createV4())
-                .when(recipeTestClient.createV4(), RunningParameter.key(againName))
-                .expect(BadRequestException.class, RunningParameter.key(againName)
-                        .withExpectedMessage("recipe already exists with name '"))
+                .whenException(recipeTestClient.createV4(), BadRequestException.class, expectedMessage("recipe already exists with name '"))
                 .validate();
     }
 
@@ -102,13 +96,11 @@ public class RecipeTest extends AbstractMockTest {
             when = "create recipe",
             then = "getting a BadRequestException")
     public void testCreateInvalidRecipeShortName(MockedTestContext testContext) {
-        String shortName = resourcePropertyProvider().getName();
         testContext
                 .given(RecipeTestDto.class)
                 .withName(getLongNameGenerator().stringGenerator(3))
-                .when(recipeTestClient.createV4(), RunningParameter.key(shortName))
-                .expect(BadRequestException.class, RunningParameter.key(shortName)
-                        .withExpectedMessage("The length of the recipe's name has to be in range of 5 to 100"))
+                .whenException(recipeTestClient.createV4(), BadRequestException.class, expectedMessage("The length of the recipe's name has to be in range" +
+                        " of 5 to 100"))
                 .validate();
     }
 
@@ -118,13 +110,11 @@ public class RecipeTest extends AbstractMockTest {
             when = "create recipe",
             then = "getting a BadRequestException")
     public void testCreateInvalidRecipeLongName(MockedTestContext testContext) {
-        String longName = resourcePropertyProvider().getName();
         testContext
                 .given(RecipeTestDto.class)
                 .withName(getLongNameGenerator().stringGenerator(101))
-                .when(recipeTestClient.createV4(), RunningParameter.key(longName))
-                .expect(BadRequestException.class, RunningParameter.key(longName)
-                        .withExpectedMessage("The length of the recipe's name has to be in range of 5 to 100"))
+                .whenException(recipeTestClient.createV4(), BadRequestException.class, expectedMessage("The length of the recipe's name has to be in range" +
+                        " of 5 to 100"))
                 .validate();
     }
 
@@ -134,13 +124,10 @@ public class RecipeTest extends AbstractMockTest {
             when = "create recipe",
             then = "getting a BadRequestException")
     public void testCreateInvalidRecipeLongDescription(MockedTestContext testContext) {
-        String longDesc = resourcePropertyProvider().getName();
         testContext
                 .given(RecipeTestDto.class)
                 .withDescription(getLongNameGenerator().stringGenerator(1001))
-                .when(recipeTestClient.createV4(), RunningParameter.key(longDesc))
-                .expect(BadRequestException.class, RunningParameter.key(longDesc)
-                        .withExpectedMessage("size must be between 0 and 1000"))
+                .whenException(recipeTestClient.createV4(), BadRequestException.class, expectedMessage("size must be between 0 and 1000"))
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseServerTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseServerTest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
+
 import java.util.UUID;
 
 import javax.inject.Inject;
@@ -14,7 +16,6 @@ import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentS
 import com.sequenceiq.it.cloudbreak.client.RedbeamsDatabaseServerTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseServerTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
@@ -84,12 +85,9 @@ public class RedbeamsDatabaseServerTest extends AbstractMockTest {
                 .given(RedbeamsDatabaseServerTestDto.class)
                 .withName(databaseName)
                 .withClusterCrn(Crn.builder(CrnResourceDescriptor.ENVIRONMENT).setAccountId("acc").setResource("res").build().toString())
-                .when(redbeamsDatabaseServerTest.createV4())
-                .expect(BadRequestException.class,
-                        RunningParameter.expectedMessage(".*Crn provided: " +
-                                "crn:cdp:environments:us-west-1:acc:environment:res has invalid resource type or service type. " +
-                                "Accepted service type / resource type pairs: [(]datalake,datalake[)],[(]datahub,cluster[)].*")
-                                .withKey("RedbeamsDatabaseServerCreateAction"))
+                .whenException(redbeamsDatabaseServerTest.createV4(), BadRequestException.class,
+                        expectedMessage(".*Crn provided: crn:cdp:environments:us-west-1:acc:environment:res has invalid resource type or" +
+                                " service type. Accepted service type / resource type pairs: [(]datalake,datalake[)],[(]datahub,cluster[)].*"))
                 .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseTest.java
@@ -60,8 +60,7 @@ public class RedbeamsDatabaseTest extends AbstractMockTest {
                 .when(databaseTestClient.createV4(), RunningParameter.key(databaseName))
                 .when(databaseTestClient.listV4(), RunningParameter.key(databaseName))
                 .then(RedbeamsDatabaseTestAssertion.containsDatabaseName(databaseName, 1), RunningParameter.key(databaseName))
-                .when(databaseTestClient.createV4(), RunningParameter.key(databaseName))
-                .expect(BadRequestException.class, RunningParameter.key(databaseName))
+                .whenException(databaseTestClient.createV4(), BadRequestException.class)
                 .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/ClouderaManagerStackCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/clouderamanager/ClouderaManagerStackCreationTest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.it.cloudbreak.testcase.mock.clouderamanager;
 
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
+
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 
@@ -9,7 +11,6 @@ import com.sequenceiq.it.cloudbreak.client.BlueprintTestClient;
 import com.sequenceiq.it.cloudbreak.client.StackTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
-import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.dto.ClouderaManagerProductTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ClouderaManagerTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
@@ -75,28 +76,19 @@ public class ClouderaManagerStackCreationTest extends AbstractClouderaManagerTes
                 .withValidateBlueprint(Boolean.FALSE)
                 .withClouderaManager(clouderaManager)
                 .given(StackTestDto.class).withCluster(cluster)
-                .when(stackTestClient.createV4(), RunningParameter.key(versionKey))
-                .expect(BadRequestException.class, RunningParameter.expectedMessage(versionValidation)
-                        .withKey(versionKey))
-
+                .whenException(stackTestClient.createV4(), BadRequestException.class, expectedMessage(versionValidation))
                 .given(partialProduct, ClouderaManagerProductTestDto.class)
                 .withName("CDH")
                 .withVersion("7.0.0.0")
                 .withParcel("")
                 .given(StackTestDto.class)
-                .when(stackTestClient.createV4(), RunningParameter.key(parcelKey))
-                .expect(BadRequestException.class, RunningParameter.expectedMessage(parcelValidation)
-                        .withKey(parcelKey))
-
+                .whenException(stackTestClient.createV4(), BadRequestException.class, expectedMessage(parcelValidation))
                 .given(partialProduct, ClouderaManagerProductTestDto.class)
                 .withName("")
                 .withVersion("7.0.0.0")
                 .withParcel("http://cdh/parcel")
                 .given(StackTestDto.class)
-                .when(stackTestClient.createV4(), RunningParameter.key(nameKey))
-                .expect(BadRequestException.class, RunningParameter.expectedMessage(nameValidation)
-                        .withKey(nameKey))
-
+                .whenException(stackTestClient.createV4(), BadRequestException.class, expectedMessage(nameValidation))
                 .validate();
     }
 


### PR DESCRIPTION
Actually in mock and authorization tests are lot of validation steps for an expected error/exception. The stack-traces of these exceptions are logged as ERROR in the related suite log. These additional errors are confusing when the test are failing and we are looking for the root cause of the issue.

So we should not log the stack-trace of the expected exceptions.

I've created new `when` test step as `whenException` where a predefined exception is handled by default. This step is failing only in case of any other kind of error/exception. Here we can catch this with the well known `TestFailException` then add to the `TestContext.exceptionMap`.