### PR TITLE
CB-10578 Populate new targetgroup_loadbalancer table from CB-10095

### DIFF
--- a/core/src/main/resources/schema/app/20210308153508_CB-10578_Populate_new_targetgroup_loadbalancer_table.sql
+++ b/core/src/main/resources/schema/app/20210308153508_CB-10578_Populate_new_targetgroup_loadbalancer_table.sql
@@ -1,0 +1,12 @@
+-- // CB-10578 Populate new targetgroup_loadbalancer table
+-- Migration SQL that makes the change goes here.
+
+INSERT INTO targetgroup_loadbalancer (
+    SELECT id, loadbalancer_id FROM targetgroup
+    WHERE id IS NOT NULL AND loadbalancer_id IS NOT NULL)
+ON CONFLICT DO NOTHING;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+


### PR DESCRIPTION
This is the second version of this logic. The first version ran into a problem when the targetgroup
table had a null loadbalancer_id, and was reverted. This new logic skips any entries that have a
null value.

Tested by creating a row in the targetgroup table with a null loadbalancer_id, and running the new
sql script to verify it was successful and migrated all non-null values.