### PR TITLE
CB-11107 - Supporting paywall for existing HDP clusters - add default…

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -196,36 +196,32 @@ cb:
         version: 2.6.2.2
         repo:
           redhat6:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/centos6/2.x/updates/2.6.2.2
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/centos6/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+            baseurl: https://archive.cloudera.com/p/ambari/2.x/2.6.2.59/centos6
+            gpgkey: https://archive.cloudera.com/p/ambari/2.x/2.6.2.59/centos6/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
           redhat7:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.6.2.2
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/centos7/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
-          debian9:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/debian9/2.x/updates/2.6.2.2
+            baseurl: https://archive.cloudera.com/p/ambari/2.x/2.6.2.59/centos7
+            gpgkey: https://archive.cloudera.com/p/ambari/2.x/2.6.2.59/centos7/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
           ubuntu16:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/ubuntu16/2.x/updates/2.6.2.2
+            baseurl: https://archive.cloudera.com/p/ambari/2.x/2.6.2.59/ubuntu16
           sles12:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/sles12/2.x/updates/2.6.2.2
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/sles12/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+            baseurl: https://archive.cloudera.com/p/ambari/2.x/2.6.2.59/sles12
       2.7:
         version: 2.7.3.0
         repo:
           redhat7:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.7.3.0
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.7.3.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+            baseurl: https://archive.cloudera.com/p/ambari/2.x/2.7.3.39/centos7
+            gpgkey: https://archive.cloudera.com/p/ambari/2.x/2.7.3.39/centos7/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
           debian9:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/debian9/2.x/updates/2.7.3.0
+            baseurl: https://archive.cloudera.com/p/ambari/2.x/2.7.3.39/debian9
           ubuntu16:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/ubuntu16/2.x/updates/2.7.3.0
+            baseurl: https://archive.cloudera.com/p/ambari/2.x/2.7.3.39/ubuntu16
           ubuntu18:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/ubuntu18/2.x/updates/2.7.3.0
+            baseurl: https://archive.cloudera.com/p/ambari/2.x/2.7.3.39/ubuntu18
           sles12:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/sles12/2.x/updates/2.7.3.0
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/sles12/2.x/updates/2.7.3.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+            baseurl: https://archive.cloudera.com/p/ambari/2.x/2.7.3.39/sles12
           amazonlinux2:
-            baseurl: http://public-repo-1.hortonworks.com/ambari/amazonlinux2/2.x/updates/2.7.3.0
-            gpgkey: http://public-repo-1.hortonworks.com/ambari/amazonlinux2/2.x/updates/2.7.3.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+            baseurl: https://archive.cloudera.com/p/ambari/2.x/2.7.3.39/amazonlinux2
+            gpgkey: https://archive.cloudera.com/p/ambari/2.x/2.7.3.39/amazonlinux2/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
       "[2.7.5]":
         version: 2.7.5.0
         paywallProtected: true
@@ -241,7 +237,6 @@ cb:
             baseurl: https://archive.cloudera.com/p/ambari/ubuntu18/2.x/updates/2.7.5.0/
           sles12:
             baseurl: https://archive.cloudera.com/p/ambari/sles12/2.x/updates/2.7.5.0/
-            gpgkey: https://archive.cloudera.com/p/ambari/sles12/2.x/updates/2.7.5.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
           amazonlinux2:
             baseurl: https://archive.cloudera.com/p/ambari/amazonlinux2/2.x/updates/2.7.5.0/
             gpgkey: https://archive.cloudera.com/p/ambari/amazonlinux2/2.x/updates/2.7.5.0/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
@@ -258,96 +253,90 @@ cb:
         repo:
           stack:
             repoid: HDP-2.5
-            redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.5.5.0
-            redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.5.5.0
-            debian9: http://public-repo-1.hortonworks.com/HDP/debian9/2.x/updates/2.5.5.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/2.x/updates/2.5.5.0
-            repository-version: 2.5.3.0-37
-            vdf-redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.5.3.0/HDP-2.5.3.0-37.xml
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.5.3.0/HDP-2.5.3.0-37.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDP/debian9/2.x/updates/2.5.3.0/HDP-2.5.3.0-37.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/2.x/updates/2.5.3.0/HDP-2.5.3.0-37.xml
+            redhat6: https://archive.cloudera.com/p/HDP/2.x/2.5.5.0/centos6
+            redhat7: https://archive.cloudera.com/p/HDP/2.x/2.5.5.0/centos7
+            ubuntu16: https://archive.cloudera.com/p/HDP/2.x/2.5.5.0/ubuntu16
+            repository-version: 2.5.5.0-157
+            vdf-redhat6: https://archive.cloudera.com/p/HDP/2.x/2.5.5.0/centos6/HDP-2.5.5.0-157.xml
+            vdf-redhat7: https://archive.cloudera.com/p/HDP/2.x/2.5.5.0/centos7/HDP-2.5.5.0-157.xml
+            vdf-ubuntu16: https://archive.cloudera.com/p/HDP/2.x/2.5.5.0/ubuntu16/HDP-2.5.5.0-157.xml
           util:
             repoid: HDP-UTILS-1.1.0.21
