### PR TITLE
CB-8529 Starting Hue fails with longer stackname. Validating blueprin…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/validation/HueWorkaroundValidatorService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/validation/HueWorkaroundValidatorService.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+
+@Service
+public class HueWorkaroundValidatorService {
+
+    private static final int MAX_ENDPOINT_LENGTH = 63;
+
+    private static final int MAX_STACK_NAME_LENGTH = 20;
+
+    private static final int MAX_HOST_GROUP_NAME = 6;
+
+    public void validateForStackRequest(Set<String> hueHostGroups, String stackName) {
+        if (isHuePresented(hueHostGroups)) {
+            validateLimitedStackNameLength(stackName);
+            // We need to validate the request for the existing blueprints which were added before this change
+            validateLimitedHostgroupNameLength(hueHostGroups);
+        }
+    }
+
+    public void validateForBlueprintRequest(Set<String> hueHostGroups) {
+        if (isHuePresented(hueHostGroups)) {
+            validateLimitedHostgroupNameLength(hueHostGroups);
+        }
+    }
+
+    public void validateForEnvironmentDomainName(Set<String> hueHostGroups, String endpointName) {
+        if (isHuePresented(hueHostGroups)) {
+            if (tooLongEnpointName(endpointName)) {
+                throw new BadRequestException(String.format("Your Data Hub contains Hue. Hue does not support CDP Data "
+                        + "Hubs where the fully qualified domain name of a VM is longer than 63 characters. "
+                        + "Generated hostname: %s. Please retry creating Data Hub using a Data Hub name that is shorter than "
+                        + "20 characters and a hostgroup name that is shorter than 6 characters.", endpointName));
+            }
+        }
+    }
+
+    private boolean isHuePresented(Set<String> hueHostGroups) {
+        return !hueHostGroups.isEmpty();
+    }
+
+    private void validateLimitedHostgroupNameLength(Set<String> hueHostGroups) {
+        if (isHuePresented(hueHostGroups)) {
+            Set<String> hostGroupsWhichAreLongerThanSixCharacter = hueHostGroups
+                    .stream()
+                    .filter(e -> e.length() > MAX_HOST_GROUP_NAME)
+                    .collect(Collectors.toSet());
+            if (!hostGroupsWhichAreLongerThanSixCharacter.isEmpty()) {
+                throw new BadRequestException(String.format("Hue does not support CDP Data Hubs where hostgroup name is longer than 6 characters. "
+                                + "Please retry creating the template by shortening the hostgroup name: %s  under 6 characters.",
+                        String.join(", ", hostGroupsWhichAreLongerThanSixCharacter)));
+            }
+        }
+    }
+
+    private void validateLimitedStackNameLength(String name) {
+        if (name.length() > MAX_STACK_NAME_LENGTH) {
+            throw new BadRequestException("Your Data Hub contains Hue. Hue does not support CDP Data Hubs where Data Hub name is longer than 20 characters. "
+                    + "Please retry creating Data Hub using a Data Hub name that is shorter than 20 characters.");
+        }
+    }
+
+    private boolean tooLongEnpointName(String enpointName) {
+        if (enpointName.length() > MAX_ENDPOINT_LENGTH) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/validation/HueWorkaroundValidatorServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/validation/HueWorkaroundValidatorServiceTest.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HueWorkaroundValidatorServiceTest {
+
+    private HueWorkaroundValidatorService underTest;
+
+    @Before
+    public void setUp() throws Exception {
+        underTest = new HueWorkaroundValidatorService();
+    }
+
+    @Test
+    public void validateBlueprintRequestWhenHueIsPresentedAndAllTheGroupNameHasTheCorrectLengthShouldNotThrowException() {
+        assertDoesNotThrow(() -> underTest.validateForBlueprintRequest(Set.of("master")));
+    }
+
+    @Test
+    public void validateBlueprintRequestWhenHueIsPresentedAndHueHostgroupIsTooLongMustThrowException() {
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.validateForBlueprintRequest(Set.of("master123456")));
+        Assert.assertEquals("Hue does not support CDP Data Hubs where hostgroup name is longer than 6 characters. "
+                        + "Please retry creating the template by shortening the hostgroup name: master123456  under 6 characters.",
+                badRequestException.getMessage());
+    }
+
+    @Test
+    public void validateStackRequestWhenHueIsPresentedAndStackNameTooLongMustThrowException() {
+        String stackName = "iamveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylong";
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.validateForStackRequest(Set.of("master"), stackName));
+        Assert.assertEquals("Your Data Hub contains Hue. Hue does not support CDP Data Hubs where Data Hub name is longer than 20 characters. "
+                        + "Please retry creating Data Hub using a Data Hub name that is shorter than 20 characters.",
+                badRequestException.getMessage());
+    }
+
+    @Test
+    public void validateStackRequestWhenHueIsPresentedAndHueHostgroupIsTooLongMustThrowException() {
+        String stackName = "thisisfine";
+
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.validateForStackRequest(Set.of("master123456"), stackName));
+        Assert.assertEquals("Hue does not support CDP Data Hubs where hostgroup name is longer than 6 characters. "
+                        + "Please retry creating the template by shortening the hostgroup name: master123456  under 6 characters.",
+                badRequestException.getMessage());
+    }
+
+    @Test
+    public void validateEndpointNameIfHuePresentedAndEndpointNameTooLongShouldThrowException() {
+        String endpointName = "thisisfine.thisisfinethisisfinethisisfinethisisfinethisisfinethisisfinethisisfinethisisfine";
+
+        BadRequestException badRequestException = assertThrows(BadRequestException.class,
+                () -> underTest.validateForEnvironmentDomainName(Set.of("master"), endpointName));
+        Assert.assertEquals("Your Data Hub contains Hue. Hue does not support CDP Data Hubs where the fully qualified domain name of a "
+                        + "VM is longer than 63 characters. Generated hostname: "
+                        + "thisisfine.thisisfinethisisfinethisisfinethisisfinethisisfinethisisfinethisisfinethisisfine. "
+                        + "Please retry creating Data Hub using a Data Hub name that is shorter than 20 characters and a"
+                        + " hostgroup name that is shorter than 6 characters.",
+                badRequestException.getMessage());
+    }
+
+}

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -46,6 +46,7 @@
     <suppress files="com[\\/]sequenceiq[\\/]mock[\\/]" checks="ExecutableStatementCount"/>
     <suppress files="client[\\/]" checks="ExecutableStatementCount"/>
     <suppress files="api[\\/]" checks="ExecutableStatementCount"/>
