### PR TITLE
CB-11006 Fix the disk mounting logic to support Azure VM types withou…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResources.java
@@ -68,8 +68,6 @@ public class AzurePlatformResources implements PlatformResources {
 
     private static final float NO_MB_PER_GB = 1024.0f;
 
-    private static final int NO_RESOURCE_DISK_ATTACHED_TO_INSTANCE = 0;
-
     @Value("${cb.azure.default.max.disk.size:32767}")
     private int maxDiskSize;
 
@@ -227,9 +225,7 @@ public class AzurePlatformResources implements PlatformResources {
 
         Set<VmType> types = new HashSet<>();
         VmType defaultVmType = null;
-        Set<String> vmTypesWithoutResourceDisks = new HashSet<>();
         for (VirtualMachineSize virtualMachineSize : vmTypes) {
-            if (virtualMachineSize.resourceDiskSizeInMB() != NO_RESOURCE_DISK_ATTACHED_TO_INSTANCE) {
                 float memoryInGB = virtualMachineSize.memoryInMB() / NO_MB_PER_GB;
                 VmTypeMetaBuilder builder = VmTypeMetaBuilder.builder().withCpuAndMemory(virtualMachineSize.numberOfCores(), memoryInGB);
 
@@ -244,12 +240,7 @@ public class AzurePlatformResources implements PlatformResources {
                 if (virtualMachineSize.name().equals(armVmDefault)) {
                     defaultVmType = vmType;
                 }
-            } else {
-                vmTypesWithoutResourceDisks.add(virtualMachineSize.name());
-            }
         }
-        LOGGER.debug("The following Azure VM types have been filtered out, because there is no resource disk available with them: {}",
-                String.join(", ", vmTypesWithoutResourceDisks));
         cloudVmResponses.put(region.value(), types);
         defaultCloudVmResponses.put(region.value(), defaultVmType);
         return new CloudVmTypes(cloudVmResponses, defaultCloudVmResponses);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureAttachmentResourceBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/resource/AzureAttachmentResourceBuilder.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure.resource;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -76,10 +77,39 @@ public class AzureAttachmentResourceBuilder extends AbstractAzureComputeBuilder 
                         LOGGER.debug("Managed disk {} is already attached to VM {}", disk, vm);
                     }
                 });
-        volumeSet.setInstanceId(instance.getInstanceId());
-        volumeSet.setStatus(CommonStatus.CREATED);
-        LOGGER.debug("Volume set {} attached successfully", volumeSet.toString());
-        return List.of(volumeSet);
+
+        VolumeSetAttributes lunFilledAttibutes = fillLogicalUnitNumbersToVolumeAttributes(instance, resourceGroupName, client, volumeSetAttributes);
+
+        CloudResource result = new CloudResource.Builder()
+                .persistent(volumeSet.isPersistent())
+                .type(volumeSet.getType())
+                .name(volumeSet.getName())
+                .group(volumeSet.getGroup())
+                .instanceId(instance.getInstanceId())
+                .status(CommonStatus.CREATED)
+                .params(Map.of(CloudResource.ATTRIBUTES, lunFilledAttibutes))
+                .build();
+        LOGGER.debug("Volume set {} attached successfully", result);
+        return List.of(result);
+    }
+
+    private VolumeSetAttributes fillLogicalUnitNumbersToVolumeAttributes(CloudResource instance, String resourceGroupName, AzureClient client,
+            VolumeSetAttributes volumeSetAttributes) {
+        VirtualMachine vm = client.getVirtualMachineByResourceGroup(resourceGroupName, instance.getName());
+        List<VolumeSetAttributes.Volume> volumes = volumeSetAttributes.getVolumes().stream()
+                .map(volume -> {
+                    String id = volume.getId();
+                    String lun = vm.dataDisks().values().stream()
+                            .filter(disk -> disk.id().equals(id))
+                            .map(disk -> "lun" + disk.lun())
+                            .findFirst()
+                            .orElseThrow(() -> new AzureResourceException("Cannot determine LUN of disk " + id));
+                    LOGGER.debug("Logical Unit Number of disk [{}] is [{}].", id, lun);
+                    return new VolumeSetAttributes.Volume(volume.getId(), lun, volume.getSize(), volume.getType(), volume.getCloudVolumeUsageType());
+                })
+                .collect(Collectors.toList());
+        volumeSetAttributes.setVolumes(volumes);
+        return volumeSetAttributes;
     }
 
     @Override

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResourcesVirtualMachineFilteringTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzurePlatformResourcesVirtualMachineFilteringTest.java
@@ -70,33 +70,6 @@ class AzurePlatformResourcesVirtualMachineFilteringTest {
                 });
     }
 
