### PR TITLE
CB-11105 use stackview for statuschecker mdc context; add lazy annotation for some instancegroup fields..

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceGroup.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceGroup.java
@@ -31,8 +31,8 @@ import com.sequenceiq.cloudbreak.converter.InstanceGroupTypeConverter;
 import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
 import com.sequenceiq.cloudbreak.domain.SecurityGroup;
 import com.sequenceiq.cloudbreak.domain.Template;
-import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.model.CloudIdentityType;
 
@@ -50,10 +50,10 @@ public class InstanceGroup implements ProvisionEntity, Comparable<InstanceGroup>
     @SequenceGenerator(name = "instancegroup_generator", sequenceName = "instancegroup_id_seq", allocationSize = 1)
     private Long id;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     private Template template;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     private SecurityGroup securityGroup;
 
     private String groupName;
@@ -61,7 +61,7 @@ public class InstanceGroup implements ProvisionEntity, Comparable<InstanceGroup>
     @Convert(converter = InstanceGroupTypeConverter.class)
     private InstanceGroupType instanceGroupType = InstanceGroupType.CORE;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     private Stack stack;
 
     @OneToMany(mappedBy = "instanceGroup", cascade = CascadeType.REMOVE, orphanRemoval = true)

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
@@ -13,6 +13,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.NamedAttributeNode;
 import javax.persistence.NamedEntityGraph;
 import javax.persistence.NamedEntityGraphs;
+import javax.persistence.NamedSubgraph;
 import javax.persistence.SequenceGenerator;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceLifeCycle;
@@ -29,7 +30,10 @@ import com.sequenceiq.common.api.type.InstanceGroupType;
 @NamedEntityGraphs({
         @NamedEntityGraph(name = "InstanceMetaData.instanceGroup",
                 attributeNodes = {
-                        @NamedAttributeNode(value = "instanceGroup")
+                        @NamedAttributeNode(value = "instanceGroup", subgraph = "instanceGroup")
+                },
+                subgraphs = {
+                    @NamedSubgraph(name = "instanceGroup", attributeNodes = @NamedAttributeNode("template"))
                 }
         ),
 })

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
@@ -5,6 +5,8 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.action.Action;
@@ -51,6 +53,9 @@ import com.sequenceiq.cloudbreak.quartz.statuschecker.service.StatusCheckerJobSe
 
 @Configuration
 public class ClusterCreationActions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterCreationActions.class);
+
     @Inject
     private ClusterCreationService clusterCreationService;
 