-            redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos6
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/ubuntu16
+            redhat6: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.21/repos/centos6
+            redhat7: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.21/repos/centos7
+            ubuntu16: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.21/repos/ubuntu16
       2.6:
         version: 2.6.5.0
         minAmbari: 2.6
         repo:
           stack:
             repoid: HDP-2.6
-            redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.5.0
-            redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.5.0
-            debian9: http://public-repo-1.hortonworks.com/HDP/debian9/2.x/updates/2.6.5.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/2.x/updates/2.6.5.0
-            sles12: http://public-repo-1.hortonworks.com/HDP/sles12/2.x/updates/2.6.5.0
+            redhat6: https://archive.cloudera.com/p/HDP/2.x/2.6.5.0/centos6
+            redhat7: https://archive.cloudera.com/p/HDP/2.x/2.6.5.0/centos7
+            ubuntu16: https://archive.cloudera.com/p/HDP/2.x/2.6.5.0/ubuntu16
+            sles12: https://archive.cloudera.com/p/HDP/2.x/2.6.5.0/sles12/
             repository-version: 2.6.5.0-292
-            vdf-redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.5.0/HDP-2.6.5.0-292.xml
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.5.0/HDP-2.6.5.0-292.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDP/debian9/2.x/updates/2.6.5.0/HDP-2.6.5.0-292.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/2.x/updates/2.6.5.0/HDP-2.6.5.0-292.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDP/sles12/2.x/updates/2.6.5.0/HDP-2.6.5.0-292.xml
+            vdf-redhat6: https://archive.cloudera.com/p/HDP/2.x/2.6.5.0/centos6/HDP-2.6.5.0-292.xml
+            vdf-redhat7: https://archive.cloudera.com/p/HDP/2.x/2.6.5.0/centos7/HDP-2.6.5.0-292.xml
+            vdf-ubuntu16: https://archive.cloudera.com/p/HDP/2.x/2.6.5.0/ubuntu16/HDP-2.6.5.0-292.xml
+            vdf-sles12: https://archive.cloudera.com/p/HDP/2.x/2.6.5.0/sles12/HDP-2.6.5.0-292.xml
           util:
             repoid: HDP-UTILS-1.1.0.22
-            redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos6
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
+            redhat6: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/centos6
+            redhat7: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/centos7
+            ubuntu16: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/ubuntu16
+            sles12: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/sles12
       3.0:
         version: 3.0.1.0
         minAmbari: 2.7
         repo:
           stack:
             repoid: HDP-3.0
-            redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.0.1.0
-            debian9: http://public-repo-1.hortonworks.com/HDP/debian9/3.x/updates/3.0.1.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/3.x/updates/3.0.1.0
-            sles12: http://public-repo-1.hortonworks.com/HDP/sles12/3.x/updates/3.0.1.0
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDP/amazonlinux2/3.x/updates/3.0.1.0
+            redhat7: https://archive.cloudera.com/p/HDP/3.x/3.0.1.0/centos7
+            debian9: https://archive.cloudera.com/p/HDP/3.x/3.0.1.0/debian9
+            ubuntu16: https://archive.cloudera.com/p/HDP/3.x/3.0.1.0/ubuntu16
+            sles12: https://archive.cloudera.com/p/HDP/3.x/3.0.1.0/sles12
+            amazonlinux2: https://archive.cloudera.com/p/HDP/3.x/3.0.1.0/amazonlinux2
             repository-version: 3.0.1.0-187
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.0.1.0/HDP-3.0.1.0-187.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDP/debian9/3.x/updates/3.0.1.0/HDP-3.0.1.0-187.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/3.x/updates/3.0.1.0/HDP-3.0.1.0-187.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDP/sles12/3.x/updates/3.0.1.0/HDP-3.0.1.0-187.xml
-            vdf-amazonlinux2: http://public-repo-1.hortonworks.com/HDP/amazonlinux2/3.x/updates/3.0.1.0/HDP-3.0.1.0-187.xml
+            vdf-redhat7: https://archive.cloudera.com/p/HDP/3.x/3.0.1.0/centos7/HDP-3.0.1.0-187.xml
+            vdf-debian9: https://archive.cloudera.com/p/HDP/3.x/3.0.1.0/debian9/HDP-3.0.1.0-187.xml
+            vdf-ubuntu16: https://archive.cloudera.com/p/HDP/3.x/3.0.1.0/ubuntu16/HDP-3.0.1.0-187.xml
+            vdf-sles12: https://archive.cloudera.com/p/HDP/3.x/3.0.1.0/sles12/HDP-3.0.1.0-187.xml
+            vdf-amazonlinux2: https://archive.cloudera.com/p/HDP/3.x/3.0.1.0/amazonlinux2/HDP-3.0.1.0-187.xml
           util:
             repoid: HDP-UTILS-1.1.0.22
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/amazonlinux2
+            redhat7: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/centos7
+            debian9: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/debian9
+            ubuntu16: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/ubuntu16
+            sles12: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/sles12
+            amazonlinux2: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/amazonlinux2
       3.1:
         version: 3.1.0.0
         minAmbari: 2.7
         repo:
           stack:
             repoid: HDP-3.1
