### PR TITLE
Flowchain names

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
@@ -1,16 +1,18 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.backup.DatabaseBackupEvent.DATABASE_BACKUP_EVENT;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.DatabaseBackupTriggerEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
-import org.springframework.stereotype.Component;
-
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
-import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.backup.DatabaseBackupEvent.DATABASE_BACKUP_EVENT;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class BackupDatalakeDatabaseFlowEventChainFactory implements FlowEventChainFactory<DatabaseBackupTriggerEvent> {
@@ -20,11 +22,11 @@ public class BackupDatalakeDatabaseFlowEventChainFactory implements FlowEventCha
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(DatabaseBackupTriggerEvent event) {
-        Queue<Selectable> chain = new ConcurrentLinkedQueue<>();
-        chain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
-        chain.add(new DatabaseBackupTriggerEvent(DATABASE_BACKUP_EVENT.event(), event.getResourceId(),
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(DatabaseBackupTriggerEvent event) {
+        Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
+        flowEventChain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
+        flowEventChain.add(new DatabaseBackupTriggerEvent(DATABASE_BACKUP_EVENT.event(), event.getResourceId(),
                 event.getBackupLocation(), event.getBackupId()));
-        return chain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterMaintenanceModeFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterMaintenanceModeFlowEventChainFactory.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.core.flow2.event.StackSyncTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.sync.StackSyncEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class ClusterMaintenanceModeFlowEventChainFactory implements FlowEventChainFactory<MaintenanceModeValidationTriggerEvent> {
@@ -23,12 +24,12 @@ public class ClusterMaintenanceModeFlowEventChainFactory implements FlowEventCha
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(MaintenanceModeValidationTriggerEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(MaintenanceModeValidationTriggerEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackSyncTriggerEvent(StackSyncEvent.STACK_SYNC_EVENT.event(), event.getResourceId(), true, event.accepted()));
         flowEventChain.add(new StackEvent(CLUSTER_SYNC_EVENT.event(), event.getResourceId()));
         flowEventChain.add(new MaintenanceModeValidationTriggerEvent(
                 MaintenanceModeValidationEvent.START_VALIDATION_FLOW_EVENT.event(), event.getResourceId()));
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
@@ -40,6 +40,7 @@ import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory<ClusterRepairTriggerEvent> {
@@ -65,9 +66,9 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(ClusterRepairTriggerEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(ClusterRepairTriggerEvent event) {
         RepairConfig repairConfig = createRepairConfig(event);
-        return createFlowTriggers(event, repairConfig);
+        return new FlowTriggerEventQueue(getName(), createFlowTriggers(event, repairConfig));
     }
 
     private RepairConfig createRepairConfig(ClusterRepairTriggerEvent event) {
@@ -152,7 +153,7 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
     }
 
     private StackAndClusterUpscaleTriggerEvent fullUpscaleEvent(ClusterRepairTriggerEvent event, String hostGroupName, List<String> hostNames,
-                                                                boolean singlePrimaryGateway, boolean restartServices, boolean kerberosSecured) {
+            boolean singlePrimaryGateway, boolean restartServices, boolean kerberosSecured) {
         Stack stack = stackService.getByIdWithListsInTransaction(event.getStackId());
         boolean singleNodeCluster = clusterService.isSingleNode(stack);
         ClusterManagerType cmType = ClusterManagerType.CLOUDERA_MANAGER;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/DownscaleFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/DownscaleFlowEventChainFactory.java
@@ -25,6 +25,7 @@ import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class DownscaleFlowEventChainFactory implements FlowEventChainFactory<ClusterAndStackDownscaleTriggerEvent> {
@@ -40,7 +41,7 @@ public class DownscaleFlowEventChainFactory implements FlowEventChainFactory<Clu
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(ClusterAndStackDownscaleTriggerEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(ClusterAndStackDownscaleTriggerEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         ClusterScaleTriggerEvent cste;
         cste = event.getPrivateIds() == null
@@ -60,6 +61,6 @@ public class DownscaleFlowEventChainFactory implements FlowEventChainFactory<Clu
                     : new StackDownscaleTriggerEvent(STACK_DOWNSCALE_EVENT.event(), event.getResourceId(), instanceGroupName, event.getPrivateIds());
             flowEventChain.add(sste);
         }
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/EphemeralFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/EphemeralFlowEventChainFactory.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.core.flow2.chain;
 
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
@@ -10,12 +9,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
 import com.sequenceiq.cloudbreak.domain.projection.StackIdView;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.EphemeralClustersUpgradeTriggerEvent;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class EphemeralFlowEventChainFactory implements FlowEventChainFactory<EphemeralClustersUpgradeTriggerEvent> {
@@ -34,7 +33,7 @@ public class EphemeralFlowEventChainFactory implements FlowEventChainFactory<Eph
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(EphemeralClustersUpgradeTriggerEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(EphemeralClustersUpgradeTriggerEvent event) {
         Set<StackIdView> ephemeralStacks = stackService.findClustersConnectedToDatalake(event.getResourceId());
         for (StackIdView stack : ephemeralStacks) {
             try {
@@ -43,6 +42,6 @@ public class EphemeralFlowEventChainFactory implements FlowEventChainFactory<Eph
                 LOGGER.debug("Cannot trigger ephemeral cluster update for stack: " + stack.getName(), e);
             }
         }
-        return new ConcurrentLinkedDeque<>();
+        return new FlowTriggerEventQueue(getName(), new ConcurrentLinkedDeque<>());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/MultiHostgroupDownscaleFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/MultiHostgroupDownscaleFlowEventChainFactory.java
@@ -18,6 +18,7 @@ import com.sequenceiq.cloudbreak.core.flow2.event.MultiHostgroupClusterAndStackD
 import com.sequenceiq.cloudbreak.core.flow2.event.StackDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackScaleTriggerEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class MultiHostgroupDownscaleFlowEventChainFactory implements FlowEventChainFactory<MultiHostgroupClusterAndStackDownscaleTriggerEvent> {
@@ -28,7 +29,7 @@ public class MultiHostgroupDownscaleFlowEventChainFactory implements FlowEventCh
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(MultiHostgroupClusterAndStackDownscaleTriggerEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(MultiHostgroupClusterAndStackDownscaleTriggerEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         for (Entry<String, Set<Long>> entry : event.getInstanceIdsByHostgroupMap().entrySet()) {
             ClusterScaleTriggerEvent cste;
@@ -41,6 +42,6 @@ public class MultiHostgroupDownscaleFlowEventChainFactory implements FlowEventCh
                 flowEventChain.add(sste);
             }
         }
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ProperTerminationFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ProperTerminationFlowEventChainFactory.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminati
 import com.sequenceiq.cloudbreak.core.flow2.stack.termination.StackTerminationEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.TerminationEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class ProperTerminationFlowEventChainFactory implements FlowEventChainFactory<TerminationEvent> {
@@ -21,11 +22,11 @@ public class ProperTerminationFlowEventChainFactory implements FlowEventChainFac
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(TerminationEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(TerminationEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new TerminationEvent(ClusterTerminationEvent.PROPER_TERMINATION_EVENT.event(), event.getResourceId(), event.getForced()));
         flowEventChain.add(new TerminationEvent(START_EXTERNAL_DATABASE_TERMINATION_EVENT.event(), event.getResourceId(), event.getForced()));
         flowEventChain.add(new TerminationEvent(StackTerminationEvent.TERMINATION_EVENT.event(), event.getResourceId(), event.getForced(), event.accepted()));
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ProvisionFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ProvisionFlowEventChainFactory.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class ProvisionFlowEventChainFactory implements FlowEventChainFactory<StackEvent> {
@@ -23,7 +24,7 @@ public class ProvisionFlowEventChainFactory implements FlowEventChainFactory<Sta
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(StackEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(StackEvent event) {
 
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackEvent(VALIDATE_CLOUD_CONFIG_EVENT.event(), event.getResourceId(), event.accepted()));
@@ -31,6 +32,6 @@ public class ProvisionFlowEventChainFactory implements FlowEventChainFactory<Sta
         flowEventChain.add(new StackEvent(START_EXTERNAL_DATABASE_CREATION_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new StackEvent(START_CREATION_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new StackEvent(CLUSTER_CREATION_EVENT.event(), event.getResourceId()));
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ResetFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ResetFlowEventChainFactory.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StartClusterSuccess;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class ResetFlowEventChainFactory implements FlowEventChainFactory<StackEvent> {
@@ -21,10 +22,10 @@ public class ResetFlowEventChainFactory implements FlowEventChainFactory<StackEv
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(StackEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(StackEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackEvent(CLUSTER_RESET_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new StartClusterSuccess(CLUSTER_INSTALL_EVENT.event(), event.getResourceId()));
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/RotateClusterCertificatesFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/RotateClusterCertificatesFlowEventChainFactory.java
@@ -11,6 +11,7 @@ import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterCertificatesRotationTriggerEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class RotateClusterCertificatesFlowEventChainFactory implements FlowEventChainFactory<ClusterCertificatesRotationTriggerEvent> {
@@ -20,11 +21,11 @@ public class RotateClusterCertificatesFlowEventChainFactory implements FlowEvent
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(ClusterCertificatesRotationTriggerEvent event) {
-        Queue<Selectable> chain = new ConcurrentLinkedQueue<>();
-        chain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
-        chain.add(new ClusterCertificatesRotationTriggerEvent(ClusterCertificatesRotationEvent.CLUSTER_CMCA_ROTATION_EVENT.event(), event.getResourceId(),
-                event.accepted(), event.getCertificateRotationType()));
-        return chain;
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(ClusterCertificatesRotationTriggerEvent event) {
+        Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
+        flowEventChain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
+        flowEventChain.add(new ClusterCertificatesRotationTriggerEvent(ClusterCertificatesRotationEvent.CLUSTER_CMCA_ROTATION_EVENT.event(),
+                event.getResourceId(), event.accepted(), event.getCertificateRotationType()));
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StackImageUpdateFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StackImageUpdateFlowEventChainFactory.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.core.flow2.stack.image.update.StackImageUpdateE
 import com.sequenceiq.cloudbreak.core.flow2.stack.sync.StackSyncEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class StackImageUpdateFlowEventChainFactory implements FlowEventChainFactory<StackImageUpdateTriggerEvent> {
@@ -23,12 +24,12 @@ public class StackImageUpdateFlowEventChainFactory implements FlowEventChainFact
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(StackImageUpdateTriggerEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(StackImageUpdateTriggerEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackSyncTriggerEvent(StackSyncEvent.STACK_SYNC_EVENT.event(), event.getResourceId(), true, event.accepted()));
         flowEventChain.add(new StackEvent(CLUSTER_SYNC_EVENT.event(), event.getResourceId()));
         flowEventChain.add(new StackImageUpdateTriggerEvent(StackImageUpdateEvent.STACK_IMAGE_UPDATE_EVENT.event(), event.getResourceId(), event.getNewImageId(),
                 event.getImageCatalogName(), event.getImageCatalogUrl()));
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StackRepairFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StackRepairFlowEventChainFactory.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.StackRepairTriggerEvent;
 import com.sequenceiq.cloudbreak.service.stack.repair.UnhealthyInstances;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class StackRepairFlowEventChainFactory implements FlowEventChainFactory<StackRepairTriggerEvent> {
@@ -23,18 +24,18 @@ public class StackRepairFlowEventChainFactory implements FlowEventChainFactory<S
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(StackRepairTriggerEvent event) {
-        Queue<Selectable> flowChainTriggers = new ConcurrentLinkedDeque<>();
-        flowChainTriggers.add(new StackEvent(FlowChainTriggers.FULL_SYNC_TRIGGER_EVENT, event.getResourceId(), event.accepted()));
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(StackRepairTriggerEvent event) {
+        Queue<Selectable> flowEventChain = new ConcurrentLinkedDeque<>();
+        flowEventChain.add(new StackEvent(FlowChainTriggers.FULL_SYNC_TRIGGER_EVENT, event.getResourceId(), event.accepted()));
         UnhealthyInstances unhealthyInstances = event.getUnhealthyInstances();
         String fullUpscaleTriggerEvent = FlowChainTriggers.FULL_UPSCALE_TRIGGER_EVENT;
         for (String hostGroupName : unhealthyInstances.getHostGroups()) {
             List<String> instances = unhealthyInstances.getInstancesForGroup(hostGroupName);
-            flowChainTriggers.add(
+            flowEventChain.add(
                     new StackAndClusterUpscaleTriggerEvent(fullUpscaleTriggerEvent, event.getResourceId(), hostGroupName,
                             instances.size(), ScalingType.UPSCALE_TOGETHER));
         }
-        return flowChainTriggers;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StartFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StartFlowEventChainFactory.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class StartFlowEventChainFactory implements FlowEventChainFactory<StackEvent> {
@@ -22,11 +23,11 @@ public class StartFlowEventChainFactory implements FlowEventChainFactory<StackEv
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(StackEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(StackEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackEvent(STACK_START_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new StackEvent(EXTERNAL_DATABASE_COMMENCE_START_EVENT.event(), event.getResourceId()));
         flowEventChain.add(new StackEvent(CLUSTER_START_EVENT.event(), event.getResourceId()));
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StopFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/StopFlowEventChainFactory.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class StopFlowEventChainFactory implements FlowEventChainFactory<StackEvent> {
@@ -21,11 +22,11 @@ public class StopFlowEventChainFactory implements FlowEventChainFactory<StackEve
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(StackEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(StackEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackEvent(CLUSTER_STOP_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new StackEvent(EXTERNAL_DATABASE_COMMENCE_STOP_EVENT.event(), event.getResourceId()));
         flowEventChain.add(new StackEvent(STACK_STOP_EVENT.event(), event.getResourceId()));
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/SyncFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/SyncFlowEventChainFactory.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.event.StackSyncTriggerEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class SyncFlowEventChainFactory implements FlowEventChainFactory<StackEvent> {
@@ -21,10 +22,10 @@ public class SyncFlowEventChainFactory implements FlowEventChainFactory<StackEve
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(StackEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(StackEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackSyncTriggerEvent(STACK_SYNC_EVENT.event(), event.getResourceId(), true, event.accepted()));
         flowEventChain.add(new StackEvent(CLUSTER_SYNC_EVENT.event(), event.getResourceId()));
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/TerminationFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/TerminationFlowEventChainFactory.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.core.flow2.stack.termination.StackTerminationEv
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.TerminationEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class TerminationFlowEventChainFactory implements FlowEventChainFactory<TerminationEvent> {
@@ -22,11 +23,11 @@ public class TerminationFlowEventChainFactory implements FlowEventChainFactory<T
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(TerminationEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(TerminationEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackEvent(ClusterTerminationEvent.TERMINATION_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new TerminationEvent(START_EXTERNAL_DATABASE_TERMINATION_EVENT.event(), event.getResourceId(), event.getForced(), event.accepted()));
         flowEventChain.add(new TerminationEvent(StackTerminationEvent.TERMINATION_EVENT.event(), event.getResourceId(), event.getForced(), event.accepted()));
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDatalakeFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpgradeDatalakeFlowEventChainFactory.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update.SaltUpdateEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterUpgradeTriggerEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class UpgradeDatalakeFlowEventChainFactory implements FlowEventChainFactory<ClusterUpgradeTriggerEvent> {
@@ -21,10 +22,11 @@ public class UpgradeDatalakeFlowEventChainFactory implements FlowEventChainFacto
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(ClusterUpgradeTriggerEvent event) {
-        Queue<Selectable> chain = new ConcurrentLinkedQueue<>();
-        chain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
-        chain.add(new ClusterUpgradeTriggerEvent(CLUSTER_UPGRADE_INIT_EVENT.event(), event.getResourceId(), event.accepted(), event.getImageId()));
-        return chain;
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(ClusterUpgradeTriggerEvent event) {
+        Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
+        flowEventChain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
+        flowEventChain.add(new ClusterUpgradeTriggerEvent(CLUSTER_UPGRADE_INIT_EVENT.event(), event.getResourceId(),
+                event.accepted(), event.getImageId()));
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpscaleFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/UpscaleFlowEventChainFactory.java
@@ -25,6 +25,7 @@ import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 @Component
 public class UpscaleFlowEventChainFactory implements FlowEventChainFactory<StackAndClusterUpscaleTriggerEvent> {
@@ -40,14 +41,14 @@ public class UpscaleFlowEventChainFactory implements FlowEventChainFactory<Stack
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(StackAndClusterUpscaleTriggerEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(StackAndClusterUpscaleTriggerEvent event) {
         StackView stackView = stackService.getViewByIdWithoutAuth(event.getResourceId());
         ClusterView clusterView = stackView.getClusterView();
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         addStackSyncTriggerEvent(event, flowEventChain);
         addStackScaleTriggerEvent(event, flowEventChain);
         addClusterScaleTriggerEventIfNeeded(event, stackView, clusterView, flowEventChain);
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 
     private void addStackSyncTriggerEvent(StackAndClusterUpscaleTriggerEvent event, Queue<Selectable> flowEventChain) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
@@ -192,7 +192,7 @@ public class OfflineStateGenerator {
 
     private Flow initializeFlow() throws Exception {
         ((AbstractFlowConfiguration<?, ?>) flowConfiguration).init();
-        Flow flow = flowConfiguration.createFlow("", "", 0L);
+        Flow flow = flowConfiguration.createFlow("", "", 0L, "");
         flow.initialize(Map.of());
         return flow;
     }

--- a/core/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
+++ b/core/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
@@ -1,0 +1,9 @@
+-- // CB-11220 introduce flowChainType into the flowChainLog table
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE flowchainlog ADD COLUMN flowchaintype CHARACTER VARYING (255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE flowchainlog DROP COLUMN IF EXISTS flowchaintype;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactoryTest.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -36,6 +35,7 @@ import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 public class ClusterRepairFlowEventChainFactoryTest {
 
@@ -89,9 +89,9 @@ public class ClusterRepairFlowEventChainFactoryTest {
         when(stackService.findClustersConnectedToDatalakeByDatalakeStackId(STACK_ID)).thenReturn(Set.of());
         setupHostGroup(true);
 
-        Queue<Selectable> eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedPrimaryGateway().build());
+        FlowTriggerEventQueue eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedPrimaryGateway().build());
 
-        List<String> triggeredOperations = eventQueues.stream().map(Selectable::selector).collect(Collectors.toList());
+        List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of("STACK_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
                 "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT"), triggeredOperations);
@@ -103,9 +103,9 @@ public class ClusterRepairFlowEventChainFactoryTest {
         when(stackService.findClustersConnectedToDatalakeByDatalakeStackId(STACK_ID)).thenReturn(Set.of(ATTACHED_WORKLOAD));
         setupHostGroup(true);
 
-        Queue<Selectable> eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedPrimaryGateway().build());
+        FlowTriggerEventQueue eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedPrimaryGateway().build());
 
-        List<String> triggeredOperations = eventQueues.stream().map(Selectable::selector).collect(Collectors.toList());
+        List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of("STACK_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
                 "EPHEMERAL_CLUSTERS_UPDATE_TRIGGER_EVENT",
@@ -123,10 +123,10 @@ public class ClusterRepairFlowEventChainFactoryTest {
         when(hostGroupService.findHostGroupInClusterByName(anyLong(), eq("hostGroup-core"))).thenReturn(Optional.of(coreHostGroup));
         setupPrimaryGateway();
 
-        Queue<Selectable> eventQueues = underTest.createFlowTriggerEventQueue(
+        FlowTriggerEventQueue eventQueues = underTest.createFlowTriggerEventQueue(
                 new TriggerEventBuilder(stack).withFailedPrimaryGateway().withFailedCore().build());
 
-        List<String> triggeredOperations = eventQueues.stream().map(Selectable::selector).collect(Collectors.toList());
+        List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of("STACK_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
                 "FULL_DOWNSCALE_TRIGGER_EVENT",
@@ -141,9 +141,9 @@ public class ClusterRepairFlowEventChainFactoryTest {
         when(stackService.findClustersConnectedToDatalakeByDatalakeStackId(STACK_ID)).thenReturn(Set.of());
         setupHostGroup(true);
 
-        Queue<Selectable> eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedPrimaryGateway().build());
+        FlowTriggerEventQueue eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedPrimaryGateway().build());
 
-        List<String> triggeredOperations = eventQueues.stream().map(Selectable::selector).collect(Collectors.toList());
+        List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of(
                 "CHANGE_PRIMARY_GATEWAY_TRIGGER_EVENT",
                 "FULL_DOWNSCALE_TRIGGER_EVENT",
@@ -157,9 +157,9 @@ public class ClusterRepairFlowEventChainFactoryTest {
         when(stackService.findClustersConnectedToDatalakeByDatalakeStackId(STACK_ID)).thenReturn(Set.of(ATTACHED_WORKLOAD));
         setupHostGroup(true);
 
-        Queue<Selectable> eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedPrimaryGateway().build());
+        FlowTriggerEventQueue eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedPrimaryGateway().build());
 
-        List<String> triggeredOperations = eventQueues.stream().map(Selectable::selector).collect(Collectors.toList());
+        List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of(
                 "CHANGE_PRIMARY_GATEWAY_TRIGGER_EVENT",
                 "FULL_DOWNSCALE_TRIGGER_EVENT",
@@ -174,9 +174,9 @@ public class ClusterRepairFlowEventChainFactoryTest {
         when(stackService.findClustersConnectedToDatalakeByDatalakeStackId(STACK_ID)).thenReturn(Set.of(ATTACHED_WORKLOAD));
         setupHostGroup(false);
 
-        Queue<Selectable> eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedCore().build());
+        FlowTriggerEventQueue eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedCore().build());
 
-        List<String> triggeredOperations = eventQueues.stream().map(Selectable::selector).collect(Collectors.toList());
+        List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of("FULL_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
                 "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT"), triggeredOperations);
@@ -188,9 +188,9 @@ public class ClusterRepairFlowEventChainFactoryTest {
         when(stackService.findClustersConnectedToDatalakeByDatalakeStackId(STACK_ID)).thenReturn(Set.of());
         setupHostGroup(false);
 
-        Queue<Selectable> eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedCore().build());
+        FlowTriggerEventQueue eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedCore().build());
 
-        List<String> triggeredOperations = eventQueues.stream().map(Selectable::selector).collect(Collectors.toList());
+        List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of("FULL_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
                 "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT"), triggeredOperations);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/MultiHostgroupDownscaleFlowEventChainFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/MultiHostgroupDownscaleFlowEventChainFactoryTest.java
@@ -36,7 +36,7 @@ public class MultiHostgroupDownscaleFlowEventChainFactoryTest {
         ClusterDownscaleDetails details = new ClusterDownscaleDetails();
         MultiHostgroupClusterAndStackDownscaleTriggerEvent event = new MultiHostgroupClusterAndStackDownscaleTriggerEvent("selector", 1L,
                 instanceIdsByHostgroupMap, details, ScalingType.DOWNSCALE_TOGETHER, new Promise<>());
-        Queue<Selectable> queue = underTest.createFlowTriggerEventQueue(event);
+        Queue<Selectable> queue = underTest.createFlowTriggerEventQueue(event).getQueue();
         assertEquals(4L, queue.size());
         assertEquals(DECOMMISSION_EVENT.event(), queue.poll().selector());
         assertEquals(STACK_DOWNSCALE_EVENT.event(), queue.poll().selector());

--- a/datalake/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
+++ b/datalake/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
@@ -1,0 +1,9 @@
+-- // CB-11220 introduce flowChainType into the flowChainLog table
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE flowchainlog ADD COLUMN flowchaintype CHARACTER VARYING (255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE flowchainlog DROP COLUMN IF EXISTS flowchaintype;

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/chain/EnvDeleteClustersFlowEventChainFactory.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/chain/EnvDeleteClustersFlowEventChainFactory.java
@@ -18,6 +18,7 @@ import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.flow.deletion.event.EnvDeleteEvent;
 import com.sequenceiq.environment.environment.service.EnvironmentService;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 import reactor.rx.Promise;
 
@@ -33,7 +34,7 @@ public class EnvDeleteClustersFlowEventChainFactory implements FlowEventChainFac
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(EnvDeleteEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(EnvDeleteEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
 
         List<Environment> childEnvironments =
@@ -45,7 +46,7 @@ public class EnvDeleteClustersFlowEventChainFactory implements FlowEventChainFac
 
         flowEventChain.addAll(getFlowEventsForParentEnvironment(event));
 
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 
     private List<Selectable> getFlowEventsForParentEnvironment(EnvDeleteEvent event) {

--- a/environment/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
+++ b/environment/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
@@ -1,0 +1,9 @@
+-- // CB-11220 introduce flowChainType into the flowChainLog table
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE flowchainlog ADD COLUMN flowchaintype CHARACTER VARYING (255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE flowchainlog DROP COLUMN IF EXISTS flowchaintype;

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowConstants.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowConstants.java
@@ -3,6 +3,8 @@ package com.sequenceiq.flow.core;
 public class FlowConstants {
     public static final String FLOW_ID = "FLOW_ID";
 
+    public static final String FLOW_CHAIN_TYPE = "FLOW_CHAIN_TYPE";
+
     public static final String FLOW_CHAIN_ID = "FLOW_CHAIN_ID";
 
     public static final String FLOW_FINAL = "FLOWFINAL";

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
@@ -3,12 +3,11 @@ package com.sequenceiq.flow.core;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.Set;
 
 import com.sequenceiq.cloudbreak.common.event.Payload;
-import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 import com.sequenceiq.flow.domain.FlowChainLog;
 import com.sequenceiq.flow.domain.FlowLog;
 
@@ -24,7 +23,7 @@ public interface FlowLogService {
 
     FlowLog terminate(Long stackId, String flowId) throws TransactionService.TransactionExecutionException;
 
-    void saveChain(String flowChainId, String parentFlowChainId, Queue<Selectable> chain, String flowTriggerUserCrn);
+    void saveChain(String flowChainId, String parentFlowChainId, FlowTriggerEventQueue chain, String flowTriggerUserCrn);
 
     void updateLastFlowLogStatus(FlowLog lastFlowLog, boolean failureEvent);
 

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowChainHandler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowChainHandler.java
@@ -16,6 +16,7 @@ import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.core.Flow2Handler;
 import com.sequenceiq.flow.core.FlowConstants;
 import com.sequenceiq.flow.core.FlowLogService;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 import com.sequenceiq.flow.domain.FlowChainLog;
 
 import reactor.bus.Event;
@@ -47,7 +48,9 @@ public class FlowChainHandler implements Consumer<Event<? extends Payload>> {
     public void restoreFlowChain(String flowChainId) {
         Optional<FlowChainLog> chainLog = flowLogService.findFirstByFlowChainIdOrderByCreatedDesc(flowChainId);
         if (chainLog.isPresent()) {
-            Queue<Selectable> chain = (Queue<Selectable>) JsonReader.jsonToJava(chainLog.get().getChain());
+            String flowChainType = chainLog.get().getFlowChainType();
+            Queue<Selectable> queue = (Queue<Selectable>) JsonReader.jsonToJava(chainLog.get().getChain());
+            FlowTriggerEventQueue chain = new FlowTriggerEventQueue(flowChainType, queue);
             flowChains.putFlowChain(flowChainId, chainLog.get().getParentFlowChainId(), chain);
             if (chainLog.get().getParentFlowChainId() != null) {
                 restoreFlowChain(chainLog.get().getParentFlowChainId());

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowEventChainFactory.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowEventChainFactory.java
@@ -1,12 +1,15 @@
 package com.sequenceiq.flow.core.chain;
 
-import java.util.Queue;
-
 import com.sequenceiq.cloudbreak.common.event.Payload;
-import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 public interface FlowEventChainFactory<P extends Payload> {
+
     String initEvent();
 
-    Queue<Selectable> createFlowTriggerEventQueue(P event);
+    FlowTriggerEventQueue createFlowTriggerEventQueue(P event);
+
+    default String getName() {
+        return getClass().getSimpleName();
+    }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/config/FlowTriggerEventQueue.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/config/FlowTriggerEventQueue.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.flow.core.chain.config;
+
+import java.util.Queue;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+
+public class FlowTriggerEventQueue {
+
+    private final String flowChainName;
+
+    private final Queue<Selectable> queue;
+
+    public FlowTriggerEventQueue(String flowChainName, Queue<Selectable> queue) {
+        this.flowChainName = flowChainName;
+        this.queue = queue;
+    }
+
+    public String getFlowChainName() {
+        return flowChainName;
+    }
+
+    public Queue<Selectable> getQueue() {
+        return queue;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/config/AbstractFlowConfiguration.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/config/AbstractFlowConfiguration.java
@@ -91,10 +91,10 @@ public abstract class AbstractFlowConfiguration<S extends FlowState, E extends F
     }
 
     @Override
-    public Flow createFlow(String flowId, String flowChainId, Long stackId) {
+    public Flow createFlow(String flowId, String flowChainId, Long stackId, String flowChainType) {
         StateMachine<S, E> sm = stateMachineFactory.getStateMachine();
         FlowEventListener<S, E> fl = (FlowEventListener<S, E>) applicationContext.getBean(FlowEventListener.class, getEdgeConfig().initState,
-                getEdgeConfig().finalState, "", getClass().getSimpleName(), flowChainId, flowId, stackId);
+                getEdgeConfig().finalState, flowChainType, getClass().getSimpleName(), flowChainId, flowId, stackId);
         Flow flow = new FlowAdapter<>(flowId, sm, new MessageFactory<>(), new StateConverterAdapter<>(stateType),
                 new EventConverterAdapter<>(eventType), (Class<? extends FlowConfiguration<E>>) getClass(), fl);
         sm.addStateListener(fl);

--- a/flow/src/main/java/com/sequenceiq/flow/core/config/FlowConfiguration.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/config/FlowConfiguration.java
@@ -7,7 +7,7 @@ import com.sequenceiq.flow.core.RestartAction;
 
 public interface FlowConfiguration<E extends FlowEvent> {
 
-    Flow createFlow(String flowId, String flowChainId, Long stackId);
+    Flow createFlow(String flowId, String flowChainId, Long stackId, String flowChainType);
 
     FlowTriggerCondition getFlowTriggerCondition();
 

--- a/flow/src/main/java/com/sequenceiq/flow/core/helloworld/config/HelloWorldFlowChainFactory.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/helloworld/config/HelloWorldFlowChainFactory.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 import com.sequenceiq.flow.reactor.api.event.BaseFlowEvent;
 
 @Component
@@ -19,9 +20,9 @@ public class HelloWorldFlowChainFactory implements FlowEventChainFactory<BaseFlo
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(BaseFlowEvent event) {
-        Queue<Selectable> flowChainTriggers = new ConcurrentLinkedDeque<>();
-        flowChainTriggers.add(new BaseFlowEvent(HELLOWORLD_TRIGGER_EVENT.event(), event.getResourceId(), event.getResourceCrn(), event.accepted()));
-        return flowChainTriggers;
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(BaseFlowEvent event) {
+        Queue<Selectable> flowEventChain = new ConcurrentLinkedDeque<>();
+        flowEventChain.add(new BaseFlowEvent(HELLOWORLD_TRIGGER_EVENT.event(), event.getResourceId(), event.getResourceCrn(), event.accepted()));
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/domain/FlowChainLog.java
+++ b/flow/src/main/java/com/sequenceiq/flow/domain/FlowChainLog.java
@@ -19,6 +19,8 @@ public class FlowChainLog {
 
     private Long created = new Date().getTime();
 
+    private String flowChainType;
+
     @Column(nullable = false)
     private String flowChainId;
 
@@ -33,7 +35,8 @@ public class FlowChainLog {
 
     }
 
-    public FlowChainLog(String flowChainId, String parentFlowChainId, String chain, String flowTriggerUserCrn) {
+    public FlowChainLog(String flowChainType, String flowChainId, String parentFlowChainId, String chain, String flowTriggerUserCrn) {
+        this.flowChainType = flowChainType;
         this.flowChainId = flowChainId;
         this.parentFlowChainId = parentFlowChainId;
         this.chain = chain;
@@ -86,5 +89,13 @@ public class FlowChainLog {
 
     public void setFlowTriggerUserCrn(String flowTriggerUserCrn) {
         this.flowTriggerUserCrn = flowTriggerUserCrn;
+    }
+
+    public String getFlowChainType() {
+        return flowChainType;
+    }
+
+    public void setFlowChainType(String flowChainType) {
+        this.flowChainType = flowChainType;
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
@@ -32,7 +32,15 @@ public class FlowChainLogService {
     private FlowChainLogRepository repository;
 
     public Optional<FlowChainLog> findFirstByFlowChainIdOrderByCreatedDesc(String flowChainId) {
+        if (flowChainId == null) {
+            return Optional.empty();
+        }
         return repository.findFirstByFlowChainIdOrderByCreatedDesc(flowChainId);
+    }
+
+    public String getFlowChainType(String flowChainId) {
+        Optional<FlowChainLog> flowChainLog = findFirstByFlowChainIdOrderByCreatedDesc(flowChainId);
+        return flowChainLog.map(FlowChainLog::getFlowChainType).orElse(null);
     }
 
     public List<FlowChainLog> findByFlowChainIdOrderByCreatedDesc(String flowChainId) {

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
@@ -5,7 +5,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -22,7 +21,6 @@ import com.cedarsoftware.util.io.JsonWriter;
 import com.google.common.base.Joiner;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.common.event.Payload;
-import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
@@ -33,6 +31,7 @@ import com.sequenceiq.flow.core.FlowLogService;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.ResourceIdProvider;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.domain.FlowChainLog;
 import com.sequenceiq.flow.domain.FlowLog;
@@ -117,9 +116,10 @@ public class FlowLogDBService implements FlowLogService {
         });
     }
 
-    public void saveChain(String flowChainId, String parentFlowChainId, Queue<Selectable> chain, String flowTriggerUserCrn) {
-        String chainJson = JsonWriter.objectToJson(chain);
-        FlowChainLog chainLog = new FlowChainLog(flowChainId, parentFlowChainId, chainJson, flowTriggerUserCrn);
+    public void saveChain(String flowChainId, String parentFlowChainId, FlowTriggerEventQueue chain, String flowTriggerUserCrn) {
+        String chainType = chain.getFlowChainName();
+        String chainJson = JsonWriter.objectToJson(chain.getQueue());
+        FlowChainLog chainLog = new FlowChainLog(chainType, flowChainId, parentFlowChainId, chainJson, flowTriggerUserCrn);
         flowChainLogService.save(chainLog);
     }
 

--- a/flow/src/test/java/com/sequenceiq/flow/core/Flow2HandlerTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/Flow2HandlerTest.java
@@ -55,6 +55,7 @@ import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 import com.sequenceiq.flow.domain.FlowLog;
 import com.sequenceiq.flow.domain.StateStatus;
 import com.sequenceiq.flow.ha.NodeConfig;
+import com.sequenceiq.flow.service.flowlog.FlowChainLogService;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.opentracing.Scope;
@@ -82,6 +83,9 @@ public class Flow2HandlerTest {
 
     @Mock
     private FlowLogService flowLogService;
+
+    @Mock
+    private FlowChainLogService flowChainLogService;
 
     @Mock
     private Map<String, FlowConfiguration<?>> flowConfigurationMap;
@@ -187,7 +191,7 @@ public class Flow2HandlerTest {
     @Test
     public void testNewFlow() {
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
-        given(flowConfig.createFlow(anyString(), any(), anyLong())).willReturn(flow);
+        given(flowConfig.createFlow(anyString(), any(), anyLong(), any())).willReturn(flow);
         given(flowConfig.getFlowTriggerCondition()).willReturn(flowTriggerCondition);
         given(flowTriggerCondition.isFlowTriggerable(anyLong())).willReturn(true);
         given(flow.getCurrentState()).willReturn(flowState);
@@ -204,7 +208,7 @@ public class Flow2HandlerTest {
     @Test
     public void testFlowCanNotBeSaved() {
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
-        given(flowConfig.createFlow(anyString(), any(), anyLong())).willReturn(flow);
+        given(flowConfig.createFlow(anyString(), any(), anyLong(), any())).willReturn(flow);
         given(flowConfig.getFlowTriggerCondition()).willReturn(flowTriggerCondition);
         given(flowTriggerCondition.isFlowTriggerable(anyLong())).willReturn(true);
         given(flow.getCurrentState()).willReturn(flowState);
@@ -227,7 +231,7 @@ public class Flow2HandlerTest {
         given(helloWorldFlowConfig.getFlowTriggerCondition()).willReturn(new DefaultFlowTriggerCondition());
 
         BDDMockito.<FlowConfiguration<?>>given(flowConfigurationMap.get(any())).willReturn(helloWorldFlowConfig);
-        given(helloWorldFlowConfig.createFlow(anyString(), any(), anyLong())).willReturn(flow);
+        given(helloWorldFlowConfig.createFlow(anyString(), any(), anyLong(), any())).willReturn(flow);
         given(helloWorldFlowConfig.getFlowTriggerCondition()).willReturn(flowTriggerCondition);
         given(flowTriggerCondition.isFlowTriggerable(anyLong())).willReturn(true);
         given(flow.getCurrentState()).willReturn(flowState);

--- a/flow/src/test/java/com/sequenceiq/flow/core/config/AbstractFlowConfigurationTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/config/AbstractFlowConfigurationTest.java
@@ -75,7 +75,7 @@ public class AbstractFlowConfigurationTest {
         edgeConfig = new FlowEdgeConfig<>(State.INIT, State.FINAL, State.FAILED, Event.FAIL_HANDLED);
         ((AbstractFlowConfiguration<State, Event>) underTest).init();
         Mockito.verify(applicationContext, Mockito.times(8)).getBean(ArgumentMatchers.anyString(), ArgumentMatchers.any(Class.class));
-        flow = underTest.createFlow("flowId", "flowChainId", 0L);
+        flow = underTest.createFlow("flowId", "flowChainId", 0L, "flowChainType");
         flow.initialize(Map.of());
     }
 

--- a/flow/src/test/java/com/sequenceiq/flow/service/flowlog/FlowChainLogServiceTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/service/flowlog/FlowChainLogServiceTest.java
@@ -2,7 +2,9 @@ package com.sequenceiq.flow.service.flowlog;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -100,6 +102,33 @@ public class FlowChainLogServiceTest {
                 flowChainLog("2", true, 2L)
         );
         assertTrue(underTest.hasEventInFlowChainQueue(flowChains));
+    }
+
+    @Test
+    public void testFlowTypeEmpty() {
+        String flowChainType = underTest.getFlowChainType(null);
+        assertNull("For null input the flowChainType must be null", flowChainType);
+    }
+
+    @Test
+    public void testFlowChainLogWhichIsEmpty() {
+        // This is mainly for flows launched before 2.39
+        FlowChainLog flowChainLog = new FlowChainLog();
+        when(flowLogRepository.findFirstByFlowChainIdOrderByCreatedDesc(any()))
+                .thenReturn(Optional.of(flowChainLog));
+        String flowChainType = underTest.getFlowChainType("chainId");
+        assertNull("For empty flowChainLog the reurn must be null", flowChainType);
+    }
+
+    @Test
+    public void testFlowChainLogWithFlowChainType() {
+        // This is mainly for flows launched before 2.39
+        FlowChainLog flowChainLog = new FlowChainLog();
+        flowChainLog.setFlowChainType("flowChainType");
+        when(flowLogRepository.findFirstByFlowChainIdOrderByCreatedDesc(any()))
+                .thenReturn(Optional.of(flowChainLog));
+        String flowChainType = underTest.getFlowChainType("chainId");
+        assertEquals("flowChainType", flowChainType);
     }
 
     private FlowChainLog flowChainLog(String flowChainId, String parentFlowChainId, long created) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/ProvisionFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/ProvisionFlowEventChainFactory.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionEvent;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 import com.sequenceiq.freeipa.flow.stack.provision.StackProvisionEvent;
@@ -19,11 +20,11 @@ public class ProvisionFlowEventChainFactory implements FlowEventChainFactory<Sta
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(StackEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(StackEvent event) {
 
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackEvent(StackProvisionEvent.START_CREATION_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new StackEvent(FreeIpaProvisionEvent.FREEIPA_PROVISION_EVENT.event(), event.getResourceId()));
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/RepairFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/RepairFlowEventChainFactory.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.event.DownscaleEvent;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowEvent;
@@ -27,7 +28,7 @@ public class RepairFlowEventChainFactory implements FlowEventChainFactory<Repair
     }
 
     @Override
-    public Queue<Selectable> createFlowTriggerEventQueue(RepairEvent event) {
+    public FlowTriggerEventQueue createFlowTriggerEventQueue(RepairEvent event) {
         Set<String> terminatedOrRemovedInstanceIdsSet = new HashSet<>(event.getRepairInstanceIds());
         terminatedOrRemovedInstanceIdsSet.addAll(event.getAdditionalTerminatedInstanceIds());
         List<String> terminatedOrRemovedInstanceIds = terminatedOrRemovedInstanceIdsSet.stream().collect(Collectors.toList());
@@ -42,6 +43,6 @@ public class RepairFlowEventChainFactory implements FlowEventChainFactory<Repair
                 event.getResourceId(), event.getInstanceCountByGroup(), Boolean.TRUE, event.getOperationId()));
         flowEventChain.add(new ChangePrimaryGatewayEvent(ChangePrimaryGatewayFlowEvent.CHANGE_PRIMARY_GATEWAY_EVENT.event(), event.getResourceId(),
                 terminatedOrRemovedInstanceIds, Boolean.TRUE, event.getOperationId()));
-        return flowEventChain;
+        return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 }

--- a/freeipa/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
+++ b/freeipa/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
@@ -1,0 +1,9 @@
+-- // CB-11220 introduce flowChainType into the flowChainLog table
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE flowchainlog ADD COLUMN flowchaintype CHARACTER VARYING (255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE flowchainlog DROP COLUMN IF EXISTS flowchaintype;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/chain/RepairFlowEventChainFactoryTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/chain/RepairFlowEventChainFactoryTest.java
@@ -40,7 +40,7 @@ public class RepairFlowEventChainFactoryTest {
         RepairEvent event = new RepairEvent(FlowChainTriggers.REPAIR_TRIGGER_EVENT, STACK_ID,
                 OPERATION_ID, INSTANCE_COUNT_BY_GROUP, INSTANCE_IDS_TO_REPAIR, TERMINATED_INSTANCE_IDS);
 
-        Queue<Selectable> eventQueues = underTest.createFlowTriggerEventQueue(event);
+        Queue<Selectable> eventQueues = underTest.createFlowTriggerEventQueue(event).getQueue();
 
         List<String> triggeredOperations = eventQueues.stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of("CHANGE_PRIMARY_GATEWAY_EVENT", "DOWNSCALE_EVENT", "UPSCALE_EVENT", "CHANGE_PRIMARY_GATEWAY_EVENT"), triggeredOperations);

--- a/redbeams/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
+++ b/redbeams/src/main/resources/schema/app/20210217140634_CB-11220_introduce_flowChainType_into_the_flowChainLog_table.sql
@@ -1,0 +1,9 @@
+-- // CB-11220 introduce flowChainType into the flowChainLog table
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE flowchainlog ADD COLUMN flowchaintype CHARACTER VARYING (255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE flowchainlog DROP COLUMN IF EXISTS flowchaintype;

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/FlowDetails.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/FlowDetails.java
@@ -102,4 +102,18 @@ public class FlowDetails implements Serializable {
     public void setDuration(Long duration) {
         this.duration = duration;
     }
+
+    @Override
+    public String toString() {
+        return "FlowDetails{" +
+                "flowChainType='" + flowChainType + '\'' +
+                ", flowType='" + flowType + '\'' +
+                ", flowChainId='" + flowChainId + '\'' +
+                ", flowId='" + flowId + '\'' +
+                ", flowState='" + flowState + '\'' +
+                ", nextFlowState='" + nextFlowState + '\'' +
+                ", flowEvent='" + flowEvent + '\'' +
+                ", duration=" + duration +
+                '}';
+    }
 }

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
@@ -25,6 +25,7 @@ public class ClusterUseCaseMapper {
         } else if (clusterRequestProcessingStepMapper.isLastStep(flow)) {
             useCase = lastStepToUseCaseMapping(flow.getFlowState());
         }
+        LOGGER.debug("FlowDetails: {}, Usecase: {}", flow, useCase);
         return useCase;
     }
 


### PR DESCRIPTION
With this commit the name of the flowchain is passed to flow and also passed to the structured events. The benefit of this is that we can create EDH events based on the FlowChain names which highly simplifies the switch case statements in ClusterUseCaseMapper and EnvironmentUseCaseMapper classes. I have no intention to track the parents of the FlowChains since tracking the child FLowChain provides enough details for us.

The ClusterUseCaseMapper and EnvironmentUseCaseMapper is going to be refactored in the next commit.