### PR TITLE
CDPAM-1344: Cloudbreak needs to add environmentCrn to CCMv2 registration for DLs (1/2)

### DIFF
--- a/ccm-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/clusterconnectivitymanagementv2/ClusterConnectivityManagementV2Grpc.java
+++ b/ccm-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/clusterconnectivitymanagementv2/ClusterConnectivityManagementV2Grpc.java
@@ -215,6 +215,80 @@ public final class ClusterConnectivityManagementV2Grpc {
      }
      return getUnregisterAgentMethod;
   }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getListAgentsMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest,
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse> METHOD_LIST_AGENTS = getListAgentsMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest,
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse> getListAgentsMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest,
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse> getListAgentsMethod() {
+    return getListAgentsMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest,
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse> getListAgentsMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse> getListAgentsMethod;
+    if ((getListAgentsMethod = ClusterConnectivityManagementV2Grpc.getListAgentsMethod) == null) {
+      synchronized (ClusterConnectivityManagementV2Grpc.class) {
+        if ((getListAgentsMethod = ClusterConnectivityManagementV2Grpc.getListAgentsMethod) == null) {
+          ClusterConnectivityManagementV2Grpc.getListAgentsMethod = getListAgentsMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "clusterconnectivitymanagementv2.ClusterConnectivityManagementV2", "ListAgents"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new ClusterConnectivityManagementV2MethodDescriptorSupplier("ListAgents"))
+                  .build();
+          }
+        }
+     }
+     return getListAgentsMethod;
+  }
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @java.lang.Deprecated // Use {@link #getGetAllAgentsCertificatesMethod()} instead. 
+  public static final io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest,
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse> METHOD_GET_ALL_AGENTS_CERTIFICATES = getGetAllAgentsCertificatesMethodHelper();
+
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest,
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse> getGetAllAgentsCertificatesMethod;
+
+  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest,
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse> getGetAllAgentsCertificatesMethod() {
+    return getGetAllAgentsCertificatesMethodHelper();
+  }
+
+  private static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest,
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse> getGetAllAgentsCertificatesMethodHelper() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse> getGetAllAgentsCertificatesMethod;
+    if ((getGetAllAgentsCertificatesMethod = ClusterConnectivityManagementV2Grpc.getGetAllAgentsCertificatesMethod) == null) {
+      synchronized (ClusterConnectivityManagementV2Grpc.class) {
+        if ((getGetAllAgentsCertificatesMethod = ClusterConnectivityManagementV2Grpc.getGetAllAgentsCertificatesMethod) == null) {
+          ClusterConnectivityManagementV2Grpc.getGetAllAgentsCertificatesMethod = getGetAllAgentsCertificatesMethod = 
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(
+                  "clusterconnectivitymanagementv2.ClusterConnectivityManagementV2", "GetAllAgentsCertificates"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse.getDefaultInstance()))
+                  .setSchemaDescriptor(new ClusterConnectivityManagementV2MethodDescriptorSupplier("GetAllAgentsCertificates"))
+                  .build();
+          }
+        }
+     }
+     return getGetAllAgentsCertificatesMethod;
+  }
 
   /**
    * Creates a new async stub that supports all call types for the service
@@ -298,6 +372,26 @@ public final class ClusterConnectivityManagementV2Grpc {
       asyncUnimplementedUnaryCall(getUnregisterAgentMethodHelper(), responseObserver);
     }
 
+    /**
+     * <pre>
+     * Lists all registered agents matching a supplied query
+     * </pre>
+     */
+    public void listAgents(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getListAgentsMethodHelper(), responseObserver);
+    }
+
+    /**
+     * <pre>
+     * GetAllAgentsCertificates for getting certificates of all the agents for an account.
+     * </pre>
+     */
+    public void getAllAgentsCertificates(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(getGetAllAgentsCertificatesMethodHelper(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -335,6 +429,20 @@ public final class ClusterConnectivityManagementV2Grpc {
                 com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.UnregisterAgentRequest,
                 com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.UnregisterAgentResponse>(
                   this, METHODID_UNREGISTER_AGENT)))
+          .addMethod(
+            getListAgentsMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest,
+                com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse>(
+                  this, METHODID_LIST_AGENTS)))
+          .addMethod(
+            getGetAllAgentsCertificatesMethodHelper(),
+            asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest,
+                com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse>(
+                  this, METHODID_GET_ALL_AGENTS_CERTIFICATES)))
           .build();
     }
   }
@@ -416,6 +524,28 @@ public final class ClusterConnectivityManagementV2Grpc {
       asyncUnaryCall(
           getChannel().newCall(getUnregisterAgentMethodHelper(), getCallOptions()), request, responseObserver);
     }
