### PR TITLE
 DWX-6365 Adding ECR repo access to cloudbreak client

### DIFF
--- a/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
+++ b/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
@@ -249,6 +249,18 @@
       ]
     },
     {
+      "Sid": "ECRAccessRead",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetRegistryPolicy",
+        "ecr:DescribeRegistry",
+        "ecr:GetAuthorizationToken"
+      ],
+      "Resource": [
+        "*"
+      ]
+    },
+    {
       "Sid": "DecodeAuthorizationMessage",
       "Action": [
         "sts:DecodeAuthorizationMessage"


### PR DESCRIPTION
A ECRAccessRead policy will enable Cloudbreak client to describe repositories. CDP has a new feature which requires customers to define custom ECR repositories and Cloudbreak client will need to have rights to be able to describe repositories if the custome repo is defined on the same account.

See detailed description in the commit message.