### PR TITLE
CDPD-19363:set tez.runtime.pipelined.sorter.lazy-allocate.memory to t…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
@@ -365,7 +365,13 @@
           {
             "refName": "tez-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
@@ -236,7 +236,13 @@
           {
             "refName": "tez-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
@@ -226,7 +226,13 @@
           {
             "refName": "tez-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                 "name": "tez-conf/tez-site.xml_client_config_safety_valve",
+                 "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
tez.runtime.pipelined.sorter.lazy-allocate.memory is set to true by default in 7.2.10 templates, The change was already made for 7.2.8 and 7.2.9 templates are part of this PR: https://github.com/hortonworks/cloudbreak/pull/10135
 