### PR TITLE
CB-11138 fix Volume device name generation on AWS

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/util/DeviceNameGenerator.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/util/DeviceNameGenerator.java
@@ -1,26 +1,27 @@
 package com.sequenceiq.cloudbreak.util;
 
-import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class DeviceNameGenerator {
 
-    private static final List<Character> DEVICE_NAME_POSTFIX_LETTER = List.of('b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
+    protected static final List<Character> DEVICE_NAME_POSTFIX_LETTER = List.of('b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
             'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z');
 
-    private String deviceNameTemplate;
+    private final String deviceNameTemplate;
 
-    private final Iterator<Character> letterIterator;
+    private final AtomicInteger offset;
 
     public DeviceNameGenerator(String deviceNameTemplate, int offset) {
         this.deviceNameTemplate = deviceNameTemplate;
-        letterIterator = DEVICE_NAME_POSTFIX_LETTER.listIterator(offset);
+        this.offset = new AtomicInteger(offset);
     }
 
     public String next() {
-        if (!letterIterator.hasNext()) {
+        int currentLetter = offset.getAndIncrement();
+        if (currentLetter > DEVICE_NAME_POSTFIX_LETTER.size() - 1) {
             throw new IllegalStateException("Ran out of device names.");
         }
-        return String.format(deviceNameTemplate, letterIterator.next());
+        return String.format(deviceNameTemplate, DEVICE_NAME_POSTFIX_LETTER.get(currentLetter));
     }
 }

--- a/cloud-common/src/test/java/com/sequenceiq/cloudbreak/util/DeviceNameGeneratorTest.java
+++ b/cloud-common/src/test/java/com/sequenceiq/cloudbreak/util/DeviceNameGeneratorTest.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.util;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+
+public class DeviceNameGeneratorTest {
+
+    private static final String DEVICE_TEMPLATE = "/dev/%s";
+
+    @Test
+    @DisplayName("test if it can generate all the device letters")
+    public void testNextForAllLetters() {
+        List<String> expectedDeviceList = List.of(
+                "/dev/b", "/dev/c", "/dev/d", "/dev/e",
+                "/dev/f", "/dev/g", "/dev/h", "/dev/i",
+                "/dev/j", "/dev/k", "/dev/l", "/dev/m",
+                "/dev/n", "/dev/o", "/dev/p", "/dev/q",
+                "/dev/r", "/dev/s", "/dev/t", "/dev/u",
+                "/dev/v", "/dev/w", "/dev/x", "/dev/y", "/dev/z");
+        DeviceNameGenerator generator = new DeviceNameGenerator(DEVICE_TEMPLATE, 0);
+        List<String> result = new ArrayList<>();
+        for (int i = 0; i < DeviceNameGenerator.DEVICE_NAME_POSTFIX_LETTER.size(); i++) {
+            result.add(generator.next());
+        }
+        assertArrayEquals(expectedDeviceList.toArray(), result.toArray());
+    }
+
+    @Test
+    @DisplayName("test if it can generate all the device letters with offset")
+    public void testNextForAllLettersWithOffset() {
+        List<String> expectedDeviceList = List.of(
+                "/dev/f", "/dev/g", "/dev/h", "/dev/i",
+                "/dev/j", "/dev/k", "/dev/l", "/dev/m",
+                "/dev/n", "/dev/o", "/dev/p", "/dev/q",
+                "/dev/r", "/dev/s", "/dev/t", "/dev/u",
+                "/dev/v", "/dev/w", "/dev/x", "/dev/y", "/dev/z");
+        int offset = 4;
+        DeviceNameGenerator generator = new DeviceNameGenerator(DEVICE_TEMPLATE, offset);
+        List<String> result = new ArrayList<>();
+        for (int i = 0; i < DeviceNameGenerator.DEVICE_NAME_POSTFIX_LETTER.size() - offset; i++) {
+            result.add(generator.next());
+        }
+        assertArrayEquals(expectedDeviceList.toArray(), result.toArray());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    @DisplayName("test if it can handle more iteration than allowed")
+    public void testNextForInvalidIteration() {
+        int offset = 4;
+        DeviceNameGenerator generator = new DeviceNameGenerator(DEVICE_TEMPLATE, offset);
+        for (int i = 0; i < DeviceNameGenerator.DEVICE_NAME_POSTFIX_LETTER.size(); i++) {
+            generator.next();
+        }
+    }
+}


### PR DESCRIPTION
CB creates the attached volumes and tells AWS where to mount those volumes.
However, our device name generation is incorrect as we're iterating over on
a list with multiple threads and it can happen that multiple threads get the
same device name. This will result in a conflict on AWS.

Infrastructure creation failed. Reason: Failed to create resources for instance with id: '1', message: 'com.amazonaws.services.ec2.model.AmazonEC2Exception: Invalid value '/dev/xvdk' for unixDevice. Attachment point /dev/xvdk is already in use (Service: AmazonEC2; Status Code: 400; Error Code: InvalidParameterValue; Request ID: ..)'

To fix this problem I made the name generation thread safe by using an atomic counter.