### PR TITLE
DWX-6635 CDW s3 bucket tags

### DIFF
--- a/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
+++ b/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
@@ -138,7 +138,8 @@
         "s3:GetBucketLocation",
         "s3:PutObject",
         "s3:DeleteBucket",
-        "s3:PutBucketPublicAccessBlock"
+        "s3:PutBucketPublicAccessBlock",
+        "s3:PutBucketTagging"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
To put tags on the s3 buckets the PutBucketTagging permission should
be added to the user policy.

See detailed description in the commit message.