### PR TITLE
CB-9926: Add more logging when the FreeIPA health check fails.

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaHealthCheckClient.java
@@ -86,6 +86,7 @@ public class FreeIpaHealthCheckClient implements AutoCloseable {
         if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL &&
                 response.getStatus() != Response.Status.SERVICE_UNAVAILABLE.getStatusCode()) {
             String message = String.format("Invoke FreeIPA health check failed: %d", response.getStatus());
+            LOGGER.warn("{}, reason: {}", message, response.readEntity(String.class));
             throw new FreeIpaClientException(message, response.getStatus());
         }
     }


### PR DESCRIPTION
Add more logging when the FreeIPA health check fails.

See detailed description in the commit message.