### PR TITLE
CB-11144 additional logs for autoscale related update endpoint

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/stack/instance/InstanceGroupAdjustmentJson.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/stack/instance/InstanceGroupAdjustmentJson.java
@@ -35,4 +35,12 @@ public class InstanceGroupAdjustmentJson implements JsonEntity {
     public void setScalingAdjustment(Integer scalingAdjustment) {
         this.scalingAdjustment = scalingAdjustment;
     }
+
+    @Override
+    public String toString() {
+        return "InstanceGroupAdjustmentJson{"
+                + "instanceGroup='" + instanceGroup + '\''
+                + ", scalingAdjustment=" + scalingAdjustment
+                + '}';
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/AutoscaleController.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/AutoscaleController.java
@@ -9,6 +9,8 @@ import javax.transaction.Transactional.TxType;
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.autoscale.AutoscaleEndpoint;
@@ -37,6 +39,8 @@ import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
 @Transactional(TxType.NEVER)
 public class AutoscaleController implements AutoscaleEndpoint {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AutoscaleController.class);
+
     @Inject
     private StackService stackService;
 
@@ -63,6 +67,8 @@ public class AutoscaleController implements AutoscaleEndpoint {
 
     @Override
     public Response putStack(Long id, String owner, @Valid UpdateStackJson updateRequest) {
+        LOGGER.info("Autoscale requested stack update for stack id '{}', with status request '{}' and adjustment: '{}'", id, updateRequest.getStatus(),
+                updateRequest.getInstanceGroupAdjustment());
         setupIdentityForAutoscale(id, owner);
         return stackCommonService.putInDefaultWorkspace(id, updateRequest);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
@@ -288,6 +288,8 @@ public class StackCommonService implements StackEndpoint {
             validateHardLimits(scalingAdjustment);
             stackService.updateNodeCount(stack, updateRequest.getInstanceGroupAdjustment(), updateRequest.getWithClusterEvent(), user);
         }
+        LOGGER.info("Stack update has been initiated name: '{}' with status: '{}' and adjustment: '{}'", stack.getName(), updateRequest.getStatus(),
+                updateRequest.getInstanceGroupAdjustment());
         return Response.status(Status.NO_CONTENT).build();
     }
 


### PR DESCRIPTION
Example of new log lines:
`2021-02-15 09:40:00,304 [http-nio-9091-exec-4] putStack:70 DEBUG c.s.c.c.AutoscaleController - [owner:undefined] [type:Autoscale] [id:20] [name:undefined] [flow:] [tracking:ab1a209f-a098-4bf2-8e23-12420277b844] Autoscale requested stack update for stack id '20', with status request 'null' and adjustment: 'InstanceGroupAdjustmentJson{instanceGroup='worker', scalingAdjustment=3}'`
`2021-02-15 09:40:00,617 [http-nio-9091-exec-4] put:291 DEBUG c.s.c.s.StackCommonService - [owner:7f8b90b0-3f3a-4138-b9d5-7bbd7cae5ee9] [type:STACK] [id:20] [name:tb-292test-2] [flow:] [tracking:ab1a209f-a098-4bf2-8e23-12420277b844] Stack update has been initiated name: 'tb-292test-2' with status: 'null' and adjustment: 'InstanceGroupAdjustmentJson{instanceGroup='worker', scalingAdjustment=3}'`