### PR TITLE
ENGESC-6437. Use forceMetricsFetch for decommision data nodes ambari …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/DNDecommissionStatusCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/DNDecommissionStatusCheckerTask.java
@@ -17,7 +17,12 @@ public class DNDecommissionStatusCheckerTask extends ClusterBasedStatusCheckerTa
     @Override
     public boolean checkStatus(AmbariOperations t) {
         AmbariClient ambariClient = t.getAmbariClient();
-        Map<String, Long> dataNodes = ambariClient.getDecommissioningDataNodes();
+        Map<String, Long> dataNodes = ambariClient.getDecommissioningDataNodes(true);
+        if (dataNodes.isEmpty()) {
+            LOGGER.info("DataNode decommision seems to be empty with forced_metrics_fetch parameter,"
+                + " validating the results without it ");
+            dataNodes = ambariClient.getDecommissioningDataNodes();
+        }
         boolean finished = dataNodes.isEmpty();
         if (!finished) {
             LOGGER.info("DataNode decommission is in progress: {}", dataNodes);

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx2048m
 
 ambariClientName=ambari-client
-ambariClientVersion=2.4.90
+ambariClientVersion=2.4.94
 springBootVersion=2.1.3.RELEASE
 springOauthVersion=2.1.0.RELEASE
 awsSdkVersion=1.11.273


### PR DESCRIPTION
…request -> use the original requests in case of empty response

See detailed description in the commit message.