### PR TITLE
CB-9432. Add flow progress API for diagnostics

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/DiagnosticsCollection.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/DiagnosticsCollection.java
@@ -1,0 +1,72 @@
+package com.sequenceiq.common.api.diagnostics;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DiagnosticsCollection implements Serializable {
+
+    private DiagnosticsCollectionStatus status;
+
+    private String flowId;
+
+    private String currentFlowStatus;
+
+    private Long created;
+
+    private Integer progressPercentage;
+
+    private Map<String, Object> properties;
+
+    public DiagnosticsCollectionStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(DiagnosticsCollectionStatus status) {
+        this.status = status;
+    }
+
+    public String getFlowId() {
+        return flowId;
+    }
+
+    public void setFlowId(String flowId) {
+        this.flowId = flowId;
+    }
+
+    public String getCurrentFlowStatus() {
+        return currentFlowStatus;
+    }
+
+    public void setCurrentFlowStatus(String currentFlowStatus) {
+        this.currentFlowStatus = currentFlowStatus;
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public void setCreated(Long created) {
+        this.created = created;
+    }
+
+    public Map<String, Object> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, Object> properties) {
+        this.properties = properties;
+    }
+
+    public Integer getProgressPercentage() {
+        return progressPercentage;
+    }
+
+    public void setProgressPercentage(Integer progressPercentage) {
+        this.progressPercentage = progressPercentage;
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/DiagnosticsCollectionStatus.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/DiagnosticsCollectionStatus.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.common.api.diagnostics;
+
+public enum DiagnosticsCollectionStatus {
+    IN_PROGRESS, FAILED, FINISHED;
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/ListDiagnosticsCollectionResponse.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/ListDiagnosticsCollectionResponse.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.common.api.diagnostics;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ListDiagnosticsCollectionResponse implements Serializable {
+
+    private List<DiagnosticsCollection> collections = new ArrayList<>();
+
+    public List<DiagnosticsCollection> getCollections() {
+        return collections;
+    }
+
+    public void setCollections(List<DiagnosticsCollection> collections) {
+        this.collections = collections;
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
@@ -25,6 +25,7 @@ public class DiagnosticsModelDescription {
     public static final String BUNDLE_SIZE_BYTES = "The maximum approximate bundle size of the output file for CM based diagnostics collection.";
     public static final String COMMENTS = "Comments to include with this CM based data collection.";
     public static final String ENABLE_MONITOR_METRICS_COLLECTION = "Flag to enable collection of metrics for chart display in CM based diagnostics collection.";
+    public static final String STACK_CRN = "Crn identifier of the stack for listing diagnostics collections.";
 
     private DiagnosticsModelDescription() {
     }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/FlowPayloadToDiagnosticDetailsConverter.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/FlowPayloadToDiagnosticDetailsConverter.java
@@ -1,0 +1,108 @@
+package com.sequenceiq.cloudbreak.telemetry.converter;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.common.api.diagnostics.DiagnosticsCollectionStatus;
+import com.sequenceiq.common.api.telemetry.model.DiagnosticsDestination;
+
+@Component
+public class FlowPayloadToDiagnosticDetailsConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowPayloadToDiagnosticDetailsConverter.class);
+
+    private static final int MAX_PERCENT = 100;
+
+    public Map<String, Object> convert(String payload) {
+        Map<String, Object> properties = new HashMap<>();
+        try {
+            JsonNode payloadNode = JsonUtil.readTree(payload);
+            if (payloadNode.isObject() && payloadNode.has("parameters")) {
+                JsonNode parametersNode = payloadNode.get("parameters");
+                if (!parametersNode.isEmpty()) {
+                    fillStrFieldIfExists(parametersNode, "accountId", "accountId", properties);
+                    fillStrFieldIfExists(parametersNode, "issue", "case", properties);
+                    fillStrFieldIfExists(parametersNode, "description", "description", properties);
+                    fillStrFieldIfExists(parametersNode, "clusterType", "clusterType", properties);
+                    fillStrFieldIfExists(parametersNode, "clusterVersion", "clusterVersion", properties);
+                    fillDestinationData(properties, parametersNode);
+                }
+            }
+            fillStrFieldIfExists(payloadNode, "resourceCrn", "resourceCrn", properties);
+        } catch (IOException e) {
+            LOGGER.warn("Flow payload cannot be read for diagnostics.", e);
+        }
+        return properties;
+    }
+
+    public int calculateProgressPercentage(boolean finalized, boolean serviceStatusFailed,
+            Supplier<Integer> calculateProgressFunction) {
+        int result = 0;
+        if (finalized || serviceStatusFailed) {
+            result = MAX_PERCENT;
+        } else {
+            result = calculateProgressFunction.get();
+        }
+        return result;
+    }
+
+    public DiagnosticsCollectionStatus calculateStatus(String currentState, String finishedState, String failedState,
+            String failedHandledEvent, String nextEvent, boolean finalized, boolean serviceStatusFailed) {
+        DiagnosticsCollectionStatus status = DiagnosticsCollectionStatus.IN_PROGRESS;
+        if (serviceStatusFailed) {
+            status = DiagnosticsCollectionStatus.FAILED;
+        } else if (finalized) {
+            if (finishedState.equals(currentState)) {
+                status = DiagnosticsCollectionStatus.FINISHED;
+            } else if (failedState.equals(currentState)
+                    || failedHandledEvent.equals(nextEvent)) {
+                status = DiagnosticsCollectionStatus.FAILED;
+            }
+        }
+        return status;
+    }
+
+    private void fillDestinationData(Map<String, Object> properties, JsonNode parametersNode) {
+        String destination = "";
+        if (parametersNode.has("destination") && parametersNode.get("destination").has("name")) {
+            destination = parametersNode.get("destination").get("name").textValue();
+            properties.put("destination", destination);
+        }
+        if (DiagnosticsDestination.CLOUD_STORAGE.name().equals(destination)) {
+            if (parametersNode.has("cloudStorageDiagnosticsParameters")) {
+                fillCloudStorageOutput(parametersNode.get("cloudStorageDiagnosticsParameters"), properties);
+            }
+        }
+        if (DiagnosticsDestination.SUPPORT.name().equals(destination)) {
+            fillStrFieldIfExists(parametersNode, "dbusUrl", "databusEndpoint", properties);
+        }
+    }
+
+    private void fillCloudStorageOutput(JsonNode cloudStorageDiagParams, Map<String, Object> properties) {
+        if (cloudStorageDiagParams.has("s3Location")) {
+            properties.put("output", "s3://"
+                    + Paths.get(cloudStorageDiagParams.get("s3Bucket").textValue(), cloudStorageDiagParams.get("s3Location").textValue()));
+        } else if (cloudStorageDiagParams.has("adlsV2StorageLocation")) {
+            properties.put("output", "abfs://" + Paths.get(cloudStorageDiagParams.get("adlsv2StorageContainer").textValue(),
+                    cloudStorageDiagParams.get("adlsv2StorageContainer").textValue()));
+        } else if (cloudStorageDiagParams.has("gcsLocation")) {
+            properties.put("output", "gcs://"
+                    + Paths.get(cloudStorageDiagParams.get("bucket").textValue(), cloudStorageDiagParams.get("gcsLocation").textValue()));
+        }
+    }
+
+    private void fillStrFieldIfExists(JsonNode parametersNode, String field, String name, Map<String, Object> properties) {
+        if (parametersNode.has(field)) {
+            properties.put(name, parametersNode.get(field).textValue());
+        }
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/converter/FlowPayloadToDiagnosticDetailsConverterTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/converter/FlowPayloadToDiagnosticDetailsConverterTest.java
@@ -1,0 +1,117 @@
+package com.sequenceiq.cloudbreak.telemetry.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.common.api.diagnostics.DiagnosticsCollectionStatus;
+
+public class FlowPayloadToDiagnosticDetailsConverterTest {
+
+    private static final String SAMPLE_INPUT = "/samples/diagnostics_payload.json";
+
+    private static final int DUMMY_PERCENT = 1;
+
+    private static final int MAX_PERCENT = 100;
+
+    private FlowPayloadToDiagnosticDetailsConverter underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new FlowPayloadToDiagnosticDetailsConverter();
+    }
+
+    @Test
+    public void testConvert() throws IOException {
+        // GIVEN
+        String sampleContent;
+        try (InputStream responseStream = FlowPayloadToDiagnosticDetailsConverterTest.class.getResourceAsStream(SAMPLE_INPUT)) {
+            sampleContent = IOUtils.toString(responseStream);
+        }
+        // WHEN
+        Map<String, Object> result = underTest.convert(sampleContent);
+        // THEN
+        assertEquals("CLOUD_STORAGE", result.get("destination"));
+        assertEquals("cloudera", result.get("accountId"));
+        assertEquals("s3://cb-group/oszabo/logs/cluster-logs/freeipa/my/diagnostics", result.get("output"));
+        assertEquals("FREEIPA", result.get("clusterType"));
+        assertEquals("crn:cdp:freeipa:us-west-1:cloudera:freeipa:4428e540-a878-42b1-a1d4-91747322d8b6", result.get("resourceCrn"));
+        assertEquals("mycase", result.get("case"));
+        assertNull(result.get("description"));
+    }
+
+    @Test
+    public void testCalculateProgressPercentage() {
+        // GIVEN
+        // WHEN
+        int result = underTest.calculateProgressPercentage(false, false, () -> DUMMY_PERCENT);
+        // THEN
+        assertEquals(DUMMY_PERCENT, result);
+    }
+
+    @Test
+    public void testCalculateProgressPercentageFinalized() {
+        // GIVEN
+        // WHEN
+        int result = underTest.calculateProgressPercentage(true, false, () -> DUMMY_PERCENT);
+        // THEN
+        assertEquals(MAX_PERCENT, result);
+    }
+
+    @Test
+    public void testCalculateStatusServiceStatus() {
+        // GIVEN
+        // WHEN
+        DiagnosticsCollectionStatus status = underTest.calculateStatus("currentState", "finished", "failed",
+                "failedEvent", "nextEvent", false, false);
+        // THEN
+        assertEquals(DiagnosticsCollectionStatus.IN_PROGRESS, status);
+    }
+
+    @Test
+    public void testCalculateStatusServiceStatusFailed() {
+        // GIVEN
+        // WHEN
+        DiagnosticsCollectionStatus status = underTest.calculateStatus("currentState", "finished", "failed",
+                "failedEvent", "nextEvent", false, true);
+        // THEN
+        assertEquals(DiagnosticsCollectionStatus.FAILED, status);
+    }
+
+    @Test
+    public void testCalculateStatusServiceFinished() {
+        // GIVEN
+        // WHEN
+        DiagnosticsCollectionStatus status = underTest.calculateStatus("finished", "finished", "failed",
+                "failedEvent", "nextEvent", true, false);
+        // THEN
+        assertEquals(DiagnosticsCollectionStatus.FINISHED, status);
+    }
+
+    @Test
+    public void testCalculateStatusServiceFinishedAndFailed() {
+        // GIVEN
+        // WHEN
+        DiagnosticsCollectionStatus status = underTest.calculateStatus("finished", "finished", "failed",
+                "failedEvent", "nextEvent", true, true);
+        // THEN
+        assertEquals(DiagnosticsCollectionStatus.FAILED, status);
+    }
+
+    @Test
+    public void testCalculateStatusServiceFinishedAndFailedNextEvent() {
+        // GIVEN
+        // WHEN
+        DiagnosticsCollectionStatus status = underTest.calculateStatus("finished", "finished", "failed",
+                "failedEvent", "failedEvent", true, true);
+        // THEN
+        assertEquals(DiagnosticsCollectionStatus.FAILED, status);
+    }
+}

--- a/common/src/test/resources/samples/diagnostics_payload.json
+++ b/common/src/test/resources/samples/diagnostics_payload.json
@@ -1,0 +1,40 @@
+{
+  "@type": "com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionEvent",
+  "parameters": {
+    "issue": "mycase",
+    "description": null,
+    "labels": {
+      "@type": "java.util.ArrayList"
+    },
+    "startTime": 1297859465863,
+    "endTime": 1929011465863,
+    "destination": {
+      "name": "CLOUD_STORAGE"
+    },
+    "hostGroups": null,
+    "hosts": null,
+    "additionalLogs": null,
+    "includeSaltLogs": false,
+    "updatePackage": false,
+    "skipValidation": false,
+    "uuid": "eecb0472-e39b-4383-b383-d487d60955df",
+    "accountId": "cloudera",
+    "clusterType": "FREEIPA",
+    "clusterVersion": "2.39.0-b33-2-g2ff4bf6",
+    "dbusUrl": "https://dbusapi.sigma-dev.cloudera.com",
+    "supportBundleDbusAccessKey": null,
+    "supportBundleDbusPrivateKey": null,
+    "supportBundleDbusAppName": "",
+    "supportBundleDbusStreamName": "UnifiedDiagnostics",
+    "cloudStorageDiagnosticsParameters": {
+      "@type": "com.sequenceiq.common.model.diagnostics.AwsDiagnosticParameters",
+      "s3Bucket": "cb-group",
+      "s3Region": "eu-central-1",
+      "s3Location": "oszabo/logs/cluster-logs/freeipa/my/diagnostics"
+    }
+  },
+  "selector": "FINALIZE_DIAGNOSTICS_COLLECTION_EVENT",
+  "resourceId": 4,
+  "resourceCrn": "crn:cdp:freeipa:us-west-1:cloudera:freeipa:4428e540-a878-42b1-a1d4-91747322d8b6",
+  "accepted": null
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/diagnostics/DiagnosticsV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/diagnostics/DiagnosticsV4Endpoint.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.docs.DiagnosticsOpe
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.model.CmDiagnosticsCollectionRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.model.DiagnosticsCollectionRequest;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.common.api.diagnostics.ListDiagnosticsCollectionResponse;
 import com.sequenceiq.common.api.telemetry.response.VmLogsResponse;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 
@@ -40,6 +41,13 @@ public interface DiagnosticsV4Endpoint {
     @ApiOperation(value = DiagnosticsOperationDescriptions.GET_VM_LOG_PATHS, produces = MediaType.APPLICATION_JSON,
             nickname = "getStackCmVmLogs")
     VmLogsResponse getVmLogs();
+
+    @GET
+    @Path("{crn}/collections")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = DiagnosticsOperationDescriptions.LIST_COLLECTIONS, produces = MediaType.APPLICATION_JSON,
+            nickname = "listStackDiagnosticsCollections")
+    ListDiagnosticsCollectionResponse listCollections(@PathParam("crn") String crn);
 
     @POST
     @Path("cm")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/diagnostics/docs/DiagnosticsOperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/diagnostics/docs/DiagnosticsOperationDescriptions.java
@@ -7,6 +7,7 @@ public final class DiagnosticsOperationDescriptions {
     public static final String GET_VM_LOG_PATHS = "Returns a list of log paths on the hosts of the stack.";
     public static final String GET_CM_ROLES = "Returns a list of CM Roles that can be used for filtering the diagnostics results. " +
             "Roles are immutable based on the deployment details";
+    public static final String LIST_COLLECTIONS = "Returns a list of the recent diagnostics collections.";
 
     private DiagnosticsOperationDescriptions() {
     }

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
@@ -63,6 +63,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Resp
 import com.sequenceiq.cloudbreak.doc.Notes;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.common.api.diagnostics.ListDiagnosticsCollectionResponse;
 import com.sequenceiq.common.api.telemetry.response.VmLogsResponse;
 import com.sequenceiq.distrox.api.v1.distrox.model.DistroXMaintenanceModeV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.DistroXRepairV1Request;
@@ -341,6 +342,13 @@ public interface DistroXV1Endpoint {
     @ApiOperation(value = DiagnosticsOperationDescriptions.GET_VM_LOG_PATHS, produces = MediaType.APPLICATION_JSON,
             nickname = "getDistroxCmVmLogsV4")
     VmLogsResponse getVmLogs();
+
+    @GET
+    @Path("diagnostics/{crn}/collections")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = DiagnosticsOperationDescriptions.LIST_COLLECTIONS, produces = MediaType.APPLICATION_JSON,
+            nickname = "listDistroxDiagnosticsCollectionsV1")
+    ListDiagnosticsCollectionResponse listCollections(@PathParam("crn") String crn);
 
     @POST
     @Path("diagnostics/cm")

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/diagnostics/docs/DiagnosticsOperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/diagnostics/docs/DiagnosticsOperationDescriptions.java
@@ -6,6 +6,7 @@ public final class DiagnosticsOperationDescriptions {
     public static final String COLLECT_CM_DIAGNOSTICS = "Initiates the collection of diagnostical data on Datahub Cloudera Manager";
     public static final String GET_VM_LOG_PATHS = "Returns a list of log paths on the hosts of Datahub";
     public static final String GET_CM_ROLES = "Returns a list of Cloudera Manager service roles that can be used for Cloudera Manager based diagnostics";
+    public static final String LIST_COLLECTIONS = "Returns a list of the recent diagnostics collections.";
 
     private DiagnosticsOperationDescriptions() {
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/diagnostics/FlowLogsToListDiagnosticsCollectionResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/diagnostics/FlowLogsToListDiagnosticsCollectionResponseConverter.java
@@ -1,0 +1,62 @@
+package com.sequenceiq.cloudbreak.converter.v4.diagnostics;
+
+import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_COLLECTION_FAILED_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_COLLECTION_FINISHED_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors.HANDLED_FAILED_DIAGNOSTICS_COLLECTION_EVENT;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.core.flow2.diagnostics.config.DiagnosticsCollectionFlowConfig;
+import com.sequenceiq.cloudbreak.telemetry.converter.FlowPayloadToDiagnosticDetailsConverter;
+import com.sequenceiq.common.api.diagnostics.DiagnosticsCollection;
+import com.sequenceiq.common.api.diagnostics.DiagnosticsCollectionStatus;
+import com.sequenceiq.common.api.diagnostics.ListDiagnosticsCollectionResponse;
+import com.sequenceiq.flow.domain.FlowLog;
+import com.sequenceiq.flow.domain.StateStatus;
+
+@Component
+public class FlowLogsToListDiagnosticsCollectionResponseConverter {
+
+    @Inject
+    private FlowPayloadToDiagnosticDetailsConverter flowPayloadToDiagnosticDetailsConverter;
+
+    @Inject
+    private DiagnosticsCollectionFlowConfig diagnosticsCollectionFlowConfig;
+
+    public ListDiagnosticsCollectionResponse convert(List<FlowLog> flowLogs) {
+        ListDiagnosticsCollectionResponse response = new ListDiagnosticsCollectionResponse();
+        if (!flowLogs.isEmpty()) {
+            List<DiagnosticsCollection> collections = flowLogs.stream()
+                    .map(flowLog -> {
+                        DiagnosticsCollection collection = new DiagnosticsCollection();
+                        collection.setFlowId(flowLog.getFlowId());
+                        collection.setCreated(flowLog.getCreated());
+                        collection.setProperties(flowPayloadToDiagnosticDetailsConverter.convert(flowLog.getPayload()));
+                        collection.setStatus(calculateStatus(flowLog));
+                        collection.setCurrentFlowStatus(flowLog.getCurrentState());
+                        collection.setProgressPercentage(calculateProgressPercentage(flowLog));
+                        return collection;
+                    }).collect(Collectors.toList());
+            response.setCollections(collections);
+        }
+        return response;
+    }
+
+    private int calculateProgressPercentage(FlowLog flowLog) {
+        return flowPayloadToDiagnosticDetailsConverter.calculateProgressPercentage(flowLog.getFinalized(),
+                StateStatus.FAILED.equals(flowLog.getStateStatus()),
+                () -> diagnosticsCollectionFlowConfig.getProgressPercentageForState(flowLog.getCurrentState()));
+    }
+
+    private DiagnosticsCollectionStatus calculateStatus(FlowLog flowLog) {
+        return flowPayloadToDiagnosticDetailsConverter.calculateStatus(flowLog.getCurrentState(),
+                DIAGNOSTICS_COLLECTION_FINISHED_STATE.name(), DIAGNOSTICS_COLLECTION_FAILED_STATE.name(),
+                HANDLED_FAILED_DIAGNOSTICS_COLLECTION_EVENT.name(), flowLog.getNextEvent(), flowLog.getFinalized(),
+                StateStatus.FAILED.equals(flowLog.getStateStatus()));
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/config/DiagnosticsCollectionFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/config/DiagnosticsCollectionFlowConfig.java
@@ -115,6 +115,11 @@ public class DiagnosticsCollectionFlowConfig extends AbstractFlowConfiguration<D
     }
 
     @Override
+    public boolean isFlowOrdered() {
+        return true;
+    }
+
+    @Override
     public DiagnosticsCollectionStateSelectors getRetryableEvent() {
         return HANDLED_FAILED_DIAGNOSTICS_COLLECTION_EVENT;
     }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/DiagnosticsEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/DiagnosticsEndpoint.java
@@ -14,6 +14,7 @@ import javax.ws.rs.core.MediaType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.model.CmDiagnosticsCollectionRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.model.DiagnosticsCollectionRequest;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.common.api.diagnostics.ListDiagnosticsCollectionResponse;
 import com.sequenceiq.common.api.telemetry.response.VmLogsResponse;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.sdx.api.model.diagnostics.docs.DiagnosticsOperationDescriptions;
@@ -40,6 +41,13 @@ public interface DiagnosticsEndpoint {
     @ApiOperation(value = DiagnosticsOperationDescriptions.GET_VM_LOG_PATHS, produces = MediaType.APPLICATION_JSON,
             nickname = "getSdxCmVmLogs")
     VmLogsResponse getVmLogs();
+
+    @GET
+    @Path("{crn}/collections")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = DiagnosticsOperationDescriptions.LIST_COLLECTIONS, produces = MediaType.APPLICATION_JSON,
+            nickname = "listSdxDiagnosticsCollections")
+    ListDiagnosticsCollectionResponse listCollections(@PathParam("crn") String crn);
 
     @POST
     @Path("cm")

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/diagnostics/docs/DiagnosticsOperationDescriptions.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/diagnostics/docs/DiagnosticsOperationDescriptions.java
@@ -7,6 +7,7 @@ public final class DiagnosticsOperationDescriptions {
     public static final String GET_VM_LOG_PATHS = "Returns a list of log paths on the hosts of the SDX";
     public static final String GET_CM_ROLES = "Returns a list of CM Roles that can be used for filtering the diagnostics results. " +
             "Roles are immutable based on the deployment details";
+    public static final String LIST_COLLECTIONS = "Returns a list of the recent diagnostics collections.";
 
     private DiagnosticsOperationDescriptions() {
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/diagnostics/DiagnosticsController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/diagnostics/DiagnosticsController.java
@@ -11,10 +11,13 @@ import javax.validation.Valid;
 import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.authorization.annotation.CheckPermissionByRequestProperty;
+import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.DisableCheckPermissions;
 import com.sequenceiq.authorization.annotation.RequestObject;
+import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.model.CmDiagnosticsCollectionRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.model.DiagnosticsCollectionRequest;
+import com.sequenceiq.common.api.diagnostics.ListDiagnosticsCollectionResponse;
 import com.sequenceiq.common.api.telemetry.response.VmLogsResponse;
 import com.sequenceiq.datalake.service.sdx.diagnostics.DiagnosticsService;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
@@ -36,6 +39,12 @@ public class DiagnosticsController implements DiagnosticsEndpoint {
     @DisableCheckPermissions
     public VmLogsResponse getVmLogs() {
         return diagnosticsService.getVmLogs();
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = DESCRIBE_DATALAKE)
+    public ListDiagnosticsCollectionResponse listCollections(@ResourceCrn String crn) {
+        return diagnosticsService.getDiagnosticsCollections(crn);
     }
 
     @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/diagnostics/DiagnosticsService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/diagnostics/DiagnosticsService.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.model.CmDiagnostics
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.model.DiagnosticsCollectionRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.common.api.diagnostics.ListDiagnosticsCollectionResponse;
 import com.sequenceiq.common.api.telemetry.response.VmLogsResponse;
 import com.sequenceiq.datalake.converter.DiagnosticsParamsConverter;
 import com.sequenceiq.datalake.entity.SdxCluster;
@@ -75,5 +76,9 @@ public class DiagnosticsService {
 
     public List<String> getCmRoles(String stackCrn) {
         return diagnosticsV4Endpoint.getCmRoles(stackCrn);
+    }
+
+    public ListDiagnosticsCollectionResponse getDiagnosticsCollections(String crn) {
+        return diagnosticsV4Endpoint.listCollections(crn);
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/config/OrderedFlowConfiguration.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/config/OrderedFlowConfiguration.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.flow.core.config;
+
+/**
+ * Marker interface for flow configurations.
+ * In case of a flow transition steps are ordered and dp not have branches, isFlowOrdered method can be set to true.
+ * By enabling this setting a progress map with states - percentage pairs will be filled, that can be used the follow
+ * the progress of the flow.
+ */
+public interface OrderedFlowConfiguration {
+    /**
+     * Override this if the flow config is ordered (flow steps are in order and no conditional steps)
+     */
+    default boolean isFlowOrdered() {
+        return false;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
@@ -42,6 +42,12 @@ public interface FlowLogRepository extends CrudRepository<FlowLog, Long> {
     @Query("SELECT fl FROM FlowLog fl WHERE fl.flowType = :flowType AND fl.resourceId = :resourceId ORDER BY fl.created DESC")
     List<FlowLog> findAllFlowByType(@Param("resourceId") Long resourceId, @Param("flowType") Class<?> clazz);
 
+    @Query("SELECT fl FROM FlowLog fl WHERE fl.created IN " +
+            "( SELECT max(fls.created) from FlowLog fls WHERE fls.flowType = :flowType and fls.resourceId = :resourceId " +
+            "GROUP BY (fls.flowId, fls.resourceId)) " +
+            "ORDER BY fl.created DESC ")
+    List<FlowLog> findLastFlowLogsByTypeAndResourceId(@Param("resourceId") Long resourceId, @Param("flowType") Class<?> clazz);
+
     @Query("SELECT fl.flowId FROM FlowLog fl WHERE fl.flowChainId IN (:chainIds)")
     Set<String> findAllFlowIdsByChainIds(@Param("chainIds") Set<String> chainIds);
 

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
@@ -287,6 +287,11 @@ public class FlowLogDBService implements FlowLogService {
         return flowLogRepository.findAllFlowByType(resourceId, clazz);
     }
 
+    public <T extends AbstractFlowConfiguration> List<FlowLog> getLatestFlowLogsByCrnAndType(String resourceCrn, Class<T> clazz) {
+        Long resourceId = getResourceIdByCrnOrName(resourceCrn);
+        return flowLogRepository.findLastFlowLogsByTypeAndResourceId(resourceId, clazz);
+    }
+
     public Predicate<FlowLog> pendingFlowLogPredicate() {
         return flowLog -> flowLog.getStateStatus().equals(StateStatus.PENDING) || !flowLog.getFinalized();
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/diagnostics/DiagnosticsV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/diagnostics/DiagnosticsV1Endpoint.java
@@ -5,10 +5,12 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.common.api.diagnostics.ListDiagnosticsCollectionResponse;
 import com.sequenceiq.common.api.telemetry.response.VmLogsResponse;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.freeipa.api.v1.diagnostics.docs.DiagnosticsOperationDescriptions;
@@ -37,4 +39,11 @@ public interface DiagnosticsV1Endpoint {
     @ApiOperation(value = DiagnosticsOperationDescriptions.GET_VM_LOG_PATHS, produces = MediaType.APPLICATION_JSON,
             notes = FreeIpaNotes.FREEIPA_NOTES, nickname = "getFreeIpaVmLogsV1")
     VmLogsResponse getVmLogs();
+
+    @GET
+    @Path("{environmentCrn}/collections")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = DiagnosticsOperationDescriptions.LIST_DIAGNOSTICS_COLLECTIONS, produces = MediaType.APPLICATION_JSON,
+            notes = FreeIpaNotes.FREEIPA_NOTES, nickname = "listDiagnosticsCollectionsV1")
+    ListDiagnosticsCollectionResponse listDiagnosticsCollections(@PathParam("environmentCrn") String environmentCrn);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/diagnostics/docs/DiagnosticsOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/diagnostics/docs/DiagnosticsOperationDescriptions.java
@@ -4,6 +4,7 @@ public final class DiagnosticsOperationDescriptions {
 
     public static final String COLLECT_FREEIPA_DIAGNOSTICS = "Initiates the collection of diagnostical data on the FreeIPA host";
     public static final String GET_VM_LOG_PATHS = "Returns a list of log paths on the FreeIpa VM";
+    public static final String LIST_DIAGNOSTICS_COLLECTIONS = "Returns a list of diagnostics collections for the specified FreeIpa cluster.";
 
     private DiagnosticsOperationDescriptions() {
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/diagnostics/FlowLogsToListDiagnosticsCollectionResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/diagnostics/FlowLogsToListDiagnosticsCollectionResponseConverter.java
@@ -1,0 +1,62 @@
+package com.sequenceiq.freeipa.converter.diagnostics;
+
+import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_COLLECTION_FAILED_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState.DIAGNOSTICS_COLLECTION_FINISHED_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.diagnostics.event.DiagnosticsCollectionStateSelectors.HANDLED_FAILED_DIAGNOSTICS_COLLECTION_EVENT;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.telemetry.converter.FlowPayloadToDiagnosticDetailsConverter;
+import com.sequenceiq.common.api.diagnostics.DiagnosticsCollection;
+import com.sequenceiq.common.api.diagnostics.DiagnosticsCollectionStatus;
+import com.sequenceiq.common.api.diagnostics.ListDiagnosticsCollectionResponse;
+import com.sequenceiq.flow.domain.FlowLog;
+import com.sequenceiq.flow.domain.StateStatus;
+import com.sequenceiq.freeipa.flow.freeipa.diagnostics.config.DiagnosticsCollectionFlowConfig;
+
+@Component
+public class FlowLogsToListDiagnosticsCollectionResponseConverter {
+
+    @Inject
+    private FlowPayloadToDiagnosticDetailsConverter flowPayloadToDiagnosticDetailsConverter;
+
+    @Inject
+    private DiagnosticsCollectionFlowConfig diagnosticsCollectionFlowConfig;
+
+    public ListDiagnosticsCollectionResponse convert(List<FlowLog> flowLogs) {
+        ListDiagnosticsCollectionResponse response = new ListDiagnosticsCollectionResponse();
+        if (!flowLogs.isEmpty()) {
+            List<DiagnosticsCollection> collections = flowLogs.stream()
+                    .map(flowLog -> {
+                        DiagnosticsCollection collection = new DiagnosticsCollection();
+                        collection.setFlowId(flowLog.getFlowId());
+                        collection.setCreated(flowLog.getCreated());
+                        collection.setProperties(flowPayloadToDiagnosticDetailsConverter.convert(flowLog.getPayload()));
+                        collection.setStatus(calculateStatus(flowLog));
+                        collection.setCurrentFlowStatus(flowLog.getCurrentState());
+                        collection.setProgressPercentage(calculateProgressPercentage(flowLog));
+                        return collection;
+                    }).collect(Collectors.toList());
+            response.setCollections(collections);
+        }
+        return response;
+    }
+
+    private int calculateProgressPercentage(FlowLog flowLog) {
+        return flowPayloadToDiagnosticDetailsConverter.calculateProgressPercentage(flowLog.getFinalized(),
+                StateStatus.FAILED.equals(flowLog.getStateStatus()),
+                () -> diagnosticsCollectionFlowConfig.getProgressPercentageForState(flowLog.getCurrentState()));
+    }
+
+    private DiagnosticsCollectionStatus calculateStatus(FlowLog flowLog) {
+        return flowPayloadToDiagnosticDetailsConverter.calculateStatus(flowLog.getCurrentState(),
+                DIAGNOSTICS_COLLECTION_FINISHED_STATE.name(), DIAGNOSTICS_COLLECTION_FAILED_STATE.name(),
+                HANDLED_FAILED_DIAGNOSTICS_COLLECTION_EVENT.name(), flowLog.getNextEvent(), flowLog.getFinalized(),
+                StateStatus.FAILED.equals(flowLog.getStateStatus()));
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/config/DiagnosticsCollectionFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/config/DiagnosticsCollectionFlowConfig.java
@@ -115,6 +115,11 @@ public class DiagnosticsCollectionFlowConfig extends AbstractFlowConfiguration<D
     }
 
     @Override
+    public boolean isFlowOrdered() {
+        return true;
+    }
+
+    @Override
     public DiagnosticsCollectionStateSelectors getRetryableEvent() {
         return HANDLED_FAILED_DIAGNOSTICS_COLLECTION_EVENT;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaService.java
@@ -13,9 +13,17 @@ import com.sequenceiq.freeipa.converter.freeipa.FreeIpaServerRequestToFreeIpaCon
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.repository.FreeIpaRepository;
+import com.sequenceiq.freeipa.service.stack.StackService;
+import com.sequenceiq.freeipa.util.CrnService;
 
 @Service
 public class FreeIpaService implements ResourceIdProvider {
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private CrnService crnService;
 
     @Inject
     private FreeIpaRepository repository;
@@ -43,5 +51,10 @@ public class FreeIpaService implements ResourceIdProvider {
 
     public List<FreeIpa> getAllByAccountId(String accountId) {
         return repository.findByAccountId(accountId);
+    }
+
+    @Override
+    public Long getResourceIdByResourceCrn(String environmentCrn) {
+        return stackService.getByEnvironmentCrnAndAccountId(environmentCrn, crnService.getCurrentAccountId()).getId();
     }
 }


### PR DESCRIPTION
- new api call for freeipa/datalake/datahub
- enhance response with flow details (get recent data from flows - not the last step - the step before that)
- added converters to transform data + figuring out the state (FAILED,FINISHED,IN_PROGRESS, IN_PROGRESS covers when that if the flow is running or pending)
- find stack by env crn for FlowLogDBService -> ResourceIdProvider implemented by FreeipaService, so adding the implementation there
- new SQL query for getting recent flow (there is a subquery there, but the subquery response already narrow)
- calcuate flow progress percentage -> only for flows that are ordered, can be provided by override a new method - change abstract flow configuration for achieving this

See detailed description in the commit message.