### PR TITLE
CB-11165 Remove test containers for services not defined in the IT Compose file

### DIFF
--- a/integration-test/scripts/docker-compose.sh
+++ b/integration-test/scripts/docker-compose.sh
@@ -18,7 +18,7 @@ cd ..
 
 date
 echo -e "\n\033[1;96m--- Kill running test container\033[0m\n"
-$INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility down
+$INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility down --remove-orphans
 
 date
 echo -e "\n\033[1;96m--- Create docker network\033[0m\n"
@@ -26,7 +26,7 @@ docker network create cbreak_default || true
 
 date
 echo -e "\n\033[1;96m--- Start thunderhead mock\033[0m\n"
-$INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility up -d thunderhead-mock
+$INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility up --remove-orphans --detach thunderhead-mock
 
 date
 echo -e "\n\033[1;96m--- Copy mock infrastructure infrastructure-mock.p12 cert to certs dir\033[0m\n"
@@ -47,9 +47,9 @@ docker ps --format ‘{{.Image}}’
 
 date
 if [ $? -ne 0 ]; then
-    echo ERROR: Failed to bring up all the necessary services! Process is about to terminate.
+    echo -e "\n\033[1;96m--- ERROR: Failed to bring up all the necessary services! Process is about to terminate!\033[0m\n"
     ./cbd kill
-    .deps/bin/docker-compose --compatibility down
+    .deps/bin/docker-compose --compatibility down --remove-orphans
     exit 1
 fi
 
@@ -121,7 +121,7 @@ if [[ "$CIRCLECI" ]]; then
     export DOCKER_CLIENT_TIMEOUT=120
     export COMPOSE_HTTP_TIMEOUT=120
 
-    $INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility up test | tee test.out
+    $INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility up --remove-orphans test | tee test.out
     echo -e "\n\033[1;96m--- Test finished\033[0m\n"
 
     echo -e "\n\033[1;96m--- Collect docker stats:\033[0m\n"

--- a/integration-test/scripts/swagger-check.sh
+++ b/integration-test/scripts/swagger-check.sh
@@ -191,12 +191,18 @@ for service in $Services; do
 done
 set -e
 IFS=$Field_Separator
-$INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility up swagger-diff | tee swagger-diff.out
+$INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility up --remove-orphans swagger-diff | tee swagger-diff.out
 grep "swagger diff finished succesfully" swagger-diff.out
 swaggerdiffresult=$?
 
-$INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility up swagger-validation | tee swagger-validation-result.out
+echo -e "\n\033[1;96m--- Kill running Swagger Diff containers\033[0m\n"
+$INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility down --remove-orphans
+
+$INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility up --remove-orphans swagger-validation | tee swagger-validation-result.out
 grep "swagger validation finished succesfully" swagger-validation-result.out
 swaggervalidationresult=$?
+
+echo -e "\n\033[1;96m--- Kill running Swagger Validation containers\033[0m\n"
+$INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility down --remove-orphans
 
 exit $swaggerdiffresult && $swaggervalidationresult


### PR DESCRIPTION
Cloudbreak real UMS tests are failing, because of:
```
ERROR: for cbreak_vault_1  Cannot start service vault: endpoint with name cbreak_vault_1 already exists in network cbreak_default
```
even the `docker ps -a` shows any running containers and `docker images` shows no pulled image on the Jenkins node, the `docker network rm cbreak_default` throws error:
```
Error response from daemon: error while removing network: network cbreak_default id 790629475ad0b286dd0ce685371b65e4157e4ca0d4b466c276d1fea8ad7e4fd3 has active endpoints
```
So we should manage stuck containers for services not defined in the Compose file.