+    <suppress files="BlueprintTestBase" checks="LineLength"/>
 
     <!-- suppressing checks in application runner classes -->
     <suppress id="sysout" files="VersionedApplication.java"/>

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -38,6 +37,7 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
+import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.securityconfig.SecurityConfigService;
@@ -158,7 +158,7 @@ class GatewayPublicEndpointManagementServiceTest {
 
         String endpointName = stack.getPrimaryGatewayInstance().getShortHostname();
         String fqdn = endpointName + ".anenvname.xcu2-8y8x.dev.cldr.work";
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(anyString(), anyString(), anyString(), anyString(), anyBoolean(), any())).thenReturn(true);
 
         boolean result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.renewCertificate(stack));
@@ -220,7 +220,7 @@ class GatewayPublicEndpointManagementServiceTest {
         String commonName = "hashofshorthostname.anenvname.xcu2-8y8x.dev.cldr.work";
         when(domainNameProvider.getCommonName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(commonName);
         String fqdn = endpointName + ".anenvname.xcu2-8y8x.dev.cldr.work";
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
         when(certificateCreationService.create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class)))
                 .thenReturn(List.of());
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(anyString(), anyString(), anyString(), anyString(), anyBoolean(), any())).thenReturn(true);
@@ -230,7 +230,7 @@ class GatewayPublicEndpointManagementServiceTest {
         verify(environmentClientService, times(2)).getByCrn(anyString());
         verify(grpcUmsClient, times(2)).getAccountDetails(USER_CRN, "123", Optional.empty());
         verify(domainNameProvider, times(1)).getCommonName(endpointName, envName, accountWorkloadSubdomain);
-        verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain);
+        verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain);
         verify(certificateCreationService, times(1))
                 .create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class));
         verify(securityConfigService, times(1)).save(any(SecurityConfig.class));
