### PR TITLE
CB-10672 Fix FreeIPA HA (repair) in GCP (take 4)

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.freeipa.converter.instance;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -45,7 +45,7 @@ public class InstanceGroupRequestToInstanceGroupConverter {
     }
 
     private void addInstanceMetadatas(InstanceGroupRequest request, InstanceGroup instanceGroup, String hostname, String domain) {
-        Set<InstanceMetaData> instanceMetaDataSet = new HashSet<>();
+        Set<InstanceMetaData> instanceMetaDataSet = new LinkedHashSet<>();
         for (int i = 0; i < request.getNodeCount(); i++) {
             InstanceMetaData instanceMetaData = new InstanceMetaData();
             instanceMetaData.setInstanceGroup(instanceGroup);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverterTest.java
@@ -72,8 +72,11 @@ public class InstanceGroupRequestToInstanceGroupConverterTest {
         assertThat(result.getSecurityGroup()).isEqualTo(securityGroup);
         assertThat(result.getNodeCount()).isEqualTo(nodeCount);
         assertThat(result.getInstanceMetaData().size()).isEqualTo(nodeCount);
+        int i = 0;
         for (InstanceMetaData instanceMetaData : result.getInstanceMetaData()) {
             assertThat(instanceMetaData.getInstanceGroup()).isEqualTo(result);
+            assertThat(instanceMetaData.getDiscoveryFQDN()).startsWith(HOSTNAME + i);
+            i++;
         }
     }
 


### PR DESCRIPTION
1. Found this during FreeIPA HA full repair, although it could have happened on an install too.
2. Sometimes it happens that ipaserver0 was assigned ipaserver1 hostname.
3. This breaks the replica install with this bug https://bugzilla.redhat.com/show_bug.cgi?id=1364139
4. There is no fix for the above bug in a VM install.
5. Nonetheless this is a nasty bug, that needs fixing anyway. Elsewhere in the code, there is an assumption that server 0 gets ipaserver0 hostname.