### PR TITLE
CDPCP-3685 Update usermanagement.proto and references to account pass…

### DIFF
--- a/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
+++ b/auth-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/usermanagement/UserManagementGrpc.java
@@ -2881,6 +2881,43 @@ public final class UserManagementGrpc {
      return getProcessWorkloadSSOAuthnReqMethod;
   }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getGenerateControlPlaneSSOAuthnReqMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse> METHOD_GENERATE_CONTROL_PLANE_SSOAUTHN_REQ = getGenerateControlPlaneSSOAuthnReqMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse> getGenerateControlPlaneSSOAuthnReqMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse> getGenerateControlPlaneSSOAuthnReqMethod() {
+    return getGenerateControlPlaneSSOAuthnReqMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse> getGenerateControlPlaneSSOAuthnReqMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse> getGenerateControlPlaneSSOAuthnReqMethod;
+    if ((getGenerateControlPlaneSSOAuthnReqMethod = UserManagementGrpc.getGenerateControlPlaneSSOAuthnReqMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getGenerateControlPlaneSSOAuthnReqMethod = UserManagementGrpc.getGenerateControlPlaneSSOAuthnReqMethod) == null) {
+          UserManagementGrpc.getGenerateControlPlaneSSOAuthnReqMethod = getGenerateControlPlaneSSOAuthnReqMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "GenerateControlPlaneSSOAuthnReq"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("GenerateControlPlaneSSOAuthnReq"))
+                  .build();
+          }
+        }
+     }
+     return getGenerateControlPlaneSSOAuthnReqMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getSetWorkloadSubdomainMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadSubdomainRequest,
       com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadSubdomainResponse> METHOD_SET_WORKLOAD_SUBDOMAIN = getSetWorkloadSubdomainMethodHelper();
@@ -3177,6 +3214,43 @@ public final class UserManagementGrpc {
      return getSetActorWorkloadCredentialsMethod;
   }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getValidateActorWorkloadCredentialsMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse> METHOD_VALIDATE_ACTOR_WORKLOAD_CREDENTIALS = getValidateActorWorkloadCredentialsMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse> getValidateActorWorkloadCredentialsMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse> getValidateActorWorkloadCredentialsMethod() {
+    return getValidateActorWorkloadCredentialsMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse> getValidateActorWorkloadCredentialsMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse> getValidateActorWorkloadCredentialsMethod;
+    if ((getValidateActorWorkloadCredentialsMethod = UserManagementGrpc.getValidateActorWorkloadCredentialsMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getValidateActorWorkloadCredentialsMethod = UserManagementGrpc.getValidateActorWorkloadCredentialsMethod) == null) {
+          UserManagementGrpc.getValidateActorWorkloadCredentialsMethod = getValidateActorWorkloadCredentialsMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "ValidateActorWorkloadCredentials"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("ValidateActorWorkloadCredentials"))
+                  .build();
+          }
+        }
+     }
+     return getValidateActorWorkloadCredentialsMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getGetActorWorkloadCredentialsMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsRequest,
       com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse> METHOD_GET_ACTOR_WORKLOAD_CREDENTIALS = getGetActorWorkloadCredentialsMethodHelper();
@@ -3436,6 +3510,43 @@ public final class UserManagementGrpc {
      return getSetWorkloadPasswordPolicyMethod;
   }
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getUnsetWorkloadPasswordPolicyMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse> METHOD_UNSET_WORKLOAD_PASSWORD_POLICY = getUnsetWorkloadPasswordPolicyMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse> getUnsetWorkloadPasswordPolicyMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse> getUnsetWorkloadPasswordPolicyMethod() {
+    return getUnsetWorkloadPasswordPolicyMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse> getUnsetWorkloadPasswordPolicyMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse> getUnsetWorkloadPasswordPolicyMethod;
+    if ((getUnsetWorkloadPasswordPolicyMethod = UserManagementGrpc.getUnsetWorkloadPasswordPolicyMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getUnsetWorkloadPasswordPolicyMethod = UserManagementGrpc.getUnsetWorkloadPasswordPolicyMethod) == null) {
+          UserManagementGrpc.getUnsetWorkloadPasswordPolicyMethod = getUnsetWorkloadPasswordPolicyMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "UnsetWorkloadPasswordPolicy"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("UnsetWorkloadPasswordPolicy"))
+                  .build();
+          }
+        }
+     }
+     return getUnsetWorkloadPasswordPolicyMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   @java.lang.Deprecated // Use {@link #getAssignCloudIdentityMethod()} instead. 
   public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest,
       com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse> METHOD_ASSIGN_CLOUD_IDENTITY = getAssignCloudIdentityMethodHelper();
