### PR TITLE
CB-11145 StackCollectorService.collectStackDetails() is expensive if there are lots of clusters in periscope

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ha/LeaderElectionService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ha/LeaderElectionService.java
@@ -46,7 +46,8 @@ public class LeaderElectionService {
 
     private static final long LEADER_TASK_DELAY = 1000L;
 
-    private static final long STACK_COLLECTOR_PERIOD = 10000L;
+    @Value("${periscope.stack.collection.period}")
+    private Long stackCollectionPeriod;
 
     @Value("${periscope.ha.heartbeat.threshold:60000}")
     private Integer heartbeatThresholdRate;
@@ -95,7 +96,7 @@ public class LeaderElectionService {
                         LOGGER.error("Error happend during fetching stacks", e);
                     }
                 }
-            }, 0L, STACK_COLLECTOR_PERIOD);
+            }, 0L, stackCollectionPeriod);
         }
     }
 
@@ -135,7 +136,7 @@ public class LeaderElectionService {
                             LOGGER.error("Error happend during fetching cluster allocating them to nodes", e);
                         }
                     }
-                }, LEADER_TASK_DELAY, STACK_COLLECTOR_PERIOD);
+                }, LEADER_TASK_DELAY, stackCollectionPeriod);
             }
         }
     }

--- a/autoscale/src/main/resources/application.yml
+++ b/autoscale/src/main/resources/application.yml
@@ -29,6 +29,7 @@ periscope:
     schema: public
     cert.file: database.crt
     ssl: false
+  stack.collection.period: 60000
 
 cb:
   server:

--- a/autoscale/src/test/java/com/sequenceiq/periscope/service/ha/LeaderElectionServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/service/ha/LeaderElectionServiceTest.java
@@ -90,6 +90,7 @@ public class LeaderElectionServiceTest {
         when(timerFactory.get()).thenReturn(timer);
         when(clock.getCurrentTime()).thenReturn(5000L);
         when(applicationContext.getBean(eq("CronTimeEvaluator"), eq(CronTimeEvaluator.class))).thenReturn(cronTimeEvaluator);
+        ReflectionTestUtils.setField(underTest, "stackCollectionPeriod", 10000L);
         ReflectionTestUtils.setField(underTest, "heartbeatThresholdRate", 70000);
     }
 


### PR DESCRIPTION
CB-11145 StackCollectorService.collectStackDetails() is expensive if there are lots of clusters in periscope

* Set the stack collection period as a configurable parameter
* Increase the default value of it to 60sec