@@ -286,6 +291,7 @@ public class ClusterCreationActions {
         return new AbstractStackFailureAction<ClusterCreationState, ClusterCreationEvent>() {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) {
+                LOGGER.error("Cluster creation failed with exception", payload.getException());
                 clusterCreationService.handleClusterCreationFailure(context.getStackView(), payload.getException());
                 getMetricService().incrementMetricCounter(MetricType.CLUSTER_CREATION_FAILED, context.getStackView(), payload.getException());
                 sendEvent(context);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/downscale/StackDownscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/downscale/StackDownscaleActions.java
@@ -74,7 +74,7 @@ public class StackDownscaleActions {
                         .collect(Collectors.toSet());
 
                 candidatesInstanceMetadata.forEach(metaData -> {
-                    CloudInstance cloudInstance = metadataConverter.convert(metaData);
+                    CloudInstance cloudInstance = metadataConverter.convert(metaData, stack.getEnvironmentCrn(), stack.getStackAuthentication());
                     instances.add(cloudInstance);
                 });
                 variables.put(INSTANCES, instances);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/AbstractInstanceTerminationAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/AbstractInstanceTerminationAction.java
@@ -92,7 +92,7 @@ abstract class AbstractInstanceTerminationAction<P extends InstancePayload>
         for (String instanceId : instanceIds) {
             InstanceMetaData instanceMetaData = instanceMetaDataService.findByStackIdAndInstanceId(stack.getId(), instanceId)
                     .orElseThrow(NotFoundException.notFound("instanceMetadata", instanceId));
-            CloudInstance cloudInstance = metadataConverter.convert(instanceMetaData);
+            CloudInstance cloudInstance = metadataConverter.convert(instanceMetaData, stack.getEnvironmentCrn(), stack.getStackAuthentication());
             instanceMetaDataList.add(instanceMetaData);
             cloudInstances.add(cloudInstance);
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationActions.java
@@ -276,8 +276,9 @@ public class StackCreationActions {
 
             @Override
             protected Selectable createRequest(StackContext context) {
-                InstanceMetaData gatewayMetaData = context.getStack().getPrimaryGatewayInstance();
-                CloudInstance gatewayInstance = metadataConverter.convert(gatewayMetaData);
+                Stack stack = context.getStack();
+                InstanceMetaData gatewayMetaData = stack.getPrimaryGatewayInstance();
+                CloudInstance gatewayInstance = metadataConverter.convert(gatewayMetaData, stack.getEnvironmentCrn(), stack.getStackAuthentication());
                 return new GetSSHFingerprintsRequest<GetSSHFingerprintsResult>(context.getCloudContext(), context.getCloudCredential(), gatewayInstance);
             }
         };

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/sync/StackSyncActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/sync/StackSyncActions.java
@@ -73,8 +73,10 @@ public class StackSyncActions {
 
             @Override
             protected Selectable createRequest(StackSyncContext context) {
-                List<CloudInstance> cloudInstances = cloudInstanceConverter.convert(context.getInstanceMetaData());
-                cloudInstances.forEach(instance -> context.getStack().getParameters().forEach(instance::putParameter));
+                Stack stack = context.getStack();
+                List<CloudInstance> cloudInstances = cloudInstanceConverter.convert(context.getInstanceMetaData(), stack.getEnvironmentCrn(),
+                        stack.getStackAuthentication());
+                cloudInstances.forEach(instance -> stack.getParameters().forEach(instance::putParameter));
                 return new GetInstancesStateRequest<>(context.getCloudContext(), context.getCloudCredential(), cloudInstances);
             }
         };

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
@@ -218,7 +218,7 @@ public class StackUpscaleActions {
                     if (null == gatewayMetaData && isRepair(variables)) {
                         throw new CloudbreakServiceException("Could not get gateway instance metadata from the cloud provider.");
                     }
-                    CloudInstance gatewayInstance = metadataConverter.convert(gatewayMetaData);
+                    CloudInstance gatewayInstance = metadataConverter.convert(gatewayMetaData, stack.getEnvironmentCrn(), stack.getStackAuthentication());
                     Selectable sshFingerPrintReq = new GetSSHFingerprintsRequest<GetSSHFingerprintsResult>(context.getCloudContext(),
                             context.getCloudCredential(), gatewayInstance);
                     sendEvent(context, sshFingerPrintReq);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -64,26 +64,28 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
             @Param("showTerminated") Boolean showTerminated,
             @Param("terminatedAfter") Long terminatedAfter);
 
-    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData "
-            + "WHERE s.resourceCrn= :crn AND s.workspace.id= :workspaceId AND " + SHOW_TERMINATED_CLUSTERS_IF_REQUESTED)
+    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData LEFT JOIN FETCH ig.template "
+            + "LEFT JOIN FETCH ig.securityGroup WHERE s.resourceCrn= :crn AND s.workspace.id= :workspaceId AND " + SHOW_TERMINATED_CLUSTERS_IF_REQUESTED)
     Optional<Stack> findByCrnAndWorkspaceIdWithLists(@Param("crn") String crn, @Param("workspaceId") Long workspaceId,
             @Param("showTerminated") Boolean showTerminated, @Param("terminatedAfter") Long terminatedAfter);
 
-    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData "
-            + "WHERE s.resourceCrn= :crn AND s.workspace.id= :workspaceId AND s.type = :type AND " + SHOW_TERMINATED_CLUSTERS_IF_REQUESTED)
+    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData LEFT JOIN FETCH ig.template "
+            + "LEFT JOIN FETCH ig.securityGroup WHERE s.resourceCrn= :crn AND s.workspace.id= :workspaceId AND s.type = :type AND " +
+            SHOW_TERMINATED_CLUSTERS_IF_REQUESTED)
     Optional<Stack> findByCrnAndWorkspaceIdWithLists(@Param("crn") String crn, @Param("type") StackType type, @Param("workspaceId") Long workspaceId,
             @Param("showTerminated") Boolean showTerminated, @Param("terminatedAfter") Long terminatedAfter);
 
