### PR TITLE
CB-11056 Create separate test suite for EnvironmentStopStartTests

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
@@ -4,7 +4,6 @@ tests:
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.NewNetworkWithNoInternetEnvironmentTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXEncryptedVolumeTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests

--- a/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-e2e-tests.yaml
@@ -3,7 +3,6 @@ tests:
   - name: "azure_e2e_tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.NewNetworkEnvironmentTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXEncryptedVolumeTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests

--- a/integration-test/src/main/resources/testsuites/e2e/environment-stopstart-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/environment-stopstart-tests.yaml
@@ -1,0 +1,5 @@
+name: "environment-stopstart-tests"
+tests:
+  - name: "environment_stopstart_tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests

--- a/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
@@ -3,7 +3,6 @@ tests:
   - name: "gcp_e2e_tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.NewNetworkEnvironmentTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests


### PR DESCRIPTION
Our API E2E testing ([CB-10912](https://jira.cloudera.com/browse/CB-10912)) is struggling with timeout issues at `com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests`, because of this test takes at least 90 minutes with optimal circumstances. So our default 100 minutes test timeout is not appropriate for this test case.

We need to create a separate Jenkins job for this long running test with a custom test timeout.