### PR TITLE
CB-10988 Disable default AvailabilitySet assignment

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformParameters.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformParameters.java
@@ -51,10 +51,6 @@ public class AzurePlatformParameters implements PlatformParameters {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AzurePlatformParameters.class);
 
-    private static final int DEFAULT_FAULT_DOMAIN_COUNTER = 2;
-
-    private static final int DEFAULT_UPDATE_DOMAIN_COUNTER = 20;
-
     private static final int START_LABEL = 98;
 
     private static final ScriptParams SCRIPT_PARAMS = new ScriptParams("sd", START_LABEL);
@@ -174,17 +170,8 @@ public class AzurePlatformParameters implements PlatformParameters {
             if (groupParameterRequest.getParameters().containsKey("availabilitySet")) {
                 instanceGroupParameterResponse.setGroupName(groupParameterRequest.getGroupName());
                 instanceGroupParameterResponse.setParameters(groupParameterRequest.getParameters());
-
             } else {
                 Map<String, Object> parameters = groupParameterRequest.getParameters();
-
-                Map<String, Object> availabilitySet = new HashMap<>();
-                availabilitySet.put("name", String.format("%s-%s-as", groupParameterRequest.getStackName(), groupParameterRequest.getGroupName()));
-                availabilitySet.put("faultDomainCount", DEFAULT_FAULT_DOMAIN_COUNTER);
-                availabilitySet.put("updateDomainCount", DEFAULT_UPDATE_DOMAIN_COUNTER);
-
-                parameters.put("availabilitySet", availabilitySet);
-
                 instanceGroupParameterResponse.setGroupName(groupParameterRequest.getGroupName());
                 instanceGroupParameterResponse.setParameters(parameters);
             }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformParametersTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformParametersTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -59,13 +60,7 @@ public class AzurePlatformParametersTest {
         assertEquals(workerAsMap.get(AS_FAULT_DOMAIN_COUNTER_KEY), 5);
         assertEquals(workerAsMap.get(AS_UPDATE_DOMAIN_COUNTER_KEY), 50);
 
-        assertTrue(instanceGroupParameterResponseMap.get(COMPUTE_GROUP_NAME).getParameters().containsKey(AS_KEY));
-        assertThat(instanceGroupParameterResponseMap.get(COMPUTE_GROUP_NAME).getParameters().get(AS_KEY), IsInstanceOf.instanceOf(Map.class));
-
-        Map<Object, Object> computeAsMap = (Map<Object, Object>) instanceGroupParameterResponseMap.get(COMPUTE_GROUP_NAME).getParameters().get(AS_KEY);
-        assertEquals(computeAsMap.get(AS_NAME_KEY), STACK_NAME + "-" + COMPUTE_GROUP_NAME + "-as");
-        assertEquals(computeAsMap.get(AS_FAULT_DOMAIN_COUNTER_KEY), 2);
-        assertEquals(computeAsMap.get(AS_UPDATE_DOMAIN_COUNTER_KEY), 20);
+        assertFalse(instanceGroupParameterResponseMap.get(COMPUTE_GROUP_NAME).getParameters().containsKey(AS_KEY));
     }
 
     private InstanceGroupParameterRequest getRequestWithoutAs(String groupName) {


### PR DESCRIPTION
If the VMs are placed into AvailabilitySet the maximum host count is 200
which is not adequate for some customers.