### PR TITLE
CB-11458 When starting the datahub delete flow, the user is not popul…

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/security/authentication/AuthenticatedUserService.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/security/authentication/AuthenticatedUserService.java
@@ -36,14 +36,6 @@ public class AuthenticatedUserService {
         return cbUser.getTenant();
     }
 
-    public String getUserCrn() {
-        CloudbreakUser cbUser = getCbUser();
-        if (cbUser == null) {
-            throw new IllegalStateException("No authentication found in the SecurityContextHolder!");
-        }
-        return cbUser.getUserCrn();
-    }
-
     public String getTokenValue(Authentication auth) {
         return ((CrnUser) auth.getPrincipal()).getUserCrn();
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/CbEventParameterFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/CbEventParameterFactory.java
@@ -2,38 +2,25 @@ package com.sequenceiq.cloudbreak.core.flow2.service;
 
 import java.util.Map;
 
-import javax.inject.Inject;
-
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.auth.security.authentication.AuthenticatedUserService;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.flow.core.EventParameterFactory;
 import com.sequenceiq.flow.core.FlowConstants;
 
 @Component
 public class CbEventParameterFactory implements EventParameterFactory {
 
-    @Inject
-    private StackService stackService;
-
-    @Inject
-    private AuthenticatedUserService authenticatedUserService;
-
+    @Override
     public Map<String, Object> createEventParameters(Long stackId) {
-        String userCrn = getUserCrn(stackId);
+        String userCrn = getUserCrn();
         return Map.of(FlowConstants.FLOW_TRIGGER_USERCRN, userCrn);
     }
 
-    private String getUserCrn(Long stackId) {
-        String userCrn;
-        try {
-            userCrn = authenticatedUserService.getUserCrn();
-        } catch (RuntimeException ex) {
-            userCrn = stackService.findById(stackId).map(Stack::getCreator).map(User::getUserCrn)
-                    .orElseThrow(() -> new IllegalStateException("No authentication found neither in the SecurityContextHolder nor in the Stack!"));
+    private String getUserCrn() {
+        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
+        if (userCrn == null) {
+            throw new IllegalStateException("Cannot get user crn!");
         }
         return userCrn;
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/service/CbEventParameterFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/service/CbEventParameterFactoryTest.java
@@ -1,22 +1,15 @@
 package com.sequenceiq.cloudbreak.core.flow2.service;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
 
 import java.util.Map;
-import java.util.Optional;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.sequenceiq.cloudbreak.TestUtil;
-import com.sequenceiq.cloudbreak.auth.security.authentication.AuthenticatedUserService;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sequenceiq.cloudbreak.workspace.model.User;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.flow.core.FlowConstants;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -24,47 +17,25 @@ public class CbEventParameterFactoryTest {
 
     private static final String CRN = "crn";
 
-    @Mock
-    private StackService stackService;
-
-    @Mock
-    private AuthenticatedUserService authenticatedUserService;
-
     @InjectMocks
     private CbEventParameterFactory underTest;
 
     @Test
     public void testUserServiceReturnCrn() {
-        when(authenticatedUserService.getUserCrn()).thenReturn(CRN);
+        ThreadBasedUserCrnProvider.doAs(CRN, () -> {
+            Map<String, Object> eventParameters = underTest.createEventParameters(1L);
 
-        Map<String, Object> eventParameters = underTest.createEventParameters(1L);
-
-        assertEquals(1, eventParameters.size());
-        assertEquals(CRN, eventParameters.get(FlowConstants.FLOW_TRIGGER_USERCRN));
-    }
-
-    @Test
-    public void testStackServiceReturnCrn() {
-        when(authenticatedUserService.getUserCrn()).thenThrow(new RuntimeException());
-        Stack stack = TestUtil.stack();
-        User creator = new User();
-        creator.setUserCrn(CRN);
-        stack.setCreator(creator);
-        when(stackService.findById(1L)).thenReturn(Optional.of(stack));
-
-        Map<String, Object> eventParameters = underTest.createEventParameters(1L);
-
-        assertEquals(1, eventParameters.size());
-        assertEquals(CRN, eventParameters.get(FlowConstants.FLOW_TRIGGER_USERCRN));
+            assertEquals(1, eventParameters.size());
+            assertEquals(CRN, eventParameters.get(FlowConstants.FLOW_TRIGGER_USERCRN));
+        });
     }
 
     @Test(expected = IllegalStateException.class)
     public void testNoCrn() {
-        when(authenticatedUserService.getUserCrn()).thenThrow(new RuntimeException());
-        when(stackService.findById(1L)).thenReturn(Optional.empty());
+        ThreadBasedUserCrnProvider.doAs(null, () -> {
+            Map<String, Object> eventParameters = underTest.createEventParameters(1L);
 
-        Map<String, Object> eventParameters = underTest.createEventParameters(1L);
-
-        assertEquals(0, eventParameters.size());
+            assertEquals(0, eventParameters.size());
+        });
     }
 }


### PR DESCRIPTION
…ated into the security context, trigggering the fallback logic to stack creator. In the flow we are calling authenticated APIs (e.g. get env by crn) that fail to authenticate the deleted user, causing the flow to fail. In this PR I have removed the legacy authenticatedUserService and changed to ThreadBasedUserCrnProvider

See detailed description in the commit message.