### PR TITLE
CB-11340 Make sure that we have a proper error message even when CM c…

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/SimpleStatusCheckerTask.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/SimpleStatusCheckerTask.java
@@ -6,7 +6,7 @@ public abstract class SimpleStatusCheckerTask<T> implements StatusCheckerTask<T>
 
     @Override
     public void handleException(Exception e) {
-        throw new CloudbreakServiceException(e);
+        throw new CloudbreakServiceException(e.getMessage(), e);
     }
 
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
@@ -52,6 +52,8 @@ import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiClientProvider;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerClientInitException;
 import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+import com.sequenceiq.cloudbreak.cm.error.mapper.ClouderaManagerStorageErrorMapper;
+import com.sequenceiq.cloudbreak.cm.exception.CloudStorageConfigurationFailedException;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil;
 import com.sequenceiq.cloudbreak.cmtemplate.CentralCmTemplateUpdater;
@@ -116,6 +118,9 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
 
     @Inject
     private ClusterCommandRepository clusterCommandRepository;
+
+    @Inject
+    private ClouderaManagerStorageErrorMapper clouderaManagerStorageErrorMapper;
 
     private final Stack stack;
 
@@ -249,6 +254,9 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
             LOGGER.info("Error while building the cluster. Message: {}; Response: {}", e.getMessage(), e.getResponseBody(), e);
             String msg = extractMessage(e);
             throw new ClouderaManagerOperationFailedException(msg, e);
+        } catch (CloudStorageConfigurationFailedException e) {
+            LOGGER.info("Error while configuring cloud storage. Message: {}", e.getMessage(), e);
+            throw new ClouderaManagerOperationFailedException(clouderaManagerStorageErrorMapper.map(e, stack.cloudPlatform(), cluster), e);
         } catch (Exception e) {
             LOGGER.info("Error while building the cluster. Message: {}", e.getMessage(), e);
             throw new ClouderaManagerOperationFailedException(e.getMessage(), e);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
@@ -340,7 +340,7 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
                 importCommand = Optional.of(clusterCommandRepository.save(clusterCommand));
                 LOGGER.debug("Cloudera cluster template has been submitted, cluster install is in progress");
             } catch (ApiException e) {
-                String msg = "Cluster template install failed: " + extractMessage(e);
+                String msg = "Installation of CDP with Cloudera Manager has failed: " + extractMessage(e);
                 throw new ClouderaManagerOperationFailedException(msg, e);
             }
         }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/error/mapper/ClouderaManagerStorageErrorMapper.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/error/mapper/ClouderaManagerStorageErrorMapper.java
