### PR TITLE
Decrease the size of DB for DH in AWS to 100G

### DIFF
--- a/core/src/main/resources/externaldatabase/aws/database-template.json
+++ b/core/src/main/resources/externaldatabase/aws/database-template.json
@@ -1,5 +1,5 @@
 {
   "instanceType": "db.m5.large",
   "vendor": "postgres",
-  "volumeSize": 1000
+  "volumeSize": 100
 }


### PR DESCRIPTION
The size of external DB for all clouds today for Datahub clusters today is 1000GB which is too high and costly for customer since most of that is going in vacuum. In order to arrive at better defaults ,changing the External DB size to 100G. Will create a separate PR for Azure and GCP as well.

Before the change: 

![image](https://user-images.githubusercontent.com/7271603/109604195-1c25cb00-7b49-11eb-9e1a-50a7e2b15ca4.png)

Post the change:

![image](https://user-images.githubusercontent.com/7271603/109604374-673fde00-7b49-11eb-975e-64608ad6c279.png)