@@ -268,7 +268,7 @@ class GatewayPublicEndpointManagementServiceTest {
         when(domainNameProvider.getCommonName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(commonName);
 
         String fqdn = endpointName + ".anenvname.xcu2-8y8x.dev.cldr.work";
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
 
         when(certificateCreationService.create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class)))
                 .thenReturn(List.of());
@@ -279,7 +279,7 @@ class GatewayPublicEndpointManagementServiceTest {
         verify(environmentClientService, times(1)).getByCrn(anyString());
         verify(grpcUmsClient, times(1)).getAccountDetails(USER_CRN, "123", Optional.empty());
         verify(domainNameProvider, times(1)).getCommonName(endpointName, envName, accountWorkloadSubdomain);
-        verify(domainNameProvider, times(1)).getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain);
+        verify(domainNameProvider, times(1)).getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain);
         verify(certificateCreationService, times(1))
                 .create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class));
         verify(securityConfigService, times(1)).save(any(SecurityConfig.class));
@@ -319,7 +319,7 @@ class GatewayPublicEndpointManagementServiceTest {
                 .setWorkloadSubdomain(accountWorkloadSubdomain)
                 .build();
         when(grpcUmsClient.getAccountDetails(USER_CRN, "123", Optional.empty())).thenReturn(umsAccount);
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), eq(Boolean.FALSE),
                 eq(List.of(primaryGatewayInstance.getPublicIpWrapper())))).thenReturn(Boolean.TRUE);
 
@@ -327,7 +327,7 @@ class GatewayPublicEndpointManagementServiceTest {
 
         verify(environmentClientService, times(1)).getByCrn(anyString());
         verify(grpcUmsClient, times(1)).getAccountDetails(USER_CRN, "123", Optional.empty());
-        verify(domainNameProvider, times(1)).getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain);
+        verify(domainNameProvider, times(1)).getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain);
         verify(dnsManagementService, times(1))
                 .createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), eq(Boolean.FALSE),
                         eq(List.of(primaryGatewayInstance.getPublicIpWrapper())));
@@ -360,7 +360,7 @@ class GatewayPublicEndpointManagementServiceTest {
                 .build();
         when(grpcUmsClient.getAccountDetails(USER_CRN, "123", Optional.empty())).thenReturn(umsAccount);
         when(domainNameProvider.getCommonName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(commonName);
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
         when(certificateCreationService.create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class)))
                 .thenReturn(List.of());
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), eq(Boolean.FALSE),
@@ -371,7 +371,7 @@ class GatewayPublicEndpointManagementServiceTest {
         verify(environmentClientService, times(2)).getByCrn(anyString());
         verify(grpcUmsClient, times(2)).getAccountDetails(USER_CRN, "123", Optional.empty());
         verify(domainNameProvider, times(1)).getCommonName(endpointName, envName, accountWorkloadSubdomain);
-        verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain);
+        verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain);
         verify(certificateCreationService, times(1))
                 .create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class));
         verify(dnsManagementService, times(1))
@@ -408,7 +408,7 @@ class GatewayPublicEndpointManagementServiceTest {
         String commonName = "hashofshorthostname.anenvname.xcu2-8y8x.dev.cldr.work";
         String fqdn = endpointName + ".anenvname.xcu2-8y8x.dev.cldr.work";
         when(domainNameProvider.getCommonName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(commonName);
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
         when(certificateCreationService.create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class)))
                 .thenReturn(List.of());
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), eq(Boolean.FALSE),
@@ -419,7 +419,7 @@ class GatewayPublicEndpointManagementServiceTest {
         verify(environmentClientService, times(2)).getByCrn(anyString());
         verify(grpcUmsClient, times(2)).getAccountDetails(USER_CRN, "123", Optional.empty());
         verify(domainNameProvider, times(1)).getCommonName(endpointName, envName, accountWorkloadSubdomain);
-        verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain);
+        verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain);
         verify(certificateCreationService, times(1))
                 .create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class));
         verify(dnsManagementService, times(1))