@@ -1,0 +1,126 @@
+package com.sequenceiq.cloudbreak.cm.error.mapper;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cm.exception.CloudStorageConfigurationFailedException;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.cloudbreak.common.type.CloudConstants;
+import com.sequenceiq.cloudbreak.domain.FileSystem;
+import com.sequenceiq.cloudbreak.domain.cloudstorage.AccountMapping;
+import com.sequenceiq.cloudbreak.domain.cloudstorage.CloudIdentity;
+import com.sequenceiq.cloudbreak.domain.cloudstorage.CloudStorage;
+import com.sequenceiq.cloudbreak.domain.cloudstorage.StorageLocation;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.common.model.CloudIdentityType;
+import com.sequenceiq.common.model.CloudStorageCdpService;
+
+@Component
+public class ClouderaManagerStorageErrorMapper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerStorageErrorMapper.class);
+
+    public String map(CloudStorageConfigurationFailedException e, String cloudPlatform, Cluster cluster) {
+        String errorMessage;
+
+        if (cluster.isRangerRazEnabled()) {
+            errorMessage = e.getMessage() + "Ranger RAZ is enabled on this cluster.";
+        } else {
+            try {
+                CloudStorage cloudStorage = cluster.getFileSystem().getCloudStorage();
+                switch (cloudPlatform) {
+                    case CloudConstants.AWS:
+                        errorMessage = awsError(cloudStorage);
+                        break;
+                    case CloudConstants.AZURE:
+                        errorMessage = azureError(cloudStorage);
+                        break;
+                    default:
+                        errorMessage = e.getMessage();
+                }
+            } catch (RuntimeException runtimeException) {
+                CloudStorage cloudStorage = Optional.ofNullable(cluster).map(Cluster::getFileSystem)
+                        .map(FileSystem::getCloudStorage).orElse(null);
+                LOGGER.error("No surprise that cluster creation has failed, probably something was not validated properly " +
+                                "in cloud storage config. This is most probably a control plane bug: {}",
+                        JsonUtil.writeValueAsStringSilent(cloudStorage), e);
+                errorMessage = e.getMessage();
+            }
+        }
+
+        LOGGER.debug("Mapped error message: {} original: {}", errorMessage, e.getMessage());
+        return errorMessage;
+    }
+
+    private String awsError(CloudStorage cloudStorage) {
+
+        String instanceProfile = "";
+
+        for (CloudIdentity cloudIdentity : cloudStorage.getCloudIdentities()) {
+            if (CloudIdentityType.ID_BROKER == cloudIdentity.getIdentityType()) {
+                instanceProfile = cloudIdentity.getS3Identity().getInstanceProfile();
+                break;
+            }
+        }
+
+        String auditLocation = getRangerAuditDir(cloudStorage);
+        AccountMapping accountMapping = cloudStorage.getAccountMapping();
+        String dataAccessRole = accountMapping.getUserMappings().get("hive");
+        // There is no ranger in the IDBroker mapping, so we can use solr
+        String rangerAuditRole = accountMapping.getUserMappings().get("solr");
+
+        return String.format("Services running on the cluster were unable to write to %s location. " +
+                        "This problem usually occurs due to cloud storage permission misconfiguration. " +
+                        "Services on the cluster are using Data Access Role (%s) and Ranger Audit Role (%s) to write to the Ranger Audit location (%s), " +
+                        "therefore please verify that these roles have write access to this location. " +
+                        "During Data Lake cluster creation, CDP Control Plane attaches Data Access Instance Profile (%s) to the IDBroker VM. " +
+                        "IDBroker will then use it to assume the Data Access Role and Ranger Audit Role, therefore Data Access Instance Profile (%s) " +
+                        "permissions must, at a minimum, allow to assume Data Access Role and Ranger Audit Role." +
+                        "Refer to Cloudera documentation at %s for the required rights.",
+                auditLocation, dataAccessRole, rangerAuditRole, auditLocation, instanceProfile, instanceProfile,
+                "https://docs.cloudera.com/management-console/cloud/environments/topics/mc-idbroker-minimum-setup.html");
+    }
+
+    private String azureError(CloudStorage cloudStorage) {
+
+        String managedIdentity = "";
+
+        for (CloudIdentity cloudIdentity : cloudStorage.getCloudIdentities()) {
+            if (CloudIdentityType.ID_BROKER == cloudIdentity.getIdentityType()) {
+                managedIdentity = cloudIdentity.getAdlsGen2Identity().getManagedIdentity();
+                break;
+            }
+        }
+
+        String auditLocation = getRangerAuditDir(cloudStorage);
+        AccountMapping accountMapping = cloudStorage.getAccountMapping();
+        String dataAccessRole = accountMapping.getUserMappings().get("hive");
+        // There is no ranger in the IDBroker mapping, so we can use solr
+        String rangerAuditRole = accountMapping.getUserMappings().get("solr");
+
+        return String.format("Services running on the cluster were unable to write to %s location. " +
+                        "This problem usually occurs due to cloud storage permission misconfiguration. " +
+                        "Services on the cluster are using Data Access Identity (%s) and Ranger Audit Identity (%s) to write to the " +
+                        "Ranger Audit location (%s), therefore please verify that these roles have write access to this location. " +
+                        "During Data Lake cluster creation, CDP Control Plane attaches Data Access Assumer Identity (%s) to the IDBroker VM. " +
+                        "IDBroker will then use it to attach the other managed identities to the IDBroker VM, therefore Data Access Identity (%s) " +
+                        "permissions must, at a minimum, allow to attach the Data Access Identity and Ranger Access Identity. " +
+                        "Refer to Cloudera documentation at %s for the required rights.",
+                auditLocation, dataAccessRole, rangerAuditRole, auditLocation, managedIdentity, managedIdentity,
+                "https://docs.cloudera.com/management-console/cloud/environments-azure/topics/mc-az-minimal-setup-for-cloud-storage.html");
+    }
+
+    private String getRangerAuditDir(CloudStorage cloudStorage) {
+        if (cloudStorage.getLocations() != null) {
+            for (StorageLocation location : cloudStorage.getLocations()) {
+                if (CloudStorageCdpService.RANGER_AUDIT == location.getType()) {
+                    return location.getValue();
+                }
+            }
+        }
+        return "";
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/exception/CloudStorageConfigurationFailedException.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/exception/CloudStorageConfigurationFailedException.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.cm.exception;
+
+import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
+
+public class CloudStorageConfigurationFailedException extends ClouderaManagerOperationFailedException {
+
+    public CloudStorageConfigurationFailedException(String message) {
+        super(message);
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerTemplateInstallationChecker.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerTemplateInstallationChecker.java
@@ -1,23 +1,17 @@
 package com.sequenceiq.cloudbreak.cm.polling.task;
 
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.cloudera.api.swagger.CommandsResourceApi;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiCommand;
-import com.cloudera.api.swagger.model.ApiCommandList;
 import com.sequenceiq.cloudbreak.cm.ClouderaManagerOperationFailedException;
 import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
+import com.sequenceiq.cloudbreak.cm.util.ClouderaManagerCommandApiErrorParserUtil;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
 
 public class ClouderaManagerTemplateInstallationChecker extends AbstractClouderaManagerCommandCheckerTask<ClouderaManagerCommandPollerObject> {
@@ -39,48 +33,22 @@ public class ClouderaManagerTemplateInstallationChecker extends AbstractCloudera
         } else if (apiCommand.getSuccess()) {
             return true;
         } else {
-            List<String> errorReasons = new ArrayList<>();
-            digForFailureCause(apiCommand, errorReasons, commandsResourceApi);
-            String msg = "Cluster template install failed: " + errorReasons;
-            LOGGER.info(msg);
-            throw new ClouderaManagerOperationFailedException(msg);
+            throw new ClouderaManagerOperationFailedException(failedMessage("", apiCommand, commandsResourceApi));
         }
-    }
-
-    private Predicate<ApiCommand> commandFailed() {
-        return cmd -> !cmd.getSuccess();
-    }
-
-    private Function<ApiCommand, ApiCommand> readCommand(CommandsResourceApi commandsResourceApi) {
-        return cmd -> {
-            try {
-                return commandsResourceApi.readCommand(cmd.getId());
-            } catch (ApiException e) {
-                LOGGER.debug("Failed to read command. id [{}]", cmd.getId(), e);
-                return new ApiCommand();
-            }
-        };
-    }
-
-    private void digForFailureCause(ApiCommand apiCommand, List<String> errorReasons, CommandsResourceApi commandsResourceApi) {
-        List<String> childErrors = new LinkedList<>();
-        Optional.ofNullable(apiCommand.getChildren()).map(ApiCommandList::getItems).orElse(List.of()).stream()
-                .filter(commandFailed())
-                .map(readCommand(commandsResourceApi))
-                .forEach(cmd -> digForFailureCause(cmd, childErrors, commandsResourceApi));
-
-        if (childErrors.isEmpty() && StringUtils.isNotEmpty(apiCommand.getResultMessage())) {
-            String reason = String.format("Command [%s], with id [%.0f] failed: %s", apiCommand.getName(), apiCommand.getId(), apiCommand.getResultMessage());
-            errorReasons.add(reason);
-        }
-
-        errorReasons.addAll(childErrors);
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerCommandPollerObject clouderaManagerCommandPollerObject) {
-        throw new ClouderaManagerOperationFailedException("Operation timed out. Template install timed out with this command id: "
-                + clouderaManagerCommandPollerObject.getId());
+    public void handleTimeout(ClouderaManagerCommandPollerObject pollerObject) {
+        String msg = "Installation of CDP with Cloudera Manager has timed out (command id: " + pollerObject.getId() + ")";
+        try {
+            CommandsResourceApi commandsResourceApi = clouderaManagerApiPojoFactory.getCommandsResourceApi(pollerObject.getApiClient());
+            ApiCommand apiCommand = commandsResourceApi.readCommand(pollerObject.getId());
+            throw new ClouderaManagerOperationFailedException(failedMessage(msg + " ", apiCommand, commandsResourceApi));
+        } catch (ApiException e) {
+            LOGGER.info("Cloudera Manager had run into a timeout and, we were unable to determine the failure reason", e);
+        }
+
+        throw new ClouderaManagerOperationFailedException(msg);
     }
 
     @Override
@@ -91,5 +59,12 @@ public class ClouderaManagerTemplateInstallationChecker extends AbstractCloudera
     @Override
     protected String getCommandName() {
         return "Template install";
+    }
+
+    private String failedMessage(String messagePrefix, ApiCommand apiCommand, CommandsResourceApi commandsResourceApi) {
+        List<String> errorReasons = ClouderaManagerCommandApiErrorParserUtil.getErrors(apiCommand, commandsResourceApi);
+        String msg = messagePrefix + "Installation of CDP with Cloudera Manager has failed: [" + String.join(", ", errorReasons) + "]";
+        LOGGER.info(msg);
+        return msg;
     }
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/util/ClouderaManagerCommandApiErrorParserUtil.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/util/ClouderaManagerCommandApiErrorParserUtil.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.cloudbreak.cm.util;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.cloudera.api.swagger.CommandsResourceApi;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiCommandList;
+
+public class ClouderaManagerCommandApiErrorParserUtil {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerCommandApiErrorParserUtil.class);
+
+    private ClouderaManagerCommandApiErrorParserUtil() {
+
+    }
+
+    private static Predicate<ApiCommand> commandFailed() {
+        return cmd -> {
+            if (cmd != null) {
+                if (cmd.getActive() != null && cmd.getActive()) {
+                    return true;
+                }
+                return cmd.getSuccess() != null && !cmd.getSuccess();
+            }
+            return false;
+        };
+    }
+
+    private static Function<ApiCommand, ApiCommand> readCommand(CommandsResourceApi commandsResourceApi) {
+        return cmd -> {
+            try {
+                return commandsResourceApi.readCommand(cmd.getId());
+            } catch (ApiException e) {
+                LOGGER.debug("Failed to read command. id [{}]", cmd.getId(), e);
+                return new ApiCommand();
+            }
+        };
+    }
+
+    public static List<String> getErrors(ApiCommand apiCommand, CommandsResourceApi commandsResourceApi) {
+        List<String> errors = new LinkedList<>();
+        try {
+            Optional.ofNullable(apiCommand.getChildren()).map(ApiCommandList::getItems).orElse(List.of()).stream()
+                    .filter(commandFailed())
+                    .map(readCommand(commandsResourceApi))
+                    .forEach(cmd -> errors.addAll(getErrors(cmd, commandsResourceApi)));
+
+            if (errors.isEmpty() && StringUtils.isNotEmpty(apiCommand.getResultMessage())) {
+                String reason = String.format("Command [%s], with id [%.0f] failed: %s",
+                        apiCommand.getName(), apiCommand.getId(), apiCommand.getResultMessage());
+                errors.add(reason);
+            }
+        } catch (RuntimeException e) {
+            LOGGER.warn("We have tried to get the error reason an go through the command tree, but it has failed. It is still better to proceed silently", e);
+        }
+
+        return errors;
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -193,7 +193,7 @@ public class StackRequestManifester {
         if (envTelemetry != null && envTelemetry.getLogging() != null) {
             TelemetryRequest telemetryRequest = new TelemetryRequest();
             LoggingRequest loggingRequest = new LoggingRequest();
-            LoggingResponse envLogging =  envTelemetry.getLogging();
+            LoggingResponse envLogging = envTelemetry.getLogging();
             loggingRequest.setS3(envLogging.getS3());
             loggingRequest.setAdlsGen2(envLogging.getAdlsGen2());
             loggingRequest.setGcs(envLogging.getGcs());
@@ -276,11 +276,17 @@ public class StackRequestManifester {
     }
 
     void validateMappingsConfig(MappingsConfig mappingsConfig, StackV4Request stackRequest) {
+        LOGGER.debug("Validating IDBMMS mapping for this cluster: {}", JsonUtil.writeValueAsStringSilent(mappingsConfig));
+        // Just to make it a bit more defensive
+        if (mappingsConfig == null || mappingsConfig.getActorMappings() == null || mappingsConfig.getActorMappings().isEmpty()) {
+            LOGGER.error("We have not found cloud storage access mapping for this cluster! {}", JsonUtil.writeValueAsStringSilent(mappingsConfig));
+            throw new BadRequestException("We have not found cloudstorage access mapping for this cluster!");
+        }
         // Validate RAZ if enabled, making sure that the RAZ mapping exists when it is required.
         if (stackRequest.getCluster().isRangerRazEnabled()) {
             if (!mappingsConfig.getActorMappings().containsKey("rangerraz")) {
-                LOGGER.error("IDBMMS mappings must contain the RAZ role if RAZ is to be created!");
-                throw new BadRequestException("IDBMMS mappings must contain the RAZ role if RAZ is to be created!");
+                LOGGER.error("Cloud storage access (IDBroker) mapping must contain the RAZ role if RAZ is to be created!");
+                throw new BadRequestException("Cloud storage access (IDBroker) mapping must contain the RAZ role if RAZ is to be created!");
             }
         }
     }


### PR DESCRIPTION
…ommand runs to timeout. In many case cloudera manager has non-deterministic behaviour and it just times out instead of returning a proper error message. With this commit, even when we run into a timeout situation we try to determine what went sideways.

Parsing the command api is a best effort and if we are unable to determine the reason through command api then we just return with the original timeout message. This commit also contains a few tweaks that makes the code more defensive, and avoid npe-s, and probably the recursive "dig" error has been rewitten in a slightly more elegenat way.

This is the first part of having proper errors messages for the problem when the customer misconfigures the cloud storage.

See detailed description in the commit message.