### PR TITLE
CB-11290 Auto upscale failing because of user permission issues on 2.9.2

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/AutoscaleController.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/AutoscaleController.java
@@ -80,6 +80,8 @@ public class AutoscaleController implements AutoscaleEndpoint {
 
     @Override
     public Response putCluster(Long stackId, String owner, @Valid UpdateClusterJson updateRequest) {
+        LOGGER.info("Autoscale requested cluster update for stack id '{}', with status request '{}' and adjustment: '{}'", stackId, updateRequest.getStatus(),
+                updateRequest.getHostGroupAdjustment());
         setupIdentityForAutoscale(stackId, owner);
         User user = userService.getOrCreate(restRequestThreadLocalService.getCloudbreakUser());
         Workspace workspace = workspaceService.get(restRequestThreadLocalService.getRequestedWorkspaceId(), user);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
@@ -179,9 +179,6 @@ public class StackCommonService implements StackEndpoint {
     }
 
     public Response putInDefaultWorkspace(Long id, UpdateStackJson updateRequest) {
-        User user = userService.getOrCreate(restRequestThreadLocalService.getCloudbreakUser());
-        permissionCheckingUtils.checkPermissionByWorkspaceIdForUser(restRequestThreadLocalService.getRequestedWorkspaceId(),
-                WorkspaceResource.STACK, Action.WRITE, user);
         Stack stack = stackService.getById(id);
         MDCBuilder.buildMdcContext(stack);
         return put(stack, updateRequest);
@@ -286,7 +283,7 @@ public class StackCommonService implements StackEndpoint {
         } else {
             Integer scalingAdjustment = updateRequest.getInstanceGroupAdjustment().getScalingAdjustment();
             validateHardLimits(scalingAdjustment);
-            stackService.updateNodeCount(stack, updateRequest.getInstanceGroupAdjustment(), updateRequest.getWithClusterEvent(), user);
+            stackService.updateNodeCount(stack, updateRequest.getInstanceGroupAdjustment(), updateRequest.getWithClusterEvent());
         }
         LOGGER.info("Stack update has been initiated name: '{}' with status: '{}' and adjustment: '{}'", stack.getName(), updateRequest.getStatus(),
                 updateRequest.getInstanceGroupAdjustment());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -690,8 +690,7 @@ public class StackService {
         }
     }
 
-    public void updateNodeCount(Stack stack, InstanceGroupAdjustmentJson instanceGroupAdjustmentJson, boolean withClusterEvent, User user) {
-        permissionCheckingUtils.checkPermissionByWorkspaceIdForUser(stack.getWorkspace().getId(), WorkspaceResource.STACK, Action.WRITE, user);
+    public void updateNodeCount(Stack stack, InstanceGroupAdjustmentJson instanceGroupAdjustmentJson, boolean withClusterEvent) {
         try {
             transactionService.required(() -> {
                 Stack stackWithLists = getByIdWithLists(stack.getId());


### PR DESCRIPTION
The removed permission check only affects the cb autoscale scaling api call and only in the case when the call originated in the periscope service.