### PR TITLE
CB-9953: back-end cloudbreak change to set up separate bu…

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/backup/base/BackupBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/backup/base/BackupBase.java
@@ -2,7 +2,6 @@ package com.sequenceiq.common.api.backup.base;
 
 import java.io.Serializable;
 
-import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -25,7 +24,6 @@ public abstract class BackupBase implements Serializable {
     @ApiModelProperty(BackupModelDescription.BACKUP_STORAGE_LOCATION)
     private String storageLocation;
 
-    @Valid
     @ApiModelProperty(BackupModelDescription.BACKUP_S3_ATTRIBUTES)
     private S3CloudStorageV1Parameters s3;
 
@@ -33,9 +31,8 @@ public abstract class BackupBase implements Serializable {
     private AdlsGen2CloudStorageV1Parameters adlsGen2;
 
     @ApiModelProperty(BackupModelDescription.BACKUP_GCS_ATTRIBUTES)
-    private @Valid GcsCloudStorageV1Parameters gcs;
+    private GcsCloudStorageV1Parameters gcs;
 
-    @Valid
     @ApiModelProperty(BackupModelDescription.BACKUP_CLOUDWATCH_ATTRIBUTES)
     private BackupCloudwatchParams cloudwatch;
 

--- a/common-model/src/main/java/com/sequenceiq/common/api/backup/base/BackupBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/backup/base/BackupBase.java
@@ -32,9 +32,8 @@ public abstract class BackupBase implements Serializable {
     @ApiModelProperty(BackupModelDescription.BACKUP_ADLS_GEN_2_ATTRIBUTES)
     private AdlsGen2CloudStorageV1Parameters adlsGen2;
 
-    @Valid
     @ApiModelProperty(BackupModelDescription.BACKUP_GCS_ATTRIBUTES)
-    private GcsCloudStorageV1Parameters gcs;
+    private @Valid GcsCloudStorageV1Parameters gcs;
 
     @Valid
     @ApiModelProperty(BackupModelDescription.BACKUP_CLOUDWATCH_ATTRIBUTES)

--- a/common-model/src/main/java/com/sequenceiq/common/api/backup/base/BackupBase.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/backup/base/BackupBase.java
@@ -1,0 +1,93 @@
+package com.sequenceiq.common.api.backup.base;
+
+import java.io.Serializable;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.backup.doc.BackupModelDescription;
+import com.sequenceiq.common.api.backup.model.BackupCloudwatchParams;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public abstract class BackupBase implements Serializable {
+
+    @NotNull
+    @ApiModelProperty(BackupModelDescription.BACKUP_STORAGE_LOCATION)
+    private String storageLocation;
+
+    @Valid
+    @ApiModelProperty(BackupModelDescription.BACKUP_S3_ATTRIBUTES)
+    private S3CloudStorageV1Parameters s3;
+
+    @ApiModelProperty(BackupModelDescription.BACKUP_ADLS_GEN_2_ATTRIBUTES)
+    private AdlsGen2CloudStorageV1Parameters adlsGen2;
+
+    @Valid
+    @ApiModelProperty(BackupModelDescription.BACKUP_GCS_ATTRIBUTES)
+    private GcsCloudStorageV1Parameters gcs;
+
+    @Valid
+    @ApiModelProperty(BackupModelDescription.BACKUP_CLOUDWATCH_ATTRIBUTES)
+    private BackupCloudwatchParams cloudwatch;
+
+    public String getStorageLocation() {
+        return storageLocation;
+    }
+
+    public void setStorageLocation(String storageLocation) {
+        this.storageLocation = storageLocation;
+    }
+
+    public S3CloudStorageV1Parameters getS3() {
+        return s3;
+    }
+
+    public void setS3(S3CloudStorageV1Parameters s3) {
+        this.s3 = s3;
+    }
+
+    public AdlsGen2CloudStorageV1Parameters getAdlsGen2() {
+        return adlsGen2;
+    }
+
+    public void setAdlsGen2(AdlsGen2CloudStorageV1Parameters adlsGen2) {
+        this.adlsGen2 = adlsGen2;
+    }
+
+    public GcsCloudStorageV1Parameters getGcs() {
+        return gcs;
+    }
+
+    public void setGcs(GcsCloudStorageV1Parameters gcs) {
+        this.gcs = gcs;
+    }
+
+    public BackupCloudwatchParams getCloudwatch() {
+        return cloudwatch;
+    }
+
+    public void setCloudwatch(BackupCloudwatchParams cloudwatch) {
+        this.cloudwatch = cloudwatch;
+    }
+
+    @Override
+    public String toString() {
+        return "BackupBase{" +
+                "storageLocation='" + storageLocation + '\'' +
+                ", s3=" + s3 +
+                ", adlsGen2=" + adlsGen2 +
+                ", gcs=" + gcs +
+                ", cloudwatch=" + cloudwatch +
+                '}';
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/backup/doc/BackupModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/backup/doc/BackupModelDescription.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.common.api.backup.doc;
+
+public class BackupModelDescription {
+
+    public static final String BACKUP_S3_ATTRIBUTES = "backup s3 attributes";
+    public static final String BACKUP_ADLS_GEN_2_ATTRIBUTES = "backup adls gen2 attributes";
+    public static final String BACKUP_GCS_ATTRIBUTES = "backup gcs attributes";
+    public static final String BACKUP_CLOUDWATCH_ATTRIBUTES = "backup cloudwatch attributes";
+    public static final String BACKUP_STORAGE_LOCATION = "backup storage location / container";
+    public static final String CLOUDWATCH_PARAMS = "CloudWatch releated parameters";
+    public static final String CLOUDWATCH_PARAMS_REGION = "CloudWatch related AWS region (should be used only outside of AWS platform)";
+
+    private BackupModelDescription() {
+    }
+
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/backup/model/BackupCloudwatchParams.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/backup/model/BackupCloudwatchParams.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.common.api.telemetry.model;
+package com.sequenceiq.common.api.backup.model;
 
 import java.io.Serializable;
 
@@ -7,22 +7,23 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.sequenceiq.common.api.telemetry.doc.TelemetryModelDescription;
+import com.sequenceiq.common.api.backup.doc.BackupModelDescription;
+import com.sequenceiq.common.api.telemetry.model.CloudwatchStreamKey;
 
 import io.swagger.annotations.ApiModelProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class CloudwatchParams implements Serializable {
+public class BackupCloudwatchParams implements Serializable {
 
     @ApiModelProperty
     @NotNull
     private String instanceProfile;
 
-    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_CLOUDWATCH_PARAMS_REGION)
+    @ApiModelProperty(BackupModelDescription.CLOUDWATCH_PARAMS_REGION)
     private String region;
 
-    @ApiModelProperty(TelemetryModelDescription.TELEMETRY_CLOUDWATCH_PARAMS)
+    @ApiModelProperty(BackupModelDescription.CLOUDWATCH_PARAMS)
     private CloudwatchStreamKey streamKey = CloudwatchStreamKey.HOSTNAME;
 
     public String getInstanceProfile() {
@@ -50,11 +51,11 @@ public class CloudwatchParams implements Serializable {
     }
 
     @JsonIgnore
-    public static CloudwatchParams copy(CloudwatchParams cloudwatchParams) {
+    public static BackupCloudwatchParams copy(BackupCloudwatchParams cloudwatchParams) {
         if (cloudwatchParams == null) {
             return null;
         }
-        CloudwatchParams newCloudwatchParams = new CloudwatchParams();
+        BackupCloudwatchParams newCloudwatchParams = new BackupCloudwatchParams();
         newCloudwatchParams.setStreamKey(cloudwatchParams.getStreamKey());
         newCloudwatchParams.setInstanceProfile(cloudwatchParams.getInstanceProfile());
         newCloudwatchParams.setRegion(cloudwatchParams.getRegion());

--- a/common-model/src/main/java/com/sequenceiq/common/api/backup/request/BackupRequest.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/backup/request/BackupRequest.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.common.api.backup.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.common.api.backup.base.BackupBase;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel(value = "BackupRequest")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BackupRequest extends BackupBase {
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/backup/response/BackupResponse.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/backup/response/BackupResponse.java
@@ -5,6 +5,5 @@ import com.sequenceiq.common.api.backup.base.BackupBase;
 import io.swagger.annotations.ApiModel;
 
 @ApiModel(value = "BackupResponse")
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class BackupResponse extends BackupBase {
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/backup/response/BackupResponse.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/backup/response/BackupResponse.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.common.api.backup.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.common.api.backup.base.BackupBase;
+import io.swagger.annotations.ApiModel;
+
+@ApiModel(value = "BackupResponse")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BackupResponse extends BackupBase {
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -59,6 +59,7 @@ public class EnvironmentModelDescription {
     public static final String LOCATION_DISPLAY_NAME = "Display name of the location of the environment.";
     public static final String NETWORK = "Network related specifics of the environment.";
     public static final String TELEMETRY = "Telemetry related specifics of the environment.";
+    public static final String BACKUP = "Backup related specifics of the environment.";
 
     public static final String CREDENTIAL_RESPONSE = "Credential of the environment.";
     public static final String CLOUD_PLATFORM = "Cloud platform of the environment.";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentEditRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentEditRequest.java
@@ -33,7 +33,7 @@ public class EnvironmentEditRequest {
     private TelemetryRequest telemetry;
 
     @ApiModelProperty(EnvironmentModelDescription.BACKUP)
-    private @Valid BackupRequest backup;
+    private BackupRequest backup;
 
     @ApiModelProperty(EnvironmentModelDescription.SECURITY_ACCESS)
     private @Valid SecurityAccessRequest securityAccess;

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentEditRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentEditRequest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.environment.api.v1.environment.model.request;
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
 
+import com.sequenceiq.common.api.backup.request.BackupRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.environment.api.doc.ModelDescriptions;
 import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
@@ -30,6 +31,9 @@ public class EnvironmentEditRequest {
 
     @ApiModelProperty(EnvironmentModelDescription.TELEMETRY)
     private TelemetryRequest telemetry;
+
+    @ApiModelProperty(EnvironmentModelDescription.BACKUP)
+    private @Valid BackupRequest backup;
 
     @ApiModelProperty(EnvironmentModelDescription.SECURITY_ACCESS)
     private @Valid SecurityAccessRequest securityAccess;
@@ -85,6 +89,14 @@ public class EnvironmentEditRequest {
 
     public void setTelemetry(TelemetryRequest telemetry) {
         this.telemetry = telemetry;
+    }
+
+    public BackupRequest getBackup() {
+        return backup;
+    }
+
+    public void setBackup(BackupRequest backup) {
+        this.backup = backup;
     }
 
     public SecurityAccessRequest getSecurityAccess() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
@@ -65,7 +65,7 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
     private TelemetryRequest telemetry;
 
     @ApiModelProperty(EnvironmentModelDescription.BACKUP)
-    private @Valid BackupRequest backup;
+    private BackupRequest backup;
 
     @Valid
     @ApiModelProperty(EnvironmentModelDescription.AUTHENTICATION)

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentRequest.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
+import com.sequenceiq.common.api.backup.request.BackupRequest;
 import com.sequenceiq.common.api.tag.request.TaggableRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.type.Tunnel;
@@ -62,6 +63,9 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
 
     @ApiModelProperty(EnvironmentModelDescription.TELEMETRY)
     private TelemetryRequest telemetry;
+
+    @ApiModelProperty(EnvironmentModelDescription.BACKUP)
+    private @Valid BackupRequest backup;
 
     @Valid
     @ApiModelProperty(EnvironmentModelDescription.AUTHENTICATION)
@@ -160,6 +164,14 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
 
     public void setTelemetry(TelemetryRequest telemetry) {
         this.telemetry = telemetry;
+    }
+
+    public BackupRequest getBackup() {
+        return backup;
+    }
+
+    public void setBackup(BackupRequest backup) {
+        this.backup = backup;
     }
 
     public EnvironmentNetworkRequest getNetwork() {
@@ -289,6 +301,7 @@ public class EnvironmentRequest extends EnvironmentBaseRequest implements Creden
                 ", location=" + location +
                 ", network=" + network +
                 ", telemetry=" + telemetry +
+                ", backupRequest=" + backup +
                 ", authentication=" + authentication +
                 ", freeIpa=" + freeIpa +
                 ", securityAccess=" + securityAccess +

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
@@ -3,6 +3,7 @@ package com.sequenceiq.environment.api.v1.environment.model.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.common.api.backup.response.BackupResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
@@ -69,6 +70,8 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
         private EnvironmentNetworkResponse network;
 
         private TelemetryResponse telemetry;
+
+        private BackupResponse backup;
 
         private EnvironmentStatus environmentStatus;
 
@@ -162,6 +165,11 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
 
         public Builder withTelemetry(TelemetryResponse telemetry) {
             this.telemetry = telemetry;
+            return this;
+        }
+
+        public Builder withBackup(BackupResponse backup) {
+            this.backup = backup;
             return this;
         }
 
@@ -288,6 +296,7 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
             detailedEnvironmentResponse.setCreated(created);
             detailedEnvironmentResponse.setAuthentication(authentication);
             detailedEnvironmentResponse.setTelemetry(telemetry);
+            detailedEnvironmentResponse.setBackup(backup);
             detailedEnvironmentResponse.setSecurityAccess(securityAccess);
             detailedEnvironmentResponse.setTunnel(tunnel);
             detailedEnvironmentResponse.setIdBrokerMappingSource(idBrokerMappingSource);

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
@@ -2,9 +2,12 @@ package com.sequenceiq.environment.api.v1.environment.model.response;
 
 import java.util.Optional;
 
+import javax.validation.Valid;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.sequenceiq.authorization.resource.ResourceCrnAwareApiModel;
+import com.sequenceiq.common.api.backup.response.BackupResponse;
 import com.sequenceiq.common.api.tag.response.TaggedResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.common.api.type.Tunnel;
@@ -52,6 +55,9 @@ public abstract class EnvironmentBaseResponse implements ResourceCrnAwareApiMode
 
     @ApiModelProperty(EnvironmentModelDescription.TELEMETRY)
     private TelemetryResponse telemetry;
+
+    @ApiModelProperty(EnvironmentModelDescription.BACKUP)
+    private @Valid BackupResponse backup;
 
     @ApiModelProperty(EnvironmentModelDescription.NETWORK)
     private EnvironmentNetworkResponse network;
@@ -168,6 +174,14 @@ public abstract class EnvironmentBaseResponse implements ResourceCrnAwareApiMode
 
     public void setTelemetry(TelemetryResponse telemetry) {
         this.telemetry = telemetry;
+    }
+
+    public BackupResponse getBackup() {
+        return backup;
+    }
+
+    public void setBackup(BackupResponse backup) {
+        this.backup = backup;
     }
 
     public EnvironmentNetworkResponse getNetwork() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
@@ -57,7 +57,7 @@ public abstract class EnvironmentBaseResponse implements ResourceCrnAwareApiMode
     private TelemetryResponse telemetry;
 
     @ApiModelProperty(EnvironmentModelDescription.BACKUP)
-    private @Valid BackupResponse backup;
+    private BackupResponse backup;
 
     @ApiModelProperty(EnvironmentModelDescription.NETWORK)
     private EnvironmentNetworkResponse network;

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/SimpleEnvironmentResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/SimpleEnvironmentResponse.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.environment.api.v1.environment.model.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.common.api.backup.response.BackupResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialViewResponse;
@@ -62,6 +63,8 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
         private LocationResponse location;
 
         private TelemetryResponse telemetry;
+
+        private BackupResponse backup;
 
         private EnvironmentNetworkResponse network;
 
@@ -131,6 +134,11 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
 
         public Builder withTelemetry(TelemetryResponse telemetry) {
             this.telemetry = telemetry;
+            return this;
+        }
+
+        public Builder withBackup(BackupResponse backup) {
+            this.backup = backup;
             return this;
         }
 
@@ -236,6 +244,7 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
             simpleEnvironmentResponse.setStatusReason(statusReason);
             simpleEnvironmentResponse.setCreated(created);
             simpleEnvironmentResponse.setTelemetry(telemetry);
+            simpleEnvironmentResponse.setBackup(backup);
             simpleEnvironmentResponse.setTunnel(tunnel);
             simpleEnvironmentResponse.setAws(aws);
             simpleEnvironmentResponse.setAzure(azure);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
@@ -25,6 +25,7 @@ import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.structuredevent.repository.AccountAwareResource;
 import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
+import com.sequenceiq.environment.environment.dto.EnvironmentBackup;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
 import com.sequenceiq.environment.parameters.dao.converter.EnvironmentStatusConverter;
@@ -61,6 +62,10 @@ public class Environment implements AuthResource, AccountAwareResource {
     @Convert(converter = JsonToString.class)
     @Column(columnDefinition = "TEXT")
     private Json telemetry;
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json backup;
 
     @Column(nullable = false)
     private String location;
@@ -290,6 +295,19 @@ public class Environment implements AuthResource, AccountAwareResource {
         }
     }
 
+    public EnvironmentBackup getBackup() {
+        if (backup != null && backup.getValue() != null) {
+            return JsonUtil.readValueOpt(backup.getValue(), EnvironmentBackup.class).orElse(null);
+        }
+        return null;
+    }
+
+    public void setBackup(EnvironmentBackup backup) {
+        if (backup != null) {
+            this.backup = new Json(backup);
+        }
+    }
+
     @Override
     public String getResourceCrn() {
         return resourceCrn;
@@ -398,6 +416,10 @@ public class Environment implements AuthResource, AccountAwareResource {
 
     public void setTelemetry(Json telemetry) {
         this.telemetry = telemetry;
+    }
+
+    public void setBackup(Json backup) {
+        this.backup = backup;
     }
 
     public String getAdminGroupName() {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentBackup.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentBackup.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.environment.environment.dto;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
+import com.sequenceiq.common.api.backup.model.BackupCloudwatchParams;
+import com.sequenceiq.environment.environment.dto.telemetry.S3CloudStorageParameters;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class EnvironmentBackup implements Serializable {
+
+    private String storageLocation;
+
+    private S3CloudStorageParameters s3;
+
+    private AdlsGen2CloudStorageV1Parameters adlsGen2;
+
+    private GcsCloudStorageV1Parameters gcs;
+
+    private BackupCloudwatchParams cloudwatch;
+
+    public String getStorageLocation() {
+        return storageLocation;
+    }
+
+    public void setStorageLocation(String storageLocation) {
+        this.storageLocation = storageLocation;
+    }
+
+    public S3CloudStorageParameters getS3() {
+        return s3;
+    }
+
+    public void setS3(S3CloudStorageParameters s3) {
+        this.s3 = s3;
+    }
+
+    public AdlsGen2CloudStorageV1Parameters getAdlsGen2() {
+        return adlsGen2;
+    }
+
+    public void setAdlsGen2(AdlsGen2CloudStorageV1Parameters adlsGen2) {
+        this.adlsGen2 = adlsGen2;
+    }
+
+    public GcsCloudStorageV1Parameters getGcs() {
+        return gcs;
+    }
+
+    public void setGcs(GcsCloudStorageV1Parameters gcs) {
+        this.gcs = gcs;
+    }
+
+    public BackupCloudwatchParams getCloudwatch() {
+        return cloudwatch;
+    }
+
+    public void setCloudwatch(BackupCloudwatchParams cloudwatch) {
+        this.cloudwatch = cloudwatch;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentCreationDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentCreationDto.java
@@ -39,6 +39,8 @@ public class EnvironmentCreationDto {
 
     private final EnvironmentTelemetry telemetry;
 
+    private final EnvironmentBackup backup;
+
     private final Long created;
 
     private final SecurityAccessDto securityAccess;
@@ -61,7 +63,7 @@ public class EnvironmentCreationDto {
     public EnvironmentCreationDto(String name, String description, String cloudPlatform, String accountId,
             String creator, LocationDto location, NetworkDto network, CredentialAwareEnvRequest credential,
             Set<String> regions, FreeIpaCreationDto freeIpaCreation, AuthenticationDto authentication,
-            Long created, EnvironmentTelemetry telemetry, SecurityAccessDto securityAccess, String adminGroupName,
+            Long created, EnvironmentTelemetry telemetry, EnvironmentBackup backup, SecurityAccessDto securityAccess, String adminGroupName,
             ParametersDto parameters, ExperimentalFeatures experimentalFeatures, Map<String, String> tags, String crn,
             String parentEnvironmentName, String proxyConfigName) {
         //CHECKSTYLE:ON
@@ -82,6 +84,7 @@ public class EnvironmentCreationDto {
         }
         this.authentication = authentication;
         this.telemetry = telemetry;
+        this.backup = backup;
         this.securityAccess = securityAccess;
         this.adminGroupName = adminGroupName;
         this.parameters = parameters;
@@ -138,6 +141,10 @@ public class EnvironmentCreationDto {
 
     public EnvironmentTelemetry getTelemetry() {
         return telemetry;
+    }
+
+    public EnvironmentBackup getBackup() {
+        return backup;
     }
 
     public FreeIpaCreationDto getFreeIpaCreation() {
@@ -215,6 +222,8 @@ public class EnvironmentCreationDto {
         private Set<String> regions;
 
         private EnvironmentTelemetry telemetry;
+
+        private EnvironmentBackup backup;
 
         private FreeIpaCreationDto freeIpaCreation = FreeIpaCreationDto.builder().build();
 
@@ -306,6 +315,11 @@ public class EnvironmentCreationDto {
             return this;
         }
 
+        public Builder withBackup(EnvironmentBackup backup) {
+            this.backup = backup;
+            return this;
+        }
+
         public Builder withSecurityAccess(SecurityAccessDto securityAccess) {
             this.securityAccess = securityAccess;
             return this;
@@ -349,7 +363,7 @@ public class EnvironmentCreationDto {
         public EnvironmentCreationDto build() {
             return new EnvironmentCreationDto(name, description, cloudPlatform, accountId, creator,
                     location, network, credential, regions, freeIpaCreation, authentication,
-                    created, telemetry, securityAccess, adminGroupName, parameters, experimentalFeatures, tags, crn,
+                    created, telemetry, backup, securityAccess, adminGroupName, parameters, experimentalFeatures, tags, crn,
                     parentEnvironmentName, proxyConfigName);
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDto.java
@@ -42,6 +42,8 @@ public class EnvironmentDto implements Payload, AccountAwareResource, Environmen
 
     private EnvironmentTelemetry telemetry;
 
+    private EnvironmentBackup backup;
+
     private boolean archived;
 
     private Long deletionTimestamp = -1L;
@@ -165,6 +167,14 @@ public class EnvironmentDto implements Payload, AccountAwareResource, Environmen
 
     public void setTelemetry(EnvironmentTelemetry telemetry) {
         this.telemetry = telemetry;
+    }
+
+    public EnvironmentBackup getBackup() {
+        return backup;
+    }
+
+    public void setBackup(EnvironmentBackup backup) {
+        this.backup = backup;
     }
 
     public boolean isArchived() {
@@ -398,6 +408,8 @@ public class EnvironmentDto implements Payload, AccountAwareResource, Environmen
 
         private EnvironmentTelemetry telemetry;
 
+        private EnvironmentBackup backup;
+
         private boolean archived;
 
         private Long deletionTimestamp = -1L;
@@ -528,6 +540,11 @@ public class EnvironmentDto implements Payload, AccountAwareResource, Environmen
             return this;
         }
 
+        public Builder withBackup(EnvironmentBackup backup) {
+            this.backup = backup;
+            return this;
+        }
+
         public Builder withAuthentication(AuthenticationDto authentication) {
             this.authentication = authentication;
             return this;
@@ -603,6 +620,7 @@ public class EnvironmentDto implements Payload, AccountAwareResource, Environmen
             environmentDto.setCredentialView(credentialView);
             environmentDto.setCloudPlatform(cloudPlatform);
             environmentDto.setTelemetry(telemetry);
+            environmentDto.setBackup(backup);
             environmentDto.setRegions(regions);
             environmentDto.setArchived(archived);
             environmentDto.setDeletionTimestamp(deletionTimestamp);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverter.java
@@ -99,6 +99,7 @@ public class EnvironmentDtoConverter {
                 .withLocationDto(environmentToLocationDto(environment))
                 .withRegions(environment.getRegionSet())
                 .withTelemetry(environment.getTelemetry())
+                .withBackup(environment.getBackup())
                 .withEnvironmentStatus(environment.getStatus())
                 .withCreator(environment.getCreator())
                 .withAuthentication(authenticationDtoConverter.authenticationToDto(environment.getAuthentication()))
@@ -137,6 +138,7 @@ public class EnvironmentDtoConverter {
         environment.setLongitude(location.getLongitude());
         environment.setLocation(location.getName());
         environment.setTelemetry(creationDto.getTelemetry());
+        environment.setBackup(creationDto.getBackup());
         environment.setLocationDisplayName(location.getDisplayName());
         environment.setStatus(EnvironmentStatus.CREATION_INITIATED);
         environment.setCreateFreeIpa(creationDto.getFreeIpaCreation().getCreate());

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentEditDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentEditDto.java
@@ -15,6 +15,8 @@ public class EnvironmentEditDto {
 
     private final EnvironmentTelemetry telemetry;
 
+    private final EnvironmentBackup backup;
+
     private final NetworkDto network;
 
     private final AuthenticationDto authentication;
@@ -37,6 +39,7 @@ public class EnvironmentEditDto {
             NetworkDto network,
             AuthenticationDto authentication,
             EnvironmentTelemetry telemetry,
+            EnvironmentBackup backup,
             SecurityAccessDto securityAccess,
             Tunnel tunnel,
             IdBrokerMappingSource idBrokerMappingSource,
@@ -48,6 +51,7 @@ public class EnvironmentEditDto {
         this.network = network;
         this.authentication = authentication;
         this.telemetry = telemetry;
+        this.backup = backup;
         this.securityAccess = securityAccess;
         this.tunnel = tunnel;
         this.idBrokerMappingSource = idBrokerMappingSource;
@@ -74,6 +78,10 @@ public class EnvironmentEditDto {
 
     public EnvironmentTelemetry getTelemetry() {
         return telemetry;
+    }
+
+    public EnvironmentBackup getBackup() {
+        return backup;
     }
 
     public SecurityAccessDto getSecurityAccess() {
@@ -115,6 +123,8 @@ public class EnvironmentEditDto {
 
         private EnvironmentTelemetry telemetry;
 
+        private EnvironmentBackup backup;
+
         private SecurityAccessDto securityAccess;
 
         private Tunnel tunnel;
@@ -155,6 +165,11 @@ public class EnvironmentEditDto {
             return this;
         }
 
+        public EnvironmentEditDtoBuilder withBackup(EnvironmentBackup backup) {
+            this.backup = backup;
+            return this;
+        }
+
         public EnvironmentEditDtoBuilder withSecurityAccess(SecurityAccessDto securityAccess) {
             this.securityAccess = securityAccess;
             return this;
@@ -186,7 +201,7 @@ public class EnvironmentEditDto {
         }
 
         public EnvironmentEditDto build() {
-            return new EnvironmentEditDto(description, accountId, network, authentication, telemetry, securityAccess, tunnel, idBrokerMappingSource,
+            return new EnvironmentEditDto(description, accountId, network, authentication, telemetry, backup, securityAccess, tunnel, idBrokerMappingSource,
                     cloudStorageValidation, adminGroupName, parameters);
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/EnvironmentValidationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/EnvironmentValidationHandler.java
@@ -75,6 +75,7 @@ public class EnvironmentValidationHandler extends EventSenderAwareHandler<Enviro
         ValidationResult.ValidationResultBuilder validationBuilder = validatorService
                 .validateRegionsAndLocation(regionWrapper.getName(), regionWrapper.getRegions(), environment, cloudRegions);
         validationBuilder.merge(validatorService.validateTelemetryLoggingStorageLocation(environment));
+        validationBuilder.merge(validatorService.validateBackupStorageLocation(environment));
         validationBuilder.merge(validatorService.validateParameters(environmentDto, environmentDto.getParameters()));
         validationBuilder.merge(validatorService.validateNetworkWithProvider(environmentDto));
         validationBuilder.merge(validatorService.validateAuthentication(environmentDto));

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandler.java
@@ -17,6 +17,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import com.sequenceiq.common.api.backup.request.BackupRequest;
+import com.sequenceiq.environment.environment.v1.converter.BackupConverter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -96,6 +98,8 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
 
     private final TelemetryApiConverter telemetryApiConverter;
 
+    private final BackupConverter backupConverter;
+
     private final CloudPlatformConnectors connectors;
 
     private final EventBus eventBus;
@@ -112,6 +116,7 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
             PollingService<FreeIpaPollerObject> freeIpaPollingService,
             FreeIpaServerRequestProvider freeIpaServerRequestProvider,
             TelemetryApiConverter telemetryApiConverter,
+            BackupConverter backupConverter,
             CloudPlatformConnectors connectors,
             EventBus eventBus, @Value("${environment.enabledChildPlatforms}") Set<String> enabledChildPlatforms) {
         super(eventSender);
@@ -123,6 +128,7 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
         this.freeIpaPollingService = freeIpaPollingService;
         this.freeIpaServerRequestProvider = freeIpaServerRequestProvider;
         this.telemetryApiConverter = telemetryApiConverter;
+        this.backupConverter = backupConverter;
         this.connectors = connectors;
         this.eventBus = eventBus;
         this.enabledChildPlatforms = enabledChildPlatforms;
@@ -217,6 +223,7 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
         setPlacementAndNetwork(environment, createFreeIpaRequest);
         setAuthentication(environment.getAuthentication(), createFreeIpaRequest);
         setTelemetry(environment, createFreeIpaRequest);
+        setBackup(environment, createFreeIpaRequest);
         setTags(environment, createFreeIpaRequest);
         SecurityGroupRequest securityGroupRequest = null;
         if (environment.getSecurityAccess() != null) {
@@ -239,6 +246,11 @@ public class FreeIpaCreationHandler extends EventSenderAwareHandler<EnvironmentD
     private void setTelemetry(EnvironmentDto environmentDto, CreateFreeIpaRequest createFreeIpaRequest) {
         TelemetryRequest telemetryRequest = telemetryApiConverter.convertToRequest(environmentDto.getTelemetry());
         createFreeIpaRequest.setTelemetry(telemetryRequest);
+    }
+
+    private void setBackup(EnvironmentDto environmentDto, CreateFreeIpaRequest createFreeIpaRequest) {
+        BackupRequest backup = backupConverter.convertToRequest(environmentDto.getBackup());
+        createFreeIpaRequest.setBackup(backup);
     }
 
     private void setPlacementAndNetwork(EnvironmentDto environment, CreateFreeIpaRequest createFreeIpaRequest) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/BackupConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/BackupConverter.java
@@ -1,0 +1,146 @@
+package com.sequenceiq.environment.environment.v1.converter;
+
+import com.sequenceiq.common.api.backup.request.BackupRequest;
+import com.sequenceiq.common.api.backup.response.BackupResponse;
+import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
+import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
+import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.backup.model.BackupCloudwatchParams;
+import com.sequenceiq.environment.environment.dto.EnvironmentBackup;
+import com.sequenceiq.environment.environment.dto.telemetry.S3CloudStorageParameters;
+
+@Component
+public class BackupConverter {
+
+    public BackupConverter() {
+    }
+
+    public EnvironmentBackup convert(BackupRequest request) {
+        return createBackupFromRequest(request);
+    }
+
+    public EnvironmentBackup convert(TelemetryRequest request) {
+        return createBackupFromRequest(request.getLogging());
+    }
+
+    public BackupResponse convert(EnvironmentBackup backup) {
+        return createBackupResponseFromSource(backup);
+    }
+
+    public BackupRequest convertToRequest(EnvironmentBackup backup) {
+        BackupRequest backupRequest = null;
+        if (backup != null) {
+            backupRequest = createBackupRequestFromEnvSource(backup);
+        }
+        return backupRequest;
+    }
+
+    private BackupResponse createBackupResponseFromSource(EnvironmentBackup backup) {
+        BackupResponse backupResponse = null;
+        if (backup != null) {
+            backupResponse = new BackupResponse();
+            backupResponse.setStorageLocation(backup.getStorageLocation());
+            backupResponse.setS3(convertS3(backup.getS3()));
+            backupResponse.setAdlsGen2(convertAdlsV2(backup.getAdlsGen2()));
+            backupResponse.setGcs(convertGcs(backup.getGcs()));
+            backupResponse.setCloudwatch(BackupCloudwatchParams.copy(backup.getCloudwatch()));
+        }
+        return backupResponse;
+    }
+
+    private BackupRequest createBackupRequestFromEnvSource(EnvironmentBackup backup) {
+        BackupRequest backupRequest = null;
+        if (backup != null) {
+            backupRequest = new BackupRequest();
+            backupRequest.setStorageLocation(backup.getStorageLocation());
+            backupRequest.setS3(convertS3(backup.getS3()));
+            backupRequest.setAdlsGen2(convertAdlsV2(backup.getAdlsGen2()));
+            backupRequest.setGcs(convertGcs(backup.getGcs()));
+            backupRequest.setCloudwatch(BackupCloudwatchParams.copy(backup.getCloudwatch()));
+        }
+        return backupRequest;
+    }
+
+    private EnvironmentBackup createBackupFromRequest(BackupRequest backupRequest) {
+        EnvironmentBackup backup = null;
+        if (backupRequest != null) {
+            backup = new EnvironmentBackup();
+            backup.setStorageLocation(backupRequest.getStorageLocation());
+            backup.setS3(convertS3(backupRequest.getS3()));
+            backup.setAdlsGen2(convertAdlsV2(backupRequest.getAdlsGen2()));
+            backup.setGcs(convertGcs(backupRequest.getGcs()));
+            backup.setCloudwatch(BackupCloudwatchParams.copy(backupRequest.getCloudwatch()));
+        }
+        return backup;
+    }
+
+    private EnvironmentBackup createBackupFromRequest(LoggingRequest loggingRequest) {
+        EnvironmentBackup backup = null;
+        if (loggingRequest != null) {
+            backup = new EnvironmentBackup();
+            backup.setStorageLocation(loggingRequest.getStorageLocation());
+            backup.setS3(convertS3(loggingRequest.getS3()));
+            backup.setAdlsGen2(convertAdlsV2(loggingRequest.getAdlsGen2()));
+            backup.setGcs(convertGcs(loggingRequest.getGcs()));
+            backup.setCloudwatch(convertBackupCloudwatchParams(loggingRequest.getCloudwatch()));
+        }
+        return backup;
+    }
+
+    private S3CloudStorageParameters convertS3(S3CloudStorageV1Parameters s3) {
+        S3CloudStorageParameters s3CloudStorageParameters = null;
+        if (s3 != null) {
+            s3CloudStorageParameters = new S3CloudStorageParameters();
+            s3CloudStorageParameters.setInstanceProfile(s3.getInstanceProfile());
+            return s3CloudStorageParameters;
+        }
+        return s3CloudStorageParameters;
+    }
+
+    private S3CloudStorageV1Parameters convertS3(S3CloudStorageParameters s3) {
+        S3CloudStorageV1Parameters s3CloudStorageV1Parameters = null;
+        if (s3 != null) {
+            s3CloudStorageV1Parameters = new S3CloudStorageV1Parameters();
+            s3CloudStorageV1Parameters.setInstanceProfile(s3.getInstanceProfile());
+            return s3CloudStorageV1Parameters;
+        }
+        return s3CloudStorageV1Parameters;
+    }
+
+    private AdlsGen2CloudStorageV1Parameters convertAdlsV2(AdlsGen2CloudStorageV1Parameters adlsV2) {
+        AdlsGen2CloudStorageV1Parameters adlsGen2CloudStorageV1Parameters = null;
+        if (adlsV2 != null) {
+            adlsGen2CloudStorageV1Parameters = new AdlsGen2CloudStorageV1Parameters();
+            adlsGen2CloudStorageV1Parameters.setAccountKey(adlsV2.getAccountKey());
+            adlsGen2CloudStorageV1Parameters.setAccountName(adlsV2.getAccountName());
+            adlsGen2CloudStorageV1Parameters.setManagedIdentity(adlsV2.getManagedIdentity());
+            adlsGen2CloudStorageV1Parameters.setSecure(adlsV2.isSecure());
+        }
+        return adlsGen2CloudStorageV1Parameters;
+    }
+
+    private GcsCloudStorageV1Parameters convertGcs(GcsCloudStorageV1Parameters gcs) {
+        GcsCloudStorageV1Parameters gcsCloudStorageV1Parameters = null;
+        if (gcs != null) {
+            gcsCloudStorageV1Parameters = new GcsCloudStorageV1Parameters();
+            gcsCloudStorageV1Parameters.setServiceAccountEmail(gcs.getServiceAccountEmail());
+        }
+        return gcsCloudStorageV1Parameters;
+    }
+
+    private BackupCloudwatchParams convertBackupCloudwatchParams(CloudwatchParams cloudwatchParams) {
+        BackupCloudwatchParams newCloudwatchParams = null;
+        if (cloudwatchParams != null) {
+            newCloudwatchParams = new BackupCloudwatchParams();
+            newCloudwatchParams.setStreamKey(cloudwatchParams.getStreamKey());
+            newCloudwatchParams.setInstanceProfile(cloudwatchParams.getInstanceProfile());
+            newCloudwatchParams.setRegion(cloudwatchParams.getRegion());
+        }
+        return newCloudwatchParams;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -53,19 +53,22 @@ public class EnvironmentResponseConverter {
 
     private final TelemetryApiConverter telemetryApiConverter;
 
+    private final BackupConverter backupConverter;
+
     private final NetworkDtoToResponseConverter networkDtoToResponseConverter;
 
     public EnvironmentResponseConverter(CredentialToCredentialV1ResponseConverter credentialConverter,
             RegionConverter regionConverter, CredentialViewConverter credentialViewConverter,
             ProxyConfigToProxyResponseConverter proxyConfigToProxyResponseConverter,
             FreeIpaConverter freeIpaConverter, TelemetryApiConverter telemetryApiConverter,
-            NetworkDtoToResponseConverter networkDtoToResponseConverter) {
+            BackupConverter backupConverter, NetworkDtoToResponseConverter networkDtoToResponseConverter) {
         this.credentialConverter = credentialConverter;
         this.regionConverter = regionConverter;
         this.credentialViewConverter = credentialViewConverter;
         this.proxyConfigToProxyResponseConverter = proxyConfigToProxyResponseConverter;
         this.freeIpaConverter = freeIpaConverter;
         this.telemetryApiConverter = telemetryApiConverter;
+        this.backupConverter = backupConverter;
         this.networkDtoToResponseConverter = networkDtoToResponseConverter;
     }
 
@@ -87,6 +90,7 @@ public class EnvironmentResponseConverter {
                 .withCreated(environmentDto.getCreated())
                 .withTag(getIfNotNull(environmentDto.getTags(), this::environmentTagsToTagResponse))
                 .withTelemetry(telemetryApiConverter.convert(environmentDto.getTelemetry()))
+                .withBackup(backupConverter.convert(environmentDto.getBackup()))
                 .withTunnel(environmentDto.getExperimentalFeatures().getTunnel())
                 .withIdBrokerMappingSource(environmentDto.getExperimentalFeatures().getIdBrokerMappingSource())
                 .withCloudStorageValidation(environmentDto.getExperimentalFeatures().getCloudStorageValidation())
@@ -130,6 +134,7 @@ public class EnvironmentResponseConverter {
                 .withAdminGroupName(environmentDto.getAdminGroupName())
                 .withTag(getIfNotNull(environmentDto.getTags(), this::environmentTagsToTagResponse))
                 .withTelemetry(telemetryApiConverter.convert(environmentDto.getTelemetry()))
+                .withBackup(backupConverter.convert(environmentDto.getBackup()))
                 .withRegions(regionConverter.convertRegions(environmentDto.getRegions()))
                 .withAws(getIfNotNull(environmentDto.getParameters(), this::awsEnvParamsToAwsEnvironmentParams))
                 .withAzure(getIfNotNull(environmentDto.getParameters(), this::azureEnvParamsToAzureEnvironmentParams))

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentFlowValidatorService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentFlowValidatorService.java
@@ -2,6 +2,7 @@ package com.sequenceiq.environment.environment.validation;
 
 import java.util.Set;
 
+import com.sequenceiq.environment.environment.validation.cloudstorage.EnvironmentBackupLocationValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -28,17 +29,20 @@ public class EnvironmentFlowValidatorService {
 
     private final EnvironmentLogStorageLocationValidator logStorageLocationValidator;
 
+    private final EnvironmentBackupLocationValidator backupLocationValidator;
+
     private final EnvironmentParameterValidator environmentParameterValidator;
 
     private final EnvironmentAuthenticationValidator environmentAuthenticationValidator;
 
     public EnvironmentFlowValidatorService(
             EnvironmentRegionValidator environmentRegionValidator, EnvironmentNetworkProviderValidator environmentNetworkProviderValidator,
-            EnvironmentLogStorageLocationValidator logStorageLocationValidator, EnvironmentParameterValidator environmentParameterValidator,
-            EnvironmentAuthenticationValidator environmentAuthenticationValidator) {
+            EnvironmentLogStorageLocationValidator logStorageLocationValidator, EnvironmentBackupLocationValidator backupLocationValidator,
+            EnvironmentParameterValidator environmentParameterValidator, EnvironmentAuthenticationValidator environmentAuthenticationValidator) {
         this.environmentRegionValidator = environmentRegionValidator;
         this.environmentNetworkProviderValidator = environmentNetworkProviderValidator;
         this.logStorageLocationValidator = logStorageLocationValidator;
+        this.backupLocationValidator = backupLocationValidator;
         this.environmentParameterValidator = environmentParameterValidator;
         this.environmentAuthenticationValidator = environmentAuthenticationValidator;
     }
@@ -56,6 +60,10 @@ public class EnvironmentFlowValidatorService {
 
     public ValidationResult validateTelemetryLoggingStorageLocation(Environment environment) {
         return logStorageLocationValidator.validateTelemetryLoggingStorageLocation(environment);
+    }
+
+    public ValidationResult validateBackupStorageLocation(Environment environment) {
+        return backupLocationValidator.validateBackupStorageLocation(environment);
     }
 
     public ValidationResult validateNetworkWithProvider(EnvironmentDto environmentDto) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/cloudstorage/EnvironmentBackupLocationValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/cloudstorage/EnvironmentBackupLocationValidator.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.environment.environment.validation.cloudstorage;
+
+import java.util.Optional;
+
+import com.sequenceiq.environment.environment.dto.EnvironmentBackup;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.environment.environment.domain.Environment;
+
+@Component
+public class EnvironmentBackupLocationValidator {
+
+    private final CloudStorageLocationValidator cloudStorageLocationValidator;
+
+    public EnvironmentBackupLocationValidator(CloudStorageLocationValidator cloudStorageLocationValidator) {
+        this.cloudStorageLocationValidator = cloudStorageLocationValidator;
+    }
+
+    /**
+     * Validate backup storage location.
+     * Currently, filter out cloudwatch (or any other cloud logging service) related validations
+     */
+    public ValidationResult validateBackupStorageLocation(Environment environment) {
+        ValidationResult.ValidationResultBuilder resultBuilder = new ValidationResult.ValidationResultBuilder();
+        Optional.ofNullable(environment.getBackup())
+                .filter(backup -> isCloudStorageEnabled(backup) && backup.getCloudwatch() == null)
+                .map(EnvironmentBackup::getStorageLocation)
+                .ifPresent(location -> cloudStorageLocationValidator.validateBackup(location, environment, resultBuilder));
+        return resultBuilder.build();
+    }
+
+    private boolean isCloudStorageEnabled(EnvironmentBackup backup) {
+        return backup.getS3() != null || backup.getAdlsGen2() != null;
+    }
+}

--- a/environment/src/main/resources/schema/app/20210111160131_CB-9953_add_backup_location_to_environmentdb.sql
+++ b/environment/src/main/resources/schema/app/20210111160131_CB-9953_add_backup_location_to_environmentdb.sql
@@ -1,0 +1,9 @@
+-- // CB-9953 add backup location to environmentdb
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE environment ADD COLUMN IF NOT EXISTS backup TEXT;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE environment DROP COLUMN IF EXISTS backup;

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandlerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationHandlerTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.sequenceiq.environment.environment.v1.converter.BackupConverter;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -106,6 +107,9 @@ public class FreeIpaCreationHandlerTest {
     private TelemetryApiConverter telemetryApiConverter;
 
     @Mock
+    private BackupConverter backupConverter;
+
+    @Mock
     private CloudPlatformConnectors connectors;
 
     @Mock
@@ -125,6 +129,7 @@ public class FreeIpaCreationHandlerTest {
                 freeIpaPollingService,
                 freeIpaServerRequestProvider,
                 telemetryApiConverter,
+                backupConverter,
                 connectors,
                 eventBus, Collections.singleton(CloudPlatform.YARN.name()));
     }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
@@ -55,6 +55,7 @@ import com.sequenceiq.environment.environment.dto.FreeIpaCreationDto;
 import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
+import com.sequenceiq.environment.environment.dto.EnvironmentBackup;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.environment.parameter.dto.ResourceGroupUsagePattern;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
@@ -78,6 +79,9 @@ public class EnvironmentApiConverterTest {
 
     @Mock
     private TelemetryApiConverter telemetryApiConverter;
+
+    @Mock
+    private BackupConverter backupConverter;
 
     @Mock
     private AccountTelemetryService accountTelemetryService;
@@ -237,6 +241,7 @@ public class EnvironmentApiConverterTest {
                 .build());
         FreeIpaCreationDto freeIpaCreationDto = mock(FreeIpaCreationDto.class);
         EnvironmentTelemetry environmentTelemetry = mock(EnvironmentTelemetry.class);
+        EnvironmentBackup environmentBackup = mock(EnvironmentBackup.class);
         AccountTelemetry accountTelemetry = mock(AccountTelemetry.class);
         Features features = mock(Features.class);
         NetworkDto networkDto = mock(NetworkDto.class);
@@ -245,6 +250,7 @@ public class EnvironmentApiConverterTest {
         when(accountTelemetry.getFeatures()).thenReturn(features);
         when(accountTelemetryService.getOrDefault(any())).thenReturn(accountTelemetry);
         when(telemetryApiConverter.convert(eq(request.getTelemetry()), any())).thenReturn(environmentTelemetry);
+        when(backupConverter.convert(eq(request.getBackup()))).thenReturn(environmentBackup);
         when(tunnelConverter.convert(request.getTunnel())).thenReturn(request.getTunnel());
         when(networkRequestToDtoConverter.convert(request.getNetwork())).thenReturn(networkDto);
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 import java.util.Set;
 
+import com.sequenceiq.common.api.backup.response.BackupResponse;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -88,6 +89,9 @@ public class EnvironmentResponseConverterTest {
     private TelemetryApiConverter telemetryApiConverter;
 
     @Mock
+    private BackupConverter backupConverter;
+
+    @Mock
     private NetworkDtoToResponseConverter networkDtoToResponseConverter;
 
     @ParameterizedTest
@@ -98,6 +102,7 @@ public class EnvironmentResponseConverterTest {
         FreeIpaResponse freeIpaResponse = mock(FreeIpaResponse.class);
         CompactRegionResponse compactRegionResponse = mock(CompactRegionResponse.class);
         TelemetryResponse telemetryResponse = mock(TelemetryResponse.class);
+        BackupResponse backupResponse = mock(BackupResponse.class);
         ProxyResponse proxyResponse = mock(ProxyResponse.class);
         EnvironmentNetworkResponse environmentNetworkResponse = mock(EnvironmentNetworkResponse.class);
 
@@ -105,6 +110,7 @@ public class EnvironmentResponseConverterTest {
         when(freeIpaConverter.convert(environment.getFreeIpaCreation())).thenReturn(freeIpaResponse);
         when(regionConverter.convertRegions(environment.getRegions())).thenReturn(compactRegionResponse);
         when(telemetryApiConverter.convert(environment.getTelemetry())).thenReturn(telemetryResponse);
+        when(backupConverter.convert(environment.getBackup())).thenReturn(backupResponse);
         when(proxyConfigToProxyResponseConverter.convert(environment.getProxyConfig())).thenReturn(proxyResponse);
         when(networkDtoToResponseConverter.convert(environment.getNetwork(), environment.getExperimentalFeatures().getTunnel(), true))
                 .thenReturn(environmentNetworkResponse);

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -34,7 +34,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
 @RetryAndMetrics
-@Path("/v1/freeipa")
+@Path("/" +
+        "v1/freeipa")
 @Consumes(MediaType.APPLICATION_JSON)
 @Api(value = "/v1/freeipa", protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
 public interface FreeIpaV1Endpoint {

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
@@ -12,6 +12,7 @@ public class FreeIpaModelDescriptions {
     public static final String FREEIPA_SERVER_SETTINGS = "settings for freeipa server";
     public static final String GATEWAY_PORT = "port of the gateway secured proxy";
     public static final String TELEMETRY = "telemetry setting for freeipa server";
+    public static final String BACKUP = "backup setting for freeipa server";
     public static final String CLOUD_STORAGE = "cloud storage details for freeipa server";
     public static final String FREEIPA_APPLICATION_VERSION = "version of the application provisioned FreeIPA";
     public static final String CLOUD_PLATFORM = "Cloud Platform for FreeIPA";

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/create/CreateFreeIpaRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/create/CreateFreeIpaRequest.java
@@ -76,7 +76,6 @@ public class CreateFreeIpaRequest implements TaggableRequest {
     private TelemetryRequest telemetry;
 
     @ApiModelProperty(FreeIpaModelDescriptions.BACKUP)
-    @Valid
     private BackupRequest backup;
 
     @ApiModelProperty(FreeIpaModelDescriptions.TAGS)

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/create/CreateFreeIpaRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/create/CreateFreeIpaRequest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.validation.ValidCrn;
+import com.sequenceiq.common.api.backup.request.BackupRequest;
 import com.sequenceiq.common.api.tag.request.TaggableRequest;
 import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.common.api.type.Tunnel;
@@ -73,6 +74,10 @@ public class CreateFreeIpaRequest implements TaggableRequest {
 
     @ApiModelProperty(FreeIpaModelDescriptions.TELEMETRY)
     private TelemetryRequest telemetry;
+
+    @ApiModelProperty(FreeIpaModelDescriptions.BACKUP)
+    @Valid
+    private BackupRequest backup;
 
     @ApiModelProperty(FreeIpaModelDescriptions.TAGS)
     private Map<String, String> tags = new HashMap<>();
@@ -165,6 +170,14 @@ public class CreateFreeIpaRequest implements TaggableRequest {
 
     public void setTelemetry(TelemetryRequest telemetry) {
         this.telemetry = telemetry;
+    }
+
+    public BackupRequest getBackup() {
+        return backup;
+    }
+
+    public void setBackup(BackupRequest backup) {
+        this.backup = backup;
     }
 
     public Boolean getUseCcm() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/backup/BackupConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/backup/BackupConverter.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.freeipa.converter.backup;
 
+import com.sequenceiq.common.api.backup.request.BackupRequest;
+import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
+import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,8 +11,6 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
-import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
-import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
 import com.sequenceiq.freeipa.api.model.Backup;
 import com.sequenceiq.freeipa.configuration.BackupConfiguration;
 
@@ -39,8 +40,20 @@ public class BackupConverter {
         return backup;
     }
 
+    public Backup convert(BackupRequest request) {
+        Backup backup = null;
+        if (freeIpaBackupEnabled && request != null) {
+            backup = new Backup();
+            backup.setMonthlyFullEnabled(backupConfiguration.isMonthlyFullEnabled());
+            backup.setInitialFullEnabled(backupConfiguration.isRunInitialFullAfterInstall());
+            backup.setHourlyEnabled(backupConfiguration.isHourlyEnabled());
+            decorateBackupFromBackupRequest(backup, request);
+        }
+        return backup;
+    }
+
     private void decorateBackupFromLoggingRequest(Backup backup, LoggingRequest loggingRequest) {
-        if (loggingRequest != null) {
+        if (backup != null && loggingRequest != null) {
             backup.setStorageLocation(loggingRequest.getStorageLocation());
             if (loggingRequest.getS3() != null) {
                 S3CloudStorageV1Parameters s3Params = new S3CloudStorageV1Parameters();
@@ -57,6 +70,30 @@ public class BackupConverter {
             } else if (loggingRequest.getGcs() != null) {
                 GcsCloudStorageV1Parameters gcsParams = new GcsCloudStorageV1Parameters();
                 GcsCloudStorageV1Parameters gcsFromRequest = loggingRequest.getGcs();
+                gcsParams.setServiceAccountEmail(gcsFromRequest.getServiceAccountEmail());
+                backup.setGcs(gcsParams);
+            }
+        }
+    }
+
+    private void decorateBackupFromBackupRequest(Backup backup, BackupRequest backupRequest) {
+        if (backup != null && backupRequest != null) {
+            backup.setStorageLocation(backupRequest.getStorageLocation());
+            if (backupRequest.getS3() != null) {
+                S3CloudStorageV1Parameters s3Params = new S3CloudStorageV1Parameters();
+                s3Params.setInstanceProfile(backupRequest.getS3().getInstanceProfile());
+                backup.setS3(s3Params);
+            } else if (backupRequest.getAdlsGen2() != null) {
+                AdlsGen2CloudStorageV1Parameters adlsGen2Params = new AdlsGen2CloudStorageV1Parameters();
+                AdlsGen2CloudStorageV1Parameters adlsGen2FromRequest = backupRequest.getAdlsGen2();
+                adlsGen2Params.setAccountKey(adlsGen2FromRequest.getAccountKey());
+                adlsGen2Params.setAccountName(adlsGen2FromRequest.getAccountName());
+                adlsGen2Params.setSecure(adlsGen2FromRequest.isSecure());
+                adlsGen2Params.setManagedIdentity(adlsGen2FromRequest.getManagedIdentity());
+                backup.setAdlsGen2(adlsGen2Params);
+            } else if (backupRequest.getGcs() != null) {
+                GcsCloudStorageV1Parameters gcsParams = new GcsCloudStorageV1Parameters();
+                GcsCloudStorageV1Parameters gcsFromRequest = backupRequest.getGcs();
                 gcsParams.setServiceAccountEmail(gcsFromRequest.getServiceAccountEmail());
                 backup.setGcs(gcsParams);
             }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/CreateFreeIpaRequestToStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/CreateFreeIpaRequestToStackConverter.java
@@ -120,7 +120,11 @@ public class CreateFreeIpaRequestToStackConverter {
             stack.setNetwork(networkConverter.convert(source.getNetwork()));
         }
         stack.setTelemetry(telemetryConverter.convert(source.getTelemetry()));
-        stack.setBackup(backupConverter.convert(source.getTelemetry()));
+        if (source.getBackup() != null && isNotEmpty(source.getBackup().getStorageLocation())) {
+            stack.setBackup(backupConverter.convert(source.getBackup()));
+        } else {
+            stack.setBackup(backupConverter.convert(source.getTelemetry()));
+        }
         decorateStackWithTunnelAndCcm(stack, source);
         updateOwnerRelatedFields(source, accountId, ownerFuture, userCrn, stack);
         extendGatewaySecurityGroupWithDefaultGatewayCidrs(stack);


### PR DESCRIPTION
…cket and role for freeipa auto-backup data

Backups for FreeIPA need to be able to have a user-defined cloud storage location that has a separate policy to be able to be defined for that location.

It should be similar as the top-level telemetry and log storage location that is usable by all SDX and Workloads including both VM and K8s based workloads.

See detailed description in the commit message.