### PR TITLE
Cherry pick from master: CB-11328 Agen token copy fails when a minion is unavailable

### DIFF
--- a/core/src/main/resources/defaults/vm-logs.json
+++ b/core/src/main/resources/defaults/vm-logs.json
@@ -293,5 +293,9 @@
     "path": "/var/run/cloudera-scm-agent/process/*/logs/stdout.log",
     "label": "CM_COMMAND.OUT",
     "type": "cm_command"
+  },
+  {
+    "path": "/var/log/cm_generate_agent_tokens.log",
+    "label": "generate_agent_token"
   }
 ]

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/generate_agent_tokens.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/generate_agent_tokens.sh.j2
@@ -2,6 +2,8 @@
 
 set -ex
 
+date '+%Y-%m-%d %H:%M:%S'
+
 CERTMANAGER_DIR="/etc/cloudera-scm-server/certs"
 declare -A AGENT_FQDN_TOKENDIR_MAP=( {%- for ip, args in pillar.get('hosts', {}).items() %}["{{ args['fqdn'] }}"]="{{ args['fqdn'] }}-{{ args['instance_id'] }}" {% endfor %})
 TOKEN_DIR="/srv/salt/agent-tls-tokens"
@@ -25,12 +27,15 @@ for fqdn in "${!AGENT_FQDN_TOKENDIR_MAP[@]}"
 do
   tokendir=$TOKEN_DIR/${AGENT_FQDN_TOKENDIR_MAP[${fqdn}]}
   if [[ ! -e ${tokendir}/agent_token_copied_to_client ]]; then
+    set +e
     # This can be fairly slow, for large clusters
     COPY_RESULT=$(salt ${fqdn} cp.get_file salt://agent-tls-tokens/${AGENT_FQDN_TOKENDIR_MAP[${fqdn}]}/cmagent.token /etc/cloudera-scm-agent/cmagent.token)
-    if [[ "$COPY_RESULT" != *"False"* ]]; then
+    SALT_CP_RET=$?
+    set -e
+    if [[ "$COPY_RESULT" != *"False"* ]] && [[ "$SALT_CP_RET" -eq 0 ]] ; then
       echo $(date +%Y-%m-%d:%H:%M:%S) >> ${tokendir}/agent_token_copied_to_client
     else
-      echo "Could not copy the token to agent: $fqdn"
+      echo "Could not copy the token to agent: $fqdn Salt copy returned with: $SALT_CP_RET Copy result is: $COPY_RESULT"
     fi
   else
     echo "CM agent token copy to ${fqdn} will be skipped as it was already copied to the agent instance."


### PR DESCRIPTION
With this commit if the copy fails we would only log it.
This is necessary because during downscale highstate is invoked thus agent token generation and copy is invoked.
If one of the instances is down, which doesn't have the token, the downscale would fail.
With this change it won't block downscale anymore.
During upscale it shouldn't cause any issues, as agents without token won't start and it means the failure would still happen in the orchestration state a bit later.

The change includes turning off `set -e` during salt copy and evaluate the return code later. In some cases the `false` text is not included in the return value so we have to check the return code too.

Another change is adding the token generation log to the diagnostic bundle as if the output is too big, it won't be in the salt minion log.

