### PR TITLE
CB-11007 CCM Enabled Icon is not show in UI for CCMV2 Environments.

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/TunnelConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/v1/converter/TunnelConverter.java
@@ -17,4 +17,8 @@ public class TunnelConverter {
         }
         return tunnelRequest;
     }
+
+    public Tunnel convertToTunnelResponse(Tunnel tunnel) {
+        return tunnel.useCcmV2() ? Tunnel.CCM : tunnel;
+    }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -25,6 +25,7 @@ import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnviro
 import com.sequenceiq.environment.api.v1.environment.model.response.TagResponse;
 import com.sequenceiq.environment.credential.v1.converter.CredentialToCredentialV1ResponseConverter;
 import com.sequenceiq.environment.credential.v1.converter.CredentialViewConverter;
+import com.sequenceiq.environment.credential.v1.converter.TunnelConverter;
 import com.sequenceiq.environment.environment.domain.EnvironmentTags;
 import com.sequenceiq.environment.environment.dto.AuthenticationDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
@@ -55,11 +56,13 @@ public class EnvironmentResponseConverter {
 
     private final NetworkDtoToResponseConverter networkDtoToResponseConverter;
 
+    private final TunnelConverter tunnelConverter;
+
     public EnvironmentResponseConverter(CredentialToCredentialV1ResponseConverter credentialConverter,
             RegionConverter regionConverter, CredentialViewConverter credentialViewConverter,
             ProxyConfigToProxyResponseConverter proxyConfigToProxyResponseConverter,
             FreeIpaConverter freeIpaConverter, TelemetryApiConverter telemetryApiConverter,
-            NetworkDtoToResponseConverter networkDtoToResponseConverter) {
+            NetworkDtoToResponseConverter networkDtoToResponseConverter, TunnelConverter tunnelConverter) {
         this.credentialConverter = credentialConverter;
         this.regionConverter = regionConverter;
         this.credentialViewConverter = credentialViewConverter;
@@ -67,6 +70,7 @@ public class EnvironmentResponseConverter {
         this.freeIpaConverter = freeIpaConverter;
         this.telemetryApiConverter = telemetryApiConverter;
         this.networkDtoToResponseConverter = networkDtoToResponseConverter;
+        this.tunnelConverter = tunnelConverter;
     }
 
     public DetailedEnvironmentResponse dtoToDetailedResponse(EnvironmentDto environmentDto) {
@@ -87,7 +91,7 @@ public class EnvironmentResponseConverter {
                 .withCreated(environmentDto.getCreated())
                 .withTag(getIfNotNull(environmentDto.getTags(), this::environmentTagsToTagResponse))
                 .withTelemetry(telemetryApiConverter.convert(environmentDto.getTelemetry()))
-                .withTunnel(environmentDto.getExperimentalFeatures().getTunnel())
+                .withTunnel(tunnelConverter.convertToTunnelResponse(environmentDto.getExperimentalFeatures().getTunnel()))
                 .withIdBrokerMappingSource(environmentDto.getExperimentalFeatures().getIdBrokerMappingSource())
                 .withCloudStorageValidation(environmentDto.getExperimentalFeatures().getCloudStorageValidation())
                 .withAdminGroupName(environmentDto.getAdminGroupName())
@@ -126,7 +130,7 @@ public class EnvironmentResponseConverter {
                 .withFreeIpa(freeIpaConverter.convert(environmentDto.getFreeIpaCreation()))
                 .withStatusReason(environmentDto.getStatusReason())
                 .withCreated(environmentDto.getCreated())
-                .withTunnel(environmentDto.getExperimentalFeatures().getTunnel())
+                .withTunnel(tunnelConverter.convertToTunnelResponse(environmentDto.getExperimentalFeatures().getTunnel()))
                 .withAdminGroupName(environmentDto.getAdminGroupName())
                 .withTag(getIfNotNull(environmentDto.getTags(), this::environmentTagsToTagResponse))
                 .withTelemetry(telemetryApiConverter.convert(environmentDto.getTelemetry()))

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
@@ -41,6 +41,7 @@ import com.sequenceiq.environment.api.v1.proxy.model.response.ProxyViewResponse;
 import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.environment.credential.v1.converter.CredentialToCredentialV1ResponseConverter;
 import com.sequenceiq.environment.credential.v1.converter.CredentialViewConverter;
+import com.sequenceiq.environment.credential.v1.converter.TunnelConverter;
 import com.sequenceiq.environment.environment.EnvironmentStatus;
 import com.sequenceiq.environment.environment.domain.EnvironmentTags;
 import com.sequenceiq.environment.environment.domain.ExperimentalFeatures;
@@ -88,6 +89,9 @@ public class EnvironmentResponseConverterTest {
     private TelemetryApiConverter telemetryApiConverter;
 
     @Mock
+    private TunnelConverter tunnelConverter;
+
+    @Mock
     private NetworkDtoToResponseConverter networkDtoToResponseConverter;
 
     @ParameterizedTest
@@ -106,6 +110,7 @@ public class EnvironmentResponseConverterTest {
         when(regionConverter.convertRegions(environment.getRegions())).thenReturn(compactRegionResponse);
         when(telemetryApiConverter.convert(environment.getTelemetry())).thenReturn(telemetryResponse);
         when(proxyConfigToProxyResponseConverter.convert(environment.getProxyConfig())).thenReturn(proxyResponse);
+        when(tunnelConverter.convertToTunnelResponse(environment.getTunnel())).thenCallRealMethod();
         when(networkDtoToResponseConverter.convert(environment.getNetwork(), environment.getExperimentalFeatures().getTunnel(), true))
                 .thenReturn(environmentNetworkResponse);
 
@@ -166,6 +171,7 @@ public class EnvironmentResponseConverterTest {
         when(proxyConfigToProxyResponseConverter.convertToView(environment.getProxyConfig())).thenReturn(proxyResponse);
         when(networkDtoToResponseConverter.convert(environment.getNetwork(), environment.getExperimentalFeatures().getTunnel(), false))
                 .thenReturn(environmentNetworkResponse);
+        when(tunnelConverter.convertToTunnelResponse(environment.getTunnel())).thenCallRealMethod();
 
         SimpleEnvironmentResponse actual = underTest.dtoToSimpleResponse(environment);
 


### PR DESCRIPTION
1. UI and CDP CLI consider an environment is CCM Enabled only when TunnelValue is CCM.
2. Since Environment is CCM enabled even when CCMV2 is used internally, Environment Api Tunnel response needs to be initialized as CCM. (Customer Facing CDP CLI only has enableTunnel(False\True), internal ccmv1, ccmv2 protocols are not exposed to customers.

See detailed description in the commit message.