### PR TITLE
CB-10578 Populate new targetgroup_loadbalancer table from CB-10095

### DIFF
--- a/core/src/main/resources/schema/app/20210203155101_CB-10578_Populate_targetgroup_loadbalancer_table.sql
+++ b/core/src/main/resources/schema/app/20210203155101_CB-10578_Populate_targetgroup_loadbalancer_table.sql
@@ -1,0 +1,9 @@
+-- // CB-10578 Populate targetgroup_loadbalancer table
+-- Migration SQL that makes the change goes here.
+
+INSERT INTO targetgroup_loadbalancer (SELECT id, loadbalancer_id FROM targetgroup) ON CONFLICT DO NOTHING;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+


### PR DESCRIPTION
Copies data from the targetgroup table's id and loadbalancer_id columns into the new
targetgroup_loadbalancer table. This does not overwrite any rows already in the
targetgroup_loadbalancer table.

See detailed description in the commit message.