### PR TITLE
DISTX-570 Suspend AS for repeated scaling failures of cluster

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/common/MessageCode.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/common/MessageCode.java
@@ -14,6 +14,8 @@ public class MessageCode {
 
     public static final String AUTOSCALING_DISABLED = "autoscale.disabled";
 
+    public static final String AUTOSCALING_SUSPENDED = "autoscale.suspended";
+
     public static final String AUTOSCALING_ENTITLEMENT_NOT_ENABLED = "autoscale.entitlement.not.enabled";
 
     public static final String AUTOSCALING_ACTIVITY_NOT_REQUIRED = "autoscale.activity.not.required";

--- a/autoscale-api/src/main/resources/messages/messages.properties
+++ b/autoscale-api/src/main/resources/messages/messages.properties
@@ -6,6 +6,7 @@ autoscale.entitlement.not.enabled=Autoscaling Entitlement is not enabled for Clo
 autoscale.config.updated=''{0}'' Autoscaling Configuration updated; HostGroup(s) ''{1}''.
 autoscale.disabled=Autoscaling has been disabled.
 autoscale.enabled=Autoscaling has been enabled.
+autoscale.suspended=Autoscaling Suspended due to repeated failure of scaling attempts.
 
 autoscale.schedule.config.overlap=''SCHEDULE-BASED'' Autoscaling Configuration ''{0}'' not triggered, overlaps with ''{1}''.
 


### PR DESCRIPTION
AS should be suspended if repeated scaling failures are encountered for the same cluster.
Just marking Cluster Status as suspended is not correct, because Cluster Status would be remarked as "Running" in the next Periscope - CB Status Sync.

See detailed description in the commit message.