### PR TITLE
CB-8476 Check instance status and detect if a machine disappears duri…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
@@ -169,7 +169,7 @@ public class ClusterBootstrapper {
             String notStartedInstanceIdsAndStatuses = notStartedInstances.stream()
                     .map(instance -> instance.getCloudInstance().getInstanceId() + ": " + instance.getStatus())
                     .collect(Collectors.joining(", "));
-            throw new CloudbreakException("Nodes were deleted or went missing during cluster install:  " + notStartedInstanceIdsAndStatuses
+            throw new CloudbreakException("Nodes were not in started state during cluster install:  " + notStartedInstanceIdsAndStatuses
                     + " Please check " + stack.getCloudPlatform() + " logs. Original message: " + e.getMessage());
         }
     }


### PR DESCRIPTION
…ng cluster bootstrap

If a VM disappears during cluster install, CB fails with timeout or with various hard to debug reasons.
Introduce instance status check in order to provide more relevant error messages.