### PR TITLE
CB-11362 reverting back azure regex for tag name validation and addin…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/conf/AzureConfig.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/conf/AzureConfig.java
@@ -18,7 +18,7 @@ public class AzureConfig {
     @Value("${cb.azure.tag.key.max.length:512}")
     private Integer maxKeyLength;
 
-    @Value("${cb.azure.tag.key.validator:^(?!microsoft|azure|windows|\\s)[^,$/<>&%?\\\\b\\\\.]*$}")
+    @Value("${cb.azure.tag.key.validator:^(?!microsoft|azure|windows|\\s)[^,]*$}")
     private String keyValidator;
 
     @Value("${cb.azure.tag.value.min.length:1}")

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/TagValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/TagValidatorTest.java
@@ -50,7 +50,12 @@ class TagValidatorTest {
                 DynamicTest.dynamicTest("tag key is invalid, regular expression is printed",
                         () -> testNegative(BAD_KEY, GOOD_VALUE, "regular expression")),
                 DynamicTest.dynamicTest("tag value is valid ",
-                        () -> testPositive(GOOD_KEY, GOOD_VALUE)));
+                        () -> testPositive(GOOD_KEY, GOOD_VALUE)),
+                DynamicTest.dynamicTest("tag value is valid ",
+                        () -> testPositive("cod_database_name", "appletree")),
+                DynamicTest.dynamicTest("tag value is valid ",
+                        () -> testPositive("cod_database_crn", "appletree"))
+        );
     }
 
     public void testNegative(String tag, String value, String messagePortion) {


### PR DESCRIPTION
…g the COD use case as unit test just to make sure we not break again.

See detailed description in the commit message.