### PR TITLE
CB-9490 Bump up JsonRpcHttpClient version for better FreeIPA error me…

### DIFF
--- a/freeipa-client/build.gradle
+++ b/freeipa-client/build.gradle
@@ -16,7 +16,7 @@ jar {
 }
 
 dependencies {
-  implementation     group: 'com.github.briandilley.jsonrpc4j', name: 'jsonrpc4j',                   version: '1.5.3'
+  implementation     group: 'com.github.briandilley.jsonrpc4j', name: 'jsonrpc4j',                   version: '1.6'
   implementation     group: 'com.fasterxml.jackson.core',       name: 'jackson-databind',            version: jacksonVersion
   implementation     group: 'org.slf4j',                        name: 'slf4j-api',                   version: slf4jApiVersion
   implementation     group: 'org.apache.commons',               name: 'commons-lang3',               version: apacheCommonsLangVersion


### PR DESCRIPTION
…ssages

JsonRpcHttpClient new version has been released. It contains an important fix for us which makes error logging better,
as the original error won't be masked.

Test: started an environment with Datalake and Datahub. I haven't experienced any new error. Usersync ran successfully.