@@ -3693,6 +3804,117 @@ public final class UserManagementGrpc {
         }
      }
      return getGetUserSyncStateModelMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getListRoleAssignmentsMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse> METHOD_LIST_ROLE_ASSIGNMENTS = getListRoleAssignmentsMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse> getListRoleAssignmentsMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse> getListRoleAssignmentsMethod() {
+    return getListRoleAssignmentsMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse> getListRoleAssignmentsMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse> getListRoleAssignmentsMethod;
+    if ((getListRoleAssignmentsMethod = UserManagementGrpc.getListRoleAssignmentsMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getListRoleAssignmentsMethod = UserManagementGrpc.getListRoleAssignmentsMethod) == null) {
+          UserManagementGrpc.getListRoleAssignmentsMethod = getListRoleAssignmentsMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "ListRoleAssignments"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("ListRoleAssignments"))
+                  .build();
+          }
+        }
+     }
+     return getListRoleAssignmentsMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getGenerateWorkloadAuthTokenMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse> METHOD_GENERATE_WORKLOAD_AUTH_TOKEN = getGenerateWorkloadAuthTokenMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse> getGenerateWorkloadAuthTokenMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse> getGenerateWorkloadAuthTokenMethod() {
+    return getGenerateWorkloadAuthTokenMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse> getGenerateWorkloadAuthTokenMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse> getGenerateWorkloadAuthTokenMethod;
+    if ((getGenerateWorkloadAuthTokenMethod = UserManagementGrpc.getGenerateWorkloadAuthTokenMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getGenerateWorkloadAuthTokenMethod = UserManagementGrpc.getGenerateWorkloadAuthTokenMethod) == null) {
+          UserManagementGrpc.getGenerateWorkloadAuthTokenMethod = getGenerateWorkloadAuthTokenMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "GenerateWorkloadAuthToken"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("GenerateWorkloadAuthToken"))
+                  .build();
+          }
+        }
+     }
+     return getGenerateWorkloadAuthTokenMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getGetWorkloadAuthConfigurationMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse> METHOD_GET_WORKLOAD_AUTH_CONFIGURATION = getGetWorkloadAuthConfigurationMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse> getGetWorkloadAuthConfigurationMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse> getGetWorkloadAuthConfigurationMethod() {
+    return getGetWorkloadAuthConfigurationMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest,
+      com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse> getGetWorkloadAuthConfigurationMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse> getGetWorkloadAuthConfigurationMethod;
+    if ((getGetWorkloadAuthConfigurationMethod = UserManagementGrpc.getGetWorkloadAuthConfigurationMethod) == null) {
+      synchronized (UserManagementGrpc.class) {
+        if ((getGetWorkloadAuthConfigurationMethod = UserManagementGrpc.getGetWorkloadAuthConfigurationMethod) == null) {
+          UserManagementGrpc.getGetWorkloadAuthConfigurationMethod = getGetWorkloadAuthConfigurationMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest, com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "usermanagement.UserManagement", "GetWorkloadAuthConfiguration"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new UserManagementMethodDescriptorSupplier("GetWorkloadAuthConfiguration"))
+                  .build();
+          }
+        }
+     }
+     return getGetWorkloadAuthConfigurationMethod;
   }
 
   /**
@@ -4513,6 +4735,16 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Generate a SSO AuthNRequest for control plane SP-initiated login.
+     * </pre>
+     */
+    public void generateControlPlaneSSOAuthnReq(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getGenerateControlPlaneSSOAuthnReqMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
      * Set the workload subdomain for an account if no such workload domain has
      * been set for a different account before.
      * </pre>
@@ -4608,6 +4840,16 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Validates the actor workloads credentials based on the password policy for the account.
+     * </pre>
+     */
+    public void validateActorWorkloadCredentials(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getValidateActorWorkloadCredentialsMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
      * Retrieves the actor workload credentials.
      * </pre>
      */
@@ -4686,6 +4928,16 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Unsets the workload password policy for an account.
+     * </pre>
+     */
+    public void unsetWorkloadPasswordPolicy(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getUnsetWorkloadPasswordPolicyMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
      * Assign a cloud identity to an actor or group.
      * </pre>
      */
@@ -4752,6 +5004,36 @@ public final class UserManagementGrpc {
     public void getUserSyncStateModel(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelRequest request,
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelResponse> responseObserver) {
       asyncUnimplementedUnaryCall(getGetUserSyncStateModelMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * List all role assignments in an account.
+     * </pre>
+     */
+    public void listRoleAssignments(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getListRoleAssignmentsMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Generate authentication token for workload API.
+     * </pre>
+     */
+    public void generateWorkloadAuthToken(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getGenerateWorkloadAuthTokenMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Get authentication configuration for workload API.
+     * </pre>
+     */
+    public void getWorkloadAuthConfiguration(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getGetWorkloadAuthConfigurationMethodHelper(), responseObserver);
     }
 
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
@@ -5296,6 +5578,13 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ProcessWorkloadSSOAuthnReqResponse>(
                   this, METHODID_PROCESS_WORKLOAD_SSOAUTHN_REQ)))
           .addMethod(
+            getGenerateControlPlaneSSOAuthnReqMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse>(
+                  this, METHODID_GENERATE_CONTROL_PLANE_SSOAUTHN_REQ)))
+          .addMethod(
             getSetWorkloadSubdomainMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
@@ -5352,6 +5641,13 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse>(
                   this, METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS)))
           .addMethod(
+            getValidateActorWorkloadCredentialsMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse>(
+                  this, METHODID_VALIDATE_ACTOR_WORKLOAD_CREDENTIALS)))
+          .addMethod(
             getGetActorWorkloadCredentialsMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
@@ -5401,6 +5697,13 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse>(
                   this, METHODID_SET_WORKLOAD_PASSWORD_POLICY)))
           .addMethod(
+            getUnsetWorkloadPasswordPolicyMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse>(
+                  this, METHODID_UNSET_WORKLOAD_PASSWORD_POLICY)))
+          .addMethod(
             getAssignCloudIdentityMethodHelper(),
             asyncUnaryCall(
               new MethodHandlers<
@@ -5449,6 +5752,27 @@ public final class UserManagementGrpc {
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelRequest,
                 com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelResponse>(
                   this, METHODID_GET_USER_SYNC_STATE_MODEL)))
+          .addMethod(
+            getListRoleAssignmentsMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse>(
+                  this, METHODID_LIST_ROLE_ASSIGNMENTS)))
+          .addMethod(
+            getGenerateWorkloadAuthTokenMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse>(
+                  this, METHODID_GENERATE_WORKLOAD_AUTH_TOKEN)))
+          .addMethod(
+            getGetWorkloadAuthConfigurationMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest,
+                com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse>(
+                  this, METHODID_GET_WORKLOAD_AUTH_CONFIGURATION)))
           .build();
     }
   }
