### PR TITLE
CB-10984 anonymize the salt-boot password when logging the user-data …

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Image.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Image.java
@@ -99,7 +99,6 @@ public class Image {
                 + ", imageCatalogUrl='" + imageCatalogUrl + '\''
                 + ", imageId='" + imageId + '\''
                 + ", imageCatalogName='" + imageCatalogName + '\''
-                + ", userdata=" + userdata + '\''
                 + ", packageVersions=" + packageVersions + '}';
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/anonymizer/AnonymizerUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/anonymizer/AnonymizerUtil.java
@@ -14,11 +14,11 @@ public class AnonymizerUtil {
     private static final ReplacePattern[] PATTERNS = {
             //common PW
             new ReplacePattern("(?i)("
-                    + "password=\'|password=|password\":\"|password:|password |"
-                    + "pass=|pass\":\"|pass:|pass |"
-                    + "secret=|secret\":\"|secret:|secret |"
-                    + "key=|key\":\"|key:|key |"
-                    + "credential=|credential\":\"|credential:|credential "
+                    + "password:[\"']|password=[\"']|password=|password\":\"|password:|password |"
+                    + "pass:[\"']|pass=[\"']|pass=|pass\":\"|pass:|pass |"
+                    + "secret:[\"']|secret=[\"']|secret=|secret\":\"|secret:|secret |"
+                    + "key:[\"']|key=[\"']|key=|key\":\"|key:|key |"
+                    + "credential:[\"']|credential=[\"']|credential=|credential\":\"|credential:|credential "
                     + ")([^\\s'\"]*)", REPLACEMENT),
             //WASB
             new ReplacePattern("(?i)(\\.blob\\.core\\.windows\\.net\":\")([^\\s'\"])*", REPLACEMENT),

--- a/common/src/test/java/com/sequenceiq/cloudbreak/common/anonymizer/AnonymizerUtilTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/common/anonymizer/AnonymizerUtilTest.java
@@ -29,6 +29,84 @@ public class AnonymizerUtilTest {
     }
 
     @Test
+    public void testWithBothSimpleAndDoubleQuotes() {
+        String testData = ""
+                + "export test1_password=pwd\n"
+                + "export test1_pass=pwd\n"
+                + "export test1_secret=pwd\n"
+                + "export test1_key=pwd\n"
+                + "export test1_credential=pwd\n"
+
+                + "export test2_password:pwd\n"
+                + "export test2_pass:pwd\n"
+                + "export test2_secret:pwd\n"
+                + "export test2_key:pwd\n"
+                + "export test1_credential:pwd\n"
+
+                + "export test3_password:'pwd'\n"
+                + "export test3_pass:'pwd'\n"
+                + "export test3_secret:'pwd'\n"
+                + "export test3_key:'pwd'\n"
+                + "export test3_credential:'pwd'\n"
+
+                + "export test4_password='pwd'\n"
+                + "export test4_pass='pwd'\n"
+                + "export test4_secret='pwd'\n"
+                + "export test4_key='pwd'\n"
+                + "export test4_credential='pwd'\n"
+
+                + "export test5_password=\"pwd\"\n"
+                + "export test5_pass=\"pwd\"\n"
+                + "export test5_secret=\"pwd\"\n"
+                + "export test5_key=\"pwd\"\n"
+                + "export test5_credential=\"pwd\"\n"
+
+                + "export \"test6_password\":\"pwd\"\n"
+                + "export \"test6_pass\":\"pwd\"\n"
+                + "export \"test6_secret\":\"pwd\"\n"
+                + "export \"test6_key\":\"pwd\"\n"
+                + "export \"test6_credential\":\"pwd\"\n";
+
+        String expected = ""
+                + "export test1_password=****\n"
+                + "export test1_pass=****\n"
+                + "export test1_secret=****\n"
+                + "export test1_key=****\n"
+                + "export test1_credential=****\n"
+
+                + "export test2_password:****\n"
+                + "export test2_pass:****\n"
+                + "export test2_secret:****\n"
+                + "export test2_key:****\n"
+                + "export test1_credential:****\n"
+
+                + "export test3_password:'****'\n"
+                + "export test3_pass:'****'\n"
+                + "export test3_secret:'****'\n"
+                + "export test3_key:'****'\n"
+                + "export test3_credential:'****'\n"
+
+                + "export test4_password='****'\n"
+                + "export test4_pass='****'\n"
+                + "export test4_secret='****'\n"
+                + "export test4_key='****'\n"
+                + "export test4_credential='****'\n"
+
+                + "export test5_password=\"****\"\n"
+                + "export test5_pass=\"****\"\n"
+                + "export test5_secret=\"****\"\n"
+                + "export test5_key=\"****\"\n"
+                + "export test5_credential=\"****\"\n"
+
+                + "export \"test6_password\":\"****\"\n"
+                + "export \"test6_pass\":\"****\"\n"
+                + "export \"test6_secret\":\"****\"\n"
+                + "export \"test6_key\":\"****\"\n"
+                + "export \"test6_credential\":\"****\"\n";
+        Assert.assertEquals(expected, anonymize(testData));
+    }
+
+    @Test
     public void testHidePasswordDoubleQuote() {
         String testData = " DC=hortonworks,DC=com \"--ldap-manager-password=2#KQ01DLbUdljJ!AVs\" --ldap-sync-usern\" sd dsds \"";
         Assert.assertEquals(" DC=hortonworks,DC=com \"--ldap-manager-password=" + REPLACEMENT + "\" --ldap-sync-usern\" sd dsds \"",

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Component.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Component.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.domain.stack;
 
+import static com.sequenceiq.cloudbreak.common.anonymizer.AnonymizerUtil.anonymize;
 import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
 
 import javax.persistence.Column;
@@ -101,7 +102,7 @@ public class Component implements ProvisionEntity {
                 + "id=" + id
                 + ", componentType=" + componentType
                 + ", name='" + name + '\''
-                + ", attributes=" + attributes
+                + ", attributes=" + anonymize(attributes.toString())
                 + '}';
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/UserDataBuilder.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.service.image.userdata;
 
+import static com.sequenceiq.cloudbreak.common.anonymizer.AnonymizerUtil.anonymize;
+
 import java.io.IOException;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -48,7 +50,7 @@ public class UserDataBuilder {
         for (InstanceGroupType type : InstanceGroupType.values()) {
             String userData = build(type, cloudPlatform, cbSshKeyDer, sshUser, parameters, saltBootPassword, cbCert, ccmParameters, proxyConfig);
             result.put(type, userData);
-            LOGGER.debug("User data for {}, content; {}", type, userData);
+            LOGGER.debug("User data for {}, content; {}", type, anonymize(userData));
         }
         return result;
     }
@@ -91,7 +93,7 @@ public class UserDataBuilder {
                 model.put("proxyUser", auth.getUserName());
                 model.put("proxyPassword", auth.getPassword());
             });
-            LOGGER.info("Proxy config set up for gateway instances' userdata script: {}", proxyConfig);
+            LOGGER.info("Proxy config set up for gateway instances' userdata script: {}", anonymize(proxyConfig.toString()));
         } else {
             model.put("proxyEnabled", Boolean.FALSE);
             LOGGER.info("No proxy config set up for {} instances' userdata script", type);

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
     <logger name="org.springframework.statemachine.support" level="ERROR"/>
     <logger name="com.sequenceiq.ambari.client.AmbariClientUtils" level="ERROR"/>
     <logger name="org.apache.kafka.clients.producer" level="ERROR"/>
-    <logger name="com.amazonaws.request" level="DEBUG"/>
+    <!-- <logger name="com.amazonaws.request" level="DEBUG"/> -->
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilder.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/userdata/UserDataBuilder.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.service.image.userdata;
 
+import static com.sequenceiq.cloudbreak.common.anonymizer.AnonymizerUtil.anonymize;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,7 +48,7 @@ public class UserDataBuilder {
             PlatformParameters parameters, String saltBootPassword, String cbCert,
             CcmConnectivityParameters ccmConnectivityParameters, ProxyConfig proxyConfig) {
         String userData = build(cloudPlatform, cbSshKeyDer, sshUser, parameters, saltBootPassword, cbCert, ccmConnectivityParameters, proxyConfig);
-        LOGGER.debug("User data  content; {}", userData);
+        LOGGER.debug("User data  content; {}", anonymize(userData));
         return userData;
     }
 
@@ -87,7 +89,7 @@ public class UserDataBuilder {
                 model.put("proxyUser", auth.getUserName());
                 model.put("proxyPassword", auth.getPassword());
             });
-            LOGGER.info("Proxy config set up for freeipa instances' userdata script: {}", proxyConfig);
+            LOGGER.info("Proxy config set up for freeipa instances' userdata script: {}", anonymize(proxyConfig.toString()));
         } else {
             model.put("proxyEnabled", Boolean.FALSE);
             LOGGER.info("No proxy config set up for freeipa instances' userdata script");


### PR DESCRIPTION
…script

Anonymization was not called when we logged the generated user-data script.
As part of this PR both the CB and FreeIPA user-data will be anonymized from
sensitive data. I also noticed that the regex matcher doesn't work when
the password is in between quotas so I have fixed that issue as well. The
user-data will be logged in the following way:

export CLOUD_PLATFORM="AZURE"
export START_LABEL=98
export PLATFORM_DISK_PREFIX=sd
export LAZY_FORMAT_DISK_LIMIT=12
export IS_GATEWAY=true
export TMP_SSH_KEY="****"
export SSH_USER=cloudbreak
export SALT_BOOT_PASSWORD=****
export SALT_BOOT_SIGN_KEY=****
export CB_CERT=cert
export IS_PROXY_ENABLED=true
export PROXY_HOST=proxy.host
export PROXY_PORT=1234
export PROXY_USER="user"
export PROXY_PASSWORD="****"
export IS_CCM_ENABLED=false
export IS_CCM_V2_ENABLED=false