### PR TITLE
CB-11132 Change datalake dr service default port

### DIFF
--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -76,7 +76,7 @@ altus:
     endpoint: localhost:8982
   datalakedr:
     enabled: false
-    endpoint: localhost:8982
+    endpoint: localhost:8989
 
 datalake:
   cert.dir: /certs/


### PR DESCRIPTION
Changed to `8989` to match the one present in CBD. It is overriden in mow deployments

See detailed description in the commit message.