-            redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.1.0.0
-            debian9: http://public-repo-1.hortonworks.com/HDP/debian9/3.x/updates/3.1.0.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/3.x/updates/3.1.0.0
-            ubuntu18: http://public-repo-1.hortonworks.com/HDP/ubuntu18/3.x/updates/3.1.0.0
-            sles12: http://public-repo-1.hortonworks.com/HDP/sles12/3.x/updates/3.1.0.0
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDP/amazonlinux2/3.x/updates/3.1.0.0
+            redhat7: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/centos7
+            debian9: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/debian9
+            ubuntu16: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/ubuntu16
+            ubuntu18: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/ubuntu18
+            sles12: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/sles12
+            amazonlinux2: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/amazonlinux2
             repository-version: 3.1.0.0-78
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDP/debian9/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDP/ubuntu16/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
-            vdf-ubuntu18: http://public-repo-1.hortonworks.com/HDP/ubuntu18/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDP/sles12/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
-            vdf-amazonlinux2: http://public-repo-1.hortonworks.com/HDP/amazonlinux2/3.x/updates/3.1.0.0/HDP-3.1.0.0-78.xml
+            vdf-redhat7: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/centos7/HDP-3.1.0.0-78.xml
+            vdf-debian9: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/debian9/HDP-3.1.0.0-78.xml
+            vdf-ubuntu16: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/ubuntu16/HDP-3.1.0.0-78.xml
+            vdf-ubuntu18: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/ubuntu18/HDP-3.1.0.0-78.xml
+            vdf-sles12: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/sles12/HDP-3.1.0.0-78.xml
+            vdf-amazonlinux2: https://archive.cloudera.com/p/HDP/3.x/3.1.0.0/amazonlinux2/HDP-3.1.0.0-78.xml
           util:
             repoid: HDP-UTILS-1.1.0.22
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-            ubuntu18: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu18
-            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/amazonlinux2
+            redhat7: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/centos7
+            debian9: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/debian9
+            ubuntu16: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/ubuntu16
+            ubuntu18: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/ubuntu18
+            sles12: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/sles12
+            amazonlinux2: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/amazonlinux2
       "[3.1.5]":
         version: 3.1.5.0
         minAmbari: 2.7.5
@@ -384,39 +373,33 @@ cb:
         repo:
           stack:
             repoid: HDF-3.1
-            redhat6: http://public-repo-1.hortonworks.com/HDF/centos6/3.x/updates/3.1.2.0
-            redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.1.2.0
-            debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.1.2.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.1.2.0
-            sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.1.2.0
+            redhat6: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/centos6
+            redhat7: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/centos7
+            ubuntu16: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/ubuntu16
+            sles12: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/sles12
             repository-version: 3.1.2.0-7
-            vdf-redhat6: http://public-repo-1.hortonworks.com/HDF/centos6/3.x/updates/3.1.2.0/HDF-3.1.2.0-7.xml
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.1.2.0/HDF-3.1.2.0-7.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.1.2.0/HDF-3.1.2.0-7.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.1.2.0/HDF-3.1.2.0-7.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.1.2.0/HDF-3.1.2.0-7.xml
+            vdf-redhat6: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/centos6/HDF-3.1.2.0-7.xml
+            vdf-redhat7: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/centos7/HDF-3.1.2.0-7.xml
+            vdf-ubuntu16: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/ubuntu16/HDF-3.1.2.0-7.xml
+            vdf-sles12: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/sles12/HDF-3.1.2.0-7.xml
           util:
             repoid: HDP-UTILS-1.1.0.22
