### PR TITLE
CB-10911 Introduce TestCaseTimeoutListener to xmlSuite.setListeners

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/IntegrationTestApp.java
@@ -188,7 +188,7 @@ public class IntegrationTestApp implements CommandLineRunner {
             xmlSuite.setVerbose(2);
             xmlSuite.setListeners(Arrays.asList(TestNgListener.class.getName(), ThreadLocalTestListener.class.getName(),
                     ReportListener.class.getName(), TestInvocationListener.class.getName(), CustomHTMLReporter.class.getName(),
-                    CustomJUnitXMLReporter.class.getName()));
+                    CustomJUnitXMLReporter.class.getName(), TestCaseTimeoutListener.class.getName()));
             LOG.info("Test are running in: {} type of parallel mode, thread count: {} and with test timeout: {}", parallel.toUpperCase(), threadCount, timeOut);
             return xmlSuite;
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestCaseTimeoutListener.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestCaseTimeoutListener.java
@@ -2,8 +2,10 @@ package com.sequenceiq.it.cloudbreak.listener;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testng.IInvokedMethod;
 import org.testng.ITestListener;
 import org.testng.ITestResult;
+import org.testng.internal.InvokedMethod;
 
 public class TestCaseTimeoutListener implements ITestListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestCaseTimeoutListener.class);
@@ -14,6 +16,7 @@ public class TestCaseTimeoutListener implements ITestListener {
         LOGGER.error("Test timed out: '{}' it took: '{}' ms", result.getName(), testRunInMs);
         LOGGER.info("Invoking TestInvocationListener to persist created resources in a JSON output file for clean up job.");
         TestInvocationListener testInvocationListener = new TestInvocationListener();
-        testInvocationListener.afterInvocation(null, result);
+        IInvokedMethod invokedMethod = new InvokedMethod(result.getTestClass(), result.getMethod(), result.getEndMillis(), result);
+        testInvocationListener.afterInvocation(invokedMethod, result);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestInvocationListener.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestInvocationListener.java
@@ -26,8 +26,8 @@ public class TestInvocationListener implements IInvokedMethodListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestInvocationListener.class);
 
     @Override
-    public void beforeInvocation(IInvokedMethod method, ITestResult testResult) {
-        LOGGER.info("Before Invocation of: " + method.getTestMethod().getMethodName()
+    public void beforeInvocation(IInvokedMethod invokedMethod, ITestResult testResult) {
+        LOGGER.info("Before Invocation of: " + invokedMethod.getTestMethod().getMethodName()
                 + " with parameters: " + Arrays.toString(testResult.getParameters()));
     }
 
@@ -40,7 +40,7 @@ public class TestInvocationListener implements IInvokedMethodListener {
      * because of each test has it's own Test Context, that has been built by the Given test steps for that thread of test execution.
      */
     @Override
-    public void afterInvocation(IInvokedMethod method, ITestResult testResult) {
+    public void afterInvocation(IInvokedMethod invokedMethod, ITestResult testResult) {
         TestContext testContext;
         JSONObject jsonObject = new JSONObject();
         Object[] parameters = testResult.getParameters();
@@ -87,7 +87,7 @@ public class TestInvocationListener implements IInvokedMethodListener {
             }
         }
         if (jsonObject.length() != 0) {
-            String fileName = "resource_names_" + testContext.getTestMethodName().orElseGet(() -> getDefaultFileNameTag()) + ".json";
+            String fileName = "resource_names_" + testContext.getTestMethodName().orElseGet(this::getDefaultFileNameTag) + ".json";
             try {
                 Files.writeString(Paths.get(fileName), jsonObject.toString());
                 LOGGER.info("Resource file have been created with name: {} and content: {}.", fileName, jsonObject);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/environment/EnvironmentStopStartTests.java
@@ -55,7 +55,7 @@ public class EnvironmentStopStartTests extends AbstractE2ETest {
         initializeDefaultBlueprints(testContext);
     }
 
-    @Test(dataProvider = TEST_CONTEXT, timeOut =  7200000)
+    @Test(dataProvider = TEST_CONTEXT, timeOut = 7200000)
     @Description(
             given = "there is a running cloudbreak",
             when = "create an attached SDX and Datahub",


### PR DESCRIPTION
E2E Environment stop/start test case is still timing out with no test failure. So the related `TestCaseTimeoutListener.class` was introduced to `xmlSuite.setListeners` application configuration as well.