### PR TITLE
CB-11025 - [Knox] Increase replayBufferSize value from 64 to 128 for Ranger service

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -444,7 +444,7 @@
         {%- endfor %}
         <param>
             <name>replayBufferSize</name>
-            <value>65</value>
+            <value>128</value>
         </param>
     </service>
     <service>

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -354,7 +354,7 @@
         {%- endfor %}
         <param>
             <name>replayBufferSize</name>
-            <value>65</value>
+            <value>128</value>
         </param>
     </service>
     {%- endif %}


### PR DESCRIPTION
**Describe the change you are making here!**
This change increases the replayBufferSize value from 64 to 128 for Ranger service. This change affects topologies cdp-proxy.xml and cdp-proxy-api.xml. 