### PR TITLE
CB-9961: Fix Azure redbeams sync to work with single RG

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -57,6 +57,7 @@ import com.microsoft.azure.management.privatedns.v2018_09_01.implementation.priv
 import com.microsoft.azure.management.resources.Deployment;
 import com.microsoft.azure.management.resources.DeploymentMode;
 import com.microsoft.azure.management.resources.DeploymentOperations;
+import com.microsoft.azure.management.resources.GenericResource;
 import com.microsoft.azure.management.resources.ResourceGroup;
 import com.microsoft.azure.management.resources.ResourceGroups;
 import com.microsoft.azure.management.resources.Subscription;
@@ -738,6 +739,10 @@ public class AzureClient {
 
     public void deleteGenericResourceById(String databaseServerId) {
         handleAuthException(() -> azure.genericResources().deleteById(databaseServerId));
+    }
+
+    public GenericResource getGenericResource(String resourceGroup, String namespace, String resourceType,  String resourceId) {
+        return handleAuthException(() -> azure.genericResources().get(resourceGroup, namespace, resourceType, resourceId));
     }
 
     public PagedList<PrivateZone> getPrivateDnsZoneList() {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/connector/resource/AzureDatabaseResourceService.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Service;
 import com.google.common.collect.Lists;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.management.resources.Deployment;
-import com.microsoft.azure.management.resources.ResourceGroup;
+import com.microsoft.azure.management.resources.GenericResource;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureCloudResourceService;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureDatabaseTemplateBuilder;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureDatabaseTemplateProvider;
@@ -50,6 +50,10 @@ public class AzureDatabaseResourceService {
     private static final int POSTGRESQL_SERVER_PORT = 5432;
 
     private static final String DATABASE_SERVER_FQDN = "databaseServerFQDN";
+
+    private static final String PSQL_NAMESPACE = "Microsoft.DBforPostgreSQL";
+
+    private static final String RESOURCE_TYPE = "servers";
 
     @Inject
     private AzureDatabaseTemplateBuilder azureDatabaseTemplateBuilder;
@@ -222,10 +226,12 @@ public class AzureDatabaseResourceService {
         CloudContext cloudContext = ac.getCloudContext();
         AzureClient client = ac.getParameter(AzureClient.class);
         String resourceGroupName = azureResourceGroupMetadataProvider.getResourceGroupName(cloudContext, stack);
-
         try {
-            ResourceGroup resourceGroup = client.getResourceGroup(resourceGroupName);
-            if (resourceGroup == null) {
+            String serverId = stack.getDatabaseServer().getServerId();
+            LOGGER.debug("Retrieving database. Resource group: {}, namespace: {}, resource type: {}, name: {}", resourceGroupName, PSQL_NAMESPACE,
+                    RESOURCE_TYPE, serverId);
+            GenericResource genericResource = client.getGenericResource(resourceGroupName, PSQL_NAMESPACE, RESOURCE_TYPE, serverId);
+            if (genericResource == null) {
                 return ExternalDatabaseStatus.DELETED;
             }
             return ExternalDatabaseStatus.STARTED;


### PR DESCRIPTION
Before this change, the CB checked only the existence of the resource group of the DB.
In case of single RG it's not a proper approach. In this commit I've changed the method to get the DB server from the Azure directly.