### PR TITLE
CB-11437 - Fix an issue with Atlas POST requests exceeding buffer size

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -558,12 +558,20 @@
         {% for hostloc in salt['pillar.get']('gateway:location')['ATLAS_SERVER'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['ATLAS'] }}</url>
         {%- endfor %}
+        <param>
+              <name>replayBufferSize</name>
+              <value>128</value>
+        </param>
     </service>
     <service>
         <role>ATLAS-API</role>
         {% for hostloc in salt['pillar.get']('gateway:location')['ATLAS_SERVER'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['ATLAS'] }}</url>
         {%- endfor %}
+        <param>
+              <name>replayBufferSize</name>
+              <value>128</value>
+        </param>
     </service>
     {%- endif %}
     {%- endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -270,6 +270,10 @@
         {% for hostloc in salt['pillar.get']('gateway:location')['ATLAS_SERVER'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['ATLAS_API'] }}</url>
         {%- endfor %}
+        <param>
+              <name>replayBufferSize</name>
+              <value>128</value>
+        </param>
     </service>
     {%- endif %}
     {%- endif %}


### PR DESCRIPTION
This is related to https://jira.cloudera.com/browse/CB-11437
Looks like Atlas POST requests are failing because the buffer size was exceeded. This fix will increase the buffer size and fix the issue. 

This has been tested on a local cluster in mow-int.