### PR TITLE
CB-11302: Allow the ability for customer to choose a previously relea…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/ImageCatalogV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/ImageCatalogV4Endpoint.java
@@ -116,4 +116,12 @@ public interface ImageCatalogV4Endpoint {
             notes = IMAGE_CATALOG_NOTES, nickname = "getImagesByNameInWorkspace")
     ImagesV4Response getImagesByName(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("stackName") String stackName, @QueryParam("platform") String platform) throws Exception;
+
+    @GET
+    @Path("{name}/image")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ImageCatalogOpDescription.GET_IMAGE_BY_NAME_AND_ID, produces = MediaType.APPLICATION_JSON,
+            notes = IMAGE_CATALOG_NOTES, nickname = "getImageByNameAndId")
+    ImagesV4Response getImageByCatalogNameAndImageId(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
+            @QueryParam("imageId") String imageId) throws Exception;
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -157,6 +157,8 @@ public class OperationDescriptions {
         public static final String GET_BY_IMAGE_CATALOG_NAME = "retrieve imagecatalog request by imagecatalog name";
         public static final String GET_IMAGES_BY_NAME = "determines available images for the given stack or platform"
                 + "from the given imagecatalog name";
+        public static final String GET_IMAGE_BY_NAME_AND_ID = "determines the image for the image UUID"
+                + "from the given imagecatalog name";
         public static final String GET_IMAGES = "determines available images for the given stack or platform"
                 + "from the default image catalog";
         public static final String LIST_BY_WORKSPACE = "list image catalogs for the given workspace";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.authorization.resource.AuthorizationResourceAction.
 import static com.sequenceiq.authorization.resource.AuthorizationVariableType.CRN;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -38,6 +39,7 @@ import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
 import com.sequenceiq.cloudbreak.common.type.ResourceEvent;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.workspace.controller.WorkspaceEntityType;
 
 @Controller
@@ -145,6 +147,14 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public ImagesV4Response getImagesByName(Long workspaceId, @ResourceName String name, String stackName, String platform) throws Exception {
         Images images = imageCatalogService.getImagesByCatalogName(workspaceId, name, stackName, platform);
+        return converterUtil.convert(images, ImagesV4Response.class);
+    }
+
+    @Override
+    @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
+    public ImagesV4Response getImageByCatalogNameAndImageId(Long workspaceId, @ResourceName String name, String imageId) throws Exception {
+        StatedImage statedImage = imageCatalogService.getImageByCatalogName(workspaceId, imageId, name);
+        Images images = new Images(List.of(), List.of(statedImage.getImage()), Set.of());
         return converterUtil.convert(images, ImagesV4Response.class);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.service.image;
 
 import static com.sequenceiq.cloudbreak.cloud.model.Platform.platform;
 import static com.sequenceiq.cloudbreak.common.type.ComponentType.CDH_PRODUCT_DETAILS;
+import static com.sequenceiq.cloudbreak.service.image.ImageCatalogService.CDP_DEFAULT_CATALOG_NAME;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -107,7 +108,11 @@ public class ImageService {
             throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
 
         if (imageSettings != null && StringUtils.isNotEmpty(imageSettings.getId())) {
-            LOGGER.debug("Image id is specified for the stack.");
+            LOGGER.debug("Image id {} is specified for the stack.", imageSettings.getId());
+
+            if (imageSettings.getCatalog() == null) {
+                imageSettings.setCatalog(CDP_DEFAULT_CATALOG_NAME);
+            }
             StatedImage image = imageCatalogService.getImageByCatalogName(workspaceId, imageSettings.getId(), imageSettings.getCatalog());
             return checkIfBasePermitted(image, baseImageEnabled);
         } else if (useBaseImage && !baseImageEnabled) {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
@@ -33,6 +33,7 @@ import com.sequenceiq.sdx.api.model.RangerCloudIdentitySyncStatus;
 import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
+import com.sequenceiq.sdx.api.model.SdxCustomClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxDatabaseBackupResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseBackupStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRestoreResponse;
@@ -255,4 +256,10 @@ public interface SdxEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ROTATE_CERTIFICATES, nickname = "rotateAutoTlsCertificatesByCrn")
     FlowIdentifier rotateAutoTlsCertificatesByCrn(@PathParam("crn") String crn, @Valid CertificatesRotationV4Request rotateCertificateRequest);
+
+    @POST
+    @Path("{name}/custom_image")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "create custom SDX cluster", produces = MediaType.APPLICATION_JSON, nickname = "createCustomSdx")
+    SdxClusterResponse create(@PathParam("name") String name, @Valid SdxCustomClusterRequest createSdxClusterRequest);
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequest.java
@@ -1,49 +1,8 @@
 package com.sequenceiq.sdx.api.model;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
-import com.sequenceiq.common.api.tag.request.TaggableRequest;
-
-public class SdxClusterRequest implements TaggableRequest {
-
-    @NotNull
-    private String environment;
-
-    @NotNull
-    private SdxClusterShape clusterShape;
+public class SdxClusterRequest extends SdxClusterRequestBase {
 
     private String runtime;
-
-    private SdxCloudStorageRequest cloudStorage;
-
-    private SdxDatabaseRequest externalDatabase;
-
-    @Valid
-    private SdxAwsRequest aws;
-
-    private Map<String, String> tags;
-
-    private boolean enableRangerRaz;
-
-    public String getEnvironment() {
-        return environment;
-    }
-
-    public void setEnvironment(String environment) {
-        this.environment = environment;
-    }
-
-    public SdxClusterShape getClusterShape() {
-        return clusterShape;
-    }
-
-    public void setClusterShape(SdxClusterShape clusterShape) {
-        this.clusterShape = clusterShape;
-    }
 
     public String getRuntime() {
         return runtime;
@@ -53,71 +12,10 @@ public class SdxClusterRequest implements TaggableRequest {
         this.runtime = runtime;
     }
 
-    public void setTags(Map<String, String> tags) {
-        this.tags = tags;
-    }
-
-    public Map<String, String> getTags() {
-        return tags;
-    }
-
-    @Override
-    public void addTag(String key, String value) {
-        initAndGetTags().put(key, value);
-    }
-
-    public Map<String, String> initAndGetTags() {
-        if (tags == null) {
-            tags = new HashMap<>();
-        }
-        return tags;
-    }
-
-    public void addTags(Map<String, String> tags) {
-        initAndGetTags().putAll(tags);
-    }
-
-    public SdxCloudStorageRequest getCloudStorage() {
-        return cloudStorage;
-    }
-
-    public void setCloudStorage(SdxCloudStorageRequest cloudStorage) {
-        this.cloudStorage = cloudStorage;
-    }
-
-    public SdxDatabaseRequest getExternalDatabase() {
-        return externalDatabase;
-    }
-
-    public void setExternalDatabase(SdxDatabaseRequest externalDatabase) {
-        this.externalDatabase = externalDatabase;
-    }
-
-    public SdxAwsRequest getAws() {
-        return aws;
-    }
-
-    public void setAws(SdxAwsRequest aws) {
-        this.aws = aws;
-    }
-
-    public boolean isEnableRangerRaz() {
-        return enableRangerRaz;
-    }
-
-    public void setEnableRangerRaz(boolean enableRangerRaz) {
-        this.enableRangerRaz = enableRangerRaz;
-    }
-
     @Override
     public String toString() {
-        return "SdxClusterRequest{" +
-                "clusterShape=" + clusterShape +
-                ", runtime='" + runtime + '\'' +
-                ", cloudStorage=" + cloudStorage +
-                ", externalDatabase=" + externalDatabase +
-                ", aws=" + aws +
-                ", enableRangerRaz=" + enableRangerRaz +
+        return "SdxClusterRequest{" + "base=" + super.toString() +
+                ", runtime=" + runtime +
                 '}';
     }
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequestBase.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequestBase.java
@@ -1,0 +1,122 @@
+package com.sequenceiq.sdx.api.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+import com.sequenceiq.common.api.tag.request.TaggableRequest;
+
+public class SdxClusterRequestBase implements TaggableRequest {
+
+    @NotNull
+    private String environment;
+
+    @NotNull
+    private SdxClusterShape clusterShape;
+
+    private SdxCloudStorageRequest cloudStorage;
+
+    private SdxDatabaseRequest externalDatabase;
+
+    @Valid
+    private SdxAwsRequest aws;
+
+    private Map<String, String> tags;
+
+    private boolean enableRangerRaz;
+
+    public String getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(String environment) {
+        this.environment = environment;
+    }
+
+    public SdxClusterShape getClusterShape() {
+        return clusterShape;
+    }
+
+    public void setClusterShape(SdxClusterShape clusterShape) {
+        this.clusterShape = clusterShape;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    @Override
+    public void addTag(String key, String value) {
+        initAndGetTags().put(key, value);
+    }
+
+    public Map<String, String> initAndGetTags() {
+        if (tags == null) {
+            tags = new HashMap<>();
+        }
+        return tags;
+    }
+
+    public void addTags(Map<String, String> tags) {
+        initAndGetTags().putAll(tags);
+    }
+
+    public SdxCloudStorageRequest getCloudStorage() {
+        return cloudStorage;
+    }
+
+    public void setCloudStorage(SdxCloudStorageRequest cloudStorage) {
+        this.cloudStorage = cloudStorage;
+    }
+
+    public SdxDatabaseRequest getExternalDatabase() {
+        return externalDatabase;
+    }
+
+    public void setExternalDatabase(SdxDatabaseRequest externalDatabase) {
+        this.externalDatabase = externalDatabase;
+    }
+
+    public SdxAwsRequest getAws() {
+        return aws;
+    }
+
+    public void setAws(SdxAwsRequest aws) {
+        this.aws = aws;
+    }
+
+    public boolean isEnableRangerRaz() {
+        return enableRangerRaz;
+    }
+
+    public void setEnableRangerRaz(boolean enableRangerRaz) {
+        this.enableRangerRaz = enableRangerRaz;
+    }
+
+    public void copyTo(SdxClusterRequestBase toInstance) {
+        toInstance.setEnvironment(environment);
+        toInstance.setClusterShape(clusterShape);
+        toInstance.setTags(tags);
+        toInstance.setCloudStorage(cloudStorage);
+        toInstance.setExternalDatabase(externalDatabase);
+        toInstance.setAws(aws);
+        toInstance.setEnableRangerRaz(enableRangerRaz);
+    }
+
+    @Override
+    public String toString() {
+        return "SdxClusterRequestBase{" +
+                "clusterShape=" + clusterShape +
+                ", cloudStorage=" + cloudStorage +
+                ", externalDatabase=" + externalDatabase +
+                ", aws=" + aws +
+                ", enableRangerRaz=" + enableRangerRaz +
+                '}';
+    }
+}

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxCustomClusterRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxCustomClusterRequest.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.sdx.api.model;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
+
+public class SdxCustomClusterRequest extends SdxClusterRequestBase {
+    private ImageSettingsV4Request imageSettingsV4Request;
+
+    public ImageSettingsV4Request getImageSettingsV4Request() {
+        return imageSettingsV4Request;
+    }
+
+    public void setImageSettingsV4Request(ImageSettingsV4Request imageSettingsV4Request) {
+        this.imageSettingsV4Request = imageSettingsV4Request;
+    }
+
+    public String getRuntime() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "SdxCustomClusterRequest{" + "base=" + super.toString() +
+                ", imageSettingsV4Request=" + imageSettingsV4Request +
+                '}';
+    }
+
+    public Pair<SdxClusterRequest, ImageSettingsV4Request> convertToPair() {
+        SdxClusterRequest newRequest = new SdxClusterRequest();
+        copyTo(newRequest);
+
+        return new Pair<SdxClusterRequest, ImageSettingsV4Request>() {
+            @Override
+            public SdxClusterRequest getLeft() {
+                return newRequest;
+            }
+
+            @Override
+            public ImageSettingsV4Request getRight() {
+                return getImageSettingsV4Request();
+            }
+
+            @Override
+            public ImageSettingsV4Request setValue(ImageSettingsV4Request value) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxClient.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxClient.java
@@ -2,9 +2,9 @@ package com.sequenceiq.sdx.client;
 
 import com.sequenceiq.authorization.info.AuthorizationUtilEndpoint;
 import com.sequenceiq.flow.api.FlowEndpoint;
+import com.sequenceiq.flow.api.FlowPublicEndpoint;
 import com.sequenceiq.sdx.api.endpoint.DatabaseServerEndpoint;
 import com.sequenceiq.sdx.api.endpoint.DiagnosticsEndpoint;
-import com.sequenceiq.flow.api.FlowPublicEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxInternalEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxUpgradeEndpoint;

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -51,6 +51,7 @@ import com.sequenceiq.sdx.api.model.SdxBackupStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
+import com.sequenceiq.sdx.api.model.SdxCustomClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxDatabaseBackupResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseBackupStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRestoreResponse;
@@ -105,6 +106,19 @@ public class SdxController implements SdxEndpoint {
         Pair<SdxCluster, FlowIdentifier> result = sdxService.createSdx(userCrn, name, createSdxClusterRequest, null);
         SdxCluster sdxCluster = result.getLeft();
         metricService.incrementMetricCounter(MetricType.EXTERNAL_SDX_REQUESTED, sdxCluster);
+        SdxClusterResponse sdxClusterResponse = sdxClusterConverter.sdxClusterToResponse(sdxCluster);
+        sdxClusterResponse.setName(sdxCluster.getClusterName());
+        sdxClusterResponse.setFlowIdentifier(result.getRight());
+        return sdxClusterResponse;
+    }
+
+    @Override
+    @CheckPermissionByAccount(action = AuthorizationResourceAction.CREATE_DATALAKE)
+    public SdxClusterResponse create(String name, @Valid SdxCustomClusterRequest createSdxClusterRequest) {
+        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
+        Pair<SdxCluster, FlowIdentifier> result = sdxService.createSdx(userCrn, name, createSdxClusterRequest);
+        SdxCluster sdxCluster = result.getLeft();
+        metricService.incrementMetricCounter(MetricType.CUSTOM_SDX_REQUESTED, sdxCluster);
         SdxClusterResponse sdxClusterResponse = sdxClusterConverter.sdxClusterToResponse(sdxCluster);
         sdxClusterResponse.setName(sdxCluster.getClusterName());
         sdxClusterResponse.setFlowIdentifier(result.getRight());

--- a/datalake/src/main/java/com/sequenceiq/datalake/metric/MetricType.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/metric/MetricType.java
@@ -3,6 +3,7 @@ package com.sequenceiq.datalake.metric;
 import com.sequenceiq.cloudbreak.common.metrics.type.Metric;
 
 public enum MetricType implements Metric {
+    CUSTOM_SDX_REQUESTED("custom.sdx.requested"),
     INTERNAL_SDX_REQUESTED("internal.sdx.requested"),
     EXTERNAL_SDX_REQUESTED("external.sdx.requested"),
     SDX_CREATION_FINISHED("sdx.creation.finished"),

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SdxClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SdxClient.java
@@ -11,6 +11,7 @@ import com.sequenceiq.it.TestParameter;
 import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.dto.util.RenewDatalakeCertificateTestDto;
@@ -63,7 +64,8 @@ public class SdxClient extends MicroserviceClient<SdxServiceApiKeyEndpoints, Voi
     public Set<String> supportedTestDtos() {
         return Set.of(SdxTestDto.class.getSimpleName(),
                 RenewDatalakeCertificateTestDto.class.getSimpleName(),
-                SdxInternalTestDto.class.getSimpleName());
+                SdxInternalTestDto.class.getSimpleName(),
+                SdxCustomTestDto.class.getSimpleName());
     }
 }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCreateCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCreateCustomAction.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+import com.sequenceiq.sdx.api.model.SdxClusterResponse;
+
+public class SdxCreateCustomAction implements Action<SdxCustomTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxCreateCustomAction.class);
+
+    @Override
+    public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient client) throws Exception {
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX create request: ", testDto.getRequest());
+        SdxClusterResponse sdxClusterResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .create(testDto.getName(), testDto.getRequest());
+        testDto.setFlow("SDX create", sdxClusterResponse.getFlowIdentifier());
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetailByCrn(sdxClusterResponse.getCrn(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX create response: ", client.getDefaultClient().sdxEndpoint().get(testDto.getName()));
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteCustomAction.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+
+public class SdxDeleteCustomAction implements Action<SdxCustomTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxDeleteCustomAction.class);
+
+    @Override
+    public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient client) throws Exception {
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX custom delete request: ", testDto.getRequest());
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
+                .sdxEndpoint()
+                .delete(testDto.getName(), false);
+        testDto.setFlow("SDX delete", flowIdentifier);
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX custom delete response: ", detailedResponse);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDescribeCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDescribeCustomAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import java.util.HashSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class SdxDescribeCustomAction implements Action<SdxCustomTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxDescribeCustomAction.class);
+
+    @Override
+    public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient client) throws Exception {
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX describe custom request: ", testDto.getRequest());
+        testDto.setResponse(client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), new HashSet<>()));
+        Log.whenJson(LOGGER, " SDX describe custom response: ", client.getDefaultClient().sdxEndpoint().get(testDto.getName()));
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDetailedDescribeCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDetailedDescribeCustomAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import java.util.HashSet;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class SdxDetailedDescribeCustomAction implements Action<SdxCustomTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxDetailedDescribeCustomAction.class);
+
+    @Override
+    public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient client) throws Exception {
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX describe detailed custom request: ", testDto.getRequest());
+        testDto.setResponse(client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), new HashSet<>()));
+        Log.whenJson(LOGGER, " SDX describe detailed custom response: ", client.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), null));
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxForceDeleteCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxForceDeleteCustomAction.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+
+public class SdxForceDeleteCustomAction implements Action<SdxCustomTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxForceDeleteCustomAction.class);
+
+    @Override
+    public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient client) throws Exception {
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
+                .sdxEndpoint()
+                .delete(testDto.getName(), true);
+        testDto.setFlow("SDX Custom force delete", flowIdentifier);
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX Custom force delete response: ", detailedResponse);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRefreshCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRefreshCustomAction.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class SdxRefreshCustomAction implements Action<SdxCustomTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxRefreshCustomAction.class);
+
+    @Override
+    public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient client) throws Exception {
+        testDto.setResponse(
+                client.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), Collections.emptySet())
+        );
+        Log.whenJson(LOGGER, " SDX Custom get detail response: ", testDto.getResponse());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairCustomAction.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import static java.lang.String.format;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+
+public class SdxRepairCustomAction implements Action<SdxCustomTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxRepairCustomAction.class);
+
+    @Override
+    public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient client) throws Exception {
+        Log.when(LOGGER, format(" Starting repair on SDX Internal: %s ", testDto.getName()));
+        Log.whenJson(LOGGER, " SDX Custom repair request: ", testDto.getSdxRepairRequest());
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
+                .sdxEndpoint()
+                .repairCluster(testDto.getName(), testDto.getSdxRepairRequest());
+        testDto.setFlow("SDX Custom repair", flowIdentifier);
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX Custom repair response: ", detailedResponse);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStartCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStartCustomAction.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import static java.lang.String.format;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+
+public class SdxStartCustomAction implements Action<SdxCustomTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxStartCustomAction.class);
+
+    @Override
+    public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient client) throws Exception {
+        Log.when(LOGGER, format(" Starting custom SDX: %s ", testDto.getName()));
+        Log.whenJson(LOGGER, " SDX start custom request: ", testDto.getRequest());
+        FlowIdentifier flowIdentifier = client.getDefaultClient().sdxEndpoint().startByName(testDto.getName());
+        testDto.setFlow("SDX start", flowIdentifier);
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX start custom response: ", detailedResponse);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStopCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStopCustomAction.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import static java.lang.String.format;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+
+public class SdxStopCustomAction implements Action<SdxCustomTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxStopCustomAction.class);
+
+    @Override
+    public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient client) throws Exception {
+        Log.when(LOGGER, format(" Stop custom SDX: %s ", testDto.getName()));
+        Log.whenJson(LOGGER, " SDX stop custom request: ", testDto.getRequest());
+        FlowIdentifier flowIdentifier = client.getDefaultClient().sdxEndpoint().stopByName(testDto.getName());
+        testDto.setFlow("SDX stop", flowIdentifier);
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX stop custom response: ", detailedResponse);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncCustomAction.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import static java.lang.String.format;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class SdxSyncCustomAction implements Action<SdxCustomTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxSyncCustomAction.class);
+
+    @Override
+    public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient client) throws Exception {
+        Log.when(LOGGER, format(" SDX's environment: %s ", testDto.getRequest().getEnvironment()));
+        Log.whenJson(LOGGER, " SDX sync custom request: ", testDto.getRequest());
+        client.getDefaultClient()
+                .sdxEndpoint()
+                .sync(testDto.getName());
+        Log.when(LOGGER, " SDX sync custom have been initiated. ");
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/SdxRetryCustomAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/SdxRetryCustomAction.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.it.cloudbreak.action.v4.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
+
+public class SdxRetryCustomAction implements Action<SdxCustomTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxRetryCustomAction.class);
+
+    @Override
+    public SdxCustomTestDto action(TestContext testContext, SdxCustomTestDto testDto, SdxClient sdxClient)
+            throws Exception {
+        sdxClient.getDefaultClient().sdxEndpoint().retryByCrn(testDto.getCrn());
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -9,16 +9,20 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxCheckForUpgradeAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCollectCMDiagnosticsAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCollectDiagnosticsAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCreateAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxCreateCustomAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxCreateInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxDeleteAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxDeleteCustomAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxDeleteInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxDescribeAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxDescribeInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxDetailedDescribeInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteCustomAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxListAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshCustomAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRepairAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRepairInternalAction;
@@ -30,6 +34,7 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxUpgradeAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.RenewDatalakeCertificateAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.SdxRetryAction;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCMDiagnosticsTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxDiagnosticsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
@@ -46,6 +51,10 @@ public class SdxTestClient {
         return new SdxCreateInternalAction();
     }
 
+    public Action<SdxCustomTestDto, SdxClient> createCustom() {
+        return new SdxCreateCustomAction();
+    }
+
     public Action<SdxTestDto, SdxClient> delete() {
         return new SdxDeleteAction();
     }
@@ -58,8 +67,16 @@ public class SdxTestClient {
         return new SdxDeleteInternalAction();
     }
 
+    public Action<SdxCustomTestDto, SdxClient> deleteCustom() {
+        return new SdxDeleteCustomAction();
+    }
+
     public Action<SdxInternalTestDto, SdxClient> forceDeleteInternal() {
         return new SdxForceDeleteInternalAction();
+    }
+
+    public Action<SdxCustomTestDto, SdxClient> forceDeleteCustom() {
+        return new SdxForceDeleteCustomAction();
     }
 
     public Action<SdxTestDto, SdxClient> describe() {
@@ -88,6 +105,10 @@ public class SdxTestClient {
 
     public Action<SdxInternalTestDto, SdxClient> refreshInternal() {
         return new SdxRefreshInternalAction();
+    }
+
+    public Action<SdxCustomTestDto, SdxClient> refreshCustom() {
+        return new SdxRefreshCustomAction();
     }
 
     public Action<SdxTestDto, SdxClient> repair() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
@@ -27,6 +27,7 @@ import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentSecurityAccessTes
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxRepairTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
@@ -193,6 +194,12 @@ public abstract class AbstractCloudProvider implements CloudProvider {
     public SdxInternalTestDto sdxInternal(SdxInternalTestDto sdxInternal) {
         sdxInternal.withDefaultSDXSettings();
         return sdxInternal;
+    }
+
+    @Override
+    public SdxCustomTestDto sdxCustom(SdxCustomTestDto sdxCustom) {
+        sdxCustom.withTags(commonCloudProperties.getTags());
+        return sdxCustom;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
@@ -30,6 +30,7 @@ import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxRepairTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
@@ -89,6 +90,8 @@ public interface CloudProvider {
     SdxTestDto sdx(SdxTestDto sdx);
 
     SdxInternalTestDto sdxInternal(SdxInternalTestDto sdxInternal);
+
+    SdxCustomTestDto sdxCustom(SdxCustomTestDto sdxCustom);
 
     SdxRepairTestDto sdxRepair(SdxRepairTestDto sdxRepair);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
@@ -38,6 +38,7 @@ import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxRepairTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
@@ -148,6 +149,11 @@ public class CloudProviderProxy implements CloudProvider {
     @Override
     public SdxInternalTestDto sdxInternal(SdxInternalTestDto sdxInternal) {
         return getDelegate(sdxInternal).sdxInternal(sdxInternal);
+    }
+
+    @Override
+    public SdxCustomTestDto sdxCustom(SdxCustomTestDto sdxCustom) {
+        return getDelegate(sdxCustom).sdxCustom(sdxCustom);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -46,6 +46,7 @@ import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentSecurityAccessTes
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDtoBase;
 import com.sequenceiq.it.cloudbreak.dto.telemetry.TelemetryTestDto;
@@ -113,6 +114,11 @@ public class GcpCloudProvider extends AbstractCloudProvider {
     public SdxInternalTestDto sdxInternal(SdxInternalTestDto sdxInternal) {
         sdxInternal.getRequest().getStackV4Request().setNetwork(null);
         return sdxInternal;
+    }
+
+    @Override
+    public SdxCustomTestDto sdxCustom(SdxCustomTestDto sdxCustom) {
+        return sdxCustom;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxCustomTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxCustomTestDto.java
@@ -1,0 +1,299 @@
+package com.sequenceiq.it.cloudbreak.dto.sdx;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunningParameter;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.DELETED;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.audits.responses.AuditEventV4Responses;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.MicroserviceClient;
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.ResourcePropertyProvider;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CommonCloudProperties;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
+import com.sequenceiq.it.cloudbreak.context.Clue;
+import com.sequenceiq.it.cloudbreak.context.Investigable;
+import com.sequenceiq.it.cloudbreak.context.Purgable;
+import com.sequenceiq.it.cloudbreak.context.RunningParameter;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
+import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.dto.ImageSettingsTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
+import com.sequenceiq.it.cloudbreak.search.Searchable;
+import com.sequenceiq.it.cloudbreak.util.AuditUtil;
+import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
+import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
+import com.sequenceiq.sdx.api.model.SdxCloudStorageRequest;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+import com.sequenceiq.sdx.api.model.SdxClusterResponse;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxCustomClusterRequest;
+import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
+import com.sequenceiq.sdx.api.model.SdxRepairRequest;
+
+@Prototype
+public class SdxCustomTestDto extends AbstractSdxTestDto<SdxCustomClusterRequest, SdxClusterDetailResponse, SdxCustomTestDto>
+        implements Purgable<SdxClusterResponse, SdxClient>, Investigable, Searchable {
+
+    private static final String SDX_RESOURCE_NAME = "sdxName";
+
+    private static final String DEFAULT_SDX_NAME = "test-sdx" + '-' + UUID.randomUUID().toString().replaceAll("-", "");
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private CommonCloudProperties commonCloudProperties;
+
+    @Inject
+    private CommonClusterManagerProperties commonClusterManagerProperties;
+
+    @Inject
+    private ResourcePropertyProvider resourcePropertyProvider;
+
+    public SdxCustomTestDto(TestContext testContext) {
+        super(new SdxCustomClusterRequest(), testContext);
+    }
+
+    @Override
+    public SdxCustomTestDto valid() {
+        ImageSettingsTestDto imageSettingsTestDto = getCloudProvider().imageSettings(getTestContext().init(ImageSettingsTestDto.class));
+        ImageSettingsV4Request imageSettingsV4Request = imageSettingsTestDto.getRequest();
+        ImageCatalogTestDto imageCatalogTestDto = getTestContext().get(ImageCatalogTestDto.class);
+
+        withName(getResourcePropertyProvider().getName(getCloudPlatform()))
+                .withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getResponse().getName())
+                .withClusterShape(getCloudProvider().getClusterShape())
+                .withTags(getCloudProvider().getTags())
+                .withImageCatalogNameAndImageId(imageCatalogTestDto.getName(), imageSettingsV4Request.getId());
+        return getCloudProvider().sdxCustom(this);
+    }
+
+    @Override
+    public String getName() {
+        return super.getName() == null ? DEFAULT_SDX_NAME : super.getName();
+    }
+
+    @Override
+    public String getCrn() {
+        if (getResponse() == null) {
+            throw new IllegalStateException("You have tried to assign to SdxCustomTestDto," +
+                    " that hasn't been created and therefore has no Response object yet.");
+        }
+        return getResponse().getCrn();
+    }
+
+    public SdxCustomTestDto withDatabase(SdxDatabaseRequest sdxDatabaseRequest) {
+        getRequest().setExternalDatabase(sdxDatabaseRequest);
+        return this;
+    }
+
+    public SdxCustomTestDto withCloudStorage(SdxCloudStorageRequest cloudStorage) {
+        getRequest().setCloudStorage(cloudStorage);
+        return this;
+    }
+
+    public SdxCustomTestDto addTags(Map<String, String> tags) {
+        getRequest().addTags(tags);
+        return this;
+    }
+
+    public SdxCustomTestDto withTags(Map<String, String> tags) {
+        getRequest().addTags(tags);
+        return this;
+    }
+
+    public SdxCustomTestDto withClusterShape(SdxClusterShape shape) {
+        getRequest().setClusterShape(shape);
+        return this;
+    }
+
+    public SdxCustomTestDto withEnvironment() {
+        EnvironmentTestDto environment = getTestContext().given(EnvironmentTestDto.class);
+        if (environment == null) {
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this internal Sdx: '%s' response!", getName()));
+        }
+        return withEnvironmentName(environment.getResponse().getName());
+    }
+
+    private SdxCustomTestDto withEnvironmentDto(EnvironmentTestDto environmentTestDto) {
+        return withEnvironmentName(environmentTestDto.getResponse().getName());
+    }
+
+    public SdxCustomTestDto withEnvironmentClass(Class<EnvironmentTestDto> environmentClass) {
+        EnvironmentTestDto environment = getTestContext().get(environmentClass.getSimpleName());
+        if (environment == null) {
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this Sdx: '%s' response!", getName()));
+        }
+        return withEnvironmentName(environment.getResponse().getName());
+    }
+
+    public SdxCustomTestDto withEnvironmentKey(RunningParameter key) {
+        EnvironmentTestDto environment = getTestContext().get(key.getKey());
+        if (environment == null) {
+            throw new IllegalArgumentException(String.format("Environment has not been provided for this internal Sdx: '%s' response!", getName()));
+        }
+        return withEnvironmentName(environment.getResponse().getName());
+    }
+
+    public SdxCustomTestDto withEnvironmentName(String environmentName) {
+        getRequest().setEnvironment(environmentName);
+        return this;
+    }
+
+    public SdxCustomTestDto withName(String name) {
+        setName(name);
+        return this;
+    }
+
+    @Override
+    public String getResourceNameType() {
+        return SDX_RESOURCE_NAME;
+    }
+
+    public SdxCustomTestDto withImageCatalogNameAndImageId(String imageCatalogName, String imageId) {
+        ImageSettingsV4Request image = new ImageSettingsV4Request();
+        image.setCatalog(imageCatalogName);
+        image.setId(imageId);
+        getRequest().setImageSettingsV4Request(image);
+        return this;
+    }
+
+    public SdxCustomTestDto await(SdxClusterStatusResponse status) {
+        return await(status, emptyRunningParameter());
+    }
+
+    public SdxCustomTestDto await(SdxClusterStatusResponse status, RunningParameter runningParameter) {
+        return getTestContext().await(this, Map.of("status", status), runningParameter);
+    }
+
+    public SdxCustomTestDto awaitForFlow() {
+        return awaitForFlow(emptyRunningParameter());
+    }
+
+    @Override
+    public SdxCustomTestDto awaitForFlow(RunningParameter runningParameter) {
+        return getTestContext().awaitForFlow(this, runningParameter);
+    }
+
+    public SdxCustomTestDto awaitForInstance(Map<String, InstanceStatus> statuses) {
+        return awaitForInstance(statuses, emptyRunningParameter());
+    }
+
+    public SdxCustomTestDto awaitForInstance(SdxCustomTestDto entity, Map<String, InstanceStatus> statuses, RunningParameter runningParameter) {
+        return getTestContext().await(entity, statuses, runningParameter);
+    }
+
+    public SdxCustomTestDto awaitForInstance(Map<String, InstanceStatus> statuses, RunningParameter runningParameter) {
+        return getTestContext().awaitForInstance(this, statuses, runningParameter);
+    }
+
+    public SdxCustomTestDto awaitForInstance(Map<String, InstanceStatus> statuses, RunningParameter runningParameter, Duration pollingInterval) {
+        return getTestContext().awaitForInstance(this, statuses, runningParameter, pollingInterval);
+    }
+
+    public SdxCustomTestDto awaitForInstance(Map<String, InstanceStatus> statuses, Duration pollingInterval) {
+        return awaitForInstance(statuses, emptyRunningParameter(), pollingInterval);
+    }
+
+    @Override
+    public CloudbreakTestDto refresh() {
+        LOGGER.info("Refresh SDX with name: {}", getName());
+        return when(sdxTestClient.refreshCustom(), key("refresh-sdx-" + getName()));
+    }
+
+    @Override
+    public void cleanUp(TestContext context, MicroserviceClient client) {
+        LOGGER.info("Cleaning up sdx internal with name: {}", getName());
+        if (getResponse() != null) {
+            when(sdxTestClient.forceDeleteCustom(), key("delete-sdx-" + getName()));
+            await(DELETED, new RunningParameter().withSkipOnFail(true));
+        } else {
+            LOGGER.info("Sdx internal: {} response is null!", getName());
+        }
+    }
+
+    @Override
+    public List<SdxClusterResponse> getAll(SdxClient client) {
+        SdxEndpoint sdxEndpoint = client.getDefaultClient().sdxEndpoint();
+        return sdxEndpoint.list(null).stream()
+                .filter(s -> s.getName() != null)
+                .map(s -> {
+                    SdxClusterResponse sdxClusterResponse = new SdxClusterResponse();
+                    sdxClusterResponse.setName(s.getName());
+                    return sdxClusterResponse;
+                }).collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean deletable(SdxClusterResponse entity) {
+        return getName().startsWith(getResourcePropertyProvider().prefix(getCloudPlatform()));
+    }
+
+    @Override
+    public void delete(TestContext testContext, SdxClusterResponse entity, SdxClient client) {
+        String sdxName = entity.getName();
+        try {
+            client.getDefaultClient().sdxEndpoint().delete(getName(), false);
+            testContext.await(this, Map.of("status", DELETED), key("wait-purge-sdx-" + getName()));
+        } catch (Exception e) {
+            LOGGER.warn("Something went wrong on {} purge. {}", sdxName, ResponseUtil.getErrorMessage(e), e);
+        }
+    }
+
+    @Override
+    public Class<SdxClient> client() {
+        return SdxClient.class;
+    }
+
+    public SdxRepairRequest getSdxRepairRequest() {
+        SdxRepairTestDto repair = getCloudProvider().sdxRepair(given(SdxRepairTestDto.class));
+        if (repair == null) {
+            throw new IllegalArgumentException("SDX Repair does not exist!");
+        }
+        return repair.getRequest();
+    }
+
+    @Override
+    public Clue investigate() {
+        if (getResponse() == null || getResponse().getCrn() == null) {
+            return null;
+        }
+
+        AuditEventV4Responses auditEvents = AuditUtil.getAuditEvents(
+                getTestContext().getMicroserviceClient(CloudbreakClient.class),
+                CloudbreakEventService.DATAHUB_RESOURCE_TYPE,
+                null,
+                getResponse().getCrn());
+        boolean hasSpotTermination = (getResponse().getStackV4Response() == null) ? false : getResponse().getStackV4Response().getInstanceGroups().stream()
+                .flatMap(ig -> ig.getMetadata().stream())
+                .anyMatch(metadata -> InstanceStatus.DELETED_BY_PROVIDER == metadata.getInstanceStatus());
+        return new Clue("SDX", auditEvents, getResponse(), hasSpotTermination);
+    }
+
+    protected CommonClusterManagerProperties commonClusterManagerProperties() {
+        return commonClusterManagerProperties;
+    }
+
+    @Override
+    public String getSearchId() {
+        return getName();
+    }
+}
+

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -28,7 +28,7 @@ auth:
     upgrade.internalrepo.enable: true
     hbase.cloudstorage.enable: true
     datalake.efs.enable: false
-    datalake.customimage.enable: false
+    datalake.customimage.enable: true
     differentdatahubversionthandatalake.enabled: true
     database.wire.encryption.enable: true
     datahub.runtime.upgrade.enable: true


### PR DESCRIPTION
…sed hotfix

-The approach is to add a new input in cdp cli. So customers can specify the image catalog and uuid when creating the data lake
-add a new field in the SdxClusterRequest that contains the image info
-the image info is set to StackV4Request

See detailed description in the commit message.