### PR TITLE
CB-10966 null check the virtual network link name in case of new Reso…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -88,6 +88,7 @@ import com.sequenceiq.cloudbreak.cloud.azure.util.AzureAuthExceptionHandler;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
 import com.sequenceiq.common.api.type.CommonStatus;
 
 import rx.Completable;
@@ -759,7 +760,7 @@ public class AzureClient {
 
     public ValidationResult validateNetworkLinkExistenceForDnsZones(String networkLinkId, List<AzurePrivateDnsZoneServiceEnum> services,
             String resourceGroupName) {
-        ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
+        ValidationResultBuilder resultBuilder = new ValidationResultBuilder();
         PagedList<PrivateZone> privateDnsZoneList = getPrivateDnsZoneList();
         for (AzurePrivateDnsZoneServiceEnum service : services) {
             String dnsZoneName = service.getDnsZoneName();
@@ -789,9 +790,9 @@ public class AzureClient {
         return privatednsManager.virtualNetworkLinks().inner().list(resourceGroupName, dnsZoneName);
     }
 
-    public VirtualNetworkLinkInner getNetworkLinkByPrivateDnsZone(String resourceGroupName, String dnsZoneName,
-            String virtualNetworkLinkName) {
-        return privatednsManager.virtualNetworkLinks().inner().get(resourceGroupName, dnsZoneName, virtualNetworkLinkName);
+    private VirtualNetworkLinkInner getNetworkLinkByPrivateDnsZone(String resourceGroupName, String dnsZoneName, String virtualNetworkLinkName) {
+        return virtualNetworkLinkName == null ? null
+                : privatednsManager.virtualNetworkLinks().inner().get(resourceGroupName, dnsZoneName, virtualNetworkLinkName);
     }
 
     public boolean checkIfDnsZonesDeployed(String resourceGroupName, List<AzurePrivateDnsZoneServiceEnum> services) {


### PR DESCRIPTION
…urce Group

The current validation does not consider when there is no network id during validation
time, because the network will be created later and the request is rejected. This is
only true when the Private Link feature is enabled on Azure. In case of new network
the validation should not fail as the resources will be created at a later step.

See detailed description in the commit message.