### PR TITLE
CB-11105 remove idbroker from cluster

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
@@ -172,9 +172,6 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
     @OneToOne(mappedBy = "cluster", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private Gateway gateway;
 
-    @OneToOne(mappedBy = "cluster", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true, fetch = FetchType.LAZY)
-    private IdBroker idBroker;
-
     @OneToMany(mappedBy = "cluster", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<HostGroup> hostGroups = new HashSet<>();
 
@@ -767,14 +764,6 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
     @Override
     public void setWorkspace(Workspace workspace) {
         this.workspace = workspace;
-    }
-
-    public IdBroker getIdBroker() {
-        return idBroker;
-    }
-
-    public void setIdBroker(IdBroker idBroker) {
-        this.idBroker = idBroker;
     }
 
     public CertExpirationState getCertExpirationState() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/IdBrokerConverterUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/IdBrokerConverterUtil.java
@@ -9,12 +9,11 @@ import com.sequenceiq.cloudbreak.certificate.PkiUtil;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.IdBroker;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
-import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 
 @Component
 public class IdBrokerConverterUtil {
 
-    public IdBroker generateIdBrokerSignKeys(Cluster cluster, Workspace workspace) {
+    public IdBroker generateIdBrokerSignKeys(Cluster cluster) {
         IdBroker idBroker = new IdBroker();
 
         KeyPair identityKey = PkiUtil.generateKeypair();
@@ -27,7 +26,7 @@ public class IdBrokerConverterUtil {
         idBroker.setMasterSecret(PasswordUtil.generatePassword());
 
         idBroker.setCluster(cluster);
-        idBroker.setWorkspace(workspace);
+        idBroker.setWorkspace(cluster.getWorkspace());
         return idBroker;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToTemplatePreparationObjectConverter.java
@@ -202,10 +202,9 @@ public class StackToTemplatePreparationObjectConverter extends AbstractConversio
             }
             IdBroker idbroker =  idBrokerService.getByCluster(cluster);
             if (idbroker == null) {
-                idbroker = idBrokerConverterUtil.generateIdBrokerSignKeys(cluster, cluster.getWorkspace());
+                idbroker = idBrokerConverterUtil.generateIdBrokerSignKeys(cluster);
                 idBrokerService.save(idbroker);
             }
-            cluster.setIdBroker(idbroker);
             String envCrnForVirtualGroups = getEnvironmentCrnForVirtualGroups(environment);
             VirtualGroupRequest virtualGroupRequest = new VirtualGroupRequest(envCrnForVirtualGroups, ldapView.map(LdapView::getAdminGroup).orElse(""));
             String accountId = source.getCreator().getTenant().getName();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterV4RequestToClusterConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/cluster/ClusterV4RequestToClusterConverter.java
@@ -29,10 +29,11 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackType;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
-import com.sequenceiq.cloudbreak.converter.IdBrokerConverterUtil;
 import com.sequenceiq.cloudbreak.converter.util.CloudStorageValidationUtil;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.cluster.clouderamanager.ClouderaManagerRepositoryV4RequestToClouderaManagerRepoConverter;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
@@ -41,11 +42,8 @@ import com.sequenceiq.cloudbreak.domain.FileSystem;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.IdBroker;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.exception.CloudbreakApiException;
-import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.service.blueprint.BlueprintService;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
@@ -72,9 +70,6 @@ public class ClusterV4RequestToClusterConverter extends AbstractConversionServic
     private CloudStorageConverter cloudStorageConverter;
 
     @Inject
-    private IdBrokerConverterUtil idBrokerConverterUtil;
-
-    @Inject
     private EntitlementService entitlementService;
 
     @Override
@@ -87,8 +82,6 @@ public class ClusterV4RequestToClusterConverter extends AbstractConversionServic
         cluster.setDatabaseServerCrn(source.getDatabaseServerCrn());
         cluster.setBlueprint(getBlueprint(source.getBlueprintName(), workspace));
         convertGateway(source, cluster);
-        IdBroker idBroker = idBrokerConverterUtil.generateIdBrokerSignKeys(cluster, workspace);
-        cluster.setIdBroker(idBroker);
         if (cloudStorageValidationUtil.isCloudStorageConfigured(source.getCloudStorage())) {
             FileSystem fileSystem = cloudStorageConverter.requestToFileSystem(source.getCloudStorage());
             cluster.setFileSystem(fileSystem);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -5,9 +5,7 @@ import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUD
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_1;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.core.bootstrap.service.ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel;
-
 import static java.util.Collections.singletonMap;
-
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -101,6 +99,7 @@ import com.sequenceiq.cloudbreak.service.cluster.flow.recipe.RecipeEngine;
 import com.sequenceiq.cloudbreak.service.datalake.DatalakeResourcesService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentConfigProvider;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
+import com.sequenceiq.cloudbreak.service.idbroker.IdBrokerService;
 import com.sequenceiq.cloudbreak.service.proxy.ProxyConfigProvider;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
@@ -221,6 +220,9 @@ public class ClusterHostServiceRunner {
 
     @Inject
     private InstanceGroupService instanceGroupService;
+
+    @Inject
+    private IdBrokerService idBrokerService;
 
     public void runClusterServices(@Nonnull Stack stack, @Nonnull Cluster cluster, List<String> candidateAddresses) {
         try {
@@ -633,10 +635,11 @@ public class ClusterHostServiceRunner {
     }
 
     private void saveIdBrokerPillar(Cluster cluster, Map<String, SaltPillarProperties> servicePillar) {
-        IdBroker clusterIdBroker = cluster.getIdBroker();
+        IdBroker clusterIdBroker = idBrokerService.getByCluster(cluster);
         Map<String, Object> idbroker = new HashMap<>();
 
         if (clusterIdBroker != null) {
+            LOGGER.info("Put idbroker keys/secrets to salt pillar for cluster: " + cluster.getName());
             idbroker.put("signpub", clusterIdBroker.getSignPub());
             idbroker.put("signcert", clusterIdBroker.getSignCert());
             idbroker.put("signkey", clusterIdBroker.getSignKey());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -71,7 +71,6 @@ import com.sequenceiq.cloudbreak.service.altus.AltusMachineUserService;
 import com.sequenceiq.cloudbreak.service.filesystem.FileSystemConfigService;
 import com.sequenceiq.cloudbreak.service.gateway.GatewayService;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
-import com.sequenceiq.cloudbreak.service.idbroker.IdBrokerService;
 import com.sequenceiq.cloudbreak.service.rdsconfig.RdsConfigService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
@@ -130,9 +129,6 @@ public class ClusterService {
     @Inject
     private UsageLoggingUtil usageLoggingUtil;
 
-    @Inject
-    private IdBrokerService idBrokerService;
-
     public Cluster saveClusterAndComponent(Cluster cluster, List<ClusterComponent> components, String stackName) {
         Cluster savedCluster;
         try {
@@ -144,11 +140,6 @@ public class ClusterService {
                 measure(() ->  gatewayService.save(savedCluster.getGateway()),
                         LOGGER,
                         "gatewayService repository save {} ms");
-            }
-            if (savedCluster.getIdBroker() != null) {
-                measure(() ->  idBrokerService.save(savedCluster.getIdBroker()),
-                        LOGGER,
-                        "idBrokerService repository save {} ms");
             }
             LOGGER.debug("Cluster object saved in {} ms for stack {}", System.currentTimeMillis() - start, stackName);
             measure(() ->  clusterComponentConfigProvider.store(components, savedCluster),

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v2/StackToTemplatePreparationObjectConverterTest.java
@@ -298,8 +298,7 @@ public class StackToTemplatePreparationObjectConverterTest {
         when(clusterService.getById(anyLong())).thenReturn(cluster);
         when(exposedServiceCollector.getAllKnoxExposed()).thenReturn(Set.of());
         when(resourceService.getAllByStackId(anyLong())).thenReturn(Collections.EMPTY_LIST);
-        IdBroker idbroker = idBrokerConverterUtil.generateIdBrokerSignKeys(cluster, cluster.getWorkspace());
-        cluster.setIdBroker(idbroker);
+        IdBroker idbroker = idBrokerConverterUtil.generateIdBrokerSignKeys(cluster);
         when(idBrokerService.getByCluster(any(Cluster.class))).thenReturn(idbroker);
         when(idBrokerService.save(any(IdBroker.class))).thenReturn(idbroker);
         when(grpcUmsClient.listServicePrincipalCloudIdentities(anyString(), anyString(), anyString(), any(Optional.class))).thenReturn(Collections.EMPTY_LIST);


### PR DESCRIPTION
IDBroker was fetched in every stack get query. (with its relations like
cluster etc -> hibernate created a join query with these relations)

Explanation: It is because Stack <--> Cluster is a OneToOne relation
and Cluster <--> IdBroker is also a OneToOne relation. A OneToOne relation
 can not be lazy in the case if the owner of the relation is the other entity.
In this example the Idbroker entity has the cluster id column.
Hibernate can not guess if Cluster has an IDBroker or not because this
information is in another table, so IDBroker table will be fetched.

With this fix IdBroker entity can be fetched only with it's service.

https://stackoverflow.com/questions/1444227/how-can-i-make-a-jpa-onetoone-relation-lazy

"Unconstrained (nullable) one-to-one association is the only one that
can not be proxied without bytecode instrumentation. The reason for this
is that owner entity MUST know whether association property should
contain a proxy object or NULL and it can't determine that by looking at
its base table's columns due to one-to-one normally being mapped via
shared PK, so it has to be eagerly fetched anyway making proxy
pointless."
