### PR TITLE
CB-11183 Specify directory where Java VM dumps are created on out-of-memory conditions

### DIFF
--- a/integration-test/.gitignore
+++ b/integration-test/.gitignore
@@ -27,3 +27,4 @@ integcb/uaa.yml
 test.out
 ImageId*
 /src/main/resources/ums-users/
+dumps/

--- a/integration-test/docker-compose_template.yml
+++ b/integration-test/docker-compose_template.yml
@@ -27,8 +27,9 @@ services:
       - 7654:7654
     volumes:
       - ./:/it
+      - ./dumps:/it/dumps
       - /etc/localtime:/etc/localtime:ro
-    command: java -XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError -jar /it/build/libs/cloudbreak-integration-test.jar com.sequenceiq.it.IntegrationTestApp --integrationtest.command=suiteurls --integrationtest.suiteFiles=${INTEGRATIONTEST_SUITEFILES} | tee cbtest.log
+    command: java -XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/it/dumps -jar /it/build/libs/cloudbreak-integration-test.jar com.sequenceiq.it.IntegrationTestApp --integrationtest.command=suiteurls --integrationtest.suiteFiles=${INTEGRATIONTEST_SUITEFILES} | tee cbtest.log
     environment:
       - INTEGRATIONTEST_USER_ACCESSKEY=${INTEGRATIONTEST_USER_ACCESSKEY}
       - INTEGRATIONTEST_USER_SECRETKEY=${INTEGRATIONTEST_USER_SECRETKEY}


### PR DESCRIPTION
```find / -name "*.hprof"```
takes too long at [cloudbreak-pull-request-builder-integration-test](http://ci-cloudbreak.eng.hortonworks.com/job/cloudbreak-pull-request-builder-integration-test/ws/integration-test/). So we need to specify a separate directory where Java VM dumps are created in case of out-of-memory conditions.