### PR TITLE
CB-10612 API changes for In place enablement of semi-private networks

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterOpDescr
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterOpDescription.SET_MAINTENANCE_MODE_BY_NAME;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterOpDescription.UPDATE_PILLAR_CONFIG;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.ClusterOpDescription.UPDATE_SALT;
+import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.UPDATE_LOAD_BALANCERS;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.CHECK_FOR_UPGRADE_CLUSTER_IN_WORKSPACE;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.CHECK_IMAGE_IN_WORKSPACE;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.CHECK_IMAGE_IN_WORKSPACE_INTERNAL;
@@ -429,5 +430,12 @@ public interface StackV4Endpoint {
     @ApiOperation(value = OperationDescriptions.StackOpDescription.RENEW_CERTIFICATE, produces = MediaType.APPLICATION_JSON,
             notes = Notes.RENEW_CERTIFICATE_NOTES, nickname = "renewStackCertificate")
     FlowIdentifier renewCertificate(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
+            @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+
+    @PUT
+    @Path("internal/{name}/update_load_balancers")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UPDATE_LOAD_BALANCERS, nickname = "updateLoadBalancersInternal")
+    FlowIdentifier updateLoadBalancersInternal(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("initiatorUserCrn") String initiatorUserCrn);
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -59,6 +59,8 @@ public class OperationDescriptions {
         public static final String DATABASE_RESTORE_INTERNAL = "Performs a restore of the database from a provided location, internal only";
         public static final String ROTATE_CERTIFICATES = "Rotates the certificates of the cluster";
         public static final String RENEW_CERTIFICATE = "Trigger a certificate renewal on the desired cluster which is identified via stack's name";
+        public static final String UPDATE_LOAD_BALANCERS = "Updates an existing cluster with load balancers, including adding the Endpoint Gateway " +
+            "if it's enabled.";
     }
 
     public static class ClusterOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -364,4 +364,10 @@ public class StackV4Controller extends NotificationController implements StackV4
     public FlowIdentifier renewCertificate(Long workspaceId, String name, @InitiatorUserCrn String initiatorUserCrn) {
         return stackOperationService.renewCertificate(name);
     }
+
+    @Override
+    @InternalOnly
+    public FlowIdentifier updateLoadBalancersInternal(Long workspaceId, String name, @InitiatorUserCrn String initiatorUserCrn) {
+        return stackOperations.updateLoadBalancers(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerUpdateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerUpdateService.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.cloudbreak.service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+
+@Service
+public class LoadBalancerUpdateService {
+
+    public FlowIdentifier updateLoadBalancers(NameOrCrn nameOrCrn, Long workspaceId) {
+        return null;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -50,6 +50,7 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.view.StackApiView;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.retry.RetryableFlow;
+import com.sequenceiq.cloudbreak.service.LoadBalancerUpdateService;
 import com.sequenceiq.cloudbreak.service.ClusterCommonService;
 import com.sequenceiq.cloudbreak.service.DatabaseBackupRestoreService;
 import com.sequenceiq.cloudbreak.service.StackCommonService;
@@ -113,6 +114,9 @@ public class StackOperations implements ResourceBasedCrnProvider {
 
     @Inject
     private ClusterDBValidationService clusterDBValidationService;
+
+    @Inject
+    private LoadBalancerUpdateService loadBalancerUpdateService;
 
     public StackViewV4Responses listByEnvironmentName(Long workspaceId, String environmentName, List<StackType> stackTypes) {
         Set<StackViewV4Response> stackViewResponses;
@@ -391,5 +395,10 @@ public class StackOperations implements ResourceBasedCrnProvider {
             CertificatesRotationV4Request certificatesRotationV4Request) {
         LOGGER.debug("Starting cluster autotls certificates rotation: " + nameOrCrn);
         return clusterCommonService.rotateAutoTlsCertificates(nameOrCrn, workspaceId, certificatesRotationV4Request);
+    }
+
+    public FlowIdentifier updateLoadBalancers(@NotNull NameOrCrn nameOrCrn, Long workspaceId) {
+        LOGGER.debug("Creating load balancers for stack: " + nameOrCrn);
+        return loadBalancerUpdateService.updateLoadBalancers(nameOrCrn, workspaceId);
     }
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
@@ -25,6 +25,10 @@ public class EnvironmentOpDescription {
     public static final String GET_CRN_BY_NAME = "Get the crn of an environment by name.";
     public static final String GET_NAME_BY_CRN = "Get the name of an environment by crn.";
     public static final String UPDATE_CONFIG_BY_CRN = "Update the configuration for all stacks in the Environment by the Environment CRN";
+    public static final String UPDATE_LOAD_BALANCERS_BY_ENV_NAME = "Updates all cluster in an environment with load balancers, including adding the " +
+        "Endpoint Access Gateway if it's enabled. Environment is specified by name.";
+    public static final String UPDATE_LOAD_BALANCERS_BY_ENV_CRN = "Updates all cluster in an environment with load balancers, including adding the " +
+        "Endpoint Access Gateway if it's enabled. Environment is specified by CRN.";
 
     private EnvironmentOpDescription() {
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
@@ -28,6 +28,7 @@ import com.sequenceiq.environment.api.doc.environment.EnvironmentOpDescription;
 import com.sequenceiq.environment.api.v1.credential.model.response.CredentialResponse;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentChangeCredentialRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentEditRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLoadBalancerUpdateRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
@@ -227,4 +228,19 @@ public interface EnvironmentEndpoint {
     @ApiOperation(value = EnvironmentOpDescription.UPDATE_CONFIG_BY_CRN, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
         nickname = "updateConfigsInEnvironmentByCrnV1")
     void updateConfigsInEnvironmentByCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @PathParam("crn") String crn);
+
+    @PUT
+    @Path("/name/{name}/update_load_balancers")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.UPDATE_LOAD_BALANCERS_BY_ENV_NAME, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+        nickname = "updateEnvironmentLoadBalancersByNameV11")
+    void updateEnvironmentLoadBalancersByName(@PathParam("name") String envName, @NotNull EnvironmentLoadBalancerUpdateRequest request);
+
+    @PUT
+    @Path("/crn/{crn}/update_load_balancers")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.UPDATE_LOAD_BALANCERS_BY_ENV_CRN, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+        nickname = "updateEnvironmentLoadBalancersByCrnV1")
+    void updateEnvironmentLoadBalancersByCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @PathParam("crn") String crn,
+            @NotNull EnvironmentLoadBalancerUpdateRequest request);
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentLoadBalancerUpdateRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/EnvironmentLoadBalancerUpdateRequest.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.environment.api.v1.environment.model.request;
+
+import java.util.Set;
+
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(value = "EnvironmentLoadBalancerUpdateRequest")
+public class EnvironmentLoadBalancerUpdateRequest {
+
+    @ApiModelProperty(EnvironmentModelDescription.PUBLIC_ENDPOINT_ACCESS_GATEWAY)
+    private PublicEndpointAccessGateway publicEndpointAccessGateway = PublicEndpointAccessGateway.DISABLED;
+
+    @ApiModelProperty(EnvironmentModelDescription.ENDPOINT_ACCESS_GATEWAY_SUBNET_IDS)
+    private Set<String> subnetIds = Set.of();
+
+    public PublicEndpointAccessGateway getPublicEndpointAccessGateway() {
+        return publicEndpointAccessGateway;
+    }
+
+    public void setPublicEndpointAccessGateway(PublicEndpointAccessGateway publicEndpointAccessGateway) {
+        this.publicEndpointAccessGateway = publicEndpointAccessGateway;
+    }
+
+    public Set<String> getSubnetIds() {
+        return subnetIds;
+    }
+
+    public void setSubnetIds(Set<String> subnetIds) {
+        this.subnetIds = subnetIds;
+    }
+
+    @Override
+    public String toString() {
+        return "EnvironmentEndpointGatewayRequest{" +
+            "publicEndpointAccessGateway=" + publicEndpointAccessGateway +
+            ", subnetIds=" + subnetIds +
+            '}';
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentLoadBalancerDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentLoadBalancerDto.java
@@ -1,0 +1,122 @@
+package com.sequenceiq.environment.environment.dto;
+
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.environment.domain.Environment;
+
+public class EnvironmentLoadBalancerDto implements Payload {
+
+    private Long id;
+
+    private Environment environment;
+
+    private EnvironmentDto environmentDto;
+
+    private PublicEndpointAccessGateway endpointAccessGateway;
+
+    private Set<String> endpointGatewaySubnetIds;
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public Long getResourceId() {
+        return id;
+    }
+
+    public Environment getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(Environment environment) {
+        this.environment = environment;
+    }
+
+    public EnvironmentDto getEnvironmentDto() {
+        return environmentDto;
+    }
+
+    public void setEnvironmentDto(EnvironmentDto environmentDto) {
+        this.environmentDto = environmentDto;
+    }
+
+    public void setEndpointAccessGateway(PublicEndpointAccessGateway endpointAccessGateway) {
+        this.endpointAccessGateway = endpointAccessGateway;
+    }
+
+    public PublicEndpointAccessGateway getEndpointAccessGateway() {
+        return endpointAccessGateway;
+    }
+
+    public Set<String> getEndpointGatewaySubnetIds() {
+        return endpointGatewaySubnetIds;
+    }
+
+    public void setEndpointGatewaySubnetIds(Set<String> endpointGatewaySubnetIds) {
+        this.endpointGatewaySubnetIds = endpointGatewaySubnetIds;
+    }
+
+    @Override
+    public String toString() {
+        return "EnvironmentLoadBalancerDto{" +
+            "id=" + id +
+            ", endpointAccessGateway=" + endpointAccessGateway +
+            ", endpointGatewaySubnetIds=" + endpointGatewaySubnetIds +
+            '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private Long id;
+
+        private Environment environment;
+
+        private EnvironmentDto environmentDto;
+
+        private PublicEndpointAccessGateway endpointAccessGateway;
+
+        private Set<String> endpointGatewaySubnetIds;
+
+        public Builder withId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withEnvironment(Environment environment) {
+            this.environment = environment;
+            return this;
+        }
+
+        public Builder withEnvironmentDto(EnvironmentDto environmentDto) {
+            this.environmentDto = environmentDto;
+            return this;
+        }
+
+        public Builder withEndpointAccessGateway(PublicEndpointAccessGateway endpointAccessGateway) {
+            this.endpointAccessGateway = endpointAccessGateway;
+            return this;
+        }
+
+        public Builder withEndpointGatewaySubnetIds(Set<String> endpointGatewaySubnetIds) {
+            this.endpointGatewaySubnetIds = endpointGatewaySubnetIds;
+            return this;
+        }
+
+        public EnvironmentLoadBalancerDto build() {
+            EnvironmentLoadBalancerDto environmentLoadBalancerDto = new EnvironmentLoadBalancerDto();
+            environmentLoadBalancerDto.setId(id);
+            environmentLoadBalancerDto.setEnvironment(environment);
+            environmentLoadBalancerDto.setEnvironmentDto(environmentDto);
+            environmentLoadBalancerDto.setEndpointAccessGateway(endpointAccessGateway);
+            environmentLoadBalancerDto.setEndpointGatewaySubnetIds(endpointGatewaySubnetIds);
+            return environmentLoadBalancerDto;
+        }
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerService.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.environment.environment.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
+
+@Service
+public class EnvironmentLoadBalancerService {
+
+    public void updateLoadBalancerInEnvironmentAndStacks(EnvironmentDto environmentDto, EnvironmentLoadBalancerDto environmentLbDto) {
+        // TODO
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
@@ -28,6 +28,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.AttachedFreeI
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentAuthenticationRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentChangeCredentialRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentEditRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLoadBalancerUpdateRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentNetworkRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.LocationRequest;
@@ -47,6 +48,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentChangeCredentialDto
 import com.sequenceiq.environment.environment.dto.EnvironmentCreationDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentCreationDto.Builder;
 import com.sequenceiq.environment.environment.dto.EnvironmentEditDto;
+import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
 import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
@@ -325,5 +327,12 @@ public class EnvironmentApiConverter {
         features.setWorkloadAnalytics(featuresRequest.getWorkloadAnalytics());
         features.setClusterLogsCollection(featuresRequest.getClusterLogsCollection());
         return features;
+    }
+
+    public EnvironmentLoadBalancerDto initLoadBalancerDto(EnvironmentLoadBalancerUpdateRequest request) {
+        EnvironmentLoadBalancerDto.Builder builder = EnvironmentLoadBalancerDto.builder()
+            .withEndpointAccessGateway(request.getPublicEndpointAccessGateway())
+            .withEndpointGatewaySubnetIds(request.getSubnetIds());
+        return builder.build();
     }
 }


### PR DESCRIPTION
The API changes that will be used for the new in-place upgrade for the new load balancer
and endpoint gateway features. The logic will be triggered via an API call to the
environment service. The environment service will then call the internal stack API
to update the laod balancer for each applicable stack.

As part of the request, the endpoint gateway can be enabled, and public subnets to use for the
gateway provided. Load balancers will be created based on the current entitlements (including
creating data lake load balancers if that entitlement is enabled), and whether or not the endpoint
gateway is enabled for the environment.

This change adds the new API calls and the services they trigger, and stubs out the logic that will
be implemented in subsequent PRs. This change will be broken into three PRs:
- API changes (this one)
- Environment service changes
- Stack service changes