### PR TITLE
CB-11004 Accept minion fingerprints on all master

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltService.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltService.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.cloudbreak.orchestrator.salt;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -32,6 +34,10 @@ public class SaltService {
 
     public SaltConnector createSaltConnector(GatewayConfig gatewayConfig) {
         return new SaltConnector(gatewayConfig, saltErrorResolver, restDebug, tracer);
+    }
+
+    public List<SaltConnector> createSaltConnector(Collection<GatewayConfig> gatewayConfigs) {
+        return gatewayConfigs.stream().map(this::createSaltConnector).collect(Collectors.toList());
     }
 
     public GatewayConfig getPrimaryGatewayConfig(List<GatewayConfig> allGatewayConfigs) throws CloudbreakOrchestratorFailedException {

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/SaltConnector.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/SaltConnector.java
@@ -85,7 +85,10 @@ public class SaltConnector implements Closeable {
 
     private final SaltErrorResolver saltErrorResolver;
 
+    private final String hostname;
+
     public SaltConnector(GatewayConfig gatewayConfig, SaltErrorResolver saltErrorResolver, boolean debug, Tracer tracer) {
+        this.hostname = gatewayConfig.getHostname();
         ClientTracingFeature tracingFeature = new ClientTracingFeature.Builder(tracer)
                 .withTraceSerialization(false)
                 .withDecorators(List.of(new TracingClientSpanDecorator())).build();
@@ -343,6 +346,10 @@ public class SaltConnector implements Closeable {
 
     public SaltErrorResolver getSaltErrorResolver() {
         return saltErrorResolver;
+    }
+
+    public String getHostname() {
+        return hostname;
     }
 
     private String toJson(Object target) {

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrap.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrap.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.orchestrator.salt.poller;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -39,6 +40,8 @@ public class SaltBootstrap implements OrchestratorBootstrap {
 
     private final SaltConnector sc;
 
+    private final Collection<SaltConnector> saltConnectors;
+
     private final List<GatewayConfig> allGatewayConfigs;
 
     private final Set<Node> originalTargets;
@@ -47,8 +50,10 @@ public class SaltBootstrap implements OrchestratorBootstrap {
 
     private Set<Node> targets;
 
-    public SaltBootstrap(SaltConnector sc, List<GatewayConfig> allGatewayConfigs, Set<Node> targets, BootstrapParams params) {
+    public SaltBootstrap(SaltConnector sc, Collection<SaltConnector> saltConnectors, List<GatewayConfig> allGatewayConfigs, Set<Node> targets,
+            BootstrapParams params) {
         this.sc = sc;
+        this.saltConnectors = saltConnectors;
         this.allGatewayConfigs = allGatewayConfigs;
         originalTargets = Collections.unmodifiableSet(targets);
         this.targets = targets;
@@ -86,7 +91,7 @@ public class SaltBootstrap implements OrchestratorBootstrap {
                 params.setRestartNeeded(false);
             }
 
-            createMinionAcceptor(saltAction).acceptMinions();
+            createMinionAcceptor().acceptMinions();
         }
 
         MinionIpAddressesResponse minionIpAddressesResponse = SaltStates.collectMinionIpAddresses(sc);
@@ -107,10 +112,11 @@ public class SaltBootstrap implements OrchestratorBootstrap {
         return true;
     }
 
-    protected MinionAcceptor createMinionAcceptor(SaltAction saltAction) {
+    protected MinionAcceptor createMinionAcceptor() {
+        List<Minion> minions = createMinionsFromOriginalTargets();
         return params.isSaltBootstrapFpSupported() ?
-                new MinionAcceptor(sc, saltAction.getMinions(), new EqualMinionFpMatcher(), new FingerprintFromSbCollector())
-                : new MinionAcceptor(sc, saltAction.getMinions(), new AcceptAllFpMatcher(), new DummyFingerprintCollector());
+                new MinionAcceptor(saltConnectors, minions, new EqualMinionFpMatcher(), new FingerprintFromSbCollector())
+                : new MinionAcceptor(saltConnectors, minions, new AcceptAllFpMatcher(), new DummyFingerprintCollector());
     }
 
     private SaltAction createBootstrap(boolean restartNeededFlagSupported, boolean restartNeeded) {
@@ -157,6 +163,12 @@ public class SaltBootstrap implements OrchestratorBootstrap {
         // set due to compatibility reasons
         minion.setServer(getGatewayPrivateIps().get(0));
         return minion;
+    }
+
+    private List<Minion> createMinionsFromOriginalTargets() {
+        return originalTargets.stream()
+                .map(ot -> createMinion(ot, params.isRestartNeededFlagSupported(), params.isRestartNeeded()))
+                .collect(Collectors.toList());
     }
 
     /***

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrapTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltBootstrapTest.java
@@ -86,9 +86,10 @@ public class SaltBootstrapTest {
         targets.add(new Node("10.0.0.2", null, null, "hg"));
         targets.add(new Node("10.0.0.3", null, null, "hg"));
 
-        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, Collections.singletonList(gatewayConfig), targets, new BootstrapParams());
+        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, List.of(saltConnector), Collections.singletonList(gatewayConfig), targets,
+                new BootstrapParams());
         saltBootstrap = spy(saltBootstrap);
-        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor(any(SaltAction.class));
+        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
 
         saltBootstrap.call();
     }
@@ -108,9 +109,10 @@ public class SaltBootstrapTest {
         String missingNodeIp = "10.0.0.3";
         targets.add(new Node(missingNodeIp, null, null, "hg"));
 
-        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, Collections.singletonList(gatewayConfig), targets, new BootstrapParams());
+        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, List.of(saltConnector), Collections.singletonList(gatewayConfig), targets,
+                new BootstrapParams());
         saltBootstrap = spy(saltBootstrap);
-        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor(any(SaltAction.class));
+        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
         try {
             saltBootstrap.call();
             fail("should throw exception");
@@ -140,9 +142,9 @@ public class SaltBootstrapTest {
         BootstrapParams params = new BootstrapParams();
         params.setRestartNeeded(true);
         params.setRestartNeededFlagSupported(false);
-        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, Collections.singletonList(gatewayConfig), targets, params);
+        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, List.of(saltConnector), Collections.singletonList(gatewayConfig), targets, params);
         saltBootstrap = spy(saltBootstrap);
-        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor(any(SaltAction.class));
+        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
 
         saltBootstrap.call();
 
@@ -177,9 +179,9 @@ public class SaltBootstrapTest {
         BootstrapParams params = new BootstrapParams();
         params.setRestartNeeded(true);
         params.setRestartNeededFlagSupported(true);
-        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, Collections.singletonList(gatewayConfig), targets, params);
+        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, List.of(saltConnector), Collections.singletonList(gatewayConfig), targets, params);
         saltBootstrap = spy(saltBootstrap);
-        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor(any(SaltAction.class));
+        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
 
         saltBootstrap.call();
 
@@ -214,9 +216,9 @@ public class SaltBootstrapTest {
         BootstrapParams params = new BootstrapParams();
         params.setRestartNeeded(false);
         params.setRestartNeededFlagSupported(true);
-        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, Collections.singletonList(gatewayConfig), targets, params);
+        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, List.of(saltConnector), Collections.singletonList(gatewayConfig), targets, params);
         saltBootstrap = spy(saltBootstrap);
-        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor(any(SaltAction.class));
+        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
 
         saltBootstrap.call();
 
@@ -251,9 +253,9 @@ public class SaltBootstrapTest {
         BootstrapParams params = new BootstrapParams();
         params.setRestartNeeded(false);
         params.setRestartNeededFlagSupported(false);
-        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, Collections.singletonList(gatewayConfig), targets, params);
+        SaltBootstrap saltBootstrap = new SaltBootstrap(saltConnector, List.of(saltConnector), Collections.singletonList(gatewayConfig), targets, params);
         saltBootstrap = spy(saltBootstrap);
-        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor(any(SaltAction.class));
+        doReturn(mock(MinionAcceptor.class)).when(saltBootstrap).createMinionAcceptor();
 
         saltBootstrap.call();
 

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/MinionAcceptorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/join/MinionAcceptorTest.java
@@ -41,7 +41,7 @@ class MinionAcceptorTest {
         when(response.getAllMinions()).thenReturn(List.of("m2.d"));
         when(sc.wheel(eq("key.list_all"), isNull(), eq(MinionKeysOnMasterResponse.class))).thenReturn(response);
 
-        MinionAcceptor underTest = new MinionAcceptor(sc, List.of(m1, m2), new EqualMinionFpMatcher(), new FingerprintFromSbCollector());
+        MinionAcceptor underTest = new MinionAcceptor(List.of(sc), List.of(m1, m2), new EqualMinionFpMatcher(), new FingerprintFromSbCollector());
 
         assertThrows(CloudbreakOrchestratorFailedException.class, underTest::acceptMinions);
     }
@@ -61,7 +61,7 @@ class MinionAcceptorTest {
         when(response.getUnacceptedMinions()).thenReturn(List.of());
         when(sc.wheel(eq("key.list_all"), isNull(), eq(MinionKeysOnMasterResponse.class))).thenReturn(response);
 
-        MinionAcceptor underTest = new MinionAcceptor(sc, List.of(m1, m2), new EqualMinionFpMatcher(), new FingerprintFromSbCollector());
+        MinionAcceptor underTest = new MinionAcceptor(List.of(sc), List.of(m1, m2), new EqualMinionFpMatcher(), new FingerprintFromSbCollector());
         underTest.acceptMinions();
     }
 
@@ -81,7 +81,7 @@ class MinionAcceptorTest {
         when(sc.wheel(eq("key.list_all"), isNull(), eq(MinionKeysOnMasterResponse.class))).thenReturn(response);
         when(sc.wheel(eq("key.finger"), anyCollection(), eq(MinionFingersOnMasterResponse.class))).thenThrow(new RuntimeException("failure"));
 
-        MinionAcceptor underTest = new MinionAcceptor(sc, List.of(m1, m2), new EqualMinionFpMatcher(), new FingerprintFromSbCollector());
+        MinionAcceptor underTest = new MinionAcceptor(List.of(sc), List.of(m1, m2), new EqualMinionFpMatcher(), new FingerprintFromSbCollector());
 
         assertThrows(CloudbreakOrchestratorFailedException.class, underTest::acceptMinions);
     }
@@ -104,7 +104,7 @@ class MinionAcceptorTest {
         when(sc.wheel(eq("key.list_all"), isNull(), eq(MinionKeysOnMasterResponse.class))).thenReturn(keysOnMasterResponse);
         when(sc.wheel(eq("key.finger"), anyCollection(), eq(MinionFingersOnMasterResponse.class))).thenReturn(fingersOnMasterResponse);
 
-        MinionAcceptor underTest = new MinionAcceptor(sc, List.of(m1, m2), new EqualMinionFpMatcher(), new FingerprintFromSbCollector());
+        MinionAcceptor underTest = new MinionAcceptor(List.of(sc), List.of(m1, m2), new EqualMinionFpMatcher(), new FingerprintFromSbCollector());
 
         assertThrows(CloudbreakOrchestratorFailedException.class, underTest::acceptMinions);
     }
@@ -151,7 +151,7 @@ class MinionAcceptorTest {
         when(fingerprintCollector.collectFingerprintFromMinions(eq(sc), argThat(arg -> arg.containsAll(List.of(m1, m2, m3))))).thenReturn(fingerprintsResponse);
         when(fingerprintsResponse.getFingerprints()).thenReturn(List.of(fp2, fp1, fp3));
 
-        MinionAcceptor underTest = spy(new MinionAcceptor(sc, List.of(m1, m2, m3, m4),  new EqualMinionFpMatcher(), fingerprintCollector));
+        MinionAcceptor underTest = spy(new MinionAcceptor(List.of(sc), List.of(m1, m2, m3, m4),  new EqualMinionFpMatcher(), fingerprintCollector));
 
         underTest.acceptMinions();
 


### PR DESCRIPTION
After https://github.com/hortonworks/cloudbreak/pull/8408/commits/451ff5441bf2924d501af6efc7a6db168accd3f0
every minion fingerprint has to be accepted on the master for SaltStack to be functional.
This was done only for the primary gateway which caused error in multi-master setup like FreeIPA HA.

The solution is we create `SaltConnector` to all the gateways during bootstrap and iterate over them in `MinionAcceptor`

Tested with FreeIPA HA, with validating salt keys:
```
(salt_3000.5) [root@ipaserver0 ~]# salt-key -L
Accepted Keys:
ipaserver0.test.xcu2-8y8x.wl.cloudera.site
ipaserver1.test.xcu2-8y8x.wl.cloudera.site
ipaserver2.test.xcu2-8y8x.wl.cloudera.site
(salt_3000.5) [root@ipaserver1 ~]# salt-key -L
Accepted Keys:
ipaserver0.test.xcu2-8y8x.wl.cloudera.site
ipaserver1.test.xcu2-8y8x.wl.cloudera.site
ipaserver2.test.xcu2-8y8x.wl.cloudera.site
(salt_3000.5) [root@ipaserver2 ~]# salt-key -L
Accepted Keys:
ipaserver0.test.xcu2-8y8x.wl.cloudera.site
ipaserver1.test.xcu2-8y8x.wl.cloudera.site
ipaserver2.test.xcu2-8y8x.wl.cloudera.site
```

See detailed description in the commit message.