### PR TITLE
DISTX-575:Use gp2 storages for AWS

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-spark3.json
@@ -16,7 +16,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -37,7 +37,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -58,7 +58,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering.json
@@ -16,7 +16,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -37,7 +37,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -58,7 +58,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -79,7 +79,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-spark3.json
@@ -16,7 +16,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -37,7 +37,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -58,7 +58,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering.json
@@ -16,7 +16,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -37,7 +37,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -58,7 +58,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -79,7 +79,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-spark3.json
@@ -16,7 +16,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -37,7 +37,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -58,7 +58,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering.json
@@ -16,7 +16,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -37,7 +37,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -58,7 +58,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {
@@ -79,7 +79,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "standard"
+              "type": "gp2"
             }
           ],
           "aws": {


### PR DESCRIPTION
The default disk types that are launched with cluster templates are changed to gp2. Screenshot below for the same:

![image](https://user-images.githubusercontent.com/7271603/110588604-40ae2280-819b-11eb-9e6b-09b21dade678.png)
The change is made for 7.2.8,7.2.9.7.2.10 for DE and DE-spark3 templates. I see the changes were already being made for DE-HA templates as part of this PR: https://github.com/hortonworks/cloudbreak/pull/10205/files