@@ -492,7 +492,7 @@ class GatewayPublicEndpointManagementServiceTest {
                 .setWorkloadSubdomain(accountWorkloadSubdomain)
                 .build();
         when(grpcUmsClient.getAccountDetails(USER_CRN, "123", Optional.empty())).thenReturn(umsAccount);
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenThrow(new IllegalStateException());
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenThrow(new IllegalStateException());
 
         String result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.updateDnsEntry(stack, null));
 
@@ -520,7 +520,7 @@ class GatewayPublicEndpointManagementServiceTest {
                 .build();
         when(grpcUmsClient.getAccountDetails(USER_CRN, "123", Optional.empty())).thenReturn(umsAccount);
         String fqdn = endpointName + ".anenvname.xcu2-8y8x.dev.cldr.work";
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
 
         String result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.updateDnsEntry(stack, null));
 
@@ -553,7 +553,7 @@ class GatewayPublicEndpointManagementServiceTest {
                 .build();
         when(grpcUmsClient.getAccountDetails(USER_CRN, "123", Optional.empty())).thenReturn(umsAccount);
         String fqdn = endpointName + ".anenvname.xcu2-8y8x.dev.cldr.work";
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
 
         String result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.updateDnsEntry(stack, gatewayIp));
 
@@ -586,7 +586,7 @@ class GatewayPublicEndpointManagementServiceTest {
                 .build();
         when(grpcUmsClient.getAccountDetails(USER_CRN, "123", Optional.empty())).thenReturn(umsAccount);
         String fqdn = endpointName + ".anenvname.xcu2-8y8x.dev.cldr.work";
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
 
         String result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.updateDnsEntry(stack, gatewayIp));
 
@@ -670,23 +670,23 @@ class GatewayPublicEndpointManagementServiceTest {
         String hostedZoneId = loadBalancer.getHostedZoneId();
 
         DetailedEnvironmentResponse environment = DetailedEnvironmentResponse.Builder
-            .builder()
-            .withName(envName)
-            .build();
+                .builder()
+                .withName(envName)
+                .build();
         when(environmentClientService.getByCrn(Mockito.anyString())).thenReturn(environment);
         UserManagementProto.Account umsAccount = UserManagementProto.Account.newBuilder()
-            .setWorkloadSubdomain(accountWorkloadSubdomain)
-            .build();
+                .setWorkloadSubdomain(accountWorkloadSubdomain)
+                .build();
         when(grpcUmsClient.getAccountDetails(USER_CRN, "123", Optional.empty())).thenReturn(umsAccount);
         when(domainNameProvider.getCommonName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(commonName);
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
-        when(domainNameProvider.getFullyQualifiedEndpointName(lbEndpointName, envName, accountWorkloadSubdomain)).thenReturn(lbfqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), lbEndpointName, envName, accountWorkloadSubdomain)).thenReturn(lbfqdn);
         when(certificateCreationService.create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class)))
-            .thenReturn(List.of());
+                .thenReturn(List.of());
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), eq(Boolean.FALSE),
-            eq(List.of(primaryGatewayInstance.getPublicIpWrapper())))).thenReturn(Boolean.TRUE);
+                eq(List.of(primaryGatewayInstance.getPublicIpWrapper())))).thenReturn(Boolean.TRUE);
         when(dnsManagementService.createOrUpdateDnsEntryWithCloudDns(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(cloudDns),
-            eq(hostedZoneId))).thenReturn(Boolean.TRUE);
+                eq(hostedZoneId))).thenReturn(Boolean.TRUE);
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(loadBalancer));
         when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
 
