### PR TITLE
CB-10259 disable http TRACE method on the IPA server

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
@@ -69,6 +69,11 @@ configure_httpd_log_filter:
     - repl: ErrorLog "|/etc/httpd/conf/httpd-log-filter.sh"
     - unless: grep "httpd-log-filter.sh" /etc/httpd/conf/httpd.conf
 
+disable_http_trace:
+  file.append:
+    - name: /etc/httpd/conf/httpd.conf
+    - text: 'TraceEnable Off'
+
 restart_httpd:
   service.running:
     - name: httpd


### PR DESCRIPTION
You can send an http TRACE request to the FreeIPA server and it might
expose sensitive information. It is used mainly for debugging
purposes, but in general it should be disabled. It's fairly easy to
disable it with Apache http server.

To test you can use this command:
```
curl -kvL -X TRACE https://localhost:443
```

The response before this change is:
```
TRACE /ipa/ui HTTP/1.1
User-Agent: curl/7.29.0
Host: ipaserver0.test-env.xcu2-8y8x.wl.cloudera.site
Accept: */*

HTTP/1.1 200 OK
Date: Mon, 08 Mar 2021 09:21:48 GMT
Server: Apache/2.4.6 (CentOS) mod_auth_gssapi/1.5.1 mod_nss/1.0.14 NSS/3.28.4 mod_wsgi/3.4 Python/2.7.5
Transfer-Encoding: chunked
Content-Type: message/http
```

and after it's disabled:
```
TRACE /ipa/ui HTTP/1.1
User-Agent: curl/7.29.0
Host: ipaserver0.test-env.xcu2-8y8x.wl.cloudera.site
Accept: */*

HTTP/1.1 405 Method Not Allowed
Date: Mon, 08 Mar 2021 09:20:31 GMT
Server: Apache/2.4.6 (CentOS) mod_auth_gssapi/1.5.1 mod_nss/1.0.14 NSS/3.28.4 mod_wsgi/3.4 Python/2.7.5
Allow:
Content-Length: 229
Content-Type: text/html; charset=iso-8859-1
```
