### PR TITLE
CB-11078 Environment FAILED_STATUSES set does not contains all the related EnvironmentStatus

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentStatus.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentStatus.java
@@ -95,6 +95,13 @@ public enum EnvironmentStatus {
             CREATE_FAILED,
             DELETE_FAILED,
             UPDATE_FAILED,
+            START_FREEIPA_FAILED,
+            START_DATAHUB_FAILED,
+            START_DATALAKE_FAILED,
+            START_SYNCHRONIZE_USERS_FAILED,
+            STOP_DATAHUB_FAILED,
+            STOP_DATALAKE_FAILED,
+            STOP_FREEIPA_FAILED,
             FREEIPA_DELETED_ON_PROVIDER_SIDE
     );
 


### PR DESCRIPTION
At `com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests.testCreateStopStartEnvironment` the stopped environment cannot get into `AVAILABLE` state. However test is waiting for this state even the `START_FREEIPA_FAILED` environment status draws up.

So we need to update the related failed statuses set at `EnvironmentStatus` class.