### PR TITLE
CB-11419 Fix waiting edge cases in integration tests

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerApiCheckerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerApiCheckerTask.java
@@ -83,12 +83,12 @@ public abstract class AbstractClouderaManagerApiCheckerTask<T extends ClouderaMa
         if (toleratedErrorCounter < TOLERATED_ERROR_LIMIT) {
             toleratedErrorCounter++;
             LOGGER.warn("Command [{}] with id [{}] failed with a tolerated error '{}' for the {}. time(s). Tolerating till {} occasions.",
-                    getCommandName(), getOperationIdentifier(pollerObject), e.getMessage(), toleratedErrorCounter, TOLERATED_ERROR_LIMIT);
+                    getCommandName(), getOperationIdentifier(pollerObject), e.getMessage(), toleratedErrorCounter, TOLERATED_ERROR_LIMIT, e);
             return false;
         } else {
             throw new ClouderaManagerOperationFailedException(
                     String.format("Command [%s] with id [%s] failed with a tolerated error '%s' for %s times. Operation is considered failed.",
-                            getCommandName(), getOperationIdentifier(pollerObject), e.getMessage(), TOLERATED_ERROR_LIMIT));
+                            getCommandName(), getOperationIdentifier(pollerObject), e.getMessage(), TOLERATED_ERROR_LIMIT), e);
         }
     }
 

--- a/integration-test/scripts/fetch-secrets.sh
+++ b/integration-test/scripts/fetch-secrets.sh
@@ -16,7 +16,7 @@ fi
 mkdir -p ./src/main/resources/ums-users
 
 echo "Executing secret fetching from Azure 'jenkins-secret' store"
-az keyvault secret show --name "real-ums-users-dev" --vault-name "jenkins-secret" --version $secret_version --query 'value' -o tsv | jq > $USER_JSON_LOCATION
+az keyvault secret show --name "real-ums-users-dev" --vault-name "jenkins-secret" --version $secret_version --query 'value' -o tsv | jq '.' > $USER_JSON_LOCATION
 
 echo "Checking if valid json file was fetched: $USER_JSON_LOCATION"
 cat $USER_JSON_LOCATION | jq type

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
@@ -18,6 +18,7 @@ import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.Instan
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.YarnInstanceTemplateV1Parameters;
 import com.sequenceiq.environment.api.v1.credential.model.parameters.yarn.YarnParameters;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkYarnParams;