@@ -695,15 +695,15 @@ class GatewayPublicEndpointManagementServiceTest {
         verify(environmentClientService, times(3)).getByCrn(anyString());
         verify(grpcUmsClient, times(3)).getAccountDetails(USER_CRN, "123", Optional.empty());
         verify(domainNameProvider, times(1)).getCommonName(endpointName, envName, accountWorkloadSubdomain);
-        verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain);
+        verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain);
         verify(certificateCreationService, times(1))
-            .create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class));
+                .create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class));
         verify(dnsManagementService, times(1))
-            .createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), eq(Boolean.FALSE),
-                eq(List.of(primaryGatewayInstance.getPublicIpWrapper())));
+                .createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), eq(Boolean.FALSE),
+                        eq(List.of(primaryGatewayInstance.getPublicIpWrapper())));
         verify(dnsManagementService, times(1))
-            .createOrUpdateDnsEntryWithCloudDns(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(cloudDns),
-                eq(hostedZoneId));
+                .createOrUpdateDnsEntryWithCloudDns(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(cloudDns),
+                        eq(hostedZoneId));
         verify(securityConfigService, times(2)).save(any(SecurityConfig.class));
         Assertions.assertEquals(Boolean.TRUE, result);
     }
@@ -732,23 +732,23 @@ class GatewayPublicEndpointManagementServiceTest {
         String lbIp = loadBalancer.getIp();
 
         DetailedEnvironmentResponse environment = DetailedEnvironmentResponse.Builder
-            .builder()
-            .withName(envName)
-            .build();
+                .builder()
+                .withName(envName)
+                .build();
         when(environmentClientService.getByCrn(Mockito.anyString())).thenReturn(environment);
         UserManagementProto.Account umsAccount = UserManagementProto.Account.newBuilder()
-            .setWorkloadSubdomain(accountWorkloadSubdomain)
-            .build();
+                .setWorkloadSubdomain(accountWorkloadSubdomain)
+                .build();
         when(grpcUmsClient.getAccountDetails(USER_CRN, "123", Optional.empty())).thenReturn(umsAccount);
         when(domainNameProvider.getCommonName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(commonName);
-        when(domainNameProvider.getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
-        when(domainNameProvider.getFullyQualifiedEndpointName(lbEndpointName, envName, accountWorkloadSubdomain)).thenReturn(lbfqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain)).thenReturn(fqdn);
+        when(domainNameProvider.getFullyQualifiedEndpointName(Set.of(), lbEndpointName, envName, accountWorkloadSubdomain)).thenReturn(lbfqdn);
         when(certificateCreationService.create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class)))
-            .thenReturn(List.of());
+                .thenReturn(List.of());
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), eq(Boolean.FALSE),
-            eq(List.of(primaryGatewayInstance.getPublicIpWrapper())))).thenReturn(Boolean.TRUE);
+                eq(List.of(primaryGatewayInstance.getPublicIpWrapper())))).thenReturn(Boolean.TRUE);
         when(dnsManagementService.createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(Boolean.FALSE),
-            eq(List.of(lbIp)))).thenReturn(Boolean.TRUE);
+                eq(List.of(lbIp)))).thenReturn(Boolean.TRUE);
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(loadBalancer));
         when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
 
@@ -757,15 +757,15 @@ class GatewayPublicEndpointManagementServiceTest {
         verify(environmentClientService, times(3)).getByCrn(anyString());
         verify(grpcUmsClient, times(3)).getAccountDetails(USER_CRN, "123", Optional.empty());
         verify(domainNameProvider, times(1)).getCommonName(endpointName, envName, accountWorkloadSubdomain);
-        verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(endpointName, envName, accountWorkloadSubdomain);
+        verify(domainNameProvider, times(2)).getFullyQualifiedEndpointName(Set.of(), endpointName, envName, accountWorkloadSubdomain);
         verify(certificateCreationService, times(1))
-            .create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class));
+                .create(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), any(PKCS10CertificationRequest.class));
         verify(dnsManagementService, times(1))
