### PR TITLE
CB-10610: Remove CDP_SDX_HBASE_CLOUD_STORAGE entitlement at GA for AWS

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
@@ -17,6 +17,7 @@ import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.SharedServiceConfigsView;
 
@@ -56,11 +57,10 @@ public class HbaseCloudStorageServiceConfigProvider implements CmTemplateCompone
         String cdhVersion = getCdhVersion(source);
         boolean is727OrNewer = isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_7);
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
-        boolean sdxHbaseCloudStorageEnabled =
-                entitlementService.sdxHbaseCloudStorageEnabled(accountId);
+        boolean sdxHbaseCloudStorageEnabled = entitlementService.sdxHbaseCloudStorageEnabled(accountId);
         return source.getFileSystemConfigurationView().isPresent()
                 && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes())
-                && (!datalakeCluster || (is727OrNewer && sdxHbaseCloudStorageEnabled));
+                && (!datalakeCluster || (is727OrNewer && (CloudPlatform.AWS.equals(source.getCloudPlatform()) || sdxHbaseCloudStorageEnabled)));
     }
 
     private String getCdhVersion(TemplatePreparationObject source) {


### PR DESCRIPTION
-From 7.2.7 Store HBase data on cloud storage for AWS at data lake even when the entitlement CDP_SDX_HBASE_CLOUD_STORAGE is disabled
-Add more test cases for this change

See detailed description in the commit message.