+import com.sequenceiq.environment.api.v1.environment.model.request.AttachedFreeIpaRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProvider;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -66,8 +67,12 @@ public class YarnCloudProvider extends AbstractCloudProvider {
 
     @Override
     public EnvironmentTestDto environment(EnvironmentTestDto environment) {
+        final AttachedFreeIpaRequest attachedFreeIpaRequest = new AttachedFreeIpaRequest();
+        attachedFreeIpaRequest.setCreate(Boolean.FALSE);
+
         return environment
-                .withLocation(location());
+                .withLocation(location())
+                .withFreeIpa(attachedFreeIpaRequest);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/StatusChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/StatusChecker.java
@@ -4,15 +4,17 @@ import java.util.Map;
 
 public interface StatusChecker<T extends WaitObject> {
 
-    boolean checkStatus(T t);
+    boolean checkStatus(T waitObject);
 
-    void handleTimeout(T t);
+    void handleTimeout(T waitObject);
 
-    String successMessage(T t);
+    String successMessage(T waitObject);
 
-    boolean exitWaiting(T t);
+    boolean exitWaiting(T waitObject);
 
     void handleException(Exception e);
 
-    Map<String, String> getStatuses(T t);
+    Map<String, String> getStatuses(T waitObject);
+
+    void refresh(T waitObject);
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitFailedChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitFailedChecker.java
@@ -3,7 +3,6 @@ package com.sequenceiq.it.cloudbreak.util.wait.service;
 import java.util.Map;
 
 import javax.ws.rs.NotFoundException;
-import javax.ws.rs.ProcessingException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,45 +13,33 @@ public class WaitFailedChecker<T extends WaitObject> extends ExceptionChecker<T>
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WaitFailedChecker.class);
 
+    private boolean failed;
+
     @Override
     public boolean checkStatus(T waitObject) {
-        String name = waitObject.getName();
-        try {
-            waitObject.fetchData();
-            Map<String, String> desiredStatuses = waitObject.getDesiredStatuses();
-            Map<String, String> actualStatuses = waitObject.actualStatuses();
-            LOGGER.info("Waiting for the '{}' state of '{}' cluster. Actual state is: '{}'", desiredStatuses, name, actualStatuses);
-            if (waitObject.isDeleted()) {
-                Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
-                LOGGER.error("Cluster '{}' has been terminated (status:'{}'), waiting is cancelled.", name, actualStatuses);
-                throw new TestFailException(String.format("Cluster '%s' has been terminated. Status: '%s' statusReason: '%s'",
-                        name, actualStatuses, actualStatusReasons));
-            }
-            if (waitObject.isInDesiredStatus()) {
-                return true;
-            }
-        } catch (NotFoundException e) {
-            LOGGER.warn("No {} found with name: {}", waitObject.getClass().getSimpleName(), name, e);
-        } catch (Exception e) {
-            LOGGER.error("Failed to get {} status or statusReason: {}", waitObject.getClass().getSimpleName(), e.getMessage(), e);
-            throw new TestFailException("Failed to get " + waitObject.getClass().getSimpleName() + " status or statusReason", e);
+        if (failed) {
+            return false;
         }
-        return false;
+        String name = waitObject.getName();
+        Map<String, String> desiredStatuses = waitObject.getDesiredStatuses();
+        Map<String, String> actualStatuses = waitObject.actualStatuses();
+        LOGGER.info("Waiting for the '{}' state of '{}' cluster. Actual state is: '{}'", desiredStatuses, name, actualStatuses);
+        if (waitObject.isDeleted()) {
+            Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
+            LOGGER.error("Cluster '{}' has been terminated (status:'{}'), waiting is cancelled.", name, actualStatuses);
+            throw new TestFailException(String.format("Cluster '%s' has been terminated. Status: '%s' statusReason: '%s'",
+                    name, actualStatuses, actualStatusReasons));
+        }
+        return waitObject.isInDesiredStatus();
     }
 
     @Override
     public void handleTimeout(T waitObject) {
         String name = waitObject.getName();
-        try {
-            waitObject.fetchData();
-            Map<String, String> actualStatuses = waitObject.actualStatuses();
-            Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
-            throw new TestFailException(String.format("Wait operation timed out, '%s' %s has not been failed. Status: '%s' " +
-                    "statusReason: '%s'", name, waitObject.getClass().getSimpleName(), actualStatuses, actualStatusReasons));
-        } catch (Exception e) {
-            LOGGER.error("Wait operation timed out! Failed to get {} status or statusReason: {}", waitObject.getClass().getSimpleName(), e.getMessage(), e);
-            throw new TestFailException("Wait operation timed out! Failed to get " + waitObject.getClass().getSimpleName() + " status or statusReason", e);
-        }
+        Map<String, String> actualStatuses = waitObject.actualStatuses();
+        Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
+        throw new TestFailException(String.format("Wait operation timed out, '%s' %s has not been failed. Status: '%s' " +
+                "statusReason: '%s'", name, waitObject.getClass().getSimpleName(), actualStatuses, actualStatusReasons));
     }
 
     @Override
@@ -63,17 +50,9 @@ public class WaitFailedChecker<T extends WaitObject> extends ExceptionChecker<T>
 
     @Override
     public boolean exitWaiting(T waitObject) {
-        try {
-            waitObject.fetchData();
-            String name = waitObject.getName();
-            if (waitObject.actualStatuses().isEmpty()) {
-                LOGGER.info("'{}' {} was not found. Exit waiting!", waitObject.getClass().getSimpleName(), name);
-                return true;
-            }
-        } catch (ProcessingException clientException) {
-            LOGGER.error("Exit waiting! Failed to get cluster due to API client exception: {}", clientException.getMessage(), clientException);
-        } catch (Exception e) {
-            LOGGER.error("Exit waiting! Failed to get cluster, because of: {}", e.getMessage(), e);
+        String name = waitObject.getName();
+        if (failed || waitObject.actualStatuses().isEmpty()) {
+            LOGGER.info("'{}' {} was not found. Exit waiting!", waitObject.getClass().getSimpleName(), name);
             return true;
         }
         return false;
@@ -81,7 +60,20 @@ public class WaitFailedChecker<T extends WaitObject> extends ExceptionChecker<T>
 
     @Override
     public Map<String, String> getStatuses(T waitObject) {
-        waitObject.fetchData();
         return waitObject.actualStatuses();
+    }
+
+    @Override
+    public void refresh(T waitObject) {
+        try {
+            waitObject.fetchData();
+            failed = false;
+        } catch (NotFoundException e) {
+            LOGGER.warn("No {} found with name: {}", waitObject.getClass().getSimpleName(), waitObject.getName(), e);
+            failed = true;
+        } catch (Exception e) {
+            LOGGER.error("Failed to get {} status or statusReason: {}", waitObject.getClass().getSimpleName(), e.getMessage(), e);
+            throw new TestFailException("Failed to get " + waitObject.getClass().getSimpleName() + " status or statusReason", e);
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
@@ -2,8 +2,6 @@ package com.sequenceiq.it.cloudbreak.util.wait.service;
 
 import java.util.Map;
 
-import javax.ws.rs.ProcessingException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,53 +13,41 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
 
     @Override
     public boolean checkStatus(T waitObject) {
-        try {
-            waitObject.fetchData();
-            String name = waitObject.getName();
-            Map<String, String> actualStatuses = waitObject.actualStatuses();
-            if (actualStatuses.isEmpty()) {
-                throw new TestFailException(String.format("'%s' stack was not found.", name));
-            }
-            Map<String, String> desiredStatuses = waitObject.getDesiredStatuses();
-            LOGGER.info("Waiting for the '{}' state of '{}' cluster. Actual state is: '{}'", desiredStatuses, name, actualStatuses);
-            if (waitObject.isDeletionInProgress() || waitObject.isDeleted()) {
-                LOGGER.error("Cluster '{}' has been getting terminated (status:'{}'), waiting is cancelled.", name, actualStatuses);
-                throw new TestFailException(String.format("Cluster '%s' has been getting terminated (status:'%s'), waiting is cancelled.", name,
-                        actualStatuses));
-            }
-            if (waitObject.isFailed()) {
-                Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
-                LOGGER.error("Cluster '{}' is in failed state (status:'{}'), waiting is cancelled.", name, actualStatuses);
-                throw new TestFailException(String.format("Cluster '%s' is in failed state. Status: '%s' statusReason: '%s'",
-                        name, actualStatuses, actualStatusReasons));
-            }
-            if (waitObject.isInDesiredStatus()) {
-                LOGGER.info("Cluster '{}' is in desired state (status:'{}').", name, actualStatuses);
-                return true;
-            }
-        } catch (Exception e) {
-            LOGGER.error("Failed to get cluster status or statusReason: {}", e.getMessage(), e);
-            throw new TestFailException("Failed to get cluster status or statusReason", e);
+        String name = waitObject.getName();
+        Map<String, String> actualStatuses = waitObject.actualStatuses();
+        if (actualStatuses.isEmpty()) {
+            throw new TestFailException(String.format("'%s' stack was not found.", name));
         }
-        return false;
+        Map<String, String> desiredStatuses = waitObject.getDesiredStatuses();
+        LOGGER.info("Waiting for the '{}' state of '{}' cluster. Actual state is: '{}'", desiredStatuses, name, actualStatuses);
+        if (waitObject.isDeletionInProgress() || waitObject.isDeleted()) {
+            LOGGER.error("Cluster '{}' has been getting terminated (status:'{}'), waiting is cancelled.", name, actualStatuses);
+            throw new TestFailException(String.format("Cluster '%s' has been getting terminated (status:'%s'), waiting is cancelled.", name,
+                    actualStatuses));
+        }
+        if (waitObject.isFailed()) {
+            Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
+            LOGGER.error("Cluster '{}' is in failed state (status:'{}'), waiting is cancelled.", name, actualStatuses);
+            throw new TestFailException(String.format("Cluster '%s' is in failed state. Status: '%s' statusReason: '%s'",
+                    name, actualStatuses, actualStatusReasons));
+        }
+        if (waitObject.isInDesiredStatus()) {
+            LOGGER.info("Cluster '{}' is in desired state (status:'{}').", name, actualStatuses);
+            return true;
+        }
+        return waitObject.isFailed();
     }
 
     @Override
     public void handleTimeout(T waitObject) {
-        try {
-            waitObject.fetchData();
-            String name = waitObject.getName();
-            Map<String, String> actualStatuses = waitObject.actualStatuses();
-            if (actualStatuses.isEmpty()) {
-                throw new TestFailException(String.format("'%s' cluster was not found.", name));
-            }
-            Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
-            throw new TestFailException(String.format("Wait operation timed out! Cluster '%s' has been failed. Cluster status: '%s' "
-                    + "statusReason: '%s'", name, actualStatuses, actualStatusReasons));
-        } catch (Exception e) {
-            LOGGER.error("Wait operation timed out! Failed to get cluster status or statusReason: {}", e.getMessage(), e);
-            throw new TestFailException("Wait operation timed out! Failed to get cluster status or statusReason", e);
+        String name = waitObject.getName();
+        Map<String, String> actualStatuses = waitObject.actualStatuses();
+        if (actualStatuses.isEmpty()) {
+            throw new TestFailException(String.format("'%s' cluster was not found.", name));
         }
+        Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
+        throw new TestFailException(String.format("Wait operation timed out! Cluster '%s' has been failed. Cluster status: '%s' "
+                + "statusReason: '%s'", name, actualStatuses, actualStatusReasons));
     }
 
     @Override
@@ -72,30 +58,31 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
 
     @Override
     public boolean exitWaiting(T waitObject) {
-        try {
-            waitObject.fetchData();
-            String name = waitObject.getName();
-            Map<String, String> actualStatuses = waitObject.actualStatuses();
-            if (actualStatuses.isEmpty()) {
-                LOGGER.info("'{}' cluster was not found. Exit waiting!", name);
-                return true;
-            }
-            if (waitObject.isCreateFailed()) {
-                LOGGER.info("'{}' the polled resource entered into creation failed state. Exit waiting!", name);
-                return true;
-            }
-        } catch (ProcessingException clientException) {
-            LOGGER.error("Exit waiting! Failed to get cluster due to API client exception: {}", clientException.getMessage(), clientException);
-        } catch (Exception e) {
-            LOGGER.error("Exit waiting! Failed to get cluster, because of: {}", e.getMessage(), e);
+        String name = waitObject.getName();
+        Map<String, String> actualStatuses = waitObject.actualStatuses();
+        if (actualStatuses.isEmpty()) {
+            LOGGER.info("'{}' cluster was not found. Exit waiting!", name);
             return true;
         }
-        return false;
+        if (waitObject.isCreateFailed()) {
+            LOGGER.info("'{}' the polled resource entered into creation failed state. Exit waiting!", name);
+            return true;
+        }
+        return waitObject.isFailed();
     }
 
     @Override
     public Map<String, String> getStatuses(T waitObject) {
-        waitObject.fetchData();
         return waitObject.actualStatuses();
+    }
+
+    @Override
+    public void refresh(T waitObject) {
+        try {
+            waitObject.fetchData();
+        } catch (Exception e) {
+            LOGGER.error("Failed to get cluster status or statusReason: {}", e.getMessage(), e);
+            throw new TestFailException("Failed to get cluster status or statusReason", e);
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceFailedChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceFailedChecker.java
@@ -4,8 +4,6 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import javax.ws.rs.ProcessingException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,48 +17,38 @@ public class InstanceFailedChecker<T extends InstanceWaitObject> extends Excepti
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InstanceFailedChecker.class);
 
+    private boolean failed;
+
     @Override
     public boolean checkStatus(T waitObject) {
-        Map<String, String> desiredStatuses = waitObject.getDesiredStatuses();
-        String hostGroup = waitObject.getHostGroup();
-        try {
-            waitObject.fetchData();
-            InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
-            InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
-            String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
-            String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
-            LOGGER.info("Waiting for the '{}'. Actual instance state is: '{}'", desiredStatuses, instanceStatus);
-            if (waitObject.isDeleted()) {
-                LOGGER.error("The '{}' has been terminated (status:'{}'), waiting is cancelled.", instanceGroupName, instanceStatus);
-                throw new TestFailException(String.format("The '%s' has been terminated, waiting is cancelled." +
-                        " Status: '%s' statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
-            }
-            if (waitObject.isInDesiredStatus()) {
-                LOGGER.info("The '{}' is in desired state (status:'{}').", instanceGroupName, instanceStatus);
-                return true;
-            }
-        } catch (NoSuchElementException e) {
-            LOGGER.warn("No instance group found with name '{}'", hostGroup, e);
-        } catch (Exception e) {
-            LOGGER.error("Failed to get instance group status: '{}', because of {}", hostGroup, e.getMessage(), e);
-            throw new TestFailException(String.format("Failed to get instance group status: '%s'", hostGroup), e);
+        if (failed) {
+            return false;
+        }
+        InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
+        InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
+        String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
+        String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
+        LOGGER.info("Waiting for the '{}'. Actual instance state is: '{}'", waitObject.getDesiredStatuses(), instanceStatus);
+        if (waitObject.isDeleted()) {
+            LOGGER.error("The '{}' has been terminated (status:'{}'), waiting is cancelled.", instanceGroupName, instanceStatus);
+            throw new TestFailException(String.format("The '%s' has been terminated, waiting is cancelled." +
+                    " Status: '%s' statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
+        }
+        if (waitObject.isInDesiredStatus()) {
+            LOGGER.info("The '{}' is in desired state (status:'{}').", instanceGroupName, instanceStatus);
+            return true;
         }
         return false;
     }
 
     @Override
     public void handleTimeout(T waitObject) {
-        try {
-            InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
-            InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
-            String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
-            String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
-            throw new TestFailException(String.format("Wait operation timed out, '%s' instance group has not been failed. Instance status: '%s' " +
-                    "statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
-        } catch (Exception e) {
-            LOGGER.error("Wait operation timed out! Failed to get instance status: {}", e.getMessage(), e);
-            throw new TestFailException("Wait operation timed out! Failed to get instance status", e);
-        }
+        InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
+        InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
+        String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
+        String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
+        throw new TestFailException(String.format("Wait operation timed out, '%s' instance group has not been failed. Instance status: '%s' " +
+                "statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
     }
 
     @Override
@@ -72,22 +60,17 @@ public class InstanceFailedChecker<T extends InstanceWaitObject> extends Excepti
     @Override
     public boolean exitWaiting(T waitObject) {
         String hostGroup = waitObject.getHostGroup();
-        try {
-            waitObject.fetchData();
-            Optional<InstanceGroupV4Response> instanceGroup = waitObject.getInstanceGroup();
-            if (instanceGroup.isEmpty()) {
-                LOGGER.info("'{}' instance group was not found. Exit waiting!", hostGroup);
-                return true;
-            } else {
-                if (instanceGroup.get().getMetadata().stream().findFirst().isEmpty()) {
-                    LOGGER.info("'{}' instance group metadata was not found. Exit waiting!", hostGroup);
-                    return true;
-                }
-            }
-        } catch (ProcessingException e) {
-            LOGGER.error("Exit waiting! Failed to get instance group due to API client exception: {}", e.getMessage(), e);
-        } catch (Exception e) {
-            LOGGER.error("Exit waiting! Failed to get instance group, because of: {}", e.getMessage(), e);
+        if (failed) {
+            LOGGER.info("'{}' instance group refresh failed. Exit waiting!", hostGroup);
+            return true;
+        }
+        Optional<InstanceGroupV4Response> instanceGroup = waitObject.getInstanceGroup();
+        if (instanceGroup.isEmpty()) {
+            LOGGER.info("'{}' instance group was not found. Exit waiting!", hostGroup);
+            return true;
+        }
+        if (instanceGroup.get().getMetadata().stream().findFirst().isEmpty()) {
+            LOGGER.info("'{}' instance group metadata was not found. Exit waiting!", hostGroup);
             return true;
         }
         return false;
@@ -95,7 +78,21 @@ public class InstanceFailedChecker<T extends InstanceWaitObject> extends Excepti
 
     @Override
     public Map<String, String> getStatuses(T waitObject) {
-        waitObject.fetchData();
         return waitObject.actualStatuses();
+    }
+
+    @Override
+    public void refresh(T waitObject) {
+        String hostGroup = waitObject.getHostGroup();
+        try {
+            waitObject.fetchData();
+            failed = false;
+        } catch (NoSuchElementException e) {
+            LOGGER.warn("No instance group found with name '{}'", hostGroup, e);
+            failed = true;
+        } catch (Exception e) {
+            LOGGER.error("Failed to get instance group status: '{}', because of {}", hostGroup, e.getMessage(), e);
+            throw new TestFailException(String.format("Failed to get instance group status: '%s'", hostGroup), e);
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceOperationChecker.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.it.cloudbreak.util.wait.service.instance;
 
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.DELETE_REQUESTED;
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.ORCHESTRATION_FAILED;
 
 import java.util.Map;
-
-import javax.ws.rs.ProcessingException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,50 +19,37 @@ public class InstanceOperationChecker<T extends InstanceWaitObject> extends Exce
     @Override
     public boolean checkStatus(T waitObject) {
         Map<String, String> desiredStatuses = waitObject.getDesiredStatuses();
-        String hostGroup = waitObject.getHostGroup();
-        try {
-            waitObject.fetchData();
-            InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
-            InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
-            String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
-            String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
-            LOGGER.info("Waiting for the '{}'. Actual instance state is: '{}'", desiredStatuses, instanceStatus);
-            if (instanceStatus.equals(DELETE_REQUESTED) || waitObject.isDeleted()) {
-                LOGGER.error("The '{}' instance group has been getting terminated (status:'{}'), waiting is cancelled.", instanceGroupName,
-                        instanceStatus);
-                throw new TestFailException(String.format("The '%s' instance group has been getting terminated, waiting is cancelled." +
-                        " Status: '%s' statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
-            }
-            if (waitObject.isFailed()) {
-                LOGGER.error("The '{}' instance group is in failed state (status:'{}'), waiting is cancelled.", instanceGroupName, instanceStatus);
-                throw new TestFailException(String.format("The '%s' instance group is in failed state. Status: '%s' statusReason: '%s'",
-                        instanceGroupName, instanceStatus, hostStatusReason));
-            }
-            if (waitObject.isInDesiredStatus()) {
-                LOGGER.info("The '{}' instance group is in desired state (status:'{}').", instanceGroupName, instanceStatus);
-                return true;
-            }
-        } catch (Exception e) {
-            LOGGER.error("Failed to get '{}' instance group status, because of {}", hostGroup, e.getMessage(), e);
-            throw new TestFailException(String.format("Failed to get '%s' instance group status", hostGroup), e);
+        InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
+        InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
+        String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
+        String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
+        LOGGER.info("Waiting for the '{}'. Actual instance state is: '{}'", desiredStatuses, instanceStatus);
+        if (instanceStatus.equals(DELETE_REQUESTED) || waitObject.isDeleted()) {
+            LOGGER.error("The '{}' instance group has been getting terminated (status:'{}'), waiting is cancelled.", instanceGroupName,
+                    instanceStatus);
+            throw new TestFailException(String.format("The '%s' instance group has been getting terminated, waiting is cancelled." +
+                    " Status: '%s' statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
+        }
+        if (waitObject.isFailed()) {
+            LOGGER.error("The '{}' instance group is in failed state (status:'{}'), waiting is cancelled.", instanceGroupName, instanceStatus);
+            throw new TestFailException(String.format("The '%s' instance group is in failed state. Status: '%s' statusReason: '%s'",
+                    instanceGroupName, instanceStatus, hostStatusReason));
+        }
+        if (waitObject.isInDesiredStatus()) {
+            LOGGER.info("The '{}' instance group is in desired state (status:'{}').", instanceGroupName, instanceStatus);
+            return true;
         }
         return false;
     }
 
     @Override
     public void handleTimeout(T waitObject) {
-        try {
-            waitObject.fetchData();
-            InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
-            InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
-            String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
-            String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
-            throw new TestFailException(String.format("Wait operation timed out, '%s' instance group has been failed. Instance status: '%s' " +
-                    "statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
-        } catch (Exception e) {
-            LOGGER.error("Wait operation timed out, failed to get instance status: {}", e.getMessage(), e);
-            throw new TestFailException("Wait operation timed out, failed to get instance status", e);
-        }
+        InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
+        InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
+        String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
+        String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
+        throw new TestFailException(String.format("Wait operation timed out, '%s' instance group has been failed. Instance status: '%s' " +
+                "statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
     }
 
     @Override
@@ -76,26 +60,22 @@ public class InstanceOperationChecker<T extends InstanceWaitObject> extends Exce
 
     @Override
     public boolean exitWaiting(T waitObject) {
-        try {
-            waitObject.fetchData();
-            InstanceStatus instanceStatus = waitObject.getInstanceStatus();
-            if (instanceStatus.equals(ORCHESTRATION_FAILED)) {
-                return true;
-            }
-            return waitObject.isFailed();
-
-        } catch (ProcessingException e) {
-            LOGGER.error("Exit waiting! Failed to get instance group due to API client exception: {}", e.getMessage(), e);
-        } catch (Exception e) {
-            LOGGER.error("Exit waiting! Failed to get instance group, because of: {}", e.getMessage(), e);
-            return true;
-        }
-        return false;
+        return waitObject.isFailed();
     }
 
     @Override
     public Map<String, String> getStatuses(T waitObject) {
-        waitObject.fetchData();
         return waitObject.actualStatuses();
+    }
+
+    @Override
+    public void refresh(T waitObject) {
+        String hostGroup = waitObject.getHostGroup();
+        try {
+            waitObject.fetchData();
+        } catch (Exception e) {
+            LOGGER.error("Failed to get '{}' instance group status, because of {}", hostGroup, e.getMessage(), e);
+            throw new TestFailException(String.format("Failed to get '%s' instance group status", hostGroup), e);
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceTerminationChecker.java
@@ -3,8 +3,6 @@ package com.sequenceiq.it.cloudbreak.util.wait.service.instance;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
-import javax.ws.rs.ProcessingException;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,47 +15,33 @@ public class InstanceTerminationChecker<T extends InstanceWaitObject> extends Ex
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InstanceTerminationChecker.class);
 
+    private boolean deleted;
+
     @Override
     public boolean checkStatus(T waitObject) {
-        String hostGroup = waitObject.getHostGroup();
-        try {
-            waitObject.fetchData();
-            InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
-            InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
-            String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
-            String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
-            if (waitObject.isDeleteFailed()) {
-                LOGGER.error("The '{}' instance group termination failed (status:'{}'), waiting is cancelled.", instanceGroupName, instanceStatus);
-                throw new TestFailException(String.format("The '%s' instance group termination failed, waiting is cancelled. " +
-                        "Status: '%s' statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
-            }
-            if (!waitObject.isDeleted()) {
-                return false;
-            }
-        } catch (NoSuchElementException e) {
-            LOGGER.warn("{} instance group is not present, may this was deleted.", hostGroup, e);
-        } catch (Exception e) {
-            LOGGER.error("'{}' instance group deletion has been failed, because of: {}", hostGroup, e.getMessage(), e);
-            throw new TestFailException(String.format("'%s' instance group deletion has been failed", hostGroup), e);
+        if (deleted) {
+            return true;
         }
-        return true;
+        InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
+        InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
+        String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
+        String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
+        if (waitObject.isDeleteFailed()) {
+            LOGGER.error("The '{}' instance group termination failed (status:'{}'), waiting is cancelled.", instanceGroupName, instanceStatus);
+            throw new TestFailException(String.format("The '%s' instance group termination failed, waiting is cancelled. " +
+                    "Status: '%s' statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
+        }
+        return waitObject.isDeleted();
     }
 
     @Override
     public void handleTimeout(T waitObject) {
-        try {
-            waitObject.fetchData();
-            InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
-            InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
-            String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
-            String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
-            throw new TestFailException(String.format("Wait operation timed out! '%s' instance group termination failed. Instance status: '%s' " +
-                    "statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
-
-        } catch (Exception e) {
-            LOGGER.error("Wait operation timed out! Failed to get instance status: {}", e.getMessage(), e);
-            throw new TestFailException("Wait operation timed out! Failed to get instance status", e);
-        }
+        InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
+        InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
+        String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
+        String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
+        throw new TestFailException(String.format("Wait operation timed out! '%s' instance group termination failed. Instance status: '%s' " +
+                "statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
     }
 
     @Override
@@ -68,25 +52,28 @@ public class InstanceTerminationChecker<T extends InstanceWaitObject> extends Ex
 
     @Override
     public boolean exitWaiting(T waitObject) {
-        try {
-            waitObject.fetchData();
-            if (waitObject.isDeleteFailed()) {
-                return false;
-            }
-            return waitObject.isFailed();
-
-        } catch (ProcessingException clientException) {
-            LOGGER.error("Exit waiting! Failed to get instance group due to API client exception: {}", clientException.getMessage(), clientException);
-        } catch (Exception e) {
-            LOGGER.warn("Exit waiting! Failed to get instance group, because of: {}", e.getMessage(), e);
-            return true;
+        if (waitObject.isDeleteFailed()) {
+            return false;
         }
-        return false;
+        return waitObject.isFailed();
     }
 
     @Override
     public Map<String, String> getStatuses(T waitObject) {
-        waitObject.fetchData();
-        return waitObject.actualStatuses();
+        return deleted ? waitObject.getDesiredStatuses() : waitObject.actualStatuses();
+    }
+
+    @Override
+    public void refresh(T waitObject) {
+        String hostGroup = waitObject.getHostGroup();
+        try {
+            waitObject.fetchData();
+        } catch (NoSuchElementException e) {
+            LOGGER.warn("{} instance group is not present, may this was deleted.", hostGroup, e);
+            deleted = true;
+        } catch (Exception e) {
+            LOGGER.error("'{}' instance group deletion has been failed, because of: {}", hostGroup, e.getMessage(), e);
+            throw new TestFailException(String.format("'%s' instance group deletion has been failed", hostGroup), e);
+        }
     }
 }


### PR DESCRIPTION
While WaitService waits for a certain criteria to be met (depedning on StatusChecker implementation), it should refresh its data only once per round. This way we can not encounter an edge case where a check runs on different data then the check before it, causing changes to not handled properly.

See detailed description in the commit message.