### PR TITLE
Revert "CB-6425 use salt to fetch reachable nodes instead of our instancemetadata states"

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
@@ -34,10 +34,8 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.dto.credential.Credential;
-import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
 import com.sequenceiq.cloudbreak.orchestrator.model.NodeVolumes;
-import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialClientService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
@@ -60,12 +58,6 @@ public class StackUtil {
     @Inject
     private LoadBalancerConfigService loadBalancerConfigService;
 
-    @Inject
-    private HostOrchestrator hostOrchestrator;
-
-    @Inject
-    private GatewayConfigService gatewayConfigService;
-
     public Set<Node> collectNodes(Stack stack) {
         Set<Node> agents = new HashSet<>();
         for (InstanceGroup instanceGroup : stack.getInstanceGroups()) {
@@ -84,7 +76,18 @@ public class StackUtil {
     }
 
     public Set<Node> collectReachableNodes(Stack stack) {
-        return hostOrchestrator.getResponsiveNodes(collectNodes(stack), gatewayConfigService.getPrimaryGatewayConfig(stack));
+        return stack.getInstanceGroups()
+                .stream()
+                .filter(ig -> ig.getNodeCount() != 0)
+                .flatMap(ig -> ig.getReachableInstanceMetaDataSet().stream())
+                .filter(im -> im.getDiscoveryFQDN() != null)
+                .map(im -> {
+                    String instanceId = im.getInstanceId();
+                    String instanceType = im.getInstanceGroup().getTemplate().getInstanceType();
+                    return new Node(im.getPrivateIp(), im.getPublicIp(), instanceId, instanceType,
+                            im.getDiscoveryFQDN(), im.getInstanceGroupName());
+                })
+                .collect(Collectors.toSet());
     }
 
     public Set<Node> collectNodesFromHostnames(Stack stack, Set<String> hostnames) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/util/StackUtilTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/util/StackUtilTest.java
@@ -1,47 +1,33 @@
 package com.sequenceiq.cloudbreak.util;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.converter.spi.CredentialToCloudCredentialConverter;
 import com.sequenceiq.cloudbreak.domain.Resource;
-import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.dto.credential.Credential;
-import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
-import com.sequenceiq.cloudbreak.orchestrator.model.Node;
-import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.environment.credential.CredentialClientService;
 import com.sequenceiq.common.api.type.ResourceType;
 
@@ -55,15 +41,6 @@ public class StackUtilTest {
 
     @Mock
     private ResourceAttributeUtil resourceAttributeUtil;
-
-    @Mock
-    private HostOrchestrator hostOrchestrator;
-
-    @Mock
-    private GatewayConfigService gatewayConfigService;
-
-    @Captor
-    private ArgumentCaptor<Set<Node>> nodesCaptor;
 
     @InjectMocks
     private final StackUtil stackUtil = new StackUtil();
@@ -140,40 +117,6 @@ public class StackUtilTest {
 
         int numberOfVolumeSetsWithoutInstanceReference = 2;
         assertEquals(volumeSets.size() - numberOfVolumeSetsWithoutInstanceReference, actual.size());
-    }
-
-    @Test
-    public void collectReachableNodesTest() {
-        Stack stack = new Stack();
-        Set<InstanceGroup> instanceGroupSet = new HashSet<>();
-        InstanceGroup instanceGroup = new InstanceGroup();
-        Set<InstanceMetaData> instanceMetaDataSet = new HashSet<>();
-        InstanceMetaData instanceMetaData1 = new InstanceMetaData();
-        instanceMetaData1.setInstanceGroup(instanceGroup);
-        instanceMetaData1.setDiscoveryFQDN("node1.example.com");
-        InstanceMetaData instanceMetaData2 = new InstanceMetaData();
-        instanceMetaData2.setInstanceStatus(InstanceStatus.TERMINATED);
-        instanceMetaData2.setInstanceGroup(instanceGroup);
-        instanceMetaData2.setDiscoveryFQDN("node2.example.com");
-        InstanceMetaData instanceMetaData3 = new InstanceMetaData();
-        instanceMetaData3.setInstanceGroup(instanceGroup);
-        instanceMetaData3.setDiscoveryFQDN("node3.example.com");
-        instanceMetaDataSet.add(instanceMetaData1);
-        instanceMetaDataSet.add(instanceMetaData2);
-        instanceMetaDataSet.add(instanceMetaData3);
-        instanceGroup.setInstanceMetaData(instanceMetaDataSet);
-        Template template = new Template();
-        template.setInstanceType("m5.xlarge");
-        instanceGroup.setTemplate(template);
-        instanceGroupSet.add(instanceGroup);
-        stack.setInstanceGroups(instanceGroupSet);
-        stackUtil.collectReachableNodes(stack);
-
-        verify(hostOrchestrator).getResponsiveNodes(nodesCaptor.capture(), any());
-        List<String> fqdns = nodesCaptor.getValue().stream().map(Node::getHostname).collect(Collectors.toList());
-        assertTrue(fqdns.contains("node1.example.com"));
-        assertFalse("Terminated node should be filtered out", fqdns.contains("node2.example.com"));
-        assertTrue(fqdns.contains("node3.example.com"));
     }
 
     private Resource getVolumeSetResource(String instanceID) {

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -55,8 +55,6 @@ public interface HostOrchestrator extends HostRecipeExecutor {
 
     List<String> getAvailableNodes(GatewayConfig gatewayConfig, Set<Node> nodes);
 
-    Set<Node> getResponsiveNodes(Set<Node> nodes, GatewayConfig gatewayConfig);
-
     void tearDown(List<GatewayConfig> allGatewayConfigs, Map<String, String> removeNodePrivateIPsByFQDN,
             Set<Node> remainingNodes, ExitCriteriaModel exitModel) throws CloudbreakOrchestratorException;
 

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -964,13 +964,6 @@ SaltOrchestrator implements HostOrchestrator {
     }
 
     @Override
-    public Set<Node> getResponsiveNodes(Set<Node> nodes, GatewayConfig gatewayConfig) {
-        try (SaltConnector saltConnector = saltService.createSaltConnector(gatewayConfig)) {
-            return getResponsiveNodes(nodes, saltConnector);
-        }
-    }
-
-    @Override
     public boolean isBootstrapApiAvailable(GatewayConfig gatewayConfig) {
         try (SaltConnector saltConnector = saltService.createSaltConnector(gatewayConfig)) {
             if (saltConnector.health().getStatusCode() == HttpStatus.OK.value()) {
@@ -1199,8 +1192,6 @@ SaltOrchestrator implements HostOrchestrator {
                 if (minionIpAddressesResponse.getAllIpAddresses().contains(node.getPrivateIp())) {
                     LOGGER.info("Salt-minion is responding on host: {}", node);
                     responsiveNodes.add(node);
-                } else {
-                    LOGGER.warn("Salt-minion is not responding on host: {}", node);
                 }
             });
         } else {


### PR DESCRIPTION
This reverts commit 4b3af7e36787ff54a7640794439d17a224b22c83.