### PR TITLE
CB-11040: Fix race condition which intermittently corrupts CS.cfg

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
@@ -10,18 +10,12 @@ update_cnames:
         - file: /opt/salt/scripts/update_cnames.sh
 
 one_week_next_update_grace_period:
-  file.replace:
-    - name: /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
-    - pattern: ^ca[.]crl[.]MasterCRL[.]nextUpdateGracePeriod=.*
-    - repl: ca.crl.MasterCRL.nextUpdateGracePeriod=10080
+  cmd.run:
+    - names:
+      - service pki-tomcatd@pki-tomcat stop
+      - sed -i 's/^ca[.]crl[.]MasterCRL[.]nextUpdateGracePeriod=.*/ca.crl.MasterCRL.nextUpdateGracePeriod=10080/' /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
+      - service pki-tomcatd@pki-tomcat start
     - unless: grep "^ca[.]crl[.]MasterCRL[.]nextUpdateGracePeriod=10080$" /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
-
-restart_pki-tomcat:
-  service.running:
-    - name: pki-tomcatd@pki-tomcat
-    - onlyif: test -f /etc/ipa/default.conf
-    - watch:
-      - file: /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
 
 /usr/lib/python2.7/site-packages/ipaserver/plugins/getkeytab.py:
   file.managed:


### PR DESCRIPTION
When pki-tomcatd@pki-tomcat starts, it always rewrites the config file
/var/lib/pki/pki-tomcat/ca/conf/CS.cfg. It even does this if the file
does not change. There is a delay of about 8 seconds between when the
service command returns and when the file is rewritten. This can cause
the file to become corrupted if any other process modifies the file
during this operation. It is recommended that the CA be shutdown
before editing this file and then the CA can be started again. This
fix was done.

This method was tested with a loop that modified the file many times
between service restarts. Without the fix, the CA failed almost every
time. With this fix, I was unable to get it to fail.

See detailed description in the commit message.