### PR TITLE
CB-10942. Add custom UDX headers for diagnostocs support output.

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
@@ -2,6 +2,7 @@ package com.sequenceiq.common.api.telemetry.doc;
 
 public class DiagnosticsModelDescription {
     public static final String ISSUE = "Issue number or JIRA ticket number related to this diagnostic collection request.";
+    public static final String UUID = "Unique identifier for the diagnostics flow. If it's empty, flow ID will be used.";
     public static final String TICKET = "Optional ticket or case number for Cloudera Manager based diagnostic collection request.";
     public static final String LABELS = "With labels you can filter what kind of logs you'd like to collect.";
     public static final String START_TIME = "Start time for the time interval of the diagnostic collection request.";

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/DiagnosticsDataToParameterConverter.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/DiagnosticsDataToParameterConverter.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.telemetry.converter;
 
 import java.nio.file.Paths;
-import java.util.UUID;
 
 import javax.inject.Inject;
 
@@ -70,7 +69,6 @@ public class DiagnosticsDataToParameterConverter {
         }
         builder.withDestination(request.getDestination());
         builder.withDescription(request.getDescription());
-        builder.withUuid(UUID.randomUUID().toString());
         builder.withClusterType(clusterType);
         builder.withClusterVersion(clusterVersion);
         builder.withAccountId(accountId);

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/diagnostics/model/DiagnosticsCollectionRequest.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/diagnostics/model/DiagnosticsCollectionRequest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
 import com.sequenceiq.common.api.diagnostics.BaseDiagnosticsCollectionRequest;
+import com.sequenceiq.common.api.telemetry.doc.DiagnosticsModelDescription;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -19,11 +20,22 @@ public class DiagnosticsCollectionRequest extends BaseDiagnosticsCollectionReque
     @ApiModelProperty(ModelDescriptions.StackModelDescription.CRN)
     private String stackCrn;
 
+    @ApiModelProperty(DiagnosticsModelDescription.UUID)
+    private String uuid;
+
     public String getStackCrn() {
         return stackCrn;
     }
 
     public void setStackCrn(String stackCrn) {
         this.stackCrn = stackCrn;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -127,14 +127,6 @@ public class ModelDescriptions {
         public static final String BLUEPRINT_ID = "id that could indentify an existing cluster defintion";
     }
 
-    public static class DiagnosticsModelDescription {
-        public static final String ISSUE = "Issue number or JIRA ticket number related to this diagnostic collection request.";
-        public static final String LABELS = "With labels you can filter what kind of logs you'd like to collect.";
-        public static final String START_TIME = "Start time for the time interval of the diagnostic collection request.";
-        public static final String END_TIME = "END time for the time interval of the diagnostic collection request.";
-        public static final String DESTINATION = "Destination for the diagnostic collection request.";
-    }
-
     public static class StackModelDescription {
         public static final String TENANANT = "name of the tenant";
         public static final String CRN = "the unique crn of the resource";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/DiagnosticsV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/DiagnosticsV4Controller.java
@@ -51,7 +51,7 @@ public class DiagnosticsV4Controller implements DiagnosticsV4Endpoint {
     public FlowIdentifier collectDiagnostics(@RequestObject @Valid DiagnosticsCollectionRequest request) {
         String userCrn = crnService.getCloudbreakUser().getUserCrn();
         LOGGER.debug("collectDiagnostics called with userCrn '{}' for stack '{}'", userCrn, request.getStackCrn());
-        return diagnosticsTriggerService.startDiagnosticsCollection(request, request.getStackCrn(), userCrn);
+        return diagnosticsTriggerService.startDiagnosticsCollection(request, request.getStackCrn(), userCrn, request.getUuid());
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsInitHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsInitHandler.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ import com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsFlowService;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionEvent;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionFailureEvent;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
+import com.sequenceiq.flow.core.FlowConstants;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
 
@@ -43,6 +45,10 @@ public class DiagnosticsInitHandler extends EventSenderAwareHandler<DiagnosticsC
         Long resourceId = data.getResourceId();
         String resourceCrn = data.getResourceCrn();
         DiagnosticParameters parameters = data.getParameters();
+        if (StringUtils.isBlank(parameters.getUuid())) {
+            LOGGER.debug("UUID is empty for diagnostics... Use flow ID as UUID.");
+            parameters.setUuid(event.getHeaders().get(FlowConstants.FLOW_ID));
+        }
         Map<String, Object> parameterMap = parameters.toMap();
         try {
             LOGGER.debug("Diagnostics collection initialization started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/DiagnosticsTriggerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/DiagnosticsTriggerService.java
@@ -68,7 +68,7 @@ public class DiagnosticsTriggerService {
     private DataBusEndpointProvider dataBusEndpointProvider;
 
     public FlowIdentifier startDiagnosticsCollection(BaseDiagnosticsCollectionRequest request, String stackCrn,
-            String userCrn) {
+            String userCrn, String uuid) {
         Stack stack = stackService.getByCrn(stackCrn);
         MDCBuilder.buildMdcContext(stack);
         LOGGER.debug("Starting diagnostics collection for Stack. Crn: '{}'", stack.getResourceCrn());
@@ -85,6 +85,8 @@ public class DiagnosticsTriggerService {
         DiagnosticParameters parameters = diagnosticsDataToParameterConverter.convert(request, telemetry,
                 StringUtils.upperCase(stack.getType().getResourceType()), clusterVersion,
                 accountId, stack.getRegion(), databusEndpoint);
+        // TODO: use DiagnosticParameters builder for UUID + decrease parameters in the converter above
+        parameters.setUuid(uuid);
         DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                 .withAccepted(new Promise<>())
                 .withResourceId(stack.getId())
@@ -95,6 +97,11 @@ public class DiagnosticsTriggerService {
                 .withHostGroups(parameters.getHostGroups())
                 .build();
         return reactorNotifier.notify(diagnosticsCollectionEvent, getFlowHeaders(userCrn));
+    }
+
+    public FlowIdentifier startDiagnosticsCollection(BaseDiagnosticsCollectionRequest request, String stackCrn,
+            String userCrn) {
+        return startDiagnosticsCollection(request, stackCrn, userCrn, null);
     }
 
     public FlowIdentifier startCmDiagnostics(BaseCmDiagnosticsCollectionRequest request, String stackCrn, String userCrn) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/converter/DiagnosticsParamsConverter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/converter/DiagnosticsParamsConverter.java
@@ -22,6 +22,8 @@ public class DiagnosticsParamsConverter {
 
     private static final String PARAMS_ISSUE = "issue";
 
+    private static final String PARAMS_UUID = "uuid";
+
     private static final String PARAMS_TICKET = "ticket";
 
     private static final String PARAM_DESCRIPTION = "description";
@@ -88,6 +90,7 @@ public class DiagnosticsParamsConverter {
         request.setIncludeSaltLogs((Boolean) Optional.ofNullable(props.get(PARAMS_INCLUDE_SALT_LOGS)).orElse(false));
         request.setUpdatePackage((Boolean) Optional.ofNullable(props.get(PARAMS_UPDATE_PACKAGE)).orElse(false));
         request.setSkipValidation((Boolean) Optional.ofNullable(props.get(PARAMS_SKIP_VALIDATION)).orElse(false));
+        request.setUuid(Optional.ofNullable(props.get(PARAMS_UUID)).map(Object::toString).orElse(null));
         return request;
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/diagnostics/SdxDiagnosticsActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/diagnostics/SdxDiagnosticsActions.java
@@ -32,6 +32,8 @@ public class SdxDiagnosticsActions {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SdxDiagnosticsActions.class);
 
+    private static final String DIAGNOSTICS_UUID_PARAM = "uuid";
+
     @Inject
     private SdxDiagnosticsFlowService diagnosticsFlowService;
 
@@ -47,6 +49,7 @@ public class SdxDiagnosticsActions {
             @Override
             protected void doExecute(SdxContext context, SdxDiagnosticsCollectionEvent payload, Map<Object, Object> variables) {
                 LOGGER.debug("Start diagnostics collection for sdx cluster with id: {}", context.getSdxId());
+                payload.getProperties().put(DIAGNOSTICS_UUID_PARAM, context.getFlowId());
                 FlowIdentifier flowIdentifier = diagnosticsFlowService.startDiagnosticsCollection(payload.getProperties());
                 SdxDiagnosticsCollectionEvent event = new SdxDiagnosticsCollectionEvent(payload.getResourceId(),
                         payload.getUserId(), payload.getProperties(), flowIdentifier);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsInitHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsInitHandler.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
+import com.sequenceiq.flow.core.FlowConstants;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
 import com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsFlowService;
@@ -42,6 +43,8 @@ public class DiagnosticsInitHandler extends EventSenderAwareHandler<DiagnosticsC
         Long resourceId = data.getResourceId();
         String resourceCrn = data.getResourceCrn();
         DiagnosticParameters parameters = data.getParameters();
+        parameters.setUuid(event.getHeaders().get(FlowConstants.FLOW_ID));
+
         Map<String, Object> parameterMap = parameters.toMap();
         try {
             LOGGER.debug("Diagnostics collection initialization started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/extra-dbus-headers.yaml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/extra-dbus-headers.yaml.j2
@@ -1,0 +1,10 @@
+{%- from 'filecollector/settings.sls' import filecollector with context %}
+udx-uuid: "{{ filecollector.uuid }}"
+udx-full-filename: "$filename"
+udx-hostname: "$hostname"
+udx-creator-crn: "{{ filecollector.creatorCrn }}"
+udx-environment-crn: "{{ filecollector.environmentCrn }}"
+udx-resource-crn: "{{ filecollector.resourceCrn }}"
+udx-accountid: "{{ filecollector.accountId }}"
+udx-part-number: "$filePartNum"
+udx-total-parts: "$fileTotalNum"

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/upload.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/upload.sls
@@ -1,3 +1,4 @@
+{%- from 'telemetry/settings.sls' import telemetry with context %}
 {%- from 'filecollector/settings.sls' import filecollector with context %}
 {% if filecollector.mode == "CLOUDERA_MANAGER" %}
 move_support_bundle_to_filecollector:
@@ -15,6 +16,13 @@ filecollector_upload_to_cloud_storage:
 {% endif %}
 
 {% if filecollector.destination == "SUPPORT" %}
+
+{% if telemetry.cdpTelemetryVersion > 3 %}
+    {% set extra_dbus_header_file_param = "-e /opt/cdp-telemetry/conf/extra-dbus-headers.yaml" %}
+{% else %}
+    {% set extra_dbus_header_file_param = "" %}
+{% endif %}
+
 /opt/cdp-telemetry/conf/support_bundle_databus.conf:
    file.managed:
     - source: salt://filecollector/template/support_bundle_databus.conf.j2
@@ -26,7 +34,7 @@ filecollector_upload_to_cloud_storage:
 
 filecollector_upload_to_support:
   cmd.run:
-    - name: "cdp-telemetry databus upload -p '{{ filecollector.compressedFilePattern }}' -c /opt/cdp-telemetry/conf/support_bundle_databus.conf --stream {{ filecollector.supportBundleDbusStreamName }} --url {{ filecollector.dbusUrl }} {{ filecollector.supportBundleDbusHeaders}}"
+    - name: "cdp-telemetry databus upload -p '{{ filecollector.compressedFilePattern }}' -c /opt/cdp-telemetry/conf/support_bundle_databus.conf --stream {{ filecollector.supportBundleDbusStreamName }} --url {{ filecollector.dbusUrl }} {{ extra_dbus_header_file_param }} {{ filecollector.supportBundleDbusHeaders}}"
     - failhard: True
     - env:
         - CDP_TELEMETRY_LOGGER_FILENAME: "upload.log"{% if filecollector.proxyUrl %}{% if filecollector.proxyProtocol == "https" %}


### PR DESCRIPTION
details:
- If newer cdp version is used (0.3.6) - add a new -e (extra databus header file) option to databus upload
- all the new headers will be defined in a file that is provided by that -e option
- in order to fill the required headers - although many of them are available by salt configs - we need to pass them into diagnostics params (like UUID)
- UUID: new request param (only for internal CB API - v4)
- UUID will be the flow ID (for datalake it will be the SDX flow ID, not the core one)
- remove some unused model descriptions

See detailed description in the commit message.