-    @Test
-    void testVirtualMachinesWhenInstanceTypeShouldBeFilteredOut() {
-        Region region = Region.region("westeruope");
-        Set<VirtualMachineSize> virtualMachineSizes = new HashSet<>();
-        VirtualMachineSize d2sTypeWithoutResourceDisk = createVirtualMachineSize("Standard_D2s_v4", 0);
-        VirtualMachineSize e64sVmTypeWithoutResourceDisk = createVirtualMachineSize("Standard_E64s_v4", 0);
-        virtualMachineSizes.add(createVirtualMachineSize("Standard_DS2_v2", 20000));
-        virtualMachineSizes.add(d2sTypeWithoutResourceDisk);
-        virtualMachineSizes.add(createVirtualMachineSize("Standard_E64ds_v4", 1400000));
-        virtualMachineSizes.add(e64sVmTypeWithoutResourceDisk);
-        when(azureClient.getVmTypes(region.value())).thenReturn(virtualMachineSizes);
-
-        CloudVmTypes actual = underTest.virtualMachines(cloudCredential, region, Map.of());
-
-        Set<VirtualMachineSize> vmTypeWithoutResourceDisk = Set.of(d2sTypeWithoutResourceDisk, e64sVmTypeWithoutResourceDisk);
-        assertNotNull(actual);
-        assertNotNull(actual.getCloudVmResponses());
-        assertFalse(actual.getCloudVmResponses().isEmpty());
-        assertNotNull(actual.getCloudVmResponses().get(region.value()));
-        assertEquals(virtualMachineSizes.size() - vmTypeWithoutResourceDisk.size(), actual.getCloudVmResponses().get(region.value()).size());
-        boolean resultContainsVmTypesWithoutResourceDisk = actual.getCloudVmResponses()
-                .get(region.value())
-                .stream()
-                .anyMatch(cloudVMResponse -> vmTypeWithoutResourceDisk.stream().anyMatch(vmSize -> vmSize.name().equals(cloudVMResponse.value())));
-        assertFalse(resultContainsVmTypesWithoutResourceDisk);
-    }
-
     @NotNull
     private VirtualMachineSize createVirtualMachineSize(String name, int resourceDiskSizeInMB) {
         return new VirtualMachineSize() {

--- a/orchestrator-salt/src/main/resources/salt/bootstrapnodes/format-and-mount-common.sh
+++ b/orchestrator-salt/src/main/resources/salt/bootstrapnodes/format-and-mount-common.sh
@@ -83,6 +83,8 @@ get_root_disk() {
     root_partition=$(lsblk | grep /$ | cut -f1 -d' ' )
     if [[ $root_partition =~ "nvme" ]]; then
         echo "/dev/$(lsblk | grep /$ | cut -f1 -d' ' | sed 's/p\w//g' | cut -c 3-)"
+    elif [[ $CLOUD_PLATFORM -eq AZURE ]]
+        echo "/dev/$(ls -l /dev/disk/azure/ | awk '{print $9"\t"$11}' | grep -E '(root\s)' | cut -f2 | cut -f3 -d'/')"
     else
         echo "/dev/$(lsblk | grep /$ | cut -f1 -d' ' | sed 's/[0-9]//g' | cut -c 3-)"
     fi

--- a/orchestrator-salt/src/main/resources/salt/salt/disks/mount/scripts/find-device-and-format.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/disks/mount/scripts/find-device-and-format.j2
@@ -10,7 +10,8 @@ LOG_FILE=/var/log/find_device_and_format.log
 VERSION="V1.0"
 
 # INPUT - expected lists
-#   ATTACHED_VOLUME_NAME_LIST - contains a list of volume device names attached to the instance, format: space separated list
+#   ATTACHED_VOLUME_NAME_LIST - contains a list of volume device names attached to the instance, format: space separated list,
+#                               in case of Azure Logical Unit Numbers passsed to find the actual devices
 #   ATTACHED_VOLUME_SERIAL_LIST - contains a list of volume serial ids, format: space separated list
 #
 # OUTPUT:
@@ -104,6 +105,26 @@ save_env_vars_to_log_file() {
     log $LOG_FILE CLOUD_PLATFORM=$CLOUD_PLATFORM
 }
 
+get_temporary_disk_device_name() {
+  if [[ $CLOUD_PLATFORM -eq AZURE ]]; then
+    temporary_device_name="$(ls -l /dev/disk/azure/ | awk '{print $9"\t"$11}' | grep -E '(resource[^-])' | cut -f2 | cut -f3 -d'/')"
+    if [[ -n $temporary_device_name ]]; then
+      temporary_disk_path="/dev/$temporary_device_name"
+      log $LOG_FILE "found temporary disk: $temporary_disk_path"
+      echo "$temporary_disk_path"
+      return 0
+    else
+      log $LOG_FILE "no temporary disk found"
+      echo ""
+      return 0
+    fi
+  else
+    log $LOG_FILE "The 'get_temporary_disk_device_name' function can only be used on the Azure platform."
+    echo ""
+    return 0
+  fi
+}
+
 main() {
     log $LOG_FILE "started, version: $VERSION"
     save_env_vars_to_log_file
@@ -114,7 +135,13 @@ main() {
     if [ ! $? -eq 0 ]; then
         exit_with_code $LOG_FILE $EXIT_CODE_ERROR "some volumes are missing"
     fi
-    ephemeral_device_name_list=$(get_ephemeral_device_names "$device_name_list")
+
+    local ephemeral_device_name_list=""
+    if [[ $CLOUD_PLATFORM -eq AZURE ]]; then
+      ephemeral_device_name_list=$(get_temporary_disk_device_name)
+    else
+      ephemeral_device_name_list=$(get_ephemeral_device_names "$device_name_list")
+    fi
     log $LOG_FILE found devices: $device_name_list $ephemeral_device_name_list
 
     format_disks_if_unformatted "$device_name_list $ephemeral_device_name_list"


### PR DESCRIPTION
…t resource/temporary disk

The mount and format scripts, in case of Azure, now dynamically determine the root, resource and managed disks.
Also reused the device names field of volumesets for Logical Unit Numbers, needed for the script to
properly pair devices to disks.

See detailed description in the commit message.