### PR TITLE
CB-11121: Fix tests that passed when a cluster was in a failed state

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
@@ -84,7 +84,6 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
                 LOGGER.info("'{}' the polled resource entered into creation failed state. Exit waiting!", name);
                 return true;
             }
-            return waitObject.isFailed();
         } catch (ProcessingException clientException) {
             LOGGER.error("Exit waiting! Failed to get cluster due to API client exception: {}", clientException.getMessage(), clientException);
         } catch (Exception e) {


### PR DESCRIPTION
Fixed tests that passed when a cluster was in a failed state. The
e2e integration tests which validated the cluster was in an available
state used to pass if the cluster entered the failed state at certain
places in the polling cycle. Specifically, the early exit criteria was
met when the cluster was in the failed state. This early exit happened
right after the sleep in the poll cycle so it was more likely
to exit the polling loop without the failed check being processed.

This was fixed by removing the early exit in the case where the
cluster enters a failed state.

See detailed description in the commit message.