### PR TITLE
CB-10614 add RDS to the VPC interface endpoint list

### DIFF
--- a/environment/src/main/resources/application.yml
+++ b/environment/src/main/resources/application.yml
@@ -176,7 +176,7 @@ cb:
       gateway:
         services: s3,dynamodb
       interface:
-        services: autoscaling,cloudformation,ec2,ecr.api,ecr.dkr,elasticfilesystem,elasticloadbalancing,sts
+        services: autoscaling,cloudformation,ec2,ecr.api,ecr.dkr,elasticfilesystem,elasticloadbalancing,sts,rds
     credential.cache.ttl: 60
   arm:
     network:


### PR DESCRIPTION
You can establish a private connection between your VPC and Amazon RDS API
endpoints by creating an interface VPC endpoint. AWS PrivateLink enables you
to privately access Amazon RDS API operations without an internet gateway,
NAT device, VPN connection, or AWS Direct Connect connection. Instances in
your VPC don't need public IP addresses to communicate with Amazon RDS API
endpoints to launch, modify, or terminate DB instances. Your instances also
don't need public IP addresses to use any of the available RDS API operations.
Traffic between your VPC and Amazon RDS doesn't leave the Amazon network.

