### PR TITLE
CB-11409 Remove mavenLocal repository references

### DIFF
--- a/audit-connector/build.gradle
+++ b/audit-connector/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.google.protobuf'
 
 buildscript {
     repositories {
-        mavenLocal()
         mavenCentral()
         maven { url = "$repoUrl" }
         jcenter()

--- a/auth-connector/build.gradle
+++ b/auth-connector/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.google.protobuf'
 
 buildscript {
   repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
     jcenter()

--- a/auth-internal-api/build.gradle
+++ b/auth-internal-api/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
   repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
     jcenter()

--- a/auth-internal/build.gradle
+++ b/auth-internal/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
   repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
     jcenter()

--- a/authorization-common-api/build.gradle
+++ b/authorization-common-api/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'io.spring.dependency-management'
 
 buildscript {
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()

--- a/authorization-common/build.gradle
+++ b/authorization-common/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'io.spring.dependency-management'
 
 buildscript {
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()

--- a/autoscale-api/build.gradle
+++ b/autoscale-api/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
 }

--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -2,7 +2,6 @@ import org.ajoberstar.grgit.Grgit
 
 buildscript {
     repositories {
-        mavenLocal()
         maven { url = "$repoUrl" }
         mavenCentral()
         jcenter()
@@ -189,7 +188,7 @@ dependencies {
     testCompile group: "com.h2database",            name: "h2",     version: h2databaseVersion
     testCompile project(path: ':common', configuration: 'tests')
     testCompile project(path: ':authorization-common', configuration: 'tests')
-    
+
     compile project(':core-api')
     compile project(':autoscale-api')
     compile project(':common')

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ import org.ajoberstar.grgit.Grgit
 
 buildscript {
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     mavenCentral()
     jcenter()
@@ -37,7 +36,6 @@ ext['junit-jupiter.version'] = "$junitJupiterVersion"
 allprojects {
 
   repositories {
-    mavenLocal()
     maven { url = "$cdpRepoUrl" }
     maven { url = "$repoUrl" }
   }
@@ -191,7 +189,6 @@ subprojects {
   }
 
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     mavenCentral()
     maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }

--- a/ccm-connector/build.gradle
+++ b/ccm-connector/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.google.protobuf'
 
 buildscript {
   repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
     jcenter()

--- a/client-cm/build.gradle
+++ b/client-cm/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }

--- a/cloud-api/build.gradle
+++ b/cloud-api/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   maven { url = "$springRepoUrl" }
   mavenCentral()

--- a/cloud-aws/build.gradle
+++ b/cloud-aws/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   maven { url = "$springRepoUrl" }
   mavenCentral()

--- a/cloud-azure/build.gradle
+++ b/cloud-azure/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   maven { url = "$springRepoUrl" }
   mavenCentral()

--- a/cloud-common/build.gradle
+++ b/cloud-common/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'io.spring.dependency-management'
 
 buildscript {
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url '= "$springRepoUrl"' }
     mavenCentral()

--- a/cloud-gcp/build.gradle
+++ b/cloud-gcp/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url '= "$springRepoUrl"' }
     mavenCentral()

--- a/cloud-mock/build.gradle
+++ b/cloud-mock/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url '= "$springRepoUrl"' }
     mavenCentral()

--- a/cloud-openstack/build.gradle
+++ b/cloud-openstack/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()

--- a/cloud-reactor-api/build.gradle
+++ b/cloud-reactor-api/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()

--- a/cloud-reactor/build.gradle
+++ b/cloud-reactor/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url '= "$springRepoUrl"' }
     mavenCentral()

--- a/cloud-template/build.gradle
+++ b/cloud-template/build.gradle
@@ -1,10 +1,8 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
-    mavenLocal()
     mavenCentral()
 }
 

--- a/cloud-yarn/build.gradle
+++ b/cloud-yarn/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()

--- a/cluster-api/build.gradle
+++ b/cluster-api/build.gradle
@@ -1,10 +1,9 @@
 plugins {
   id "java"
-  id 'maven' 
+  id 'maven'
 }
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }

--- a/cluster-cm/build.gradle
+++ b/cluster-cm/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }

--- a/cluster-dns-connector/build.gradle
+++ b/cluster-dns-connector/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.google.protobuf'
 
 buildscript {
   repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }

--- a/cluster-proxy/build.gradle
+++ b/cluster-proxy/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
   repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }

--- a/common-handlebar/build.gradle
+++ b/common-handlebar/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     mavenCentral()
 }

--- a/common-model/build.gradle
+++ b/common-model/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }

--- a/core-api/build.gradle
+++ b/core-api/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-  mavenLocal()
   mavenCentral()
   maven { url = "$repoUrl" }
 }

