### PR TITLE
DWX-6365 Fixing ECR repository access

### DIFF
--- a/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
+++ b/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
@@ -252,8 +252,8 @@
       "Sid": "ECRAccessRead",
       "Effect": "Allow",
       "Action": [
-        "ecr:GetRegistryPolicy",
-        "ecr:DescribeRegistry",
+        "ecr:DescribeRepositories",
+        "ecr:DescribeImages",
         "ecr:GetAuthorizationToken"
       ],
       "Resource": [


### PR DESCRIPTION
Updating ECRAccessRead policy:

Adding missing DescribeRepositories action: to be able to describe repositories on validation
Adding Describe images action to be able to describe images and see their version matches
Adding GetAuthorizationToken to be able to obtain a temporary token

See detailed description in the commit message.