### PR TITLE
CB-10796 Disable changing of primary gateway for SDX.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
@@ -16,6 +16,7 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerType;
 import com.sequenceiq.cloudbreak.common.type.ScalingType;
@@ -83,7 +84,7 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
                         instanceGroup.getId());
                 boolean primaryGatewayRepairable = primaryGatewayHostName.isPresent() && hostNames.contains(primaryGatewayHostName.get());
                 boolean singlePrimaryGatewayRepairable = primaryGatewayRepairable && !stack.isMultipleGateway();
-                if (singlePrimaryGatewayRepairable) {
+                if (singlePrimaryGatewayRepairable || StackType.DATALAKE.equals(stack.getType())) {
                     repairConfig.setSinglePrimaryGateway(new Repair(instanceGroup.getGroupName(), hostGroup.getName(), hostNames));
                 } else if (primaryGatewayRepairable) {
                     repairConfig.setChangePGW(true);


### PR DESCRIPTION
This disables the change primary gateway flow for the Datalake since CM HA is not yet implemented.