### PR TITLE
CB-11231 GCP : Adding external database for dataengineering ha

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-ha.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "7.2.10 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [
       {
         "name": "manager",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering-ha.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "7.2.7 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [
       {
         "name": "manager",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-ha.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "7.2.8 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [
       {
         "name": "manager",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-ha.json
@@ -8,6 +8,9 @@
     "cluster": {
       "blueprintName": "7.2.9 - Data Engineering: HA: Apache Spark, Apache Hive, Apache Oozie"
     },
+    "externalDatabase": {
+      "availabilityType": "HA"
+    },
     "instanceGroups": [
       {
         "name": "manager",


### PR DESCRIPTION
1. I missed this setting during the definition creation.
2. This is already used by flow management HD template in GCP.