### PR TITLE
CB-8476 Azure instance deallocation improvement

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureInstanceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureInstanceConnector.java
@@ -65,7 +65,12 @@ public class AzureInstanceConnector implements InstanceConnector {
     @Override
     public List<CloudVmInstanceStatus> stop(AuthenticatedContext ac, List<CloudResource> resources, List<CloudInstance> vms) {
         LOGGER.info("Stopping vms on Azure: {}", vms.stream().map(CloudInstance::getInstanceId).collect(Collectors.toList()));
-        return azureUtils.deallocateInstances(ac, vms);
+        try {
+            return azureUtils.deallocateInstances(ac, vms);
+        } catch (BatchInstanceActionFailedException e) {
+            LOGGER.error("Stoppings vms on Azure failed: {}", e.getFailedInstanceStatusReasons());
+            return e.getInstanceStatuses();
+        }
     }
 
     @Override

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/BatchInstanceActionFailedException.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/BatchInstanceActionFailedException.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+
+public class BatchInstanceActionFailedException extends Exception {
+
+    private final List<CloudVmInstanceStatus> instanceStatuses;
+
+    public BatchInstanceActionFailedException(List<CloudVmInstanceStatus> instanceStatuses) {
+        this.instanceStatuses = instanceStatuses;
+    }
+
+    public BatchInstanceActionFailedException(List<CloudVmInstanceStatus> instanceStatuses, Throwable cause) {
+        super(cause);
+        this.instanceStatuses = instanceStatuses;
+    }
+
+    public List<CloudVmInstanceStatus> getInstanceStatuses() {
+        return instanceStatuses;
+    }
+
+    public String getFailedInstanceStatusReasons() {
+        return instanceStatuses.stream()
+                .filter(instance -> InstanceStatus.FAILED.equals(instance.getStatus()))
+                .map(instance -> StringUtils.join(instance.getCloudInstance().getInstanceId(), ":", instance.getStatusReason()))
+                .collect(Collectors.joining(" - "));
+    }
+}


### PR DESCRIPTION
 - Check actual status of instances and deallocate only those that are not STOPPED
 - Collect deallocation results properly
 - Retry deallocation if something went wrong (exception raised)
 - Improve error logging