+
+    /**
+     * <pre>
+     * Lists all registered agents matching a supplied query
+     * </pre>
+     */
+    public void listAgents(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getListAgentsMethodHelper(), getCallOptions()), request, responseObserver);
+    }
+
+    /**
+     * <pre>
+     * GetAllAgentsCertificates for getting certificates of all the agents for an account.
+     * </pre>
+     */
+    public void getAllAgentsCertificates(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse> responseObserver) {
+      asyncUnaryCall(
+          getChannel().newCall(getGetAllAgentsCertificatesMethodHelper(), getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -489,6 +619,26 @@ public final class ClusterConnectivityManagementV2Grpc {
     public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.UnregisterAgentResponse unregisterAgent(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.UnregisterAgentRequest request) {
       return blockingUnaryCall(
           getChannel(), getUnregisterAgentMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * Lists all registered agents matching a supplied query
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse listAgents(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getListAgentsMethodHelper(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     * GetAllAgentsCertificates for getting certificates of all the agents for an account.
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse getAllAgentsCertificates(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest request) {
+      return blockingUnaryCall(
+          getChannel(), getGetAllAgentsCertificatesMethodHelper(), getCallOptions(), request);
     }
   }
 
@@ -569,6 +719,28 @@ public final class ClusterConnectivityManagementV2Grpc {
       return futureUnaryCall(
           getChannel().newCall(getUnregisterAgentMethodHelper(), getCallOptions()), request);
     }
+
+    /**
+     * <pre>
+     * Lists all registered agents matching a supplied query
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse> listAgents(
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getListAgentsMethodHelper(), getCallOptions()), request);
+    }
+
+    /**
+     * <pre>
+     * GetAllAgentsCertificates for getting certificates of all the agents for an account.
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse> getAllAgentsCertificates(
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest request) {
+      return futureUnaryCall(
+          getChannel().newCall(getGetAllAgentsCertificatesMethodHelper(), getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_GET_VERSION = 0;
@@ -576,6 +748,8 @@ public final class ClusterConnectivityManagementV2Grpc {
   private static final int METHODID_REMOVE_INVERTING_PROXY = 2;
   private static final int METHODID_REGISTER_AGENT = 3;
   private static final int METHODID_UNREGISTER_AGENT = 4;
+  private static final int METHODID_LIST_AGENTS = 5;
+  private static final int METHODID_GET_ALL_AGENTS_CERTIFICATES = 6;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -613,6 +787,14 @@ public final class ClusterConnectivityManagementV2Grpc {
         case METHODID_UNREGISTER_AGENT:
           serviceImpl.unregisterAgent((com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.UnregisterAgentRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.UnregisterAgentResponse>) responseObserver);
+          break;
+        case METHODID_LIST_AGENTS:
+          serviceImpl.listAgents((com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse>) responseObserver);
+          break;
+        case METHODID_GET_ALL_AGENTS_CERTIFICATES:
+          serviceImpl.getAllAgentsCertificates((com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -680,6 +862,8 @@ public final class ClusterConnectivityManagementV2Grpc {
               .addMethod(getRemoveInvertingProxyMethodHelper())
               .addMethod(getRegisterAgentMethodHelper())
               .addMethod(getUnregisterAgentMethodHelper())
+              .addMethod(getListAgentsMethodHelper())
+              .addMethod(getGetAllAgentsCertificatesMethodHelper())
               .build();
         }
       }

--- a/ccm-connector/src/generated/main/java/com/cloudera/thunderhead/service/clusterconnectivitymanagementv2/ClusterConnectivityManagementV2Proto.java
+++ b/ccm-connector/src/generated/main/java/com/cloudera/thunderhead/service/clusterconnectivitymanagementv2/ClusterConnectivityManagementV2Proto.java
@@ -2326,6 +2326,34 @@ public final class ClusterConnectivityManagementV2Proto {
      */
     com.google.protobuf.ByteString
         getKeyIdBytes();
+
+    /**
+     * <pre>
+     * CRN of the environment this agent is going to be deployed in. Passing the environmentCrn as
+     * part of registration implies that the provisioning service consents to the use this agent to
+     * target backend services outside the host it is deployed on.
+     * As part of future work, we intend to bring a dedicated pool of agents which would be shared
+     * across the environment. Fos suce agents, we expect that environmentCrn would always be
+     * supplied during registration.
+     * </pre>
+     *
+     * <code>string environmentCrn = 4;</code>
+     */
+    java.lang.String getEnvironmentCrn();
+    /**
+     * <pre>
+     * CRN of the environment this agent is going to be deployed in. Passing the environmentCrn as
+     * part of registration implies that the provisioning service consents to the use this agent to
+     * target backend services outside the host it is deployed on.
+     * As part of future work, we intend to bring a dedicated pool of agents which would be shared
+     * across the environment. Fos suce agents, we expect that environmentCrn would always be
+     * supplied during registration.
+     * </pre>
+     *
+     * <code>string environmentCrn = 4;</code>
+     */
+    com.google.protobuf.ByteString
+        getEnvironmentCrnBytes();
   }
   /**
    * Protobuf type {@code clusterconnectivitymanagementv2.RegisterAgentRequest}
@@ -2343,6 +2371,7 @@ public final class ClusterConnectivityManagementV2Proto {
       accountId_ = "";
       domainName_ = "";
       keyId_ = "";
+      environmentCrn_ = "";
     }
 
     @java.lang.Override
@@ -2385,6 +2414,12 @@ public final class ClusterConnectivityManagementV2Proto {
               java.lang.String s = input.readStringRequireUtf8();
 
               keyId_ = s;
+              break;
+            }
+            case 34: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              environmentCrn_ = s;
               break;
             }
             default: {
@@ -2549,6 +2584,58 @@ public final class ClusterConnectivityManagementV2Proto {
       }
     }
 
+    public static final int ENVIRONMENTCRN_FIELD_NUMBER = 4;
+    private volatile java.lang.Object environmentCrn_;
+    /**
+     * <pre>
+     * CRN of the environment this agent is going to be deployed in. Passing the environmentCrn as
+     * part of registration implies that the provisioning service consents to the use this agent to
+     * target backend services outside the host it is deployed on.
+     * As part of future work, we intend to bring a dedicated pool of agents which would be shared
+     * across the environment. Fos suce agents, we expect that environmentCrn would always be
+     * supplied during registration.
+     * </pre>
+     *
+     * <code>string environmentCrn = 4;</code>
+     */
+    public java.lang.String getEnvironmentCrn() {
+      java.lang.Object ref = environmentCrn_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        environmentCrn_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * CRN of the environment this agent is going to be deployed in. Passing the environmentCrn as
+     * part of registration implies that the provisioning service consents to the use this agent to
+     * target backend services outside the host it is deployed on.
+     * As part of future work, we intend to bring a dedicated pool of agents which would be shared
+     * across the environment. Fos suce agents, we expect that environmentCrn would always be
+     * supplied during registration.
+     * </pre>
+     *
+     * <code>string environmentCrn = 4;</code>
+     */
+    public com.google.protobuf.ByteString
+        getEnvironmentCrnBytes() {
+      java.lang.Object ref = environmentCrn_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        environmentCrn_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -2572,6 +2659,9 @@ public final class ClusterConnectivityManagementV2Proto {
       if (!getKeyIdBytes().isEmpty()) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, keyId_);
       }
+      if (!getEnvironmentCrnBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, environmentCrn_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -2589,6 +2679,9 @@ public final class ClusterConnectivityManagementV2Proto {
       }
       if (!getKeyIdBytes().isEmpty()) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, keyId_);
+      }
+      if (!getEnvironmentCrnBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, environmentCrn_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -2612,6 +2705,8 @@ public final class ClusterConnectivityManagementV2Proto {
           .equals(other.getDomainName());
       result = result && getKeyId()
           .equals(other.getKeyId());
+      result = result && getEnvironmentCrn()
+          .equals(other.getEnvironmentCrn());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -2629,6 +2724,8 @@ public final class ClusterConnectivityManagementV2Proto {
       hash = (53 * hash) + getDomainName().hashCode();
       hash = (37 * hash) + KEYID_FIELD_NUMBER;
       hash = (53 * hash) + getKeyId().hashCode();
+      hash = (37 * hash) + ENVIRONMENTCRN_FIELD_NUMBER;
+      hash = (53 * hash) + getEnvironmentCrn().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -2768,6 +2865,8 @@ public final class ClusterConnectivityManagementV2Proto {
 
         keyId_ = "";
 
+        environmentCrn_ = "";
+
         return this;
       }
 
@@ -2797,6 +2896,7 @@ public final class ClusterConnectivityManagementV2Proto {
         result.accountId_ = accountId_;
         result.domainName_ = domainName_;
         result.keyId_ = keyId_;
+        result.environmentCrn_ = environmentCrn_;
         onBuilt();
         return result;
       }
@@ -2855,6 +2955,10 @@ public final class ClusterConnectivityManagementV2Proto {
         }
         if (!other.getKeyId().isEmpty()) {
           keyId_ = other.keyId_;
+          onChanged();
+        }
+        if (!other.getEnvironmentCrn().isEmpty()) {
+          environmentCrn_ = other.environmentCrn_;
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -3162,6 +3266,120 @@ public final class ClusterConnectivityManagementV2Proto {
         onChanged();
         return this;
       }
+
+      private java.lang.Object environmentCrn_ = "";
+      /**
+       * <pre>
+       * CRN of the environment this agent is going to be deployed in. Passing the environmentCrn as
+       * part of registration implies that the provisioning service consents to the use this agent to
+       * target backend services outside the host it is deployed on.
+       * As part of future work, we intend to bring a dedicated pool of agents which would be shared
+       * across the environment. Fos suce agents, we expect that environmentCrn would always be
+       * supplied during registration.
+       * </pre>
+       *
+       * <code>string environmentCrn = 4;</code>
+       */
+      public java.lang.String getEnvironmentCrn() {
+        java.lang.Object ref = environmentCrn_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          environmentCrn_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * CRN of the environment this agent is going to be deployed in. Passing the environmentCrn as
+       * part of registration implies that the provisioning service consents to the use this agent to
+       * target backend services outside the host it is deployed on.
+       * As part of future work, we intend to bring a dedicated pool of agents which would be shared
+       * across the environment. Fos suce agents, we expect that environmentCrn would always be
+       * supplied during registration.
+       * </pre>
+       *
+       * <code>string environmentCrn = 4;</code>
+       */
+      public com.google.protobuf.ByteString
+          getEnvironmentCrnBytes() {
+        java.lang.Object ref = environmentCrn_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          environmentCrn_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * CRN of the environment this agent is going to be deployed in. Passing the environmentCrn as
+       * part of registration implies that the provisioning service consents to the use this agent to
+       * target backend services outside the host it is deployed on.
+       * As part of future work, we intend to bring a dedicated pool of agents which would be shared
+       * across the environment. Fos suce agents, we expect that environmentCrn would always be
+       * supplied during registration.
+       * </pre>
+       *
+       * <code>string environmentCrn = 4;</code>
+       */
+      public Builder setEnvironmentCrn(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        environmentCrn_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * CRN of the environment this agent is going to be deployed in. Passing the environmentCrn as
+       * part of registration implies that the provisioning service consents to the use this agent to
+       * target backend services outside the host it is deployed on.
+       * As part of future work, we intend to bring a dedicated pool of agents which would be shared
+       * across the environment. Fos suce agents, we expect that environmentCrn would always be
+       * supplied during registration.
+       * </pre>
+       *
+       * <code>string environmentCrn = 4;</code>
+       */
+      public Builder clearEnvironmentCrn() {
+        
+        environmentCrn_ = getDefaultInstance().getEnvironmentCrn();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * CRN of the environment this agent is going to be deployed in. Passing the environmentCrn as
+       * part of registration implies that the provisioning service consents to the use this agent to
+       * target backend services outside the host it is deployed on.
+       * As part of future work, we intend to bring a dedicated pool of agents which would be shared
+       * across the environment. Fos suce agents, we expect that environmentCrn would always be
+       * supplied during registration.
+       * </pre>
+       *
+       * <code>string environmentCrn = 4;</code>
+       */
+      public Builder setEnvironmentCrnBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        environmentCrn_ = value;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -3221,7 +3439,7 @@ public final class ClusterConnectivityManagementV2Proto {
 
     /**
      * <pre>
-     *Inverting proxy agent with required fields.
+     * Inverting proxy agent with required fields.
      * </pre>
      *
      * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3229,7 +3447,7 @@ public final class ClusterConnectivityManagementV2Proto {
     boolean hasInvertingProxyAgent();
     /**
      * <pre>
-     *Inverting proxy agent with required fields.
+     * Inverting proxy agent with required fields.
      * </pre>
      *
      * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3237,7 +3455,7 @@ public final class ClusterConnectivityManagementV2Proto {
     com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent getInvertingProxyAgent();
     /**
      * <pre>
-     *Inverting proxy agent with required fields.
+     * Inverting proxy agent with required fields.
      * </pre>
      *
      * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3332,7 +3550,7 @@ public final class ClusterConnectivityManagementV2Proto {
     private com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent invertingProxyAgent_;
     /**
      * <pre>
-     *Inverting proxy agent with required fields.
+     * Inverting proxy agent with required fields.
      * </pre>
      *
      * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3342,7 +3560,7 @@ public final class ClusterConnectivityManagementV2Proto {
     }
     /**
      * <pre>
-     *Inverting proxy agent with required fields.
+     * Inverting proxy agent with required fields.
      * </pre>
      *
      * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3352,7 +3570,7 @@ public final class ClusterConnectivityManagementV2Proto {
     }
     /**
      * <pre>
-     *Inverting proxy agent with required fields.
+     * Inverting proxy agent with required fields.
      * </pre>
      *
      * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3682,7 +3900,7 @@ public final class ClusterConnectivityManagementV2Proto {
           com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgentOrBuilder> invertingProxyAgentBuilder_;
       /**
        * <pre>
-       *Inverting proxy agent with required fields.
+       * Inverting proxy agent with required fields.
        * </pre>
        *
        * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3692,7 +3910,7 @@ public final class ClusterConnectivityManagementV2Proto {
       }
       /**
        * <pre>
-       *Inverting proxy agent with required fields.
+       * Inverting proxy agent with required fields.
        * </pre>
        *
        * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3706,7 +3924,7 @@ public final class ClusterConnectivityManagementV2Proto {
       }
       /**
        * <pre>
-       *Inverting proxy agent with required fields.
+       * Inverting proxy agent with required fields.
        * </pre>
        *
        * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3726,7 +3944,7 @@ public final class ClusterConnectivityManagementV2Proto {
       }
       /**
        * <pre>
-       *Inverting proxy agent with required fields.
+       * Inverting proxy agent with required fields.
        * </pre>
        *
        * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3744,7 +3962,7 @@ public final class ClusterConnectivityManagementV2Proto {
       }
       /**
        * <pre>
-       *Inverting proxy agent with required fields.
+       * Inverting proxy agent with required fields.
        * </pre>
        *
        * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3766,7 +3984,7 @@ public final class ClusterConnectivityManagementV2Proto {
       }
       /**
        * <pre>
-       *Inverting proxy agent with required fields.
+       * Inverting proxy agent with required fields.
        * </pre>
        *
        * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3784,7 +4002,7 @@ public final class ClusterConnectivityManagementV2Proto {
       }
       /**
        * <pre>
-       *Inverting proxy agent with required fields.
+       * Inverting proxy agent with required fields.
        * </pre>
        *
        * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3796,7 +4014,7 @@ public final class ClusterConnectivityManagementV2Proto {
       }
       /**
        * <pre>
-       *Inverting proxy agent with required fields.
+       * Inverting proxy agent with required fields.
        * </pre>
        *
        * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -3811,7 +4029,7 @@ public final class ClusterConnectivityManagementV2Proto {
       }
       /**
        * <pre>
-       *Inverting proxy agent with required fields.
+       * Inverting proxy agent with required fields.
        * </pre>
        *
        * <code>.clusterconnectivitymanagementv2.InvertingProxyAgent invertingProxyAgent = 1;</code>
@@ -4468,6 +4686,1264 @@ public final class ClusterConnectivityManagementV2Proto {
 
   }
 
+  public interface GetAllAgentsCertificatesRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:clusterconnectivitymanagementv2.GetAllAgentsCertificatesRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Account ID for which the certificates need to retrieved.
+     * </pre>
+     *
+     * <code>string accountId = 1;</code>
+     */
+    java.lang.String getAccountId();
+    /**
+     * <pre>
+     * Account ID for which the certificates need to retrieved.
+     * </pre>
+     *
+     * <code>string accountId = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getAccountIdBytes();
+  }
+  /**
+   * Protobuf type {@code clusterconnectivitymanagementv2.GetAllAgentsCertificatesRequest}
+   */
+  public  static final class GetAllAgentsCertificatesRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:clusterconnectivitymanagementv2.GetAllAgentsCertificatesRequest)
+      GetAllAgentsCertificatesRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use GetAllAgentsCertificatesRequest.newBuilder() to construct.
+    private GetAllAgentsCertificatesRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private GetAllAgentsCertificatesRequest() {
+      accountId_ = "";
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private GetAllAgentsCertificatesRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              accountId_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest.class, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest.Builder.class);
+    }
+
+    public static final int ACCOUNTID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object accountId_;
+    /**
+     * <pre>
+     * Account ID for which the certificates need to retrieved.
+     * </pre>
+     *
+     * <code>string accountId = 1;</code>
+     */
+    public java.lang.String getAccountId() {
+      java.lang.Object ref = accountId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        accountId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Account ID for which the certificates need to retrieved.
+     * </pre>
+     *
+     * <code>string accountId = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getAccountIdBytes() {
+      java.lang.Object ref = accountId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        accountId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!getAccountIdBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, accountId_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!getAccountIdBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, accountId_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest other = (com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest) obj;
+
+      boolean result = true;
+      result = result && getAccountId()
+          .equals(other.getAccountId());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + ACCOUNTID_FIELD_NUMBER;
+      hash = (53 * hash) + getAccountId().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code clusterconnectivitymanagementv2.GetAllAgentsCertificatesRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:clusterconnectivitymanagementv2.GetAllAgentsCertificatesRequest)
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest.class, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        accountId_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest build() {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest buildPartial() {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest result = new com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest(this);
+        result.accountId_ = accountId_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest) {
+          return mergeFrom((com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest other) {
+        if (other == com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest.getDefaultInstance()) return this;
+        if (!other.getAccountId().isEmpty()) {
+          accountId_ = other.accountId_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object accountId_ = "";
+      /**
+       * <pre>
+       * Account ID for which the certificates need to retrieved.
+       * </pre>
+       *
+       * <code>string accountId = 1;</code>
+       */
+      public java.lang.String getAccountId() {
+        java.lang.Object ref = accountId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          accountId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Account ID for which the certificates need to retrieved.
+       * </pre>
+       *
+       * <code>string accountId = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getAccountIdBytes() {
+        java.lang.Object ref = accountId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          accountId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Account ID for which the certificates need to retrieved.
+       * </pre>
+       *
+       * <code>string accountId = 1;</code>
+       */
+      public Builder setAccountId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        accountId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Account ID for which the certificates need to retrieved.
+       * </pre>
+       *
+       * <code>string accountId = 1;</code>
+       */
+      public Builder clearAccountId() {
+        
+        accountId_ = getDefaultInstance().getAccountId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Account ID for which the certificates need to retrieved.
+       * </pre>
+       *
+       * <code>string accountId = 1;</code>
+       */
+      public Builder setAccountIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        accountId_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:clusterconnectivitymanagementv2.GetAllAgentsCertificatesRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:clusterconnectivitymanagementv2.GetAllAgentsCertificatesRequest)
+    private static final com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest();
+    }
+
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<GetAllAgentsCertificatesRequest>
+        PARSER = new com.google.protobuf.AbstractParser<GetAllAgentsCertificatesRequest>() {
+      @java.lang.Override
+      public GetAllAgentsCertificatesRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new GetAllAgentsCertificatesRequest(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<GetAllAgentsCertificatesRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<GetAllAgentsCertificatesRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface GetAllAgentsCertificatesResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:clusterconnectivitymanagementv2.GetAllAgentsCertificatesResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Certificates of all the agents.
+     * </pre>
+     *
+     * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    java.util.List<java.lang.String>
+        getCertificatesList();
+    /**
+     * <pre>
+     * Certificates of all the agents.
+     * </pre>
+     *
+     * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    int getCertificatesCount();
+    /**
+     * <pre>
+     * Certificates of all the agents.
+     * </pre>
+     *
+     * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    java.lang.String getCertificates(int index);
+    /**
+     * <pre>
+     * Certificates of all the agents.
+     * </pre>
+     *
+     * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    com.google.protobuf.ByteString
+        getCertificatesBytes(int index);
+  }
+  /**
+   * Protobuf type {@code clusterconnectivitymanagementv2.GetAllAgentsCertificatesResponse}
+   */
+  public  static final class GetAllAgentsCertificatesResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:clusterconnectivitymanagementv2.GetAllAgentsCertificatesResponse)
+      GetAllAgentsCertificatesResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use GetAllAgentsCertificatesResponse.newBuilder() to construct.
+    private GetAllAgentsCertificatesResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private GetAllAgentsCertificatesResponse() {
+      certificates_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private GetAllAgentsCertificatesResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                certificates_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000001;
+              }
+              certificates_.add(s);
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+          certificates_ = certificates_.getUnmodifiableView();
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse.class, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse.Builder.class);
+    }
+
+    public static final int CERTIFICATES_FIELD_NUMBER = 1;
+    private com.google.protobuf.LazyStringList certificates_;
+    /**
+     * <pre>
+     * Certificates of all the agents.
+     * </pre>
+     *
+     * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getCertificatesList() {
+      return certificates_;
+    }
+    /**
+     * <pre>
+     * Certificates of all the agents.
+     * </pre>
+     *
+     * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    public int getCertificatesCount() {
+      return certificates_.size();
+    }
+    /**
+     * <pre>
+     * Certificates of all the agents.
+     * </pre>
+     *
+     * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    public java.lang.String getCertificates(int index) {
+      return certificates_.get(index);
+    }
+    /**
+     * <pre>
+     * Certificates of all the agents.
+     * </pre>
+     *
+     * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    public com.google.protobuf.ByteString
+        getCertificatesBytes(int index) {
+      return certificates_.getByteString(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      for (int i = 0; i < certificates_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, certificates_.getRaw(i));
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      {
+        int dataSize = 0;
+        for (int i = 0; i < certificates_.size(); i++) {
+          dataSize += computeStringSizeNoTag(certificates_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getCertificatesList().size();
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse other = (com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse) obj;
+
+      boolean result = true;
+      result = result && getCertificatesList()
+          .equals(other.getCertificatesList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (getCertificatesCount() > 0) {
+        hash = (37 * hash) + CERTIFICATES_FIELD_NUMBER;
+        hash = (53 * hash) + getCertificatesList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code clusterconnectivitymanagementv2.GetAllAgentsCertificatesResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:clusterconnectivitymanagementv2.GetAllAgentsCertificatesResponse)
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse.class, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        certificates_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse build() {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse buildPartial() {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse result = new com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse(this);
+        int from_bitField0_ = bitField0_;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          certificates_ = certificates_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000001);
+        }
+        result.certificates_ = certificates_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse) {
+          return mergeFrom((com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse other) {
+        if (other == com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse.getDefaultInstance()) return this;
+        if (!other.certificates_.isEmpty()) {
+          if (certificates_.isEmpty()) {
+            certificates_ = other.certificates_;
+            bitField0_ = (bitField0_ & ~0x00000001);
+          } else {
+            ensureCertificatesIsMutable();
+            certificates_.addAll(other.certificates_);
+          }
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private com.google.protobuf.LazyStringList certificates_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureCertificatesIsMutable() {
+        if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+          certificates_ = new com.google.protobuf.LazyStringArrayList(certificates_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+      /**
+       * <pre>
+       * Certificates of all the agents.
+       * </pre>
+       *
+       * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getCertificatesList() {
+        return certificates_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       * Certificates of all the agents.
+       * </pre>
+       *
+       * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public int getCertificatesCount() {
+        return certificates_.size();
+      }
+      /**
+       * <pre>
+       * Certificates of all the agents.
+       * </pre>
+       *
+       * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public java.lang.String getCertificates(int index) {
+        return certificates_.get(index);
+      }
+      /**
+       * <pre>
+       * Certificates of all the agents.
+       * </pre>
+       *
+       * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public com.google.protobuf.ByteString
+          getCertificatesBytes(int index) {
+        return certificates_.getByteString(index);
+      }
+      /**
+       * <pre>
+       * Certificates of all the agents.
+       * </pre>
+       *
+       * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder setCertificates(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureCertificatesIsMutable();
+        certificates_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Certificates of all the agents.
+       * </pre>
+       *
+       * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder addCertificates(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureCertificatesIsMutable();
+        certificates_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Certificates of all the agents.
+       * </pre>
+       *
+       * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder addAllCertificates(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureCertificatesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, certificates_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Certificates of all the agents.
+       * </pre>
+       *
+       * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder clearCertificates() {
+        certificates_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Certificates of all the agents.
+       * </pre>
+       *
+       * <code>repeated string certificates = 1 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder addCertificatesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensureCertificatesIsMutable();
+        certificates_.add(value);
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:clusterconnectivitymanagementv2.GetAllAgentsCertificatesResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:clusterconnectivitymanagementv2.GetAllAgentsCertificatesResponse)
+    private static final com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse();
+    }
+
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<GetAllAgentsCertificatesResponse>
+        PARSER = new com.google.protobuf.AbstractParser<GetAllAgentsCertificatesResponse>() {
+      @java.lang.Override
+      public GetAllAgentsCertificatesResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new GetAllAgentsCertificatesResponse(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<GetAllAgentsCertificatesResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<GetAllAgentsCertificatesResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.GetAllAgentsCertificatesResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface UnregisterAgentResponseOrBuilder extends
       // @@protoc_insertion_point(interface_extends:clusterconnectivitymanagementv2.UnregisterAgentResponse)
       com.google.protobuf.MessageOrBuilder {
@@ -4944,20 +6420,40 @@ public final class ClusterConnectivityManagementV2Proto {
     /**
      * <pre>
      * Certificate of inverting-proxy that needs to be passed to agent.
+     * We intend to depracate this field in favor of 'caCertificate'.
      * </pre>
      *
-     * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true];</code>
+     * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
      */
     java.lang.String getCertificate();
     /**
      * <pre>
      * Certificate of inverting-proxy that needs to be passed to agent.
+     * We intend to depracate this field in favor of 'caCertificate'.
      * </pre>
      *
-     * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true];</code>
+     * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
      */
     com.google.protobuf.ByteString
         getCertificateBytes();
+
+    /**
+     * <pre>
+     * CA Certificate used to sign certificate of inverting-proxy server. It needs to be passed to agent.
+     * </pre>
+     *
+     * <code>string caCertificate = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    java.lang.String getCaCertificate();
+    /**
+     * <pre>
+     * CA Certificate used to sign certificate of inverting-proxy server. It needs to be passed to agent.
+     * </pre>
+     *
+     * <code>string caCertificate = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    com.google.protobuf.ByteString
+        getCaCertificateBytes();
   }
   /**
    * Protobuf type {@code clusterconnectivitymanagementv2.InvertingProxy}
@@ -4976,6 +6472,7 @@ public final class ClusterConnectivityManagementV2Proto {
       hostname_ = "";
       causeOfFailure_ = "";
       certificate_ = "";
+      caCertificate_ = "";
     }
 
     @java.lang.Override
@@ -5024,6 +6521,12 @@ public final class ClusterConnectivityManagementV2Proto {
               java.lang.String s = input.readStringRequireUtf8();
 
               certificate_ = s;
+              break;
+            }
+            case 42: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              caCertificate_ = s;
               break;
             }
             default: {
@@ -5311,9 +6814,10 @@ public final class ClusterConnectivityManagementV2Proto {
     /**
      * <pre>
      * Certificate of inverting-proxy that needs to be passed to agent.
+     * We intend to depracate this field in favor of 'caCertificate'.
      * </pre>
      *
-     * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true];</code>
+     * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
      */
     public java.lang.String getCertificate() {
       java.lang.Object ref = certificate_;
@@ -5330,9 +6834,10 @@ public final class ClusterConnectivityManagementV2Proto {
     /**
      * <pre>
      * Certificate of inverting-proxy that needs to be passed to agent.
+     * We intend to depracate this field in favor of 'caCertificate'.
      * </pre>
      *
-     * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true];</code>
+     * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
      */
     public com.google.protobuf.ByteString
         getCertificateBytes() {
@@ -5342,6 +6847,48 @@ public final class ClusterConnectivityManagementV2Proto {
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         certificate_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CACERTIFICATE_FIELD_NUMBER = 5;
+    private volatile java.lang.Object caCertificate_;
+    /**
+     * <pre>
+     * CA Certificate used to sign certificate of inverting-proxy server. It needs to be passed to agent.
+     * </pre>
+     *
+     * <code>string caCertificate = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    public java.lang.String getCaCertificate() {
+      java.lang.Object ref = caCertificate_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        caCertificate_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * CA Certificate used to sign certificate of inverting-proxy server. It needs to be passed to agent.
+     * </pre>
+     *
+     * <code>string caCertificate = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    public com.google.protobuf.ByteString
+        getCaCertificateBytes() {
+      java.lang.Object ref = caCertificate_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        caCertificate_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -5374,6 +6921,9 @@ public final class ClusterConnectivityManagementV2Proto {
       if (!getCertificateBytes().isEmpty()) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 4, certificate_);
       }
+      if (!getCaCertificateBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, caCertificate_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -5395,6 +6945,9 @@ public final class ClusterConnectivityManagementV2Proto {
       }
       if (!getCertificateBytes().isEmpty()) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, certificate_);
+      }
+      if (!getCaCertificateBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, caCertificate_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -5419,6 +6972,8 @@ public final class ClusterConnectivityManagementV2Proto {
           .equals(other.getCauseOfFailure());
       result = result && getCertificate()
           .equals(other.getCertificate());
+      result = result && getCaCertificate()
+          .equals(other.getCaCertificate());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -5438,6 +6993,8 @@ public final class ClusterConnectivityManagementV2Proto {
       hash = (53 * hash) + getCauseOfFailure().hashCode();
       hash = (37 * hash) + CERTIFICATE_FIELD_NUMBER;
       hash = (53 * hash) + getCertificate().hashCode();
+      hash = (37 * hash) + CACERTIFICATE_FIELD_NUMBER;
+      hash = (53 * hash) + getCaCertificate().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -5579,6 +7136,8 @@ public final class ClusterConnectivityManagementV2Proto {
 
         certificate_ = "";
 
+        caCertificate_ = "";
+
         return this;
       }
 
@@ -5609,6 +7168,7 @@ public final class ClusterConnectivityManagementV2Proto {
         result.hostname_ = hostname_;
         result.causeOfFailure_ = causeOfFailure_;
         result.certificate_ = certificate_;
+        result.caCertificate_ = caCertificate_;
         onBuilt();
         return result;
       }
@@ -5670,6 +7230,10 @@ public final class ClusterConnectivityManagementV2Proto {
         }
         if (!other.getCertificate().isEmpty()) {
           certificate_ = other.certificate_;
+          onChanged();
+        }
+        if (!other.getCaCertificate().isEmpty()) {
+          caCertificate_ = other.caCertificate_;
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -5958,9 +7522,10 @@ public final class ClusterConnectivityManagementV2Proto {
       /**
        * <pre>
        * Certificate of inverting-proxy that needs to be passed to agent.
+       * We intend to depracate this field in favor of 'caCertificate'.
        * </pre>
        *
-       * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true];</code>
+       * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
        */
       public java.lang.String getCertificate() {
         java.lang.Object ref = certificate_;
@@ -5977,9 +7542,10 @@ public final class ClusterConnectivityManagementV2Proto {
       /**
        * <pre>
        * Certificate of inverting-proxy that needs to be passed to agent.
+       * We intend to depracate this field in favor of 'caCertificate'.
        * </pre>
        *
-       * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true];</code>
+       * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
        */
       public com.google.protobuf.ByteString
           getCertificateBytes() {
@@ -5997,9 +7563,10 @@ public final class ClusterConnectivityManagementV2Proto {
       /**
        * <pre>
        * Certificate of inverting-proxy that needs to be passed to agent.
+       * We intend to depracate this field in favor of 'caCertificate'.
        * </pre>
        *
-       * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true];</code>
+       * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
        */
       public Builder setCertificate(
           java.lang.String value) {
@@ -6014,9 +7581,10 @@ public final class ClusterConnectivityManagementV2Proto {
       /**
        * <pre>
        * Certificate of inverting-proxy that needs to be passed to agent.
+       * We intend to depracate this field in favor of 'caCertificate'.
        * </pre>
        *
-       * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true];</code>
+       * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
        */
       public Builder clearCertificate() {
         
@@ -6027,9 +7595,10 @@ public final class ClusterConnectivityManagementV2Proto {
       /**
        * <pre>
        * Certificate of inverting-proxy that needs to be passed to agent.
+       * We intend to depracate this field in favor of 'caCertificate'.
        * </pre>
        *
-       * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true];</code>
+       * <code>string certificate = 4 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
        */
       public Builder setCertificateBytes(
           com.google.protobuf.ByteString value) {
@@ -6039,6 +7608,95 @@ public final class ClusterConnectivityManagementV2Proto {
   checkByteStringIsUtf8(value);
         
         certificate_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object caCertificate_ = "";
+      /**
+       * <pre>
+       * CA Certificate used to sign certificate of inverting-proxy server. It needs to be passed to agent.
+       * </pre>
+       *
+       * <code>string caCertificate = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public java.lang.String getCaCertificate() {
+        java.lang.Object ref = caCertificate_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          caCertificate_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * CA Certificate used to sign certificate of inverting-proxy server. It needs to be passed to agent.
+       * </pre>
+       *
+       * <code>string caCertificate = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public com.google.protobuf.ByteString
+          getCaCertificateBytes() {
+        java.lang.Object ref = caCertificate_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          caCertificate_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * CA Certificate used to sign certificate of inverting-proxy server. It needs to be passed to agent.
+       * </pre>
+       *
+       * <code>string caCertificate = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder setCaCertificate(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        caCertificate_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * CA Certificate used to sign certificate of inverting-proxy server. It needs to be passed to agent.
+       * </pre>
+       *
+       * <code>string caCertificate = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder clearCaCertificate() {
+        
+        caCertificate_ = getDefaultInstance().getCaCertificate();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * CA Certificate used to sign certificate of inverting-proxy server. It needs to be passed to agent.
+       * </pre>
+       *
+       * <code>string caCertificate = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder setCaCertificateBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        caCertificate_ = value;
         onChanged();
         return this;
       }
@@ -6138,20 +7796,81 @@ public final class ClusterConnectivityManagementV2Proto {
     /**
      * <pre>
      * Generated cert for the agent
+     * We intend to deprecate this field in favor of 'certificates'.
+     * This is required to support CA signed certificates for agents.
      * </pre>
      *
-     * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true];</code>
+     * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
      */
     java.lang.String getCertificate();
     /**
      * <pre>
      * Generated cert for the agent
+     * We intend to deprecate this field in favor of 'certificates'.
+     * This is required to support CA signed certificates for agents.
      * </pre>
      *
-     * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true];</code>
+     * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
      */
     com.google.protobuf.ByteString
         getCertificateBytes();
+
+    /**
+     * <pre>
+     * CRN of the environment this agent is going to be deployed in. Having the environmentCrn set here
+     * implies that the provisioning service has consented to the use of this agent to target backend services
+     * outside the host it is deployed on.
+     * </pre>
+     *
+     * <code>string environmentCrn = 4;</code>
+     */
+    java.lang.String getEnvironmentCrn();
+    /**
+     * <pre>
+     * CRN of the environment this agent is going to be deployed in. Having the environmentCrn set here
+     * implies that the provisioning service has consented to the use of this agent to target backend services
+     * outside the host it is deployed on.
+     * </pre>
+     *
+     * <code>string environmentCrn = 4;</code>
+     */
+    com.google.protobuf.ByteString
+        getEnvironmentCrnBytes();
+
+    /**
+     * <pre>
+     * Generated certificate and the trust chain for agent
+     * </pre>
+     *
+     * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    java.util.List<java.lang.String>
+        getCertificatesList();
+    /**
+     * <pre>
+     * Generated certificate and the trust chain for agent
+     * </pre>
+     *
+     * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    int getCertificatesCount();
+    /**
+     * <pre>
+     * Generated certificate and the trust chain for agent
+     * </pre>
+     *
+     * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    java.lang.String getCertificates(int index);
+    /**
+     * <pre>
+     * Generated certificate and the trust chain for agent
+     * </pre>
+     *
+     * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    com.google.protobuf.ByteString
+        getCertificatesBytes(int index);
   }
   /**
    * Protobuf type {@code clusterconnectivitymanagementv2.InvertingProxyAgent}
@@ -6169,6 +7888,8 @@ public final class ClusterConnectivityManagementV2Proto {
       agentCrn_ = "";
       encipheredPrivateKey_ = "";
       certificate_ = "";
+      environmentCrn_ = "";
+      certificates_ = com.google.protobuf.LazyStringArrayList.EMPTY;
     }
 
     @java.lang.Override
@@ -6213,6 +7934,21 @@ public final class ClusterConnectivityManagementV2Proto {
               certificate_ = s;
               break;
             }
+            case 34: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              environmentCrn_ = s;
+              break;
+            }
+            case 42: {
+              java.lang.String s = input.readStringRequireUtf8();
+              if (!((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+                certificates_ = new com.google.protobuf.LazyStringArrayList();
+                mutable_bitField0_ |= 0x00000010;
+              }
+              certificates_.add(s);
+              break;
+            }
             default: {
               if (!parseUnknownFieldProto3(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -6228,6 +7964,9 @@ public final class ClusterConnectivityManagementV2Proto {
         throw new com.google.protobuf.InvalidProtocolBufferException(
             e).setUnfinishedMessage(this);
       } finally {
+        if (((mutable_bitField0_ & 0x00000010) == 0x00000010)) {
+          certificates_ = certificates_.getUnmodifiableView();
+        }
         this.unknownFields = unknownFields.build();
         makeExtensionsImmutable();
       }
@@ -6245,6 +7984,7 @@ public final class ClusterConnectivityManagementV2Proto {
               com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.class, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder.class);
     }
 
+    private int bitField0_;
     public static final int AGENTCRN_FIELD_NUMBER = 1;
     private volatile java.lang.Object agentCrn_;
     /**
@@ -6334,9 +8074,11 @@ public final class ClusterConnectivityManagementV2Proto {
     /**
      * <pre>
      * Generated cert for the agent
+     * We intend to deprecate this field in favor of 'certificates'.
+     * This is required to support CA signed certificates for agents.
      * </pre>
      *
-     * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true];</code>
+     * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
      */
     public java.lang.String getCertificate() {
       java.lang.Object ref = certificate_;
@@ -6353,9 +8095,11 @@ public final class ClusterConnectivityManagementV2Proto {
     /**
      * <pre>
      * Generated cert for the agent
+     * We intend to deprecate this field in favor of 'certificates'.
+     * This is required to support CA signed certificates for agents.
      * </pre>
      *
-     * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true];</code>
+     * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
      */
     public com.google.protobuf.ByteString
         getCertificateBytes() {
@@ -6369,6 +8113,97 @@ public final class ClusterConnectivityManagementV2Proto {
       } else {
         return (com.google.protobuf.ByteString) ref;
       }
+    }
+
+    public static final int ENVIRONMENTCRN_FIELD_NUMBER = 4;
+    private volatile java.lang.Object environmentCrn_;
+    /**
+     * <pre>
+     * CRN of the environment this agent is going to be deployed in. Having the environmentCrn set here
+     * implies that the provisioning service has consented to the use of this agent to target backend services
+     * outside the host it is deployed on.
+     * </pre>
+     *
+     * <code>string environmentCrn = 4;</code>
+     */
+    public java.lang.String getEnvironmentCrn() {
+      java.lang.Object ref = environmentCrn_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        environmentCrn_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * CRN of the environment this agent is going to be deployed in. Having the environmentCrn set here
+     * implies that the provisioning service has consented to the use of this agent to target backend services
+     * outside the host it is deployed on.
+     * </pre>
+     *
+     * <code>string environmentCrn = 4;</code>
+     */
+    public com.google.protobuf.ByteString
+        getEnvironmentCrnBytes() {
+      java.lang.Object ref = environmentCrn_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        environmentCrn_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CERTIFICATES_FIELD_NUMBER = 5;
+    private com.google.protobuf.LazyStringList certificates_;
+    /**
+     * <pre>
+     * Generated certificate and the trust chain for agent
+     * </pre>
+     *
+     * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    public com.google.protobuf.ProtocolStringList
+        getCertificatesList() {
+      return certificates_;
+    }
+    /**
+     * <pre>
+     * Generated certificate and the trust chain for agent
+     * </pre>
+     *
+     * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    public int getCertificatesCount() {
+      return certificates_.size();
+    }
+    /**
+     * <pre>
+     * Generated certificate and the trust chain for agent
+     * </pre>
+     *
+     * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    public java.lang.String getCertificates(int index) {
+      return certificates_.get(index);
+    }
+    /**
+     * <pre>
+     * Generated certificate and the trust chain for agent
+     * </pre>
+     *
+     * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+     */
+    public com.google.protobuf.ByteString
+        getCertificatesBytes(int index) {
+      return certificates_.getByteString(index);
     }
 
     private byte memoizedIsInitialized = -1;
@@ -6394,6 +8229,12 @@ public final class ClusterConnectivityManagementV2Proto {
       if (!getCertificateBytes().isEmpty()) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, certificate_);
       }
+      if (!getEnvironmentCrnBytes().isEmpty()) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, environmentCrn_);
+      }
+      for (int i = 0; i < certificates_.size(); i++) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, certificates_.getRaw(i));
+      }
       unknownFields.writeTo(output);
     }
 
@@ -6411,6 +8252,17 @@ public final class ClusterConnectivityManagementV2Proto {
       }
       if (!getCertificateBytes().isEmpty()) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, certificate_);
+      }
+      if (!getEnvironmentCrnBytes().isEmpty()) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, environmentCrn_);
+      }
+      {
+        int dataSize = 0;
+        for (int i = 0; i < certificates_.size(); i++) {
+          dataSize += computeStringSizeNoTag(certificates_.getRaw(i));
+        }
+        size += dataSize;
+        size += 1 * getCertificatesList().size();
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -6434,6 +8286,10 @@ public final class ClusterConnectivityManagementV2Proto {
           .equals(other.getEncipheredPrivateKey());
       result = result && getCertificate()
           .equals(other.getCertificate());
+      result = result && getEnvironmentCrn()
+          .equals(other.getEnvironmentCrn());
+      result = result && getCertificatesList()
+          .equals(other.getCertificatesList());
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -6451,6 +8307,12 @@ public final class ClusterConnectivityManagementV2Proto {
       hash = (53 * hash) + getEncipheredPrivateKey().hashCode();
       hash = (37 * hash) + CERTIFICATE_FIELD_NUMBER;
       hash = (53 * hash) + getCertificate().hashCode();
+      hash = (37 * hash) + ENVIRONMENTCRN_FIELD_NUMBER;
+      hash = (53 * hash) + getEnvironmentCrn().hashCode();
+      if (getCertificatesCount() > 0) {
+        hash = (37 * hash) + CERTIFICATES_FIELD_NUMBER;
+        hash = (53 * hash) + getCertificatesList().hashCode();
+      }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -6590,6 +8452,10 @@ public final class ClusterConnectivityManagementV2Proto {
 
         certificate_ = "";
 
+        environmentCrn_ = "";
+
+        certificates_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -6616,9 +8482,18 @@ public final class ClusterConnectivityManagementV2Proto {
       @java.lang.Override
       public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent buildPartial() {
         com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent result = new com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
         result.agentCrn_ = agentCrn_;
         result.encipheredPrivateKey_ = encipheredPrivateKey_;
         result.certificate_ = certificate_;
+        result.environmentCrn_ = environmentCrn_;
+        if (((bitField0_ & 0x00000010) == 0x00000010)) {
+          certificates_ = certificates_.getUnmodifiableView();
+          bitField0_ = (bitField0_ & ~0x00000010);
+        }
+        result.certificates_ = certificates_;
+        result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
       }
@@ -6679,6 +8554,20 @@ public final class ClusterConnectivityManagementV2Proto {
           certificate_ = other.certificate_;
           onChanged();
         }
+        if (!other.getEnvironmentCrn().isEmpty()) {
+          environmentCrn_ = other.environmentCrn_;
+          onChanged();
+        }
+        if (!other.certificates_.isEmpty()) {
+          if (certificates_.isEmpty()) {
+            certificates_ = other.certificates_;
+            bitField0_ = (bitField0_ & ~0x00000010);
+          } else {
+            ensureCertificatesIsMutable();
+            certificates_.addAll(other.certificates_);
+          }
+          onChanged();
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -6707,6 +8596,7 @@ public final class ClusterConnectivityManagementV2Proto {
         }
         return this;
       }
+      private int bitField0_;
 
       private java.lang.Object agentCrn_ = "";
       /**
@@ -6890,9 +8780,11 @@ public final class ClusterConnectivityManagementV2Proto {
       /**
        * <pre>
        * Generated cert for the agent
+       * We intend to deprecate this field in favor of 'certificates'.
+       * This is required to support CA signed certificates for agents.
        * </pre>
        *
-       * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true];</code>
+       * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
        */
       public java.lang.String getCertificate() {
         java.lang.Object ref = certificate_;
@@ -6909,9 +8801,11 @@ public final class ClusterConnectivityManagementV2Proto {
       /**
        * <pre>
        * Generated cert for the agent
+       * We intend to deprecate this field in favor of 'certificates'.
+       * This is required to support CA signed certificates for agents.
        * </pre>
        *
-       * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true];</code>
+       * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
        */
       public com.google.protobuf.ByteString
           getCertificateBytes() {
@@ -6929,9 +8823,11 @@ public final class ClusterConnectivityManagementV2Proto {
       /**
        * <pre>
        * Generated cert for the agent
+       * We intend to deprecate this field in favor of 'certificates'.
+       * This is required to support CA signed certificates for agents.
        * </pre>
        *
-       * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true];</code>
+       * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
        */
       public Builder setCertificate(
           java.lang.String value) {
@@ -6946,9 +8842,11 @@ public final class ClusterConnectivityManagementV2Proto {
       /**
        * <pre>
        * Generated cert for the agent
+       * We intend to deprecate this field in favor of 'certificates'.
+       * This is required to support CA signed certificates for agents.
        * </pre>
        *
-       * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true];</code>
+       * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
        */
       public Builder clearCertificate() {
         
@@ -6959,9 +8857,11 @@ public final class ClusterConnectivityManagementV2Proto {
       /**
        * <pre>
        * Generated cert for the agent
+       * We intend to deprecate this field in favor of 'certificates'.
+       * This is required to support CA signed certificates for agents.
        * </pre>
        *
-       * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true];</code>
+       * <code>string certificate = 3 [(.options.FieldExtension.skipLogging) = true, (.options.FieldExtension.deprecated) = true];</code>
        */
       public Builder setCertificateBytes(
           com.google.protobuf.ByteString value) {
@@ -6971,6 +8871,235 @@ public final class ClusterConnectivityManagementV2Proto {
   checkByteStringIsUtf8(value);
         
         certificate_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object environmentCrn_ = "";
+      /**
+       * <pre>
+       * CRN of the environment this agent is going to be deployed in. Having the environmentCrn set here
+       * implies that the provisioning service has consented to the use of this agent to target backend services
+       * outside the host it is deployed on.
+       * </pre>
+       *
+       * <code>string environmentCrn = 4;</code>
+       */
+      public java.lang.String getEnvironmentCrn() {
+        java.lang.Object ref = environmentCrn_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          environmentCrn_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * CRN of the environment this agent is going to be deployed in. Having the environmentCrn set here
+       * implies that the provisioning service has consented to the use of this agent to target backend services
+       * outside the host it is deployed on.
+       * </pre>
+       *
+       * <code>string environmentCrn = 4;</code>
+       */
+      public com.google.protobuf.ByteString
+          getEnvironmentCrnBytes() {
+        java.lang.Object ref = environmentCrn_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          environmentCrn_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * CRN of the environment this agent is going to be deployed in. Having the environmentCrn set here
+       * implies that the provisioning service has consented to the use of this agent to target backend services
+       * outside the host it is deployed on.
+       * </pre>
+       *
+       * <code>string environmentCrn = 4;</code>
+       */
+      public Builder setEnvironmentCrn(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        environmentCrn_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * CRN of the environment this agent is going to be deployed in. Having the environmentCrn set here
+       * implies that the provisioning service has consented to the use of this agent to target backend services
+       * outside the host it is deployed on.
+       * </pre>
+       *
+       * <code>string environmentCrn = 4;</code>
+       */
+      public Builder clearEnvironmentCrn() {
+        
+        environmentCrn_ = getDefaultInstance().getEnvironmentCrn();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * CRN of the environment this agent is going to be deployed in. Having the environmentCrn set here
+       * implies that the provisioning service has consented to the use of this agent to target backend services
+       * outside the host it is deployed on.
+       * </pre>
+       *
+       * <code>string environmentCrn = 4;</code>
+       */
+      public Builder setEnvironmentCrnBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        environmentCrn_ = value;
+        onChanged();
+        return this;
+      }
+
+      private com.google.protobuf.LazyStringList certificates_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      private void ensureCertificatesIsMutable() {
+        if (!((bitField0_ & 0x00000010) == 0x00000010)) {
+          certificates_ = new com.google.protobuf.LazyStringArrayList(certificates_);
+          bitField0_ |= 0x00000010;
+         }
+      }
+      /**
+       * <pre>
+       * Generated certificate and the trust chain for agent
+       * </pre>
+       *
+       * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getCertificatesList() {
+        return certificates_.getUnmodifiableView();
+      }
+      /**
+       * <pre>
+       * Generated certificate and the trust chain for agent
+       * </pre>
+       *
+       * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public int getCertificatesCount() {
+        return certificates_.size();
+      }
+      /**
+       * <pre>
+       * Generated certificate and the trust chain for agent
+       * </pre>
+       *
+       * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public java.lang.String getCertificates(int index) {
+        return certificates_.get(index);
+      }
+      /**
+       * <pre>
+       * Generated certificate and the trust chain for agent
+       * </pre>
+       *
+       * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public com.google.protobuf.ByteString
+          getCertificatesBytes(int index) {
+        return certificates_.getByteString(index);
+      }
+      /**
+       * <pre>
+       * Generated certificate and the trust chain for agent
+       * </pre>
+       *
+       * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder setCertificates(
+          int index, java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureCertificatesIsMutable();
+        certificates_.set(index, value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Generated certificate and the trust chain for agent
+       * </pre>
+       *
+       * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder addCertificates(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureCertificatesIsMutable();
+        certificates_.add(value);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Generated certificate and the trust chain for agent
+       * </pre>
+       *
+       * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder addAllCertificates(
+          java.lang.Iterable<java.lang.String> values) {
+        ensureCertificatesIsMutable();
+        com.google.protobuf.AbstractMessageLite.Builder.addAll(
+            values, certificates_);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Generated certificate and the trust chain for agent
+       * </pre>
+       *
+       * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder clearCertificates() {
+        certificates_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        bitField0_ = (bitField0_ & ~0x00000010);
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Generated certificate and the trust chain for agent
+       * </pre>
+       *
+       * <code>repeated string certificates = 5 [(.options.FieldExtension.skipLogging) = true];</code>
+       */
+      public Builder addCertificatesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        ensureCertificatesIsMutable();
+        certificates_.add(value);
         onChanged();
         return this;
       }
@@ -7027,6 +9156,2237 @@ public final class ClusterConnectivityManagementV2Proto {
 
   }
 
+  public interface ListAgentsRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:clusterconnectivitymanagementv2.ListAgentsRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>int32 pageSize = 1;</code>
+     */
+    int getPageSize();
+
+    /**
+     * <code>.paging.PageToken pageToken = 2;</code>
+     */
+    boolean hasPageToken();
+    /**
+     * <code>.paging.PageToken pageToken = 2;</code>
+     */
+    com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken getPageToken();
+    /**
+     * <code>.paging.PageToken pageToken = 2;</code>
+     */
+    com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder getPageTokenOrBuilder();
+
+    /**
+     * <pre>
+     * If an accountId is passed-in, all agents belonging to this accountId would be returned.
+     * </pre>
+     *
+     * <code>string accountId = 3;</code>
+     */
+    java.lang.String getAccountId();
+    /**
+     * <pre>
+     * If an accountId is passed-in, all agents belonging to this accountId would be returned.
+     * </pre>
+     *
+     * <code>string accountId = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getAccountIdBytes();
+
+    /**
+     * <pre>
+     * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
+     * </pre>
+     *
+     * <code>string envirinmentCrn = 4;</code>
+     */
+    java.lang.String getEnvirinmentCrn();
+    /**
+     * <pre>
+     * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
+     * </pre>
+     *
+     * <code>string envirinmentCrn = 4;</code>
+     */
+    com.google.protobuf.ByteString
+        getEnvirinmentCrnBytes();
+
+    public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest.FilterOneofCase getFilterOneofCase();
+  }
+  /**
+   * Protobuf type {@code clusterconnectivitymanagementv2.ListAgentsRequest}
+   */
+  public  static final class ListAgentsRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:clusterconnectivitymanagementv2.ListAgentsRequest)
+      ListAgentsRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use ListAgentsRequest.newBuilder() to construct.
+    private ListAgentsRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private ListAgentsRequest() {
+      pageSize_ = 0;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ListAgentsRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 8: {
+
+              pageSize_ = input.readInt32();
+              break;
+            }
+            case 18: {
+              com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder subBuilder = null;
+              if (pageToken_ != null) {
+                subBuilder = pageToken_.toBuilder();
+              }
+              pageToken_ = input.readMessage(com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(pageToken_);
+                pageToken_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
+            case 26: {
+              java.lang.String s = input.readStringRequireUtf8();
+              filterOneofCase_ = 3;
+              filterOneof_ = s;
+              break;
+            }
+            case 34: {
+              java.lang.String s = input.readStringRequireUtf8();
+              filterOneofCase_ = 4;
+              filterOneof_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest.class, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest.Builder.class);
+    }
+
+    private int filterOneofCase_ = 0;
+    private java.lang.Object filterOneof_;
+    public enum FilterOneofCase
+        implements com.google.protobuf.Internal.EnumLite {
+      ACCOUNTID(3),
+      ENVIRINMENTCRN(4),
+      FILTERONEOF_NOT_SET(0);
+      private final int value;
+      private FilterOneofCase(int value) {
+        this.value = value;
+      }
+      /**
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
+      public static FilterOneofCase valueOf(int value) {
+        return forNumber(value);
+      }
+
+      public static FilterOneofCase forNumber(int value) {
+        switch (value) {
+          case 3: return ACCOUNTID;
+          case 4: return ENVIRINMENTCRN;
+          case 0: return FILTERONEOF_NOT_SET;
+          default: return null;
+        }
+      }
+      public int getNumber() {
+        return this.value;
+      }
+    };
+
+    public FilterOneofCase
+    getFilterOneofCase() {
+      return FilterOneofCase.forNumber(
+          filterOneofCase_);
+    }
+
+    public static final int PAGESIZE_FIELD_NUMBER = 1;
+    private int pageSize_;
+    /**
+     * <code>int32 pageSize = 1;</code>
+     */
+    public int getPageSize() {
+      return pageSize_;
+    }
+
+    public static final int PAGETOKEN_FIELD_NUMBER = 2;
+    private com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken pageToken_;
+    /**
+     * <code>.paging.PageToken pageToken = 2;</code>
+     */
+    public boolean hasPageToken() {
+      return pageToken_ != null;
+    }
+    /**
+     * <code>.paging.PageToken pageToken = 2;</code>
+     */
+    public com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken getPageToken() {
+      return pageToken_ == null ? com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.getDefaultInstance() : pageToken_;
+    }
+    /**
+     * <code>.paging.PageToken pageToken = 2;</code>
+     */
+    public com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder getPageTokenOrBuilder() {
+      return getPageToken();
+    }
+
+    public static final int ACCOUNTID_FIELD_NUMBER = 3;
+    /**
+     * <pre>
+     * If an accountId is passed-in, all agents belonging to this accountId would be returned.
+     * </pre>
+     *
+     * <code>string accountId = 3;</code>
+     */
+    public java.lang.String getAccountId() {
+      java.lang.Object ref = "";
+      if (filterOneofCase_ == 3) {
+        ref = filterOneof_;
+      }
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (filterOneofCase_ == 3) {
+          filterOneof_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * If an accountId is passed-in, all agents belonging to this accountId would be returned.
+     * </pre>
+     *
+     * <code>string accountId = 3;</code>
+     */
+    public com.google.protobuf.ByteString
+        getAccountIdBytes() {
+      java.lang.Object ref = "";
+      if (filterOneofCase_ == 3) {
+        ref = filterOneof_;
+      }
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        if (filterOneofCase_ == 3) {
+          filterOneof_ = b;
+        }
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ENVIRINMENTCRN_FIELD_NUMBER = 4;
+    /**
+     * <pre>
+     * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
+     * </pre>
+     *
+     * <code>string envirinmentCrn = 4;</code>
+     */
+    public java.lang.String getEnvirinmentCrn() {
+      java.lang.Object ref = "";
+      if (filterOneofCase_ == 4) {
+        ref = filterOneof_;
+      }
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (filterOneofCase_ == 4) {
+          filterOneof_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
+     * </pre>
+     *
+     * <code>string envirinmentCrn = 4;</code>
+     */
+    public com.google.protobuf.ByteString
+        getEnvirinmentCrnBytes() {
+      java.lang.Object ref = "";
+      if (filterOneofCase_ == 4) {
+        ref = filterOneof_;
+      }
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        if (filterOneofCase_ == 4) {
+          filterOneof_ = b;
+        }
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (pageSize_ != 0) {
+        output.writeInt32(1, pageSize_);
+      }
+      if (pageToken_ != null) {
+        output.writeMessage(2, getPageToken());
+      }
+      if (filterOneofCase_ == 3) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, filterOneof_);
+      }
+      if (filterOneofCase_ == 4) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, filterOneof_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (pageSize_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(1, pageSize_);
+      }
+      if (pageToken_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getPageToken());
+      }
+      if (filterOneofCase_ == 3) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, filterOneof_);
+      }
+      if (filterOneofCase_ == 4) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, filterOneof_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest other = (com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest) obj;
+
+      boolean result = true;
+      result = result && (getPageSize()
+          == other.getPageSize());
+      result = result && (hasPageToken() == other.hasPageToken());
+      if (hasPageToken()) {
+        result = result && getPageToken()
+            .equals(other.getPageToken());
+      }
+      result = result && getFilterOneofCase().equals(
+          other.getFilterOneofCase());
+      if (!result) return false;
+      switch (filterOneofCase_) {
+        case 3:
+          result = result && getAccountId()
+              .equals(other.getAccountId());
+          break;
+        case 4:
+          result = result && getEnvirinmentCrn()
+              .equals(other.getEnvirinmentCrn());
+          break;
+        case 0:
+        default:
+      }
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + PAGESIZE_FIELD_NUMBER;
+      hash = (53 * hash) + getPageSize();
+      if (hasPageToken()) {
+        hash = (37 * hash) + PAGETOKEN_FIELD_NUMBER;
+        hash = (53 * hash) + getPageToken().hashCode();
+      }
+      switch (filterOneofCase_) {
+        case 3:
+          hash = (37 * hash) + ACCOUNTID_FIELD_NUMBER;
+          hash = (53 * hash) + getAccountId().hashCode();
+          break;
+        case 4:
+          hash = (37 * hash) + ENVIRINMENTCRN_FIELD_NUMBER;
+          hash = (53 * hash) + getEnvirinmentCrn().hashCode();
+          break;
+        case 0:
+        default:
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code clusterconnectivitymanagementv2.ListAgentsRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:clusterconnectivitymanagementv2.ListAgentsRequest)
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest.class, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        pageSize_ = 0;
+
+        if (pageTokenBuilder_ == null) {
+          pageToken_ = null;
+        } else {
+          pageToken_ = null;
+          pageTokenBuilder_ = null;
+        }
+        filterOneofCase_ = 0;
+        filterOneof_ = null;
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest build() {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest buildPartial() {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest result = new com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest(this);
+        result.pageSize_ = pageSize_;
+        if (pageTokenBuilder_ == null) {
+          result.pageToken_ = pageToken_;
+        } else {
+          result.pageToken_ = pageTokenBuilder_.build();
+        }
+        if (filterOneofCase_ == 3) {
+          result.filterOneof_ = filterOneof_;
+        }
+        if (filterOneofCase_ == 4) {
+          result.filterOneof_ = filterOneof_;
+        }
+        result.filterOneofCase_ = filterOneofCase_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest) {
+          return mergeFrom((com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest other) {
+        if (other == com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest.getDefaultInstance()) return this;
+        if (other.getPageSize() != 0) {
+          setPageSize(other.getPageSize());
+        }
+        if (other.hasPageToken()) {
+          mergePageToken(other.getPageToken());
+        }
+        switch (other.getFilterOneofCase()) {
+          case ACCOUNTID: {
+            filterOneofCase_ = 3;
+            filterOneof_ = other.filterOneof_;
+            onChanged();
+            break;
+          }
+          case ENVIRINMENTCRN: {
+            filterOneofCase_ = 4;
+            filterOneof_ = other.filterOneof_;
+            onChanged();
+            break;
+          }
+          case FILTERONEOF_NOT_SET: {
+            break;
+          }
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int filterOneofCase_ = 0;
+      private java.lang.Object filterOneof_;
+      public FilterOneofCase
+          getFilterOneofCase() {
+        return FilterOneofCase.forNumber(
+            filterOneofCase_);
+      }
+
+      public Builder clearFilterOneof() {
+        filterOneofCase_ = 0;
+        filterOneof_ = null;
+        onChanged();
+        return this;
+      }
+
+
+      private int pageSize_ ;
+      /**
+       * <code>int32 pageSize = 1;</code>
+       */
+      public int getPageSize() {
+        return pageSize_;
+      }
+      /**
+       * <code>int32 pageSize = 1;</code>
+       */
+      public Builder setPageSize(int value) {
+        
+        pageSize_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>int32 pageSize = 1;</code>
+       */
+      public Builder clearPageSize() {
+        
+        pageSize_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken pageToken_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken, com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder, com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder> pageTokenBuilder_;
+      /**
+       * <code>.paging.PageToken pageToken = 2;</code>
+       */
+      public boolean hasPageToken() {
+        return pageTokenBuilder_ != null || pageToken_ != null;
+      }
+      /**
+       * <code>.paging.PageToken pageToken = 2;</code>
+       */
+      public com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken getPageToken() {
+        if (pageTokenBuilder_ == null) {
+          return pageToken_ == null ? com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.getDefaultInstance() : pageToken_;
+        } else {
+          return pageTokenBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>.paging.PageToken pageToken = 2;</code>
+       */
+      public Builder setPageToken(com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken value) {
+        if (pageTokenBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          pageToken_ = value;
+          onChanged();
+        } else {
+          pageTokenBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>.paging.PageToken pageToken = 2;</code>
+       */
+      public Builder setPageToken(
+          com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder builderForValue) {
+        if (pageTokenBuilder_ == null) {
+          pageToken_ = builderForValue.build();
+          onChanged();
+        } else {
+          pageTokenBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <code>.paging.PageToken pageToken = 2;</code>
+       */
+      public Builder mergePageToken(com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken value) {
+        if (pageTokenBuilder_ == null) {
+          if (pageToken_ != null) {
+            pageToken_ =
+              com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.newBuilder(pageToken_).mergeFrom(value).buildPartial();
+          } else {
+            pageToken_ = value;
+          }
+          onChanged();
+        } else {
+          pageTokenBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>.paging.PageToken pageToken = 2;</code>
+       */
+      public Builder clearPageToken() {
+        if (pageTokenBuilder_ == null) {
+          pageToken_ = null;
+          onChanged();
+        } else {
+          pageToken_ = null;
+          pageTokenBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <code>.paging.PageToken pageToken = 2;</code>
+       */
+      public com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder getPageTokenBuilder() {
+        
+        onChanged();
+        return getPageTokenFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.paging.PageToken pageToken = 2;</code>
+       */
+      public com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder getPageTokenOrBuilder() {
+        if (pageTokenBuilder_ != null) {
+          return pageTokenBuilder_.getMessageOrBuilder();
+        } else {
+          return pageToken_ == null ?
+              com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.getDefaultInstance() : pageToken_;
+        }
+      }
+      /**
+       * <code>.paging.PageToken pageToken = 2;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken, com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder, com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder> 
+          getPageTokenFieldBuilder() {
+        if (pageTokenBuilder_ == null) {
+          pageTokenBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken, com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder, com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder>(
+                  getPageToken(),
+                  getParentForChildren(),
+                  isClean());
+          pageToken_ = null;
+        }
+        return pageTokenBuilder_;
+      }
+
+      /**
+       * <pre>
+       * If an accountId is passed-in, all agents belonging to this accountId would be returned.
+       * </pre>
+       *
+       * <code>string accountId = 3;</code>
+       */
+      public java.lang.String getAccountId() {
+        java.lang.Object ref = "";
+        if (filterOneofCase_ == 3) {
+          ref = filterOneof_;
+        }
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (filterOneofCase_ == 3) {
+            filterOneof_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * If an accountId is passed-in, all agents belonging to this accountId would be returned.
+       * </pre>
+       *
+       * <code>string accountId = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getAccountIdBytes() {
+        java.lang.Object ref = "";
+        if (filterOneofCase_ == 3) {
+          ref = filterOneof_;
+        }
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          if (filterOneofCase_ == 3) {
+            filterOneof_ = b;
+          }
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * If an accountId is passed-in, all agents belonging to this accountId would be returned.
+       * </pre>
+       *
+       * <code>string accountId = 3;</code>
+       */
+      public Builder setAccountId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  filterOneofCase_ = 3;
+        filterOneof_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * If an accountId is passed-in, all agents belonging to this accountId would be returned.
+       * </pre>
+       *
+       * <code>string accountId = 3;</code>
+       */
+      public Builder clearAccountId() {
+        if (filterOneofCase_ == 3) {
+          filterOneofCase_ = 0;
+          filterOneof_ = null;
+          onChanged();
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * If an accountId is passed-in, all agents belonging to this accountId would be returned.
+       * </pre>
+       *
+       * <code>string accountId = 3;</code>
+       */
+      public Builder setAccountIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        filterOneofCase_ = 3;
+        filterOneof_ = value;
+        onChanged();
+        return this;
+      }
+
+      /**
+       * <pre>
+       * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
+       * </pre>
+       *
+       * <code>string envirinmentCrn = 4;</code>
+       */
+      public java.lang.String getEnvirinmentCrn() {
+        java.lang.Object ref = "";
+        if (filterOneofCase_ == 4) {
+          ref = filterOneof_;
+        }
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (filterOneofCase_ == 4) {
+            filterOneof_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
+       * </pre>
+       *
+       * <code>string envirinmentCrn = 4;</code>
+       */
+      public com.google.protobuf.ByteString
+          getEnvirinmentCrnBytes() {
+        java.lang.Object ref = "";
+        if (filterOneofCase_ == 4) {
+          ref = filterOneof_;
+        }
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          if (filterOneofCase_ == 4) {
+            filterOneof_ = b;
+          }
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
+       * </pre>
+       *
+       * <code>string envirinmentCrn = 4;</code>
+       */
+      public Builder setEnvirinmentCrn(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  filterOneofCase_ = 4;
+        filterOneof_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
+       * </pre>
+       *
+       * <code>string envirinmentCrn = 4;</code>
+       */
+      public Builder clearEnvirinmentCrn() {
+        if (filterOneofCase_ == 4) {
+          filterOneofCase_ = 0;
+          filterOneof_ = null;
+          onChanged();
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
+       * </pre>
+       *
+       * <code>string envirinmentCrn = 4;</code>
+       */
+      public Builder setEnvirinmentCrnBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        filterOneofCase_ = 4;
+        filterOneof_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:clusterconnectivitymanagementv2.ListAgentsRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:clusterconnectivitymanagementv2.ListAgentsRequest)
+    private static final com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest();
+    }
+
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ListAgentsRequest>
+        PARSER = new com.google.protobuf.AbstractParser<ListAgentsRequest>() {
+      @java.lang.Override
+      public ListAgentsRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ListAgentsRequest(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<ListAgentsRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ListAgentsRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface ListAgentsResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:clusterconnectivitymanagementv2.ListAgentsResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>.paging.PageToken nextPageToken = 1;</code>
+     */
+    boolean hasNextPageToken();
+    /**
+     * <code>.paging.PageToken nextPageToken = 1;</code>
+     */
+    com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken getNextPageToken();
+    /**
+     * <code>.paging.PageToken nextPageToken = 1;</code>
+     */
+    com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder getNextPageTokenOrBuilder();
+
+    /**
+     * <pre>
+     * List of all agents (matching the optional filter if supplied)
+     * </pre>
+     *
+     * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+     */
+    java.util.List<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent> 
+        getAgentsList();
+    /**
+     * <pre>
+     * List of all agents (matching the optional filter if supplied)
+     * </pre>
+     *
+     * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+     */
+    com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent getAgents(int index);
+    /**
+     * <pre>
+     * List of all agents (matching the optional filter if supplied)
+     * </pre>
+     *
+     * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+     */
+    int getAgentsCount();
+    /**
+     * <pre>
+     * List of all agents (matching the optional filter if supplied)
+     * </pre>
+     *
+     * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+     */
+    java.util.List<? extends com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgentOrBuilder> 
+        getAgentsOrBuilderList();
+    /**
+     * <pre>
+     * List of all agents (matching the optional filter if supplied)
+     * </pre>
+     *
+     * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+     */
+    com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgentOrBuilder getAgentsOrBuilder(
+        int index);
+  }
+  /**
+   * Protobuf type {@code clusterconnectivitymanagementv2.ListAgentsResponse}
+   */
+  public  static final class ListAgentsResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:clusterconnectivitymanagementv2.ListAgentsResponse)
+      ListAgentsResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use ListAgentsResponse.newBuilder() to construct.
+    private ListAgentsResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private ListAgentsResponse() {
+      agents_ = java.util.Collections.emptyList();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ListAgentsResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder subBuilder = null;
+              if (nextPageToken_ != null) {
+                subBuilder = nextPageToken_.toBuilder();
+              }
+              nextPageToken_ = input.readMessage(com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.parser(), extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(nextPageToken_);
+                nextPageToken_ = subBuilder.buildPartial();
+              }
+
+              break;
+            }
+            case 18: {
+              if (!((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+                agents_ = new java.util.ArrayList<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent>();
+                mutable_bitField0_ |= 0x00000002;
+              }
+              agents_.add(
+                  input.readMessage(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.parser(), extensionRegistry));
+              break;
+            }
+            default: {
+              if (!parseUnknownFieldProto3(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        if (((mutable_bitField0_ & 0x00000002) == 0x00000002)) {
+          agents_ = java.util.Collections.unmodifiableList(agents_);
+        }
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse.class, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int NEXTPAGETOKEN_FIELD_NUMBER = 1;
+    private com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken nextPageToken_;
+    /**
+     * <code>.paging.PageToken nextPageToken = 1;</code>
+     */
+    public boolean hasNextPageToken() {
+      return nextPageToken_ != null;
+    }
+    /**
+     * <code>.paging.PageToken nextPageToken = 1;</code>
+     */
+    public com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken getNextPageToken() {
+      return nextPageToken_ == null ? com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.getDefaultInstance() : nextPageToken_;
+    }
+    /**
+     * <code>.paging.PageToken nextPageToken = 1;</code>
+     */
+    public com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder getNextPageTokenOrBuilder() {
+      return getNextPageToken();
+    }
+
+    public static final int AGENTS_FIELD_NUMBER = 2;
+    private java.util.List<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent> agents_;
+    /**
+     * <pre>
+     * List of all agents (matching the optional filter if supplied)
+     * </pre>
+     *
+     * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+     */
+    public java.util.List<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent> getAgentsList() {
+      return agents_;
+    }
+    /**
+     * <pre>
+     * List of all agents (matching the optional filter if supplied)
+     * </pre>
+     *
+     * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+     */
+    public java.util.List<? extends com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgentOrBuilder> 
+        getAgentsOrBuilderList() {
+      return agents_;
+    }
+    /**
+     * <pre>
+     * List of all agents (matching the optional filter if supplied)
+     * </pre>
+     *
+     * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+     */
+    public int getAgentsCount() {
+      return agents_.size();
+    }
+    /**
+     * <pre>
+     * List of all agents (matching the optional filter if supplied)
+     * </pre>
+     *
+     * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+     */
+    public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent getAgents(int index) {
+      return agents_.get(index);
+    }
+    /**
+     * <pre>
+     * List of all agents (matching the optional filter if supplied)
+     * </pre>
+     *
+     * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+     */
+    public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgentOrBuilder getAgentsOrBuilder(
+        int index) {
+      return agents_.get(index);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (nextPageToken_ != null) {
+        output.writeMessage(1, getNextPageToken());
+      }
+      for (int i = 0; i < agents_.size(); i++) {
+        output.writeMessage(2, agents_.get(i));
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (nextPageToken_ != null) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getNextPageToken());
+      }
+      for (int i = 0; i < agents_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, agents_.get(i));
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse other = (com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse) obj;
+
+      boolean result = true;
+      result = result && (hasNextPageToken() == other.hasNextPageToken());
+      if (hasNextPageToken()) {
+        result = result && getNextPageToken()
+            .equals(other.getNextPageToken());
+      }
+      result = result && getAgentsList()
+          .equals(other.getAgentsList());
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasNextPageToken()) {
+        hash = (37 * hash) + NEXTPAGETOKEN_FIELD_NUMBER;
+        hash = (53 * hash) + getNextPageToken().hashCode();
+      }
+      if (getAgentsCount() > 0) {
+        hash = (37 * hash) + AGENTS_FIELD_NUMBER;
+        hash = (53 * hash) + getAgentsList().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code clusterconnectivitymanagementv2.ListAgentsResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:clusterconnectivitymanagementv2.ListAgentsResponse)
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse.class, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+          getAgentsFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        if (nextPageTokenBuilder_ == null) {
+          nextPageToken_ = null;
+        } else {
+          nextPageToken_ = null;
+          nextPageTokenBuilder_ = null;
+        }
+        if (agentsBuilder_ == null) {
+          agents_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+        } else {
+          agentsBuilder_.clear();
+        }
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse build() {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse buildPartial() {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse result = new com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (nextPageTokenBuilder_ == null) {
+          result.nextPageToken_ = nextPageToken_;
+        } else {
+          result.nextPageToken_ = nextPageTokenBuilder_.build();
+        }
+        if (agentsBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) == 0x00000002)) {
+            agents_ = java.util.Collections.unmodifiableList(agents_);
+            bitField0_ = (bitField0_ & ~0x00000002);
+          }
+          result.agents_ = agents_;
+        } else {
+          result.agents_ = agentsBuilder_.build();
+        }
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse) {
+          return mergeFrom((com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse other) {
+        if (other == com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse.getDefaultInstance()) return this;
+        if (other.hasNextPageToken()) {
+          mergeNextPageToken(other.getNextPageToken());
+        }
+        if (agentsBuilder_ == null) {
+          if (!other.agents_.isEmpty()) {
+            if (agents_.isEmpty()) {
+              agents_ = other.agents_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+            } else {
+              ensureAgentsIsMutable();
+              agents_.addAll(other.agents_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.agents_.isEmpty()) {
+            if (agentsBuilder_.isEmpty()) {
+              agentsBuilder_.dispose();
+              agentsBuilder_ = null;
+              agents_ = other.agents_;
+              bitField0_ = (bitField0_ & ~0x00000002);
+              agentsBuilder_ = 
+                com.google.protobuf.GeneratedMessageV3.alwaysUseFieldBuilders ?
+                   getAgentsFieldBuilder() : null;
+            } else {
+              agentsBuilder_.addAllMessages(other.agents_);
+            }
+          }
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken nextPageToken_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken, com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder, com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder> nextPageTokenBuilder_;
+      /**
+       * <code>.paging.PageToken nextPageToken = 1;</code>
+       */
+      public boolean hasNextPageToken() {
+        return nextPageTokenBuilder_ != null || nextPageToken_ != null;
+      }
+      /**
+       * <code>.paging.PageToken nextPageToken = 1;</code>
+       */
+      public com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken getNextPageToken() {
+        if (nextPageTokenBuilder_ == null) {
+          return nextPageToken_ == null ? com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.getDefaultInstance() : nextPageToken_;
+        } else {
+          return nextPageTokenBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>.paging.PageToken nextPageToken = 1;</code>
+       */
+      public Builder setNextPageToken(com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken value) {
+        if (nextPageTokenBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          nextPageToken_ = value;
+          onChanged();
+        } else {
+          nextPageTokenBuilder_.setMessage(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>.paging.PageToken nextPageToken = 1;</code>
+       */
+      public Builder setNextPageToken(
+          com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder builderForValue) {
+        if (nextPageTokenBuilder_ == null) {
+          nextPageToken_ = builderForValue.build();
+          onChanged();
+        } else {
+          nextPageTokenBuilder_.setMessage(builderForValue.build());
+        }
+
+        return this;
+      }
+      /**
+       * <code>.paging.PageToken nextPageToken = 1;</code>
+       */
+      public Builder mergeNextPageToken(com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken value) {
+        if (nextPageTokenBuilder_ == null) {
+          if (nextPageToken_ != null) {
+            nextPageToken_ =
+              com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.newBuilder(nextPageToken_).mergeFrom(value).buildPartial();
+          } else {
+            nextPageToken_ = value;
+          }
+          onChanged();
+        } else {
+          nextPageTokenBuilder_.mergeFrom(value);
+        }
+
+        return this;
+      }
+      /**
+       * <code>.paging.PageToken nextPageToken = 1;</code>
+       */
+      public Builder clearNextPageToken() {
+        if (nextPageTokenBuilder_ == null) {
+          nextPageToken_ = null;
+          onChanged();
+        } else {
+          nextPageToken_ = null;
+          nextPageTokenBuilder_ = null;
+        }
+
+        return this;
+      }
+      /**
+       * <code>.paging.PageToken nextPageToken = 1;</code>
+       */
+      public com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder getNextPageTokenBuilder() {
+        
+        onChanged();
+        return getNextPageTokenFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.paging.PageToken nextPageToken = 1;</code>
+       */
+      public com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder getNextPageTokenOrBuilder() {
+        if (nextPageTokenBuilder_ != null) {
+          return nextPageTokenBuilder_.getMessageOrBuilder();
+        } else {
+          return nextPageToken_ == null ?
+              com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.getDefaultInstance() : nextPageToken_;
+        }
+      }
+      /**
+       * <code>.paging.PageToken nextPageToken = 1;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken, com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder, com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder> 
+          getNextPageTokenFieldBuilder() {
+        if (nextPageTokenBuilder_ == null) {
+          nextPageTokenBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken, com.cloudera.thunderhead.service.common.paging.PagingProto.PageToken.Builder, com.cloudera.thunderhead.service.common.paging.PagingProto.PageTokenOrBuilder>(
+                  getNextPageToken(),
+                  getParentForChildren(),
+                  isClean());
+          nextPageToken_ = null;
+        }
+        return nextPageTokenBuilder_;
+      }
+
+      private java.util.List<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent> agents_ =
+        java.util.Collections.emptyList();
+      private void ensureAgentsIsMutable() {
+        if (!((bitField0_ & 0x00000002) == 0x00000002)) {
+          agents_ = new java.util.ArrayList<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent>(agents_);
+          bitField0_ |= 0x00000002;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgentOrBuilder> agentsBuilder_;
+
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public java.util.List<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent> getAgentsList() {
+        if (agentsBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(agents_);
+        } else {
+          return agentsBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public int getAgentsCount() {
+        if (agentsBuilder_ == null) {
+          return agents_.size();
+        } else {
+          return agentsBuilder_.getCount();
+        }
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent getAgents(int index) {
+        if (agentsBuilder_ == null) {
+          return agents_.get(index);
+        } else {
+          return agentsBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public Builder setAgents(
+          int index, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent value) {
+        if (agentsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureAgentsIsMutable();
+          agents_.set(index, value);
+          onChanged();
+        } else {
+          agentsBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public Builder setAgents(
+          int index, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder builderForValue) {
+        if (agentsBuilder_ == null) {
+          ensureAgentsIsMutable();
+          agents_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          agentsBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public Builder addAgents(com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent value) {
+        if (agentsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureAgentsIsMutable();
+          agents_.add(value);
+          onChanged();
+        } else {
+          agentsBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public Builder addAgents(
+          int index, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent value) {
+        if (agentsBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureAgentsIsMutable();
+          agents_.add(index, value);
+          onChanged();
+        } else {
+          agentsBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public Builder addAgents(
+          com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder builderForValue) {
+        if (agentsBuilder_ == null) {
+          ensureAgentsIsMutable();
+          agents_.add(builderForValue.build());
+          onChanged();
+        } else {
+          agentsBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public Builder addAgents(
+          int index, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder builderForValue) {
+        if (agentsBuilder_ == null) {
+          ensureAgentsIsMutable();
+          agents_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          agentsBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public Builder addAllAgents(
+          java.lang.Iterable<? extends com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent> values) {
+        if (agentsBuilder_ == null) {
+          ensureAgentsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, agents_);
+          onChanged();
+        } else {
+          agentsBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public Builder clearAgents() {
+        if (agentsBuilder_ == null) {
+          agents_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000002);
+          onChanged();
+        } else {
+          agentsBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public Builder removeAgents(int index) {
+        if (agentsBuilder_ == null) {
+          ensureAgentsIsMutable();
+          agents_.remove(index);
+          onChanged();
+        } else {
+          agentsBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder getAgentsBuilder(
+          int index) {
+        return getAgentsFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgentOrBuilder getAgentsOrBuilder(
+          int index) {
+        if (agentsBuilder_ == null) {
+          return agents_.get(index);  } else {
+          return agentsBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public java.util.List<? extends com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgentOrBuilder> 
+           getAgentsOrBuilderList() {
+        if (agentsBuilder_ != null) {
+          return agentsBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(agents_);
+        }
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder addAgentsBuilder() {
+        return getAgentsFieldBuilder().addBuilder(
+            com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder addAgentsBuilder(
+          int index) {
+        return getAgentsFieldBuilder().addBuilder(
+            index, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.getDefaultInstance());
+      }
+      /**
+       * <pre>
+       * List of all agents (matching the optional filter if supplied)
+       * </pre>
+       *
+       * <code>repeated .clusterconnectivitymanagementv2.InvertingProxyAgent agents = 2;</code>
+       */
+      public java.util.List<com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder> 
+           getAgentsBuilderList() {
+        return getAgentsFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilderV3<
+          com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgentOrBuilder> 
+          getAgentsFieldBuilder() {
+        if (agentsBuilder_ == null) {
+          agentsBuilder_ = new com.google.protobuf.RepeatedFieldBuilderV3<
+              com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgent.Builder, com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.InvertingProxyAgentOrBuilder>(
+                  agents_,
+                  ((bitField0_ & 0x00000002) == 0x00000002),
+                  getParentForChildren(),
+                  isClean());
+          agents_ = null;
+        }
+        return agentsBuilder_;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFieldsProto3(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:clusterconnectivitymanagementv2.ListAgentsResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:clusterconnectivitymanagementv2.ListAgentsResponse)
+    private static final com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse();
+    }
+
+    public static com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ListAgentsResponse>
+        PARSER = new com.google.protobuf.AbstractParser<ListAgentsResponse>() {
+      @java.lang.Override
+      public ListAgentsResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ListAgentsResponse(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<ListAgentsResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ListAgentsResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_clusterconnectivitymanagementv2_CreateOrGetInvertingProxyRequest_descriptor;
   private static final 
@@ -7063,6 +11423,16 @@ public final class ClusterConnectivityManagementV2Proto {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_clusterconnectivitymanagementv2_UnregisterAgentRequest_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesRequest_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_clusterconnectivitymanagementv2_UnregisterAgentResponse_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -7077,6 +11447,16 @@ public final class ClusterConnectivityManagementV2Proto {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_clusterconnectivitymanagementv2_InvertingProxyAgent_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -7088,48 +11468,68 @@ public final class ClusterConnectivityManagementV2Proto {
     java.lang.String[] descriptorData = {
       "\n%clusterconnectivitymanagementv2.proto\022" +
       "\037clusterconnectivitymanagementv2\032\rversio" +
-      "n.proto\032\roptions.proto\"5\n CreateOrGetInv" +
-      "ertingProxyRequest\022\021\n\taccountId\030\001 \001(\t\"l\n" +
-      "!CreateOrGetInvertingProxyResponse\022G\n\016in" +
-      "vertingProxy\030\001 \001(\0132/.clusterconnectivity" +
-      "managementv2.InvertingProxy\"0\n\033RemoveInv" +
-      "ertingProxyRequest\022\021\n\taccountId\030\001 \001(\t\"\036\n" +
-      "\034RemoveInvertingProxyResponse\"L\n\024Registe" +
-      "rAgentRequest\022\021\n\taccountId\030\001 \001(\t\022\022\n\ndoma" +
-      "inName\030\002 \001(\t\022\r\n\005keyId\030\003 \001(\t\"j\n\025RegisterA" +
-      "gentResponse\022Q\n\023invertingProxyAgent\030\001 \001(" +
-      "\01324.clusterconnectivitymanagementv2.Inve" +
-      "rtingProxyAgent\"*\n\026UnregisterAgentReques" +
-      "t\022\020\n\010agentCrn\030\001 \001(\t\"\031\n\027UnregisterAgentRe" +
-      "sponse\"\314\001\n\016InvertingProxy\022F\n\006status\030\001 \001(" +
-      "\01626.clusterconnectivitymanagementv2.Inve" +
-      "rtingProxy.Status\022\020\n\010hostname\030\002 \001(\t\022\026\n\016c" +
-      "auseOfFailure\030\003 \001(\t\022\031\n\013certificate\030\004 \001(\t" +
-      "B\004\210\265\030\001\"-\n\006Status\022\014\n\010CREATING\020\000\022\t\n\005READY\020" +
-      "\001\022\n\n\006FAILED\020\002\"f\n\023InvertingProxyAgent\022\020\n\010" +
-      "agentCrn\030\001 \001(\t\022\"\n\024encipheredPrivateKey\030\002" +
-      " \001(\tB\004\210\265\030\001\022\031\n\013certificate\030\003 \001(\tB\004\210\265\030\0012\257\005" +
-      "\n\037ClusterConnectivityManagementV2\022A\n\nGet" +
-      "Version\022\027.version.VersionRequest\032\030.versi" +
-      "on.VersionResponse\"\000\022\244\001\n\031CreateOrGetInve" +
-      "rtingProxy\022A.clusterconnectivitymanageme" +
-      "ntv2.CreateOrGetInvertingProxyRequest\032B." +
-      "clusterconnectivitymanagementv2.CreateOr" +
-      "GetInvertingProxyResponse\"\000\022\225\001\n\024RemoveIn" +
-      "vertingProxy\022<.clusterconnectivitymanage" +
-      "mentv2.RemoveInvertingProxyRequest\032=.clu" +
-      "sterconnectivitymanagementv2.RemoveInver" +
-      "tingProxyResponse\"\000\022\200\001\n\rRegisterAgent\0225." +
-      "clusterconnectivitymanagementv2.Register" +
-      "AgentRequest\0326.clusterconnectivitymanage" +
-      "mentv2.RegisterAgentResponse\"\000\022\206\001\n\017Unreg" +
-      "isterAgent\0227.clusterconnectivitymanageme" +
-      "ntv2.UnregisterAgentRequest\0328.clustercon" +
-      "nectivitymanagementv2.UnregisterAgentRes" +
-      "ponse\"\000Bh\n@com.cloudera.thunderhead.serv" +
-      "ice.clusterconnectivitymanagementv2B$Clu" +
-      "sterConnectivityManagementV2Protob\006proto" +
-      "3"
+      "n.proto\032\roptions.proto\032\014paging.proto\"5\n " +
+      "CreateOrGetInvertingProxyRequest\022\021\n\tacco" +
+      "untId\030\001 \001(\t\"l\n!CreateOrGetInvertingProxy" +
+      "Response\022G\n\016invertingProxy\030\001 \001(\0132/.clust" +
+      "erconnectivitymanagementv2.InvertingProx" +
+      "y\"0\n\033RemoveInvertingProxyRequest\022\021\n\tacco" +
+      "untId\030\001 \001(\t\"\036\n\034RemoveInvertingProxyRespo" +
+      "nse\"d\n\024RegisterAgentRequest\022\021\n\taccountId" +
+      "\030\001 \001(\t\022\022\n\ndomainName\030\002 \001(\t\022\r\n\005keyId\030\003 \001(" +
+      "\t\022\026\n\016environmentCrn\030\004 \001(\t\"j\n\025RegisterAge" +
+      "ntResponse\022Q\n\023invertingProxyAgent\030\001 \001(\0132" +
+      "4.clusterconnectivitymanagementv2.Invert" +
+      "ingProxyAgent\"*\n\026UnregisterAgentRequest\022" +
+      "\020\n\010agentCrn\030\001 \001(\t\"4\n\037GetAllAgentsCertifi" +
+      "catesRequest\022\021\n\taccountId\030\001 \001(\t\">\n GetAl" +
+      "lAgentsCertificatesResponse\022\032\n\014certifica" +
+      "tes\030\001 \003(\tB\004\210\265\030\001\"\031\n\027UnregisterAgentRespon" +
+      "se\"\355\001\n\016InvertingProxy\022F\n\006status\030\001 \001(\01626." +
+      "clusterconnectivitymanagementv2.Invertin" +
+      "gProxy.Status\022\020\n\010hostname\030\002 \001(\t\022\026\n\016cause" +
+      "OfFailure\030\003 \001(\t\022\035\n\013certificate\030\004 \001(\tB\010\210\265" +
+      "\030\001\370\265\030\001\022\033\n\rcaCertificate\030\005 \001(\tB\004\210\265\030\001\"-\n\006S" +
+      "tatus\022\014\n\010CREATING\020\000\022\t\n\005READY\020\001\022\n\n\006FAILED" +
+      "\020\002\"\236\001\n\023InvertingProxyAgent\022\020\n\010agentCrn\030\001" +
+      " \001(\t\022\"\n\024encipheredPrivateKey\030\002 \001(\tB\004\210\265\030\001" +
+      "\022\035\n\013certificate\030\003 \001(\tB\010\210\265\030\001\370\265\030\001\022\026\n\016envir" +
+      "onmentCrn\030\004 \001(\t\022\032\n\014certificates\030\005 \003(\tB\004\210" +
+      "\265\030\001\"\212\001\n\021ListAgentsRequest\022\020\n\010pageSize\030\001 " +
+      "\001(\005\022$\n\tpageToken\030\002 \001(\0132\021.paging.PageToke" +
+      "n\022\023\n\taccountId\030\003 \001(\tH\000\022\030\n\016envirinmentCrn" +
+      "\030\004 \001(\tH\000B\016\n\014filter_oneof\"\204\001\n\022ListAgentsR" +
+      "esponse\022(\n\rnextPageToken\030\001 \001(\0132\021.paging." +
+      "PageToken\022D\n\006agents\030\002 \003(\01324.clusterconne" +
+      "ctivitymanagementv2.InvertingProxyAgent2" +
+      "\314\007\n\037ClusterConnectivityManagementV2\022A\n\nG" +
+      "etVersion\022\027.version.VersionRequest\032\030.ver" +
+      "sion.VersionResponse\"\000\022\244\001\n\031CreateOrGetIn" +
+      "vertingProxy\022A.clusterconnectivitymanage" +
+      "mentv2.CreateOrGetInvertingProxyRequest\032" +
+      "B.clusterconnectivitymanagementv2.Create" +
+      "OrGetInvertingProxyResponse\"\000\022\225\001\n\024Remove" +
+      "InvertingProxy\022<.clusterconnectivitymana" +
+      "gementv2.RemoveInvertingProxyRequest\032=.c" +
+      "lusterconnectivitymanagementv2.RemoveInv" +
+      "ertingProxyResponse\"\000\022\200\001\n\rRegisterAgent\022" +
+      "5.clusterconnectivitymanagementv2.Regist" +
+      "erAgentRequest\0326.clusterconnectivitymana" +
+      "gementv2.RegisterAgentResponse\"\000\022\206\001\n\017Unr" +
+      "egisterAgent\0227.clusterconnectivitymanage" +
+      "mentv2.UnregisterAgentRequest\0328.clusterc" +
+      "onnectivitymanagementv2.UnregisterAgentR" +
+      "esponse\"\000\022w\n\nListAgents\0222.clusterconnect" +
+      "ivitymanagementv2.ListAgentsRequest\0323.cl" +
+      "usterconnectivitymanagementv2.ListAgents" +
+      "Response\"\000\022\241\001\n\030GetAllAgentsCertificates\022" +
+      "@.clusterconnectivitymanagementv2.GetAll" +
+      "AgentsCertificatesRequest\032A.clusterconne" +
+      "ctivitymanagementv2.GetAllAgentsCertific" +
+      "atesResponse\"\000B\203\001\n@com.cloudera.thunderh" +
+      "ead.service.clusterconnectivitymanagemen" +
+      "tv2B$ClusterConnectivityManagementV2Prot" +
+      "oZ\031com/cloudera/cdp/protobufb\006proto3"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -7144,6 +11544,7 @@ public final class ClusterConnectivityManagementV2Proto {
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.cloudera.thunderhead.service.common.version.Version.getDescriptor(),
           com.cloudera.thunderhead.service.common.options.Options.getDescriptor(),
+          com.cloudera.thunderhead.service.common.paging.PagingProto.getDescriptor(),
         }, assigner);
     internal_static_clusterconnectivitymanagementv2_CreateOrGetInvertingProxyRequest_descriptor =
       getDescriptor().getMessageTypes().get(0);
@@ -7174,7 +11575,7 @@ public final class ClusterConnectivityManagementV2Proto {
     internal_static_clusterconnectivitymanagementv2_RegisterAgentRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_clusterconnectivitymanagementv2_RegisterAgentRequest_descriptor,
-        new java.lang.String[] { "AccountId", "DomainName", "KeyId", });
+        new java.lang.String[] { "AccountId", "DomainName", "KeyId", "EnvironmentCrn", });
     internal_static_clusterconnectivitymanagementv2_RegisterAgentResponse_descriptor =
       getDescriptor().getMessageTypes().get(5);
     internal_static_clusterconnectivitymanagementv2_RegisterAgentResponse_fieldAccessorTable = new
@@ -7187,31 +11588,57 @@ public final class ClusterConnectivityManagementV2Proto {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_clusterconnectivitymanagementv2_UnregisterAgentRequest_descriptor,
         new java.lang.String[] { "AgentCrn", });
-    internal_static_clusterconnectivitymanagementv2_UnregisterAgentResponse_descriptor =
+    internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesRequest_descriptor =
       getDescriptor().getMessageTypes().get(7);
+    internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesRequest_descriptor,
+        new java.lang.String[] { "AccountId", });
+    internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesResponse_descriptor =
+      getDescriptor().getMessageTypes().get(8);
+    internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_clusterconnectivitymanagementv2_GetAllAgentsCertificatesResponse_descriptor,
+        new java.lang.String[] { "Certificates", });
+    internal_static_clusterconnectivitymanagementv2_UnregisterAgentResponse_descriptor =
+      getDescriptor().getMessageTypes().get(9);
     internal_static_clusterconnectivitymanagementv2_UnregisterAgentResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_clusterconnectivitymanagementv2_UnregisterAgentResponse_descriptor,
         new java.lang.String[] { });
     internal_static_clusterconnectivitymanagementv2_InvertingProxy_descriptor =
-      getDescriptor().getMessageTypes().get(8);
+      getDescriptor().getMessageTypes().get(10);
     internal_static_clusterconnectivitymanagementv2_InvertingProxy_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_clusterconnectivitymanagementv2_InvertingProxy_descriptor,
-        new java.lang.String[] { "Status", "Hostname", "CauseOfFailure", "Certificate", });
+        new java.lang.String[] { "Status", "Hostname", "CauseOfFailure", "Certificate", "CaCertificate", });
     internal_static_clusterconnectivitymanagementv2_InvertingProxyAgent_descriptor =
-      getDescriptor().getMessageTypes().get(9);
+      getDescriptor().getMessageTypes().get(11);
     internal_static_clusterconnectivitymanagementv2_InvertingProxyAgent_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_clusterconnectivitymanagementv2_InvertingProxyAgent_descriptor,
-        new java.lang.String[] { "AgentCrn", "EncipheredPrivateKey", "Certificate", });
+        new java.lang.String[] { "AgentCrn", "EncipheredPrivateKey", "Certificate", "EnvironmentCrn", "Certificates", });
+    internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_descriptor =
+      getDescriptor().getMessageTypes().get(12);
+    internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_descriptor,
+        new java.lang.String[] { "PageSize", "PageToken", "AccountId", "EnvirinmentCrn", "FilterOneof", });
+    internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_descriptor =
+      getDescriptor().getMessageTypes().get(13);
+    internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_descriptor,
+        new java.lang.String[] { "NextPageToken", "Agents", });
     com.google.protobuf.ExtensionRegistry registry =
         com.google.protobuf.ExtensionRegistry.newInstance();
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.deprecated);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.skipLogging);
     com.google.protobuf.Descriptors.FileDescriptor
         .internalUpdateFileDescriptor(descriptor, registry);
     com.cloudera.thunderhead.service.common.version.Version.getDescriptor();
     com.cloudera.thunderhead.service.common.options.Options.getDescriptor();
+    com.cloudera.thunderhead.service.common.paging.PagingProto.getDescriptor();
   }
 
   // @@protoc_insertion_point(outer_class_scope)

--- a/ccm-connector/src/main/proto/clusterconnectivitymanagementv2.proto
+++ b/ccm-connector/src/main/proto/clusterconnectivitymanagementv2.proto
@@ -4,9 +4,11 @@ package clusterconnectivitymanagementv2;
 
 option java_package = "com.cloudera.thunderhead.service.clusterconnectivitymanagementv2";
 option java_outer_classname = "ClusterConnectivityManagementV2Proto";
+option go_package = "com/cloudera/cdp/protobuf";
 
 import "version.proto";
 import "options.proto";
+import "paging.proto";
 
 // ClusterConnectivityManagementV2 service for provisioning and managing inverting-proxy.
 service ClusterConnectivityManagementV2 {
@@ -32,6 +34,13 @@ service ClusterConnectivityManagementV2 {
   rpc UnregisterAgent(UnregisterAgentRequest)
     returns (UnregisterAgentResponse) {}
 
+  // Lists all registered agents matching a supplied query
+  rpc ListAgents(ListAgentsRequest)
+    returns (ListAgentsResponse) {}
+
+  // GetAllAgentsCertificates for getting certificates of all the agents for an account.
+  rpc GetAllAgentsCertificates(GetAllAgentsCertificatesRequest)
+    returns (GetAllAgentsCertificatesResponse) {}
 }
 
 message CreateOrGetInvertingProxyRequest {
@@ -60,16 +69,33 @@ message RegisterAgentRequest {
   // Key ID to identify the cluster uniquely.
   // This will be used to encipher private key.
   string keyId = 3;
+  // CRN of the environment this agent is going to be deployed in. Passing the environmentCrn as
+  // part of registration implies that the provisioning service consents to the use this agent to
+  // target backend services outside the host it is deployed on.
+  // As part of future work, we intend to bring a dedicated pool of agents which would be shared
+  // across the environment. Fos suce agents, we expect that environmentCrn would always be
+  // supplied during registration.
+  string environmentCrn = 4;
 }
 
 message RegisterAgentResponse {
-  //Inverting proxy agent with required fields.
+  // Inverting proxy agent with required fields.
   InvertingProxyAgent invertingProxyAgent = 1;
 }
 
 message UnregisterAgentRequest {
   // Unique identifier for each agent
   string agentCrn = 1;
+}
+
+message GetAllAgentsCertificatesRequest {
+  // Account ID for which the certificates need to retrieved.
+  string accountId = 1;
+}
+
+message GetAllAgentsCertificatesResponse {
+  // Certificates of all the agents.
+  repeated string certificates = 1 [(options.FieldExtension.skipLogging) = true];
 }
 
 message UnregisterAgentResponse {}
@@ -94,7 +120,10 @@ message InvertingProxy {
   // This is not sent if the inverting proxy is created and is ready to accept requests
   string causeOfFailure = 3;
   // Certificate of inverting-proxy that needs to be passed to agent.
-  string certificate = 4 [(options.FieldExtension.skipLogging) = true];
+  // We intend to depracate this field in favor of 'caCertificate'.
+  string certificate = 4 [(options.FieldExtension.skipLogging) = true, (options.FieldExtension.deprecated) = true];
+  // CA Certificate used to sign certificate of inverting-proxy server. It needs to be passed to agent.
+  string caCertificate = 5 [(options.FieldExtension.skipLogging) = true];
 }
 
 message InvertingProxyAgent {
@@ -103,5 +132,33 @@ message InvertingProxyAgent {
   // Enciphered Generated key for the agent
   string encipheredPrivateKey = 2 [(options.FieldExtension.skipLogging) = true];
   // Generated cert for the agent
-  string certificate = 3 [(options.FieldExtension.skipLogging) = true];
+  // We intend to deprecate this field in favor of 'certificates'.
+  // This is required to support CA signed certificates for agents.
+  string certificate = 3 [(options.FieldExtension.skipLogging) = true, (options.FieldExtension.deprecated) = true];
+  // CRN of the environment this agent is going to be deployed in. Having the environmentCrn set here
+  // implies that the provisioning service has consented to the use of this agent to target backend services
+  // outside the host it is deployed on.
+  string environmentCrn = 4;
+  // Generated certificate and the trust chain for agent
+  repeated string certificates = 5 [(options.FieldExtension.skipLogging) = true];
+}
+
+message ListAgentsRequest {
+  int32 pageSize = 1;
+  paging.PageToken pageToken = 2;
+
+  // Optional filter to narrow results. If not supplied, all agents would be returned.
+  oneof filter_oneof {
+    // If an accountId is passed-in, all agents belonging to this accountId would be returned.
+    string accountId = 3;
+    // If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
+    string envirinmentCrn = 4;
+  }
+}
+
+message ListAgentsResponse {
+  paging.PageToken nextPageToken = 1;
+
+  // List of all agents (matching the optional filter if supplied)
+  repeated InvertingProxyAgent agents = 2;
 }


### PR DESCRIPTION
With CDPAM-1289, we enhanced CCMv2 to optionally accept `environmentCrn` during agent registration. Agents registered with an `environmentCrn` would now be reused by experiences to route their requests to Kubernetes style workloads deployed inside the same environment.

This is 1 of 2 changes and would update the proto file to reflect more recent changes in thunderhead and also add the generated gRPC client.