### PR TITLE
CB-11261 Use calculated `replaceVms` value instead of the one in request

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/upgrade/UpgradeV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/upgrade/UpgradeV4Response.java
@@ -17,6 +17,8 @@ public class UpgradeV4Response {
 
     private FlowIdentifier flowIdentifier;
 
+    private boolean replaceVms;
+
     public UpgradeV4Response() {
     }
 
@@ -72,12 +74,21 @@ public class UpgradeV4Response {
         this.flowIdentifier = flowIdentifier;
     }
 
+    public boolean isReplaceVms() {
+        return replaceVms;
+    }
+
+    public void setReplaceVms(boolean replaceVms) {
+        this.replaceVms = replaceVms;
+    }
+
     @Override
     public String toString() {
         return "UpgradeOptionsV4Response{" +
                 "current=" + current +
                 ", upgradeCandidates=" + upgradeCandidates +
                 ", reason='" + reason + '\'' +
+                ", replaceVms='" + replaceVms + '\'' +
                 '}';
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterDBValidationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterDBValidationService.java
@@ -19,7 +19,7 @@ public class ClusterDBValidationService {
     @Inject
     private RdsConfigService rdsConfigService;
 
-    public Boolean isGatewayRepairEnabled(Cluster cluster) {
+    public boolean isGatewayRepairEnabled(Cluster cluster) {
         return cluster.getEmbeddedDatabaseOnAttachedDisk() || isGatewayDatabaseAvailable(cluster);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityService.java
@@ -72,8 +72,9 @@ public class ClusterUpgradeAvailabilityService {
     @Inject
     private ImageFilterParamsFactory imageFilterParamsFactory;
 
-    public UpgradeV4Response checkForUpgradesByName(Stack stack, boolean lockComponents, Boolean replaceVms) {
+    public UpgradeV4Response checkForUpgradesByName(Stack stack, boolean lockComponents, boolean replaceVms) {
         UpgradeV4Response upgradeOptions = checkForUpgrades(stack, lockComponents);
+        upgradeOptions.setReplaceVms(replaceVms);
         if (StringUtils.isEmpty(upgradeOptions.getReason())) {
             if (!stack.getStatus().isAvailable()) {
                 upgradeOptions.setReason(String.format("Cannot upgrade cluster because it is in %s state.", stack.getStatus()));

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -248,7 +248,7 @@ public class StackOperations implements ResourceBasedCrnProvider {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         MDCBuilder.buildMdcContext(stack);
         boolean osUpgrade = upgradeService.isOsUpgrade(request);
-        Boolean replacevms = determineReplaceVmsParameter(stack, request.getReplaceVms());
+        boolean replacevms = determineReplaceVmsParameter(stack, request.getReplaceVms());
         UpgradeV4Response upgradeResponse = clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, osUpgrade, replacevms);
         if (CollectionUtils.isNotEmpty(upgradeResponse.getUpgradeCandidates())) {
             clusterUpgradeAvailabilityService.filterUpgradeOptions(upgradeResponse, request);
@@ -264,9 +264,9 @@ public class StackOperations implements ResourceBasedCrnProvider {
         }
     }
 
-    private Boolean determineReplaceVmsParameter(Stack stack, Boolean replaceVms) {
+    private boolean determineReplaceVmsParameter(Stack stack, Boolean replaceVms) {
         if (stack.isDatalake() || replaceVms != null) {
-            return replaceVms;
+            return Optional.ofNullable(replaceVms).orElse(Boolean.TRUE);
         } else {
             return clusterDBValidationService.isGatewayRepairEnabled(stack.getCluster());
         }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeService.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.distrox.v1.distrox.service.upgrade;
 
-import java.util.List;
-
 import javax.inject.Inject;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -64,14 +62,14 @@ public class DistroXUpgradeService {
         UpgradeV4Response upgradeV4Response = upgradeAvailabilityService.checkForUpgrade(cluster, workspaceId, request, userCrn);
         validateUpgradeCandidates(cluster, upgradeV4Response);
         verifyPaywallAccess(userCrn, request);
-        return initUpgrade(request, upgradeV4Response.getUpgradeCandidates(), cluster, workspaceId);
+        return initUpgrade(request, upgradeV4Response, cluster, workspaceId);
     }
 
-    private UpgradeV4Response initUpgrade(UpgradeV4Request request, List<ImageInfoV4Response> upgradeCandidates, NameOrCrn cluster, Long workspaceId) {
-        ImageInfoV4Response image = imageSelector.determineImageId(request, upgradeCandidates);
+    private UpgradeV4Response initUpgrade(UpgradeV4Request request, UpgradeV4Response upgradeV4Response, NameOrCrn cluster, Long workspaceId) {
+        ImageInfoV4Response image = imageSelector.determineImageId(request, upgradeV4Response.getUpgradeCandidates());
         ImageChangeDto imageChangeDto = createImageChangeDto(cluster, workspaceId, image);
         Long stackId = stackService.getIdByNameOrCrnInWorkspace(cluster, workspaceId);
-        FlowIdentifier flowIdentifier = reactorFlowManager.triggerDistroXUpgrade(stackId, imageChangeDto, request.getReplaceVms());
+        FlowIdentifier flowIdentifier = reactorFlowManager.triggerDistroXUpgrade(stackId, imageChangeDto, upgradeV4Response.isReplaceVms());
         return new UpgradeV4Response("Upgrade started with Image: " + image.getImageId(), flowIdentifier);
     }
 


### PR DESCRIPTION
If the replaceVms value is not specified in the request there is some logic to determine it.
Instead of depending the one in the request which can be null, we use the one calculated for the response.

See detailed description in the commit message.