### PR TITLE
CB-10710 Create Real UMS test for the DataSteward resource role

### DIFF
--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -87,6 +87,8 @@ Test cases are located under folder `https://github.com/hortonworks/cloudbreak/t
  - Integration Tests: `mock`
  - End To End Tests: `e2e`
  - Smoke Tests: `smoke`
+ - Real UMS Tests: `authorization` (UMS host and cache timeout values needs to be changed before running these tests)
+
 *Note:*
 [E2E tests](https://github.com/hortonworks/cloudbreak/tree/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e) are organized into domain-specific packages (distrox, sdx etc.).
 

--- a/integration-test/scripts/fetch-secrets.sh
+++ b/integration-test/scripts/fetch-secrets.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-secret_version="f67ffa3143964f5ea7b1e7f65a2d0f15"
+secret_version="e8d987e86fa6459ba2a1bf789d3ffae0"
 
 USER_JSON_LOCATION="./src/main/resources/ums-users/api-credentials.json"
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ums/UmsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ums/UmsTestDto.java
@@ -25,6 +25,8 @@ public class UmsTestDto extends AbstractTestDto<AssignResourceRequest, Object, U
 
     private static final String ENV_ADMIN_CRN = "crn:altus:iam:us-west-1:altus:resourceRole:EnvironmentAdmin";
 
+    private static final String DATA_STEWARD_CRN = "crn:altus:iam:us-west-1:altus:resourceRole:DataSteward";
+
     public UmsTestDto(TestContext testContext) {
         super(new AssignResourceRequest(), testContext);
     }
@@ -46,6 +48,11 @@ public class UmsTestDto extends AbstractTestDto<AssignResourceRequest, Object, U
 
     public UmsTestDto withEnvironmentAdmin() {
         getRequest().setRoleCrn(ENV_ADMIN_CRN);
+        return this;
+    }
+
+    public UmsTestDto withDataSteward() {
+        getRequest().setRoleCrn(DATA_STEWARD_CRN);
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/AuthUserKeys.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/AuthUserKeys.java
@@ -10,6 +10,8 @@ public class AuthUserKeys {
 
     public static final String ENV_ADMIN_A = "CB-Machine-EnvAdminA";
 
+    public static final String ENV_DATA_STEWARD = "CB-Machine-DataSteward";
+
     public static final String DH_ADMIN_A = "CB-Machine-DhAdminA";
 
     public static final String DH_ADMIN_B = "CB-Machine-DhAdminB";

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/CreateDhWithDatahubCreator.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/CreateDhWithDatahubCreator.java
@@ -1,6 +1,10 @@
 package com.sequenceiq.it.cloudbreak.testcase.authorization;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
+import static com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil.datahubPattern;
+import static com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil.datahubRecipePattern;
+import static com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil.environmentDatahubPattern;
+import static com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil.environmentPattern;
 
 import java.util.List;
 import java.util.Map;
@@ -36,6 +40,7 @@ import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
 import com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil;
 
 public class CreateDhWithDatahubCreator extends AbstractIntegrationTest {
+
     @Inject
     private EnvironmentTestClient environmentTestClient;
 
@@ -87,9 +92,9 @@ public class CreateDhWithDatahubCreator extends AbstractIntegrationTest {
                 .await(EnvironmentStatus.AVAILABLE)
                 // testing unauthorized calls for environment
                 .whenException(environmentTestClient.describe(), ForbiddenException.class, expectedMessage("Doesn't have 'environments/describeEnvironment'" +
-                        " right on 'environment' " + environmentShortPattern(testContext)).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
+                        " right on 'environment' " + environmentPattern(testContext)).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .whenException(environmentTestClient.describe(), ForbiddenException.class, expectedMessage("Doesn't have 'environments/describeEnvironment'" +
-                        " right on 'environment' " + environmentShortPattern(testContext)).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
+                        " right on 'environment' " + environmentPattern(testContext)).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .validate();
 
         useRealUmsUser(testContext, AuthUserKeys.ENV_CREATOR_A);
@@ -121,29 +126,11 @@ public class CreateDhWithDatahubCreator extends AbstractIntegrationTest {
                 .await(STACK_AVAILABLE, RunningParameter.who(cloudbreakActor.useRealUmsUser(AuthUserKeys.ACCOUNT_ADMIN)))
                 .given(RenewDistroXCertificateTestDto.class)
                 .whenException(distroXClient.renewDistroXCertificateV4(), ForbiddenException.class, expectedMessage("Doesn't have 'datahub/repairDatahub'" +
-                        " right on any of the " + environmentDhPattern(testContext) + " or on " + datahubPattern(testContext))
+                        " right on any of the " + environmentDatahubPattern(testContext) + " or on " + datahubPattern(testContext))
                         .withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .validate();
 
         testCheckRightUtil(testContext, testContext.given(DistroXTestDto.class).getCrn());
-    }
-
-    private String environmentDhPattern(TestContext testContext) {
-        return "'environment'[(]-s[)] [\\[]crn='crn:cdp:environments:us-west-1:.*:environment:.*";
-    }
-
-    private String environmentShortPattern(TestContext testContext) {
-        return String.format("[\\[]name='%s', crn='crn:cdp:environments:us-west-1:.*:environment:.*",
-                testContext.get(EnvironmentTestDto.class).getName());
-    }
-
-    private String datahubPattern(TestContext testContext) {
-        return String.format("'cluster'[(]-s[)] [\\[]name='%s', crn='crn:cdp:datahub:us-west-1:.*:cluster:.*",
-                testContext.get(DistroXTestDto.class).getName());
-    }
-
-    private String datahubRecipePattern(String recipeName) {
-        return String.format("[\\[]name='%s', crn='crn:cdp:datahub:us-west-1:.*:recipe:.*'[]]\\.", recipeName);
     }
 
     private void testCheckRightUtil(TestContext testContext, String dhCrn) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DataStewardTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DataStewardTest.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.it.cloudbreak.testcase.authorization;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
+import static com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil.datalakePattern;
+import static com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil.environmentPattern;
+
+import javax.inject.Inject;
+import javax.ws.rs.ForbiddenException;
+
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.actor.CloudbreakActor;
+import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.RunningParameter;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
+import com.sequenceiq.it.cloudbreak.testcase.AbstractIntegrationTest;
+
+public class DataStewardTest extends AbstractIntegrationTest {
+
+    @Inject
+    private EnvironmentTestClient environmentTestClient;
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private CloudbreakActor cloudbreakActor;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        useRealUmsUser(testContext, AuthUserKeys.ACCOUNT_ADMIN);
+        initializeDefaultBlueprints(testContext);
+        createDefaultImageCatalog(testContext);
+        useRealUmsUser(testContext, AuthUserKeys.ENV_CREATOR_A);
+        useRealUmsUser(testContext, AuthUserKeys.ENV_DATA_STEWARD);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Description(
+            given = "there is a running env service",
+            when = "data steward is assigned to a new environment",
+            then = "data steward should access the required endpoints, but nothing else")
+    public void testDataStewardRoleRights(TestContext testContext) {
+        useRealUmsUser(testContext, AuthUserKeys.ENV_CREATOR_A);
+        createDefaultCredential(testContext);
+        createDefaultEnvironment(testContext);
+
+        testContext
+                .given(UmsTestDto.class)
+                .assignTarget(EnvironmentTestDto.class.getSimpleName())
+                .withEnvironmentAdmin()
+                .when(environmentTestClient.assignResourceRole(AuthUserKeys.ENV_ADMIN_A))
+                .withDataSteward()
+                .when(environmentTestClient.assignResourceRole(AuthUserKeys.ENV_DATA_STEWARD))
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.describe(), RunningParameter.who(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_DATA_STEWARD)))
+                .whenException(environmentTestClient.stop(), ForbiddenException.class, expectedMessage("Doesn't have 'environments/stopEnvironment'" +
+                        " right on 'environment' " + environmentPattern(testContext)).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_DATA_STEWARD)))
+                .whenException(environmentTestClient.delete(), ForbiddenException.class, expectedMessage("Doesn't have 'environments/deleteCdpEnvironment'" +
+                        " right on 'environment' " + environmentPattern(testContext)).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_DATA_STEWARD)))
+                .validate();
+
+        useRealUmsUser(testContext, AuthUserKeys.ENV_CREATOR_A);
+        createDatalake(testContext);
+
+        testContext
+                .given(SdxInternalTestDto.class)
+                .whenException(sdxTestClient.repairInternal(), ForbiddenException.class, expectedMessage("Doesn't have 'datalake/repairDatalake'" +
+                        " right on any of the 'environment'[(]-s[)] [\\[]crn='crn:cdp:environments:us-west-1:.*:environment:.*[]] or on " +
+                        datalakePattern(testContext)).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_DATA_STEWARD)))
+                .validate();
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DatalakeDatahubCreateAuthTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/DatalakeDatahubCreateAuthTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.it.cloudbreak.testcase.authorization;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+import static com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil.datalakePattern;
 
 import javax.inject.Inject;
 import javax.ws.rs.ForbiddenException;
@@ -95,10 +96,6 @@ public class DatalakeDatahubCreateAuthTest extends AbstractIntegrationTest {
                         " right on any of the 'environment'[(]-s[)] [\\[]crn='crn:cdp:environments:us-west-1:.*:environment:.*[]] or on " +
                         datalakePattern(testContext.get(sdxInternal).getName())).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .validate();
-    }
-
-    private String datalakePattern(String name) {
-        return String.format("'datalake'[(]-s[)] [\\[]name='%s', crn='crn:cdp:datalake:us-west-1:.*:datalake:.*\\.", name);
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/EnvStopStartWithEnvAdmin.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/EnvStopStartWithEnvAdmin.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.it.cloudbreak.testcase.authorization;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
+import static com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil.environmentPattern;
 
 import java.util.List;
 import java.util.Map;
@@ -120,11 +121,6 @@ public class EnvStopStartWithEnvAdmin extends AbstractIntegrationTest {
                 .validate();
 
         testCheckRightUtil(testContext, testContext.given(DistroXTestDto.class).getCrn());
-    }
-
-    private String environmentPattern(TestContext testContext) {
-        return String.format("[\\[]name='%s', crn='crn:cdp:environments:us-west-1:.*:environment:.*[]]\\.",
-                testContext.get(EnvironmentTestDto.class).getName());
     }
 
     private void testCheckRightUtil(TestContext testContext, String dhCrn) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/EnvironmentCreateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/EnvironmentCreateTest.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.it.cloudbreak.testcase.authorization;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
+import static com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil.environmentFreeIpaPattern;
+import static com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil.environmentPattern;
 
 import java.util.List;
 import java.util.Map;
@@ -150,15 +152,6 @@ public class EnvironmentCreateTest extends AbstractMockTest {
                 .whenException(freeIpaTestClient.start(), ForbiddenException.class, expectedMessage("Doesn't have 'environments/startEnvironment' right on" +
                         " 'environment' " + environmentFreeIpaPattern(testContext)).withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .validate();
-    }
-
-    private String environmentPattern(TestContext testContext) {
-        return String.format("[\\[]name='%s', crn='crn:cdp:environments:us-west-1:.*:environment:.*[]]\\.",
-                testContext.get(EnvironmentTestDto.class).getName());
-    }
-
-    private String environmentFreeIpaPattern(TestContext testContext) {
-        return String.format("[\\[]crn='crn:cdp:environments:us-west-1:.*:environment:.*[]]\\.");
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/RecipeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/RecipeTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.it.cloudbreak.testcase.authorization;
 
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
 import static com.sequenceiq.it.cloudbreak.context.RunningParameter.who;
+import static com.sequenceiq.it.cloudbreak.util.AuthorizationTestUtil.datahubRecipePattern;
 
 import javax.inject.Inject;
 import javax.ws.rs.ForbiddenException;
@@ -54,19 +55,19 @@ public class RecipeTest extends AbstractIntegrationTest {
                 })
                 .whenException(recipeTestClient.getV4(), ForbiddenException.class,
                         expectedMessage("Doesn't have 'environments/useSharedResource' right on 'recipe' " +
-                                patternWithName(testContext.get(RecipeTestDto.class).getName()))
+                                datahubRecipePattern(testContext.get(RecipeTestDto.class).getName()))
                                 .withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .whenException(recipeTestClient.getV4(), ForbiddenException.class,
                         expectedMessage("Doesn't have 'environments/useSharedResource' right on 'recipe' " +
-                                patternWithName(testContext.get(RecipeTestDto.class).getName()))
+                                datahubRecipePattern(testContext.get(RecipeTestDto.class).getName()))
                                 .withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .whenException(recipeTestClient.deleteV4(), ForbiddenException.class,
                         expectedMessage("Doesn't have 'environments/deleteRecipe' right on 'recipe' " +
-                                patternWithName(testContext.get(RecipeTestDto.class).getName()))
+                                datahubRecipePattern(testContext.get(RecipeTestDto.class).getName()))
                                 .withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_B)))
                 .whenException(recipeTestClient.deleteV4(), ForbiddenException.class,
                         expectedMessage("Doesn't have 'environments/deleteRecipe' right on 'recipe' " +
-                                        patternWithName(testContext.get(RecipeTestDto.class).getName()))
+                                datahubRecipePattern(testContext.get(RecipeTestDto.class).getName()))
                                 .withWho(cloudbreakActor.useRealUmsUser(AuthUserKeys.ZERO_RIGHTS)))
                 .when(recipeTestClient.deleteV4(), who(cloudbreakActor.useRealUmsUser(AuthUserKeys.ENV_CREATOR_A)))
                 .when(recipeTestClient.listV4())
@@ -80,7 +81,4 @@ public class RecipeTest extends AbstractIntegrationTest {
                 .validate();
     }
 
-    private String patternWithName(String name) {
-        return String.format("[\\[]name='%s', crn='crn:cdp:datahub:us-west-1:.*:recipe:.*'[]].", name);
-    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/AbstractMockTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/AbstractMockTest.java
@@ -25,6 +25,7 @@ public abstract class AbstractMockTest extends AbstractIntegrationTest {
     @Inject
     private FreeIpaTestClient freeIpaTestClient;
 
+    @Override
     protected void setupTest(TestContext testContext) {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/AuthorizationTestUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/AuthorizationTestUtil.java
@@ -14,6 +14,10 @@ import com.sequenceiq.it.cloudbreak.assertion.Assertion;
 import com.sequenceiq.it.cloudbreak.client.UtilTestClient;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.recipe.RecipeTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.CheckResourceRightTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.CheckRightTestDto;
 
@@ -38,4 +42,39 @@ public class AuthorizationTestUtil {
                 .when(utilTestClient.checkResourceRight(), RunningParameter.who(cloudbreakActor.useRealUmsUser(testUmsUser)))
                 .then(assertion);
     }
+
+    public static String environmentPattern(TestContext testContext) {
+        return String.format("[\\[]name='%s', crn='crn:cdp:environments:us-west-1:.*:environment:.*[]]\\.",
+                testContext.get(EnvironmentTestDto.class).getName());
+    }
+
+    public static String environmentDatahubPattern(TestContext testContext) {
+        return "'environment'[(]-s[)] [\\[]crn='crn:cdp:environments:us-west-1:.*:environment:.*";
+    }
+
+    public static String environmentFreeIpaPattern(TestContext testContext) {
+        return "[\\[]crn='crn:cdp:environments:us-west-1:.*:environment:.*[]]\\.";
+    }
+
+    public static String datalakePattern(TestContext testContext) {
+        return datalakePattern(testContext.get(SdxInternalTestDto.class).getName());
+    }
+
+    public static String datalakePattern(String name) {
+        return String.format("'datalake'[(]-s[)] [\\[]name='%s', crn='crn:cdp:datalake:us-west-1:.*:datalake:.*\\.", name);
+    }
+
+    public static String datahubPattern(TestContext testContext) {
+        return String.format("'cluster'[(]-s[)] [\\[]name='%s', crn='crn:cdp:datahub:us-west-1:.*:cluster:.*",
+                testContext.get(DistroXTestDto.class).getName());
+    }
+
+    public static String datahubRecipePattern(TestContext testContext) {
+        return datahubRecipePattern(testContext.get(RecipeTestDto.class).getName());
+    }
+
+    public static String datahubRecipePattern(String recipeName) {
+        return String.format("[\\[]name='%s', crn='crn:cdp:datahub:us-west-1:.*:recipe:.*'[]]\\.", recipeName);
+    }
+
 }

--- a/integration-test/src/main/resources/testsuites/v4/mock/real-ums-mock-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/v4/mock/real-ums-mock-tests.yaml
@@ -4,6 +4,7 @@ tests:
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.authorization.CreateDhWithDatahubCreator
       - name: com.sequenceiq.it.cloudbreak.testcase.authorization.CredentialCreateTest
+      - name: com.sequenceiq.it.cloudbreak.testcase.authorization.DataStewardTest
       - name: com.sequenceiq.it.cloudbreak.testcase.authorization.DatalakeDatahubCreateAuthTest
       - name: com.sequenceiq.it.cloudbreak.testcase.authorization.EnvironmentCreateTest
       - name: com.sequenceiq.it.cloudbreak.testcase.authorization.EnvStopStartWithEnvAdmin


### PR DESCRIPTION
CB-10710 Create Real UMS test for the DataSteward resource role

And minor refactor regarding authorization error message validation in Real UMS tests.

Testcase scenario:
 - Create new environment and datalake
 - Assign the Datasteward actor to the environment
 - Call allowed and not allowed APIs