### PR TITLE
CB-11122. Do not check cdpTelemetryVersion (role) in case of updatePa…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/init.sls
@@ -81,7 +81,7 @@ fail_if_telemetry_rpm_is_not_installed:
     - mode: '0750'
     - failhard: True
 
-{% if telemetry.cdpTelemetryVersion > 3 and filecollector.destination == "SUPPORT" %}
+{% if (filecollector.updatePackage or telemetry.cdpTelemetryVersion > 3) and filecollector.destination == "SUPPORT" %}
 /opt/cdp-telemetry/conf/extra-dbus-headers.yaml:
    file.managed:
     - source: salt://filecollector/template/extra-dbus-headers.yaml.j2

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/cdp-doctor-commands.yaml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/cdp-doctor-commands.yaml.j2
@@ -29,7 +29,7 @@ commands:
     - command: cdp-doctor recipe results
       output: /tmp/doctor_recipes.txt
     - command: cdp-doctor scm list-commands
-      output: /tmp/doctor_scm_agent_commands.txt{% endif %}{% if filecollector.clusterType == "DATAHUB" and telemetry.cdpTelemetryVersion > 0 %}
+      output: /tmp/doctor_scm_agent_commands.txt{% endif %}{% if filecollector.clusterType == "DATAHUB" and (filecollector.updatePackage or telemetry.cdpTelemetryVersion > 0) %}
     - command: cdp-doctor metering status
       output: /tmp/doctor_metering.txt{% endif %}
 report:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/upload.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/upload.sls
@@ -17,7 +17,7 @@ filecollector_upload_to_cloud_storage:
 
 {% if filecollector.destination == "SUPPORT" %}
 
-{% if telemetry.cdpTelemetryVersion > 3 %}
+{% if filecollector.updatePackage or telemetry.cdpTelemetryVersion > 3 %}
     {% set extra_dbus_header_file_param = "-e /opt/cdp-telemetry/conf/extra-dbus-headers.yaml" %}
 {% else %}
     {% set extra_dbus_header_file_param = "" %}


### PR DESCRIPTION
…ckage parameter is provided.

details:
if updatePackage is used, cdp-telemetry binari is updated to the latest available version (non-snapshot), if that's the case, makes no sense to not run certain part of the code that are version specific

See detailed description in the commit message.