### PR TITLE
CB-11038 Attached disks leaked during a rollback that had been triggered by an upscale failure on Azure

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/exception/RolledbackResourcesException.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/exception/RolledbackResourcesException.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.cloud.exception;
+
+public class RolledbackResourcesException extends CloudConnectorException {
+
+    public RolledbackResourcesException(String message) {
+        super(message);
+    }
+
+    public RolledbackResourcesException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RolledbackResourcesException(Throwable cause) {
+        super(cause);
+    }
+
+    protected RolledbackResourcesException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsAttachmentResourceBuilder.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsAttachmentResourceBuilder.java
@@ -32,6 +32,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
+import com.sequenceiq.cloudbreak.cloud.template.compute.PreserveResourceException;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -103,8 +104,8 @@ public class AwsAttachmentResourceBuilder extends AbstractAwsComputeBuilder {
     }
 
     @Override
-    public CloudResource delete(AwsContext context, AuthenticatedContext auth, CloudResource resource) throws InterruptedException {
-        throw new InterruptedException("Prevent volume resource deletion.");
+    public CloudResource delete(AwsContext context, AuthenticatedContext auth, CloudResource resource) throws PreserveResourceException {
+        throw new PreserveResourceException("Prevent volume resource deletion.");
     }
 
     @Override

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilder.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilder.java
@@ -59,6 +59,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes.Volume;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
+import com.sequenceiq.cloudbreak.cloud.template.compute.PreserveResourceException;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.cloudbreak.util.DeviceNameGenerator;
 import com.sequenceiq.common.api.type.CommonStatus;
@@ -271,7 +272,7 @@ public class AwsVolumeResourceBuilder extends AbstractAwsComputeBuilder {
     }
 
     @Override
-    public CloudResource delete(AwsContext context, AuthenticatedContext auth, CloudResource resource) throws InterruptedException {
+    public CloudResource delete(AwsContext context, AuthenticatedContext auth, CloudResource resource) throws PreserveResourceException {
         LOGGER.debug("Set delete on termination to true, on instances");
         VolumeSetAttributes volumeSetAttributes = resource.getParameter(CloudResource.ATTRIBUTES, VolumeSetAttributes.class);
         List<CloudResourceStatus> cloudResourceStatuses = checkResources(ResourceType.AWS_VOLUMESET, context, auth, List.of(resource));
@@ -283,7 +284,7 @@ public class AwsVolumeResourceBuilder extends AbstractAwsComputeBuilder {
             volumeSetAttributes.setDeleteOnTermination(Boolean.TRUE);
             resource.putParameter(CloudResource.ATTRIBUTES, volumeSetAttributes);
             resourceNotifier.notifyUpdate(resource, auth.getCloudContext());
-            throw new InterruptedException("Resource will be preserved for later reattachment.");
+            throw new PreserveResourceException("Resource will be preserved for later reattachment.");
         }
 
         AmazonEc2RetryClient client = getAmazonEC2Client(auth);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -522,12 +522,12 @@ public class AzureUtils {
 
             Observable<String> deletionObservable = azureClient.deleteManagedDisksAsync(managedDiskIds)
                     .doOnError(throwable -> {
-                        LOGGER.error("Error happened during the deletion of the managed disks ", throwable);
-                        throw new CloudbreakServiceException("Can't delete all managed disks: ", throwable);
+                        LOGGER.error("Error happened during the deletion of the managed disks: " + managedDiskIds, throwable);
+                        throw new CloudbreakServiceException("Can't delete all managed disks: " + managedDiskIds, throwable);
                     })
-                    .doOnCompleted(() -> LOGGER.debug("Delete managed disks completed successfully"))
+                    .doOnCompleted(() -> LOGGER.info("Delete managed disks completed successfully: {}", managedDiskIds))
                     .subscribeOn(Schedulers.io());
-            deletionObservable.subscribe(disk -> LOGGER.debug("Deleting {}", disk));
+            deletionObservable.subscribe(disk -> LOGGER.info("Deleting {}, managed disks ids: {}", disk, managedDiskIds));
             deletionObservable.toCompletable().await();
         }
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureVolumeResourceBuilderTest.java
@@ -47,6 +47,7 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
+import com.sequenceiq.cloudbreak.cloud.template.compute.PreserveResourceException;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
 
@@ -175,7 +176,7 @@ public class AzureVolumeResourceBuilderTest {
     }
 
     @Test
-    public void deleteTestWhenDiskIsDeletedOnAzure() throws InterruptedException {
+    public void deleteTestWhenDiskIsDeletedOnAzure() throws PreserveResourceException {
         CloudResource mock = CloudResource.builder().type(ResourceType.AZURE_RESOURCE_GROUP).name("resource-group").build();
         when(context.getNetworkResources()).thenReturn(List.of(mock));
         ArrayList<VolumeSetAttributes.Volume> volumes = new ArrayList<>();
@@ -190,7 +191,7 @@ public class AzureVolumeResourceBuilderTest {
     }
 
     @Test
-    public void deleteTestWhenDiskIsOnAzureAndNotAttached() throws InterruptedException {
+    public void deleteTestWhenDiskIsOnAzureAndNotAttached() throws PreserveResourceException {
         CloudResource mock = CloudResource.builder().type(ResourceType.AZURE_RESOURCE_GROUP).name("resource-group").build();
         when(context.getNetworkResources()).thenReturn(List.of(mock));
         ArrayList<VolumeSetAttributes.Volume> volumes = new ArrayList<>();
@@ -211,6 +212,9 @@ public class AzureVolumeResourceBuilderTest {
         diskList.add(disk1);
         diskList.add(disk2);
         diskList.add(disk3);
+        Disk disk = mock(Disk.class);
+        when(disk.isAttachedToVirtualMachine()).thenReturn(false);
+        when(azureClient.getDiskById(any())).thenReturn(disk);
         when(pagedList.stream()).thenAnswer(invocation -> diskList.stream());
         when(azureClient.listDisksByResourceGroup(eq("resource-group"))).thenReturn(pagedList);
         ArgumentCaptor<Collection<String>> captor = ArgumentCaptor.forClass(Collection.class);
@@ -223,7 +227,7 @@ public class AzureVolumeResourceBuilderTest {
     }
 
     @Test
-    public void deleteTestWhenDiskIsOnAzureAndAttached() throws InterruptedException {
+    public void deleteTestWhenDiskIsOnAzureAndAttached() throws PreserveResourceException {
         CloudResource mock = CloudResource.builder().type(ResourceType.AZURE_RESOURCE_GROUP).name("resource-group").build();
         when(context.getNetworkResources()).thenReturn(List.of(mock));
         ArrayList<VolumeSetAttributes.Volume> volumes = new ArrayList<>();
@@ -248,16 +252,20 @@ public class AzureVolumeResourceBuilderTest {
         diskList.add(disk1);
         diskList.add(disk2);
         diskList.add(disk3);
+        Disk disk = mock(Disk.class);
+        when(disk.isAttachedToVirtualMachine()).thenReturn(true);
+        when(disk.virtualMachineId()).thenReturn("instance1");
+        when(azureClient.getDiskById(any())).thenReturn(disk);
         when(pagedList.stream()).thenAnswer(invocation -> diskList.stream());
         when(azureClient.listDisksByResourceGroup(eq("resource-group"))).thenReturn(pagedList);
         VirtualMachine virtualMachine = mock(VirtualMachine.class);
-        when(azureClient.getVirtualMachine(any(), eq("instance1"))).thenReturn(virtualMachine);
+        when(azureClient.getVirtualMachine(eq("instance1"))).thenReturn(virtualMachine);
         ArgumentCaptor<Collection<String>> captor = ArgumentCaptor.forClass(Collection.class);
         underTest.delete(context, auth, volumeSetResource);
 
-        verify(azureUtils, times(1)).deleteManagedDisks(any(), captor.capture());
-        verify(azureClient, times(1)).getVirtualMachine(eq("resource-group"), eq("instance1"));
+        verify(azureClient, times(1)).getVirtualMachine(eq("instance1"));
         verify(azureClient, times(1)).detachDiskFromVm(eq("vol1"), eq(virtualMachine));
+        verify(azureUtils, times(1)).deleteManagedDisks(any(), captor.capture());
         Collection<String> deletedAzureManagedDisks = captor.getValue();
         assertThat(deletedAzureManagedDisks, containsInAnyOrder("vol1"));
     }

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/ComputeResourceService.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/ComputeResourceService.java
@@ -291,7 +291,8 @@ public class ComputeResourceService {
                     List<CloudResourceStatus> resourceStatuses = waitForResourceCreations(cloudResourceStatusChunks);
                     List<CloudResourceStatus> failedResources = filterResourceStatuses(resourceStatuses, ResourceStatus.FAILED);
                     CloudFailureContext cloudFailureContext = new CloudFailureContext(auth, new ScaleContext(upscale, adjustmentType, threshold), ctx);
-                    cloudFailureHandler.rollback(cloudFailureContext, failedResources, resourceStatuses, group, resourceBuilders, getFullNodeCount(groups)
+                    cloudFailureHandler.rollbackIfNecessary(cloudFailureContext, failedResources, resourceStatuses, group, resourceBuilders,
+                            getFullNodeCount(groups)
                     );
                     results.addAll(filterResourceStatuses(resourceStatuses, ResourceStatus.CREATED));
                 }

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/PreserveResourceException.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/PreserveResourceException.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.cloudbreak.cloud.template.compute;
+
+public class PreserveResourceException extends Exception {
+
+    public PreserveResourceException(String message) {
+        super(message);
+    }
+
+    public PreserveResourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/ResourceDeleteThread.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/ResourceDeleteThread.java
@@ -65,7 +65,7 @@ public class ResourceDeleteThread implements Callable<ResourceRequestResult<List
             CloudResource deletedResource;
             try {
                 deletedResource = builder.delete(context, auth, resource);
-            } catch (InterruptedException ignored) {
+            } catch (PreserveResourceException ignored) {
                 LOGGER.debug("Preserve resource for later use.");
                 CloudResourceStatus status = new CloudResourceStatus(resource, ResourceStatus.CREATED);
                 return new ResourceRequestResult<>(FutureResult.SUCCESS, Collections.singletonList(status));

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -155,6 +155,7 @@ public enum ResourceEvent {
     STACK_PROVISIONING("stack.provisioning"),
     STACK_INFRASTRUCTURE_TIME("stack.infrastructure.time"),
     STACK_INFRASTRUCTURE_CREATE_FAILED("stack.infrastructure.create.failed"),
+    STACK_INFRASTRUCTURE_ROLLBACK("stack.infrastructure.rollback"),
     STACK_INFRASTRUCTURE_ROLLBACK_FAILED("stack.infrastructure.rollback.failed"),
     STACK_REMOVING_INSTANCE("stack.removing.instance"),
     STACK_SCALING_TERMINATING_HOST_FROM_HOSTGROUP("stack.scaling.terminating.host.from.hostgroup"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -30,6 +30,7 @@ stack.infrastructure.subnets.updating=Updating allowed subnets
 stack.infrastructure.subnets.updated=Allowed subnets updated
 stack.infrastructure.update.failed=Stack update failed. Reason: {0}
 stack.infrastructure.create.failed=Infrastructure creation failed. Reason: {0}
+stack.infrastructure.rollback=Infrastructure rollback. Reason: {0}
 stack.infrastructure.rollback.failed=Infrastructure rollback failed. Reason: {0}
 stack.infrastructure.delete.failed=Infrastructure termination failed. Reason: {0}
 stack.infrastructure.start.failed=Infrastructure start failed. Reason: {0}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/TemplateDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/TemplateDecorator.java
@@ -18,6 +18,7 @@ import com.sequenceiq.cloudbreak.cloud.model.VmType;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterConfig;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType;
 import com.sequenceiq.cloudbreak.cloud.service.CloudParameterService;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.controller.validation.LocationService;
 import com.sequenceiq.cloudbreak.converter.spi.CredentialToExtendedCloudCredentialConverter;
 import com.sequenceiq.cloudbreak.dto.credential.Credential;
@@ -84,6 +85,10 @@ public class TemplateDecorator {
                 .filter(curr -> curr.value().equals(template.getInstanceType())).findFirst().get();
         Map<String, VolumeParameterType> map = platformDisks.getDiskMappings().get(platform);
         VolumeParameterType volumeParameterType = map.get(volumeTemplate.getVolumeType());
+
+        if (volumeParameterType == null) {
+            throw new BadRequestException("Volume type not supported: " + volumeTemplate.getVolumeType());
+        }
 
         return vmType.getVolumeParameterbyVolumeParameterType(volumeParameterType);
     }


### PR DESCRIPTION
In some cases, the managed disks were not rolled back properly in case of a failed infrastructure update. Sometimes some disks are not in "attached" state, but they are attached on Azure. In this fix, we will ask for attachment info from Azure instead of our state information. Also added a retry mechanism to managed disk deletion. Code is extended with more logs.