### PR TITLE
CB-11200 There was no HibernateNPlusOneLogger warning in the last 30 …

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLogger.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/tx/HibernateNPlusOneLogger.java
@@ -9,7 +9,7 @@ public class HibernateNPlusOneLogger extends HibernateStatementStatistics {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HibernateNPlusOneLogger.class);
 
-    private static final int DEFAULT_SESSION_MAX_STATEMENT_WARNING = 500;
+    private static final int DEFAULT_SESSION_MAX_STATEMENT_WARNING = 100;
 
     private final int maxStatementWarning;
 


### PR DESCRIPTION
…days on Mow Dev/Int/Stage/Prod, we shall just set the bar lower in order to detect problems.

See detailed description in the commit message.