### PR TITLE
CB-11020. Metering heartbeat versioning is broken.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/metering/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/metering/settings.sls
@@ -16,14 +16,16 @@
 {% set service_version = salt['pillar.get']('metering:serviceVersion') %}
 {% set stream_name = salt['pillar.get']('metering:streamName') %}
 
-{% if cluster_name and stream_name and stream_name != "Metering" %}
-    {% if "metering_prewarmed_v2" in grains.get('roles', []) or not salt['file.directory_exists' ]('/etc/metering') %}
-        {% set version = 2 %}
-    {% else %}
-        {% set version = 1 %}
-    {% endif %}
+{% set version_data = namespace(entities=[]) %}
+{% for role in grains.get('roles', []) %}
+{% if role.startswith("metering_prewarmed") %}
+  {% set version_data.entities = version_data.entities + [role.split("metering_prewarmed_v")[1]]%}
+{% endif %}
+{% endfor %}
+{% if cluster_name and stream_name and stream_name != "Metering" and version_data.entities|length > 0 %}
+{% set version = version_data.entities[0] | int %}
 {% else %}
-    {% set version = 1 %}
+{% set version = 1 %}
 {% endif %}
 
 {% if salt['pillar.get']('tags:Cloudera-External-Resource-Name') %}


### PR DESCRIPTION
See detailed description in the commit message.

it only uses version 1 or 2, not any newer one, version 3 is already used from 2020 dec 16, that means newer images uses the older metering streams instead of the new ones