### PR TITLE
DISTX-546 Implement cloud provider load-balancer support for datahub …

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/StackV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/StackV4Request.java
@@ -97,6 +97,9 @@ public class StackV4Request extends StackV4Base implements TaggableRequest {
     @ApiModelProperty(StackModelDescription.EXTERNAL_DATABASE)
     private DatabaseRequest externalDatabase;
 
+    @ApiModelProperty(StackModelDescription.ENABLE_LOAD_BALANCER)
+    private boolean enableLoadBalancer;
+
     @DatalakeCrn
     @ApiModelProperty(value = StackModelDescription.RESOURCE_CRN)
     private String resourceCrn;
@@ -231,6 +234,14 @@ public class StackV4Request extends StackV4Base implements TaggableRequest {
 
     public void setExternalDatabase(DatabaseRequest externalDatabase) {
         this.externalDatabase = externalDatabase;
+    }
+
+    public boolean isEnableLoadBalancer() {
+        return enableLoadBalancer;
+    }
+
+    public void setEnableLoadBalancer(boolean enableLoadBalancer) {
+        this.enableLoadBalancer = enableLoadBalancer;
     }
 
     public String getResourceCrn() {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -237,6 +237,7 @@ public class ModelDescriptions {
         public static final String FLOW_ID = "Flow identifier for the current stack creation. Only returned during the stack create request/response.";
         public static final String EXTERNAL_DATABASE = "External database parameters for the stack.";
         public static final String ENDPOINT_GATEWAY_FLOWS = "A list of stack and the flow id for the add endpoint gateway flow";
+        public static final String ENABLE_LOAD_BALANCER = "Enable load balancer.";
     }
 
     public static class ClusterModelDescription {

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/DistroXV1Request.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/DistroXV1Request.java
@@ -52,6 +52,8 @@ public class DistroXV1Request extends DistroXV1Base implements TaggableRequest {
     @ApiModelProperty(hidden = true)
     private Integer gatewayPort;
 
+    private boolean enableLoadBalancer;
+
     public String getEnvironmentName() {
         return environmentName;
     }
@@ -142,6 +144,14 @@ public class DistroXV1Request extends DistroXV1Base implements TaggableRequest {
 
     public void setGatewayPort(Integer port) {
         gatewayPort = port;
+    }
+
+    public boolean isEnableLoadBalancer() {
+        return enableLoadBalancer;
+    }
+
+    public void setEnableLoadBalancer(boolean enableLoadBalancer) {
+        this.enableLoadBalancer = enableLoadBalancer;
     }
 
     @JsonIgnore

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
@@ -178,7 +178,7 @@ public class StackV4RequestToStackConverter extends AbstractConversionServiceAwa
         stack.setExternalDatabaseCreationType(getIfNotNull(source.getExternalDatabase(), DatabaseRequest::getAvailabilityType));
         determineServiceTypeTag(stack, source.getTags());
         determineServiceFeatureTag(stack, source.getTags());
-        stack.setLoadBalancers(loadBalancerConfigService.createLoadBalancers(stack, environment));
+        stack.setLoadBalancers(loadBalancerConfigService.createLoadBalancers(stack, environment, source.isEnableLoadBalancer()));
         return stack;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cli/StackToStackV4RequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cli/StackToStackV4RequestConverter.java
@@ -80,6 +80,9 @@ public class StackToStackV4RequestConverter extends AbstractConversionServiceAwa
         stackV4Request.setCluster(getConversionService().convert(source.getCluster(), ClusterV4Request.class));
         stackV4Request.setExternalDatabase(getIfNotNull(source.getExternalDatabaseCreationType(),
                 databaseAvailabilityTypeToExternalDatabaseRequestConverter::convert));
+        if (!source.getLoadBalancers().isEmpty()) {
+            stackV4Request.setEnableLoadBalancer(true);
+        }
         stackV4Request.setInstanceGroups(getInstanceGroups(source));
         prepareImage(source, stackV4Request);
         prepareTags(source, stackV4Request);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateLoadBalancerEntityHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateLoadBalancerEntityHandler.java
@@ -93,7 +93,7 @@ public class CreateLoadBalancerEntityHandler extends ExceptionCatcherEventHandle
             instanceGroups.forEach(ig -> ig.setTargetGroups(targetGroupPersistenceService.findByIntanceGroupId(ig.getId())));
             Set<LoadBalancer> existingLoadBalancers = loadBalancerPersistenceService.findByStackId(stack.getId());
             stack.setInstanceGroups(instanceGroups);
-            Set<LoadBalancer> newLoadBalancers = loadBalancerConfigService.createLoadBalancers(stack, environment);
+            Set<LoadBalancer> newLoadBalancers = loadBalancerConfigService.createLoadBalancers(stack, environment, false);
 
             Stack savedStack;
             if (doLoadBalancersAlreadyExist(existingLoadBalancers, newLoadBalancers)) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceGroupV1ToInstanceGroupV4Converter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceGroupV1ToInstanceGroupV4Converter.java
@@ -19,7 +19,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.In
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.securitygroup.SecurityGroupV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.SecurityRuleUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.requests.SecurityRuleV4Request;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.util.CidrUtil;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.InstanceGroupV1Request;
@@ -45,9 +44,6 @@ public class InstanceGroupV1ToInstanceGroupV4Converter {
 
     private InstanceGroupV4Request convert(InstanceGroupV1Request source, DetailedEnvironmentResponse environment) {
         InstanceGroupV4Request response = new InstanceGroupV4Request();
-        if (InstanceGroupType.GATEWAY == source.getType() && source.getNodeCount() != 1) {
-            throw new BadRequestException("Instance group with GATEWAY type must contain 1 node!");
-        }
         response.setNodeCount(source.getNodeCount());
         response.setType(source.getType());
         response.setCloudPlatform(source.getCloudPlatform());

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-ha.json
@@ -11,10 +11,11 @@
     "externalDatabase": {
       "availabilityType": "HA"
     },
+    "enableLoadBalancer": true,
     "instanceGroups": [{
       "nodeCount": 1,
       "name": "manager",
-      "type": "GATEWAY",
+      "type": "CORE",
       "recoveryMode": "MANUAL",
       "template": {
         "aws": {},
@@ -94,7 +95,7 @@
       {
         "nodeCount": 2,
         "name": "master",
-        "type": "CORE",
+        "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
           "aws": {},

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
@@ -408,7 +408,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
         given(providerParameterCalculator.get(request)).willReturn(getMappable());
         given(conversionService.convert(any(ClusterV4Request.class), eq(Cluster.class))).willReturn(new Cluster());
         given(telemetryConverter.convert(null, StackType.DATALAKE)).willReturn(new Telemetry());
-        given(loadBalancerConfigService.createLoadBalancers(any(), any())).willReturn(Set.of(loadBalancer));
+        given(loadBalancerConfigService.createLoadBalancers(any(), any(), eq(false))).willReturn(Set.of(loadBalancer));
         // WHEN
         Stack stack = underTest.convert(request);
         // THEN

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceGroupV1ToInstanceGroupV4ConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceGroupV1ToInstanceGroupV4ConverterTest.java
@@ -1,14 +1,12 @@
 package com.sequenceiq.distrox.v1.distrox.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Set;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -23,7 +21,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.In
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.securitygroup.SecurityGroupV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.InstanceTemplateV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.requests.SecurityRuleV4Request;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.AwsInstanceGroupV1Parameters;
@@ -61,24 +58,6 @@ class InstanceGroupV1ToInstanceGroupV4ConverterTest {
 
     @InjectMocks
     private InstanceGroupV1ToInstanceGroupV4Converter underTest;
-
-    @Test
-    void gatewayIGMustContain1Node() {
-        when(instanceGroupParameterConverter.convert(AWS_INSTANCE_GROUP_V1_PARAMETERS)).thenReturn(AWS_INSTANCE_GROUP_V4_PARAMETERS);
-        when(instanceTemplateConverter.convert(any(InstanceTemplateV1Request.class))).thenReturn(INSTANCE_TEMPLATE_V4_REQUEST);
-        Set<InstanceGroupV1Request> instanceGroups = prepareInstanceGroupV1Requests(InstanceGroupType.GATEWAY);
-
-        instanceGroups.stream().findFirst().ifPresent(instanceGroup -> instanceGroup.setNodeCount(2));
-        BadRequestException exception = Assertions.assertThrows(BadRequestException.class, () -> underTest.convertTo(instanceGroups, null));
-        assertEquals("Instance group with GATEWAY type must contain 1 node!", exception.getMessage());
-
-        instanceGroups.stream().findFirst().ifPresent(instanceGroup -> instanceGroup.setNodeCount(0));
-        exception = Assertions.assertThrows(BadRequestException.class, () -> underTest.convertTo(instanceGroups, null));
-        assertEquals("Instance group with GATEWAY type must contain 1 node!", exception.getMessage());
-
-        instanceGroups.stream().findFirst().ifPresent(instanceGroup -> instanceGroup.setNodeCount(1));
-        underTest.convertTo(instanceGroups, null);
-    }
 
     @Test
     void convertToAwsWithoutSecurityGroupsHappyPathTest() {


### PR DESCRIPTION
…cluster

1. This allows explicitly setting up a load-balancer to any datahub cluster
2. This reuses the load-balancer implementation for semi-private networks
3. When the load-balancer is enabled removed the restriction of one gateway node because this will be used by DE HA cluster and clusters with custom HA definition
4. If the load-balancer is enabled in the environment, then it is not possible to disable the load-balancer for a particular datahub cluster.
5. Modified 7.2.8 only for now to do the testing and getting the review in parallel, while I hash out the backward incompatibility in the endpoint for the released versions.

Tested with 7.2.7 HA cluster definition in the private stack that the load balancer is created. Also tested if it is not in the cluster definition the load balancer is not created