### PR TITLE
CB-11023 Cannot create datahub cluster with t2 instances. Disabling t…

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -166,8 +166,6 @@ cb:
     disabled.instance.types:
     distrox:
       enabled.instance.types: >
-        t2.large,
-        t2.xlarge,
         m5.xlarge,
         m5.2xlarge,
         m5.4xlarge,


### PR DESCRIPTION
…2 instances for Data Hub

See detailed description in the commit message.