-            .createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), eq(Boolean.FALSE),
-                eq(List.of(primaryGatewayInstance.getPublicIpWrapper())));
+                .createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(endpointName), eq(envName), eq(Boolean.FALSE),
+                        eq(List.of(primaryGatewayInstance.getPublicIpWrapper())));
         verify(dnsManagementService, times(1))
-            .createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(Boolean.FALSE),
-                eq(List.of(lbIp)));
+                .createOrUpdateDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(Boolean.FALSE),
+                        eq(List.of(lbIp)));
         verify(securityConfigService, times(2)).save(any(SecurityConfig.class));
         Assertions.assertEquals(Boolean.TRUE, result);
     }
@@ -788,15 +788,15 @@ class GatewayPublicEndpointManagementServiceTest {
         String hostedZoneId = loadBalancer.getHostedZoneId();
 
         when(dnsManagementService.deleteDnsEntryWithCloudDns(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(cloudDns),
-            eq(hostedZoneId))).thenReturn(Boolean.TRUE);
+                eq(hostedZoneId))).thenReturn(Boolean.TRUE);
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(loadBalancer));
         when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.deleteLoadBalancerDnsEntry(stack, envName));
 
         verify(dnsManagementService, times(1))
-            .deleteDnsEntryWithCloudDns(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(cloudDns),
-                eq(hostedZoneId));
+                .deleteDnsEntryWithCloudDns(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(cloudDns),
+                        eq(hostedZoneId));
     }
 
     @Test
@@ -815,14 +815,14 @@ class GatewayPublicEndpointManagementServiceTest {
         String ip = loadBalancer.getIp();
 
         when(dnsManagementService.deleteDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(Boolean.FALSE),
-            eq(List.of(ip)))).thenReturn(Boolean.TRUE);
+                eq(List.of(ip)))).thenReturn(Boolean.TRUE);
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(loadBalancer));
         when(loadBalancerConfigService.selectLoadBalancer(any(), any())).thenReturn(Optional.of(loadBalancer));
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.deleteLoadBalancerDnsEntry(stack, envName));
 
         verify(dnsManagementService, times(1))
