### PR TITLE
CB-11340 We are always wrapping exceptions in handleException, this m…

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/SimpleStatusCheckerTask.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/polling/SimpleStatusCheckerTask.java
@@ -6,6 +6,9 @@ public abstract class SimpleStatusCheckerTask<T> implements StatusCheckerTask<T>
 
     @Override
     public void handleException(Exception e) {
+        if (e instanceof CloudbreakServiceException) {
+            throw (CloudbreakServiceException) e;
+        }
         throw new CloudbreakServiceException(e.getMessage(), e);
     }
 

--- a/cloud-common/src/test/java/com/sequenceiq/cloudbreak/polling/SimpleStatusCheckerTaskTest.java
+++ b/cloud-common/src/test/java/com/sequenceiq/cloudbreak/polling/SimpleStatusCheckerTaskTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.cloudbreak.polling;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+
+public class SimpleStatusCheckerTaskTest {
+
+    private SimpleStatusCheckerTask<Object> underTest;
+
+    @Before
+    public void setup() {
+        underTest = new SimpleStatusCheckerTask<>() {
+            @Override
+            public boolean checkStatus(Object o) {
+                return false;
+            }
+
+            @Override
+            public void handleTimeout(Object o) {
+
+            }
+
+            @Override
+            public String successMessage(Object o) {
+                return null;
+            }
+
+            @Override
+            public boolean exitPolling(Object o) {
+                return false;
+            }
+        };
+    }
+
+    @Test(expected = CloudbreakServiceException.class)
+    public void testHandleException() {
+        underTest.handleException(new RuntimeException());
+        Assert.fail("This shall not pass, since handleException is expected to throw an Exception");
+    }
+
+    @Test(expected = SimpleStatusCheckerTaskTestException.class)
+    public void testWeThrowChildException() {
+        // Child of SimpleStatusCheckerTaskTestException should be thrown and we shall not wrap it
+        // since SimpleStatusCheckerTaskTestException is a child of CloudbreakServiceException
+        underTest.handleException(new SimpleStatusCheckerTaskTestException());
+        Assert.fail("This shall not pass, since handleException is expected to throw an Exception");
+    }
+
+    static class SimpleStatusCheckerTaskTestException extends CloudbreakServiceException {
+
+        SimpleStatusCheckerTaskTestException() {
+            super("message");
+        }
+
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/error/mapper/ClouderaManagerStorageErrorMapper.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/error/mapper/ClouderaManagerStorageErrorMapper.java
@@ -24,10 +24,11 @@ public class ClouderaManagerStorageErrorMapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerStorageErrorMapper.class);
 
     public String map(CloudStorageConfigurationFailedException e, String cloudPlatform, Cluster cluster) {
-        String errorMessage;
+
+        String errorMessage = e.getMessage();
 
         if (cluster.isRangerRazEnabled()) {
-            errorMessage = e.getMessage() + "Ranger RAZ is enabled on this cluster.";
+            errorMessage += "Ranger RAZ is enabled on this cluster.";
         } else {
             try {
                 CloudStorage cloudStorage = cluster.getFileSystem().getCloudStorage();
@@ -39,15 +40,14 @@ public class ClouderaManagerStorageErrorMapper {
                         errorMessage = azureError(cloudStorage);
                         break;
                     default:
-                        errorMessage = e.getMessage();
+                        LOGGER.debug("We don't have error massage mapper for platform: {}", cloudPlatform);
                 }
             } catch (RuntimeException runtimeException) {
                 CloudStorage cloudStorage = Optional.ofNullable(cluster).map(Cluster::getFileSystem)
                         .map(FileSystem::getCloudStorage).orElse(null);
                 LOGGER.error("No surprise that cluster creation has failed, probably something was not validated properly " +
                                 "in cloud storage config. This is most probably a control plane bug: {}",
-                        JsonUtil.writeValueAsStringSilent(cloudStorage), e);
-                errorMessage = e.getMessage();
+                        JsonUtil.writeValueAsStringSilent(cloudStorage), runtimeException);
             }
         }
 


### PR DESCRIPTION
We are always wrapping exceptions in handleException, this makes error handling harder since we need to deal with one kind of exception. It is better that if the exception is a child of CloudbreakServiceException, then we shall just reuse it and not wrap it