### PR TITLE
CB-11188 Optionally initialize real UMS users by parameter

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/AbstractEnvironmentAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/AbstractEnvironmentAction.java
@@ -20,7 +20,6 @@ public abstract class AbstractEnvironmentAction implements Action<EnvironmentTes
             try {
                 return environmentAction(testContext, testDto, client);
             } catch (Exception e) {
-                LOGGER.info("Exception during executing Environment action: ", e);
                 if (e.getMessage().contains("flow under operation")) {
                     waitTillFlowInOperation(testDto.getFlowUtil());
                     retries++;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentChangeAuthenticationAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentChangeAuthenticationAction.java
@@ -22,9 +22,9 @@ public class EnvironmentChangeAuthenticationAction implements Action<Environment
         environmentAuthenticationRequest.setPublicKey(testDto.getRequest().getAuthentication().getPublicKey());
         environmentAuthenticationRequest.setPublicKeyId(testDto.getRequest().getAuthentication().getPublicKeyId());
         request.setAuthentication(environmentAuthenticationRequest);
-        environmentClient.getEnvironmentClient()
+        testDto.setResponse(environmentClient.getEnvironmentClient()
                 .environmentV1Endpoint()
-                .editByCrn(testDto.getResponse().getCrn(), request);
+                .editByCrn(testDto.getResponse().getCrn(), request));
         Log.when(LOGGER, "Environment edit authentication action posted");
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentChangeSecurityAccessAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentChangeSecurityAccessAction.java
@@ -21,9 +21,9 @@ public class EnvironmentChangeSecurityAccessAction implements Action<Environment
         SecurityAccessRequest securityAccess = testDto.getRequest().getSecurityAccess();
         SecurityAccessRequest clone = cloneSecurityAccessRequest(securityAccess);
         request.setSecurityAccess(clone);
-        environmentClient.getEnvironmentClient()
+        testDto.setResponse(environmentClient.getEnvironmentClient()
                 .environmentV1Endpoint()
-                .editByCrn(testDto.getResponse().getCrn(), request);
+                .editByCrn(testDto.getResponse().getCrn(), request));
         Log.when(LOGGER, "Environment edit authentication action posted");
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteAction.java
@@ -14,6 +14,7 @@ public class EnvironmentDeleteAction implements Action<EnvironmentTestDto, Envir
         SimpleEnvironmentResponse delete = environmentClient.getEnvironmentClient()
                 .environmentV1Endpoint()
                 .deleteByCrn(testDto.getResponse().getCrn(), true, false);
+        testDto.setResponseSimpleEnv(delete);
         Log.whenJson("Environment delete response: ", delete);
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteByNameAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteByNameAction.java
@@ -23,6 +23,7 @@ public class EnvironmentDeleteByNameAction extends AbstractEnvironmentAction {
         SimpleEnvironmentResponse delete = client.getEnvironmentClient()
                 .environmentV1Endpoint()
                 .deleteByName(testDto.getName(), cascading, false);
+        testDto.setResponseSimpleEnv(delete);
         Log.whenJson("Environment delete response: ", delete);
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteMultipleByCrnsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteMultipleByCrnsAction.java
@@ -21,6 +21,7 @@ public class EnvironmentDeleteMultipleByCrnsAction extends AbstractEnvironmentAc
         SimpleEnvironmentResponses delete = client.getEnvironmentClient()
                 .environmentV1Endpoint()
                 .deleteMultipleByCrns(crns, true, false);
+        testDto.setResponseSimpleEnvSet(delete.getResponses());
         Log.whenJson("Environments delete response: ", delete);
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteMultipleByNamesAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteMultipleByNamesAction.java
@@ -21,6 +21,7 @@ public class EnvironmentDeleteMultipleByNamesAction extends AbstractEnvironmentA
         SimpleEnvironmentResponses delete = client.getEnvironmentClient()
                 .environmentV1Endpoint()
                 .deleteMultipleByNames(envNames, true, false);
+        testDto.setResponseSimpleEnvSet(delete.getResponses());
         Log.whenJson("Environments delete response: ", delete);
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/actor/CloudbreakActor.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/actor/CloudbreakActor.java
@@ -50,7 +50,7 @@ public class CloudbreakActor extends CloudbreakUserCache implements Actor {
     @Override
     public CloudbreakUser useRealUmsUser(String key) {
         LOGGER.info("Getting the requested real UMS user by key:: {}", key);
-        return getByDisplayName(key);
+        return getUserByDisplayName(key);
     }
 
     private void checkNonEmpty(String name, String value) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -42,9 +42,13 @@ public class MeasuredTestContext extends MockedTestContext {
     }
 
     @Override
-    public TestContext as(CloudbreakUser actor) {
-        wrappedTestContext.as(actor);
-        return this;
+    public TestContext as() {
+        return wrappedTestContext.as();
+    }
+
+    @Override
+    public TestContext as(CloudbreakUser cloudbreakUser) {
+        return wrappedTestContext.as(cloudbreakUser);
     }
 
     @Override
@@ -70,6 +74,21 @@ public class MeasuredTestContext extends MockedTestContext {
     @Override
     public void setShutdown(boolean shutdown) {
         wrappedTestContext.setShutdown(shutdown);
+    }
+
+    @Override
+    public void useUmsUserCache(boolean useUmsStore) {
+        wrappedTestContext.useUmsUserCache(useUmsStore);
+    }
+
+    @Override
+    public boolean umsUserCacheInUse() {
+        return wrappedTestContext.umsUserCacheInUse();
+    }
+
+    @Override
+    public boolean realUmsUserCacheReadyToUse() {
+        return wrappedTestContext.realUmsUserCacheReadyToUse();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/RunningParameter.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/RunningParameter.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.it.cloudbreak.actor.CloudbreakActor;
 import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
 import com.sequenceiq.it.cloudbreak.testcase.authorization.AuthUserKeys;
 
@@ -37,17 +36,12 @@ public class RunningParameter {
     private boolean waitForFlow = true;
 
     @Inject
-    private CloudbreakActor cloudbreakActor;
+    private TestContext testContext;
 
     public CloudbreakUser getWho() {
         if (doAsAdmin) {
-            try {
-                if (cloudbreakActor.isInitialized()) {
-                    return cloudbreakActor.useRealUmsUser(AuthUserKeys.ACCOUNT_ADMIN);
-                }
-            } catch (Exception ignored) {
-                LOGGER.warn("Even the 'doAsAdmin' is 'true' in {}, the UMS users have not been initialized, falling back to the already defined user!",
-                        getClass().getSimpleName());
+            if (testContext.realUmsUserCacheReadyToUse()) {
+                return testContext.getRealUmsUserByKey(AuthUserKeys.ACCOUNT_ADMIN);
             }
         }
         return who;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -65,7 +65,7 @@ public class EnvironmentTestDto
     @Inject
     private AwsProperties awsProperties;
 
-    private Collection<SimpleEnvironmentResponse> response;
+    private Collection<SimpleEnvironmentResponse> simpleResponses;
 
     private SimpleEnvironmentResponse simpleResponse;
 
@@ -264,11 +264,11 @@ public class EnvironmentTestDto
     }
 
     public Collection<SimpleEnvironmentResponse> getResponseSimpleEnvSet() {
-        return response;
+        return simpleResponses;
     }
 
-    public void setResponseSimpleEnvSet(Collection<SimpleEnvironmentResponse> response) {
-        this.response = response;
+    public void setResponseSimpleEnvSet(Collection<SimpleEnvironmentResponse> simpleResponses) {
+        this.simpleResponses = simpleResponses;
     }
 
     public SimpleEnvironmentResponse getResponseSimpleEnv() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -258,7 +258,9 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
     }
 
     protected void useRealUmsUser(TestContext testContext, String key) {
-        testContext.as(cloudbreakActor.useRealUmsUser(key));
+        testContext
+                .as(cloudbreakActor.useRealUmsUser(key))
+                .useUmsUserCache(true);
     }
 
     protected void initializeDefaultBlueprints(TestContext testContext) {


### PR DESCRIPTION
Integration tests' flow polling is failing in case of `ums-users/api-credentials.json` is present at `integration-test` project. This is a special case, when the real UMS user store has been initialised but we do not want to run UMS or AuthZ test suits. However flow polling is happening with admin user. So mistakenly UMS admin has been provided for `getAdminMicroserviceClient`.

We agreed we should introduce the needed validation for `accountId` in `getAdminByAccountId` and an additional parameter for authorisation tests only.

**_NOTES:_**
- `additional parameter for authorization tests only` was implemented different way: Instead of introducing a separate test suite parameter I applied a new `CloudbreakUserCache` class parameter as `useUmsStore`. This new parameter is going to be set when we use `useRealUmsUser` (from `AbstractIntegrationTest`). So on this way we can rest assured the `getAdminMicroserviceClient` and `doAsAdmin` are getting the UMS admin for the used UMS account when and only when we use Real UMS user for tests.
- In case os some Environment service related actions (edit and delete where these are returning with the response) the `testDto.setResponse` step was missing. So I made up the flaw.