### PR TITLE
CB-11356 Handle LB with missing endpoint

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.cloudbreak.service;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -56,6 +58,9 @@ public class LoadBalancerConfigService {
 
     @Value("${cb.knox.port:8443}")
     private String knoxServicePort;
+
+    @Value("${cb.loadBalancer.supportedPlatforms:}")
+    private String supportedPlatforms;
 
     @Inject
     private LoadBalancerPersistenceService loadBalancerPersistenceService;
@@ -150,7 +155,7 @@ public class LoadBalancerConfigService {
         LOGGER.info("Setting up load balancers for stack {}", stack.getDisplayName());
         Set<LoadBalancer> loadBalancers = new HashSet<>();
 
-        if (isLoadBalancerEnabled(stack.getType(), environment)) {
+        if (isLoadBalancerEnabled(stack.getType(), environment) && getSupportedPlatforms().contains(stack.getCloudPlatform())) {
             LOGGER.debug("Load balancers are enabled for data lake and data hub stacks.");
             Optional<TargetGroup> knoxTargetGroup = setupKnoxTargetGroup(stack);
             if (knoxTargetGroup.isPresent()) {
@@ -271,5 +276,9 @@ public class LoadBalancerConfigService {
     private void setupKnoxLoadBalancer(LoadBalancer loadBalancer, TargetGroup knoxTargetGroup) {
         loadBalancer.addTargetGroup(knoxTargetGroup);
         knoxTargetGroup.addLoadBalancer(loadBalancer);
+    }
+
+    private List<String> getSupportedPlatforms() {
+        return supportedPlatforms == null ? List.of() : Arrays.asList(supportedPlatforms.split(","));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementService.java
@@ -9,17 +9,18 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 
-import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
-import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hue.HueRoles;
+import org.apache.commons.lang3.StringUtils;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.certificate.PkiUtil;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hue.HueRoles;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -294,9 +295,12 @@ public class GatewayPublicEndpointManagementService extends BasePublicEndpointMa
         return stack.getPrimaryGatewayInstance().getShortHostname();
     }
 
-    private Set<String> getLoadBalancerNamesForStack(Stack stack) {
+    @VisibleForTesting
+    Set<String> getLoadBalancerNamesForStack(Stack stack) {
         return loadBalancerPersistenceService.findByStackId(stack.getId()).stream()
-            .map(LoadBalancer::getEndpoint).collect(Collectors.toSet());
+            .filter(lb -> StringUtils.isNotEmpty(lb.getEndpoint()))
+            .map(LoadBalancer::getEndpoint)
+            .collect(Collectors.toSet());
     }
 
     private Optional<LoadBalancer> getLoadBalancerWithEndpoint(Stack stack) {

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -644,6 +644,9 @@ cb:
         prewarmed: true
   paywall.url: "https://archive.cloudera.com/p/cdp-public/"
 
+  loadBalancer:
+    supportedPlatforms: AWS
+
 clusterProxy:
   url: http://localhost:10180/cluster-proxy
   enabled: true

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/GatewayPublicEndpointManagementServiceTest.java
@@ -825,4 +825,22 @@ class GatewayPublicEndpointManagementServiceTest {
                 .deleteDnsEntryWithIp(eq(USER_CRN), eq("123"), eq(lbEndpointName), eq(envName), eq(Boolean.FALSE),
                         eq(List.of(ip)));
     }
+
+    @Test
+    void testSkipLoadBalancersWithMissingEndpoints() {
+        String validEndpoint = "valid-endpoint";
+        LoadBalancer nullEndpointLb = new LoadBalancer();
+        LoadBalancer emptyEndpointLb = new LoadBalancer();
+        emptyEndpointLb.setEndpoint("");
+        LoadBalancer validEndpointLb = new LoadBalancer();
+        emptyEndpointLb.setEndpoint(validEndpoint);
+        Stack stack = new Stack();
+        stack.setId(1L);
+
+        when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Set.of(nullEndpointLb, emptyEndpointLb, validEndpointLb));
+
+        Set<String> loadBalancerEndpoints = underTest.getLoadBalancerNamesForStack(stack);
+
+        Assertions.assertEquals(Set.of(validEndpoint), loadBalancerEndpoints);
+    }
 }


### PR DESCRIPTION
Cherry-picked from master.

Adds a new filter for LB endpoint names in GatewayPublicEndpointManagementService that will ignore
any null or empty endpoint values. Also adds a supported platform condition in LoadBalancerConfigService,
to prevent unexpeced results on platforms that haven't been fully implemented yet.

Tested with unit tests.

It was discovered in CB-11436 that there is a regression that causes Azure environment creation failures that this change should fix, so I'm requesting it be merged into 2.39.