### PR TITLE
DISTX-564 DE HA Template has been updated for production workloads.

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-ha.json
@@ -17,12 +17,19 @@
       "type": "GATEWAY",
       "recoveryMode": "MANUAL",
       "template": {
-        "aws": {},
-        "instanceType": "m5.2xlarge",
+        "aws": {
+          "placementGroup" : {
+            "strategy" : "PARTITION"
+          }
+        },
+        "instanceType": "m5.4xlarge",
+        "rootVolume": {
+          "size": 150
+        },
         "attachedVolumes": [{
-          "size": 100,
+          "size": 150,
           "count": 1,
-          "type": "standard"
+          "type": "gp2"
         }],
         "cloudPlatform": "AWS"
       },
@@ -35,11 +42,11 @@
         "recoveryMode": "MANUAL",
         "template": {
           "aws": {},
-          "instanceType": "m5.2xlarge",
+          "instanceType": "m5.4xlarge",
           "attachedVolumes": [{
-            "size": 100,
+            "size": 150,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },
@@ -52,11 +59,14 @@
         "recoveryMode": "MANUAL",
         "template": {
           "aws": {},
-          "instanceType": "m5.2xlarge",
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
-            "size": 100,
+            "size": 150,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },
@@ -68,12 +78,19 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "aws": {},
-          "instanceType": "m5.2xlarge",
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
-            "size": 100,
+            "size": 500,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },
@@ -85,12 +102,19 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "aws": {},
-          "instanceType": "m5.2xlarge",
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
-            "size": 100,
+            "size": 150,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering-ha.json
@@ -25,10 +25,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -44,17 +47,14 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "azure": {
-            "availabilitySet": {
-              "name": "",
-              "faultDomainCount": 2,
-              "updateDomainCount": 20
-            }
+          "azure": {},
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
           },
-          "instanceType": "Standard_D8_v3",
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -77,10 +77,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 500,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -103,10 +106,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -128,10 +134,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-ha.json
@@ -18,12 +18,19 @@
       "type": "CORE",
       "recoveryMode": "MANUAL",
       "template": {
-        "aws": {},
-        "instanceType": "m5.2xlarge",
+        "aws": {
+          "placementGroup" : {
+            "strategy" : "PARTITION"
+          }
+        },
+        "instanceType": "m5.4xlarge",
+        "rootVolume": {
+          "size": 150
+        },
         "attachedVolumes": [{
-          "size": 100,
+          "size": 150,
           "count": 1,
-          "type": "standard"
+          "type": "gp2"
         }],
         "cloudPlatform": "AWS"
       },
@@ -36,11 +43,14 @@
         "recoveryMode": "MANUAL",
         "template": {
           "aws": {},
-          "instanceType": "m5.2xlarge",
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
-            "size": 100,
+            "size": 150,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },
@@ -53,11 +63,14 @@
         "recoveryMode": "MANUAL",
         "template": {
           "aws": {},
-          "instanceType": "m5.2xlarge",
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
-            "size": 100,
+            "size": 150,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },
@@ -69,12 +82,19 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "aws": {},
-          "instanceType": "m5.2xlarge",
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
-            "size": 100,
+            "size": 500,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },
@@ -86,12 +106,19 @@
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",
         "template": {
-          "aws": {},
-          "instanceType": "m5.2xlarge",
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
-            "size": 100,
+            "size": 150,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering-ha.json
@@ -25,10 +25,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -44,17 +47,14 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "azure": {
-            "availabilitySet": {
-              "name": "",
-              "faultDomainCount": 2,
-              "updateDomainCount": 20
-            }
+          "azure": {},
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
           },
-          "instanceType": "Standard_D8_v3",
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -77,10 +77,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 500,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -103,10 +106,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -128,10 +134,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-ha.json
@@ -17,12 +17,19 @@
       "type": "GATEWAY",
       "recoveryMode": "MANUAL",
       "template": {
-        "aws": {},
-        "instanceType": "m5.2xlarge",
+        "aws": {
+          "placementGroup" : {
+            "strategy" : "PARTITION"
+          }
+        },
+        "instanceType": "m5.4xlarge",
+        "rootVolume": {
+          "size": 150
+        },
         "attachedVolumes": [{
-          "size": 100,
+          "size": 150,
           "count": 1,
-          "type": "standard"
+          "type": "gp2"
         }],
         "cloudPlatform": "AWS"
       },
@@ -35,11 +42,11 @@
         "recoveryMode": "MANUAL",
         "template": {
           "aws": {},
-          "instanceType": "m5.2xlarge",
+          "instanceType": "m5.4xlarge",
           "attachedVolumes": [{
-            "size": 100,
+            "size": 150,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },
@@ -52,11 +59,14 @@
         "recoveryMode": "MANUAL",
         "template": {
           "aws": {},
-          "instanceType": "m5.2xlarge",
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
-            "size": 100,
+            "size": 150,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },
@@ -68,12 +78,19 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "aws": {},
-          "instanceType": "m5.2xlarge",
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
-            "size": 100,
+            "size": 500,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },
@@ -85,12 +102,19 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "aws": {},
-          "instanceType": "m5.2xlarge",
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
-            "size": 100,
+            "size": 150,
             "count": 1,
-            "type": "standard"
+            "type": "gp2"
           }],
           "cloudPlatform": "AWS"
         },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering-ha.json
@@ -25,10 +25,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -44,17 +47,14 @@
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
-          "azure": {
-            "availabilitySet": {
-              "name": "",
-              "faultDomainCount": 2,
-              "updateDomainCount": 20
-            }
+          "azure": {},
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
           },
-          "instanceType": "Standard_D8_v3",
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -77,10 +77,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 500,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -103,10 +106,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }
@@ -128,10 +134,13 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3",
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [
             {
-              "size": 100,
+              "size": 150,
               "count": 1,
               "type": "StandardSSD_LRS"
             }


### PR DESCRIPTION
1. Manager, Master, Compute, Gateway : Root Volume increased to 150gb, attached volume increased to 150gb ssd
2. Worker : Root Volume increased to 150gb, attached volume increased to 500gb ssd (1.5TB for 3 workers)
3. Manager, Master, Gateway, Worker, Compute upgraded to 64 GB Machines
4. AWS Manager, Worker, Master HostGroups configured with AWS Placement Settings.
5. Azure  Availability Set definition for Compute HostGroup removed since Compute is expected to scale beyond 200.
6. Above changes applied in 7.2.8, 7.2.9 and 7.2.10 templates.

See detailed description in the commit message.