### PR TITLE
CB-10566 Endpoints for collecting used images

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/UtilV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/UtilV4Endpoint.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.RepoConfigValida
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.ResourceEventResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.SecurityRulesV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackMatrixV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.UsedImagesListV4Response;
 import com.sequenceiq.cloudbreak.doc.Notes;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.AccountPreferencesDescription;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.RepositoryConfigsValidationOpDescription;
@@ -91,4 +92,10 @@ public interface UtilV4Endpoint {
     @ApiOperation(value = UtilityOpDescription.RENEW_CERTIFICATE, produces = MediaType.APPLICATION_JSON, notes = Notes.RENEW_CERTIFICATE_NOTES,
             nickname = "renewCertificate")
     Response renewCertificate(RenewCertificateV4Request renewCertificateV4Request);
+
+    @GET
+    @Path("used_images")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UtilityOpDescription.USED_IMAGES, produces = MediaType.APPLICATION_JSON, nickname = "usedImages")
+    UsedImagesListV4Response usedImages();
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/UsedImageStacksV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/UsedImageStacksV4Response.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses;
+
+public class UsedImageStacksV4Response {
+
+    private UsedImageV4Response image;
+
+    private int numberOfStacks;
+
+    public UsedImageStacksV4Response(UsedImageV4Response image) {
+        this.image = image;
+        this.numberOfStacks = 1;
+    }
+
+    public UsedImageStacksV4Response() {
+    }
+
+    public UsedImageV4Response getImage() {
+        return image;
+    }
+
+    public int getNumberOfStacks() {
+        return numberOfStacks;
+    }
+
+    public void addUsage() {
+        this.numberOfStacks++;
+    }
+
+    public void setImage(UsedImageV4Response image) {
+        this.image = image;
+    }
+
+    public void setNumberOfStacks(int numberOfStacks) {
+        this.numberOfStacks = numberOfStacks;
+    }
+
+    @Override
+    public String toString() {
+        return "UsedImageStacksV4Response{" +
+                "image=" + image +
+                ", numberOfStacks=" + numberOfStacks +
+                '}';
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/UsedImageV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/UsedImageV4Response.java
@@ -1,0 +1,62 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses;
+
+import java.util.Objects;
+
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion;
+
+public class UsedImageV4Response {
+
+    private String imageId;
+
+    private String stackVersion;
+
+    public UsedImageV4Response(Image image) {
+        this.imageId = image.getImageId();
+        this.stackVersion = image.getPackageVersions().get(ImagePackageVersion.STACK.getKey());
+    }
+
+    public UsedImageV4Response() {
+    }
+
+    public String getImageId() {
+        return imageId;
+    }
+
+    public String getStackVersion() {
+        return stackVersion;
+    }
+
+    public void setImageId(String imageId) {
+        this.imageId = imageId;
+    }
+
+    public void setStackVersion(String stackVersion) {
+        this.stackVersion = stackVersion;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof UsedImageV4Response)) {
+            return false;
+        }
+        UsedImageV4Response that = (UsedImageV4Response) o;
+        return Objects.equals(imageId, that.imageId) && Objects.equals(stackVersion, that.stackVersion);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(imageId, stackVersion);
+    }
+
+    @Override
+    public String toString() {
+        return "UsedImageV4Response{" +
+                "imageId='" + imageId + '\'' +
+                ", stackVersion='" + stackVersion + '\'' +
+                '}';
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/UsedImagesListV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/responses/UsedImagesListV4Response.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+
+public class UsedImagesListV4Response {
+
+    private List<UsedImageStacksV4Response> usedImages;
+
+    public UsedImagesListV4Response() {
+        this.usedImages = new LinkedList<>();
+    }
+
+    public List<UsedImageStacksV4Response> getUsedImages() {
+        return usedImages;
+    }
+
+    public void setUsedImages(List<UsedImageStacksV4Response> usedImages) {
+        this.usedImages = usedImages;
+    }
+
+    public void addImage(Image image) {
+        final UsedImageV4Response imageView = new UsedImageV4Response(image);
+        this.usedImages.stream()
+                .filter(usedImage -> usedImage.getImage().equals(imageView))
+                .findFirst()
+                .ifPresentOrElse(UsedImageStacksV4Response::addUsage, () -> this.usedImages.add(new UsedImageStacksV4Response(imageView)));
+    }
+
+    @Override
+    public String toString() {
+        return "UsedImagesListV4Response{" +
+                "usedImages=" + usedImages +
+                '}';
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -134,6 +134,7 @@ public class OperationDescriptions {
         public static final String CUSTOM_PARAMETERS = "returns custom parameters";
         public static final String NOTIFICATION_TEST = "Trigger a new notification to the notification system could be validated from the begins";
         public static final String RENEW_CERTIFICATE = "Trigger a certificate renewal on the desired cluster which is identified via stack's name";
+        public static final String USED_IMAGES = "List the images that are in use";
     }
 
     public static class DatabaseOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.annotation.DisableCheckPermissions;
+import com.sequenceiq.authorization.annotation.InternalOnly;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.UtilV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.requests.RenewCertificateV4Request;
@@ -21,6 +22,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.ResourceEventRes
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.SecurityRulesV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.StackMatrixV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.SupportedExternalDatabaseServiceEntryV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.UsedImagesListV4Response;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
@@ -29,6 +31,7 @@ import com.sequenceiq.cloudbreak.service.StackMatrixService;
 import com.sequenceiq.cloudbreak.service.account.PreferencesService;
 import com.sequenceiq.cloudbreak.service.cluster.RepositoryConfigValidationService;
 import com.sequenceiq.cloudbreak.service.filesystem.FileSystemSupportMatrixService;
+import com.sequenceiq.cloudbreak.service.image.UsedImagesProvider;
 import com.sequenceiq.cloudbreak.service.securityrule.SecurityRuleService;
 import com.sequenceiq.cloudbreak.service.stack.flow.StackOperationService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
@@ -65,6 +68,9 @@ public class UtilV4Controller extends NotificationController implements UtilV4En
 
     @Inject
     private StackOperationService stackOperationService;
+
+    @Inject
+    private UsedImagesProvider usedImagesProvider;
 
     @Value("${info.app.version:}")
     private String cbVersion;
@@ -129,4 +135,9 @@ public class UtilV4Controller extends NotificationController implements UtilV4En
         return Response.ok().build();
     }
 
+    @Override
+    @InternalOnly
+    public UsedImagesListV4Response usedImages() {
+        return usedImagesProvider.getUsedImages();
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
@@ -34,6 +34,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.core.flow2.AbstractStackAction;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.EphemeralClusterFlowConfig;
@@ -375,6 +376,11 @@ public class OfflineStateGenerator {
 
         @Override
         public Set<Stack> findAllAliveWithInstanceGroups() {
+            return null;
+        }
+
+        @Override
+        public List<Json> findImagesOfAliveStacks() {
             return null;
         }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -18,6 +18,7 @@ import com.sequenceiq.authorization.service.list.AuthorizationResource;
 import com.sequenceiq.authorization.service.model.projection.ResourceCrnAndNameView;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.projection.AutoscaleStack;
 import com.sequenceiq.cloudbreak.domain.projection.StackClusterStatusView;
@@ -106,6 +107,10 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
     @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig "
             + "WHERE s.terminated = null AND (s.type is not 'TEMPLATE' OR s.type is null)")
     Set<Stack> findAllAliveWithInstanceGroups();
+
+    @Query("SELECT im.image FROM Stack s LEFT JOIN s.instanceGroups ig LEFT JOIN ig.instanceMetaData im "
+            + "WHERE s.terminated = null AND (s.type is not 'TEMPLATE' OR s.type is null) AND im.image is not null")
+    List<Json> findImagesOfAliveStacks();
 
     @Query("SELECT s.id as id, s.name as name, s.stackStatus as status FROM Stack s "
             + "WHERE s.stackStatus.status IN :statuses AND (s.type is not 'TEMPLATE' OR s.type is null)")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/UsedImagesProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/UsedImagesProvider.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.UsedImagesListV4Response;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@Service
+public class UsedImagesProvider {
+
+    @Inject
+    private StackService stackService;
+
+    public UsedImagesListV4Response getUsedImages() {
+        final UsedImagesListV4Response usedImages = new UsedImagesListV4Response();
+
+        stackService.getImagesOfAliveStacks()
+                .forEach(usedImages::addImage);
+
+        return usedImages;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -50,6 +50,7 @@ import com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts;
 import com.sequenceiq.cloudbreak.cloud.event.platform.GetPlatformTemplateRequest;
 import com.sequenceiq.cloudbreak.cloud.model.CloudbreakDetails;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.StackTags;
 import com.sequenceiq.cloudbreak.cloud.model.StackTemplate;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
@@ -663,6 +664,20 @@ public class StackService implements ResourceIdProvider, ResourceNameProvider {
 
     public Set<Stack> getAllAliveWithInstanceGroups() {
         return stackRepository.findAllAliveWithInstanceGroups();
+    }
+
+    public List<Image> getImagesOfAliveStacks() {
+        return stackRepository.findImagesOfAliveStacks().stream()
+                .map(image -> {
+                    try {
+                        return image.get(Image.class);
+                    } catch (IOException e) {
+                        final String message = "Could not deserialize image from string " + image.getValue();
+                        LOGGER.error(message, e);
+                        throw new IllegalStateException(message, e);
+                    }
+                })
+                .collect(Collectors.toList());
     }
 
     public List<StackStatusView> getByStatuses(List<Status> statuses) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/UsedImagesProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/UsedImagesProviderTest.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.UsedImagesListV4Response;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class UsedImagesProviderTest {
+
+    @Mock
+    private StackService stackService;
+
+    @InjectMocks
+    private UsedImagesProvider underTest;
+
+    @Test
+    void testEmpty() {
+        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of());
+
+        final UsedImagesListV4Response result = underTest.getUsedImages();
+
+        assertThat(result.getUsedImages()).isEmpty();
+    }
+
+    @Test
+    void testSingleImage() {
+        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of(
+                createImage("aws-image")));
+
+        final UsedImagesListV4Response result = underTest.getUsedImages();
+
+        assertThat(result.getUsedImages())
+                .hasSize(1)
+                .first()
+                .matches(usedImage -> usedImage.getNumberOfStacks() == 1);
+    }
+
+    @Test
+    void testMultipleImages() {
+        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of(
+                createImage("aws-image"),
+                createImage("aws-image"),
+                createImage("azure-image")));
+
+        final UsedImagesListV4Response result = underTest.getUsedImages();
+
+        assertThat(result.getUsedImages())
+                .hasSize(2)
+                .anyMatch(usedImage -> usedImage.getImage().getImageId().equals("aws-image") && usedImage.getNumberOfStacks() == 2)
+                .anyMatch(usedImage -> usedImage.getImage().getImageId().equals("azure-image") && usedImage.getNumberOfStacks() == 1);
+    }
+
+    private Image createImage(String imageId) {
+        return new Image("imageName", Map.of(), "os", "osType", "imageCatalogUrl", "imageCatalogName", imageId, null);
+    }
+
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiKeyEndpoints.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiKeyEndpoints.java
@@ -15,6 +15,7 @@ import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.KerberosMgmtV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.ldap.LdapConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.util.UtilV1Endpoint;
 
 public class FreeIpaApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint implements FreeIpaClient {
 
@@ -80,5 +81,10 @@ public class FreeIpaApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint impl
     @Override
     public CDPStructuredEventV1Endpoint structuredEventsV1Endpoint() {
         return getEndpoint(CDPStructuredEventV1Endpoint.class);
+    }
+
+    @Override
+    public UtilV1Endpoint utilV1Endpoint() {
+        return getEndpoint(UtilV1Endpoint.class);
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiUserCrnEndpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiUserCrnEndpoint.java
@@ -15,6 +15,7 @@ import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.KerberosMgmtV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.ldap.LdapConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.util.UtilV1Endpoint;
 
 public class FreeIpaApiUserCrnEndpoint extends AbstractUserCrnServiceEndpoint implements FreeIpaClient {
     public FreeIpaApiUserCrnEndpoint(WebTarget webTarget, String crn) {
@@ -79,5 +80,10 @@ public class FreeIpaApiUserCrnEndpoint extends AbstractUserCrnServiceEndpoint im
     @Override
     public CDPStructuredEventV1Endpoint structuredEventsV1Endpoint() {
         return getEndpoint(CDPStructuredEventV1Endpoint.class);
+    }
+
+    @Override
+    public UtilV1Endpoint utilV1Endpoint() {
+        return getEndpoint(UtilV1Endpoint.class);
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaClient.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaClient.java
@@ -12,6 +12,7 @@ import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.KerberosMgmtV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.ldap.LdapConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.util.UtilV1Endpoint;
 
 public interface FreeIpaClient {
 
@@ -38,4 +39,6 @@ public interface FreeIpaClient {
     FlowPublicEndpoint getFlowPublicEndpoint();
 
     CDPStructuredEventV1Endpoint structuredEventsV1Endpoint();
+
+    UtilV1Endpoint utilV1Endpoint();
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/UtilV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/UtilV1Endpoint.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.freeipa.api.v1.util;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.freeipa.api.v1.util.doc.UtilDescriptions;
+import com.sequenceiq.freeipa.api.v1.util.model.UsedImagesListV1Response;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@RetryAndMetrics
+@Path("/v1/utils")
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(value = "/v1/utils", description = UtilDescriptions.NOTES, protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+public interface UtilV1Endpoint {
+
+    @GET
+    @Path("used_images")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UtilDescriptions.USED_IMAGES, produces = MediaType.APPLICATION_JSON, nickname = "usedImagesV1")
+    UsedImagesListV1Response usedImages();
+}
+

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/doc/UtilDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/doc/UtilDescriptions.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.freeipa.api.v1.util.doc;
+
+public final class UtilDescriptions {
+    public static final String NOTES = "Miscellaneous utility operations";
+    public static final String USED_IMAGES = "List the images that are in use";
+
+    private UtilDescriptions() {
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/model/UsedImageStacksV1Response.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/model/UsedImageStacksV1Response.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.freeipa.api.v1.util.model;
+
+public class UsedImageStacksV1Response {
+
+    private UsedImageV1Response image;
+
+    private int numberOfStacks;
+
+    public UsedImageStacksV1Response(UsedImageV1Response image) {
+        this.image = image;
+        this.numberOfStacks = 1;
+    }
+
+    public UsedImageStacksV1Response() {
+    }
+
+    public UsedImageV1Response getImage() {
+        return image;
+    }
+
+    public int getNumberOfStacks() {
+        return numberOfStacks;
+    }
+
+    public void addUsage() {
+        this.numberOfStacks++;
+    }
+
+    public void setImage(UsedImageV1Response image) {
+        this.image = image;
+    }
+
+    public void setNumberOfStacks(int numberOfStacks) {
+        this.numberOfStacks = numberOfStacks;
+    }
+
+    @Override
+    public String toString() {
+        return "UsedImageStacksV1Response{" +
+                "image=" + image +
+                ", numberOfStacks=" + numberOfStacks +
+                '}';
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/model/UsedImageV1Response.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/model/UsedImageV1Response.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.freeipa.api.v1.util.model;
+
+import java.util.Objects;
+
+public class UsedImageV1Response {
+
+    private String imageId;
+
+    public UsedImageV1Response(String imageId) {
+        this.imageId = imageId;
+    }
+
+    public UsedImageV1Response() {
+    }
+
+    public String getImageId() {
+        return imageId;
+    }
+
+    public void setImageId(String imageId) {
+        this.imageId = imageId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof UsedImageV1Response)) {
+            return false;
+        }
+        UsedImageV1Response that = (UsedImageV1Response) o;
+        return Objects.equals(imageId, that.imageId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(imageId);
+    }
+
+    @Override
+    public String toString() {
+        return "UsedImageV1Response{" +
+                "imageId='" + imageId + '\'' +
+                '}';
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/model/UsedImagesListV1Response.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/model/UsedImagesListV1Response.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.freeipa.api.v1.util.model;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class UsedImagesListV1Response {
+
+    private List<UsedImageStacksV1Response> usedImages;
+
+    public UsedImagesListV1Response() {
+        this.usedImages = new LinkedList<>();
+    }
+
+    public List<UsedImageStacksV1Response> getUsedImages() {
+        return usedImages;
+    }
+
+    public void addImage(String imageId) {
+        final UsedImageV1Response imageView = new UsedImageV1Response(imageId);
+        this.usedImages.stream()
+                .filter(usedImage -> usedImage.getImage().equals(imageView))
+                .findFirst()
+                .ifPresentOrElse(UsedImageStacksV1Response::addUsage, () -> this.usedImages.add(new UsedImageStacksV1Response(imageView)));
+    }
+
+    public void setUsedImages(List<UsedImageStacksV1Response> usedImages) {
+        this.usedImages = usedImages;
+    }
+
+    @Override
+    public String toString() {
+        return "UsedImagesListV1Response{" +
+                "usedImages=" + usedImages +
+                '}';
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/EndpointConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/EndpointConfig.java
@@ -24,6 +24,7 @@ import com.sequenceiq.freeipa.controller.FreeIpaV1Controller;
 import com.sequenceiq.freeipa.controller.OperationV1Controller;
 import com.sequenceiq.freeipa.controller.ProgressV1Controller;
 import com.sequenceiq.freeipa.controller.UserV1Controller;
+import com.sequenceiq.freeipa.controller.UtilV1Controller;
 import com.sequenceiq.freeipa.controller.mapper.DefaultExceptionMapper;
 import com.sequenceiq.freeipa.controller.mapper.WebApplicaitonExceptionMapper;
 import com.sequenceiq.freeipa.kerberos.v1.KerberosConfigV1Controller;
@@ -44,7 +45,7 @@ public class EndpointConfig extends ResourceConfig {
             UserV1Controller.class, ClientTestV1Controller.class, FreeIpaV1Controller.class, LdapConfigV1Controller.class,
             KerberosConfigV1Controller.class, KerberosMgmtV1Controller.class, DnsV1Controller.class, OperationV1Controller.class,
             FlowController.class, FlowPublicController.class, AuthorizationInfoController.class, DiagnosticsV1Controller.class,
-            ProgressV1Controller.class, CDPStructuredEventV1Controller.class);
+            ProgressV1Controller.class, CDPStructuredEventV1Controller.class, UtilV1Controller.class);
 
     @Value("${info.app.version:unspecified}")
     private String applicationVersion;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UtilV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UtilV1Controller.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.freeipa.controller;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Controller;
+
+import com.sequenceiq.authorization.annotation.InternalOnly;
+import com.sequenceiq.freeipa.api.v1.util.UtilV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.util.model.UsedImagesListV1Response;
+import com.sequenceiq.freeipa.service.UsedImagesProvider;
+
+@Controller
+public class UtilV1Controller implements UtilV1Endpoint {
+
+    @Inject
+    private UsedImagesProvider usedImagesProvider;
+
+    @Override
+    @InternalOnly
+    public UsedImagesListV1Response usedImages() {
+        return usedImagesProvider.getUsedImages();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
@@ -17,6 +17,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -109,6 +110,9 @@ public class Stack implements AccountAwareResource {
 
     @OneToOne(cascade = CascadeType.ALL)
     private StackStatus stackStatus;
+
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "stack")
+    private ImageEntity image;
 
     @Convert(converter = SecretToString.class)
     @SecretValue
@@ -303,6 +307,14 @@ public class Stack implements AccountAwareResource {
 
     public void setStackStatus(StackStatus stackStatus) {
         this.stackStatus = stackStatus;
+    }
+
+    public ImageEntity getImage() {
+        return image;
+    }
+
+    public void setImage(ImageEntity image) {
+        this.image = image;
     }
 
     public String getDatabusCredential() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.structuredevent.repository.AccountAwareResource
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.dto.StackIdWithStatus;
+import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
 
 @Transactional(Transactional.TxType.REQUIRED)
@@ -96,4 +97,7 @@ public interface StackRepository extends AccountAwareResourceRepository<Stack, L
             " WHERE s.accountId = :accountId AND s.terminated = -1 AND s.resourceCrn IN (:resourceCrns)")
     List<ResourceCrnAndNameView> findNamesByResourceCrnAndAccountId(@Param("resourceCrns") Collection<String> resourceCrns,
             @Param("accountId") String accountId);
+
+    @Query("SELECT i FROM Stack s INNER JOIN s.image i WHERE s.terminated = -1")
+    List<ImageEntity> findImagesOfAliveStacks();
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/UsedImagesProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/UsedImagesProvider.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.freeipa.service;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.freeipa.api.v1.util.model.UsedImagesListV1Response;
+import com.sequenceiq.freeipa.entity.ImageEntity;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Service
+public class UsedImagesProvider {
+
+    @Inject
+    private StackService stackService;
+
+    public UsedImagesListV1Response getUsedImages() {
+        final UsedImagesListV1Response usedImages = new UsedImagesListV1Response();
+
+        stackService.getImagesOfAliveStacks().stream()
+                .map(ImageEntity::getImageId)
+                .forEach(usedImages::addImage);
+
+        return usedImages;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.dto.StackIdWithStatus;
+import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.repository.StackRepository;
 
@@ -159,5 +160,9 @@ public class StackService implements ResourceCrnAndNameProvider {
     @Override
     public EnumSet<Crn.ResourceType> getCrnTypes() {
         return EnumSet.of(Crn.ResourceType.FREEIPA, Crn.ResourceType.ENVIRONMENT);
+    }
+
+    public List<ImageEntity> getImagesOfAliveStacks() {
+        return stackRepository.findImagesOfAliveStacks();
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/UsedImagesProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/UsedImagesProviderTest.java
@@ -1,0 +1,70 @@
+package com.sequenceiq.freeipa.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.freeipa.api.v1.util.model.UsedImagesListV1Response;
+import com.sequenceiq.freeipa.entity.ImageEntity;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class UsedImagesProviderTest {
+
+    @Mock
+    private StackService stackService;
+
+    @InjectMocks
+    private UsedImagesProvider underTest;
+
+    @Test
+    void testEmpty() {
+        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of());
+
+        final UsedImagesListV1Response result = underTest.getUsedImages();
+
+        assertThat(result.getUsedImages()).isEmpty();
+    }
+
+    @Test
+    void testSingleImage() {
+        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of(
+                createImage("aws-image")));
+
+        final UsedImagesListV1Response result = underTest.getUsedImages();
+
+        assertThat(result.getUsedImages())
+                .hasSize(1);
+        assertThat(result.getUsedImages().get(0).getNumberOfStacks())
+                .isEqualTo(1);
+    }
+
+    @Test
+    void testMultipleImages() {
+        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of(
+                createImage("aws-image"),
+                createImage("aws-image"),
+                createImage("azure-image")));
+
+        final UsedImagesListV1Response result = underTest.getUsedImages();
+
+        assertThat(result.getUsedImages())
+                .hasSize(2)
+                .anyMatch(usedImage -> usedImage.getImage().getImageId().equals("aws-image") && usedImage.getNumberOfStacks() == 2)
+                .anyMatch(usedImage -> usedImage.getImage().getImageId().equals("azure-image") && usedImage.getNumberOfStacks() == 1);
+    }
+
+    private ImageEntity createImage(String imageId) {
+        final ImageEntity image = new ImageEntity();
+        image.setImageId(imageId);
+        return image;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakClient.java
@@ -42,6 +42,7 @@ import com.sequenceiq.it.cloudbreak.dto.util.DeploymentPreferencesTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.NotificationTestingTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.RenewDistroXCertificateTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.StackMatrixTestDto;
+import com.sequenceiq.it.cloudbreak.dto.util.UsedImagesTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.VersionCheckTestDto;
 import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.cloudbreak.CloudbreakWaitObject;
@@ -180,7 +181,8 @@ public class CloudbreakClient extends MicroserviceClient<com.sequenceiq.cloudbre
                 CheckRightTestDto.class.getSimpleName(),
                 CheckResourceRightTestDto.class.getSimpleName(),
                 RenewDistroXCertificateTestDto.class.getSimpleName(),
-                ImageCatalogTestDto.class.getSimpleName());
+                ImageCatalogTestDto.class.getSimpleName(),
+                UsedImagesTestDto.class.getSimpleName());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/FreeIpaClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/FreeIpaClient.java
@@ -25,6 +25,7 @@ import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaChildEnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncStatusDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeipaUsedImagesTestDto;
 import com.sequenceiq.it.cloudbreak.dto.kerberos.KerberosTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ldap.LdapTestDto;
 import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
@@ -105,7 +106,8 @@ public class FreeIpaClient extends MicroserviceClient<com.sequenceiq.freeipa.api
                 LdapTestDto.class.getSimpleName(),
                 FreeIpaChildEnvironmentTestDto.class.getSimpleName(),
                 KerberosTestDto.class.getSimpleName(),
-                FreeIpaUserSyncStatusDto.class.getSimpleName());
+                FreeIpaUserSyncStatusDto.class.getSimpleName(),
+                FreeipaUsedImagesTestDto.class.getSimpleName());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeipaUsedImagesAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeipaUsedImagesAction.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.it.cloudbreak.action.freeipa;
+
+import com.sequenceiq.freeipa.api.v1.util.model.UsedImagesListV1Response;
+import com.sequenceiq.it.cloudbreak.FreeIpaClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeipaUsedImagesTestDto;
+
+public class FreeipaUsedImagesAction implements Action<FreeipaUsedImagesTestDto, FreeIpaClient> {
+
+    @Override
+    public FreeipaUsedImagesTestDto action(TestContext testContext, FreeipaUsedImagesTestDto testDto, FreeIpaClient client) throws Exception {
+        final UsedImagesListV1Response usedImages = client.getInternalClient(testContext).utilV1Endpoint().usedImages();
+        testDto.setResponse(usedImages);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/UsedImagesAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/UsedImagesAction.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.it.cloudbreak.action.v4.util;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.UsedImagesListV4Response;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.util.UsedImagesTestDto;
+
+public class UsedImagesAction implements Action<UsedImagesTestDto, CloudbreakClient> {
+
+    @Override
+    public UsedImagesTestDto action(TestContext testContext, UsedImagesTestDto testDto, CloudbreakClient client) throws Exception {
+        final UsedImagesListV4Response usedImages = client.getInternalClient(testContext).utilV4Endpoint().usedImages();
+        testDto.setResponse(usedImages);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/FreeIpaTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/FreeIpaTestClient.java
@@ -17,10 +17,12 @@ import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaRepairAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaStartAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaStopAction;
 import com.sequenceiq.it.cloudbreak.action.freeipa.FreeIpaSynchronizeAllUsersAction;
+import com.sequenceiq.it.cloudbreak.action.freeipa.FreeipaUsedImagesAction;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaChildEnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaDiagnosticsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeipaUsedImagesTestDto;
 
 @Service
 public class FreeIpaTestClient {
@@ -71,5 +73,9 @@ public class FreeIpaTestClient {
 
     public Action<FreeIpaDiagnosticsTestDto, FreeIpaClient> collectDiagnostics() {
         return new FreeIpaCollectDiagnosticsAction();
+    }
+
+    public Action<FreeipaUsedImagesTestDto, FreeIpaClient> usedImages() {
+        return new FreeipaUsedImagesAction();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/UtilTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/UtilTestClient.java
@@ -12,6 +12,7 @@ import com.sequenceiq.it.cloudbreak.action.v4.util.DeploymentPreferencesAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.RepoConfigValidationAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.SecurityRulesAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.StackMatrixAction;
+import com.sequenceiq.it.cloudbreak.action.v4.util.UsedImagesAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.VersionCheckAction;
 import com.sequenceiq.it.cloudbreak.dto.RawCloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.securityrule.SecurityRulesTestDto;
@@ -21,6 +22,7 @@ import com.sequenceiq.it.cloudbreak.dto.util.CloudStorageMatrixTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.DeploymentPreferencesTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.RepoConfigValidationTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.StackMatrixTestDto;
+import com.sequenceiq.it.cloudbreak.dto.util.UsedImagesTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.VersionCheckTestDto;
 
 @Service
@@ -60,6 +62,10 @@ public class UtilTestClient {
 
     public Action<RawCloudbreakTestDto, CloudbreakClient> checkRightRaw() {
         return new CheckRightRawAction();
+    }
+
+    public Action<UsedImagesTestDto, CloudbreakClient> usedImages() {
+        return new UsedImagesAction();
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeipaUsedImagesTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeipaUsedImagesTestDto.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.it.cloudbreak.dto.freeipa;
+
+import com.sequenceiq.freeipa.api.v1.util.model.UsedImagesListV1Response;
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractFreeIpaTestDto;
+
+@Prototype
+public class FreeipaUsedImagesTestDto extends AbstractFreeIpaTestDto<Object, UsedImagesListV1Response, FreeipaUsedImagesTestDto> {
+
+    protected FreeipaUsedImagesTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public FreeipaUsedImagesTestDto valid() {
+        return this;
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/UsedImagesTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/util/UsedImagesTestDto.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.it.cloudbreak.dto.util;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.UsedImagesListV4Response;
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractCloudbreakTestDto;
+
+@Prototype
+public class UsedImagesTestDto extends AbstractCloudbreakTestDto<Object, UsedImagesListV4Response, UsedImagesTestDto> {
+
+    protected UsedImagesTestDto(TestContext testContext) {
+        super(null, testContext);
+    }
+
+    @Override
+    public UsedImagesTestDto valid() {
+        return this;
+    }
+
+    @Override
+    public int order() {
+        return 500;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/mock/ImageCatalogMockServerSetup.java
@@ -78,6 +78,15 @@ public class ImageCatalogMockServerSetup {
                 cdhRuntime);
     }
 
+    public String getFreeIpaImageCatalogUrlWitdDefaultImageUuid(String defaultImageUuid) {
+        return String.format("http://%s/thunderhead/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&default-image-uuid=%s",
+                mockImageCatalogServer,
+                "freeipa-catalog",
+                cbVersion,
+                cdhRuntime,
+                defaultImageUuid);
+    }
+
     public String getImageCatalogUrl() {
         return String.format("http://%s/thunderhead/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s",
                 mockImageCatalogServer,
@@ -92,6 +101,15 @@ public class ImageCatalogMockServerSetup {
                 "catalog-with-prewarmed",
                 cbVersion,
                 cdhRuntime);
+    }
+
+    public String getPreWarmedImageCatalogUrlWithDefaultImageUuid(String defaultImageUuid) {
+        return String.format("http://%s/thunderhead/mock-image-catalog?catalog-name=%s&cb-version=%s&runtime=%s&default-image-uuid=%s",
+                mockImageCatalogServer,
+                "catalog-with-prewarmed",
+                cbVersion,
+                cdhRuntime,
+                defaultImageUuid);
     }
 
     public String getPreWarmedImageCatalogUrlWithCmAndCdhVersions(String cmVersion, String cdhVersion) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/UsedImagesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/UsedImagesTest.java
@@ -1,0 +1,173 @@
+package com.sequenceiq.it.cloudbreak.testcase.mock;
+
+import java.util.List;
+import java.util.UUID;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.util.responses.UsedImageStacksV4Response;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.util.model.UsedImageStacksV1Response;
+import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.client.ImageCatalogTestClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.client.UtilTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeipaUsedImagesTestDto;
+import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.util.UsedImagesTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+
+public class UsedImagesTest extends AbstractMockTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UsedImagesTest.class);
+
+    @Inject
+    private EnvironmentTestClient environmentTestClient;
+
+    @Inject
+    private ImageCatalogTestClient imageCatalogTestClient;
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private UtilTestClient utilTestClient;
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
+    private String freeipaImageUuid;
+
+    private String sdxImageUuid;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        freeipaImageUuid = UUID.randomUUID().toString();
+        sdxImageUuid = UUID.randomUUID().toString();
+
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        createDefaultImageCatalog(testContext);
+        initializeDefaultBlueprints(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Description(
+            given = "a running environment with an sdx",
+            when = "list used images requests are sent to cb and freeipa",
+            then = "response should have the images",
+            and = "after deleting env used images should not those images"
+    )
+    public void testUsedImages(MockedTestContext testContext) {
+        String cbImageCatalogName = resourcePropertyProvider().getName();
+
+        testContext
+                .given(ImageCatalogTestDto.class)
+                    .withName(cbImageCatalogName)
+                    .withUrl(getImageCatalogMockServerSetup().getPreWarmedImageCatalogUrlWithDefaultImageUuid(sdxImageUuid))
+                .when(imageCatalogTestClient.createV4())
+
+                .given(EnvironmentNetworkTestDto.class)
+                .given(EnvironmentTestDto.class)
+                    .withNetwork()
+                    .withCreateFreeIpa(Boolean.FALSE)
+                .when(environmentTestClient.create())
+                .await(EnvironmentStatus.AVAILABLE)
+                .when(environmentTestClient.describe())
+
+                .given(FreeIpaTestDto.class)
+                    .withCatalog(getImageCatalogMockServerSetup().getFreeIpaImageCatalogUrlWitdDefaultImageUuid(freeipaImageUuid))
+                .when(freeIpaTestClient.create())
+                .await(Status.AVAILABLE)
+                .when(freeIpaTestClient.describe())
+
+                .given(SdxInternalTestDto.class)
+                    .withImageCatalogNameAndImageId(cbImageCatalogName, sdxImageUuid)
+                .when(sdxTestClient.createInternal())
+                .await(SdxClusterStatusResponse.RUNNING)
+                .when(sdxTestClient.describeInternal())
+
+                .then((tc, testDto, client) -> verifyImagesAreUsed(tc, testDto))
+
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.delete())
+                .await(EnvironmentStatus.ARCHIVED)
+
+                .then((tc, testDto, client) -> verifyImagesAreNotUsed(tc, testDto))
+                .validate();
+    }
+
+    private <T extends CloudbreakTestDto> T verifyImagesAreUsed(TestContext testContext, T testDto) {
+        testContext
+                .given(UsedImagesTestDto.class)
+                .when(utilTestClient.usedImages())
+                .then((tc, usedImagesTestDto, client) -> {
+                    List<UsedImageStacksV4Response> usedImages = usedImagesTestDto.getResponse().getUsedImages();
+                    UsedImageStacksV4Response usedImageStacksV4Response = usedImages.stream()
+                            .filter(usedImage -> usedImage.getImage().getImageId().contains(sdxImageUuid))
+                            .findFirst().orElseThrow(() -> new TestFailException(String.format("SDX image is NOT in use with ID:: %s", sdxImageUuid)));
+                    LOGGER.info("Used SDX image ID:: {}", usedImageStacksV4Response.getImage().getImageId());
+                    return usedImagesTestDto;
+                })
+
+                .given(FreeipaUsedImagesTestDto.class)
+                .when(freeIpaTestClient.usedImages())
+                .then((tc, usedImagesTestDto, client) -> {
+                    List<UsedImageStacksV1Response> usedImages = usedImagesTestDto.getResponse().getUsedImages();
+                    UsedImageStacksV1Response usedImageStacksV1Response = usedImages.stream()
+                            .filter(usedImage -> usedImage.getImage().getImageId().contains(freeipaImageUuid))
+                            .findFirst().orElseThrow(() -> new TestFailException(String.format("FreeIpa image is NOT in use with ID:: %s",
+                                    freeipaImageUuid)));
+                    LOGGER.info("Used FreeIpa image ID:: {}", usedImageStacksV1Response.getImage().getImageId());
+                    return usedImagesTestDto;
+                })
+                .validate();
+        return testDto;
+    }
+
+    private <T extends CloudbreakTestDto> T verifyImagesAreNotUsed(TestContext testContext, T testDto) {
+        testContext
+                .given(UsedImagesTestDto.class)
+                .when(utilTestClient.usedImages())
+                .then((tc, usedImagesTestDto, client) -> {
+                    List<UsedImageStacksV4Response> usedImages = usedImagesTestDto.getResponse().getUsedImages();
+                    if (usedImages.stream()
+                            .noneMatch(usedImage -> usedImage.getImage().getImageId().contains(sdxImageUuid))) {
+                        LOGGER.info("SDX image (ID:: {}) is not in use anymore", sdxImageUuid);
+                    } else {
+                        throw new TestFailException(String.format("SDX image (ID:: %s) is still in use!", sdxImageUuid));
+                    }
+                    return usedImagesTestDto;
+                })
+
+                .given(FreeipaUsedImagesTestDto.class)
+                .when(freeIpaTestClient.usedImages())
+                .then((tc, usedImagesTestDto, client) -> {
+                    List<UsedImageStacksV1Response> usedImages = usedImagesTestDto.getResponse().getUsedImages();
+                    if (usedImages.stream()
+                            .noneMatch(usedImage -> usedImage.getImage().getImageId().contains(freeipaImageUuid))) {
+                        LOGGER.info("FreeIpa image (ID:: {}) is not in use anymore", freeipaImageUuid);
+                    } else {
+                        throw new TestFailException(String.format("FreeIpa image (ID:: %s) is still in use!", freeipaImageUuid));
+                    }
+                    return usedImagesTestDto;
+                })
+                .validate();
+        return testDto;
+    }
+}

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/controller/MockImageCatalogController.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/controller/MockImageCatalogController.java
@@ -20,7 +20,9 @@ public class MockImageCatalogController {
     public String auth(@RequestParam("catalog-name") String name,
             @RequestParam("cb-version") String cbVersion,
             @RequestParam("runtime") String runtime,
-            @RequestParam(name = "cm", required = false) String cm) {
-        return imageCatalogMockService.getImageCatalogByName(name, cbVersion, runtime, cm);
+            @RequestParam(name = "cm", required = false) String cm,
+            @RequestParam(name = "default-image-uuid", required = false) String defaultImageUuid,
+            @RequestParam(name = "non-default-image-uuid", required = false) String nonDefaultImageUuid) {
+        return imageCatalogMockService.getImageCatalogByName(name, cbVersion, runtime, cm, defaultImageUuid, nonDefaultImageUuid);
     }
 }

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/service/ImageCatalogMockService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/service/ImageCatalogMockService.java
@@ -10,11 +10,18 @@ import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 @Component
 public class ImageCatalogMockService {
 
-    public String getImageCatalogByName(String name, String cbVersion, String runtimeVersion, String cmVersion) {
+    private static final String DEFAULT_IMAGE_UUID = "f6e778fc-7f17-4535-9021-515351df3691";
+
+    private static final String NON_DEFAULT_IMAGE_UUID = "1a6eadd2-5B95-4EC9-B300-13dc43208b64";
+
+    public String getImageCatalogByName(String name, String cbVersion, String runtimeVersion, String cmVersion, String defaultImageUuid,
+            String nonDefaultImageUuid) {
         String catalog = FileReaderUtils.readFileFromClasspathQuietly(String.format("mock-image-catalogs/%s.json", name));
         return catalog.replace("CB_VERSION", cbVersion)
                 .replace("CDH_RUNTIME", runtimeVersion)
-                .replace("CM_VERSION", Objects.requireNonNullElse(cmVersion, runtimeVersion));
+                .replace("CM_VERSION", Objects.requireNonNullElse(cmVersion, runtimeVersion))
+                .replace("DEFAULT_IMAGE_UUID", Objects.requireNonNullElse(defaultImageUuid, DEFAULT_IMAGE_UUID))
+                .replace("NON_DEFAULT_IMAGE_UUID", Objects.requireNonNullElse(nonDefaultImageUuid, NON_DEFAULT_IMAGE_UUID));
     }
 
 }

--- a/mock-thunderhead/src/main/resources/mock-image-catalogs/catalog-with-prewarmed.json
+++ b/mock-thunderhead/src/main/resources/mock-image-catalogs/catalog-with-prewarmed.json
@@ -12,7 +12,7 @@
         },
         "os": "centos7",
         "os_type": "redhat7",
-        "uuid": "f6e778fc-7f17-4535-9021-515351df3691",
+        "uuid": "DEFAULT_IMAGE_UUID",
         "defaultImage": true,
         "package-versions": {
           "cm": "CM_VERSION",
@@ -68,7 +68,7 @@
         },
         "os": "centos7",
         "os_type": "redhat7",
-        "uuid": "1a6eadd2-5B95-4EC9-B300-13dc43208b64",
+        "uuid": "NON_DEFAULT_IMAGE_UUID",
         "package-versions": {
           "cm": "7.x.0",
           "salt": "2017.7.5",
@@ -118,11 +118,11 @@
     "cloudbreak": [
       {
         "images": [
-          "f6e778fc-7f17-4535-9021-515351df3691",
-          "1a6eadd2-5B95-4EC9-B300-13dc43208b64"
+          "NON_DEFAULT_IMAGE_UUID",
+          "DEFAULT_IMAGE_UUID"
         ],
         "defaults": [
-          "f6e778fc-7f17-4535-9021-515351df3691"
+          "DEFAULT_IMAGE_UUID"
         ],
         "versions": [
           "CB_VERSION"

--- a/mock-thunderhead/src/main/resources/mock-image-catalogs/freeipa-catalog.json
+++ b/mock-thunderhead/src/main/resources/mock-image-catalogs/freeipa-catalog.json
@@ -11,7 +11,7 @@
         },
         "os": "redhat7",
         "os_type": "redhat7",
-        "uuid": "81851893-8340-411d-afb7-e1b55107fb10"
+        "uuid": "DEFAULT_IMAGE_UUID"
       }
     ]
   }


### PR DESCRIPTION
Cloudbreak and Freeipa endpoints for collecting the images that are in use. These can and will be used for runtime statistics and cleaning up unused images from the catalogs and cloud provider storage to save on cloud costs.