### PR TITLE
CB-11144 ScalingRequest.scaleup() will be executed without any error, in case if error has happened on cloudbreak side

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/AutoScalingException.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/AutoScalingException.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.periscope.service;
+
+public class AutoScalingException extends RuntimeException {
+    public AutoScalingException(String message) {
+        super(message);
+    }
+
+    public AutoScalingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
CB-11144 ScalingRequest.scaleup() will be executed without any error, in case if error has happened on cloudbreak side

* Check the putstack rest response from cloudbreak in ScalingRequest.scaleup() and if its statuscode is not in the SUCCESSFUL family, throws an AutoScalingException
* New entry will be created about the error in the Periscope History and notification will be sent
