### PR TITLE
CB-11322 Set freeipa instanceprofile using backup when telemetry is null

### DIFF
--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverterTest.java
@@ -5,8 +5,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudFileSystemView;
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.model.Logging;
+import com.sequenceiq.common.api.telemetry.model.Telemetry;
+import com.sequenceiq.freeipa.api.model.Backup;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -25,6 +34,9 @@ import com.sequenceiq.freeipa.service.SecurityRuleService;
 import com.sequenceiq.freeipa.service.client.CachedEnvironmentClientService;
 import com.sequenceiq.freeipa.service.image.ImageService;
 
+import javax.ws.rs.BadRequestException;
+import java.util.Optional;
+
 public class StackToCloudStackConverterTest {
 
     private static final Long TEST_STACK_ID = 1L;
@@ -38,6 +50,9 @@ public class StackToCloudStackConverterTest {
     private static final String IMAGE_NAME = "image-name";
 
     private static final String ENV_CRN = "env-crn";
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
 
     @InjectMocks
     private StackToCloudStackConverter underTest;
@@ -83,5 +98,119 @@ public class StackToCloudStackConverterTest {
         when(template.getVolumeCount()).thenReturn(VOLUME_COUNT);
         CloudInstance cloudInstance = underTest.buildInstance(stack, instanceMetaData, instanceGroup, stackAuthentication, 0L, InstanceStatus.CREATED);
         assertEquals(INSTANCE_ID, cloudInstance.getInstanceId());
+    }
+
+    @Test
+    public void testBuildFileSystemViewDifferentAWSInstanceProfile() throws Exception {
+        Telemetry telemetry = mock(Telemetry.class);
+        Backup backup = mock(Backup.class);
+        Logging logging = mock(Logging.class);
+        S3CloudStorageV1Parameters s3Logging = new S3CloudStorageV1Parameters();
+        s3Logging.setInstanceProfile("arn:aws:iam::id:instance-profile/role1");
+        S3CloudStorageV1Parameters s3Backup = new S3CloudStorageV1Parameters();
+        s3Backup.setInstanceProfile("arn:aws:iam::id:instance-profile/role2");
+        when(stack.getTelemetry()).thenReturn(telemetry);
+        when(telemetry.getLogging()).thenReturn(logging);
+        when(stack.getBackup()).thenReturn(backup);
+        when(backup.getS3()).thenReturn(s3Backup);
+        when(logging.getS3()).thenReturn(s3Logging);
+
+        expectedException.expect(BadRequestException.class);
+        underTest.buildFileSystemView(stack);
+    }
+
+    @Test
+    public void testBuildFileSystemViewDifferentAzureManagedIdentity() throws Exception {
+        Telemetry telemetry = mock(Telemetry.class);
+        Backup backup = mock(Backup.class);
+        Logging logging = mock(Logging.class);
+        AdlsGen2CloudStorageV1Parameters adlsGen2Logging = new AdlsGen2CloudStorageV1Parameters();
+        adlsGen2Logging.setManagedIdentity("/subscriptions/id/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1");
+        AdlsGen2CloudStorageV1Parameters adlsGen2Backup = new AdlsGen2CloudStorageV1Parameters();
+        adlsGen2Backup.setManagedIdentity("/subscriptions/id/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity2");
+        when(stack.getTelemetry()).thenReturn(telemetry);
+        when(telemetry.getLogging()).thenReturn(logging);
+        when(stack.getBackup()).thenReturn(backup);
+        when(backup.getAdlsGen2()).thenReturn(adlsGen2Logging);
+        when(logging.getAdlsGen2()).thenReturn(adlsGen2Backup);
+
+        expectedException.expect(BadRequestException.class);
+        underTest.buildFileSystemView(stack);
+    }
+
+    @Test
+    public void testBuildFileSystemViewDifferentGCPEmail() throws Exception {
+        Telemetry telemetry = mock(Telemetry.class);
+        Backup backup = mock(Backup.class);
+        Logging logging = mock(Logging.class);
+        GcsCloudStorageV1Parameters gcsLogging = new GcsCloudStorageV1Parameters();
+        gcsLogging.setServiceAccountEmail("myaccount1@myprojectid.iam.gserviceaccount.com");
+        GcsCloudStorageV1Parameters gcsBackup = new GcsCloudStorageV1Parameters();
+        gcsBackup.setServiceAccountEmail("myaccount2@myprojectid.iam.gserviceaccount.com");
+        when(stack.getTelemetry()).thenReturn(telemetry);
+        when(telemetry.getLogging()).thenReturn(logging);
+        when(stack.getBackup()).thenReturn(backup);
+        when(backup.getGcs()).thenReturn(gcsBackup);
+        when(logging.getGcs()).thenReturn(gcsLogging);
+
+        expectedException.expect(BadRequestException.class);
+        underTest.buildFileSystemView(stack);
+    }
+
+    @Test
+    public void testBuildFileSystemViewSameAWSInstanceProfile() throws Exception {
+        Telemetry telemetry = mock(Telemetry.class);
+        Backup backup = mock(Backup.class);
+        Logging logging = mock(Logging.class);
+        S3CloudStorageV1Parameters s3Logging = new S3CloudStorageV1Parameters();
+        s3Logging.setInstanceProfile("arn:aws:iam::id:instance-profile/role");
+        S3CloudStorageV1Parameters s3Backup = new S3CloudStorageV1Parameters();
+        s3Backup.setInstanceProfile("arn:aws:iam::id:instance-profile/role");
+        when(stack.getTelemetry()).thenReturn(telemetry);
+        when(telemetry.getLogging()).thenReturn(logging);
+        when(stack.getBackup()).thenReturn(backup);
+        when(backup.getS3()).thenReturn(s3Backup);
+        when(logging.getS3()).thenReturn(s3Logging);
+
+        Optional<CloudFileSystemView> fileSystemView = underTest.buildFileSystemView(stack);
+        assertEquals(Optional.empty(), fileSystemView);
+    }
+
+    @Test
+    public void testBuildFileSystemViewSameAzureManagedIdentity() throws Exception {
+        Telemetry telemetry = mock(Telemetry.class);
+        Backup backup = mock(Backup.class);
+        Logging logging = mock(Logging.class);
+        AdlsGen2CloudStorageV1Parameters adlsGen2Logging = new AdlsGen2CloudStorageV1Parameters();
+        adlsGen2Logging.setManagedIdentity("/subscriptions/id/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity");
+        AdlsGen2CloudStorageV1Parameters adlsGen2Backup = new AdlsGen2CloudStorageV1Parameters();
+        adlsGen2Backup.setManagedIdentity("/subscriptions/id/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity");
+        when(stack.getTelemetry()).thenReturn(telemetry);
+        when(telemetry.getLogging()).thenReturn(logging);
+        when(stack.getBackup()).thenReturn(backup);
+        when(backup.getAdlsGen2()).thenReturn(adlsGen2Logging);
+        when(logging.getAdlsGen2()).thenReturn(adlsGen2Backup);
+
+        Optional<CloudFileSystemView> fileSystemView = underTest.buildFileSystemView(stack);
+        assertEquals(Optional.empty(), fileSystemView);
+    }
+
+    @Test
+    public void testBuildFileSystemViewSameGCPEmail() throws Exception {
+        Telemetry telemetry = mock(Telemetry.class);
+        Backup backup = mock(Backup.class);
+        Logging logging = mock(Logging.class);
+        GcsCloudStorageV1Parameters gcsLogging = new GcsCloudStorageV1Parameters();
+        gcsLogging.setServiceAccountEmail("myaccount@myprojectid.iam.gserviceaccount.com");
+        GcsCloudStorageV1Parameters gcsBackup = new GcsCloudStorageV1Parameters();
+        gcsBackup.setServiceAccountEmail("myaccount@myprojectid.iam.gserviceaccount.com");
+        when(stack.getTelemetry()).thenReturn(telemetry);
+        when(telemetry.getLogging()).thenReturn(logging);
+        when(stack.getBackup()).thenReturn(backup);
+        when(backup.getGcs()).thenReturn(gcsBackup);
+        when(logging.getGcs()).thenReturn(gcsLogging);
+
+        Optional<CloudFileSystemView> fileSystemView = underTest.buildFileSystemView(stack);
+        assertEquals(Optional.empty(), fileSystemView);
     }
 }


### PR DESCRIPTION
The original design was always taking instanceprofile from telemetry for freeipa so that user don't mistakenly set it in backup, because there is only one instanceprofile. Now We want to use the instanceprofile from backup if telemetry is null to include below test case.

See detailed description in the commit message.