--- a/core-model/build.gradle
+++ b/core-model/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     mavenCentral()
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,7 +2,6 @@ import org.ajoberstar.grgit.Grgit
 
 buildscript {
     repositories {
-        mavenLocal()
         maven { url = "$repoUrl" }
         maven { url = "$springRepoUrl" }
         mavenCentral()

--- a/datalake-dr-connector/build.gradle
+++ b/datalake-dr-connector/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.google.protobuf'
 
 buildscript {
     repositories {
-        mavenLocal()
         mavenCentral()
         maven { url = "$repoUrl" }
         jcenter()

--- a/datalake/build.gradle
+++ b/datalake/build.gradle
@@ -2,7 +2,6 @@ import org.ajoberstar.grgit.Grgit
 
 buildscript {
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()

--- a/environment/build.gradle
+++ b/environment/build.gradle
@@ -2,7 +2,6 @@ import org.ajoberstar.grgit.Grgit
 
 buildscript {
     repositories {
-        mavenLocal()
         maven { url = "$repoUrl" }
         maven { url = "$springRepoUrl" }
         mavenCentral()

--- a/flow-api/build.gradle
+++ b/flow-api/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-  mavenLocal()
   mavenCentral()
   maven { url = "$repoUrl" }
 }

--- a/flow/build.gradle
+++ b/flow/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }

--- a/freeipa-api/build.gradle
+++ b/freeipa-api/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }

--- a/freeipa-client/build.gradle
+++ b/freeipa-client/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }

--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -2,7 +2,6 @@ import org.ajoberstar.grgit.Grgit
 
 buildscript {
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()
@@ -73,7 +72,7 @@ dependencies {
   implementation     group: 'com.google.guava',          name: 'guava',                                version: guavaVersion
 
   implementation     group: 'org.apache.kerby',          name: 'kerb-util',                            version: '2.0.0'
-  
+
   implementation     group: 'com.github.briandilley.jsonrpc4j', name: 'jsonrpc4j',                     version: '1.5.3'
 
   testImplementation ('org.springframework.boot:spring-boot-starter-test') {
@@ -136,7 +135,7 @@ dependencies {
   runtime project(':cloud-azure')
   runtime project(':cloud-gcp')
   implementation     project(":structuredevent-service-cdp")
-  
+
   testCompile group: 'com.hubspot.jinjava', name: 'jinjava', version: jinjavaVersion
   testImplementation project(path: ':authorization-common', configuration: 'tests')
 }
@@ -154,7 +153,7 @@ bootRun {
   if (project.hasProperty("jvmArgs")) {
     jvmArgs += project.jvmArgs.split("\\s+").toList()
   }
-} 
+}
 
 springBoot {
   mainClassName = 'com.sequenceiq.freeipa.FreeIpaApplication'

--- a/grpc-common/build.gradle
+++ b/grpc-common/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.google.protobuf'
 
 buildscript {
   repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
     jcenter()

--- a/idbmms-connector/build.gradle
+++ b/idbmms-connector/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.google.protobuf'
 
 buildscript {
   repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
     maven { url '= "$springRepoUrl"' }

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -2,7 +2,6 @@ import org.ajoberstar.grgit.Grgit
 
 buildscript {
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()

--- a/mock-infrastructure/build.gradle
+++ b/mock-infrastructure/build.gradle
@@ -2,7 +2,6 @@ import org.ajoberstar.grgit.Grgit
 
 buildscript {
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()

--- a/mock-thunderhead/build.gradle
+++ b/mock-thunderhead/build.gradle
@@ -2,7 +2,6 @@ import org.ajoberstar.grgit.Grgit
 
 buildscript {
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()

--- a/node-status-monitor-client/build.gradle
+++ b/node-status-monitor-client/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }

--- a/orchestrator-api/build.gradle
+++ b/orchestrator-api/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
 }

--- a/orchestrator-salt/build.gradle
+++ b/orchestrator-salt/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
 }

--- a/orchestrator-yarn/build.gradle
+++ b/orchestrator-yarn/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
 }

--- a/redbeams-api/build.gradle
+++ b/redbeams-api/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
 }

--- a/redbeams-model/build.gradle
+++ b/redbeams-model/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     mavenCentral()
 }

--- a/redbeams/build.gradle
+++ b/redbeams/build.gradle
@@ -2,7 +2,6 @@ import org.ajoberstar.grgit.Grgit
 
 buildscript {
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()

--- a/status-checker/build.gradle
+++ b/status-checker/build.gradle
@@ -4,7 +4,6 @@ plugins {
 }
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
   maven { url "https://cloudbreak-maven.s3.amazonaws.com/releases" }

--- a/structuredevent-api-cdp/build.gradle
+++ b/structuredevent-api-cdp/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
 }

--- a/structuredevent-model/build.gradle
+++ b/structuredevent-model/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
 }

--- a/structuredevent-service-cdp/build.gradle
+++ b/structuredevent-service-cdp/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
 }

--- a/structuredevent-service-legacy/build.gradle
+++ b/structuredevent-service-legacy/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
 }

--- a/template-manager-cmtemplate/build.gradle
+++ b/template-manager-cmtemplate/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: "java"
 
 repositories {
-  mavenLocal()
   maven { url = "$repoUrl" }
   mavenCentral()
 }

--- a/template-manager-core/build.gradle
+++ b/template-manager-core/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     mavenCentral()
 }

--- a/template-manager-recipe/build.gradle
+++ b/template-manager-recipe/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     mavenCentral()
 }

--- a/template-manager-tag/build.gradle
+++ b/template-manager-tag/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'java'
 
 repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     mavenCentral()
 }

--- a/usage-collection/build.gradle
+++ b/usage-collection/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
   repositories {
-    mavenLocal()
     mavenCentral()
     maven { url = "$repoUrl" }
     jcenter()

--- a/workspace/build.gradle
+++ b/workspace/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'io.spring.dependency-management'
 
 buildscript {
   repositories {
-    mavenLocal()
     maven { url = "$repoUrl" }
     maven { url = "$springRepoUrl" }
     mavenCentral()


### PR DESCRIPTION
Usually, for people who work with other projects that utilize Maven, the .m2 cache might not be totally adequate, as they experience missing library references in IDEA and during gradle build as well.