-    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData WHERE s.id= :id "
-            + "AND (s.type is not 'TEMPLATE' OR s.type is null)")
+    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData LEFT JOIN FETCH ig.template " +
+            "LEFT JOIN FETCH ig.securityGroup WHERE s.id= :id AND (s.type is not 'TEMPLATE' OR s.type is null)")
     Optional<Stack> findOneWithLists(@Param("id") Long id);
 
-    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData WHERE s.resourceCrn= :crn "
-            + "AND (s.type is not 'TEMPLATE' OR s.type is null)")
+    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData LEFT JOIN FETCH ig.template " +
+            "LEFT JOIN FETCH ig.securityGroup WHERE s.resourceCrn= :crn AND (s.type is not 'TEMPLATE' OR s.type is null)")
     Optional<Stack> findOneByCrnWithLists(@Param("crn") String crn);
 
-    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData "
-            + "LEFT JOIN FETCH s.cluster c LEFT JOIN FETCH c.components WHERE s.id= :id AND (s.type is not 'TEMPLATE' OR s.type is null)")
+    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData LEFT JOIN FETCH ig.template " +
+            "LEFT JOIN FETCH ig.securityGroup LEFT JOIN FETCH s.cluster c LEFT JOIN FETCH c.components WHERE s.id= :id " +
+            "AND (s.type is not 'TEMPLATE' OR s.type is null)")
     Optional<Stack> findOneWithCluster(@Param("id") Long id);
 
     @Query("SELECT s.id as id, s.name as name FROM Stack s "

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/EmbeddedDatabaseService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/EmbeddedDatabaseService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
 import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
 import com.sequenceiq.cloudbreak.domain.VolumeUsageType;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -41,6 +42,6 @@ public class EmbeddedDatabaseService {
         Template template = gatewayGroup.map(InstanceGroup::getTemplate).orElse(null);
         return template == null ? 0 : template.getVolumeTemplates().stream()
                 .filter(volumeTemplate -> volumeTemplate.getUsageType() == VolumeUsageType.DATABASE)
-                .mapToInt(volume -> volume.getVolumeCount()).sum();
+                .mapToInt(VolumeTemplate::getVolumeCount).sum();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackInstanceStatusChecker.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackInstanceStatusChecker.java
@@ -5,7 +5,6 @@ import static com.sequenceiq.cloudbreak.cloud.model.Location.location;
 import static com.sequenceiq.cloudbreak.cloud.model.Region.region;
 import static java.util.stream.Collectors.toList;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -21,17 +20,12 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.converter.spi.CredentialToCloudCredentialConverter;
-import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialConverter;
 import com.sequenceiq.environment.client.EnvironmentInternalCrnClient;
 
 @Service
 public class StackInstanceStatusChecker {
-
-    @Inject
-    private InstanceMetaDataToCloudInstanceConverter cloudInstanceConverter;
 
     @Inject
     private InstanceStateQuery instanceStateQuery;
@@ -45,10 +39,9 @@ public class StackInstanceStatusChecker {
     @Inject
     private CredentialToCloudCredentialConverter cloudCredentialConverter;
 
-    public List<CloudVmInstanceStatus> queryInstanceStatuses(Stack stack, Collection<InstanceMetaData> instanceMetaData) {
+    public List<CloudVmInstanceStatus> queryInstanceStatuses(Stack stack, List<CloudInstance> cloudInstances) {
         List<CloudVmInstanceStatus> result = Collections.emptyList();
-        if (!instanceMetaData.isEmpty()) {
-            List<CloudInstance> cloudInstances = cloudInstanceConverter.convert(instanceMetaData);
+        if (!cloudInstances.isEmpty()) {
             cloudInstances.forEach(instance -> stack.getParameters().forEach(instance::putParameter));
             Location location = location(region(stack.getRegion()), availabilityZone(stack.getAvailabilityZone()));
             CloudContext cloudContext = CloudContext.Builder.builder()

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackViewService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackViewService.java
@@ -10,12 +10,17 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.repository.StackViewRepository;
+import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
 
 @Service
 public class StackViewService {
 
     @Inject
     private StackViewRepository stackViewRepository;
+
+    public StackView getById(Long id) {
+        return stackViewRepository.findById(id).orElseThrow(() -> new CloudbreakRuntimeException("Can not find stackview by stack id: " + id));
+    }
 
     public Optional<StackView> findById(Long id) {
         return stackViewRepository.findById(id);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/adapter/ServiceProviderConnectorAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/adapter/ServiceProviderConnectorAdapter.java
@@ -98,7 +98,7 @@ public class ServiceProviderConnectorAdapter {
         InstanceGroup group = stack.getInstanceGroupByInstanceGroupName(instanceGroup);
         for (InstanceMetaData metaData : group.getAllInstanceMetaData()) {
             if (instanceIds.contains(metaData.getInstanceId())) {
-                CloudInstance cloudInstance = metadataConverter.convert(metaData);
+                CloudInstance cloudInstance = metadataConverter.convert(metaData, stack.getEnvironmentCrn(), stack.getStackAuthentication());
                 instances.add(cloudInstance);
             }
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/adapter/ServiceProviderMetadataAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/adapter/ServiceProviderMetadataAdapter.java
@@ -65,7 +65,7 @@ public class ServiceProviderMetadataAdapter {
         CloudInstance instance = null;
         for (InstanceMetaData metaData : ig.getAllInstanceMetaData()) {
             if (instanceId.equalsIgnoreCase(metaData.getInstanceId())) {
-                instance = metadataConverter.convert(metaData);
+                instance = metadataConverter.convert(metaData, stack.getEnvironmentCrn(), stack.getStackAuthentication());
                 break;
             }
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/repair/UnhealthyInstancesFinalizer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/repair/UnhealthyInstancesFinalizer.java
@@ -53,7 +53,8 @@ public class UnhealthyInstancesFinalizer {
                 .withAccountId(stack.getTenant().getId())
                 .build();
         CloudCredential cloudCredential = stackUtil.getCloudCredential(stack);
-        List<CloudInstance> cloudInstances = cloudInstanceConverter.convert(candidateUnhealthyInstances);
+        List<CloudInstance> cloudInstances = cloudInstanceConverter.convert(candidateUnhealthyInstances, stack.getEnvironmentCrn(),
+                stack.getStackAuthentication());
 
         List<CloudVmInstanceStatus> cloudVmInstanceStatuses = instanceStateQuery.getCloudVmInstanceStatuses(
                 cloudCredential, cloudContext, cloudInstances);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/InstanceMetaDataToCloudInstanceConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/InstanceMetaDataToCloudInstanceConverterTest.java
@@ -47,11 +47,10 @@ public class InstanceMetaDataToCloudInstanceConverterTest extends AbstractEntity
         params.put(CloudInstance.SUBNET_ID, SUBNET_ID);
         params.put(CloudInstance.INSTANCE_NAME, INSTANCE_NAME);
         when(stackToCloudStackConverter.buildCloudInstanceParameters(any(), any(), any())).thenReturn(params);
-        CloudInstance cloudInstance = underTest.convert(source);
+        CloudInstance cloudInstance = underTest.convert(source, "envCrn", new StackAuthentication());
 
         assertEquals(2, cloudInstance.getParameters().size());
         assertEquals(source.getInstanceId(), cloudInstance.getInstanceId());
-
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
@@ -20,14 +20,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 import java.util.stream.Collectors;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,9 +70,9 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
+import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
-import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.securityrule.SecurityRuleService;
 import com.sequenceiq.cloudbreak.service.stack.DefaultRootVolumeSizeProvider;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
@@ -480,7 +480,7 @@ public class StackToCloudStackConverterTest {
 
     @Test
     public void testConvertWhenSecurityGroupIsNotNullAndSecurityRuleRepositoryCanFindRulesButThereIsNoPortDefinitionThenEmptyPortDefinitionShouldBeStored() {
-        List<SecurityRule> securityRules = new ArrayList<>(1);
+        Set<SecurityRule> securityRules = new HashSet<>(1);
         SecurityRule securityRule = mock(SecurityRule.class);
         securityRules.add(securityRule);
         when(securityRule.getPorts()).thenReturn(EMPTY_STRING);
@@ -490,12 +490,12 @@ public class StackToCloudStackConverterTest {
         Template template = mock(Template.class);
         SecurityGroup securityGroup = new SecurityGroup();
         securityGroup.setId(1L);
+        securityGroup.setSecurityRules(securityRules);
         when(instanceGroup.getTemplate()).thenReturn(template);
         when(instanceGroup.getNotDeletedInstanceMetaDataSet()).thenReturn(Collections.emptySet());
         when(instanceGroup.getSecurityGroup()).thenReturn(securityGroup);
         when(instanceGroup.getStack()).thenReturn(stack);
         when(stack.getInstanceGroupsAsList()).thenReturn(new ArrayList<>(instanceGroups));
-        when(securityRuleService.findAllBySecurityGroupId(securityGroup.getId())).thenReturn(securityRules);
 
         CloudStack result = underTest.convert(stack);
 
@@ -506,7 +506,7 @@ public class StackToCloudStackConverterTest {
 
     @Test
     public void testConvertWhenThereArePortDefinitionsInSecurityRulesAndSegmentsLengthIsGreaterThanOneThenExpectedPartsShouldBeStored() {
-        List<SecurityRule> securityRules = new ArrayList<>(1);
+        Set<SecurityRule> securityRules = new HashSet<>(1);
         SecurityRule securityRule = mock(SecurityRule.class);
         securityRules.add(securityRule);
         String[] ports = new String[1];
@@ -518,12 +518,12 @@ public class StackToCloudStackConverterTest {
         Template template = mock(Template.class);
         SecurityGroup securityGroup = new SecurityGroup();
         securityGroup.setId(1L);
+        securityGroup.setSecurityRules(securityRules);
         when(instanceGroup.getTemplate()).thenReturn(template);
         when(instanceGroup.getNotDeletedInstanceMetaDataSet()).thenReturn(Collections.emptySet());
         when(instanceGroup.getSecurityGroup()).thenReturn(securityGroup);
         when(instanceGroup.getStack()).thenReturn(stack);
         when(stack.getInstanceGroupsAsList()).thenReturn(new ArrayList<>(instanceGroups));
-        when(securityRuleService.findAllBySecurityGroupId(securityGroup.getId())).thenReturn(securityRules);
 
         CloudStack result = underTest.convert(stack);
 
@@ -536,7 +536,7 @@ public class StackToCloudStackConverterTest {
 
     @Test
     public void testConvertWhenThereArePortDefinitionsInSecurityRulesButSegmentsLengthIsOneThanOneThenExpectedPartsShouldBeStored() {
-        List<SecurityRule> securityRules = new ArrayList<>(1);
+        Set<SecurityRule> securityRules = new HashSet<>(1);
         SecurityRule securityRule = mock(SecurityRule.class);
         securityRules.add(securityRule);
         String[] ports = new String[1];
@@ -548,12 +548,12 @@ public class StackToCloudStackConverterTest {
         Template template = mock(Template.class);
         SecurityGroup securityGroup = new SecurityGroup();
         securityGroup.setId(1L);
+        securityGroup.setSecurityRules(securityRules);
         when(instanceGroup.getTemplate()).thenReturn(template);
         when(instanceGroup.getNotDeletedInstanceMetaDataSet()).thenReturn(Collections.emptySet());
         when(instanceGroup.getSecurityGroup()).thenReturn(securityGroup);
         when(instanceGroup.getStack()).thenReturn(stack);
         when(stack.getInstanceGroupsAsList()).thenReturn(new ArrayList<>(instanceGroups));
-        when(securityRuleService.findAllBySecurityGroupId(securityGroup.getId())).thenReturn(securityRules);
 
         CloudStack result = underTest.convert(stack);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -48,6 +49,7 @@ import com.sequenceiq.cloudbreak.cmtemplate.sharedservice.SharedServiceConfigsVi
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 import com.sequenceiq.cloudbreak.converter.IdBrokerConverterUtil;
 import com.sequenceiq.cloudbreak.converter.StackToTemplatePreparationObjectConverter;
@@ -239,6 +241,9 @@ public class StackToTemplatePreparationObjectConverterTest {
     @Mock
     private GatewayConfigService gatewayConfigService;
 
+    @Mock
+    private TransactionService transactionService;
+
     @Spy
     @SuppressFBWarnings(value = "UrF", justification = "This gets injected")
     private IdBrokerConverterUtil idBrokerConverterUtil = new IdBrokerConverterUtil();
@@ -250,8 +255,12 @@ public class StackToTemplatePreparationObjectConverterTest {
     private LoadBalancerConfigService loadBalancerConfigService;
 
     @BeforeEach
-    public void setUp() throws IOException {
+    public void setUp() throws IOException, TransactionService.TransactionExecutionException {
         MockitoAnnotations.initMocks(this);
+        doAnswer(invocation -> {
+            invocation.getArgument(0, Runnable.class).run();
+            return null;
+        }).when(transactionService).required(any(Runnable.class));
         User user = new User();
         user.setUserName("applebob@apple.com");
         user.setUserCrn("user-crn");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
@@ -41,6 +41,7 @@ import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerState;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerState.ClusterManagerStatus;
+import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -112,6 +113,9 @@ public class StackStatusCheckerJobTest {
 
     @Mock
     private InstanceMetaData instanceMetaData;
+
+    @Mock
+    private InstanceMetaDataToCloudInstanceConverter cloudInstanceConverter;
 
     @Before
     public void init() {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
@@ -71,6 +71,7 @@ import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackInstanceStatusChecker;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.stack.StackViewService;
 import com.sequenceiq.cloudbreak.service.stack.connector.adapter.ServiceProviderMetadataAdapter;
 import com.sequenceiq.cloudbreak.service.stack.flow.StackSyncService;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
@@ -118,6 +119,9 @@ class StackStatusIntegrationTest {
 
     @MockBean
     private Tracer tracer;
+
+    @MockBean
+    private StackViewService stackViewService;
 
     @Mock
     private ClusterStatusService clusterStatusService;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackInstanceStatusCheckerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackInstanceStatusCheckerTest.java
@@ -1,12 +1,13 @@
 package com.sequenceiq.cloudbreak.service.stack;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Collection;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
@@ -19,12 +20,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.cloud.handler.InstanceStateQuery;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.converter.spi.CredentialToCloudCredentialConverter;
 import com.sequenceiq.cloudbreak.converter.spi.InstanceMetaDataToCloudInstanceConverter;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialConverter;
 import com.sequenceiq.environment.api.v1.credential.endpoint.CredentialEndpoint;
 import com.sequenceiq.environment.client.EnvironmentInternalCrnClient;
@@ -59,12 +60,13 @@ class StackInstanceStatusCheckerTest {
 
     private Stack stack;
 
-    private Collection<InstanceMetaData> instanceMetaData;
+    private List<CloudInstance> instanceMetaData;
 
     @BeforeEach
     void setUp() {
         stack = TestUtil.stack();
-        instanceMetaData = new HashSet<>();
+        stack.setParameters(new HashMap<>());
+        instanceMetaData = new ArrayList<>();
     }
 
     private void setUpCredentials() {
@@ -83,7 +85,7 @@ class StackInstanceStatusCheckerTest {
     @Test
     void shouldQueryWhenInstancesArePresent() {
         setUpCredentials();
-        instanceMetaData.add(new InstanceMetaData());
+        instanceMetaData.add(mock(CloudInstance.class));
 
         underTest.queryInstanceStatuses(stack, instanceMetaData);
 
@@ -94,7 +96,7 @@ class StackInstanceStatusCheckerTest {
     @Test
     void shouldReportUnknownStatusWhenStatusQueryFails() {
         setUpCredentials();
-        instanceMetaData.add(new InstanceMetaData());
+        instanceMetaData.add(mock(CloudInstance.class));
         when(instanceStateQuery.getCloudVmInstanceStatusesWithoutRetry(any(), any(), any())).thenThrow(RuntimeException.class);
 
         List<CloudVmInstanceStatus> cloudVmInstanceStatuses = underTest.queryInstanceStatuses(stack, instanceMetaData);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/repair/UnhealthyInstancesFinalizerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/repair/UnhealthyInstancesFinalizerTest.java
@@ -63,7 +63,7 @@ public class UnhealthyInstancesFinalizerTest {
         List<CloudInstance> cloudInstances = new ArrayList<>();
         CloudInstance cloudInstance1 = setupCloudInstance(instanceId1, cloudInstances);
         CloudInstance cloudInstance2 = setupCloudInstance(instanceId2, cloudInstances);
-        when(cloudInstanceConverter.convert(candidateUnhealthyInstances)).thenReturn(cloudInstances);
+        when(cloudInstanceConverter.convert(candidateUnhealthyInstances, stack.getEnvironmentCrn(), stack.getStackAuthentication())).thenReturn(cloudInstances);
 
         List<CloudVmInstanceStatus> cloudVmInstanceStatusList = new ArrayList<>();
         setupCloudVmInstanceStatus(cloudInstance1, InstanceStatus.STOPPED, cloudVmInstanceStatusList);
@@ -93,7 +93,7 @@ public class UnhealthyInstancesFinalizerTest {
 
         List<CloudInstance> cloudInstances = new ArrayList<>();
         CloudInstance cloudInstance1 = setupCloudInstance(instanceId1, cloudInstances);
-        when(cloudInstanceConverter.convert(candidateUnhealthyInstances)).thenReturn(cloudInstances);
+        when(cloudInstanceConverter.convert(candidateUnhealthyInstances, stack.getEnvironmentCrn(), stack.getStackAuthentication())).thenReturn(cloudInstances);
 
         List<CloudVmInstanceStatus> cloudVmInstanceStatusList = new ArrayList<>();
         setupCloudVmInstanceStatus(cloudInstance1, InstanceStatus.TERMINATED, cloudVmInstanceStatusList);


### PR DESCRIPTION
..to optimize InstanceMetaDataRepository.findNotTerminatedForStack query

findNotTerminatedForStack query has this where condition:
"WHERE i.instanceGroup.stack.id= :stackId"
Because of this condition hibernate does a fetch query for stack object.
To avoid this behavior lazy is added to stack field in InstanceGroup.

Lazy annotation added to Stack, SecurityGroup and Template for InstanceGroup.