### PR TITLE
CB-11152: Add keyUrl CLI param in Azure environment creation.

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -102,6 +102,8 @@ public class EnvironmentModelDescription {
     public static final String RESOURCE_GROUP_USAGE = "Resource group usage: single resource group for all resources where possible "
             + "or use multiple resource groups.";
 
+    public static final String KEY_URL = "URL of the CustomerManagedkey to encrypt Azure resources";
+    public static final String RESOURCE_ENCRYPTION_PARAMETERS = "Parameter: keyUrl - to encrypt Azure resources.";
     public static final String PARENT_ENVIRONMENT_CRN = "Parent environment global identifier";
     public static final String PARENT_ENVIRONMENT_NAME = "Parent environment name";
     public static final String PARENT_ENVIRONMENT_CLOUD_PLATFORM = "Parent environment cloud platform";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureEnvironmentParameters.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureEnvironmentParameters.java
@@ -14,6 +14,10 @@ public class AzureEnvironmentParameters {
     @ApiModelProperty(EnvironmentModelDescription.RESOURCE_GROUP_PARAMETERS)
     private AzureResourceGroup resourceGroup;
 
+    @Valid
+    @ApiModelProperty(EnvironmentModelDescription.RESOURCE_ENCRYPTION_PARAMETERS)
+    private AzureResourceEncryptionParameters resourceEncryptionParameters;
+
     public AzureResourceGroup getResourceGroup() {
         return resourceGroup;
     }
@@ -22,10 +26,19 @@ public class AzureEnvironmentParameters {
         this.resourceGroup = resourceGroup;
     }
 
+    public AzureResourceEncryptionParameters getResourceEncryptionParameters() {
+        return resourceEncryptionParameters;
+    }
+
+    public void setResourceEncryptionParameters(AzureResourceEncryptionParameters resourceEncryptionParameters) {
+        this.resourceEncryptionParameters = resourceEncryptionParameters;
+    }
+
     @Override
     public String toString() {
         return "AzureEnvironmentParameters{" +
                 "resourceGroup=" + resourceGroup +
+                ", resourceEncryptionParameters=" + resourceEncryptionParameters +
                 '}';
     }
 
@@ -37,14 +50,22 @@ public class AzureEnvironmentParameters {
 
         private AzureResourceGroup azureResourceGroup;
 
+        private AzureResourceEncryptionParameters resourceEncryptionParameters;
+
         public Builder withAzureResourceGroup(AzureResourceGroup azureResourceGroup) {
             this.azureResourceGroup = azureResourceGroup;
+            return this;
+        }
+
+        public Builder withResourceEncryptionParameters(AzureResourceEncryptionParameters resourceEncryptionParameters) {
+            this.resourceEncryptionParameters = resourceEncryptionParameters;
             return this;
         }
 
         public AzureEnvironmentParameters build() {
             AzureEnvironmentParameters azureEnvironmentParameters = new AzureEnvironmentParameters();
             azureEnvironmentParameters.setResourceGroup(azureResourceGroup);
+            azureEnvironmentParameters.setResourceEncryptionParameters(resourceEncryptionParameters);
             return azureEnvironmentParameters;
         }
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureResourceEncryptionParameters.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureResourceEncryptionParameters.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.environment.api.v1.environment.model.request.azure;
+
+import javax.validation.constraints.Pattern;
+
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(value = "AzureResourceEncryptionV1Parameters")
+public class AzureResourceEncryptionParameters {
+
+    @ApiModelProperty(EnvironmentModelDescription.KEY_URL)
+    @Pattern(regexp = "^https:\\/\\/[a-zA-Z-][0-9a-zA-Z-]*\\.vault\\.azure\\.net\\/keys\\/[0-9a-zA-Z-]+\\/[0-9A-Za-z]+",
+            message = "It should be of format 'https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>'" +
+                    "keyName can only contain alphanumeric characters and dashes." +
+                    "keyVersion can only contain alphanumeric characters.")
+    private String keyUrl;
+
+    public String getKeyUrl() {
+        return keyUrl;
+    }
+
+    public void setKeyUrl(String keyUrl) {
+        this.keyUrl = keyUrl;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "AzureResourceEncryptionParameters{" +
+                "keyUrl=" + keyUrl +
+                '}';
+    }
+
+    public static class Builder {
+
+        private String keyUrl;
+
+        public Builder withKeyUrl(String keyUrl) {
+            this.keyUrl = keyUrl;
+            return this;
+        }
+
+        public AzureResourceEncryptionParameters build() {
+            AzureResourceEncryptionParameters resourceEncryptionParameters = new AzureResourceEncryptionParameters();
+            resourceEncryptionParameters.setKeyUrl(keyUrl);
+            return resourceEncryptionParameters;
+        }
+    }
+}


### PR DESCRIPTION
CB-11152: Add keyUrl CLI param in Azure environment creation. 
This param will be used to create Disk Encryption Set which enables ServerSideEncryption with CustomerManagedKey for Azure resources. For now, SSE with CMK will be implemented for Azure Managed disks for datahub clusters.
More details are captured in CB-9920

On successful build - contents of environment json looks like -
```
"AzureEnvironmentV1Parameters" : {
      "type" : "object",
      "properties" : {
        "resourceGroup" : {
          "description" : "Azure resource group parameters.",
          "$ref" : "#/definitions/AzureResourceGroupV1Parameters"
        },
        "resourceEncryptionParameters" : {
          "description" : "Parameter: keyUrl - to encrypt Azure resources.",
          "$ref" : "#/definitions/AzureResourceEncryptionV1Parameters"
        }
      }
    },
    "AzureResourceEncryptionV1Parameters" : {
      "type" : "object",
      "properties" : {
        "keyUrl" : {
          "type" : "string",
          "description" : "URL of the CustomerManagedkey to encrypt Azure resources",
          "pattern" : "(^https:\\/\\/[a-zA-Z-][0-9a-zA-Z-]*\\.vault\\.azure\\.net\\/keys\\/[0-9a-zA-Z-]*\\/[0-9A-Za-z]*)"
        }
      }
    }
```



See detailed description in the commit message.