### PR TITLE
CB-11133 Falling back to 7.2.2 upgrade tests. Current upgrade tests a…

### DIFF
--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -69,7 +69,7 @@ integrationtest:
   runtimeVersion: 7.2.7
   upgrade:
     currentRuntimeVersion: 7.2.0
-    targetRuntimeVersion: 7.2.6
+    targetRuntimeVersion: 7.2.2
   privateEndpointEnabled: false
 
   spot:


### PR DESCRIPTION
…re set to 7.2.6, but they are failing quite often due to OPSAPS-59201, in order to make sure that our test automation is stable we shall use stable CM.

See detailed description in the commit message.