### PR TITLE
CB-10963. Add salt connectivity check before diagnostics initialization.

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/BaseDiagnosticsCollectionRequest.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/BaseDiagnosticsCollectionRequest.java
@@ -59,7 +59,7 @@ public class BaseDiagnosticsCollectionRequest {
     @ApiModelProperty(DiagnosticsModelDescription.SKIP_VALIDATION)
     private Boolean skipValidation = Boolean.FALSE;
 
-    @ApiModelProperty(DiagnosticsModelDescription.SKIP_WORKSPACE_CLEANUp)
+    @ApiModelProperty(DiagnosticsModelDescription.SKIP_WORKSPACE_CLEANUP)
     private Boolean skipWorkspaceCleanupOnStartup = Boolean.FALSE;
 
     @ApiModelProperty(DiagnosticsModelDescription.SKIP_UNRESPONSIVE_HOSTS)

--- a/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/BaseDiagnosticsCollectionRequest.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/BaseDiagnosticsCollectionRequest.java
@@ -44,6 +44,9 @@ public class BaseDiagnosticsCollectionRequest {
     @ApiModelProperty(DiagnosticsModelDescription.HOSTS)
     private Set<String> hosts = new HashSet<>();
 
+    @ApiModelProperty(DiagnosticsModelDescription.EXCLUDE_HOSTS)
+    private Set<String> excludeHosts = new HashSet<>();
+
     @ApiModelProperty(DiagnosticsModelDescription.ADDITIONAL_LOGS)
     private List<VmLog> additionalLogs = List.of();
 
@@ -55,6 +58,12 @@ public class BaseDiagnosticsCollectionRequest {
 
     @ApiModelProperty(DiagnosticsModelDescription.SKIP_VALIDATION)
     private Boolean skipValidation = Boolean.FALSE;
+
+    @ApiModelProperty(DiagnosticsModelDescription.SKIP_WORKSPACE_CLEANUp)
+    private Boolean skipWorkspaceCleanupOnStartup = Boolean.FALSE;
+
+    @ApiModelProperty(DiagnosticsModelDescription.SKIP_UNRESPONSIVE_HOSTS)
+    private Boolean skipUnresponsiveHosts = Boolean.FALSE;
 
     public List<String> getLabels() {
         return labels;
@@ -150,5 +159,29 @@ public class BaseDiagnosticsCollectionRequest {
 
     public void setSkipValidation(Boolean skipValidation) {
         this.skipValidation = skipValidation;
+    }
+
+    public Boolean getSkipWorkspaceCleanupOnStartup() {
+        return skipWorkspaceCleanupOnStartup;
+    }
+
+    public void setSkipWorkspaceCleanupOnStartup(Boolean skipWorkspaceCleanupOnStartup) {
+        this.skipWorkspaceCleanupOnStartup = skipWorkspaceCleanupOnStartup;
+    }
+
+    public Boolean getSkipUnresponsiveHosts() {
+        return skipUnresponsiveHosts;
+    }
+
+    public void setSkipUnresponsiveHosts(Boolean skipUnresponsiveHosts) {
+        this.skipUnresponsiveHosts = skipUnresponsiveHosts;
+    }
+
+    public Set<String> getExcludeHosts() {
+        return excludeHosts;
+    }
+
+    public void setExcludeHosts(Set<String> excludeHosts) {
+        this.excludeHosts = excludeHosts;
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
@@ -18,7 +18,7 @@ public class DiagnosticsModelDescription {
     public static final String UPDATE_PACKAGE = "Upgrade or install required telemetry cli tool on the nodes (works only with network)";
     public static final String SKIP_VALIDATION = "Skip cloud storage write operation testing or databus connection " +
             "check (depends on the destination) during init stage.";
-    public static final String SKIP_WORKSPACE_CLEANUp = "Skip workspace cleanup on the VM nodes at the start of the diagnostic ";
+    public static final String SKIP_WORKSPACE_CLEANUP = "Skip workspace cleanup on the VM nodes at the start of the diagnostic ";
     public static final String SKIP_UNRESPONSIVE_HOSTS = "Skip unresponsive VM hosts from diagnostics";
     public static final String ROLES = "List of roles for which to get logs and metrics. If set, this restricts the roles for log and metrics collection " +
             "to the list specified. If empty, the default is to get logs for all roles.";

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
@@ -10,6 +10,7 @@ public class DiagnosticsModelDescription {
     public static final String DESTINATION = "Destination for the diagnostic collection request.";
     public static final String DESCRIPTION = "Description of the diagnostics collection";
     public static final String HOSTS = "Host (fqdn) filter, use it to run diagnostics collection on only specific hosts";
+    public static final String EXCLUDE_HOSTS = "Host (fqdn) filter, skip diagnostics on the specified hosts";
     public static final String HOST_GROUPS = "Host groups (instance groups), used it to run diagnostics collection only those " +
             "hosts that are included the specific host groups";
     public static final String ADDITIONAL_LOGS = "Additional log path and label pairs that will be sent in the diagnostics collection";
@@ -17,6 +18,8 @@ public class DiagnosticsModelDescription {
     public static final String UPDATE_PACKAGE = "Upgrade or install required telemetry cli tool on the nodes (works only with network)";
     public static final String SKIP_VALIDATION = "Skip cloud storage write operation testing or databus connection " +
             "check (depends on the destination) during init stage.";
+    public static final String SKIP_WORKSPACE_CLEANUp = "Skip workspace cleanup on the VM nodes at the start of the diagnostic ";
+    public static final String SKIP_UNRESPONSIVE_HOSTS = "Skip unresponsive VM hosts from diagnostics";
     public static final String ROLES = "List of roles for which to get logs and metrics. If set, this restricts the roles for log and metrics collection " +
             "to the list specified. If empty, the default is to get logs for all roles.";
     public static final String BUNDLE_SIZE_BYTES = "The maximum approximate bundle size of the output file for CM based diagnostics collection.";

--- a/common-model/src/main/java/com/sequenceiq/common/model/diagnostics/DiagnosticParameters.java
+++ b/common-model/src/main/java/com/sequenceiq/common/model/diagnostics/DiagnosticParameters.java
@@ -31,6 +31,8 @@ public class DiagnosticParameters {
 
     private Set<String> hosts = new HashSet<>();
 
+    private Set<String> excludeHosts = new HashSet<>();
+
     private List<VmLog> additionalLogs = List.of();
 
     private Boolean includeSaltLogs = Boolean.FALSE;
@@ -38,6 +40,10 @@ public class DiagnosticParameters {
     private Boolean updatePackage = Boolean.FALSE;
 
     private Boolean skipValidation = Boolean.FALSE;
+
+    private Boolean skipUnresponsiveHosts = Boolean.FALSE;
+
+    private Boolean skipWorkspaceCleanupOnStartup = Boolean.FALSE;
 
     private String uuid;
 
@@ -71,9 +77,12 @@ public class DiagnosticParameters {
                 .map(Date::getTime).orElse(null));
         parameters.put("hostGroups", Optional.ofNullable(hostGroups).orElse(null));
         parameters.put("hosts", Optional.ofNullable(hosts).orElse(null));
+        parameters.put("excludeHosts", Optional.ofNullable(hosts).orElse(null));
         parameters.put("includeSaltLogs", Optional.ofNullable(includeSaltLogs).orElse(false));
         parameters.put("updatePackage", Optional.ofNullable(updatePackage).orElse(false));
         parameters.put("skipValidation", Optional.ofNullable(skipValidation).orElse(false));
+        parameters.put("skipUnresponsiveHosts", Optional.ofNullable(skipUnresponsiveHosts).orElse(false));
+        parameters.put("skipWorkspaceCleanupOnStartup", Optional.ofNullable(skipWorkspaceCleanupOnStartup).orElse(false));
         parameters.put("additionalLogs", additionalLogs);
         parameters.put("uuid", uuid);
         parameters.put("accountId", accountId);
@@ -127,6 +136,10 @@ public class DiagnosticParameters {
         this.hosts = hosts;
     }
 
+    public void setExcludeHosts(Set<String> excludeHosts) {
+        this.excludeHosts = excludeHosts;
+    }
+
     public void setAdditionalLogs(List<VmLog> additionalLogs) {
         this.additionalLogs = additionalLogs;
     }
@@ -141,6 +154,14 @@ public class DiagnosticParameters {
 
     public void setSkipValidation(Boolean skipValidation) {
         this.skipValidation = skipValidation;
+    }
+
+    public void setSkipUnresponsiveHosts(Boolean skipUnresponsiveHosts) {
+        this.skipUnresponsiveHosts = skipUnresponsiveHosts;
+    }
+
+    public void setSkipWorkspaceCleanupOnStartup(Boolean skipWorkspaceCleanupOnStartup) {
+        this.skipWorkspaceCleanupOnStartup = skipWorkspaceCleanupOnStartup;
     }
 
     public void setUuid(String uuid) {
@@ -215,6 +236,10 @@ public class DiagnosticParameters {
         return hosts;
     }
 
+    public Set<String> getExcludeHosts() {
+        return excludeHosts;
+    }
+
     public List<VmLog> getAdditionalLogs() {
         return additionalLogs;
     }
@@ -229,6 +254,14 @@ public class DiagnosticParameters {
 
     public Boolean getSkipValidation() {
         return skipValidation;
+    }
+
+    public Boolean getSkipUnresponsiveHosts() {
+        return skipUnresponsiveHosts;
+    }
+
+    public Boolean getSkipWorkspaceCleanupOnStartup() {
+        return skipWorkspaceCleanupOnStartup;
     }
 
     public String getUuid() {
@@ -346,6 +379,11 @@ public class DiagnosticParameters {
             return this;
         }
 
+        public DiagnosticParametersBuilder withExcludeHosts(Set<String> excludeHosts) {
+            diagnosticParameters.setExcludeHosts(excludeHosts);
+            return this;
+        }
+
         public DiagnosticParametersBuilder withAdditionalLogs(List<VmLog> additionalLogs) {
             diagnosticParameters.setAdditionalLogs(additionalLogs);
             return this;
@@ -363,6 +401,16 @@ public class DiagnosticParameters {
 
         public DiagnosticParametersBuilder withSkipValidation(Boolean skipValidation) {
             diagnosticParameters.setSkipValidation(skipValidation);
+            return this;
+        }
+
+        public DiagnosticParametersBuilder withSkipWorkspaceCleanupOnStartup(Boolean skipWorkspaceCleanupOnStartup) {
+            diagnosticParameters.setSkipWorkspaceCleanupOnStartup(skipWorkspaceCleanupOnStartup);
+            return this;
+        }
+
+        public DiagnosticParametersBuilder withSkipUnresponsiveHosts(Boolean skipUnresponsiveHosts) {
+            diagnosticParameters.setSkipUnresponsiveHosts(skipUnresponsiveHosts);
             return this;
         }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -183,6 +183,7 @@ public enum ResourceEvent {
     STACK_DATALAKE_UPDATE("stack.datalake.update"),
     STACK_DATALAKE_UPDATE_FINISHED("stack.datalake.update.finished"),
     STACK_DATALAKE_UPDATE_FAILED("stack.datalake.update.failed"),
+    STACK_DIAGNOSTICS_SALT_VALIDATION_RUNNING("stack.diagnostics.salt.validation.running"),
     STACK_DIAGNOSTICS_INIT_RUNNING("stack.diagnostics.init.running"),
     STACK_DIAGNOSTICS_ENSURE_MACHINE_USER("stack.diagnostics.ensure.machine.user"),
     STACK_DIAGNOSTICS_COLLECTION_RUNNING("stack.diagnostics.collection.running"),

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -184,6 +184,7 @@ public enum ResourceEvent {
     STACK_DATALAKE_UPDATE_FINISHED("stack.datalake.update.finished"),
     STACK_DATALAKE_UPDATE_FAILED("stack.datalake.update.failed"),
     STACK_DIAGNOSTICS_SALT_VALIDATION_RUNNING("stack.diagnostics.salt.validation.running"),
+    STACK_DIAGNOSTICS_SALT_VALIDATION_RUNNING_SKIP_UNRESPONSIVE("stack.diagnostics.salt.validation.running.skip.unresponsive"),
     STACK_DIAGNOSTICS_INIT_RUNNING("stack.diagnostics.init.running"),
     STACK_DIAGNOSTICS_ENSURE_MACHINE_USER("stack.diagnostics.ensure.machine.user"),
     STACK_DIAGNOSTICS_COLLECTION_RUNNING("stack.diagnostics.collection.running"),

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/DiagnosticsDataToParameterConverter.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/DiagnosticsDataToParameterConverter.java
@@ -78,9 +78,12 @@ public class DiagnosticsDataToParameterConverter {
         builder.withEndTime(request.getEndTime());
         builder.withHostGroups(request.getHostGroups());
         builder.withHosts(request.getHosts());
+        builder.withExcludeHosts(request.getExcludeHosts());
         builder.withIncludeSaltLogs(request.getIncludeSaltLogs());
         builder.withUpdatePackage(request.getUpdatePackage());
         builder.withSkipValidation(request.getSkipValidation());
+        builder.withSkipWorkspaceCleanupOnStartup(request.getSkipWorkspaceCleanupOnStartup());
+        builder.withSkipUnresponsiveHosts(request.getSkipUnresponsiveHosts());
         builder.withAdditionalLogs(request.getAdditionalLogs());
         if (supportBundleConfiguration.isEnabled()) {
             builder.withDbusUrl(databusEndpoint);

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -46,6 +46,7 @@ stack.infrastructure.create.rollback=Could not create {0} instance(s), node coun
 stack.cleanup.service.trigger.sync=Couldn't retrieve the cluster's status, starting to sync.
 
 stack.diagnostics.salt.validation.running=Validating salt minion connectivity before initializing diagnostics collection. Esxclude hosts: {0}
+stack.diagnostics.salt.validation.running.skip.unresponsive=Validating salt minion connectivity before initializing diagnostics collection (skip unresponsive hosts). Initially excluded hosts: {0}
 stack.diagnostics.init.running=Diagnostics collection initialization in progress. Hosts: {0}, Excluded hosts: {1}, Host-groups: {2}
 stack.diagnostics.ensure.machine.user=Check availability of UMS resources for diagnostics.
 stack.diagnostics.collection.running=Diagnostics collection in progress. Destination for logs: {0}

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -45,7 +45,8 @@ stack.datalake.update.failed=Failed to update the cluster
 stack.infrastructure.create.rollback=Could not create {0} instance(s), node count is decreased on group {1}. Reason: {2}
 stack.cleanup.service.trigger.sync=Couldn't retrieve the cluster's status, starting to sync.
 
-stack.diagnostics.init.running=Diagnostics collection initialization in progress. Hosts: {0}, Host-groups: {1}
+stack.diagnostics.salt.validation.running=Validating salt minion connectivity before initializing diagnostics collection. Esxclude hosts: {0}
+stack.diagnostics.init.running=Diagnostics collection initialization in progress. Hosts: {0}, Excluded hosts: {1}, Host-groups: {2}
 stack.diagnostics.ensure.machine.user=Check availability of UMS resources for diagnostics.
 stack.diagnostics.collection.running=Diagnostics collection in progress. Destination for logs: {0}
 stack.diagnostics.upload.running=Diagnostics uploading in progress. {0}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionActions.java
@@ -58,10 +58,15 @@ public class DiagnosticsCollectionActions {
                 String resourceCrn = payload.getResourceCrn();
                 LOGGER.debug("Flow entered into DIAGNOSTICS_SALT_VALIDATION_STATE. resourceCrn: '{}'", resourceCrn);
                 InMemoryStateStore.putStack(resourceId, PollGroup.POLLABLE);
-                String excludedHosts = CollectionUtils.isEmpty(payload.getHosts())
-                        ? "[NONE]" : String.format("[%s]", String.join(",", payload.getExcludedHosts()));
-                cloudbreakEventService.fireCloudbreakEvent(resourceId, UPDATE_IN_PROGRESS.name(),
-                        ResourceEvent.STACK_DIAGNOSTICS_SALT_VALIDATION_RUNNING, List.of(excludedHosts));
+                String excludedHosts = CollectionUtils.isEmpty(payload.getParameters().getExcludeHosts())
+                        ? "[NONE]" : String.format("[%s]", String.join(",", payload.getParameters().getExcludeHosts()));
+                if (payload.getParameters().getSkipUnresponsiveHosts()) {
+                    cloudbreakEventService.fireCloudbreakEvent(resourceId, UPDATE_IN_PROGRESS.name(),
+                            ResourceEvent.STACK_DIAGNOSTICS_SALT_VALIDATION_RUNNING_SKIP_UNRESPONSIVE, List.of(excludedHosts));
+                } else {
+                    cloudbreakEventService.fireCloudbreakEvent(resourceId, UPDATE_IN_PROGRESS.name(),
+                            ResourceEvent.STACK_DIAGNOSTICS_SALT_VALIDATION_RUNNING, List.of(excludedHosts));
+                }
                 DiagnosticsCollectionEvent event = DiagnosticsCollectionEvent.builder()
                         .withResourceId(resourceId)
                         .withResourceCrn(resourceCrn)
@@ -69,6 +74,7 @@ public class DiagnosticsCollectionActions {
                         .withParameters(payload.getParameters())
                         .withHosts(payload.getHosts())
                         .withHostGroups(payload.getHostGroups())
+                        .withExcludeHosts(payload.getExcludeHosts())
                         .build();
                 sendEvent(context, event);
             }
@@ -85,8 +91,8 @@ public class DiagnosticsCollectionActions {
                 LOGGER.debug("Flow entered into DIAGNOSTICS_INIT_STATE. resourceCrn: '{}'", resourceCrn);
                 String hosts = CollectionUtils.isEmpty(payload.getHosts())
                         ? "[ALL]" : String.format("[%s]", String.join(",", payload.getHosts()));
-                String excludedHosts = CollectionUtils.isEmpty(payload.getHosts())
-                        ? "[NONE]" : String.format("[%s]", String.join(",", payload.getExcludedHosts()));
+                String excludedHosts = CollectionUtils.isEmpty(payload.getExcludeHosts())
+                        ? "[NONE]" : String.format("[%s]", String.join(",", payload.getExcludeHosts()));
                 String hostGroups = CollectionUtils.isEmpty(payload.getHostGroups())
                         ? "[ALL]" : String.format("[%s]", String.join(",", payload.getHostGroups()));
                 cloudbreakEventService.fireCloudbreakEvent(resourceId, UPDATE_IN_PROGRESS.name(),
@@ -98,6 +104,7 @@ public class DiagnosticsCollectionActions {
                         .withParameters(payload.getParameters())
                         .withHosts(payload.getHosts())
                         .withHostGroups(payload.getHostGroups())
+                        .withExcludeHosts(payload.getExcludeHosts())
                         .build();
                 sendEvent(context, event);
             }
@@ -121,6 +128,7 @@ public class DiagnosticsCollectionActions {
                         .withParameters(payload.getParameters())
                         .withHosts(payload.getHosts())
                         .withHostGroups(payload.getHostGroups())
+                        .withExcludeHosts(payload.getExcludeHosts())
                         .build();
                 sendEvent(context, event);
             }
@@ -144,6 +152,7 @@ public class DiagnosticsCollectionActions {
                         .withParameters(payload.getParameters())
                         .withHosts(payload.getHosts())
                         .withHostGroups(payload.getHostGroups())
+                        .withExcludeHosts(payload.getExcludeHosts())
                         .build();
                 sendEvent(context, event);
             }
@@ -166,6 +175,7 @@ public class DiagnosticsCollectionActions {
                         .withParameters(payload.getParameters())
                         .withHosts(payload.getHosts())
                         .withHostGroups(payload.getHostGroups())
+                        .withExcludeHosts(payload.getExcludeHosts())
                         .build();
                 sendEvent(context, event);
             }
@@ -235,6 +245,7 @@ public class DiagnosticsCollectionActions {
                         .withParameters(payload.getParameters())
                         .withHosts(payload.getHosts())
                         .withHostGroups(payload.getHostGroups())
+                        .withExcludeHosts(payload.getExcludeHosts())
                         .build();
                 sendEvent(context, event);
             }
@@ -258,6 +269,7 @@ public class DiagnosticsCollectionActions {
                         .withParameters(payload.getParameters())
                         .withHosts(payload.getHosts())
                         .withHostGroups(payload.getHostGroups())
+                        .withExcludeHosts(payload.getExcludeHosts())
                         .build();
                 sendEvent(context, event);
             }
@@ -282,6 +294,7 @@ public class DiagnosticsCollectionActions {
                         .withParameters(payload.getParameters())
                         .withHosts(payload.getHosts())
                         .withHostGroups(payload.getHostGroups())
+                        .withExcludeHosts(payload.getExcludeHosts())
                         .build();
                 sendEvent(context, event);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionActions.java
@@ -83,7 +83,6 @@ public class DiagnosticsCollectionActions {
                 Long resourceId = payload.getResourceId();
                 String resourceCrn = payload.getResourceCrn();
                 LOGGER.debug("Flow entered into DIAGNOSTICS_INIT_STATE. resourceCrn: '{}'", resourceCrn);
-                InMemoryStateStore.putStack(resourceId, PollGroup.POLLABLE);
                 String hosts = CollectionUtils.isEmpty(payload.getHosts())
                         ? "[ALL]" : String.format("[%s]", String.join(",", payload.getHosts()));
                 String excludedHosts = CollectionUtils.isEmpty(payload.getHosts())

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionsState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionsState.java
@@ -4,6 +4,7 @@ import com.sequenceiq.flow.core.FlowState;
 
 public enum DiagnosticsCollectionsState implements FlowState {
     INIT_STATE,
+    DIAGNOSTICS_SALT_VALIDATION_STATE,
     DIAGNOSTICS_INIT_STATE,
     DIAGNOSTICS_ENSURE_MACHINE_USER_STATE,
     DIAGNOSTICS_COLLECTION_STATE,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowService.java
@@ -55,92 +55,88 @@ public class DiagnosticsFlowService {
                 .map(Node::getHostname).collect(Collectors.toSet());
     }
 
-    public boolean init(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
+    public void init(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
         LOGGER.debug("Diagnostics init will be called only on the primary gateway address");
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         String primaryGatewayIp = gatewayConfigService.getPrimaryGatewayIp(stack);
         Set<String> hosts = new HashSet<>(Arrays.asList(primaryGatewayIp));
-        return init(stackId, parameters, hosts, new HashSet<>(), excludeHosts);
+        init(stackId, parameters, hosts, new HashSet<>(), excludeHosts);
     }
 
-    public boolean init(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
+    public void init(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
             throws CloudbreakOrchestratorFailedException {
-        boolean executed = false;
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, hosts, hostGroups);
         LOGGER.debug("Starting diagnostics init. resourceCrn: '{}'", stack.getResourceCrn());
         ClusterDeletionBasedExitCriteriaModel exitModel = new ClusterDeletionBasedExitCriteriaModel(stackId, stack.getCluster().getId());
-        if (!allNodes.isEmpty()) {
+        if (allNodes.isEmpty()) {
+            LOGGER.debug("Diagnostics initialization has been skipped. (no target minions)");
+        } else {
             telemetryOrchestrator.initDiagnosticCollection(gatewayConfigs, allNodes, parameters, exitModel);
-            executed = true;
         }
-        return executed;
     }
 
-    public boolean collect(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
+    public void collect(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
             throws CloudbreakOrchestratorFailedException {
-        boolean executed = false;
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, hosts, hostGroups);
         LOGGER.debug("Starting diagnostics collection. resourceCrn: '{}'", stack.getResourceCrn());
         ClusterDeletionBasedExitCriteriaModel exitModel = new ClusterDeletionBasedExitCriteriaModel(stackId, stack.getCluster().getId());
-        if (!allNodes.isEmpty()) {
+        if (allNodes.isEmpty()) {
+            LOGGER.debug("Diagnostics collect has been skipped. (no target minions)");
+        } else {
             telemetryOrchestrator.executeDiagnosticCollection(gatewayConfigs, allNodes, parameters, exitModel);
-            executed = true;
         }
-        return executed;
     }
 
-    public boolean upload(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
+    public void upload(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
         LOGGER.debug("Diagnostics upload will be called only on the primary gateway address");
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         String primaryGatewayIp = gatewayConfigService.getPrimaryGatewayIp(stack);
         Set<String> hosts = new HashSet<>(Arrays.asList(primaryGatewayIp));
-        return upload(stackId, parameters, hosts, new HashSet<>(), excludeHosts);
+        upload(stackId, parameters, hosts, new HashSet<>(), excludeHosts);
     }
 
-    public boolean upload(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
+    public void upload(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
             throws CloudbreakOrchestratorFailedException {
-        boolean executed = false;
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, hosts, hostGroups);
         LOGGER.debug("Starting diagnostics upload. resourceCrn: '{}'", stack.getResourceCrn());
         ClusterDeletionBasedExitCriteriaModel exitModel = new ClusterDeletionBasedExitCriteriaModel(stackId, stack.getCluster().getId());
-        if (!allNodes.isEmpty()) {
+        if (allNodes.isEmpty()) {
+            LOGGER.debug("Diagnostics upload has been skipped. (no target minions)");
+        } else {
             telemetryOrchestrator.uploadCollectedDiagnostics(gatewayConfigs, allNodes, parameters, exitModel);
-            executed = true;
         }
-        return executed;
     }
 
-    public boolean cleanup(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
+    public void cleanup(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
         LOGGER.debug("Diagnostics cleanup will be called only on the primary gateway address");
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         String primaryGatewayIp = gatewayConfigService.getPrimaryGatewayIp(stack);
         Set<String> hosts = new HashSet<>(Arrays.asList(primaryGatewayIp));
-        return cleanup(stackId, parameters, hosts, new HashSet<>(), excludeHosts);
+        cleanup(stackId, parameters, hosts, new HashSet<>(), excludeHosts);
     }
 
-    public boolean cleanup(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
+    public void cleanup(Long stackId, Map<String, Object> parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts)
             throws CloudbreakOrchestratorFailedException {
-        boolean executed = false;
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
         Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
         Set<Node> allNodes = getNodes(instanceMetaDataSet, hosts, hostGroups);
         LOGGER.debug("Starting diagnostics cleanup. resourceCrn: '{}'", stack.getResourceCrn());
         ClusterDeletionBasedExitCriteriaModel exitModel = new ClusterDeletionBasedExitCriteriaModel(stackId, stack.getCluster().getId());
-        if (!allNodes.isEmpty()) {
+        if (allNodes.isEmpty()) {
+            LOGGER.debug("Diagnostics cleanup has been skipped. (no target minions)");
+        } else {
             telemetryOrchestrator.cleanupCollectedDiagnostics(gatewayConfigs, allNodes, parameters, exitModel);
-            executed = true;
         }
-        return executed;
     }
 
     private Set<Node> getNodes(Set<InstanceMetaData> instanceMetaDataSet, Set<String> hosts, Set<String> hostGroups) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/config/DiagnosticsCollectionFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/config/DiagnosticsCollectionFlowConfig.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollec
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_COLLECTION_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_ENSURE_MACHINE_USER_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_INIT_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_SALT_VALIDATION_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_UPLOAD_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.FINAL_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.INIT_STATE;
@@ -17,6 +18,7 @@ import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.Diagnostics
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_COLLECTION_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_INIT_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_SALT_VALIDATION_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_UPLOAD_EVENT;
 
 import java.util.List;
@@ -36,7 +38,12 @@ public class DiagnosticsCollectionFlowConfig extends AbstractFlowConfiguration<D
             = new Transition.Builder<DiagnosticsCollectionsState, DiagnosticsCollectionStateSelectors>()
             .defaultFailureEvent(FAILED_DIAGNOSTICS_COLLECTION_EVENT)
 
-            .from(INIT_STATE).to(DIAGNOSTICS_INIT_STATE)
+            .from(INIT_STATE).to(DIAGNOSTICS_SALT_VALIDATION_STATE)
+            .event(START_DIAGNOSTICS_SALT_VALIDATION_EVENT)
+            .failureState(DIAGNOSTICS_COLLECTION_FAILED_STATE)
+            .defaultFailureEvent()
+
+            .from(DIAGNOSTICS_SALT_VALIDATION_STATE).to(DIAGNOSTICS_INIT_STATE)
             .event(START_DIAGNOSTICS_INIT_EVENT)
             .failureState(DIAGNOSTICS_COLLECTION_FAILED_STATE)
             .defaultFailureEvent()
@@ -98,7 +105,7 @@ public class DiagnosticsCollectionFlowConfig extends AbstractFlowConfiguration<D
     @Override
     public DiagnosticsCollectionStateSelectors[] getInitEvents() {
         return new DiagnosticsCollectionStateSelectors[] {
-                START_DIAGNOSTICS_INIT_EVENT
+                START_DIAGNOSTICS_SALT_VALIDATION_EVENT
         };
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionEvent.java
@@ -16,20 +16,24 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
 
     private final Set<String> hostGroups;
 
+    private final Set<String> excludedHosts;
+
     DiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, DiagnosticParameters parameters,
-            Set<String> hosts, Set<String> hostGroups) {
+            Set<String> hosts, Set<String> hostGroups, Set<String> excludedHosts) {
         super(selector, resourceId, resourceCrn);
         this.parameters = parameters;
         this.hosts = hosts;
         this.hostGroups = hostGroups;
+        this.excludedHosts = excludedHosts;
     }
 
     DiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, Promise<AcceptResult> accepted,
-            DiagnosticParameters parameters, Set<String> hosts, Set<String> hostGroups) {
+            DiagnosticParameters parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludedHosts) {
         super(selector, resourceId, resourceCrn, accepted);
         this.parameters = parameters;
         this.hosts = hosts;
         this.hostGroups = hostGroups;
+        this.excludedHosts = excludedHosts;
     }
 
     public static DiagnosticsCollectionEventBuilder builder() {
@@ -48,6 +52,10 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
         return hostGroups;
     }
 
+    public Set<String> getExcludedHosts() {
+        return excludedHosts;
+    }
+
     public static final class DiagnosticsCollectionEventBuilder {
 
         private String resourceCrn;
@@ -63,6 +71,8 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
         private Set<String> hosts;
 
         private Set<String> hostGroups;
+
+        private Set<String> excludedHosts;
 
         private DiagnosticsCollectionEventBuilder() {
         }
@@ -102,9 +112,14 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
             return this;
         }
 
+        public DiagnosticsCollectionEventBuilder withExcludedHosts(Set<String> excludedHosts) {
+            this.excludedHosts = excludedHosts;
+            return this;
+        }
+
         public DiagnosticsCollectionEvent build() {
             return new DiagnosticsCollectionEvent(selector, resourceId, resourceCrn, accepted,
-                    parameters, hosts, hostGroups);
+                    parameters, hosts, hostGroups, excludedHosts);
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionEvent.java
@@ -16,24 +16,24 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
 
     private final Set<String> hostGroups;
 
-    private final Set<String> excludedHosts;
+    private final Set<String> excludeHosts;
 
     DiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, DiagnosticParameters parameters,
-            Set<String> hosts, Set<String> hostGroups, Set<String> excludedHosts) {
+            Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts) {
         super(selector, resourceId, resourceCrn);
         this.parameters = parameters;
         this.hosts = hosts;
         this.hostGroups = hostGroups;
-        this.excludedHosts = excludedHosts;
+        this.excludeHosts = excludeHosts;
     }
 
     DiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, Promise<AcceptResult> accepted,
-            DiagnosticParameters parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludedHosts) {
+            DiagnosticParameters parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts) {
         super(selector, resourceId, resourceCrn, accepted);
         this.parameters = parameters;
         this.hosts = hosts;
         this.hostGroups = hostGroups;
-        this.excludedHosts = excludedHosts;
+        this.excludeHosts = excludeHosts;
     }
 
     public static DiagnosticsCollectionEventBuilder builder() {
@@ -52,8 +52,8 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
         return hostGroups;
     }
 
-    public Set<String> getExcludedHosts() {
-        return excludedHosts;
+    public Set<String> getExcludeHosts() {
+        return excludeHosts;
     }
 
     public static final class DiagnosticsCollectionEventBuilder {
@@ -72,7 +72,7 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
 
         private Set<String> hostGroups;
 
-        private Set<String> excludedHosts;
+        private Set<String> excludeHosts;
 
         private DiagnosticsCollectionEventBuilder() {
         }
@@ -112,14 +112,14 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
             return this;
         }
 
-        public DiagnosticsCollectionEventBuilder withExcludedHosts(Set<String> excludedHosts) {
-            this.excludedHosts = excludedHosts;
+        public DiagnosticsCollectionEventBuilder withExcludeHosts(Set<String> excludeHosts) {
+            this.excludeHosts = excludeHosts;
             return this;
         }
 
         public DiagnosticsCollectionEvent build() {
             return new DiagnosticsCollectionEvent(selector, resourceId, resourceCrn, accepted,
-                    parameters, hosts, hostGroups, excludedHosts);
+                    parameters, hosts, hostGroups, excludeHosts);
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionFailureEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionFailureEvent.java
@@ -10,7 +10,7 @@ public class DiagnosticsCollectionFailureEvent extends DiagnosticsCollectionEven
     private final Exception exception;
 
     public DiagnosticsCollectionFailureEvent(Long resourceId, Exception exception, String resourceCrn, DiagnosticParameters parameters) {
-        super(FAILED_DIAGNOSTICS_COLLECTION_EVENT.name(), resourceId, resourceCrn, parameters, null, null);
+        super(FAILED_DIAGNOSTICS_COLLECTION_EVENT.name(), resourceId, resourceCrn, parameters, null, null, null);
         this.exception = exception;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionHandlerSelectors.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionHandlerSelectors.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.core.flow2.diagnostics.event;
 import com.sequenceiq.flow.core.FlowEvent;
 
 public enum DiagnosticsCollectionHandlerSelectors implements FlowEvent {
+    SALT_VALIDATION_DIAGNOSTICS_EVENT,
     INIT_DIAGNOSTICS_EVENT,
     ENSURE_MACHINE_USER_EVENT,
     COLLECT_DIAGNOSTICS_EVENT,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionStateSelectors.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionStateSelectors.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.core.flow2.diagnostics.event;
 import com.sequenceiq.flow.core.FlowEvent;
 
 public enum DiagnosticsCollectionStateSelectors implements FlowEvent {
+    START_DIAGNOSTICS_SALT_VALIDATION_EVENT,
     START_DIAGNOSTICS_INIT_EVENT,
     START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT,
     START_DIAGNOSTICS_COLLECTION_EVENT,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsCleanupHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsCleanupHandler.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.core.flow2.diagnostics.handler;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionHandlerSelectors.CLEANUP_CM_DIAGNOSTICS_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionStateSelectors.FINISH_CM_DIAGNOSTICS_COLLECTION_EVENT;
 
+import java.util.HashSet;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -54,7 +55,7 @@ public class CmDiagnosticsCleanupHandler extends EventSenderAwareHandler<CmDiagn
             if (DiagnosticsDestination.SUPPORT.equals(parameters.getDestination())) {
                 LOGGER.debug("CM based diagnostics uses SUPPORT destination, no support specific cleanup step yet.");
             } else {
-                diagnosticsFlowService.cleanup(resourceId, parameterMap);
+                diagnosticsFlowService.cleanup(resourceId, parameterMap, new HashSet<>());
             }
             CmDiagnosticsCollectionEvent diagnosticsCollectionEvent = CmDiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsInitHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsInitHandler.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.core.flow2.diagnostics.handler;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionHandlerSelectors.INIT_CM_DIAGNOSTICS_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionStateSelectors.START_CM_DIAGNOSTICS_COLLECTION_EVENT;
 
+import java.util.HashSet;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -54,7 +55,7 @@ public class CmDiagnosticsInitHandler extends EventSenderAwareHandler<CmDiagnost
             if (DiagnosticsDestination.SUPPORT.equals(parameters.getDestination())) {
                 LOGGER.debug("CM based diagnostics uses SUPPORT destination, no support specific init step yet.");
             } else {
-                diagnosticsFlowService.init(resourceId, parameterMap);
+                diagnosticsFlowService.init(resourceId, parameterMap, new HashSet<>());
             }
             CmDiagnosticsCollectionEvent diagnosticsCollectionEvent = CmDiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsUploadHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/CmDiagnosticsUploadHandler.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.core.flow2.diagnostics.handler;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionHandlerSelectors.UPLOAD_CM_DIAGNOSTICS_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.CmDiagnosticsCollectionStateSelectors.START_CM_DIAGNOSTICS_CLEANUP_EVENT;
 
+import java.util.HashSet;
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -54,7 +55,7 @@ public class CmDiagnosticsUploadHandler extends EventSenderAwareHandler<CmDiagno
             if (DiagnosticsDestination.SUPPORT.equals(parameters.getDestination())) {
                 LOGGER.debug("CM based diagnostics uses SUPPORT destination, no support specific upload step yet.");
             } else {
-                diagnosticsFlowService.upload(resourceId, parameterMap);
+                diagnosticsFlowService.upload(resourceId, parameterMap, new HashSet<>());
             }
             CmDiagnosticsCollectionEvent diagnosticsCollectionEvent = CmDiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsCleanupHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsCleanupHandler.java
@@ -46,10 +46,10 @@ public class DiagnosticsCleanupHandler extends EventSenderAwareHandler<Diagnosti
         Map<String, Object> parameterMap = parameters.toMap();
         try {
             LOGGER.debug("Diagnostics cleanup started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
-            Set<String> hosts = data.getHosts();
-            Set<String> hostGroups = data.getHostGroups();
-            Set<String> excludeHosts = data.getExcludedHosts();
-            diagnosticsFlowService.cleanup(resourceId, parameterMap, hosts, hostGroups, excludeHosts);
+            Set<String> hosts = parameters.getHosts();
+            Set<String> hostGroups = parameters.getHostGroups();
+            Set<String> excludedHosts = parameters.getExcludeHosts();
+            diagnosticsFlowService.cleanup(resourceId, parameterMap, hosts, hostGroups, excludedHosts);
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)
@@ -57,6 +57,7 @@ public class DiagnosticsCleanupHandler extends EventSenderAwareHandler<Diagnosti
                     .withParameters(parameters)
                     .withHosts(hosts)
                     .withHostGroups(hostGroups)
+                    .withExcludeHosts(excludedHosts)
                     .build();
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsCleanupHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsCleanupHandler.java
@@ -48,7 +48,8 @@ public class DiagnosticsCleanupHandler extends EventSenderAwareHandler<Diagnosti
             LOGGER.debug("Diagnostics cleanup started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
             Set<String> hosts = data.getHosts();
             Set<String> hostGroups = data.getHostGroups();
-            diagnosticsFlowService.cleanup(resourceId, parameterMap, hosts, hostGroups);
+            Set<String> excludeHosts = data.getExcludedHosts();
+            diagnosticsFlowService.cleanup(resourceId, parameterMap, hosts, hostGroups, excludeHosts);
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsCollectionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsCollectionHandler.java
@@ -48,7 +48,8 @@ public class DiagnosticsCollectionHandler extends EventSenderAwareHandler<Diagno
             LOGGER.debug("Diagnostics collection started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
             Set<String> hosts = data.getHosts();
             Set<String> hostGroups = data.getHostGroups();
-            diagnosticsService.collect(resourceId, parameterMap, hosts, hostGroups);
+            Set<String> excludeHosts = data.getExcludedHosts();
+            diagnosticsService.collect(resourceId, parameterMap, hosts, hostGroups, excludeHosts);
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsCollectionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsCollectionHandler.java
@@ -48,8 +48,8 @@ public class DiagnosticsCollectionHandler extends EventSenderAwareHandler<Diagno
             LOGGER.debug("Diagnostics collection started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
             Set<String> hosts = data.getHosts();
             Set<String> hostGroups = data.getHostGroups();
-            Set<String> excludeHosts = data.getExcludedHosts();
-            diagnosticsService.collect(resourceId, parameterMap, hosts, hostGroups, excludeHosts);
+            Set<String> excludedHosts = data.getExcludeHosts();
+            diagnosticsService.collect(resourceId, parameterMap, hosts, hostGroups, excludedHosts);
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)
@@ -57,6 +57,7 @@ public class DiagnosticsCollectionHandler extends EventSenderAwareHandler<Diagno
                     .withParameters(parameters)
                     .withHosts(hosts)
                     .withHostGroups(hostGroups)
+                    .withExcludeHosts(excludedHosts)
                     .build();
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsInitHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsInitHandler.java
@@ -52,9 +52,9 @@ public class DiagnosticsInitHandler extends EventSenderAwareHandler<DiagnosticsC
         Map<String, Object> parameterMap = parameters.toMap();
         try {
             LOGGER.debug("Diagnostics collection initialization started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
-            Set<String> hosts = data.getHosts();
-            Set<String> hostGroups = data.getHostGroups();
-            Set<String> excludedHosts = data.getExcludedHosts();
+            Set<String> hosts = parameters.getHosts();
+            Set<String> hostGroups = parameters.getHostGroups();
+            Set<String> excludedHosts = parameters.getExcludeHosts();
             diagnosticsFlowService.init(resourceId, parameterMap, hosts, hostGroups, excludedHosts);
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
@@ -63,6 +63,7 @@ public class DiagnosticsInitHandler extends EventSenderAwareHandler<DiagnosticsC
                     .withParameters(parameters)
                     .withHosts(hosts)
                     .withHostGroups(hostGroups)
+                    .withExcludeHosts(excludedHosts)
                     .build();
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsSaltValidationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsSaltValidationHandler.java
@@ -48,7 +48,8 @@ public class DiagnosticsSaltValidationHandler extends EventSenderAwareHandler<Di
         DiagnosticParameters parameters = data.getParameters();
         Map<String, Object> parameterMap = parameters.toMap();
         try {
-            Set<String> unresponsiveHosts = diagnosticsFlowService.collectUnresponsiveNodes(resourceId, parameters.getExcludeHosts());
+            Set<String> unresponsiveHosts = diagnosticsFlowService.collectUnresponsiveNodes(resourceId,
+                    parameters.getHosts(), parameters.getHostGroups(), parameters.getExcludeHosts());
             LOGGER.debug("Diagnostics collection salt validation operation has been started. resourceCrn: '{}', parameters: '{}'",
                     resourceCrn, parameterMap);
             if (CollectionUtils.isNotEmpty(unresponsiveHosts)) {
@@ -68,6 +69,9 @@ public class DiagnosticsSaltValidationHandler extends EventSenderAwareHandler<Di
                     .withResourceId(resourceId)
                     .withSelector(START_DIAGNOSTICS_INIT_EVENT.selector())
                     .withParameters(parameters)
+                    .withHosts(parameters.getHosts())
+                    .withHostGroups(parameters.getHostGroups())
+                    .withExcludeHosts(parameters.getExcludeHosts())
                     .build();
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsSaltValidationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsSaltValidationHandler.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.diagnostics.handler;
 
-import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionHandlerSelectors.INIT_DIAGNOSTICS_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionHandlerSelectors.SALT_VALIDATION_DIAGNOSTICS_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_INIT_EVENT;
 
 import java.util.Map;
 import java.util.Set;
@@ -66,7 +66,7 @@ public class DiagnosticsSaltValidationHandler extends EventSenderAwareHandler<Di
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)
-                    .withSelector(INIT_DIAGNOSTICS_EVENT.selector())
+                    .withSelector(START_DIAGNOSTICS_INIT_EVENT.selector())
                     .withParameters(parameters)
                     .build();
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsSaltValidationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsSaltValidationHandler.java
@@ -1,13 +1,14 @@
 package com.sequenceiq.cloudbreak.core.flow2.diagnostics.handler;
 
 import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionHandlerSelectors.INIT_DIAGNOSTICS_EVENT;
-import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionHandlerSelectors.SALT_VALIDATION_DIAGNOSTICS_EVENT;
 
 import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,8 +17,8 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsFlowService;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionEvent;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionFailureEvent;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
 import com.sequenceiq.common.model.diagnostics.DiagnosticParameters;
-import com.sequenceiq.flow.core.FlowConstants;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.reactor.api.handler.EventSenderAwareHandler;
 
@@ -25,9 +26,9 @@ import reactor.bus.Event;
 import reactor.bus.EventBus;
 
 @Component
-public class DiagnosticsInitHandler extends EventSenderAwareHandler<DiagnosticsCollectionEvent> {
+public class DiagnosticsSaltValidationHandler extends EventSenderAwareHandler<DiagnosticsCollectionEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(DiagnosticsInitHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DiagnosticsSaltValidationHandler.class);
 
     @Inject
     private EventBus eventBus;
@@ -35,7 +36,7 @@ public class DiagnosticsInitHandler extends EventSenderAwareHandler<DiagnosticsC
     @Inject
     private DiagnosticsFlowService diagnosticsFlowService;
 
-    public DiagnosticsInitHandler(EventSender eventSender) {
+    protected DiagnosticsSaltValidationHandler(EventSender eventSender) {
         super(eventSender);
     }
 
@@ -45,28 +46,32 @@ public class DiagnosticsInitHandler extends EventSenderAwareHandler<DiagnosticsC
         Long resourceId = data.getResourceId();
         String resourceCrn = data.getResourceCrn();
         DiagnosticParameters parameters = data.getParameters();
-        if (StringUtils.isBlank(parameters.getUuid())) {
-            LOGGER.debug("UUID is empty for diagnostics... Use flow ID as UUID.");
-            parameters.setUuid(event.getHeaders().get(FlowConstants.FLOW_ID));
-        }
         Map<String, Object> parameterMap = parameters.toMap();
         try {
-            LOGGER.debug("Diagnostics collection initialization started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
-            Set<String> hosts = data.getHosts();
-            Set<String> hostGroups = data.getHostGroups();
-            Set<String> excludedHosts = data.getExcludedHosts();
-            diagnosticsFlowService.init(resourceId, parameterMap, hosts, hostGroups, excludedHosts);
+            Set<String> unresponsiveHosts = diagnosticsFlowService.collectUnresponsiveNodes(resourceId, parameters.getExcludeHosts());
+            LOGGER.debug("Diagnostics collection salt validation operation has been started. resourceCrn: '{}', parameters: '{}'",
+                    resourceCrn, parameterMap);
+            if (CollectionUtils.isNotEmpty(unresponsiveHosts)) {
+                if (parameters.getSkipUnresponsiveHosts()) {
+                    parameters.getExcludeHosts().addAll(unresponsiveHosts);
+                    parameterMap = parameters.toMap();
+                    LOGGER.debug("Diagnostics parameters has been updated with excluded hosts. resourceCrn: '{}', parameters: '{}'",
+                            resourceCrn, parameterMap);
+                } else {
+                    throw new CloudbreakOrchestratorFailedException(
+                            String.format("Some of the hosts are unresponsive, check the states of salt-minions on the following nodes: %s",
+                                    StringUtils.join(unresponsiveHosts, ',')));
+                }
+            }
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)
-                    .withSelector(START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT.selector())
+                    .withSelector(INIT_DIAGNOSTICS_EVENT.selector())
                     .withParameters(parameters)
-                    .withHosts(hosts)
-                    .withHostGroups(hostGroups)
                     .build();
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {
-            LOGGER.debug("Diagnostics collection initialization failed. resourceCrn: '{}', parameters: '{}'.", resourceCrn, parameterMap, e);
+            LOGGER.debug("Diagnostics salt validation failed. resourceCrn: '{}', parameters: '{}'.", resourceCrn, parameterMap, e);
             DiagnosticsCollectionFailureEvent failureEvent = new DiagnosticsCollectionFailureEvent(resourceId, e, resourceCrn, parameters);
             eventBus.notify(failureEvent.selector(), new Event<>(event.getHeaders(), failureEvent));
         }
@@ -74,6 +79,6 @@ public class DiagnosticsInitHandler extends EventSenderAwareHandler<DiagnosticsC
 
     @Override
     public String selector() {
-        return INIT_DIAGNOSTICS_EVENT.selector();
+        return SALT_VALIDATION_DIAGNOSTICS_EVENT.selector();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsUploadHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsUploadHandler.java
@@ -48,8 +48,8 @@ public class DiagnosticsUploadHandler extends EventSenderAwareHandler<Diagnostic
             LOGGER.debug("Diagnostics upload started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
             Set<String> hosts = data.getHosts();
             Set<String> hostGroups = data.getHostGroups();
-            Set<String> excludeHosts = data.getExcludedHosts();
-            diagnosticsFlowService.upload(resourceId, parameterMap, hosts, hostGroups, excludeHosts);
+            Set<String> excludedHosts = data.getExcludeHosts();
+            diagnosticsFlowService.upload(resourceId, parameterMap, hosts, hostGroups, excludedHosts);
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)
@@ -57,6 +57,7 @@ public class DiagnosticsUploadHandler extends EventSenderAwareHandler<Diagnostic
                     .withParameters(parameters)
                     .withHosts(hosts)
                     .withHostGroups(hostGroups)
+                    .withExcludeHosts(excludedHosts)
                     .build();
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsUploadHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/handler/DiagnosticsUploadHandler.java
@@ -48,7 +48,8 @@ public class DiagnosticsUploadHandler extends EventSenderAwareHandler<Diagnostic
             LOGGER.debug("Diagnostics upload started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
             Set<String> hosts = data.getHosts();
             Set<String> hostGroups = data.getHostGroups();
-            diagnosticsFlowService.upload(resourceId, parameterMap, hosts, hostGroups);
+            Set<String> excludeHosts = data.getExcludedHosts();
+            diagnosticsFlowService.upload(resourceId, parameterMap, hosts, hostGroups, excludeHosts);
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/DiagnosticsTriggerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/DiagnosticsTriggerService.java
@@ -91,7 +91,7 @@ public class DiagnosticsTriggerService {
                 .withAccepted(new Promise<>())
                 .withResourceId(stack.getId())
                 .withResourceCrn(stack.getResourceCrn())
-                .withSelector(DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_INIT_EVENT.selector())
+                .withSelector(DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_SALT_VALIDATION_EVENT.selector())
                 .withParameters(parameters)
                 .withHosts(parameters.getHosts())
                 .withHostGroups(parameters.getHostGroups())

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/DiagnosticsTriggerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/DiagnosticsTriggerService.java
@@ -95,6 +95,7 @@ public class DiagnosticsTriggerService {
                 .withParameters(parameters)
                 .withHosts(parameters.getHosts())
                 .withHostGroups(parameters.getHostGroups())
+                .withExcludeHosts(parameters.getExcludeHosts())
                 .build();
         return reactorNotifier.notify(diagnosticsCollectionEvent, getFlowHeaders(userCrn));
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowServiceTest.java
@@ -26,7 +26,7 @@ public class DiagnosticsFlowServiceTest {
         Set<String> hosts = new HashSet<>();
         hosts.add("host1");
         // WHEN
-        boolean result = underTest.filterNodes(createNode(), hosts, new HashSet<>());
+        boolean result = underTest.filterNodes(createNode(), hosts, new HashSet<>(), new HashSet<>());
         // THEN
         assertTrue(result);
     }
@@ -37,7 +37,7 @@ public class DiagnosticsFlowServiceTest {
         Set<String> hosts = new HashSet<>();
         hosts.add("host2");
         // WHEN
-        boolean result = underTest.filterNodes(createNode(), hosts, new HashSet<>());
+        boolean result = underTest.filterNodes(createNode(), hosts, new HashSet<>(), new HashSet<>());
         // THEN
         assertFalse(result);
     }
@@ -48,7 +48,7 @@ public class DiagnosticsFlowServiceTest {
         Set<String> hostGroups = new HashSet<>();
         hostGroups.add("master");
         // WHEN
-        boolean result = underTest.filterNodes(createNode(), new HashSet<>(), hostGroups);
+        boolean result = underTest.filterNodes(createNode(), new HashSet<>(), hostGroups, new HashSet<>());
         // THEN
         assertTrue(result);
     }
@@ -59,7 +59,7 @@ public class DiagnosticsFlowServiceTest {
         Set<String> hostGroups = new HashSet<>();
         hostGroups.add("idbroker");
         // WHEN
-        boolean result = underTest.filterNodes(createNode(), new HashSet<>(), hostGroups);
+        boolean result = underTest.filterNodes(createNode(), new HashSet<>(), hostGroups, new HashSet<>());
         // THEN
         assertFalse(result);
     }
@@ -72,7 +72,7 @@ public class DiagnosticsFlowServiceTest {
         Set<String> hosts = new HashSet<>();
         hosts.add("host1");
         // WHEN
-        boolean result = underTest.filterNodes(createNode(), hosts, hostGroups);
+        boolean result = underTest.filterNodes(createNode(), hosts, hostGroups, new HashSet<>());
         // THEN
         assertTrue(result);
     }
@@ -85,7 +85,7 @@ public class DiagnosticsFlowServiceTest {
         Set<String> hosts = new HashSet<>();
         hosts.add("host1");
         // WHEN
-        boolean result = underTest.filterNodes(createNode(), hosts, hostGroups);
+        boolean result = underTest.filterNodes(createNode(), hosts, hostGroups, new HashSet<>());
         // THEN
         assertFalse(result);
     }
@@ -98,7 +98,7 @@ public class DiagnosticsFlowServiceTest {
         Set<String> hosts = new HashSet<>();
         hosts.add("host2");
         // WHEN
-        boolean result = underTest.filterNodes(createNode(), hosts, hostGroups);
+        boolean result = underTest.filterNodes(createNode(), hosts, hostGroups, new HashSet<>());
         // THEN
         assertFalse(result);
     }
@@ -107,9 +107,44 @@ public class DiagnosticsFlowServiceTest {
     public void testFilterNodesWithEmptyFilters() {
         // GIVEN
         // WHEN
-        boolean result = underTest.filterNodes(createNode(), new HashSet<>(), new HashSet<>());
+        boolean result = underTest.filterNodes(createNode(), new HashSet<>(), new HashSet<>(), new HashSet<>());
         // THEN
         assertTrue(result);
+    }
+
+    @Test
+    public void testFilterNodesWithExcludedHosts() {
+        // GIVEN
+        Set<String> excludedHosts = new HashSet<>();
+        excludedHosts.add("host1");
+        // WHEN
+        boolean result = underTest.filterNodes(createNode(), new HashSet<>(), new HashSet<>(), excludedHosts);
+        // THEN
+        assertFalse(result);
+    }
+
+    @Test
+    public void testFilterNodesWithExcludedHostsWithDifferentHost() {
+        // GIVEN
+        Set<String> excludedHosts = new HashSet<>();
+        excludedHosts.add("host2");
+        // WHEN
+        boolean result = underTest.filterNodes(createNode(), new HashSet<>(), new HashSet<>(), excludedHosts);
+        // THEN
+        assertTrue(result);
+    }
+
+    @Test
+    public void testFilterNodesWithExcludedHostsWithPrecedence() {
+        // GIVEN
+        Set<String> hosts = new HashSet<>();
+        hosts.add("host2");
+        Set<String> excludedHosts = new HashSet<>();
+        excludedHosts.add("host1");
+        // WHEN
+        boolean result = underTest.filterNodes(createNode(), hosts, new HashSet<>(), excludedHosts);
+        // THEN
+        assertFalse(result);
     }
 
     private Node createNode() {

--- a/datalake/src/main/java/com/sequenceiq/datalake/converter/DiagnosticsParamsConverter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/converter/DiagnosticsParamsConverter.java
@@ -34,6 +34,8 @@ public class DiagnosticsParamsConverter {
 
     private static final String PARAMS_HOST_GROUPS = "hostGroups";
 
+    private static final String PARAMS_EXCLUDE_HOSTs = "excludeHosts";
+
     private static final String PARAMS_LABELS = "labels";
 
     private static final String PARAMS_ROLES = "roles";
@@ -52,6 +54,10 @@ public class DiagnosticsParamsConverter {
 
     private static final String PARAMS_SKIP_VALIDATION = "skipValidation";
 
+    private static final String PARAMS_SKIP_WORKSPACE_CLEANUP_ON_STARTUP = "skipWorkspaceCleanupOnStartup";
+
+    private static final String PARAMS_SKIP_UNRESPONSIVE_HOSTS = "skipUnresponsiveHosts";
+
     private static final String PARAMS_ENABLE_MONITOR_METRICS_COLLECTION = "enableMonitorMetricsCollection";
 
     private static final String PARAMS_BUNDLE_SIZE_BYTES = "bundleSizeBytes";
@@ -62,6 +68,7 @@ public class DiagnosticsParamsConverter {
         props.put(PARAM_DESTINATION, request.getDestination());
         props.put(PARAM_DESCRIPTION, request.getDescription());
         props.put(PARAM_HOSTS, request.getHosts());
+        props.put(PARAMS_EXCLUDE_HOSTs, request.getExcludeHosts());
         props.put(PARAMS_HOST_GROUPS, request.getHostGroups());
         props.put(PARAMS_ISSUE, request.getIssue());
         props.put(PARAMS_LABELS, request.getLabels());
@@ -71,6 +78,8 @@ public class DiagnosticsParamsConverter {
         props.put(PARAMS_INCLUDE_SALT_LOGS, request.getIncludeSaltLogs());
         props.put(PARAMS_UPDATE_PACKAGE, request.getUpdatePackage());
         props.put(PARAMS_SKIP_VALIDATION, request.getSkipValidation());
+        props.put(PARAMS_SKIP_WORKSPACE_CLEANUP_ON_STARTUP, request.getSkipWorkspaceCleanupOnStartup());
+        props.put(PARAMS_SKIP_UNRESPONSIVE_HOSTS, request.getSkipUnresponsiveHosts());
         return props;
     }
 
@@ -80,6 +89,7 @@ public class DiagnosticsParamsConverter {
                 .map(v -> DiagnosticsDestination.valueOf(v.toString())).orElse(null));
         request.setStackCrn(Optional.ofNullable(props.get(PARAMS_STACK_CRN)).map(Object::toString).orElse(null));
         request.setHosts((Set<String>) Optional.ofNullable(props.get(PARAM_HOSTS)).orElse(null));
+        request.setExcludeHosts((Set<String>) Optional.ofNullable(props.get(PARAMS_EXCLUDE_HOSTs)).orElse(null));
         request.setHostGroups((Set<String>) Optional.ofNullable(props.get(PARAMS_HOST_GROUPS)).orElse(null));
         request.setLabels((List<String>) Optional.ofNullable(props.get(PARAMS_LABELS)).orElse(null));
         request.setAdditionalLogs((List<VmLog>) Optional.ofNullable(props.get(PARAMS_ADDITIONAL_LOGS)).orElse(null));

--- a/datalake/src/main/java/com/sequenceiq/datalake/converter/DiagnosticsParamsConverter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/converter/DiagnosticsParamsConverter.java
@@ -34,7 +34,7 @@ public class DiagnosticsParamsConverter {
 
     private static final String PARAMS_HOST_GROUPS = "hostGroups";
 
-    private static final String PARAMS_EXCLUDE_HOSTs = "excludeHosts";
+    private static final String PARAMS_EXCLUDE_HOSTS = "excludeHosts";
 
     private static final String PARAMS_LABELS = "labels";
 
@@ -68,7 +68,7 @@ public class DiagnosticsParamsConverter {
         props.put(PARAM_DESTINATION, request.getDestination());
         props.put(PARAM_DESCRIPTION, request.getDescription());
         props.put(PARAM_HOSTS, request.getHosts());
-        props.put(PARAMS_EXCLUDE_HOSTs, request.getExcludeHosts());
+        props.put(PARAMS_EXCLUDE_HOSTS, request.getExcludeHosts());
         props.put(PARAMS_HOST_GROUPS, request.getHostGroups());
         props.put(PARAMS_ISSUE, request.getIssue());
         props.put(PARAMS_LABELS, request.getLabels());
@@ -89,7 +89,7 @@ public class DiagnosticsParamsConverter {
                 .map(v -> DiagnosticsDestination.valueOf(v.toString())).orElse(null));
         request.setStackCrn(Optional.ofNullable(props.get(PARAMS_STACK_CRN)).map(Object::toString).orElse(null));
         request.setHosts((Set<String>) Optional.ofNullable(props.get(PARAM_HOSTS)).orElse(null));
-        request.setExcludeHosts((Set<String>) Optional.ofNullable(props.get(PARAMS_EXCLUDE_HOSTs)).orElse(null));
+        request.setExcludeHosts((Set<String>) Optional.ofNullable(props.get(PARAMS_EXCLUDE_HOSTS)).orElse(null));
         request.setHostGroups((Set<String>) Optional.ofNullable(props.get(PARAMS_HOST_GROUPS)).orElse(null));
         request.setLabels((List<String>) Optional.ofNullable(props.get(PARAMS_LABELS)).orElse(null));
         request.setAdditionalLogs((List<VmLog>) Optional.ofNullable(props.get(PARAMS_ADDITIONAL_LOGS)).orElse(null));
@@ -100,6 +100,8 @@ public class DiagnosticsParamsConverter {
         request.setIncludeSaltLogs((Boolean) Optional.ofNullable(props.get(PARAMS_INCLUDE_SALT_LOGS)).orElse(false));
         request.setUpdatePackage((Boolean) Optional.ofNullable(props.get(PARAMS_UPDATE_PACKAGE)).orElse(false));
         request.setSkipValidation((Boolean) Optional.ofNullable(props.get(PARAMS_SKIP_VALIDATION)).orElse(false));
+        request.setSkipUnresponsiveHosts((Boolean) Optional.ofNullable(props.get(PARAMS_SKIP_UNRESPONSIVE_HOSTS)).orElse(false));
+        request.setSkipWorkspaceCleanupOnStartup((Boolean) Optional.ofNullable(props.get(PARAMS_SKIP_WORKSPACE_CLEANUP_ON_STARTUP)).orElse(false));
         request.setUuid(Optional.ofNullable(props.get(PARAMS_UUID)).map(Object::toString).orElse(null));
         return request;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionActions.java
@@ -53,7 +53,6 @@ public class DiagnosticsCollectionActions {
             protected void doExecute(CommonContext context, DiagnosticsCollectionEvent payload, Map<Object, Object> variables) {
                 String resourceCrn = payload.getResourceCrn();
                 LOGGER.debug("Flow entered into DIAGNOSTICS_INIT_STATE. resourceCrn: '{}'", resourceCrn);
-                //InMemoryStateStore.putStack(payload.getResourceId(), PollGroup.POLLABLE);
                 DiagnosticsCollectionEvent event = DiagnosticsCollectionEvent.builder()
                         .withResourceId(payload.getResourceId())
                         .withResourceCrn(resourceCrn)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionActions.java
@@ -27,6 +27,25 @@ public class DiagnosticsCollectionActions {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DiagnosticsCollectionActions.class);
 
+    @Bean(name = "DIAGNOSTICS_SALT_VALIDATION_STATE")
+    public Action<?, ?> diagnosticsSaltValidateAction() {
+        return new AbstractDiagnosticsCollectionActions<>(DiagnosticsCollectionEvent.class) {
+            @Override
+            protected void doExecute(CommonContext context, DiagnosticsCollectionEvent payload, Map<Object, Object> variables) {
+                String resourceCrn = payload.getResourceCrn();
+                LOGGER.debug("Flow entered into DIAGNOSTICS_SALT_VALIDATION_STATE. resourceCrn: '{}'", resourceCrn);
+                InMemoryStateStore.putStack(payload.getResourceId(), PollGroup.POLLABLE);
+                DiagnosticsCollectionEvent event = DiagnosticsCollectionEvent.builder()
+                        .withResourceId(payload.getResourceId())
+                        .withResourceCrn(resourceCrn)
+                        .withSelector(DiagnosticsCollectionHandlerSelectors.SALT_VALIDATION_DIAGNOSTICS_EVENT.selector())
+                        .withParameters(payload.getParameters())
+                        .build();
+                sendEvent(context, event);
+            }
+        };
+    }
+
     @Bean(name = "DIAGNOSTICS_INIT_STATE")
     public Action<?, ?> diagnosticsInitAction() {
         return new AbstractDiagnosticsCollectionActions<>(DiagnosticsCollectionEvent.class) {
@@ -34,7 +53,7 @@ public class DiagnosticsCollectionActions {
             protected void doExecute(CommonContext context, DiagnosticsCollectionEvent payload, Map<Object, Object> variables) {
                 String resourceCrn = payload.getResourceCrn();
                 LOGGER.debug("Flow entered into DIAGNOSTICS_INIT_STATE. resourceCrn: '{}'", resourceCrn);
-                InMemoryStateStore.putStack(payload.getResourceId(), PollGroup.POLLABLE);
+                //InMemoryStateStore.putStack(payload.getResourceId(), PollGroup.POLLABLE);
                 DiagnosticsCollectionEvent event = DiagnosticsCollectionEvent.builder()
                         .withResourceId(payload.getResourceId())
                         .withResourceCrn(resourceCrn)
@@ -52,7 +71,7 @@ public class DiagnosticsCollectionActions {
             @Override
             protected void doExecute(CommonContext context, DiagnosticsCollectionEvent payload, Map<Object, Object> variables) {
                 String resourceCrn = payload.getResourceCrn();
-                LOGGER.debug("Flow entered into DIAGNOSTICS_CREATE_MACHINE_USER_STATE. resourceCrn: '{}'", resourceCrn);
+                LOGGER.debug("Flow entered into ENSURE_MACHINE_USER_EVENT. resourceCrn: '{}'", resourceCrn);
                 DiagnosticsCollectionEvent event = DiagnosticsCollectionEvent.builder()
                         .withResourceId(payload.getResourceId())
                         .withResourceCrn(payload.getResourceCrn())

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionsState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionsState.java
@@ -4,6 +4,7 @@ import com.sequenceiq.flow.core.FlowState;
 
 public enum DiagnosticsCollectionsState implements FlowState {
     INIT_STATE,
+    DIAGNOSTICS_SALT_VALIDATION_STATE,
     DIAGNOSTICS_INIT_STATE,
     DIAGNOSTICS_ENSURE_MACHINE_USER_STATE,
     DIAGNOSTICS_COLLECTION_STATE,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsFlowService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsFlowService.java
@@ -44,7 +44,8 @@ public class DiagnosticsFlowService {
     @Inject
     private FreeIpaNodeUtilService freeIpaNodeUtilService;
 
-    public Set<String> collectUnresponsiveNodes(Long stackId, Set<String> initialExcludeHosts) throws CloudbreakOrchestratorFailedException {
+    public Set<String> collectUnresponsiveNodes(Long stackId, Set<String> initialExcludeHosts)
+            throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getStackById(stackId);
         Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getNotDeletedGatewayConfigs(stack);
@@ -55,60 +56,56 @@ public class DiagnosticsFlowService {
                 .map(Node::getHostname).collect(Collectors.toSet());
     }
 
-    public boolean init(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
-        boolean executed = false;
+    public void init(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getStackById(stackId);
         Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getNotDeletedGatewayConfigs(stack);
         Set<Node> allNodes = filterNodesByExcludeHosts(excludeHosts, instanceMetaDataSet);
         LOGGER.debug("Starting diagnostics init. resourceCrn: '{}'", stack.getResourceCrn());
-        if (!allNodes.isEmpty()) {
+        if (allNodes.isEmpty()) {
+            LOGGER.debug("Diagnostics init has been skipped. (no target minions)");
+        } else {
             telemetryOrchestrator.initDiagnosticCollection(gatewayConfigs, allNodes, parameters, new StackBasedExitCriteriaModel(stackId));
-            executed = true;
         }
-        return executed;
     }
 
-    public boolean collect(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
-        boolean executed = false;
+    public void collect(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getStackById(stackId);
         Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getNotDeletedGatewayConfigs(stack);
         Set<Node> allNodes = filterNodesByExcludeHosts(excludeHosts, instanceMetaDataSet);
         LOGGER.debug("Starting diagnostics collection. resourceCrn: '{}'", stack.getResourceCrn());
-        if (!allNodes.isEmpty()) {
+        if (allNodes.isEmpty()) {
+            LOGGER.debug("Diagnostics collect has been skipped. (no target minions)");
+        } else {
             telemetryOrchestrator.executeDiagnosticCollection(gatewayConfigs, allNodes, parameters, new StackBasedExitCriteriaModel(stackId));
-            executed = true;
         }
-        return executed;
     }
 
-    public boolean upload(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
-        boolean executed = false;
+    public void upload(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getStackById(stackId);
         Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getNotDeletedGatewayConfigs(stack);
         Set<Node> allNodes = filterNodesByExcludeHosts(excludeHosts, instanceMetaDataSet);
         LOGGER.debug("Starting diagnostics upload. resourceCrn: '{}'", stack.getResourceCrn());
-        if (!allNodes.isEmpty()) {
+        if (allNodes.isEmpty()) {
+            LOGGER.debug("Diagnostics upload has been skipped. (no target minions)");
+        } else {
             telemetryOrchestrator.uploadCollectedDiagnostics(gatewayConfigs, allNodes, parameters, new StackBasedExitCriteriaModel(stackId));
-            executed = true;
         }
-        return executed;
     }
 
-    public boolean cleanup(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
-        boolean executed = false;
+    public void cleanup(Long stackId, Map<String, Object> parameters, Set<String> excludeHosts) throws CloudbreakOrchestratorFailedException {
         Stack stack = stackService.getStackById(stackId);
         Set<InstanceMetaData> instanceMetaDataSet = instanceMetaDataService.findNotTerminatedForStack(stackId);
         List<GatewayConfig> gatewayConfigs = gatewayConfigService.getNotDeletedGatewayConfigs(stack);
         Set<Node> allNodes = filterNodesByExcludeHosts(excludeHosts, instanceMetaDataSet);
         LOGGER.debug("Starting diagnostics cleanup. resourceCrn: '{}'", stack.getResourceCrn());
-        if (!allNodes.isEmpty()) {
+        if (allNodes.isEmpty()) {
+            LOGGER.debug("Diagnostics cleanup has been skipped. (no target minions)");
+        } else {
             telemetryOrchestrator.cleanupCollectedDiagnostics(gatewayConfigs, allNodes, parameters, new StackBasedExitCriteriaModel(stackId));
-            executed = true;
         }
-        return executed;
     }
 
     private Set<Node> filterNodesByExcludeHosts(Set<String> excludeHosts, Set<InstanceMetaData> instanceMetaDataSet) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/config/DiagnosticsCollectionFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/config/DiagnosticsCollectionFlowConfig.java
@@ -7,6 +7,7 @@ import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollect
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_ENSURE_MACHINE_USER_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_INIT_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_UPLOAD_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_SALT_VALIDATION_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.FINAL_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.INIT_STATE;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.FAILED_DIAGNOSTICS_COLLECTION_EVENT;
@@ -18,6 +19,7 @@ import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsC
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_INIT_EVENT;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_UPLOAD_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_SALT_VALIDATION_EVENT;
 
 import java.util.List;
 
@@ -36,7 +38,12 @@ public class DiagnosticsCollectionFlowConfig extends AbstractFlowConfiguration<D
             = new Transition.Builder<DiagnosticsCollectionsState, DiagnosticsCollectionStateSelectors>()
             .defaultFailureEvent(FAILED_DIAGNOSTICS_COLLECTION_EVENT)
 
-            .from(INIT_STATE).to(DIAGNOSTICS_INIT_STATE)
+            .from(INIT_STATE).to(DIAGNOSTICS_SALT_VALIDATION_STATE)
+            .event(START_DIAGNOSTICS_SALT_VALIDATION_EVENT)
+            .failureState(DIAGNOSTICS_COLLECTION_FAILED_STATE)
+            .defaultFailureEvent()
+
+            .from(DIAGNOSTICS_SALT_VALIDATION_STATE).to(DIAGNOSTICS_INIT_STATE)
             .event(START_DIAGNOSTICS_INIT_EVENT)
             .failureState(DIAGNOSTICS_COLLECTION_FAILED_STATE)
             .defaultFailureEvent()
@@ -98,7 +105,7 @@ public class DiagnosticsCollectionFlowConfig extends AbstractFlowConfiguration<D
     @Override
     public DiagnosticsCollectionStateSelectors[] getInitEvents() {
         return new DiagnosticsCollectionStateSelectors[] {
-                START_DIAGNOSTICS_INIT_EVENT
+                START_DIAGNOSTICS_SALT_VALIDATION_EVENT
         };
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionHandlerSelectors.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionHandlerSelectors.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.flow.freeipa.diagnostics.event;
 import com.sequenceiq.flow.core.FlowEvent;
 
 public enum DiagnosticsCollectionHandlerSelectors implements FlowEvent {
+    SALT_VALIDATION_DIAGNOSTICS_EVENT,
     INIT_DIAGNOSTICS_EVENT,
     ENSURE_MACHINE_USER_EVENT,
     COLLECT_DIAGNOSTICS_EVENT,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionStateSelectors.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/event/DiagnosticsCollectionStateSelectors.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.flow.freeipa.diagnostics.event;
 import com.sequenceiq.flow.core.FlowEvent;
 
 public enum DiagnosticsCollectionStateSelectors implements FlowEvent {
+    START_DIAGNOSTICS_SALT_VALIDATION_EVENT,
     START_DIAGNOSTICS_INIT_EVENT,
     START_DIAGNOSTICS_ENSURE_MACHINE_USER_EVENT,
     START_DIAGNOSTICS_COLLECTION_EVENT,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsCleanupHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsCleanupHandler.java
@@ -45,7 +45,7 @@ public class DiagnosticsCleanupHandler extends EventSenderAwareHandler<Diagnosti
         Map<String, Object> parameterMap = parameters.toMap();
         try {
             LOGGER.debug("Diagnostics cleanup started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
-            diagnosticsFlowService.cleanup(resourceId, parameterMap);
+            diagnosticsFlowService.cleanup(resourceId, parameterMap, parameters.getExcludeHosts());
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsCollectionHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsCollectionHandler.java
@@ -45,7 +45,7 @@ public class DiagnosticsCollectionHandler extends EventSenderAwareHandler<Diagno
         Map<String, Object> parameterMap = parameters.toMap();
         try {
             LOGGER.debug("Diagnostics collection started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
-            diagnosticsService.collect(resourceId, parameterMap);
+            diagnosticsService.collect(resourceId, parameterMap, parameters.getExcludeHosts());
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsSaltValidationHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsSaltValidationHandler.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.freeipa.flow.freeipa.diagnostics.handler;
 
-import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionHandlerSelectors.INIT_DIAGNOSTICS_EVENT;
 import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionHandlerSelectors.SALT_VALIDATION_DIAGNOSTICS_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_INIT_EVENT;
 
 import java.util.Map;
 import java.util.Set;
@@ -66,7 +66,7 @@ public class DiagnosticsSaltValidationHandler extends EventSenderAwareHandler<Di
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)
-                    .withSelector(INIT_DIAGNOSTICS_EVENT.selector())
+                    .withSelector(START_DIAGNOSTICS_INIT_EVENT.selector())
                     .withParameters(parameters)
                     .build();
             eventSender().sendEvent(diagnosticsCollectionEvent, event.getHeaders());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsUploadHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/handler/DiagnosticsUploadHandler.java
@@ -45,7 +45,7 @@ public class DiagnosticsUploadHandler extends EventSenderAwareHandler<Diagnostic
         Map<String, Object> parameterMap = parameters.toMap();
         try {
             LOGGER.debug("Diagnostics upload started. resourceCrn: '{}', parameters: '{}'", resourceCrn, parameterMap);
-            diagnosticsFlowService.upload(resourceId, parameterMap);
+            diagnosticsFlowService.upload(resourceId, parameterMap, parameters.getExcludeHosts());
             DiagnosticsCollectionEvent diagnosticsCollectionEvent = DiagnosticsCollectionEvent.builder()
                     .withResourceCrn(resourceCrn)
                     .withResourceId(resourceId)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/diagnostics/DiagnosticsTriggerService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/diagnostics/DiagnosticsTriggerService.java
@@ -63,7 +63,7 @@ public class DiagnosticsTriggerService {
                 .withAccepted(new Promise<>())
                 .withResourceId(stack.getId())
                 .withResourceCrn(stack.getResourceCrn())
-                .withSelector(DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_INIT_EVENT.selector())
+                .withSelector(DiagnosticsCollectionStateSelectors.START_DIAGNOSTICS_SALT_VALIDATION_EVENT.selector())
                 .withParameters(parameters)
                 .build();
         return flowManager.notify(diagnosticsCollectionEvent, getFlowHeaders(userCrn));

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/TelemetryOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/TelemetryOrchestrator.java
@@ -28,4 +28,6 @@ public interface TelemetryOrchestrator {
 
     void cleanupCollectedDiagnostics(List<GatewayConfig> gatewayConfigs, Set<Node> allNodes, Map<String, Object> parameters,
             ExitCriteriaModel exitModel) throws CloudbreakOrchestratorFailedException;
+
+    Set<Node> collectUnresponsiveNodes(List<GatewayConfig> gatewayConfigs, Set<Node> allNodes, ExitCriteriaModel exitModel) throws CloudbreakOrchestratorFailedException;
 }

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/TelemetryOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/TelemetryOrchestrator.java
@@ -29,5 +29,6 @@ public interface TelemetryOrchestrator {
     void cleanupCollectedDiagnostics(List<GatewayConfig> gatewayConfigs, Set<Node> allNodes, Map<String, Object> parameters,
             ExitCriteriaModel exitModel) throws CloudbreakOrchestratorFailedException;
 
-    Set<Node> collectUnresponsiveNodes(List<GatewayConfig> gatewayConfigs, Set<Node> allNodes, ExitCriteriaModel exitModel) throws CloudbreakOrchestratorFailedException;
+    Set<Node> collectUnresponsiveNodes(List<GatewayConfig> gatewayConfigs, Set<Node> allNodes, ExitCriteriaModel exitModel)
+            throws CloudbreakOrchestratorFailedException;
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
@@ -206,6 +206,10 @@ public class SaltStates {
         return measure(() -> sc.run(target, "test.ping", LOCAL, PingResponse.class), LOGGER, "Ping took {}ms");
     }
 
+    public static PingResponse ping(SaltConnector sc) {
+        return measure(() -> sc.run(Glob.ALL, "test.ping", LOCAL, PingResponse.class), LOGGER, "Ping took {}ms");
+    }
+
     public static void stopMinions(SaltConnector sc, Map<String, String> privateIPsByFQDN) {
         SaltAction saltAction = new SaltAction(SaltActionType.STOP);
         for (Entry<String, String> entry : privateIPsByFQDN.entrySet()) {

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/init.sls
@@ -131,3 +131,19 @@ check_support_dbus_connection:
        - HTTPS_PROXY: {{ filecollector.proxyUrl }}{% else %}
        - HTTP_PROXY: {{ filecollector.proxyUrl }}{% endif %}{% endif %}
 {% endif %}
+
+{% if not filecollector.skipWorkspaceCleanupOnStartup %}
+filecollector_clean_dirs_at_startup:
+  cmd.run:
+    - names:
+{% if filecollector.destination == "LOCAL" %}
+        - cdp-telemetry utils clean -d /var/lib/filecollector/ -p tmp/**
+{% elif filecollector.destination == "ENG" %}
+        - cdp-telemetry utils clean -d /var/lib/filecollector/
+{% else %}
+        - cdp-telemetry utils clean -d /var/lib/filecollector/ -p tmp/**
+        - cdp-telemetry utils clean -d /var/lib/filecollector/ -p *.gz
+{% if filecollector.mode == "CLOUDERA_MANAGER" %}
+        - cdp-telemetry utils clean -d /var/lib/filecollector/ -p *.zip{% endif %}
+{% endif %}
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
@@ -60,6 +60,11 @@
     {% set skip_validation = True %}
 {% endif %}
 
+{% set skip_workspace_cleanup_on_startup = False %}
+{% if salt['pillar.get']('filecollector:skipWorkspaceCleanupOnStartup') %}
+    {% set skip_workspace_cleanup_on_startup = True %}
+{% endif %}
+
 {% set proxy_full_url = None %}
 {% set proxy_protocol = None %}
 {% if salt['pillar.get']('proxy:host') %}
@@ -122,6 +127,7 @@
     "includeSaltLogs": include_salt_logs,
     "updatePackage": update_package,
     "skipValidation": skip_validation,
+    "skipWorkspaceCleanupOnStartup": skip_workspace_cleanup_on_startup,
     "proxyUrl": proxy_full_url,
     "proxyProtocol": proxy_protocol,
     "mode": mode,


### PR DESCRIPTION
details:
- new flow step beefore diagnostics init salt step for both freeipa and core flows
- add option to exclude hosts (based on where the validations failed or provided exclude hosts by default)
- update init flow to cleanup workspace at diagnostics start
- option to skip workspace cleanup at the start