### PR TITLE
CB-11171 Increase the default root volume size to 100GB

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/DefaultRootVolumeSizeProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/DefaultRootVolumeSizeProvider.java
@@ -30,7 +30,7 @@ public class DefaultRootVolumeSizeProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRootVolumeSizeProvider.class);
 
-    private static final Integer DEFAULT_ROOT_VOLUME_SIZE = 50;
+    private static final Integer DEFAULT_ROOT_VOLUME_SIZE = 100;
 
     private static final String ROOT_VOLUME_SIZE_PROPERTY_PREFIX = "cb.platform.default.rootVolumeSize.";
 

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -100,9 +100,9 @@ altus:
 cb:
   enabledplatforms: AZURE,AWS,GCP,OPENSTACK
   platform.default.rootVolumeSize:
-    AWS: 50
-    AZURE: 50
-    GCP: 50
+    AWS: 100
+    AZURE: 100
+    GCP: 100
   enabled.linux.types: redhat6,redhat7,centos6,centos7
   default.gateway.cidr: 0.0.0.0/0
   publicip:

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/dataengineering-ha.json
@@ -19,9 +19,6 @@
       "template": {
         "aws": {},
         "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [{
           "size": 100,
           "count": 1,
@@ -39,9 +36,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -59,9 +53,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -79,9 +70,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -99,9 +87,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/dataengineering.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/opdb.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/rt-datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -120,10 +108,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/streaming-small.json
@@ -19,10 +19,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "size": 500,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/aws/streaming.json
@@ -19,10 +19,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "size": 1000,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/azure/dataengineering-ha.json
@@ -26,9 +26,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -55,9 +52,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -84,9 +78,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -113,9 +104,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -141,9 +129,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/azure/dataengineering.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -103,10 +94,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/azure/datamart.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/azure/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/azure/opdb.json
@@ -28,9 +28,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -55,9 +52,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -82,9 +76,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -109,9 +100,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/azure/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/azure/rt-datamart.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -104,10 +95,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -130,10 +118,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/dataengineering-ha.json
@@ -18,9 +18,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -34,9 +31,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -50,9 +44,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -66,9 +57,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -81,9 +69,6 @@
         "name": "gateway",
         "type": "CORE",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/dataengineering.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -56,9 +47,6 @@
       {
         "name": "gateway",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/datamart.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/opdb.json
@@ -13,9 +13,6 @@
         "nodeCount": 2,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -28,9 +25,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -43,9 +37,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -58,9 +49,6 @@
         "nodeCount": 3,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/rt-datamart.json
@@ -12,9 +12,6 @@
       {
         "name": "master1",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "master2",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "master3",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -57,9 +48,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -72,9 +60,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/streaming-small.json
@@ -15,9 +15,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -30,9 +27,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.0.2/yarn/streaming.json
@@ -15,9 +15,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -30,9 +27,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,
@@ -45,9 +39,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/dataengineering-ha.json
@@ -19,9 +19,6 @@
       "template": {
         "aws": {},
         "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [{
           "size": 100,
           "count": 1,
@@ -39,9 +36,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -59,9 +53,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -79,9 +70,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -99,9 +87,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/dataengineering-spark3.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/dataengineering.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/flow-management-small.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/flow-management.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/opdb.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/rt-datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -120,10 +108,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/streaming-small.json
@@ -19,10 +19,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "size": 500,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/aws/streaming.json
@@ -19,10 +19,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "size": 1000,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/dataengineering-ha.json
@@ -26,9 +26,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -55,9 +52,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -84,9 +78,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -113,9 +104,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -141,9 +129,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/dataengineering-spark3.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/dataengineering.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -103,10 +94,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/datamart.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/flow-management-small.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/flow-management.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/azure/rt-datamart.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -104,10 +95,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -130,10 +118,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/dataengineering-ha.json
@@ -18,9 +18,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -34,9 +31,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -50,9 +44,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -66,9 +57,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -81,9 +69,6 @@
         "name": "gateway",
         "type": "CORE",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/dataengineering-spark3.json
@@ -12,9 +12,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/dataengineering.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -56,9 +47,6 @@
       {
         "name": "gateway",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/datamart.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/flow-management-small.json
@@ -14,9 +14,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -29,9 +26,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/flow-management.json
@@ -13,9 +13,6 @@
         "name": "gateway",
         "type": "GATEWAY",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -28,9 +25,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -43,9 +37,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/opdb.json
@@ -13,9 +13,6 @@
         "nodeCount": 2,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -28,9 +25,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -43,9 +37,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -58,9 +49,6 @@
         "nodeCount": 3,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/rt-datamart.json
@@ -12,9 +12,6 @@
       {
         "name": "master1",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "master2",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "master3",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -57,9 +48,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -72,9 +60,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/streaming-small.json
@@ -15,9 +15,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -30,9 +27,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.1.0/yarn/streaming.json
@@ -15,9 +15,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -30,9 +27,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,
@@ -45,9 +39,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/dataengineering-ha.json
@@ -19,9 +19,6 @@
       "template": {
         "aws": {},
         "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [{
           "size": 100,
           "count": 1,
@@ -39,9 +36,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -59,9 +53,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -79,9 +70,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -99,9 +87,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/dataengineering-spark3.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/dataengineering.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/dde.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -127,9 +115,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/flow-management-small.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/flow-management.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/opdb.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/rt-datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -120,10 +108,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/streaming-small.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -40,10 +37,7 @@
               "size": 1000,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/aws/streaming.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -45,10 +42,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -69,10 +63,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -88,10 +79,7 @@
               "size": 1000,
               "type": "gp2"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/dataengineering-ha.json
@@ -26,9 +26,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -55,9 +52,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -84,9 +78,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -113,9 +104,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -141,9 +129,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/dataengineering-spark3.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/dataengineering.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -103,10 +94,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/datamart.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/dde.json
@@ -22,9 +22,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -42,9 +39,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -62,9 +56,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -82,9 +73,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -102,9 +90,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/flow-management-small.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/flow-management.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/rt-datamart.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -104,10 +95,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -130,10 +118,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/azure/streaming.json
@@ -40,10 +40,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -62,10 +59,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/dataengineering-ha.json
@@ -18,9 +18,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -34,9 +31,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -50,9 +44,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -66,9 +57,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -81,9 +69,6 @@
         "name": "gateway",
         "type": "CORE",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/dataengineering-spark3.json
@@ -12,9 +12,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/dataengineering.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -56,9 +47,6 @@
       {
         "name": "gateway",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/datamart.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/dde.json
@@ -14,9 +14,6 @@
         "nodeCount": 2,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -29,9 +26,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -44,9 +38,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -59,9 +50,6 @@
         "nodeCount": 3,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -74,9 +62,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/flow-management-small.json
@@ -14,9 +14,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -29,9 +26,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/flow-management.json
@@ -13,9 +13,6 @@
         "name": "gateway",
         "type": "GATEWAY",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -28,9 +25,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -43,9 +37,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/opdb.json
@@ -13,9 +13,6 @@
         "nodeCount": 2,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -28,9 +25,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -43,9 +37,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -58,9 +49,6 @@
         "nodeCount": 3,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/rt-datamart.json
@@ -12,9 +12,6 @@
       {
         "name": "master1",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "master2",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "master3",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -57,9 +48,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -72,9 +60,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/streaming-small.json
@@ -17,9 +17,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -32,9 +29,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.0/yarn/streaming.json
@@ -17,9 +17,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -32,9 +29,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -47,9 +41,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -62,9 +53,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering-ha.json
@@ -19,9 +19,6 @@
       "template": {
         "aws": {},
         "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [{
           "size": 100,
           "count": 1,
@@ -39,9 +36,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -59,9 +53,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -79,9 +70,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -99,9 +87,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering-spark3.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dataengineering.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/dde.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -127,9 +115,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/flink-heavy.json
@@ -21,10 +21,7 @@
             "type": "NONE"
           }
         },
-        "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 100
-        }
+        "instanceType": "m5.2xlarge"
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -43,10 +40,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -65,10 +59,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/flink-light.json
@@ -21,10 +21,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 3,
 					"type": "CORE",
@@ -43,10 +40,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 1,
 					"type": "GATEWAY",
@@ -65,10 +59,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 2,
 					"type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/flow-management-small.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/flow-management.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/opdb.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/rt-datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -120,10 +108,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/streaming-small.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -40,10 +37,7 @@
               "size": 1000,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/aws/streaming.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -45,10 +42,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -69,10 +63,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -88,10 +79,7 @@
               "size": 1000,
               "type": "gp2"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering-ha.json
@@ -26,9 +26,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -55,9 +52,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -84,9 +78,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -113,9 +104,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -141,9 +129,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering-spark3.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dataengineering.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -103,10 +94,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/datamart.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/dde.json
@@ -22,9 +22,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -42,9 +39,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -62,9 +56,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -82,9 +73,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -102,9 +90,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/flink-heavy.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/flink-light.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/flow-management-small.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/flow-management.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/rt-datamart.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -104,10 +95,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -130,10 +118,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/azure/streaming.json
@@ -40,10 +40,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -62,10 +59,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/dataengineering-ha.json
@@ -18,9 +18,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -34,9 +31,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -50,9 +44,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -66,9 +57,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -81,9 +69,6 @@
         "name": "gateway",
         "type": "CORE",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/dataengineering-spark3.json
@@ -12,9 +12,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/dataengineering.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -56,9 +47,6 @@
       {
         "name": "gateway",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/datamart.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/dde.json
@@ -14,9 +14,6 @@
         "nodeCount": 2,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -29,9 +26,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -44,9 +38,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -59,9 +50,6 @@
         "nodeCount": 3,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -74,9 +62,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/flink-heavy.json
@@ -12,9 +12,6 @@
       {
         "name": "manager",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -27,9 +24,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/flink-light.json
@@ -12,9 +12,6 @@
       {
         "name": "manager",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -27,9 +24,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/flow-management-small.json
@@ -14,9 +14,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -29,9 +26,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/flow-management.json
@@ -13,9 +13,6 @@
         "name": "gateway",
         "type": "GATEWAY",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -28,9 +25,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -43,9 +37,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/rt-datamart.json
@@ -12,9 +12,6 @@
       {
         "name": "master1",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "master2",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "master3",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -57,9 +48,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -72,9 +60,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/streaming-small.json
@@ -17,9 +17,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -32,9 +29,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.1/yarn/streaming.json
@@ -17,9 +17,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -32,9 +29,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -47,9 +41,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -62,9 +53,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-ha.json
@@ -19,9 +19,6 @@
       "template": {
         "aws": {},
         "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [{
           "size": 100,
           "count": 1,
@@ -39,9 +36,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -59,9 +53,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -79,9 +70,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -99,9 +87,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-spark3.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dde.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -127,9 +115,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/flink-heavy.json
@@ -21,10 +21,7 @@
             "type": "NONE"
           }
         },
-        "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 100
-        }
+        "instanceType": "m5.2xlarge"
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -43,10 +40,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -65,10 +59,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/flink-light.json
@@ -21,10 +21,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 3,
 					"type": "CORE",
@@ -43,10 +40,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 1,
 					"type": "GATEWAY",
@@ -65,10 +59,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 2,
 					"type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/flow-management-small.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/flow-management.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/opdb.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/rt-datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -120,10 +108,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/streaming-small.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -40,10 +37,7 @@
               "size": 1000,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/streaming.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -45,10 +42,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -69,10 +63,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -88,10 +79,7 @@
               "size": 1000,
               "type": "gp2"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -113,10 +101,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering-ha.json
@@ -26,9 +26,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -55,9 +52,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -84,9 +78,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -113,9 +104,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -141,9 +129,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering-spark3.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -103,10 +94,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/datamart.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dde.json
@@ -22,9 +22,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -42,9 +39,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -62,9 +56,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -82,9 +73,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -102,9 +90,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/flink-heavy.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/flink-light.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/flow-management-small.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/flow-management.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/rt-datamart.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -104,10 +95,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -130,10 +118,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/streaming.json
@@ -40,10 +40,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -62,10 +59,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -101,10 +95,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-ha.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -95,10 +83,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-spark3.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/flow-management-small.json
@@ -19,9 +19,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/flow-management.json
@@ -19,9 +19,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/rt-datamart.json
@@ -19,10 +19,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -95,10 +83,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/streaming-small.json
@@ -22,10 +22,7 @@
               "size": 100,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -41,10 +38,7 @@
               "size": 1000,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/streaming.json
@@ -22,10 +22,7 @@
               "size": 100,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -46,10 +43,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -70,10 +64,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -89,10 +80,7 @@
               "size": 1000,
               "type": "pd-ssd"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -114,10 +102,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering-ha.json
@@ -19,9 +19,6 @@
       "template": {
         "aws": {},
         "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [{
           "size": 100,
           "count": 1,
@@ -39,9 +36,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -59,9 +53,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -79,9 +70,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -99,9 +87,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering-spark3.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dataengineering.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/dde.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -127,9 +115,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/flink-heavy.json
@@ -21,10 +21,7 @@
             "type": "NONE"
           }
         },
-        "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 100
-        }
+        "instanceType": "m5.2xlarge"
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -43,10 +40,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -65,10 +59,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/flink-light.json
@@ -21,10 +21,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 3,
 					"type": "CORE",
@@ -43,10 +40,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 1,
 					"type": "GATEWAY",
@@ -65,10 +59,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 2,
 					"type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/flow-management-small.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/flow-management.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/opdb.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/rt-datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -120,10 +108,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/streaming-small.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -40,10 +37,7 @@
               "size": 1000,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/streaming.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -45,10 +42,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -69,10 +63,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -88,10 +79,7 @@
               "size": 1000,
               "type": "gp2"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering-ha.json
@@ -26,9 +26,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -55,9 +52,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -84,9 +78,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -113,9 +104,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -141,9 +129,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering-spark3.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dataengineering.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -103,10 +94,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/datamart.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/dde.json
@@ -22,9 +22,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -42,9 +39,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -62,9 +56,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -82,9 +73,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -102,9 +90,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/flink-heavy.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/flink-light.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/flow-management-small.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/flow-management.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/rt-datamart.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -104,10 +95,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -130,10 +118,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/streaming.json
@@ -40,10 +40,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -62,10 +59,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/dataengineering-ha.json
@@ -18,9 +18,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -34,9 +31,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -50,9 +44,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -66,9 +57,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -81,9 +69,6 @@
         "name": "gateway",
         "type": "CORE",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/dataengineering-spark3.json
@@ -12,9 +12,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/dataengineering.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -56,9 +47,6 @@
       {
         "name": "gateway",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/datamart.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/dde.json
@@ -14,9 +14,6 @@
         "nodeCount": 2,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -29,9 +26,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -44,9 +38,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -59,9 +50,6 @@
         "nodeCount": 3,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -74,9 +62,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/flink-heavy.json
@@ -12,9 +12,6 @@
       {
         "name": "manager",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -27,9 +24,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/flink-light.json
@@ -12,9 +12,6 @@
       {
         "name": "manager",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -27,9 +24,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/flow-management-small.json
@@ -14,9 +14,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -29,9 +26,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/flow-management.json
@@ -13,9 +13,6 @@
         "name": "gateway",
         "type": "GATEWAY",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -28,9 +25,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -43,9 +37,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/rt-datamart.json
@@ -12,9 +12,6 @@
       {
         "name": "master1",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "master2",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "master3",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -57,9 +48,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -72,9 +60,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/streaming-small.json
@@ -17,9 +17,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -32,9 +29,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/streaming.json
@@ -17,9 +17,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -32,9 +29,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -47,9 +41,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -62,9 +53,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering-ha.json
@@ -19,9 +19,6 @@
       "template": {
         "aws": {},
         "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [{
           "size": 100,
           "count": 1,
@@ -39,9 +36,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -59,9 +53,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -79,9 +70,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -99,9 +87,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering-spark3.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dataengineering.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/dde.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -127,9 +115,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/flink-heavy.json
@@ -21,10 +21,7 @@
             "type": "NONE"
           }
         },
-        "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 100
-        }
+        "instanceType": "m5.2xlarge"
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -43,10 +40,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -65,10 +59,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/flink-light.json
@@ -21,10 +21,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 3,
 					"type": "CORE",
@@ -43,10 +40,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 1,
 					"type": "GATEWAY",
@@ -65,10 +59,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 2,
 					"type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/flow-management-small.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/flow-management.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/opdb.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/rt-datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -120,10 +108,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/streaming-small.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -40,10 +37,7 @@
               "size": 1000,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/streaming.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -45,10 +42,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -69,10 +63,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -88,10 +79,7 @@
               "size": 1000,
               "type": "gp2"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -113,10 +101,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering-ha.json
@@ -26,9 +26,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -55,9 +52,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -84,9 +78,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -113,9 +104,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -141,9 +129,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering-spark3.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dataengineering.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -103,10 +94,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/datamart.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/dde.json
@@ -22,9 +22,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -42,9 +39,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -62,9 +56,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -82,9 +73,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -102,9 +90,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/flink-heavy.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/flink-light.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/flow-management-small.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/flow-management.json
@@ -15,9 +15,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/rt-datamart.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -104,10 +95,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -130,10 +118,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/streaming.json
@@ -40,10 +40,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -62,10 +59,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -101,10 +95,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/gcp/dataengineering.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/gcp/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/gcp/flow-management-small.json
@@ -16,9 +16,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/gcp/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/gcp/flow-management.json
@@ -16,9 +16,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/dataengineering-ha.json
@@ -18,9 +18,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -34,9 +31,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -50,9 +44,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -66,9 +57,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -81,9 +69,6 @@
         "name": "gateway",
         "type": "CORE",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/dataengineering-spark3.json
@@ -12,9 +12,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/dataengineering.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -56,9 +47,6 @@
       {
         "name": "gateway",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/datamart.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/dde.json
@@ -14,9 +14,6 @@
         "nodeCount": 2,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -29,9 +26,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -44,9 +38,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -59,9 +50,6 @@
         "nodeCount": 3,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -74,9 +62,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/flink-heavy.json
@@ -12,9 +12,6 @@
       {
         "name": "manager",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -27,9 +24,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/flink-light.json
@@ -12,9 +12,6 @@
       {
         "name": "manager",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -27,9 +24,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/flow-management-small.json
@@ -14,9 +14,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -29,9 +26,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/flow-management.json
@@ -13,9 +13,6 @@
         "name": "gateway",
         "type": "GATEWAY",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -28,9 +25,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -43,9 +37,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/rt-datamart.json
@@ -12,9 +12,6 @@
       {
         "name": "master1",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "master2",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "master3",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -57,9 +48,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -72,9 +60,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/streaming-small.json
@@ -14,9 +14,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -29,9 +26,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/streaming.json
@@ -14,9 +14,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -29,9 +26,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -44,9 +38,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -59,9 +50,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,
@@ -75,9 +63,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 0,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering-ha.json
@@ -19,9 +19,6 @@
       "template": {
         "aws": {},
         "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [{
           "size": 100,
           "count": 1,
@@ -39,9 +36,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -59,9 +53,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -79,9 +70,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -99,9 +87,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering-spark3.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dataengineering.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/dde.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -127,9 +115,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/flink-heavy.json
@@ -21,10 +21,7 @@
             "type": "NONE"
           }
         },
-        "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 100
-        }
+        "instanceType": "m5.2xlarge"
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -43,10 +40,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -65,10 +59,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/flink-light.json
@@ -21,10 +21,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 3,
 					"type": "CORE",
@@ -43,10 +40,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 1,
 					"type": "GATEWAY",
@@ -65,10 +59,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 2,
 					"type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/flow-management-small.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/flow-management.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/opdb.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/rt-datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -120,10 +108,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/streaming-small.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -40,10 +37,7 @@
               "size": 1000,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/streaming.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -45,10 +42,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -69,10 +63,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -88,10 +79,7 @@
               "size": 1000,
               "type": "gp2"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -113,10 +101,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering-ha.json
@@ -26,9 +26,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -55,9 +52,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -84,9 +78,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -113,9 +104,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -141,9 +129,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering-spark3.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dataengineering.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -103,10 +94,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/datamart.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/dde.json
@@ -22,9 +22,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -42,9 +39,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -62,9 +56,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -82,9 +73,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -102,9 +90,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/flink-heavy.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/flink-light.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/flow-management-small.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/flow-management.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/rt-datamart.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -104,10 +95,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -130,10 +118,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/streaming.json
@@ -40,10 +40,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -62,10 +59,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -101,10 +95,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering-ha.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -95,10 +83,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering-spark3.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/datamart.json
@@ -19,10 +19,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/flow-management-small.json
@@ -19,9 +19,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/flow-management.json
@@ -19,9 +19,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/rt-datamart.json
@@ -19,10 +19,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -95,10 +83,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/streaming-small.json
@@ -22,10 +22,7 @@
               "size": 100,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -41,10 +38,7 @@
               "size": 1000,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/streaming.json
@@ -22,10 +22,7 @@
               "size": 100,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -46,10 +43,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -70,10 +64,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -89,10 +80,7 @@
               "size": 1000,
               "type": "pd-ssd"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -114,10 +102,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/dataengineering-ha.json
@@ -18,9 +18,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -34,9 +31,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -50,9 +44,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -66,9 +57,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -81,9 +69,6 @@
         "name": "gateway",
         "type": "CORE",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/dataengineering-spark3.json
@@ -12,9 +12,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/dataengineering.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -56,9 +47,6 @@
       {
         "name": "gateway",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/datamart.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/dde.json
@@ -14,9 +14,6 @@
         "nodeCount": 2,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -29,9 +26,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -44,9 +38,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -59,9 +50,6 @@
         "nodeCount": 3,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -74,9 +62,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/flink-heavy.json
@@ -12,9 +12,6 @@
       {
         "name": "manager",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -27,9 +24,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/flink-light.json
@@ -12,9 +12,6 @@
       {
         "name": "manager",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -27,9 +24,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/flow-management-small.json
@@ -14,9 +14,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -29,9 +26,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/flow-management.json
@@ -13,9 +13,6 @@
         "name": "gateway",
         "type": "GATEWAY",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -28,9 +25,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -43,9 +37,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/rt-datamart.json
@@ -12,9 +12,6 @@
       {
         "name": "master1",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "master2",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "master3",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -57,9 +48,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -72,9 +60,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/streaming-small.json
@@ -14,9 +14,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -29,9 +26,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/streaming.json
@@ -14,9 +14,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -29,9 +26,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -44,9 +38,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -59,9 +50,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,
@@ -75,9 +63,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 0,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-ha.json
@@ -20,9 +20,6 @@
       "template": {
         "aws": {},
         "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [{
           "size": 100,
           "count": 1,
@@ -40,9 +37,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -60,9 +54,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -80,9 +71,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -100,9 +88,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-spark3.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dde.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -127,9 +115,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/flink-heavy.json
@@ -21,10 +21,7 @@
             "type": "NONE"
           }
         },
-        "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 100
-        }
+        "instanceType": "m5.2xlarge"
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -43,10 +40,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -65,10 +59,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/flink-light.json
@@ -21,10 +21,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 3,
 					"type": "CORE",
@@ -43,10 +40,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 1,
 					"type": "GATEWAY",
@@ -65,10 +59,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 2,
 					"type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/flow-management-small.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/flow-management.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/opdb.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/rt-datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -120,10 +108,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/streaming-small.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -40,10 +37,7 @@
               "size": 1000,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/streaming.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -45,10 +42,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -69,10 +63,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -88,10 +79,7 @@
               "size": 1000,
               "type": "gp2"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -113,10 +101,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering-ha.json
@@ -26,9 +26,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -55,9 +52,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -84,9 +78,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -113,9 +104,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -141,9 +129,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering-spark3.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -103,10 +94,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/datamart.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dde.json
@@ -22,9 +22,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -42,9 +39,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -62,9 +56,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -82,9 +73,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -102,9 +90,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/flink-heavy.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/flink-light.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/flow-management-small.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/flow-management.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/rt-datamart.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -104,10 +95,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -130,10 +118,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/streaming.json
@@ -40,10 +40,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -62,10 +59,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -101,10 +95,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-ha.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -95,10 +83,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-spark3.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/flow-management-small.json
@@ -19,9 +19,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/flow-management.json
@@ -19,9 +19,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/rt-datamart.json
@@ -19,10 +19,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -95,10 +83,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/streaming-small.json
@@ -22,10 +22,7 @@
               "size": 100,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -41,10 +38,7 @@
               "size": 1000,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/streaming.json
@@ -22,10 +22,7 @@
               "size": 100,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -46,10 +43,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -70,10 +64,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -89,10 +80,7 @@
               "size": 1000,
               "type": "pd-ssd"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -114,10 +102,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/dataengineering-ha.json
@@ -18,9 +18,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -34,9 +31,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -50,9 +44,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -66,9 +57,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -81,9 +69,6 @@
         "name": "gateway",
         "type": "CORE",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/dataengineering-spark3.json
@@ -12,9 +12,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/dataengineering.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "compute",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -56,9 +47,6 @@
       {
         "name": "gateway",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/datamart.json
@@ -11,9 +11,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -26,9 +23,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -41,9 +35,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/dde.json
@@ -14,9 +14,6 @@
         "nodeCount": 2,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -29,9 +26,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -44,9 +38,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -59,9 +50,6 @@
         "nodeCount": 3,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -74,9 +62,6 @@
         "nodeCount": 1,
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/flink-heavy.json
@@ -12,9 +12,6 @@
       {
         "name": "manager",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -27,9 +24,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/flink-light.json
@@ -12,9 +12,6 @@
       {
         "name": "manager",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -27,9 +24,6 @@
       {
         "name": "master",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "worker",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/flow-management-small.json
@@ -14,9 +14,6 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -29,9 +26,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/flow-management.json
@@ -13,9 +13,6 @@
         "name": "management",
         "type": "GATEWAY",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -28,9 +25,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -43,9 +37,6 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "YARN"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/rt-datamart.json
@@ -12,9 +12,6 @@
       {
         "name": "master1",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -27,9 +24,6 @@
       {
         "name": "master2",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -42,9 +36,6 @@
       {
         "name": "master3",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 32768
@@ -57,9 +48,6 @@
       {
         "name": "coordinator",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192
@@ -72,9 +60,6 @@
       {
         "name": "executor",
         "template": {
-          "rootVolume": {
-            "size": 50
-          },
           "yarn": {
             "cpus": 4,
             "memory": 8192

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/streaming-small.json
@@ -14,9 +14,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -29,9 +26,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/streaming.json
@@ -14,9 +14,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 32768
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -29,9 +26,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -44,9 +38,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 1,
@@ -59,9 +50,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 3,
@@ -75,9 +63,6 @@
           "yarn": {
             "cpus": 4,
             "memory": 16384
-          },
-          "rootVolume": {
-            "size": 50
           }
         },
         "nodeCount": 0,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-ha.json
@@ -19,9 +19,6 @@
       "template": {
         "aws": {},
         "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [{
           "size": 100,
           "count": 1,
@@ -39,9 +36,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -59,9 +53,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -79,9 +70,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,
@@ -99,9 +87,6 @@
         "template": {
           "aws": {},
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [{
             "size": 100,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-spark3.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5d.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5d.4xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dde.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -127,9 +115,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/flink-heavy.json
@@ -21,10 +21,7 @@
             "type": "NONE"
           }
         },
-        "instanceType": "m5.2xlarge",
-        "rootVolume": {
-          "size": 100
-        }
+        "instanceType": "m5.2xlarge"
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -43,10 +40,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -65,10 +59,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/flink-light.json
@@ -21,10 +21,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 3,
 					"type": "CORE",
@@ -43,10 +40,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 1,
 					"type": "GATEWAY",
@@ -65,10 +59,7 @@
 								"type": "NONE"
 							}
 						},
-						"instanceType": "m5.2xlarge",
-						"rootVolume": {
-							"size": 50
-						}
+						"instanceType": "m5.2xlarge"
 					},
 					"nodeCount": 2,
 					"type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/flow-management-small.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/flow-management.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/opdb.json
@@ -27,9 +27,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -52,9 +49,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "GATEWAY"
@@ -77,9 +71,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"
@@ -102,9 +93,6 @@
             }
           },
           "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AWS"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/rt-datamart.json
@@ -24,10 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -48,10 +45,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -72,10 +66,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "r5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "r5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -96,10 +87,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -120,10 +108,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "i3.4xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "i3.4xlarge"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/streaming-small.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -40,10 +37,7 @@
               "size": 1000,
               "type": "st1"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/streaming.json
@@ -21,10 +21,7 @@
               "size": 100,
               "type": "standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -45,10 +42,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -69,10 +63,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -88,10 +79,7 @@
               "size": 1000,
               "type": "gp2"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -113,10 +101,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "m5.2xlarge"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering-ha.json
@@ -26,9 +26,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -55,9 +52,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -84,9 +78,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -113,9 +104,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,
@@ -141,9 +129,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering-spark3.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -103,10 +94,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/datamart.json
@@ -25,10 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -51,10 +48,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -77,10 +71,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_E16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_E16_v3"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dde.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dde.json
@@ -22,9 +22,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -42,9 +39,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -62,9 +56,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -82,9 +73,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -102,9 +90,6 @@
             }
           ],
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/flink-heavy.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/flink-heavy.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 100
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/flink-light.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/flink-light.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/flow-management-small.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/flow-management.json
@@ -18,9 +18,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/opdb.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/opdb.json
@@ -29,9 +29,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -56,9 +53,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "GATEWAY"
@@ -83,9 +77,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"
@@ -110,9 +101,6 @@
             }
           },
           "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          },
           "cloudPlatform": "AZURE"
         },
         "type": "CORE"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/rt-datamart.json
@@ -26,10 +26,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -52,10 +49,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -78,10 +72,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -104,10 +95,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -130,10 +118,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D16_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/streaming.json
@@ -40,10 +40,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -62,10 +59,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -101,10 +95,7 @@
           "azure": {
             "manageDisk": true
           },
-          "instanceType": "Standard_D8_v3",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "Standard_D8_v3"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-ha.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -95,10 +83,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-spark3.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering.json
@@ -19,10 +19,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-standard"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/datamart.json
@@ -19,10 +19,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 2,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/flow-management-small.json
@@ -19,9 +19,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/flow-management.json
@@ -19,9 +19,6 @@
         "recoveryMode": "MANUAL",
         "template": {
           "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          },
           "attachedVolumes": [
             {
               "size": 100,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/rt-datamart.json
@@ -19,10 +19,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -38,10 +35,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -57,10 +51,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -76,10 +67,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -95,10 +83,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/streaming-small.json
@@ -22,10 +22,7 @@
               "size": 100,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -41,10 +38,7 @@
               "size": 1000,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/streaming.json
@@ -22,10 +22,7 @@
               "size": 100,
               "type": "pd-standard"
             }
-          ],
-          "rootVolume": {
-            "size": 100
-          }
+          ]
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -46,10 +43,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -70,10 +64,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -89,10 +80,7 @@
               "size": 1000,
               "type": "pd-ssd"
             }
-          ],
-          "rootVolume": {
-            "size": 50
-          }
+          ]
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -114,10 +102,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "e2-standard-8",
-          "rootVolume": {
-            "size": 50
-          }
+          "instanceType": "e2-standard-8"
         },
         "nodeCount": 0,
         "type": "CORE",

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/DefaultRootVolumeSizeProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/DefaultRootVolumeSizeProviderTest.java
@@ -44,7 +44,7 @@ public class DefaultRootVolumeSizeProviderTest {
     public void testNoPropertySetForKnownPlatform() {
         underTest = new DefaultRootVolumeSizeProvider(mockConnectors, environment);
         int rootVolumeSize = underTest.getForPlatform("AWS");
-        assertEquals(50L, rootVolumeSize);
+        assertEquals(100L, rootVolumeSize);
     }
 
     @Test
@@ -59,6 +59,6 @@ public class DefaultRootVolumeSizeProviderTest {
     public void testWithUnknownPlatform() {
         underTest = new DefaultRootVolumeSizeProvider(mockConnectors, environment);
         int rootVolumeSize = underTest.getForPlatform("UNKNOWN_PLATFORM");
-        assertEquals(50L, rootVolumeSize);
+        assertEquals(100L, rootVolumeSize);
     }
 }

--- a/datalake/src/main/resources/duties/7.0.2/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.0.2/aws/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.0.2/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.0.2/azure/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.0.2/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.0.2/mock/light_duty.json
@@ -23,9 +23,6 @@
       "name": "idbroker",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "count": 0,
@@ -42,9 +39,6 @@
       "name": "master",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "size": 100,

--- a/datalake/src/main/resources/duties/7.1.0/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.1.0/aws/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.1.0/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.1.0/azure/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.1.0/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.1.0/mock/light_duty.json
@@ -23,9 +23,6 @@
       "name": "idbroker",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "count": 0,
@@ -42,9 +39,6 @@
       "name": "master",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "size": 100,

--- a/datalake/src/main/resources/duties/7.2.0/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.0/aws/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.0/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.0/azure/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.0/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.0/mock/light_duty.json
@@ -23,9 +23,6 @@
       "name": "idbroker",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "count": 0,
@@ -42,9 +39,6 @@
       "name": "master",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "size": 100,

--- a/datalake/src/main/resources/duties/7.2.1/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.1/aws/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.1/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.1/azure/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.1/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.1/mock/light_duty.json
@@ -23,9 +23,6 @@
       "name": "idbroker",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "count": 0,
@@ -42,9 +39,6 @@
       "name": "master",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "size": 100,

--- a/datalake/src/main/resources/duties/7.2.10/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.10/aws/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.10/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.10/aws/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.10/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.10/azure/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.10/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.10/azure/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.10/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.10/gcp/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.10/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.10/gcp/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.2/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.2/aws/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.2/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.2/aws/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",
@@ -57,10 +51,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.2/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.2/azure/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.2/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.2/azure/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",
@@ -57,10 +51,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.2/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.2/mock/light_duty.json
@@ -23,9 +23,6 @@
       "name": "idbroker",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "count": 0,
@@ -42,9 +39,6 @@
       "name": "master",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "size": 100,

--- a/datalake/src/main/resources/duties/7.2.6/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/aws/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.6/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.6/aws/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",
@@ -57,10 +51,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.6/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/azure/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.6/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.6/azure/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",
@@ -57,10 +51,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.6/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/gcp/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.6/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.6/gcp/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",
@@ -57,10 +51,7 @@
             "count": 0,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.6/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/mock/light_duty.json
@@ -23,9 +23,6 @@
       "name": "idbroker",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "count": 0,
@@ -42,9 +39,6 @@
       "name": "master",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "size": 100,

--- a/datalake/src/main/resources/duties/7.2.7/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/aws/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.7/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/aws/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.7/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/azure/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.7/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/azure/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.7/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/gcp/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.7/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.7/gcp/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.7/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/mock/light_duty.json
@@ -23,9 +23,6 @@
       "name": "idbroker",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "count": 0,
@@ -42,9 +39,6 @@
       "name": "master",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "size": 100,

--- a/datalake/src/main/resources/duties/7.2.8/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.8/aws/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.8/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.8/aws/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.8/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.8/azure/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.8/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.8/azure/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.8/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.8/gcp/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.8/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.8/gcp/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.8/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.8/mock/light_duty.json
@@ -23,9 +23,6 @@
       "name": "idbroker",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "count": 0,
@@ -42,9 +39,6 @@
       "name": "master",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "size": 100,

--- a/datalake/src/main/resources/duties/7.2.9/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.9/aws/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.9/aws/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.9/aws/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.9/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.9/azure/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.9/azure/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.9/azure/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "StandardSSD_LRS"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.9/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.9/gcp/light_duty.json
@@ -17,10 +17,7 @@
             "count": 0,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -37,10 +34,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/datalake/src/main/resources/duties/7.2.9/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.9/gcp/medium_duty_ha.json
@@ -18,10 +18,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",
@@ -38,10 +35,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "GATEWAY",
@@ -58,10 +52,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 3,
       "type": "CORE",
@@ -78,10 +69,7 @@
             "size": 250,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 100
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -97,10 +85,7 @@
             "count": 0,
             "type": "pd-standard"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 2,
       "type": "CORE",

--- a/datalake/src/main/resources/duties/7.2.9/mock/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.9/mock/light_duty.json
@@ -23,9 +23,6 @@
       "name": "idbroker",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "count": 0,
@@ -42,9 +39,6 @@
       "name": "master",
       "template": {
         "instanceType": "large",
-        "rootVolume": {
-          "size": 50
-        },
         "attachedVolumes": [
           {
             "size": 100,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/DefaultRootVolumeSizeProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/DefaultRootVolumeSizeProvider.java
@@ -30,7 +30,7 @@ public class DefaultRootVolumeSizeProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRootVolumeSizeProvider.class);
 
-    private static final Integer DEFAULT_ROOT_VOLUME_SIZE = 50;
+    private static final Integer DEFAULT_ROOT_VOLUME_SIZE = 100;
 
     private static final String ROOT_VOLUME_SIZE_PROPERTY_PREFIX = "cb.platform.default.rootVolumeSize.";
 

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -166,9 +166,9 @@ vault:
 cb:
   enabledplatforms: AZURE,AWS,GCP,OPENSTACK
   platform.default.rootVolumeSize:
-    AWS: 50
-    AZURE: 30
-    GCP: 50
+    AWS: 100
+    AZURE: 100
+    GCP: 100
   enabled.linux.types: redhat6,redhat7,centos6,centos7,amazonlinux,amazonlinux2
   publicip:
   etc.config.dir: /etc/freeipa

--- a/integration-test/src/main/resources/templates/sdx-cluster-template.json
+++ b/integration-test/src/main/resources/templates/sdx-cluster-template.json
@@ -34,10 +34,7 @@
             "size": 100,
             "type": "magnetic"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "CORE",
@@ -65,10 +62,7 @@
             "size": 100,
             "type": "magnetic"
           }
-        ],
-        "rootVolume": {
-          "size": 50
-        }
+        ]
       },
       "nodeCount": 1,
       "type": "GATEWAY",

--- a/redbeams/src/main/resources/application.yml
+++ b/redbeams/src/main/resources/application.yml
@@ -175,9 +175,9 @@ cb:
   uaa.startup.timeout.sec: 300
   enabledplatforms: AZURE,AWS,GCP,OPENSTACK
   platform.default.rootVolumeSize:
-    AWS: 50
-    AZURE: 30
-    GCP: 50
+    AWS: 100
+    AZURE: 100
+    GCP: 100
   enabled.linux.types: redhat6,redhat7,centos6,centos7,amazonlinux,amazonlinux2
   publicip:
   etc.config.dir: /etc/redbeams


### PR DESCRIPTION
In ENGESC-6845 there is a customer request that the default 50GB root disk size is not enough in their use-cases. As we don't support the resizing of the root volumes, it has been decided that the default root disk size needs to be increased.
100GB needs to be the new default for root volumes on every provider.

See detailed description in the commit message.