-            .deleteDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(Boolean.FALSE),
-                eq(List.of(ip)));
+                .deleteDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(Boolean.FALSE),
+                        eq(List.of(ip)));
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/ResourcePropertyProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/ResourcePropertyProvider.java
@@ -14,7 +14,7 @@ import com.sequenceiq.it.cloudbreak.cloud.v4.CommonCloudProperties;
 @Component
 public class ResourcePropertyProvider {
 
-    private static final int MAX_LENGTH = 40;
+    private static final int MAX_LENGTH = 19;
 
     private static final int ENVIRONMENT_NAME_MAX_LENGTH = 28;
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/BlueprintTestBase.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/BlueprintTestBase.java
@@ -6,9 +6,7 @@ public class BlueprintTestBase extends AbstractMockTest {
             "\"HDFS\",\"roleConfigGroups\":[{\"refName\":\"hdfs-NAMENODE-BASE\",\"roleType\":\"NAMENODE\",\"base\":true},{\"refName\":\"" +
             "hdfs-SECONDARYNAMENODE-BASE\",\"roleType\":\"SECONDARYNAMENODE\",\"base\":true},{\"refName\":\"hdfs-DATANODE-BASE\",\"roleType\":\"DATANODE\"," +
             "\"configs\":[{\"name\":\"dfs_datanode_max_locked_memory\",\"value\":\"0\",\"autoConfig\":false}],\"base\":true},{\"refName\":\"" +
-            "hdfs-BALANCER-BASE\",\"roleType\":\"BALANCER\",\"base\":true}]},{\"refName\":\"hue\",\"serviceType\":\"HUE\",\"roleConfigGroups\":" +
-            "[{\"refName\":\"hue-HUE_SERVER-BASE\",\"roleType\":\"HUE_SERVER\",\"base\":true},{\"refName\":\"hue-HUE_LOAD_BALANCER-BASE\",\"roleType\":" +
-            "\"HUE_LOAD_BALANCER\",\"base\":true}]},{\"refName\":\"impala\",\"serviceType\":\"IMPALA\",\"serviceConfigs\":[{\"name\":\"" +
+            "hdfs-BALANCER-BASE\",\"roleType\":\"BALANCER\",\"base\":true}]},{\"refName\":\"impala\",\"serviceType\":\"IMPALA\",\"serviceConfigs\":[{\"name\":\"" +
             "impala_cmd_args_safety_valve\",\"value\":\"--cache_s3_file_handles=true\"}],\"roleConfigGroups\":[{\"refName\":\"impala-IMPALAD-COORDINATOR\"" +
             ",\"roleType\":\"IMPALAD\",\"configs\":[{\"name\":\"impalad_specialization\",\"value\":\"COORDINATOR_ONLY\"},{\"name\":\"" +
             "impala_hdfs_site_conf_safety_valve\",\"value\":\"<property><name>fs.s3a.block.size</name><value>268435456</value></property><property" +
@@ -19,7 +17,7 @@ public class BlueprintTestBase extends AbstractMockTest {
             "</property><property><name>fs.s3a.fast.upload</name><value>true</value></property>\"}],\"base\":false},{\"refName\":\"impala-STATESTORE-BASE\"" +
             ",\"roleType\":\"STATESTORE\",\"base\":true},{\"refName\":\"impala-CATALOGSERVER-BASE\",\"roleType\":\"CATALOGSERVER\",\"base\":true}]}],\"" +
             "hostTemplates\":[{\"refName\":\"master\",\"cardinality\":\"1\",\"roleConfigGroupsRefNames\":[\"hdfs-BALANCER-BASE\",\"hdfs-NAMENODE-BASE\"," +
-            "\"hdfs-SECONDARYNAMENODE-BASE\",\"hue-HUE_LOAD_BALANCER-BASE\",\"hue-HUE_SERVER-BASE\",\"impala-CATALOGSERVER-BASE\",\"impala-STATESTORE-BASE\"" +
+            "\"hdfs-SECONDARYNAMENODE-BASE\",\"impala-CATALOGSERVER-BASE\",\"impala-STATESTORE-BASE\"" +
             "]},{\"refName\":\"coordinator\",\"cardinality\":\"1\",\"roleConfigGroupsRefNames\":[\"hdfs-DATANODE-BASE\",\"impala-IMPALAD-COORDINATOR\"]}," +
             "{\"refName\":\"executor\",\"cardinality\":\"2\",\"roleConfigGroupsRefNames\":[\"hdfs-DATANODE-BASE\",\"impala-IMPALAD-EXECUTOR\"]}]}";
 

--- a/integration-test/src/main/resources/blueprint/clouderamanager.bp
+++ b/integration-test/src/main/resources/blueprint/clouderamanager.bp
@@ -213,28 +213,6 @@
         ]
       },
       {
-        "refName": "hue",
-        "serviceType": "HUE",
-        "serviceConfigs": [
-          {
-            "name": "hue_service_safety_valve",
-            "value": "[desktop]\napp_blacklist=spark,zookeeper,hbase,impala,search,sqoop,security,pig"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "hue-HUE_SERVER-BASE",
-            "roleType": "HUE_SERVER",
-            "base": true
-          },
-          {
-            "refName": "hue-HUE_LOAD_BALANCER-BASE",
-            "roleType": "HUE_LOAD_BALANCER",
-            "base": true
-          }
-        ]
-      },
-      {
         "refName": "livy",
         "serviceType": "LIVY",
         "roleConfigGroups": [
@@ -321,8 +299,6 @@
           "hms-HIVEMETASTORE-BASE",
           "hive_on_tez-HIVESERVER2-BASE",
           "hive_on_tez-GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "hue-HUE_SERVER-BASE",
           "tez-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",


### PR DESCRIPTION
…t groups, generated endpoints and stackname. The validation will fails:

1. IF distrox_cluster_name.length > 20 AND cm_Template contains HUE
2. IF distrox_template_hostgroup_name.length > 6 AND hostgroup contains HUE
3. generated_hostname.length > 63 AND hostgroup contains HUE

See detailed description in the commit message.