@@ -6339,6 +6663,17 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Generate a SSO AuthNRequest for control plane SP-initiated login.
+     * </pre>
+     */
+    public void generateControlPlaneSSOAuthnReq(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getGenerateControlPlaneSSOAuthnReqMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
      * Set the workload subdomain for an account if no such workload domain has
      * been set for a different account before.
      * </pre>
@@ -6442,6 +6777,17 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Validates the actor workloads credentials based on the password policy for the account.
+     * </pre>
+     */
+    public void validateActorWorkloadCredentials(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getValidateActorWorkloadCredentialsMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
      * Retrieves the actor workload credentials.
      * </pre>
      */
@@ -6527,6 +6873,17 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Unsets the workload password policy for an account.
+     * </pre>
+     */
+    public void unsetWorkloadPasswordPolicy(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getUnsetWorkloadPasswordPolicyMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
      * Assign a cloud identity to an actor or group.
      * </pre>
      */
@@ -6600,6 +6957,39 @@ public final class UserManagementGrpc {
         io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelResponse> responseObserver) {
       asyncUnaryCall(
           getChannel().newCall(getGetUserSyncStateModelMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * List all role assignments in an account.
+     * </pre>
+     */
+    public void listRoleAssignments(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getListRoleAssignmentsMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Generate authentication token for workload API.
+     * </pre>
+     */
+    public void generateWorkloadAuthToken(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getGenerateWorkloadAuthTokenMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * Get authentication configuration for workload API.
+     * </pre>
+     */
+    public void getWorkloadAuthConfiguration(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getGetWorkloadAuthConfigurationMethodHelper(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -7412,6 +7802,16 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Generate a SSO AuthNRequest for control plane SP-initiated login.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse generateControlPlaneSSOAuthnReq(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getGenerateControlPlaneSSOAuthnReqMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * Set the workload subdomain for an account if no such workload domain has
      * been set for a different account before.
      * </pre>
@@ -7507,6 +7907,16 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Validates the actor workloads credentials based on the password policy for the account.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse validateActorWorkloadCredentials(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getValidateActorWorkloadCredentialsMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * Retrieves the actor workload credentials.
      * </pre>
      */
@@ -7585,6 +7995,16 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Unsets the workload password policy for an account.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse unsetWorkloadPasswordPolicy(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getUnsetWorkloadPasswordPolicyMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
      * Assign a cloud identity to an actor or group.
      * </pre>
      */
@@ -7651,6 +8071,36 @@ public final class UserManagementGrpc {
     public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelResponse getUserSyncStateModel(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelRequest request) {
       return blockingUnaryCall(
           getChannel(), getGetUserSyncStateModelMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * List all role assignments in an account.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse listRoleAssignments(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getListRoleAssignmentsMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Generate authentication token for workload API.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse generateWorkloadAuthToken(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getGenerateWorkloadAuthTokenMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Get authentication configuration for workload API.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse getWorkloadAuthConfiguration(com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getGetWorkloadAuthConfigurationMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -8540,6 +8990,17 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Generate a SSO AuthNRequest for control plane SP-initiated login.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse> generateControlPlaneSSOAuthnReq(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getGenerateControlPlaneSSOAuthnReqMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
      * Set the workload subdomain for an account if no such workload domain has
      * been set for a different account before.
      * </pre>
@@ -8643,6 +9104,17 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Validates the actor workloads credentials based on the password policy for the account.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse> validateActorWorkloadCredentials(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getValidateActorWorkloadCredentialsMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
      * Retrieves the actor workload credentials.
      * </pre>
      */
@@ -8728,6 +9200,17 @@ public final class UserManagementGrpc {
 
     /**
      * <pre>
+     * Unsets the workload password policy for an account.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse> unsetWorkloadPasswordPolicy(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getUnsetWorkloadPasswordPolicyMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
      * Assign a cloud identity to an actor or group.
      * </pre>
      */
@@ -8801,6 +9284,39 @@ public final class UserManagementGrpc {
         com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelRequest request) {
       return futureUnaryCall(
           getChannel().newCall(getGetUserSyncStateModelMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * List all role assignments in an account.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse> listRoleAssignments(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getListRoleAssignmentsMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Generate authentication token for workload API.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse> generateWorkloadAuthToken(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getGenerateWorkloadAuthTokenMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * Get authentication configuration for workload API.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse> getWorkloadAuthConfiguration(
+        com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getGetWorkloadAuthConfigurationMethodHelper(), getCallOptions()), request);
     }
   }
 
@@ -8881,28 +9397,34 @@ public final class UserManagementGrpc {
   private static final int METHODID_SET_CLOUDERA_SSOLOGIN_ENABLED = 74;
   private static final int METHODID_GET_ID_PMETADATA_FOR_WORKLOAD_SSO = 75;
   private static final int METHODID_PROCESS_WORKLOAD_SSOAUTHN_REQ = 76;
-  private static final int METHODID_SET_WORKLOAD_SUBDOMAIN = 77;
-  private static final int METHODID_CREATE_WORKLOAD_MACHINE_USER = 78;
-  private static final int METHODID_DELETE_WORKLOAD_MACHINE_USER = 79;
-  private static final int METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 80;
-  private static final int METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 81;
-  private static final int METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME = 82;
-  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS = 83;
-  private static final int METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS = 84;
-  private static final int METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS = 85;
-  private static final int METHODID_GET_EVENT_GENERATION_IDS = 86;
-  private static final int METHODID_ADD_ACTOR_SSH_PUBLIC_KEY = 87;
-  private static final int METHODID_LIST_ACTOR_SSH_PUBLIC_KEYS = 88;
-  private static final int METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY = 89;
-  private static final int METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY = 90;
-  private static final int METHODID_SET_WORKLOAD_PASSWORD_POLICY = 91;
-  private static final int METHODID_ASSIGN_CLOUD_IDENTITY = 92;
-  private static final int METHODID_UNASSIGN_CLOUD_IDENTITY = 93;
-  private static final int METHODID_ASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 94;
-  private static final int METHODID_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 95;
-  private static final int METHODID_LIST_SERVICE_PRINCIPAL_CLOUD_IDENTITIES = 96;
-  private static final int METHODID_GET_DEFAULT_IDENTITY_PROVIDER_CONNECTOR = 97;
-  private static final int METHODID_GET_USER_SYNC_STATE_MODEL = 98;
+  private static final int METHODID_GENERATE_CONTROL_PLANE_SSOAUTHN_REQ = 77;
+  private static final int METHODID_SET_WORKLOAD_SUBDOMAIN = 78;
+  private static final int METHODID_CREATE_WORKLOAD_MACHINE_USER = 79;
+  private static final int METHODID_DELETE_WORKLOAD_MACHINE_USER = 80;
+  private static final int METHODID_GET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 81;
+  private static final int METHODID_SET_WORKLOAD_ADMINISTRATION_GROUP_NAME = 82;
+  private static final int METHODID_DELETE_WORKLOAD_ADMINISTRATION_GROUP_NAME = 83;
+  private static final int METHODID_LIST_WORKLOAD_ADMINISTRATION_GROUPS = 84;
+  private static final int METHODID_SET_ACTOR_WORKLOAD_CREDENTIALS = 85;
+  private static final int METHODID_VALIDATE_ACTOR_WORKLOAD_CREDENTIALS = 86;
+  private static final int METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS = 87;
+  private static final int METHODID_GET_EVENT_GENERATION_IDS = 88;
+  private static final int METHODID_ADD_ACTOR_SSH_PUBLIC_KEY = 89;
+  private static final int METHODID_LIST_ACTOR_SSH_PUBLIC_KEYS = 90;
+  private static final int METHODID_DESCRIBE_ACTOR_SSH_PUBLIC_KEY = 91;
+  private static final int METHODID_DELETE_ACTOR_SSH_PUBLIC_KEY = 92;
+  private static final int METHODID_SET_WORKLOAD_PASSWORD_POLICY = 93;
+  private static final int METHODID_UNSET_WORKLOAD_PASSWORD_POLICY = 94;
+  private static final int METHODID_ASSIGN_CLOUD_IDENTITY = 95;
+  private static final int METHODID_UNASSIGN_CLOUD_IDENTITY = 96;
+  private static final int METHODID_ASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 97;
+  private static final int METHODID_UNASSIGN_SERVICE_PRINCIPAL_CLOUD_IDENTITY = 98;
+  private static final int METHODID_LIST_SERVICE_PRINCIPAL_CLOUD_IDENTITIES = 99;
+  private static final int METHODID_GET_DEFAULT_IDENTITY_PROVIDER_CONNECTOR = 100;
+  private static final int METHODID_GET_USER_SYNC_STATE_MODEL = 101;
+  private static final int METHODID_LIST_ROLE_ASSIGNMENTS = 102;
+  private static final int METHODID_GENERATE_WORKLOAD_AUTH_TOKEN = 103;
+  private static final int METHODID_GET_WORKLOAD_AUTH_CONFIGURATION = 104;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -9229,6 +9751,10 @@ public final class UserManagementGrpc {
           serviceImpl.processWorkloadSSOAuthnReq((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ProcessWorkloadSSOAuthnReqRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ProcessWorkloadSSOAuthnReqResponse>) responseObserver);
           break;
+        case METHODID_GENERATE_CONTROL_PLANE_SSOAUTHN_REQ:
+          serviceImpl.generateControlPlaneSSOAuthnReq((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateControlPlaneSSOAuthnReqResponse>) responseObserver);
+          break;
         case METHODID_SET_WORKLOAD_SUBDOMAIN:
           serviceImpl.setWorkloadSubdomain((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadSubdomainRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadSubdomainResponse>) responseObserver);
@@ -9261,6 +9787,10 @@ public final class UserManagementGrpc {
           serviceImpl.setActorWorkloadCredentials((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetActorWorkloadCredentialsResponse>) responseObserver);
           break;
+        case METHODID_VALIDATE_ACTOR_WORKLOAD_CREDENTIALS:
+          serviceImpl.validateActorWorkloadCredentials((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ValidateActorWorkloadCredentialsResponse>) responseObserver);
+          break;
         case METHODID_GET_ACTOR_WORKLOAD_CREDENTIALS:
           serviceImpl.getActorWorkloadCredentials((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetActorWorkloadCredentialsResponse>) responseObserver);
@@ -9289,6 +9819,10 @@ public final class UserManagementGrpc {
           serviceImpl.setWorkloadPasswordPolicy((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.SetWorkloadPasswordPolicyResponse>) responseObserver);
           break;
+        case METHODID_UNSET_WORKLOAD_PASSWORD_POLICY:
+          serviceImpl.unsetWorkloadPasswordPolicy((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.UnsetWorkloadPasswordPolicyResponse>) responseObserver);
+          break;
         case METHODID_ASSIGN_CLOUD_IDENTITY:
           serviceImpl.assignCloudIdentity((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.AssignCloudIdentityResponse>) responseObserver);
@@ -9316,6 +9850,18 @@ public final class UserManagementGrpc {
         case METHODID_GET_USER_SYNC_STATE_MODEL:
           serviceImpl.getUserSyncStateModel((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetUserSyncStateModelResponse>) responseObserver);
+          break;
+        case METHODID_LIST_ROLE_ASSIGNMENTS:
+          serviceImpl.listRoleAssignments((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.ListRoleAssignmentsResponse>) responseObserver);
+          break;
+        case METHODID_GENERATE_WORKLOAD_AUTH_TOKEN:
+          serviceImpl.generateWorkloadAuthToken((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GenerateWorkloadAuthTokenResponse>) responseObserver);
+          break;
+        case METHODID_GET_WORKLOAD_AUTH_CONFIGURATION:
+          serviceImpl.getWorkloadAuthConfiguration((com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.usermanagement.UserManagementProto.GetWorkloadAuthConfigurationResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -9455,6 +10001,7 @@ public final class UserManagementGrpc {
               .addMethod(getSetClouderaSSOLoginEnabledMethodHelper())
               .addMethod(getGetIdPMetadataForWorkloadSSOMethodHelper())
               .addMethod(getProcessWorkloadSSOAuthnReqMethodHelper())
+              .addMethod(getGenerateControlPlaneSSOAuthnReqMethodHelper())
               .addMethod(getSetWorkloadSubdomainMethodHelper())
               .addMethod(getCreateWorkloadMachineUserMethodHelper())
               .addMethod(getDeleteWorkloadMachineUserMethodHelper())
@@ -9463,6 +10010,7 @@ public final class UserManagementGrpc {
               .addMethod(getDeleteWorkloadAdministrationGroupNameMethodHelper())
               .addMethod(getListWorkloadAdministrationGroupsMethodHelper())
               .addMethod(getSetActorWorkloadCredentialsMethodHelper())
+              .addMethod(getValidateActorWorkloadCredentialsMethodHelper())
               .addMethod(getGetActorWorkloadCredentialsMethodHelper())
               .addMethod(getGetEventGenerationIdsMethodHelper())
               .addMethod(getAddActorSshPublicKeyMethodHelper())
@@ -9470,6 +10018,7 @@ public final class UserManagementGrpc {
               .addMethod(getDescribeActorSshPublicKeyMethodHelper())
               .addMethod(getDeleteActorSshPublicKeyMethodHelper())
               .addMethod(getSetWorkloadPasswordPolicyMethodHelper())
+              .addMethod(getUnsetWorkloadPasswordPolicyMethodHelper())
               .addMethod(getAssignCloudIdentityMethodHelper())
               .addMethod(getUnassignCloudIdentityMethodHelper())
               .addMethod(getAssignServicePrincipalCloudIdentityMethodHelper())
@@ -9477,6 +10026,9 @@ public final class UserManagementGrpc {
               .addMethod(getListServicePrincipalCloudIdentitiesMethodHelper())
               .addMethod(getGetDefaultIdentityProviderConnectorMethodHelper())
               .addMethod(getGetUserSyncStateModelMethodHelper())
+              .addMethod(getListRoleAssignmentsMethodHelper())
+              .addMethod(getGenerateWorkloadAuthTokenMethodHelper())
+              .addMethod(getGetWorkloadAuthConfigurationMethodHelper())
               .build();
         }
       }

--- a/auth-connector/src/main/proto/usermanagement.proto
+++ b/auth-connector/src/main/proto/usermanagement.proto
@@ -341,6 +341,10 @@ service UserManagement {
   rpc ProcessWorkloadSSOAuthnReq(ProcessWorkloadSSOAuthnReqRequest)
     returns (ProcessWorkloadSSOAuthnReqResponse) {}
 
+  // Generate a SSO AuthNRequest for control plane SP-initiated login.
+  rpc GenerateControlPlaneSSOAuthnReq(GenerateControlPlaneSSOAuthnReqRequest)
+    returns (GenerateControlPlaneSSOAuthnReqResponse) {}
+
   // Set the workload subdomain for an account if no such workload domain has
   // been set for a different account before.
   rpc SetWorkloadSubdomain(SetWorkloadSubdomainRequest)
@@ -388,6 +392,10 @@ service UserManagement {
   rpc SetActorWorkloadCredentials(SetActorWorkloadCredentialsRequest)
     returns (SetActorWorkloadCredentialsResponse) {}
 
+  // Validates the actor workloads credentials based on the password policy for the account.
+  rpc ValidateActorWorkloadCredentials(ValidateActorWorkloadCredentialsRequest)
+    returns (ValidateActorWorkloadCredentialsResponse) {}
+
   // Retrieves the actor workload credentials.
   rpc GetActorWorkloadCredentials(GetActorWorkloadCredentialsRequest)
     returns (GetActorWorkloadCredentialsResponse) {}
@@ -424,6 +432,10 @@ service UserManagement {
   rpc SetWorkloadPasswordPolicy (SetWorkloadPasswordPolicyRequest)
     returns (SetWorkloadPasswordPolicyResponse) {}
 
+  // Unsets the workload password policy for an account.
+  rpc UnsetWorkloadPasswordPolicy (UnsetWorkloadPasswordPolicyRequest)
+    returns (UnsetWorkloadPasswordPolicyResponse) {}
+
   // Assign a cloud identity to an actor or group.
   rpc AssignCloudIdentity (AssignCloudIdentityRequest)
     returns (AssignCloudIdentityResponse) {}
@@ -451,6 +463,18 @@ service UserManagement {
   // Get user sync state model, including actors, groups, workload administration groups, etc
   rpc GetUserSyncStateModel (GetUserSyncStateModelRequest)
     returns (GetUserSyncStateModelResponse) {}
+
+  // List all role assignments in an account.
+  rpc ListRoleAssignments (ListRoleAssignmentsRequest)
+      returns (ListRoleAssignmentsResponse) {}
+
+  // Generate authentication token for workload API.
+  rpc GenerateWorkloadAuthToken (GenerateWorkloadAuthTokenRequest)
+    returns (GenerateWorkloadAuthTokenResponse) {}
+
+  // Get authentication configuration for workload API.
+  rpc GetWorkloadAuthConfiguration(GetWorkloadAuthConfigurationRequest)
+    returns (GetWorkloadAuthConfigurationResponse) {}
 }
 
 // The state of the actor.
@@ -1182,8 +1206,10 @@ message Account {
   // Note that this is ensured to be unique, that is, there will not be two
   // accounts with the same workload sub domain.
   string workloadSubdomain = 14;
-  // The workload password policy.
-  WorkloadPasswordPolicy passwordPolicy = 15;
+  // The global workload password policy.
+  WorkloadPasswordPolicy globalPasswordPolicy = 15;
+  // The workload password policy for machine users.
+  WorkloadPasswordPolicy machineUserPasswordPolicy = 16;
 }
 
 // Either the accountId or externalAccountId is required to get
@@ -1736,9 +1762,10 @@ message ListMachineUsersRequest {
   // Whether to include workload machine users. All regular machine users are
   // workload machine users. This is a subset of the internal machine users,
   // which have a password set. This field has no effect if internal machine
-  // users are requested because all workload machine users will already be
-  // included in the results. Note that this has no impact when listing by name
-  // or CRN. For those calls, internal machine users are always returned.
+  // users are requested (`includeInternal` is `true`) because all workload
+  // machine users will already be included in the results. Note that this has
+  // no impact when listing by name or CRN. For those calls, internal machine
+  // users are always returned.
   bool includeWorkloadMachineUsers = 7;
   // See the PageToken comment in paging.proto on paging usage.
   int32 pageSize = 3;
@@ -1756,6 +1783,9 @@ message DeleteMachineUserRequest {
   string accountId = 1;
   // The name or crn of the machine user to delete.
   string machineUserNameOrCrn = 2;
+  // Whether to delete the machine user immediately (and in rare cases risk
+  // orphaning associated resources) or spend more time to fully clean up.
+  bool unsafeDelete = 3;
 }
 
 message DeleteMachineUserResponse {
@@ -1778,6 +1808,18 @@ message WorkloadPasswordPolicyStorage {
   // Account-wide max lifetime, in ms, of actors workload passwords.
   // The magic value 0 indicates that passwords never expire.
   uint64 workloadPasswordMaxLifetime = 1;
+  // The min length of a password. Can be any number between 6 and 256.
+  // The default minimum password length is 1.
+  uint32 minPasswordLength = 2;
+  // Whether passwords must include upper case characters. The default is 'false'.
+  bool mustIncludeUpperCaseCharacters = 3;
+  // Whether passwords must include lower case characters. The default is 'false'.
+  bool mustIncludeLowerCaseCharacters = 4;
+  // Whether passwords must include numbers. The default is 'false'.
+  bool mustIncludeNumbers = 5;
+  // Whether passwords must include symbols. The symbols are '#', '&', '*', '$', '%',
+  // '@', '^', '.', '_', and '!'. The default is 'false'.
+  bool mustIncludeSymbols = 6;
 }
 
 // Object used to serialize account metadata that does not require its own
@@ -1790,8 +1832,11 @@ message AccountDetails {
   repeated EntitlementGrant entitlement = 2;
   // Whether login using Cloudera SSO is disabled
   bool clouderaSSOLoginDisabled = 3;
-  // The account workload password policy
-  WorkloadPasswordPolicyStorage passwordPolicy = 4;
+  // The global password policy.
+  WorkloadPasswordPolicyStorage globalPasswordPolicy = 4;
+  // The password policy for machine users. If set, this will be used for enforcing
+  // password complexity for machine users instead of the global password policy
+  WorkloadPasswordPolicyStorage machineUsersPasswordPolicy = 5;
 }
 
 // Set Account Messages request object.
@@ -2040,6 +2085,10 @@ message ListGroupMembersRequest {
   // See the PageToken comment in paging.proto on paging usage.
   int32 pageSize = 3;
   paging.PageToken pageToken = 4;
+  // Whether to list the group memberships of a deleted group. When it is 'true',
+  // the request must pass group CRN. It must ALWAYS be 'false' for public API calls,
+  // irrespective of whether the request contains a group name or CRN.
+  bool includeDeleted = 5;
 }
 
 message ListGroupMembersResponse {
@@ -2163,7 +2212,10 @@ message LdapProviderDetails {
   // certificate can match or chain to. For self-signed certificates, the certificate is its own CA, and must be provided.
   // For PEM encoded certificates, supported types are "TRUSTED CERTIFICATE", "X509 CERTIFICATE", and "CERTIFICATE".
   // If the user is setup with a referral, we must provide certificates which can verify connection to every server
-  repeated string tlsCaCertificates = 10;
+  repeated string tlsCaCertificates = 10 [(options.FieldExtension.sensitive) = true];
+
+  // Indicates whether a start TLS request should be initiated on connecting to ldap.
+  bool startTls = 19;
 
   // All LDAP servers are slightly different in their own way. Information required to create a UMS user might be stored under
   // a different attribute. Following properties would help in mapping attributes from a given LDAP server.
@@ -2227,6 +2279,8 @@ message SamlProviderInfo {
   string metadata = 1;
   // The certs provided to us in the IdP metadata xml.
   repeated SamlCert certs = 2;
+  // The XML SAML metadata we provided to the customer.
+  string cdpSpMetadata = 3;
 }
 
 // Information about an LDAP identity provider connector. Certain fields may
@@ -2280,7 +2334,10 @@ message LdapProviderInfo {
   // certificate can match or chain to. For self-signed certificates, the certificate is its own CA, and must be provided.
   // For PEM encoded certificates, supported types are "TRUSTED CERTIFICATE", "X509 CERTIFICATE", and "CERTIFICATE".
   // If the user is setup with a referral, we must provide certificates which can verify connection to every server
-  repeated string tlsCaCertificates = 10;
+  repeated string tlsCaCertificates = 10 [(options.FieldExtension.sensitive) = true];
+
+  // Indicates whether a start TLS request should be initiated on connecting to ldap.
+  bool startTls = 19;
 
   // All LDAP servers are slightly different in their own way. Information required to create a UMS user might be stored under
   // a different attribute. Following properties would help in mapping attributes from a given LDAP server.
@@ -2421,6 +2478,8 @@ message SamlIdpDetails {
   string metadataXml = 1 [(options.FieldExtension.skipLogging) = true];
   // The certs provided to us in the IdP metadata xml.
   repeated SamlCert certs = 2;
+  // The XML SAML metadata we provided to the customer.
+  string cdpSpMetadata = 3;
 }
 
 // The IdP connector details for a LDAP typed connector. Used only for
@@ -2474,7 +2533,10 @@ message LdapIdpDetails {
   // certificate can match or chain to. For self-signed certificates, the certificate is its own CA, and must be provided.
   // For PEM encoded certificates, supported types are "TRUSTED CERTIFICATE", "X509 CERTIFICATE", and "CERTIFICATE".
   // If the user is setup with a referral, we must provide certificates which can verify connection to every server
-  repeated string tlsCaCertificates = 10;
+  repeated string tlsCaCertificates = 10 [(options.FieldExtension.sensitive) = true];
+
+  // Indicates whether a start TLS request should be initiated on connecting to ldap.
+  bool startTls = 19;
 
   // All LDAP servers are slightly different in their own way. Information required to create a UMS user might be stored under
   // a different attribute. Following properties would help in mapping attributes from a given LDAP server.
@@ -2604,11 +2666,21 @@ message IdpAuthnRequest {
   // Where to send the authn request. This can be either cloudera sso or a
   // customer identity provider.
   string destination = 1;
-  // The HTTP method to use to send the request. This is one
+  // The HTTP method to use to send the request. This is one of
   // 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST' or
-  // 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
+  // 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'.
   string binding = 2;
-  // The authn response - a SAML 2.0 signed authn response.
+  // A SAML 2.0 authn request. This is unsigned unless the customer's IdP metadata specifies
+  // `WantAuthnRequestsSigned="true"`.
+  // How we send a signed request is dependent on the `binding`:
+  // - HTTP-POST: Send the authnRequest with an embedded signature.
+  // - HTTP-Redirect: Send the authnRequest as three query parameters:
+  //   - The unsigned authnRequest.
+  //   - The signature.
+  //   - The signing algorithm.
+  // Note: we currently only support signing authn requests over HTTP-POST (that is, the
+  // `IDPSSODescriptor` > `SingleSignOnService` `Binding` is HTTP-POST).
+  // See CDPCP-3590.
   string authnRequest = 3 [(options.FieldExtension.skipLogging) = true];
 }
 
@@ -2865,6 +2937,10 @@ message ActorDetails {
   repeated StoredKerberosKey kerberosKeys = 2;
   // A list of ssh public keys for the actor.
   repeated SshPublicKeyStorage sshPublicKeys = 3;
+  // The version of the actor's workload credentials. Version numbering begins at
+  // zero. The version is incremented whenever any change is persisted to the actor's
+  // password hash, password hash expiration, kerberos keys, or ssh public keys.
+  int64 workloadCredentialsVersion = 7;
   // Cloud identities assigned to the actor.
   CloudIdentitiesStorage cloudIdentities = 5;
 }
@@ -2892,6 +2968,16 @@ message SetActorWorkloadCredentialsRequest {
 }
 
 message SetActorWorkloadCredentialsResponse {
+}
+
+message ValidateActorWorkloadCredentialsRequest {
+  // The actor's CRN
+  string actorCrn = 1;
+  // The CDP workload password to validate.
+  string password = 2 [(options.FieldExtension.sensitive) = true];
+}
+
+message ValidateActorWorkloadCredentialsResponse {
 }
 
 // Definition of a Kerberos Key used in rpc calls (vs storage)
@@ -2925,6 +3011,8 @@ message GetActorWorkloadCredentialsResponse {
   string workloadUsername = 4;
   // A list of Ssh public keys for the actor.
   repeated SshPublicKey sshPublicKey = 5;
+  // The version number of the workload credentials. Version numbering begins at zero.
+  int64 workloadCredentialsVersion = 6;
 }
 
 message GetEventGenerationIdsRequest {
@@ -3056,16 +3144,43 @@ message WorkloadPasswordPolicy {
   // Account-wide max lifetime, in ms, of actors workload passwords.
   // The magic value 0 indicates that passwords never expire.
   uint64 workloadPasswordMaxLifetime = 1;
+  // The min length of a password. Can be any number between 6 and 256.
+  // The default minimum password length is 1.
+  uint32 minPasswordLength = 2;
+  // Whether passwords must include upper case characters. The default is 'false'.
+  bool mustIncludeUpperCaseCharacters = 3;
+  // Whether passwords must include lower case characters. The default is 'false'.
+  bool mustIncludeLowerCaseCharacters = 4;
+  // Whether passwords must include numbers. The default is 'false'.
+  bool mustIncludeNumbers = 5;
+  // Whether passwords must include symbols. The symbols are '#', '&', '*', '$', '%',
+  // '@', '^', '.', '_', and '!'. The default is 'false'.
+  bool mustIncludeSymbols = 6;
 }
 
 message SetWorkloadPasswordPolicyRequest {
   // The account ID
   string accountId = 1;
-  // The password policy to set.
-  WorkloadPasswordPolicy policy = 2;
+  // The global password policy to set.
+  WorkloadPasswordPolicy globalPolicy = 2;
+  // The password policy for machine users. If set, this will be used for enforcing
+  // password complexity for machine users instead of the global password policy
+  WorkloadPasswordPolicy machineUsersPolicy = 3;
 }
 
 message SetWorkloadPasswordPolicyResponse {
+}
+
+message UnsetWorkloadPasswordPolicyRequest {
+  // The account ID
+  string accountId = 1;
+  // Whether to unset the global password policy.
+  bool unsetGlobalPolicy = 2;
+  // Whether to unset the machine user policy
+  bool unsetMachineUsersPolicy = 3;
+}
+
+message UnsetWorkloadPasswordPolicyResponse {
 }
 
 // A namespace for cloud identities. All cloud identities exist within a cloud
@@ -3218,7 +3333,8 @@ message GetUserSyncStateModelRequest {
   // The account id.
   string accountId = 1;
   // The rights checks to be performed on each actor. The response model contains
-  // all actors and the results of these rights checks for each actor.
+  // actors that pass at least one of these rights checks. The results of the rights
+  // checks are included in the response for each included actor.
   repeated RightsCheck rightsCheck = 2;
 }
 
@@ -3226,8 +3342,9 @@ message GetUserSyncStateModelResponse {
   // Event generation ids when the user sync state model is created. The responses are guaranteed
   // to be at least as recent as the event generation ids.
   EventGenerationIds eventGenerationIds = 1;
-  // All users and machine users in this account, along with supporting information needed for
-  // user sync.
+  // Users and machine users in this account, along with supporting information needed for
+  // user sync. Only users and machine users that have passed at least one right check from the
+  // request are included.
   repeated UserSyncActor actor = 2;
   // All groups in this account.
   repeated Group group = 3;
@@ -3250,9 +3367,10 @@ message ActorWorkloadCredentials {
   repeated ActorKerberosKey kerberosKeys = 2;
   // A list of Ssh public keys for the actor.
   repeated SshPublicKey sshPublicKey = 5;
+  // The version number of the workload credentials. Version numbering begins at zero.
+  int64 workloadCredentialsVersion = 6;
 }
 
-//
 message RightsCheckResult {
   // Results of a rights checks, returned in the same order as
   // the right list in the corresponding RightsCheck
@@ -3286,4 +3404,130 @@ message UserSyncActorDetails {
   string workloadUsername = 4;
   // The actor's cloud identities
   repeated CloudIdentity cloudIdentity = 5;
+}
+
+// Encapsulation of metadata associated with actors in workload clusters.
+// This metadata is used by user sync to optimize the updating of workload
+// credentials.
+message WorkloadUserSyncActorMetadata {
+  // sint64 encodes negative numbers more efficiently than int64. This gives
+  // us the option of using -1 as an "unknown" version value on the workload
+  // side, with compact encoding.
+  sint64 workloadCredentialsVersion = 1;
+}
+
+message RoleAssignmentRecord {
+  // The CRN of an assignee to whom role is assigned.
+  string assigneeCrn = 1;
+  // The CRN of a role assigned to an assignee.
+  string roleCrn = 2;
+}
+
+message ListRoleAssignmentsRequest {
+  // Account for which to list the resource role assignments
+  string accountId = 1;
+  // See the PageToken comment in paging.proto on paging usage.
+  int32 pageSize = 2;
+  paging.PageToken pageToken = 3;
+}
+
+message ListRoleAssignmentsResponse {
+  // The list of role assignments in an account.
+  repeated RoleAssignmentRecord roleAssignment = 1;
+  // See the PageToken comment in paging.proto on paging usage.
+  paging.PageToken nextPageToken = 2;
+}
+
+message GenerateWorkloadAuthTokenRequest {
+  // The workload endpoint URL which will receive and validate the auth token.
+  string workloadEndpointUrl = 1;
+}
+
+message GenerateWorkloadAuthTokenResponse {
+  // The authentication token
+  string token = 1;
+  // When the token will expire (in ms from the Java epoch of 1970-01-01T00:00:00Z)
+  uint64 expireAt = 2;
+}
+
+message GetWorkloadAuthConfigurationRequest {
+  string accountId = 1;
+}
+
+// Metadata describing the configuration
+// This response contains all required and recommended data defined by the OpenId-Connect-Discovery 1.0
+// spec [https://openid.net/specs/openid-connect-discovery-1_0.html], for maximum compatibility now and in the future.
+message GetWorkloadAuthConfigurationResponse {
+  // URL using the https scheme with no query or fragment component that the OP asserts as its Issuer Identifier.
+  // This MUST be identical to the iss Claim value in ID Tokens issued from this Issuer.
+  string issuer = 1;
+  // URL of the OP's OAuth 2.0 Authorization Endpoint (Empty)
+  string authorizationEndpoint = 2;
+  // URL of the OP's OAuth 2.0 Token Endpoint
+  string tokenEndpoint = 3;
+  // URL of the OP's UserInfo Endpoint (Empty)
+  string userInfoEndpoint = 4;
+  // URL of the OP's Dynamic Client Registration Endpoint (Empty)
+  string registrationEndpoint = 5;
+  // JSON Web Key Set document
+  // This contains the signing key(s) the RP uses to validate signatures from the OP.
+  JsonWebKeySet jwks = 6;
+  // An array containing a list of the OAuth 2.0 scope values that this server supports. (Empty)
+  repeated string scopesSupported = 7;
+  // An array containing a list of the OAuth 2.0 response_type values that this OP supports. (id_token)
+  repeated string responseTypesSupported = 8;
+  // An array containing a list of the Claim Names of the Claims that this OP MAY be able to supply values for.
+  repeated string claimsSupported = 9;
+  // array containing a list of the Subject Identifier types that this OP supports. (public)
+  repeated string subjectTypesSupported = 10;
+  // An array containing a list of the JWS signing algorithms (alg values) supported for the ID Token to encode the Claims in a JWT. (RS256)
+  repeated string idTokenSigningAlgValuesSupported = 11;
+}
+
+// JWK Set, defined by JSON Web Key (JWK) [https://tools.ietf.org/html/rfc7517]
+message JsonWebKeySet {
+  // JsonWebKey set.
+  repeated JsonWebKey keys = 1;
+}
+
+// JSON Web Key, defined by JSON Web Key (JWK) [https://tools.ietf.org/html/rfc7517]
+message JsonWebKey {
+  // The "kty" (key type) parameter
+  string kty = 1;
+  // The "use" (public key use) parameter
+  string use = 2;
+  // The "key_ops" (key operations) parameter
+  repeated string key_ops = 3;
+  // The "alg" (algorithm) parameter
+  string alg = 4;
+  // The "kid" (key ID) parameter
+  string kid = 5;
+  // The "x5u" (X.509 URL) parameter
+  string x5u = 6;
+  // The "x5c" (X.509 certificate chain) parameter
+  repeated string x5c = 7;
+  // The "x5t" (X.509 certificate SHA-1 thumbprint) parameter
+  string x5t = 8;
+  // The "x5t#S256" (X.509 certificate SHA-256 thumbprint) parameter
+  string x5t_S256 = 9;
+  // RSA key modulus "n"
+  string n = 10;
+  // RSA key public exponent "e"
+  string e = 11;
+}
+
+message GenerateControlPlaneSSOAuthnReqRequest {
+  // The account id.
+  string accountId = 1;
+  // The identity provider name or CRN to use to login.
+  // The identity provider should be a SAML IdP.
+  // This field is optional. Default IdP will be used if the value is not set.
+  string identityProviderNameOrCrn = 2;
+  // The SAML RelayState.
+  string relayState = 3;
+}
+
+message GenerateControlPlaneSSOAuthnReqResponse {
+  // SAML AuthnRequest to login with IdP.
+  IdpAuthnRequest authnRequest = 1;
 }

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -631,7 +631,7 @@ public class MockUserManagementService extends UserManagementImplBase {
                                 .addEntitlements(createEntitlement(DATAHUB_STREAMING_SCALING))
                                 .addEntitlements(createEntitlement(CDP_CP_CUSTOM_DL_TEMPLATE))
                                 .addEntitlements(createEntitlement(FMS_FREEIPA_BATCH_CALL))
-                                .setPasswordPolicy(workloadPasswordPolicy)
+                                .setGlobalPasswordPolicy(workloadPasswordPolicy)
                                 .setAccountId(request.getAccountId())
                                 .setExternalAccountId("external-" + request.getAccountId())
                                 .build())

--- a/mock-thunderhead/src/test/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementServiceTest.java
+++ b/mock-thunderhead/src/test/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementServiceTest.java
@@ -150,8 +150,8 @@ public class MockUserManagementServiceTest {
             GetAccountResponse res = observer.getValues().get(0);
             assertThat(res.hasAccount()).isTrue();
             Account account = res.getAccount();
-            assertThat(account.hasPasswordPolicy()).isTrue();
-            WorkloadPasswordPolicy passwordPolicy = account.getPasswordPolicy();
+            assertThat(account.hasGlobalPasswordPolicy()).isTrue();
+            WorkloadPasswordPolicy passwordPolicy = account.getGlobalPasswordPolicy();
             assertThat(passwordPolicy.getWorkloadPasswordMaxLifetime()).isEqualTo(MockUserManagementService.PASSWORD_LIFETIME);
         } finally {
             Files.delete(licenseFilePath);


### PR DESCRIPTION
…word policy

This commit updates usermanagement.proto to be in sync with the
version UMS is running in mow-dev. The motivation for the update
is to bring in changes needed to optimize password hash update
during user sync.

Since the last time the proto was updated, a compatibility-breaking
change was made to the Account message: the 'passwordPolicy' field
was replaced by 'globalPasswordPolicy' and 'machineUserPasswordPolicy'.
The 'passwordPolicy' field number was reused for 'globalPasswordPolicy',
which means that for the last two months or so, Cloudbreak was getting
the global password policy when it accessed 'passwordPolicy'. If any
customers set a machine user-specific policy, it was ignored.

This commit updates the references to the password policy fields,
and implements the semantics of the machine user policy: if present,
it is used for machine users; otherwise, the global policy is used,
if present.

See detailed description in the commit message.