### PR TITLE
ENGESC-7200 Azure disk naming fix

### DIFF
--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -379,12 +379,12 @@
                            "dataDisks": [
                            <#list instance.volumes as volume>
                                {
-                                   "name": "[concat('datadisk', '${instance.instanceId}', '${volume_index}')]",
+                                   "name": "[concat('datadisk', '${instance.instanceId}', '-', '${volume_index}')]",
                                    "diskSizeGB": ${volume.size},
                                    "lun":  ${volume_index},
                                    <#if instance.managedDisk == false>
                                    "vhd": {
-                                        "Uri": "[concat('${instance.attachedDiskStorageUrl}',parameters('userDataStorageContainerName'),'/',parameters('vmNamePrefix'),'datadisk','${instance.instanceId}', '${volume_index}', '.vhd')]"
+                                        "Uri": "[concat('${instance.attachedDiskStorageUrl}',parameters('userDataStorageContainerName'),'/',parameters('vmNamePrefix'),'datadisk','${instance.instanceId}', '-', '${volume_index}', '.vhd')]"
                                    },
                                    <#else>
                                    "managedDisk": {


### PR DESCRIPTION
There was an issue with disk naming as it was calculated by concatenating
the instance's auto-increment id and the disk's auto-incrementing id
without a separator character.
This caused instance no. 1 disk 10 and instance no 11 disk id 0 having a
name collision.
The fix is to put a separator character '-' in between, but unfortunately
the clusters created with the previous unfixed template has persisted
the wrong template into the 'component' table for STACK_TYPE component type.
These clusters will need a manual data fix by replacing the template with
a fixed version.