### PR TITLE
CB-11227 adding Standard_E4a_v4 which comes with 4 vcores, 32 gb memory

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -301,6 +301,7 @@ cb:
         Standard_D8as_v4,
         Standard_D16as_v4,
         Standard_D32as_v4,
+        Standard_E4a_v4,
         Standard_E8a_v4,
         Standard_E16a_v4,
         Standard_E32a_v4,


### PR DESCRIPTION
See detailed description in the commit message.