### PR TITLE
CB-11303: Add retries for IOExceptions in the FreeIPA client

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.client;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -11,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.googlecode.jsonrpc4j.JsonRpcClientException;
 
 public class FreeIpaClientExceptionUtil {
@@ -103,6 +105,12 @@ public class FreeIpaClientExceptionUtil {
                 .anyMatch(c -> isFreeIpaErrorCodeInSet(errorCodes, c));
     }
 
+    @VisibleForTesting
+    static boolean isExceptionWithIOExceptionCause(FreeIpaClientException e) {
+        return Stream.of(getAncestorCauseBeforeFreeIpaClientExceptions(e))
+                .anyMatch(IOException.class::isInstance);
+    }
+
     private static boolean isFreeIpaErrorCodeInSet(Set<FreeIpaErrorCodes> errorCodes, FreeIpaErrorCodes c) {
         return errorCodes.contains(c);
     }
@@ -150,7 +158,7 @@ public class FreeIpaClientExceptionUtil {
     }
 
     private static boolean isRetryable(FreeIpaClientException e) {
-        return isExceptionWithErrorCode(e, RETRYABLE_ERROR_CODES) || isExceptionWithHttpCode(retryableHttpCodes, e);
+        return isExceptionWithErrorCode(e, RETRYABLE_ERROR_CODES) || isExceptionWithHttpCode(retryableHttpCodes, e) || isExceptionWithIOExceptionCause(e);
     }
 
     private static boolean isExceptionWithHttpCode(Set<Integer> codes, FreeIpaClientException e) {

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtilV1Test.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtilV1Test.java
@@ -2,6 +2,7 @@ package com.sequenceiq.freeipa.client;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
 
@@ -92,6 +93,12 @@ public class FreeIpaClientExceptionUtilV1Test {
         Assertions.assertFalse(FreeIpaClientExceptionUtil.convertToRetryableIfNeeded(
                 new FreeIpaClientException(MESSAGE, HttpStatus.OK.value()))
                 instanceof RetryableFreeIpaClientException);
+        assertTrue(FreeIpaClientExceptionUtil.convertToRetryableIfNeeded(
+                new FreeIpaClientException(MESSAGE, new IOException()))
+                instanceof RetryableFreeIpaClientException);
+        Assertions.assertFalse(FreeIpaClientExceptionUtil.convertToRetryableIfNeeded(
+                new FreeIpaClientException(MESSAGE, new IllegalStateException()))
+                instanceof RetryableFreeIpaClientException);
     }
 
     @Test
@@ -106,6 +113,16 @@ public class FreeIpaClientExceptionUtilV1Test {
         Assertions.assertEquals(ancestor,
                 FreeIpaClientExceptionUtil.getAncestorCauseBeforeFreeIpaClientExceptions(
                         new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE, ancestor)))));
+    }
+
+    @Test
+    public void testIsExceptionWithIOExceptionCause() {
+        Assertions.assertTrue(FreeIpaClientExceptionUtil.isExceptionWithIOExceptionCause(new FreeIpaClientException(MESSAGE, new IOException())));
+        Assertions.assertFalse(FreeIpaClientExceptionUtil.isExceptionWithIOExceptionCause(new FreeIpaClientException(MESSAGE, new IllegalStateException())));
+        Assertions.assertTrue(FreeIpaClientExceptionUtil.isExceptionWithIOExceptionCause(
+                new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE, new IOException()))));
+        Assertions.assertFalse(FreeIpaClientExceptionUtil.isExceptionWithIOExceptionCause(
+                new FreeIpaClientException(MESSAGE, new FreeIpaClientException(MESSAGE, new IllegalStateException()))));
     }
 
     @Test


### PR DESCRIPTION
Add retries for IOExceptions in the FreeIPA client.

This was tested with unit tests and with a local deployment of
cloudbreak.

See detailed description in the commit message.