-            redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos6
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
+            redhat6: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/centos6
+            redhat7: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/centos7
+            ubuntu16: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/ubuntu16
+            sles12: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/sles12
           mpacks:
             redhat6:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/centos6/3.x/updates/3.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/centos6/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
                 stackDefault: true
             redhat7:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
-                stackDefault: true
-            debian9:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/centos7/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
                 stackDefault: true
             ubuntu16:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/ubuntu16/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
                 stackDefault: true
             sles12:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.1.2.0/sles12/tars/hdf_ambari_mp/hdf-ambari-mpack-3.1.2.0-7.tar.gz
                 stackDefault: true
       3.2:
         version: 3.2.0.0-520
@@ -424,39 +407,38 @@ cb:
         repo:
           stack:
             repoid: HDF-3.2
-            redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.2.0.0
-            debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.2.0.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.2.0.0
-            sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.2.0.0
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.2.0.0
+            amazonlinux2: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/amazonlinux2
+            redhat7: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/centos7
+            ubuntu16: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/ubuntu16
+            sles12: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/sles12
             repository-version: 3.2.0.0-520
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.2.0.0/HDF-3.2.0.0-520.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.2.0.0/HDF-3.2.0.0-520.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.2.0.0/HDF-3.2.0.0-520.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.2.0.0/HDF-3.2.0.0-520.xml
-            vdf-amazonlinux2: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.2.0.0/HDF-3.2.0.0-520.xml
+            vdf-redhat7: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/centos7/HDF-3.2.0.0-520.xml
+            vdf-debian9: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/debian9/HDF-3.2.0.0-520.xml
+            vdf-amazonlinux2: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/amazonlinux2/HDF-3.2.0.0-520.xml
+            vdf-ubuntu16: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/ubuntu16/HDF-3.2.0.0-520.xml
+            vdf-sles12: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/sles12/HDF-3.2.0.0-520.xml
           util:
             repoid: HDP-UTILS-1.1.0.22
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/amazonlinux2
+            redhat7: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/centos7
+            debian9: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/debian9
+            ubuntu16: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/ubuntu16
+            sles12: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/sles12
+            amazonlinux2: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/amazonlinux2
           mpacks:
-            redhat7:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
+            amazonlinux2:
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/amazonlinux2/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
                 stackDefault: true
-            debian9:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
+            redhat7:
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/centos7/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
                 stackDefault: true
             ubuntu16:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/ubuntu16/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
                 stackDefault: true
             sles12:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/sles12/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
                 stackDefault: true
-            amazonlinux2:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.2.0.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
+            debian9:
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.2.0.0/debian9/tars/hdf_ambari_mp/hdf-ambari-mpack-3.2.0.0-520.tar.gz
                 stackDefault: true
       3.3:
         version: 3.3.1.0-10
@@ -464,39 +446,79 @@ cb:
         repo:
           stack:
             repoid: HDF-3.3
-            redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.3.1.0
-            debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.3.1.0
-            ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.3.1.0
-            sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.3.1.0
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.3.1.0
+            amazonlinux2: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/amazonlinux2
+            redhat7: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/centos7
+            debian9: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/debian9
+            ubuntu16: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/ubuntu16
+            sles12: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/sles12
             repository-version: 3.3.1.0-10
-            vdf-redhat7: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.3.1.0/HDF-3.3.1.0-10.xml
-            vdf-debian9: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.3.1.0/HDF-3.3.1.0-10.xml
-            vdf-ubuntu16: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.3.1.0/HDF-3.3.1.0-10.xml
-            vdf-sles12: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.3.1.0/HDF-3.3.1.0-10.xml
-            vdf-amazonlinux2: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.3.1.0/HDF-3.3.1.0-10.xml
+            vdf-redhat7: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/centos7/HDF-3.3.1.0-10.xml
+            vdf-debian9: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/debian9/HDF-3.3.1.0-10.xml
+            vdf-amazonlinux2: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/amazonlinux2/HDF-3.3.1.0-10.xml
+            vdf-ubuntu16: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/ubuntu16/HDF-3.3.1.0-10.xml
+            vdf-sles12: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/sles12/HDF-3.3.1.0-10.xml
           util:
             repoid: HDP-UTILS-1.1.0.22
