### PR TITLE
CB-11063: Fix error message when the FreeIPA password has expired

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/PasswordExpiredException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/auth/PasswordExpiredException.java
@@ -4,7 +4,7 @@ import com.sequenceiq.freeipa.client.FreeIpaClientException;
 
 public class PasswordExpiredException extends FreeIpaClientException {
     public PasswordExpiredException() {
-        super("Invalid password");
+        super("Password expired");
     }
 
     @Override


### PR DESCRIPTION
Fix error message when the password has expired.

See detailed description in the commit message.