### PR TITLE
CDPAM-1344: Cloudbreak needs to add environmentCrn to CCMv2 registration for FreeIPA (2/2)

### DIFF
--- a/ccm-connector/src/main/java/com/sequenceiq/cloudbreak/ccmimpl/ccmv2/CcmV2ManagementClient.java
+++ b/ccm-connector/src/main/java/com/sequenceiq/cloudbreak/ccmimpl/ccmv2/CcmV2ManagementClient.java
@@ -16,6 +16,8 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.ccm.exception.CcmV2Exception;
 import com.sequenceiq.cloudbreak.ccmimpl.ccmv2.config.GrpcCcmV2Config;
 
+import java.util.Optional;
+
 @Component
 public class CcmV2ManagementClient {
 
@@ -45,13 +47,16 @@ public class CcmV2ManagementClient {
                 });
     }
 
-    public InvertingProxyAgent registerInvertingProxyAgent(String requestId, String accountId, String domainName, String keyId) {
+    public InvertingProxyAgent registerInvertingProxyAgent(String requestId, String accountId, Optional<String> environmentCrnOpt,
+        String domainName, String keyId) {
         return getRetryTemplate().execute(
                 retryContext -> {
-                    LOGGER.debug("Registering Agent for accountId '{}', domainName '{}'", accountId, domainName);
-                    InvertingProxyAgent invertingProxyAgent = grpcCcmV2Client.registerAgent(requestId, accountId, domainName, keyId,
-                            ThreadBasedUserCrnProvider.getUserCrn());
-                    LOGGER.debug("Registered Agent for accountId '{}', domainName '{}', invertingProxyAgent '{}'", accountId, domainName, invertingProxyAgent);
+                    LOGGER.debug("Registering Agent for accountId '{}', environmentCrnOpt: '{}', domainName '{}'",
+                            accountId, environmentCrnOpt, domainName);
+                    InvertingProxyAgent invertingProxyAgent = grpcCcmV2Client.registerAgent(requestId, accountId, environmentCrnOpt,
+                            domainName, keyId, ThreadBasedUserCrnProvider.getUserCrn());
+                    LOGGER.debug("Registered Agent for accountId '{}', environmentCrnOpt: '{}', domainName '{}', invertingProxyAgent '{}'",
+                            accountId, environmentCrnOpt, domainName, invertingProxyAgent);
                     return invertingProxyAgent;
                 },
                 retryExhausted -> {

--- a/ccm-connector/src/test/java/com/sequenceiq/cloudbreak/ccmimpl/ccmv2/CcmV2ManagementClientTest.java
+++ b/ccm-connector/src/test/java/com/sequenceiq/cloudbreak/ccmimpl/ccmv2/CcmV2ManagementClientTest.java
@@ -18,12 +18,16 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.ccm.exception.CcmV2Exception;
 import com.sequenceiq.cloudbreak.ccmimpl.ccmv2.config.GrpcCcmV2Config;
 
+import java.util.Optional;
+
 @RunWith(MockitoJUnitRunner.class)
 public class CcmV2ManagementClientTest {
 
     private static final String TEST_ACCOUNT_ID = "us-west-1:e7b1345f-4ae1-4594-9113-fc91f22ef8bd";
 
     private static final String TEST_REQUEST_ID = "requestId";
+
+    private static final String TEST_ENVIRONMENT_CRN = "environmentCrn";
 
     private static final String TEST_USER_CRN = "testUserCrn";
 
@@ -77,8 +81,10 @@ public class CcmV2ManagementClientTest {
         String keyId = "keyId";
 
         InvertingProxyAgent mockAgent = InvertingProxyAgent.newBuilder().setAgentCrn("testAgentCrn").build();
-        when(grpcCcmV2Client.registerAgent(TEST_REQUEST_ID, TEST_ACCOUNT_ID, domain, keyId, TEST_USER_CRN)).thenReturn(mockAgent);
-        InvertingProxyAgent registeredAgent = underTest.registerInvertingProxyAgent(TEST_REQUEST_ID, TEST_ACCOUNT_ID, domain, keyId);
+        when(grpcCcmV2Client.registerAgent(TEST_REQUEST_ID, TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN), domain, keyId, TEST_USER_CRN))
+                .thenReturn(mockAgent);
+        InvertingProxyAgent registeredAgent =
+                underTest.registerInvertingProxyAgent(TEST_REQUEST_ID, TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN), domain, keyId);
         assertEquals(TEST_AGENT_CRN, registeredAgent.getAgentCrn(), "InvertingProxyAgent agentCrn  should match.");
     }
 
@@ -87,8 +93,9 @@ public class CcmV2ManagementClientTest {
         String domain = "test.domain";
         String keyId = "keyId";
 
-        when(grpcCcmV2Client.registerAgent(TEST_REQUEST_ID, TEST_ACCOUNT_ID, domain, keyId, TEST_USER_CRN)).thenThrow(new RuntimeException());
-        underTest.registerInvertingProxyAgent(TEST_REQUEST_ID, TEST_ACCOUNT_ID, domain, keyId);
+        when(grpcCcmV2Client.registerAgent(TEST_REQUEST_ID, TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN), domain, keyId, TEST_USER_CRN))
+                .thenThrow(new RuntimeException());
+        underTest.registerInvertingProxyAgent(TEST_REQUEST_ID, TEST_ACCOUNT_ID, Optional.of(TEST_ENVIRONMENT_CRN), domain, keyId);
     }
 
     @Test

--- a/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmV2ParameterSupplier.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/ccm/cloudinit/CcmV2ParameterSupplier.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.ccm.cloudinit;
 
+import java.util.Optional;
+
 public interface CcmV2ParameterSupplier {
 
-    CcmV2Parameters getCcmV2Parameters(String accountId, String domainName, String agentKeyId);
+    CcmV2Parameters getCcmV2Parameters(String accountId, Optional<String> environmentCrnOpt, String domainName, String agentKeyId);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/CcmUserDataService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/userdata/CcmUserDataService.java
@@ -74,7 +74,7 @@ public class CcmUserDataService {
             String generatedGatewayFqdn = hostDiscoveryService.determineGatewayFqdn(gatewayHostName, stackDomain);
 
             CcmV2Parameters ccmV2Parameters = ccmV2ParameterSupplier.getCcmV2Parameters(ThreadBasedUserCrnProvider.getAccountId(),
-                    generatedGatewayFqdn, CcmResourceUtil.getKeyId(stack.getResourceCrn()));
+                    Optional.empty(), generatedGatewayFqdn, CcmResourceUtil.getKeyId(stack.getResourceCrn()));
             ccmConnectivityParameters = new CcmConnectivityParameters(ccmV2Parameters);
 
             saveCcmV2Config(stack.getId(), ccmV2Parameters);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/userdata/CcmUserDataServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/userdata/CcmUserDataServiceTest.java
@@ -96,14 +96,14 @@ public class CcmUserDataServiceTest {
         stack.setTunnel(Tunnel.CCMV2);
         DefaultCcmV2Parameters defaultCcmV2Parameters = mock(DefaultCcmV2Parameters.class);
 
-        when(ccmV2ParameterSupplier.getCcmV2Parameters(anyString(), anyString(), anyString())).thenReturn(defaultCcmV2Parameters);
+        when(ccmV2ParameterSupplier.getCcmV2Parameters(anyString(), any(Optional.class), anyString(), anyString())).thenReturn(defaultCcmV2Parameters);
         when(defaultCcmV2Parameters.getAgentCrn()).thenReturn("testAgentCrn");
         when(hostDiscoveryService.determineGatewayFqdn(any(), any())).thenReturn("datahub.master0.cldr.work.site");
 
         CcmConnectivityParameters ccmParameters = ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.fetchAndSaveCcmParameters(stack));
         assertEquals(CcmConnectivityMode.CCMV2, ccmParameters.getConnectivityMode(), "CCM V2 should be enabled.");
         assertEquals(defaultCcmV2Parameters, ccmParameters.getCcmV2Parameters(), "CCM V2 Parameters should match.");
-        verify(ccmV2ParameterSupplier, times(1)).getCcmV2Parameters(anyString(), anyString(), anyString());
+        verify(ccmV2ParameterSupplier, times(1)).getCcmV2Parameters(anyString(), any(Optional.class), anyString(), anyString());
         verifyNoInteractions(ccmParameterSupplier);
         verify(stackService, times(1)).setCcmV2AgentCrnByStackId(100L, "testAgentCrn");
         verify(stackService, never()).setMinaSshdServiceIdByStackId(any(), any());

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/userdata/CcmUserDataService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/userdata/CcmUserDataService.java
@@ -70,7 +70,8 @@ public class CcmUserDataService {
             String gatewayHostName = hostDiscoveryService.generateHostname(freeIpa.getHostname(), null, 0, false);
             String generatedClusterDomain = hostDiscoveryService.determineGatewayFqdn(gatewayHostName, freeIpa.getDomain());
 
-            CcmV2Parameters ccmV2Parameters = ccmV2ParameterSupplier.getCcmV2Parameters(stack.getAccountId(), generatedClusterDomain, keyId);
+            CcmV2Parameters ccmV2Parameters = ccmV2ParameterSupplier.getCcmV2Parameters(stack.getAccountId(), Optional.of(stack.getEnvironmentCrn()),
+                    generatedClusterDomain, keyId);
             ccmConnectivityParameters = new CcmConnectivityParameters(ccmV2Parameters);
             saveCcmV2Config(stack.getId(), ccmV2Parameters);
         } else {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/CcmUserDataServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/userdata/CcmUserDataServiceTest.java
@@ -41,6 +41,10 @@ public class CcmUserDataServiceTest {
 
     private static final String TEST_USER_CRN = String.format("crn:cdp:iam:us-west-1:%s:user:mockuser@cloudera.com", TEST_ACCOUNT_ID);
 
+    private static final String TEST_ENVIRONMENT_ID = "aa8997d3-527d-4e7f-af8a-7f7cd10eb8f6";
+
+    private static final String TEST_ENVIRONMENT_CRN = String.format("crn:cdp:iam:us-west-1:%s:environment:%s", TEST_ACCOUNT_ID, TEST_ENVIRONMENT_ID);
+
     private static final String TEST_RESOURCE_ID = "aa8997d3-527d-4e7f-af8a-7f7cd10eb8f7";
 
     private static final String TEST_CLUSTER_CRN = String.format("crn:cdp:datahub:us-west-1:e7b1345f-4ae1-4594-9113-fc91f22ef8bd:cluster:%s", TEST_RESOURCE_ID);
@@ -105,14 +109,14 @@ public class CcmUserDataServiceTest {
         when(stackService.getStackById(stack.getId())).thenReturn(stack);
         when(freeIpaService.findByStack(stack)).thenReturn(freeIpa);
         when(freeIpa.getDomain()).thenReturn("cldr.work.site");
-        when(ccmV2ParameterSupplier.getCcmV2Parameters(anyString(), anyString(), anyString())).thenReturn(defaultCcmV2Parameters);
+        when(ccmV2ParameterSupplier.getCcmV2Parameters(anyString(), any(Optional.class), anyString(), anyString())).thenReturn(defaultCcmV2Parameters);
         when(defaultCcmV2Parameters.getAgentCrn()).thenReturn("testAgentCrn");
         when(hostDiscoveryService.determineGatewayFqdn(any(), any())).thenReturn("datahub.master0.cldr.work.site");
 
         CcmConnectivityParameters ccmParameters = ThreadBasedUserCrnProvider.doAs(TEST_USER_CRN, () -> underTest.fetchAndSaveCcmParameters(stack));
         assertEquals(CcmConnectivityMode.CCMV2, ccmParameters.getConnectivityMode(), "CCM V2 should be enabled.");
         assertEquals(defaultCcmV2Parameters, ccmParameters.getCcmV2Parameters(), "CCM V2 Parameters should match.");
-        verify(ccmV2ParameterSupplier, times(1)).getCcmV2Parameters(anyString(), anyString(), anyString());
+        verify(ccmV2ParameterSupplier, times(1)).getCcmV2Parameters(anyString(), any(Optional.class), anyString(), anyString());
         verifyNoInteractions(ccmParameterSupplier);
 
         assertEquals("testAgentCrn", stack.getCcmV2AgentCrn(), "Ccm V2 Config should be initialized");
@@ -124,6 +128,7 @@ public class CcmUserDataServiceTest {
         aStack.setId(100L);
         aStack.setAccountId(TEST_ACCOUNT_ID);
         aStack.setResourceCrn(TEST_CLUSTER_CRN);
+        aStack.setEnvironmentCrn(TEST_ENVIRONMENT_CRN);
         return aStack;
     }
 }


### PR DESCRIPTION
With CDPAM-1289, we enhanced CCMv2 to optionally accept environmentCrn during agent registration. Agents registered with an environmentCrn would now be reused by experiences to route their requests to Kubernetes style workloads deployed inside the same environment.

This is 2 of 2 changes and would update the calling code to conditionally add environmentCrn during CCMv2 registration **for FreeIPA only**.