### PR TITLE
CB-11380 Add more meaningful message in case saltbootstrap is not rea…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/HostBootstrapApiCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/HostBootstrapApiCheckerTask.java
@@ -16,7 +16,11 @@ public class HostBootstrapApiCheckerTask extends StackBasedStatusCheckerTask<Hos
 
     @Override
     public void handleTimeout(HostBootstrapApiContext t) {
-        throw new CloudbreakServiceException("Operation timed out. Could not reach bootstrap API in time.");
+        throw new CloudbreakServiceException("Operation timed out. Could not reach bootstrap API in time. "
+                + "The Control Plane was not able to establish the connection with the gateway instance. "
+                + "This could be caused by the reverse SSH tunnel (autossh process) running on this instance could not connect to the Cloudera server. "
+                + "Please check your connection and proxy settings and make sure the instance can reach *.ccm.cdp.cloudera.com "
+                + "Please check your instance on the cloud provider side if it's up and running. Restart it if it couldn't start up properly.");
     }
 
     @Override


### PR DESCRIPTION
…chable

If the instance don't start properly or CCM can't connect we will show a more helpful message.

See detailed description in the commit message.