### PR TITLE
CB-11361: Add missing dependency on okhttp-urlconnection

### DIFF
--- a/cloud-azure/build.gradle
+++ b/cloud-azure/build.gradle
@@ -19,6 +19,7 @@ dependencies {
   compile project(':cloud-template')
 
   compile (group: 'com.squareup.okhttp3',               name: 'okhttp',                     version: okhttpVersion)
+  compile (group: 'com.squareup.okhttp3',               name: 'okhttp-urlconnection',       version: okhttpVersion)
 
   compile (group: 'com.microsoft.azure',         name: 'azure-client-authentication') {
     exclude group: 'org.slf4j'


### PR DESCRIPTION
Add missing dependency on okhttp-urlconnection which fixes an
intermittent issue.

See detailed description in the commit message.

https://github.com/hortonworks/cloudbreak/blob/22ee0f6c7b3c77f488ee845c3f488eb8af3bef41/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientCredentials.java#L21 okhttp3.JavaNetAuthenticator depends on okhttp-urlconnection 