### PR TITLE
CB-10901 Subnet should not be public by the main route table in case of a route table is associated explicitly.

### DIFF
--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSubnetIgwExplorerTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSubnetIgwExplorerTest.java
@@ -264,11 +264,11 @@ public class AwsSubnetIgwExplorerTest {
 
         boolean hasInternetGateway = awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(describeRouteTablesResult, SUBNET_ID, VPC_ID);
 
-        assertTrue(hasInternetGateway);
+        assertFalse(hasInternetGateway);
     }
 
     @Test
-    public void testWithMainAndCustomRouteTablesWithAssociationsAndIgwAttachedToACustomRouteTable() {
+    public void testWithMainAndCustomRouteTableWithAssociationsAndIgwAttachedToACustomRouteTable() {
         DescribeRouteTablesResult describeRouteTablesResult = new DescribeRouteTablesResult();
         Set<RouteTable> routeTables = new HashSet<>();
         RouteTable mainRouteTable = new RouteTable().withVpcId(VPC_ID);
@@ -281,23 +281,14 @@ public class AwsSubnetIgwExplorerTest {
         routeTables.add(mainRouteTable);
 
         RouteTable customRouteTable = new RouteTable().withVpcId(VPC_ID);
-        Route customRoute = new Route()
-                .withDestinationCidrBlock(INTERNAL_DESTINATION_CIDR_BLOCK);
-        customRouteTable.setRoutes(List.of(customRoute));
-        RouteTableAssociation customRouteTableAssociation = new RouteTableAssociation()
-                .withSubnetId(SUBNET_ID);
-        customRouteTable.setAssociations(List.of(customRouteTableAssociation));
-        routeTables.add(customRouteTable);
-
-        RouteTable custom2RouteTable = new RouteTable().withVpcId(VPC_ID);
         Route custom2Route = new Route()
                 .withGatewayId(GATEWAY_ID)
                 .withDestinationCidrBlock(OPEN_CIDR_BLOCK);
-        custom2RouteTable.setRoutes(List.of(custom2Route));
+        customRouteTable.setRoutes(List.of(custom2Route));
         RouteTableAssociation custom2RouteTableAssociation = new RouteTableAssociation()
                 .withSubnetId(SUBNET_ID);
-        custom2RouteTable.setAssociations(List.of(custom2RouteTableAssociation));
-        routeTables.add(custom2RouteTable);
+        customRouteTable.setAssociations(List.of(custom2RouteTableAssociation));
+        routeTables.add(customRouteTable);
         describeRouteTablesResult.setRouteTables(routeTables);
 
         boolean hasInternetGateway = awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(describeRouteTablesResult, SUBNET_ID, VPC_ID);


### PR DESCRIPTION
This change needs to be back-ported to 2.37 line of CB as other customers started to deal with the same issue which has been fixed by this commit. For example [ENGESC-6706](https://jira.cloudera.com/browse/ENGESC-6706).