### PR TITLE
CB-11385:Decrease the size of DB for Datahubs for GCP and AZURE

### DIFF
--- a/core/src/main/resources/externaldatabase/azure/database-template.json
+++ b/core/src/main/resources/externaldatabase/azure/database-template.json
@@ -1,5 +1,5 @@
 {
   "instanceType": "MO_Gen5_4",
   "vendor": "postgres",
-  "volumeSize": 1000
+  "volumeSize": 100
 }

--- a/core/src/main/resources/externaldatabase/gcp/database-template.json
+++ b/core/src/main/resources/externaldatabase/gcp/database-template.json
@@ -1,5 +1,5 @@
 {
   "instanceType": "db-custom-2-13312",
   "vendor": "postgres",
-  "volumeSize": 1000
+  "volumeSize": 100
 }


### PR DESCRIPTION
Changes tested in Azure and the screenshots below:

Before the change with 1000GB:
<img width="976" alt="Screenshot 2021-03-02 at 8 04 51 PM" src="https://user-images.githubusercontent.com/7271603/110309625-96fa5480-8027-11eb-86b7-4f2207262483.png">


post the change reduced to 100G:
<img width="499" alt="Screenshot 2021-03-02 at 9 58 13 PM" src="https://user-images.githubusercontent.com/7271603/110309644-9c579f00-8027-11eb-9524-ca2f2787bd40.png">
