### PR TITLE
CDPD-19363:set tez.runtime.pipelined.sorter.lazy-allocate.memory to true by default in DH

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
@@ -365,7 +365,13 @@
           {
             "refName": "tez-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-spark3.bp
@@ -236,7 +236,13 @@
           {
             "refName": "tez-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering.bp
@@ -226,7 +226,13 @@
           {
             "refName": "tez-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
@@ -365,7 +365,13 @@
           {
             "refName": "tez-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-spark3.bp
@@ -236,7 +236,13 @@
           {
             "refName": "tez-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering.bp
@@ -226,7 +226,13 @@
           {
             "refName": "tez-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
tez.runtime.pipelined.sorter.lazy-allocate.memory is set to true by default and the screenshot from tez-site.xml is :
<img width="579" alt="Screenshot 2021-02-23 at 10 13 31 PM" src="https://user-images.githubusercontent.com/7271603/109030901-3b0c0380-76ea-11eb-9d73-c3c614548c64.png">
 
and the CM UI having the value in tez gateway configs:

![image](https://user-images.githubusercontent.com/7271603/109031075-62fb6700-76ea-11eb-9d60-b4217251de30.png)
