### PR TITLE
CB-10167: Create load balancers as part of Data Lake provisioning in Azure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,15 @@ idea.max.intellisense.filesize=15000
 ```
 Restart IDEA, and Rebuild.
 
+#### Activating CloudBreak Code Styles
+After importing, be sure to navigate to:
+```text
+IntelliJ IDEA -> Preferences -> Editor -> Code Style -> Java -> Scheme
+```
+And, select the new scheme `Default (1)`.
+
+Otherwise, IntelliJ will constantly reorder your imports differently from CB conventions.
+
 ### Running Cloudbreak in IDEA
 
 To launch the Cloudbreak application execute the `com.sequenceiq.cloudbreak.CloudbreakApplication` class (set `Use classpath of module` to `cloudbreak.core.main`) with the following JVM options:

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/MetadataCollector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/MetadataCollector.java
@@ -26,6 +26,6 @@ public interface MetadataCollector {
     List<CloudVmMetaDataStatus> collect(AuthenticatedContext authenticatedContext, List<CloudResource> resources,
             List<CloudInstance> vms, List<CloudInstance> allInstances);
 
-    List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes);
-
+    List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes,
+            List<CloudResource> resources);
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudInstance.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudInstance.java
@@ -7,6 +7,17 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
 
+/**
+ * A common, abstract representation of a virtual machine in a cloud provider.
+ *
+ * For example, this class can be used to represent an AWS EC2 instance, Azure virtual machine, or GCP virtual machine instance.
+ *
+ * This is a <em>minimal</em> representation, containing the unique (cloud vendor specific) instance ID, template used to create the
+ * instance, and necessary information to authenticate and connect to the instance.
+ *
+ * @see InstanceTemplate
+ * @see InstanceAuthentication
+ */
 public class CloudInstance extends DynamicModel {
 
     public static final String INSTANCE_NAME = "InstanceName";

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancer.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancer.java
@@ -32,4 +32,12 @@ public class CloudLoadBalancer {
     public LoadBalancerType getType() {
         return type;
     }
+
+    @Override
+    public String toString() {
+        return "CloudLoadBalancer{" +
+            "type=" + type +
+            ", portToTargetGroupMapping=" + portToTargetGroupMapping +
+            '}';
+    }
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudStack.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudStack.java
@@ -63,7 +63,7 @@ public class CloudStack {
         this.loginUserName = loginUserName;
         this.publicKey = publicKey;
         this.fileSystem = Optional.ofNullable(fileSystem);
-        this.loadBalancers = loadBalancers;
+        this.loadBalancers = loadBalancers != null ? loadBalancers : Collections.emptyList();
         this.additionalFileSystem = Optional.ofNullable(additionalFileSystem);
     }
 

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetadataCollector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetadataCollector.java
@@ -181,7 +181,8 @@ public class AwsMetadataCollector implements MetadataCollector {
     }
 
     @Override
-    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes) {
+    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes,
+            List<CloudResource> resources) {
         LOGGER.debug("Collect AWS load balancer metadata, for cluster {}", ac.getCloudContext().getName());
 
         List<CloudLoadBalancerMetadata> cloudLoadBalancerMetadata = new ArrayList<>();

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetaDataCollectorTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetaDataCollectorTest.java
@@ -334,7 +334,7 @@ public class AwsMetaDataCollectorTest {
 
         AuthenticatedContext ac = authenticatedContext();
         List<CloudLoadBalancerMetadata> metadata = awsMetadataCollector.collectLoadBalancer(ac,
-                List.of(LoadBalancerType.PRIVATE, LoadBalancerType.PUBLIC));
+                List.of(LoadBalancerType.PRIVATE, LoadBalancerType.PUBLIC), null);
 
         Assert.assertEquals(2, metadata.size());
         Optional<CloudLoadBalancerMetadata> internalMetadata = metadata.stream()
@@ -357,7 +357,7 @@ public class AwsMetaDataCollectorTest {
 
         AuthenticatedContext ac = authenticatedContext();
         List<CloudLoadBalancerMetadata> metadata = awsMetadataCollector.collectLoadBalancer(ac,
-                List.of(LoadBalancerType.PRIVATE));
+                List.of(LoadBalancerType.PRIVATE), null);
 
         Assert.assertEquals(1, metadata.size());
         Optional<CloudLoadBalancerMetadata> internalMetadata = metadata.stream()
@@ -374,7 +374,7 @@ public class AwsMetaDataCollectorTest {
 
         AuthenticatedContext ac = authenticatedContext();
         List<CloudLoadBalancerMetadata> metadata = awsMetadataCollector.collectLoadBalancer(ac,
-                List.of(LoadBalancerType.PUBLIC));
+                List.of(LoadBalancerType.PUBLIC), null);
 
         Assert.assertEquals(1, metadata.size());
         Optional<CloudLoadBalancerMetadata> externalMetadata = metadata.stream()
@@ -391,7 +391,7 @@ public class AwsMetaDataCollectorTest {
 
         AuthenticatedContext ac = authenticatedContext();
         List<CloudLoadBalancerMetadata> metadata = awsMetadataCollector.collectLoadBalancer(ac,
-                List.of(LoadBalancerType.PRIVATE, LoadBalancerType.PUBLIC));
+                List.of(LoadBalancerType.PRIVATE, LoadBalancerType.PUBLIC), null);
 
         Assert.assertEquals(1, metadata.size());
         Optional<CloudLoadBalancerMetadata> externalMetadata = metadata.stream()

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureCloudResourceService.java
@@ -143,6 +143,9 @@ public class AzureCloudResourceService {
             case "Microsoft.Network/privateDnsZones/virtualNetworkLinks":
                 cloudResourceBuilder.type(ResourceType.AZURE_VIRTUAL_NETWORK_LINK);
                 break;
+            case "Microsoft.Network/loadBalancers":
+                cloudResourceBuilder.type(ResourceType.AZURE_LOAD_BALANCER);
+                break;
             default:
                 LOGGER.info("Unknown resource type {}", targetResource.resourceType());
                 return null;

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerModelBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerModelBuilder.java
@@ -1,0 +1,109 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.MultimapBuilder;
+import com.sequenceiq.cloudbreak.cloud.azure.loadbalancer.AzureLoadBalancer;
+import com.sequenceiq.cloudbreak.cloud.azure.loadbalancer.AzureLoadBalancingRule;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.common.api.type.LoadBalancerType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+
+public class AzureLoadBalancerModelBuilder {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureLoadBalancerModelBuilder.class);
+
+    private final CloudStack cloudStack;
+
+    private final String stackName;
+
+    public AzureLoadBalancerModelBuilder(CloudStack cloudStack, String stackName) {
+        this.cloudStack = cloudStack;
+        this.stackName = stackName;
+    }
+
+    /**
+     * Create a model of Azure load balancers from stack information.
+     *
+     * @param cloudStack containing CloudLoadBalancers to base the AzureLoadBalancers off of
+     * @param stackName  part of the load balancer name, usually a stack name
+     * @return a list of models representing Azure load balancers
+     */
+    private List<AzureLoadBalancer> buildAzureLoadBalancerModel(CloudStack cloudStack, String stackName) {
+        return cloudStack.getLoadBalancers().stream()
+                .map(lb -> convertCloudLoadBalancerToAzureLoadBalancer(lb, stackName))
+                .collect(toList());
+    }
+
+    private AzureLoadBalancer convertCloudLoadBalancerToAzureLoadBalancer(CloudLoadBalancer cloudLoadBalancer, String stackName) {
+        Set<String> instanceGroupNames = collectInstanceGroupNames(cloudLoadBalancer);
+        List<AzureLoadBalancingRule> rules = collectLoadBalancingRules(cloudLoadBalancer);
+        return buildAzureLb(cloudLoadBalancer.getType(), instanceGroupNames, rules, stackName);
+    }
+
+    private AzureLoadBalancer buildAzureLb(LoadBalancerType type, Set<String> instanceGroupNames, List<AzureLoadBalancingRule> rules, String stackName) {
+        return new AzureLoadBalancer.Builder()
+                .setType(type)
+                .setInstanceGroupNames(instanceGroupNames)
+                .setRules(rules)
+                .setStackName(stackName)
+                .createAzureLoadBalancer();
+
+    }
+
+    private List<AzureLoadBalancingRule> collectLoadBalancingRules(CloudLoadBalancer cloudLoadBalancer) {
+        return cloudLoadBalancer.getPortToTargetGroupMapping()
+                .keySet()
+                .stream()
+                .map(AzureLoadBalancingRule::new)
+                .collect(toList());
+    }
+
+    private Set<String> collectInstanceGroupNames(CloudLoadBalancer cloudLoadBalancer) {
+        return cloudLoadBalancer.getPortToTargetGroupMapping().values().stream()
+                .flatMap(Collection::stream)
+                .map(Group::getName)
+                .collect(Collectors.toSet());
+    }
+
+    public Map<String, Object> buildModel() {
+        List<AzureLoadBalancer> azureLoadBalancers = buildAzureLoadBalancerModel(cloudStack, stackName);
+        Map<String, Collection<AzureLoadBalancer>> instanceGroupToLoadBalancers = createTargetInstanceGroupMapping(azureLoadBalancers);
+
+        return Map.of("loadBalancers", azureLoadBalancers,
+                "loadBalancerMapping", instanceGroupToLoadBalancers);
+    }
+
+    /**
+     * Creates a mapping between the instances groups and the load balancers.
+     * Each instance group is mapped to a list of all the load balancers that route to it.
+     * <p>
+     * While this information is available via the AzureLoadBalancer#getInstanceGroupName method, this map is used to simplify the ARM template
+     * logic because it shows which load balancers are associated with which instances groups, without having to iterate
+     * over the entire list of load balancers in the template.
+     *
+     * @return A map of instance group names to the load balancers associated with them
+     */
+    private Map<String, Collection<AzureLoadBalancer>> createTargetInstanceGroupMapping(List<AzureLoadBalancer> azureLoadBalancers) {
+        ListMultimap<String, AzureLoadBalancer> mapping = MultimapBuilder.hashKeys().arrayListValues().build();
+        for (AzureLoadBalancer lb : azureLoadBalancers) {
+            for (String group : lb.getInstanceGroupNames()) {
+                mapping.put(group, lb);
+            }
+        }
+        Map<String, Collection<AzureLoadBalancer>> map = mapping.asMap();
+
+        LOGGER.debug("InstanceGroup to LoadBalancer mapping result: {}", map);
+        return map;
+    }
+}
+

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollector.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -11,6 +10,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.retry.annotation.Backoff;
@@ -21,6 +21,7 @@ import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.network.NetworkInterface;
 import com.sequenceiq.cloudbreak.cloud.MetadataCollector;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.loadbalancer.AzureLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
@@ -73,7 +74,7 @@ public class AzureMetadataCollector implements MetadataCollector {
 
                     Integer faultDomainCount = azureClient.getFaultDomainNumber(resourceGroup, vm.name());
 
-                    String publicIp = azureVmPublicIpProvider.getPublicIp(azureClient, azureUtils, networkInterface, resourceGroup);
+                    String publicIp = azureVmPublicIpProvider.getPublicIp(networkInterface);
 
                     String instanceId = instance.getKey();
                     String localityIndicator = Optional.ofNullable(faultDomainCount)
@@ -129,9 +130,76 @@ public class AzureMetadataCollector implements MetadataCollector {
     }
 
     @Override
-    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes) {
-        // no-op
-        return Collections.emptyList();
+    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes,
+            List<CloudResource> resources) {
+        LOGGER.debug("Collecting Azure load balancer metadata, for cluster {}", ac.getCloudContext().getName());
+
+        List<CloudLoadBalancerMetadata> cloudLoadBalancerMetadata = new ArrayList<>();
+        String resourceGroup = azureUtils.getTemplateResource(resources).getName();
+        final String stackName = azureUtils.getStackName(ac.getCloudContext());
+        AzureClient azureClient = ac.getParameter(AzureClient.class);
+
+        for (LoadBalancerType type : loadBalancerTypes) {
+            String loadBalancerName = AzureLoadBalancer.getLoadBalancerName(type, stackName);
+            LOGGER.debug("Attempting to collect metadata for load balancer {}, type {}", loadBalancerName, type);
+            try {
+                String ip = null;
+                if (LoadBalancerType.PUBLIC.equals(type)) {
+                    ip = lookupPublicIp(resourceGroup, azureClient, loadBalancerName);
+                } else if (LoadBalancerType.PRIVATE.equals(type)) {
+                    ip = lookupPrivateIp(resourceGroup, azureClient, loadBalancerName);
+                }
+
+                if (StringUtils.isNotEmpty(ip)) {
+                    CloudLoadBalancerMetadata loadBalancerMetadata = new CloudLoadBalancerMetadata.Builder()
+                        .withType(type)
+                        .withIp(ip)
+                        .withName(loadBalancerName)
+                        .build();
+                    cloudLoadBalancerMetadata.add(loadBalancerMetadata);
+                    LOGGER.debug("Saved metadata for load balancer: {}", loadBalancerMetadata);
+                } else {
+                    LOGGER.warn("Unable to find metadata for load balancer {}.", loadBalancerName);
+                }
+            } catch (RuntimeException e) {
+                LOGGER.warn("Unable to find metadata for load balancer " + loadBalancerName, e);
+            }
+        }
+
+        return cloudLoadBalancerMetadata;
     }
 
+    private String lookupPrivateIp(String resourceGroup, AzureClient azureClient, String loadBalancerName) {
+        String ip = null;
+        List<String> privateIps = azureClient.getLoadBalancerIps(resourceGroup, loadBalancerName, LoadBalancerType.PRIVATE);
+        if (privateIps.isEmpty()) {
+            LOGGER.warn("Unable to find private ip address for load balancer {}", loadBalancerName);
+        } else {
+            ip = privateIps.get(0);
+            if (privateIps.size() > 1) {
+                LOGGER.warn("Found multiple private IPs ({}) for load balancer {}. Only one, {}, will be used.",
+                        String.join(", ", privateIps),
+                        loadBalancerName,
+                        ip);
+            }
+        }
+        return ip;
+    }
+
+    private String lookupPublicIp(String resourceGroup, AzureClient azureClient, String loadBalancerName) {
+        String ip = null;
+        List<String> publicIps = azureClient.getLoadBalancerIps(resourceGroup, loadBalancerName, LoadBalancerType.PUBLIC);
+        if (publicIps.isEmpty()) {
+            LOGGER.warn("Unable to find public ip address for load balancer {}", loadBalancerName);
+        } else {
+            ip = publicIps.get(0);
+            if (publicIps.size() > 1) {
+                LOGGER.warn("Found multiple public IPs ({}) for load balancer {}. Only one, {}, will be used.",
+                        String.join(", ", publicIps),
+                        loadBalancerName,
+                        ip);
+            }
+        }
+        return ip;
+    }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.management.resources.Deployment;
@@ -141,7 +142,8 @@ public class AzureResourceConnector extends AbstractResourceConnector {
     @Override
     public List<CloudResourceStatus> launchLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack, PersistenceNotifier persistenceNotifier)
             throws Exception {
-        throw new UnsupportedOperationException("Load balancers are not supported for Azure.");
+        // todo: we're implementing this method as part of the work to add LBs to an existing environment. See CB-11647
+        return ImmutableList.of();
     }
 
     private List<CloudResource> persistCloudResources(

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilder.java
@@ -75,7 +75,9 @@ public class AzureTemplateBuilder {
             String rootDiskStorage = azureStorage.getImageStorageName(armCredentialView, cloudContext, cloudStack);
             AzureSecurityView armSecurityView = new AzureSecurityView(cloudStack.getGroups());
 
-            // needed for pre 1.16.5 templates
+            AzureLoadBalancerModelBuilder loadBalancerModelBuilder = new AzureLoadBalancerModelBuilder(cloudStack, stackName);
+
+            // needed for pre 1.16.5 templates and Load balancer setup on Medium duty datalakes.
             model.put("existingSubnetName", azureUtils.getCustomSubnetIds(network).stream().findFirst().orElse(""));
 
             model.put("customImageId", customImageId);
@@ -101,6 +103,7 @@ public class AzureTemplateBuilder {
             model.put("userDefinedTags", cloudStack.getTags());
             model.put("acceleratedNetworkEnabled", azureAcceleratedNetworkValidator.validate(armStack));
             model.put("isUpscale", UPSCALE.equals(azureInstanceTemplateOperation));
+            model.putAll(loadBalancerModelBuilder.buildModel());
             String generatedTemplate = freeMarkerTemplateUtils.processTemplateIntoString(getTemplate(cloudStack), model);
             LOGGER.info("Generated Arm template: {}", generatedTemplate);
             return generatedTemplate;

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperService.java
@@ -98,6 +98,9 @@ public class AzureTerminationHelperService {
         azureUtils.deleteNetworkInterfaces(client, resourceGroupName, networkInterfaceNames);
         deleteCloudResourceList(ac, resourcesToRemove, ResourceType.AZURE_NETWORK_INTERFACE);
 
+        // load balancers must be deleted before public IP addresses
+        deleteLoadBalancersIfNecessary(ac, resourcesToRemove, deleteWholeDeployment, client, resourceGroupName);
+
         List<String> publicAddressNames = getResourceNamesByResourceType(resourcesToRemove, ResourceType.AZURE_PUBLIC_IP);
         azureUtils.deletePublicIps(client, resourceGroupName, publicAddressNames);
         deleteCloudResourceList(ac, resourcesToRemove, ResourceType.AZURE_PUBLIC_IP);
@@ -128,6 +131,18 @@ public class AzureTerminationHelperService {
 
         LOGGER.debug("All the necessary resources have been deleted successfully");
         return azureResourceConnector.check(ac, resourcesToRemove);
+    }
+
+    private void deleteLoadBalancersIfNecessary(AuthenticatedContext ac,
+                                                List<CloudResource> resourcesToRemove,
+                                                boolean deleteWholeDeployment,
+                                                AzureClient client,
+                                                String resourceGroupName) {
+        if (deleteWholeDeployment) {
+            List<String> loadBalancerNames = getResourceNamesByResourceType(resourcesToRemove, ResourceType.AZURE_LOAD_BALANCER);
+            azureUtils.deleteLoadBalancers(client, resourceGroupName, loadBalancerNames);
+            deleteCloudResourceList(ac, resourcesToRemove, ResourceType.AZURE_LOAD_BALANCER);
+        }
     }
 
     private void deleteInstancesInProgress(AuthenticatedContext ac, List<CloudInstance> vms, List<CloudResource> resourcesToRemove, String resourceGroupName) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureVmPublicIpProvider.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureVmPublicIpProvider.java
@@ -1,32 +1,26 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
-import java.util.List;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.microsoft.azure.management.network.LoadBalancerBackend;
-import com.microsoft.azure.management.network.LoadBalancerInboundNatRule;
 import com.microsoft.azure.management.network.NetworkInterface;
 import com.microsoft.azure.management.network.PublicIPAddress;
-import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 
 @Component
 class AzureVmPublicIpProvider {
 
-    String getPublicIp(AzureClient azureClient, AzureUtils azureUtils, NetworkInterface networkInterface, String resourceGroup) {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureVmPublicIpProvider.class);
+
+    String getPublicIp(NetworkInterface networkInterface) {
         PublicIPAddress publicIpAddress = networkInterface.primaryIPConfiguration().getPublicIPAddress();
 
-        List<LoadBalancerBackend> backends = networkInterface.primaryIPConfiguration().listAssociatedLoadBalancerBackends();
-        List<LoadBalancerInboundNatRule> inboundNatRules = networkInterface.primaryIPConfiguration().listAssociatedLoadBalancerInboundNatRules();
-        String publicIp = null;
-        if (!backends.isEmpty() || !inboundNatRules.isEmpty()) {
-            publicIp = azureClient.getLoadBalancerIps(resourceGroup, azureUtils.getLoadBalancerId(resourceGroup)).get(0);
-        }
-
         if (publicIpAddress != null && publicIpAddress.ipAddress() != null) {
-            publicIp = publicIpAddress.ipAddress();
+            LOGGER.info("Azure network interface {} has public IP address {}.", networkInterface.id(), publicIpAddress.ipAddress());
+            return publicIpAddress.ipAddress();
+        } else {
+            LOGGER.info("Azure network interface {} does not have a public IP.", networkInterface.id());
+            return null;
         }
-
-        return publicIp;
     }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancer.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancer.java
@@ -1,0 +1,106 @@
+package com.sequenceiq.cloudbreak.cloud.azure.loadbalancer;
+
+import com.sequenceiq.common.api.type.LoadBalancerType;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+
+public class AzureLoadBalancer {
+    private static final String LOAD_BALANCER_NAME_PREFIX = "LoadBalancer";
+
+    private final List<AzureLoadBalancingRule> rules;
+
+    private final Set<AzureLoadBalancerProbe> probes;
+
+    private final String name;
+
+    private final LoadBalancerType type;
+
+    private final Set<String> instanceGroupNames;
+
+    private AzureLoadBalancer(Builder builder) {
+        this.rules = List.copyOf(builder.rules);
+        this.probes = Set.copyOf(builder.probes);
+        this.name = getLoadBalancerName(builder.type, builder.stackName);
+        this.type = builder.type;
+        this.instanceGroupNames = Set.copyOf(builder.instanceGroupNames);
+    }
+
+    public static String getLoadBalancerName(LoadBalancerType type, String stackName) {
+        return LOAD_BALANCER_NAME_PREFIX + stackName + type.toString();
+    }
+
+    public Collection<AzureLoadBalancingRule> getRules() {
+        return rules;
+    }
+
+    public Collection<AzureLoadBalancerProbe> getProbes() {
+        return probes;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public LoadBalancerType getType() {
+        return type;
+    }
+
+    public Set<String> getInstanceGroupNames() {
+        return instanceGroupNames;
+    }
+
+    @Override
+    public String toString() {
+        return "AzureLoadBalancer{" +
+                "rules=" + rules +
+                ", probes=" + probes +
+                ", name='" + name + '\'' +
+                ", type=" + type +
+                ", instanceGroupNames=" + instanceGroupNames +
+                '}';
+    }
+
+    public static final class Builder {
+        private List<AzureLoadBalancingRule> rules;
+
+        private Set<AzureLoadBalancerProbe> probes;
+
+        private String stackName;
+
+        private LoadBalancerType type;
+
+        private Set<String> instanceGroupNames;
+
+        public Builder setRules(List<AzureLoadBalancingRule> rules) {
+            this.rules = rules;
+            return this;
+        }
+
+        public Builder setStackName(String stackName) {
+            this.stackName = stackName;
+            return this;
+        }
+
+        public Builder setType(LoadBalancerType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder setInstanceGroupNames(Set<String> instanceGroupNames) {
+            this.instanceGroupNames = instanceGroupNames;
+            return this;
+        }
+
+        public AzureLoadBalancer createAzureLoadBalancer() {
+            probes = rules.stream()
+                    .map(AzureLoadBalancingRule::getProbe)
+                    .collect(toSet());
+
+            return new AzureLoadBalancer(this);
+        }
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancerProbe.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancerProbe.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.cloudbreak.cloud.azure.loadbalancer;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
+
+public class AzureLoadBalancerProbe {
+    private final int port;
+
+    private final String name;
+
+    public AzureLoadBalancerProbe(int port) {
+        this(port, "port-" + Integer.toString(port) + "-probe");
+    }
+
+    public AzureLoadBalancerProbe(int port, String name) {
+        Objects.requireNonNull(name);
+
+        this.port = port;
+        this.name = name;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "AzureLoadBalancerProbe{" +
+                "port=" + port +
+                ", name='" + name + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        AzureLoadBalancerProbe rhs = (AzureLoadBalancerProbe) obj;
+        return new EqualsBuilder()
+                .appendSuper(super.equals(obj))
+                .append(port, rhs.port)
+                .append(name, rhs.name)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(19, 35)
+                .append(name)
+                .append(port)
+                .toHashCode();
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancingRule.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancingRule.java
@@ -1,0 +1,64 @@
+package com.sequenceiq.cloudbreak.cloud.azure.loadbalancer;
+
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
+
+public final class AzureLoadBalancingRule {
+    private final String name;
+
+    private final int backendPort;
+
+    private final int frontendPort;
+
+    private final AzureLoadBalancerProbe probe;
+
+    public AzureLoadBalancingRule(TargetGroupPortPair portPair) {
+        this.backendPort = portPair.getTrafficPort();
+        this.frontendPort = portPair.getTrafficPort();
+        this.name = defaultNameFromPort(portPair.getTrafficPort());
+        this.probe = new AzureLoadBalancerProbe(portPair.getHealthCheckPort());
+    }
+
+    private String defaultNameFromPort(int port) {
+        return "port-" + port + "-rule";
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getBackendPort() {
+        return backendPort;
+    }
+
+    public int getFrontendPort() {
+        return frontendPort;
+    }
+
+    public AzureLoadBalancerProbe getProbe() {
+        return probe;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class AzureLoadBalancingRule {\n");
+        sb.append("    name: ").append(name).append("\n");
+        sb.append("    backendPort: ").append(backendPort).append("\n");
+        sb.append("    frontendPort: ").append(frontendPort).append("\n");
+        sb.append("    probe: ").append(toIndentedString(probe)).append("\n");
+        sb.append("}");
+
+        return sb.toString();
+    }
+
+    /**
+     * Convert the given object to string with each line indented by 4 spaces
+     * (except the first line).
+     */
+    private String toIndentedString(java.lang.Object o) {
+        if (o == null) {
+            return "null";
+        }
+        return o.toString().replace("\n", "\n    ");
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureInstanceGroupView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureInstanceGroupView.java
@@ -77,7 +77,7 @@ public class AzureInstanceGroupView {
     }
 
     /**
-     * needed because of Freemarker template generating (1.6 -> 1.16 compatibility)
+     * needed because of Freemarker template generating (1.6 {@literal ->} 1.16 compatibility)
      *
      * @return name of the instance group
      */

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureInstanceView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureInstanceView.java
@@ -102,7 +102,7 @@ public class AzureInstanceView {
     }
 
     /**
-     * Used in OLD freemarker template -> backward compatibility
+     * Used in OLD freemarker template {@literal ->} backward compatibility
      */
     public boolean isBootDiagnosticsEnabled() {
         return AzureDiskType.LOCALLY_REDUNDANT.equals(AzureDiskType.getByValue(instanceTemplate.getVolumes().get(0).getType()));

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerModelBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerModelBuilderTest.java
@@ -1,0 +1,73 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import com.sequenceiq.cloudbreak.cloud.azure.loadbalancer.AzureLoadBalancer;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.common.api.type.LoadBalancerType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AzureLoadBalancerModelBuilderTest {
+    public static final String STACK_NAME = "stack-name";
+
+    public static final String INSTANCE_GROUP_NAME = "bderriso-linz-sdx-gateway";
+
+    public static final String INSTANCE_NAME = "bderriso-linz-sdx-g0";
+
+    public static final String LOAD_BALANCERS_KEY = "loadBalancers";
+
+    public static final String LOAD_BALANCER_STACK_NAME = "LoadBalancerstack-namePRIVATE";
+
+    public static final String LOAD_BALANCER_MAPPING_KEY = "loadBalancerMapping";
+
+    private AzureLoadBalancerModelBuilder underTest;
+
+    @Test
+    void testGetModel() {
+        CloudStack mockCloudStack = mock(CloudStack.class);
+        Group targetGroup = new Group(INSTANCE_GROUP_NAME,
+                InstanceGroupType.GATEWAY,
+                List.of(new CloudInstance(INSTANCE_NAME, null, null)),
+                null,
+                null,
+                null,
+                null,
+                null,
+                64,
+                null);
+        CloudLoadBalancer cloudLoadBalancer = new CloudLoadBalancer(LoadBalancerType.PRIVATE);
+        cloudLoadBalancer.addPortToTargetGroupMapping(new TargetGroupPortPair(443, 443), Set.of(targetGroup));
+        when(mockCloudStack.getLoadBalancers()).thenReturn(List.of(cloudLoadBalancer));
+
+        underTest = new AzureLoadBalancerModelBuilder(mockCloudStack, STACK_NAME);
+
+        Map<String, Object> result = underTest.buildModel();
+
+        assertTrue(result.containsKey(LOAD_BALANCERS_KEY));
+        assertTrue(result.get(LOAD_BALANCERS_KEY) instanceof List);
+        List<AzureLoadBalancer> loadBalancers = (List<AzureLoadBalancer>) result.get(LOAD_BALANCERS_KEY);
+        assertEquals(1, loadBalancers.size());
+        AzureLoadBalancer lb = loadBalancers.get(0);
+        assertEquals(LOAD_BALANCER_STACK_NAME, lb.getName());
+        assertEquals(LoadBalancerType.PRIVATE, lb.getType());
+
+        assertTrue(result.containsKey(LOAD_BALANCER_MAPPING_KEY));
+        assertTrue(result.get(LOAD_BALANCER_MAPPING_KEY) instanceof Map);
+        Map<String, List<AzureLoadBalancer>> mapping = (Map<String, List<AzureLoadBalancer>>) result.get(LOAD_BALANCER_MAPPING_KEY);
+        List<AzureLoadBalancer> mappingList = mapping.get(INSTANCE_GROUP_NAME);
+        assertEquals(1, mappingList.size());
+        assertEquals(LOAD_BALANCER_STACK_NAME, mappingList.get(0).getName());
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
@@ -1,29 +1,14 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.anySet;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
-
 import com.microsoft.azure.management.compute.VirtualMachine;
 import com.microsoft.azure.management.network.NetworkInterface;
 import com.microsoft.azure.management.network.NicIPConfiguration;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.loadbalancer.AzureLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmMetaDataStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
@@ -32,7 +17,27 @@ import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.common.api.type.ResourceType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AzureMetadataCollectorTest {
@@ -71,6 +76,8 @@ public class AzureMetadataCollectorTest {
 
     private static final String LOCALITY_INDICATOR = "/AZURE/EU-WEST1/resourceGroup-1/test-instance-group/1";
 
+    private static final String SECOND_PUBLIC_IP = "10.32.13.1";
+
     @InjectMocks
     private AzureMetadataCollector underTest;
 
@@ -88,6 +95,9 @@ public class AzureMetadataCollectorTest {
 
     @Mock
     private AzureClient azureClient;
+
+    @Mock
+    private CloudContext mockCloudContext;
 
     @Test
     public void testCollectShouldReturnsTheAllVmMetadata() {
@@ -109,7 +119,7 @@ public class AzureMetadataCollectorTest {
         when(azureClient.getFaultDomainNumber(RESOURCE_GROUP_NAME, INSTANCE_1)).thenReturn(FAULT_DOMAIN_COUNT);
         when(azureClient.getFaultDomainNumber(RESOURCE_GROUP_NAME, INSTANCE_2)).thenReturn(FAULT_DOMAIN_COUNT);
         when(azureClient.getFaultDomainNumber(RESOURCE_GROUP_NAME, INSTANCE_3)).thenReturn(FAULT_DOMAIN_COUNT);
-        when(azureVmPublicIpProvider.getPublicIp(eq(azureClient), eq(azureUtils), any(), eq(RESOURCE_GROUP_NAME))).thenReturn(PUBLIC_IP);
+        when(azureVmPublicIpProvider.getPublicIp(any())).thenReturn(PUBLIC_IP);
         when(cloudContext.getPlatform()).thenReturn(Platform.platform(PLATFORM));
         when(cloudContext.getLocation()).thenReturn(Location.location(Region.region(REGION), null));
 
@@ -173,4 +183,137 @@ public class AzureMetadataCollectorTest {
                 .build();
     }
 
+    @Test
+    public void testCollectSinglePublicLoadBalancer() {
+        List<CloudResource> resources = new ArrayList<>();
+        CloudResource cloudResource = createCloudResource();
+
+        when(authenticatedContext.getCloudContext()).thenReturn(mockCloudContext);
+        when(mockCloudContext.getName()).thenReturn(RESOURCE_GROUP_NAME);
+
+        when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
+        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
+
+        final String loadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PUBLIC, STACK_NAME);
+        when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, loadBalancerName, LoadBalancerType.PUBLIC))
+            .thenReturn(List.of(PUBLIC_IP));
+
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PUBLIC), resources);
+
+        assertEquals(1, result.size());
+        assertEquals(PUBLIC_IP, result.get(0).getIp());
+        assertEquals(LoadBalancerType.PUBLIC, result.get(0).getType());
+    }
+
+    @Test
+    public void testCollectSinglePublicLoadBalancerWithMultipleIps() {
+        List<CloudResource> resources = new ArrayList<>();
+        CloudResource cloudResource = createCloudResource();
+
+        when(authenticatedContext.getCloudContext()).thenReturn(mockCloudContext);
+        when(mockCloudContext.getName()).thenReturn(RESOURCE_GROUP_NAME);
+
+        when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
+        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
+
+        final String loadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PUBLIC, STACK_NAME);
+        when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, loadBalancerName, LoadBalancerType.PUBLIC))
+                .thenReturn(List.of(PUBLIC_IP, SECOND_PUBLIC_IP));
+
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PUBLIC), resources);
+
+
+        // We're retrieving only one Public IP address by design
+        assertEquals(1, result.size());
+        assertEquals(LoadBalancerType.PUBLIC, result.get(0).getType());
+        final String resultIpAddress = result.get(0).getIp();
+        assertTrue(PUBLIC_IP.equals(resultIpAddress) || SECOND_PUBLIC_IP.equals(resultIpAddress));
+    }
+
+    @Test
+    public void testCollectPublicAndPrivateLoadBalancer() {
+        List<CloudResource> resources = new ArrayList<>();
+        CloudResource cloudResource = createCloudResource();
+
+        when(authenticatedContext.getCloudContext()).thenReturn(mockCloudContext);
+        when(mockCloudContext.getName()).thenReturn(RESOURCE_GROUP_NAME);
+
+        when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
+        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
+
+        final String publicLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PUBLIC, STACK_NAME);
+        when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, publicLoadBalancerName, LoadBalancerType.PUBLIC))
+                .thenReturn(List.of(PUBLIC_IP));
+
+        final String privateLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PRIVATE, STACK_NAME);
+        when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, privateLoadBalancerName, LoadBalancerType.PRIVATE))
+                .thenReturn(List.of(PRIVATE_IP));
+
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext,
+                List.of(LoadBalancerType.PUBLIC, LoadBalancerType.PRIVATE), resources);
+
+        assertEquals(2, result.size());
+        Optional<CloudLoadBalancerMetadata> publicLoadBalancerMetadata = result.stream()
+                .filter(metadata -> metadata.getType() == LoadBalancerType.PUBLIC)
+                .findAny();
+        assertTrue(publicLoadBalancerMetadata.isPresent());
+        assertEquals(PUBLIC_IP, publicLoadBalancerMetadata.get().getIp());
+
+        Optional<CloudLoadBalancerMetadata> privateLoadBalancerMetadata = result.stream()
+                .filter(metadata -> metadata.getType() == LoadBalancerType.PRIVATE)
+                .findAny();
+        assertTrue(privateLoadBalancerMetadata.isPresent());
+        assertEquals(PRIVATE_IP, privateLoadBalancerMetadata.get().getIp());
+    }
+
+    @Test
+    public void testCollectPrivateLoadBalancer() {
+        List<CloudResource> resources = new ArrayList<>();
+        CloudResource cloudResource = createCloudResource();
+
+        when(authenticatedContext.getCloudContext()).thenReturn(mockCloudContext);
+        when(mockCloudContext.getName()).thenReturn(RESOURCE_GROUP_NAME);
+
+        when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
+        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
+
+        final String privateLoadBalancerName = AzureLoadBalancer.getLoadBalancerName(LoadBalancerType.PRIVATE, STACK_NAME);
+        when(azureClient.getLoadBalancerIps(RESOURCE_GROUP_NAME, privateLoadBalancerName, LoadBalancerType.PRIVATE))
+                .thenReturn(List.of(PRIVATE_IP));
+
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PRIVATE), resources);
+
+        assertEquals(1, result.size());
+        assertEquals(LoadBalancerType.PRIVATE, result.get(0).getType());
+        assertEquals(PRIVATE_IP, result.get(0).getIp());
+    }
+
+    @Test
+    public void testCollectLoadBalancerWithNoIps() {
+        List<CloudResource> resources = new ArrayList<>();
+        CloudResource cloudResource = createCloudResource();
+
+        when(authenticatedContext.getCloudContext()).thenReturn(mockCloudContext);
+        when(mockCloudContext.getName()).thenReturn(RESOURCE_GROUP_NAME);
+
+        when(azureUtils.getTemplateResource(resources)).thenReturn(cloudResource);
+        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
+
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(
+                authenticatedContext,
+                List.of(LoadBalancerType.PRIVATE, LoadBalancerType.PUBLIC),
+                resources);
+
+        assertEquals(0, result.size());
+    }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTerminationHelperServiceTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.cloud.azure;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -135,6 +137,15 @@ class AzureTerminationHelperServiceTest {
         verify(azureComputeResourceService).deleteComputeResources(any(), any(), eq(volumeSets), any());
         verify(azureUtils).deleteSecurityGroups(any(), eq(NSG_ID_LIST));
         verify(azureUtils).deleteNetworks(any(), eq(NETWORK_ID_LIST));
+    }
+
+    @Test
+    void testWhenDeleteWholeDeploymentThenLoadBalancersAreRemovedBeforePublicIps() {
+        underTest.terminate(ac, cloudStack, resourcesToRemoveList);
+
+        InOrder inOrder = inOrder(azureUtils);
+        inOrder.verify(azureUtils).deleteLoadBalancers(any(), any(), any());
+        inOrder.verify(azureUtils).deletePublicIps(any(), any(), any());
     }
 
     private List<CloudResource> setupCloudResources() {

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpMetadataCollector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpMetadataCollector.java
@@ -118,7 +118,8 @@ public class GcpMetadataCollector implements MetadataCollector {
     }
 
     @Override
-    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes) {
+    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes,
+            List<CloudResource> resources) {
         // no-op
         return Collections.emptyList();
     }

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockMetadataCollector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockMetadataCollector.java
@@ -44,7 +44,8 @@ public class MockMetadataCollector implements MetadataCollector {
     }
 
     @Override
-    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes) {
+    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes,
+            List<CloudResource> resources) {
         // no-op
         return Collections.emptyList();
     }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackMetadataCollector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackMetadataCollector.java
@@ -85,7 +85,8 @@ public class OpenStackMetadataCollector implements MetadataCollector {
     }
 
     @Override
-    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes) {
+    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes,
+            List<CloudResource> resources) {
         // no-op
         return Collections.emptyList();
     }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeMetaDataCollector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeMetaDataCollector.java
@@ -79,7 +79,8 @@ public class OpenStackNativeMetaDataCollector implements MetadataCollector {
     }
 
     @Override
-    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes) {
+    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes,
+            List<CloudResource> resources) {
         // no-op
         return Collections.emptyList();
     }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/loadbalancer/CollectLoadBalancerMetadataRequest.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/loadbalancer/CollectLoadBalancerMetadataRequest.java
@@ -1,23 +1,31 @@
 package com.sequenceiq.cloudbreak.cloud.event.loadbalancer;
 
-import java.util.List;
-
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformRequest;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.common.api.type.LoadBalancerType;
+
+import java.util.List;
 
 public class CollectLoadBalancerMetadataRequest extends CloudPlatformRequest<CollectLoadBalancerMetadataResult> {
 
     private final List<LoadBalancerType> typesPresentInStack;
 
+    private final List<CloudResource> cloudResources;
+
     public CollectLoadBalancerMetadataRequest(CloudContext cloudContext, CloudCredential cloudCredential,
-            List<LoadBalancerType> typesPresentInStack) {
+            List<LoadBalancerType> typesPresentInStack, List<CloudResource> cloudResources) {
         super(cloudContext, cloudCredential);
         this.typesPresentInStack = typesPresentInStack;
+        this.cloudResources = cloudResources;
     }
 
     public List<LoadBalancerType> getTypesPresentInStack() {
         return typesPresentInStack;
+    }
+
+    public List<CloudResource> getCloudResources() {
+        return cloudResources;
     }
 }

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/CollectLoadBalancerMetadataHandler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/CollectLoadBalancerMetadataHandler.java
@@ -1,20 +1,17 @@
 package com.sequenceiq.cloudbreak.cloud.handler;
 
-import java.util.List;
-
-import javax.inject.Inject;
-
+import com.sequenceiq.cloudbreak.cloud.event.loadbalancer.CollectLoadBalancerMetadataRequest;
+import com.sequenceiq.cloudbreak.cloud.event.loadbalancer.CollectLoadBalancerMetadataResult;
+import com.sequenceiq.cloudbreak.cloud.handler.service.LoadBalancerMetadataService;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-
-import com.sequenceiq.cloudbreak.cloud.event.loadbalancer.CollectLoadBalancerMetadataRequest;
-import com.sequenceiq.cloudbreak.cloud.event.loadbalancer.CollectLoadBalancerMetadataResult;
-import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
-import com.sequenceiq.cloudbreak.cloud.handler.service.LoadBalancerMetadataService;
-
 import reactor.bus.Event;
 import reactor.bus.EventBus;
+
+import javax.inject.Inject;
+import java.util.List;
 
 @Component
 public class CollectLoadBalancerMetadataHandler implements CloudPlatformEventHandler<CollectLoadBalancerMetadataRequest> {
@@ -38,7 +35,7 @@ public class CollectLoadBalancerMetadataHandler implements CloudPlatformEventHan
         CollectLoadBalancerMetadataRequest request = collectLBMetadataRequestEvent.getData();
         try {
             List<CloudLoadBalancerMetadata> loadBalancerStatuses = loadBalancerMetadataService.collectMetadata(request.getCloudContext(),
-                request.getCloudCredential(), request.getTypesPresentInStack());
+                request.getCloudCredential(), request.getTypesPresentInStack(), request.getCloudResources());
             CollectLoadBalancerMetadataResult collectLBMetadataResult =
                 new CollectLoadBalancerMetadataResult(request.getResourceId(), loadBalancerStatuses);
 

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/service/LoadBalancerMetadataService.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/service/LoadBalancerMetadataService.java
@@ -1,20 +1,19 @@
 package com.sequenceiq.cloudbreak.cloud.handler.service;
 
-import java.util.List;
-
-import javax.inject.Inject;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
-
 import com.sequenceiq.cloudbreak.cloud.CloudConnector;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.common.api.type.LoadBalancerType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;
+import java.util.List;
 
 @Service
 public class LoadBalancerMetadataService {
@@ -25,11 +24,11 @@ public class LoadBalancerMetadataService {
     private CloudPlatformConnectors cloudPlatformConnectors;
 
     public List<CloudLoadBalancerMetadata> collectMetadata(CloudContext cloudContext, CloudCredential cloudCredential,
-            List<LoadBalancerType> types) {
+            List<LoadBalancerType> types, List<CloudResource> cloudResources) {
         LOGGER.debug("Initiating load balancer metadata collection");
         CloudConnector<Object> connector = cloudPlatformConnectors.get(cloudContext.getPlatformVariant());
         AuthenticatedContext ac = connector.authentication().authenticate(cloudContext, cloudCredential);
-        List<CloudLoadBalancerMetadata> loadBalancerStatuses = connector.metadata().collectLoadBalancer(ac, types);
+        List<CloudLoadBalancerMetadata> loadBalancerStatuses = connector.metadata().collectLoadBalancer(ac, types, cloudResources);
         LOGGER.debug("Load balancer metadata collection successfully finished. Collected metadata: {}", loadBalancerStatuses);
         return loadBalancerStatuses;
     }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnMetadataCollector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnMetadataCollector.java
@@ -144,7 +144,8 @@ public class YarnMetadataCollector implements MetadataCollector {
     }
 
     @Override
-    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes) {
+    public List<CloudLoadBalancerMetadata> collectLoadBalancer(AuthenticatedContext ac, List<LoadBalancerType> loadBalancerTypes,
+            List<CloudResource> resources) {
         List<CloudLoadBalancerMetadata> loadBalancerMetadata = Lists.newArrayList();
 
         if (loadBalancerTypes.size() == 0) {

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/ResourceType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/ResourceType.java
@@ -67,6 +67,7 @@ public enum ResourceType {
     AZURE_PRIVATE_DNS_ZONE,
     AZURE_DNS_ZONE_GROUP,
     AZURE_VIRTUAL_NETWORK_LINK,
+    AZURE_LOAD_BALANCER,
 
     // ARM
     ARM_TEMPLATE(CommonResourceType.TEMPLATE),

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/NetworkV4Base.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/NetworkV4Base.java
@@ -1,16 +1,18 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base;
 
-import com.sequenceiq.common.model.JsonEntity;
-import com.sequenceiq.cloudbreak.common.mappable.ProviderParametersBase;
+import java.util.Optional;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AwsNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AzureNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.GcpNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.MockNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.OpenStackNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.YarnNetworkV4Parameters;
+import com.sequenceiq.cloudbreak.common.mappable.ProviderParametersBase;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.NetworkModelDescription;
 import com.sequenceiq.cloudbreak.validation.SubnetType;
 import com.sequenceiq.cloudbreak.validation.ValidSubnet;
+import com.sequenceiq.common.model.JsonEntity;
 
 import io.swagger.annotations.ApiModelProperty;
 
@@ -56,6 +58,16 @@ public class NetworkV4Base extends ProviderParametersBase implements JsonEntity 
 
     public void setSubnetCIDR(String subnetCIDR) {
         this.subnetCIDR = subnetCIDR;
+    }
+
+    public Optional<Boolean> isNoPublicIp() {
+        if (azure != null) {
+            return Optional.ofNullable(azure.getNoPublicIp());
+        } else if (gcp != null) {
+            return Optional.ofNullable(gcp.getNoPublicIp());
+        } else {
+            return Optional.empty();
+        }
     }
 
     public AwsNetworkV4Parameters createAws() {

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/NetworkV4BaseTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/NetworkV4BaseTest.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AwsNetworkV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AzureNetworkV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.GcpNetworkV4Parameters;
+
+class NetworkV4BaseTest {
+
+    NetworkV4Base underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new NetworkV4Base();
+    }
+
+    @Test
+    void testAzureNetworkPublicIpIsNotEmpty() {
+        AzureNetworkV4Parameters networkParameters = new AzureNetworkV4Parameters();
+        networkParameters.setNoPublicIp(true);
+        underTest.setAzure(networkParameters);
+
+        assertTrue(underTest.isNoPublicIp().get());
+    }
+
+    @Test
+    void testGcpNetworkPublicIpIsNotEmpty() {
+        GcpNetworkV4Parameters networkParameters = new GcpNetworkV4Parameters();
+        networkParameters.setNoPublicIp(true);
+        underTest.setGcp(networkParameters);
+
+        assertTrue(underTest.isNoPublicIp().get());
+    }
+
+    @Test
+    void testAwsNetworkPublicIpIsEmpty() {
+        AwsNetworkV4Parameters networkParameters = new AwsNetworkV4Parameters();
+        underTest.setAws(networkParameters);
+
+        assertTrue(underTest.isNoPublicIp().isEmpty());
+    }
+
+    @Test
+    void testIsNoPublicIpIsEmptyOnNull() {
+        underTest.createAzure();
+
+        assertTrue(underTest.isNoPublicIp().isEmpty());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
@@ -43,6 +43,7 @@ import com.sequenceiq.cloudbreak.cloud.model.StackTags;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.cmtemplate.metering.MeteringServiceFieldResolver;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.mappable.ProviderParameterCalculator;
@@ -59,10 +60,10 @@ import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
-import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
+import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.datalake.DatalakeResourcesService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
-import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.stack.GatewaySecurityGroupDecorator;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
 import com.sequenceiq.cloudbreak.tag.ClusterTemplateApplicationTag;
@@ -178,7 +179,9 @@ public class StackV4RequestToStackConverter extends AbstractConversionServiceAwa
         stack.setExternalDatabaseCreationType(getIfNotNull(source.getExternalDatabase(), DatabaseRequest::getAvailabilityType));
         determineServiceTypeTag(stack, source.getTags());
         determineServiceFeatureTag(stack, source.getTags());
-        stack.setLoadBalancers(loadBalancerConfigService.createLoadBalancers(stack, environment, source.isEnableLoadBalancer()));
+
+        Set<LoadBalancer> loadBalancers = loadBalancerConfigService.createLoadBalancers(stack, environment, source.isEnableLoadBalancer());
+        stack.setLoadBalancers(loadBalancers);
         return stack;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceGroupV4RequestToInstanceGroupConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceGroupV4RequestToInstanceGroupConverter.java
@@ -8,15 +8,15 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.common.mappable.ProviderParameterCalculator;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.InstanceGroupV4Request;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.mappable.ProviderParameterCalculator;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
 import com.sequenceiq.cloudbreak.domain.SecurityGroup;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.common.api.type.ScalabilityOption;
 
 @Component

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationActions.java
@@ -246,8 +246,9 @@ public class StackCreationActions {
                 List<LoadBalancerType> loadBalancerTypes = loadBalancerPersistenceService.findByStackId(context.getStack().getId()).stream()
                     .map(LoadBalancer::getType)
                     .collect(Collectors.toList());
+                List<CloudResource> cloudResources = cloudResourceConverter.convert(context.getStack().getResources());
                 return new CollectLoadBalancerMetadataRequest(context.getCloudContext(), context.getCloudCredential(),
-                    loadBalancerTypes);
+                    loadBalancerTypes, cloudResources);
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/update/loadbalancer/StackLoadBalancerUpdateActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/update/loadbalancer/StackLoadBalancerUpdateActions.java
@@ -21,10 +21,12 @@ import org.springframework.statemachine.action.Action;
 
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.converter.spi.ResourceToCloudResourceConverter;
 import com.sequenceiq.cloudbreak.converter.spi.StackToCloudStackConverter;
 import com.sequenceiq.cloudbreak.core.flow2.AbstractStackAction;
 import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
@@ -66,6 +68,9 @@ public class StackLoadBalancerUpdateActions {
 
     @Inject
     private StackLoadBalancerUpdateService stackLoadBalancerUpdateService;
+
+    @Inject
+    private ResourceToCloudResourceConverter cloudResourceConverter;
 
     @Bean(name = "CREATING_LOAD_BALANCER_ENTITY_STATE")
     public Action<?, ?> createLoadBalancerEntityAction() {
@@ -116,8 +121,9 @@ public class StackLoadBalancerUpdateActions {
                 List<LoadBalancerType> loadBalancerTypes = loadBalancerPersistenceService.findByStackId(context.getStack().getId()).stream()
                     .map(LoadBalancer::getType)
                     .collect(Collectors.toList());
+                List<CloudResource> cloudResources = cloudResourceConverter.convert(context.getStack().getResources());
                 return new LoadBalancerMetadataRequest(context.getStack(), context.getCloudContext(), context.getCloudCredential(),
-                    context.getCloudStack(), loadBalancerTypes);
+                    context.getCloudStack(), loadBalancerTypes, cloudResources);
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/LoadBalancerMetadataRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/LoadBalancerMetadataRequest.java
@@ -1,12 +1,14 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer;
 
+import java.util.List;
+
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.common.api.type.LoadBalancerType;
-import java.util.List;
 
 public class LoadBalancerMetadataRequest extends StackEvent {
 
@@ -20,14 +22,17 @@ public class LoadBalancerMetadataRequest extends StackEvent {
 
     private final Stack stack;
 
+    private final List<CloudResource> cloudResources;
+
     public LoadBalancerMetadataRequest(Stack stack, CloudContext cloudContext, CloudCredential cloudCredential, CloudStack cloudStack,
-            List<LoadBalancerType> typesPresentInStack) {
+            List<LoadBalancerType> typesPresentInStack, List<CloudResource> cloudResources) {
         super(stack.getId());
         this.stack = stack;
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
         this.cloudStack = cloudStack;
         this.typesPresentInStack = typesPresentInStack;
+        this.cloudResources = cloudResources;
     }
 
     public CloudContext getCloudContext() {
@@ -48,5 +53,9 @@ public class LoadBalancerMetadataRequest extends StackEvent {
 
     public Stack getStack() {
         return stack;
+    }
+
+    public List<CloudResource> getCloudResources() {
+        return cloudResources;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateLoadBalancerEntityHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateLoadBalancerEntityHandler.java
@@ -95,7 +95,7 @@ public class CreateLoadBalancerEntityHandler extends ExceptionCatcherEventHandle
             }
 
             Set<InstanceGroup> instanceGroups = instanceGroupService.getByStackAndFetchTemplates(stack.getId());
-            instanceGroups.forEach(ig -> ig.setTargetGroups(targetGroupPersistenceService.findByIntanceGroupId(ig.getId())));
+            instanceGroups.forEach(ig -> ig.setTargetGroups(targetGroupPersistenceService.findByInstanceGroupId(ig.getId())));
             Set<LoadBalancer> existingLoadBalancers = loadBalancerPersistenceService.findByStackId(stack.getId());
             stack.setInstanceGroups(instanceGroups);
             Set<LoadBalancer> newLoadBalancers = loadBalancerConfigService.createLoadBalancers(stack, environment, false);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/LoadBalancerMetadataHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/LoadBalancerMetadataHandler.java
@@ -54,7 +54,7 @@ public class LoadBalancerMetadataHandler extends ExceptionCatcherEventHandler<Lo
         try {
             LOGGER.info("Fetch cloud load balancer metadata");
             List<CloudLoadBalancerMetadata> loadBalancerStatuses = loadBalancerMetadataService.collectMetadata(cloudContext,
-                request.getCloudCredential(), request.getTypesPresentInStack());
+                request.getCloudCredential(), request.getTypesPresentInStack(), request.getCloudResources());
 
             Set<CloudLoadBalancerMetadata> failedStatues = loadBalancerStatuses.stream()
                 .filter(this::isMissingMetadata)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/TargetGroupPersistenceService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/TargetGroupPersistenceService.java
@@ -31,7 +31,7 @@ public class TargetGroupPersistenceService {
         return targetGroups;
     }
 
-    public Set<TargetGroup> findByIntanceGroupId(Long instanceGroupId) {
+    public Set<TargetGroup> findByInstanceGroupId(Long instanceGroupId) {
         return repository.findByInstanceGroupId(instanceGroupId);
     }
 }

--- a/core/src/test/resources/input/clouderamanager-multi-knox.bp
+++ b/core/src/test/resources/input/clouderamanager-multi-knox.bp
@@ -1,0 +1,316 @@
+{
+  "cdhVersion": "6.1.0",
+  "products": [
+    {
+      "version": "6.1.0-1.cdh6.1.0.p0.770702",
+      "product": "CDH"
+    }
+  ],
+  "services": [
+    {
+      "refName": "isilon",
+      "serviceType": "ISILON",
+      "serviceConfigs": [
+        {
+          "name": "default_fs_name",
+          "value": "hdfs",
+          "ref": null,
+          "variable": null,
+          "autoConfig": null
+        }
+      ],
+      "roleConfigGroups": null,
+      "roles": null,
+      "displayName": null
+    },
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "serviceConfigs": null,
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        }
+      ],
+      "roles": null,
+      "displayName": null
+    },
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "serviceConfigs": null,
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        },
+        {
+          "refName": "hdfs-SECONDARYNAMENODE-BASE",
+          "roleType": "SECONDARYNAMENODE",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": null,
+          "displayName": null,
+          "configs": null
+        },
+        {
+          "refName": "hdfs-BALANCER-BASE",
+          "roleType": "BALANCER",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        }
+      ],
+      "roles": null,
+      "displayName": null
+    },
+    {
+      "refName": "kafka",
+      "serviceType": "KAFKA",
+      "serviceConfigs": null,
+      "roleConfigGroups": [
+        {
+          "refName": "kafka-KAFKA_BROKER-BASE",
+          "roleType": "KAFKA_BROKER",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        }
+      ],
+      "roles": null,
+      "displayName": null
+    },
+    {
+      "refName": "hbase",
+      "serviceType": "HBASE",
+      "serviceConfigs": null,
+      "roleConfigGroups": [
+        {
+          "refName": "hbase-REGIONSERVER-BASE",
+          "roleType": "REGIONSERVER",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        },
+        {
+          "refName": "hbase-MASTER-BASE",
+          "roleType": "MASTER",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        }
+      ],
+      "roles": null,
+      "displayName": null
+    },
+    {
+      "refName": "yarn",
+      "serviceType": "YARN",
+      "serviceConfigs": null,
+      "roleConfigGroups": [
+        {
+          "refName": "yarn-RESOURCEMANAGER-BASE",
+          "roleType": "RESOURCEMANAGER",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        },
+        {
+          "refName": "yarn-NODEMANAGER-BASE",
+          "roleType": "NODEMANAGER",
+          "base": false,
+          "displayName": null,
+          "configs": null
+        },
+        {
+          "refName": "yarn-JOBHISTORY-BASE",
+          "roleType": "JOBHISTORY",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        }
+      ],
+      "roles": null,
+      "displayName": null
+    },
+    {
+      "refName": "spark_on_yarn",
+      "serviceType": "SPARK_ON_YARN",
+      "serviceConfigs": null,
+      "roleConfigGroups": [
+        {
+          "refName": "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "roleType": "SPARK_YARN_HISTORY_SERVER",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        },
+        {
+          "refName": "spark_on_yarn-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        }
+      ],
+      "roles": null,
+      "displayName": null
+    },
+    {
+      "refName": "hive",
+      "serviceType": "HIVE",
+      "serviceConfigs": null,
+      "roleConfigGroups": [
+        {
+          "refName": "hive-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        },
+        {
+          "refName": "hive-HIVESERVER2-BASE",
+          "roleType": "HIVESERVER2",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        },
+        {
+          "refName": "hive-HIVEMETASTORE-BASE",
+          "roleType": "HIVEMETASTORE",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        }
+      ],
+      "roles": null,
+      "displayName": null
+    },
+    {
+      "refName": "ranger",
+      "serviceType": "RANGER",
+      "serviceConfigs": [
+        {
+          "name": "rangeradmin_user_password",
+          "value": "{{{ general.password }}}",
+          "ref": null,
+          "variable": null,
+          "autoConfig": null
+        }
+      ],
+      "roleConfigGroups": null,
+      "roles": null,
+      "displayName": null
+    },
+    {
+      "refName": "impala",
+      "serviceType": "IMPALA",
+      "serviceConfigs": null,
+      "roleConfigGroups": [
+        {
+          "refName": "impala-IMPALAD-BASE",
+          "roleType": "IMPALAD",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        },
+        {
+          "refName": "impala-STATESTORE-BASE",
+          "roleType": "STATESTORE",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        },
+        {
+          "refName": "impala-CATALOGSERVER-BASE",
+          "roleType": "CATALOGSERVER",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        }
+      ],
+      "roles": null,
+      "displayName": null
+    },
+    {
+      "refName": "knox",
+      "serviceType": "KNOX",
+      "serviceConfigs": null,
+      "roleConfigGroups": [
+        {
+          "refName": "knox-KNOX_GATEWAY-BASE",
+          "roleType": "KNOX_GATEWAY",
+          "base": true,
+          "displayName": null,
+          "configs": null
+        }
+      ],
+      "roles": null,
+      "displayName": null
+    }
+  ],
+  "hostTemplates": [
+    {
+      "refName": "master",
+      "roleConfigGroupsRefNames": [
+        "hbase-MASTER-BASE",
+        "hdfs-BALANCER-BASE",
+        "hdfs-NAMENODE-BASE",
+        "hdfs-SECONDARYNAMENODE-BASE",
+        "hive-GATEWAY-BASE",
+        "hive-HIVEMETASTORE-BASE",
+        "hive-HIVESERVER2-BASE",
+        "impala-CATALOGSERVER-BASE",
+        "impala-STATESTORE-BASE",
+        "kafka-KAFKA_BROKER-BASE",
+        "spark_on_yarn-GATEWAY-BASE",
+        "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+        "yarn-JOBHISTORY-BASE",
+        "yarn-RESOURCEMANAGER-BASE",
+        "zookeeper-SERVER-BASE",
+        "knox-KNOX_GATEWAY-BASE"
+      ],
+      "cardinality": 1
+    },
+    {
+      "refName": "worker",
+      "roleConfigGroupsRefNames": [
+        "hbase-REGIONSERVER-BASE",
+        "hdfs-DATANODE-BASE",
+        "hive-GATEWAY-BASE",
+        "impala-IMPALAD-BASE",
+        "spark_on_yarn-GATEWAY-BASE",
+        "yarn-NODEMANAGER-BASE",
+        "knox-KNOX_GATEWAY-BASE"
+      ],
+      "cardinality": 1
+    }
+  ],
+  "displayName": "simple_template",
+  "cmVersion": "6.1.0",
+  "instantiator": null,
+  "repositories": [
+    "https://archive.cloudera.com/cdh6/{latest_supported}/parcels/",
+    "https://archive.cloudera.com/cdh5/parcels/5.14/",
+    "https://archive.cloudera.com/accumulo-c5/parcels/latest/",
+    "https://archive.cloudera.com/kafka/parcels/latest/",
+    "http://archive.cloudera.com/kudu/parcels/latest/",
+    "https://archive.cloudera.com/spark/parcels/latest/",
+    "https://archive.cloudera.com/sqoop-teradata-connector1/latest/",
+    "https://archive.cloudera.com/sqoop-netezza-connector1/latest/",
+    "https://archive.cloudera.com/sqoop-connectors/parcels/latest/"
+  ],
+  "clusterSpec": null
+}


### PR DESCRIPTION
Closes [CB-10167](https://jira.cloudera.com/browse/CB-10167).

Adds support for Azure load balancers in front of gateway nodes.

For an Azure LB to be set up, it needs a few things:
* The load balancer itself
* A public IP address configuration
* Backend pool (containing NICs to route to)
* Health check rules
* Forwarding rules

## A note on LB SKUs
The LB SKU is `Basic`, because the NICs created for instances are `Basic` and they must be the same.
The `Basic` SKU supports up to 300 instances, does not support multiple AZs, and must route to instances in the same Availability Set.
The `Basic` SKU also does not have an SLA.

The SKU associated with NIC public IPs has been updated, along with load balancer and backend address pools.

## Code changes
The bulk of the changes are in the `arm-v2.ftl` file.
* Addition of a `loadbalancer` resource
* Addition of a `publicIPAddress` resource
* Create a _dependency_ between NICs in the gateway group and the LB
* Place NICs that are part of the gateway group in the backend pool for the gateway load balancer

There are view objects that are used to pass relevant properties into the ARM template. `AzureLoadBalancer`, `AzureLoadBalancerProbe`, and `AzureLoadBalancingRule`.

An implementation of `collectLoadBalancer` is provided in `AzureMetadataCollector` now, courtesy of @hreeve-cloudera, which retrieves the name, type (public/private), and ip address of load balancers.

## Testing
Tested by setting up many, many medium duty datalakes while running CB locally. An example CDP cli incantation:
```
cdp datalake create-azure-datalake \
  --profile default \
  --endpoint-url http://localhost \
  --datalake-name bderriso-borba-sdx \
  --environment-name bderriso-borba \
  --cloud-provider-configuration managedIdentity=<managed-identity>,storageLocation=abfs://data@bderrisorgsan.dfs.core.windows.net \
  --runtime 7.2.7 \
  --scale MEDIUM_DUTY_HA
```

Set up and verified tear down of a LIGHT_DUTY data lake as well.

## Limitations
* See the disclaimer about LB skus above
* Upscale/downscale is not supported yet