-            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/centos7
-            debian9: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/debian9
-            ubuntu16: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/ubuntu16
-            sles12: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/sles12
-            amazonlinux2: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.22/repos/amazonlinux2
+            redhat7: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/centos7
+            debian9: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/debian9
+            ubuntu16: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/ubuntu16
+            sles12: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/sles12
+            amazonlinux2: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/amazonlinux2
           mpacks:
-            redhat7:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/centos7/3.x/updates/3.3.1.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
+            amazonlinux2:
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/amazonlinux2/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
                 stackDefault: true
-            debian9:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/debian9/3.x/updates/3.3.1.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
+            redhat7:
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/centos7/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
                 stackDefault: true
             ubuntu16:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/ubuntu16/3.x/updates/3.3.1.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/ubuntu16/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
                 stackDefault: true
             sles12:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/sles12/3.x/updates/3.3.1.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/sles12/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
                 stackDefault: true
+            debian9:
+              - mpackUrl: https://archive.cloudera.com/p/HDF/3.x/3.3.1.0/debian9/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
+                stackDefault: true
+      3.5:
+        version: 3.5.2.0-99
+        min-ambari: 2.7
+        repo:
+          stack:
+            repoid: HDF-3.5
+            amazonlinux2: https://archive.cloudera.com/p/HDF/amazonlinux2/3.x/updates/3.5.2.0
+            redhat7: https://archive.cloudera.com/p/HDF/centos7/3.x/updates/3.5.2.0
+            debian9: https://archive.cloudera.com/p/HDF/debian9/3.x/updates/3.5.2.0
+            ubuntu16: https://archive.cloudera.com/p/HDF/ubuntu16/3.x/updates/3.5.2.0
+            sles12: https://archive.cloudera.com/p/HDF/sles12/3.x/updates/3.5.2.0
+            repository-version: 3.5.2.0-99
+            vdf-redhat7: https://archive.cloudera.com/p/HDF/centos7/3.x/updates/3.5.2.0/HDF-3.5.2.0-99.xml
+            vdf-debian9: https://archive.cloudera.com/p/HDF/debian9/3.x/updates/3.5.2.0/HDF-3.5.2.0-99.xml
+            vdf-amazonlinux2: https://archive.cloudera.com/p/HDF/amazonlinux2/3.x/updates/3.5.2.0/HDF-3.5.2.0-99.xml
+            vdf-ubuntu16: https://archive.cloudera.com/p/HDF/ubuntu16/3.x/updates/3.5.2.0/HDF-3.5.2.0-99.xml
+            vdf-sles12: https://archive.cloudera.com/p/HDF/sles12/3.x/updates/3.5.2.0/HDF-3.5.2.0-99.xml
+          util:
+            repoid: HDP-UTILS-1.1.0.22
+            redhat7: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/centos7
+            debian9: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/debian9
+            ubuntu16: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/ubuntu16
+            sles12: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/sles12
+            amazonlinux2: https://archive.cloudera.com/p/HDP-UTILS/1.1.0.22/repos/amazonlinux2
+          mpacks:
             amazonlinux2:
-              - mpackUrl: http://public-repo-1.hortonworks.com/HDF/amazonlinux2/3.x/updates/3.3.1.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.3.1.0-10.tar.gz
+              - mpackUrl: https://archive.cloudera.com/p/HDF/amazonlinux2/3.x/updates/3.5.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.5.2.0-99.tar.gz
+                stackDefault: true
+            redhat7:
+              - mpackUrl: https://archive.cloudera.com/p/HDF/centos7/3.x/updates/3.5.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.5.2.0-99.tar.gz
+                stackDefault: true
+            ubuntu16:
+              - mpackUrl: https://archive.cloudera.com/p/HDF/ubuntu16/3.x/updates/3.5.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.5.2.0-99.tar.gz
+                stackDefault: true
+            sles12:
+              - mpackUrl: https://archive.cloudera.com/p/HDF/sles12/3.x/updates/3.5.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.5.2.0-99.tar.gz
+                stackDefault: true
+            debian9:
+              - mpackUrl: https://archive.cloudera.com/p/HDF/debian9/3.x/updates/3.5.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-3.5.2.0-99.tar.gz
                 stackDefault: true
   smartsense.configure: false
   smartsense.enabled: true


### PR DESCRIPTION
… repos behind paywall

- repos in application.yml are moved behind paywall.
- Debian9 repos that are not present anymore are deleted.
- added HDF-3.5