### PR TITLE
CB-10577: Removed medium duty and loadbalancer entitlement checks for AWS.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
@@ -42,6 +42,8 @@ import com.sequenceiq.common.api.type.TargetGroupType;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
+
 @Service
 public class LoadBalancerConfigService {
 
@@ -245,7 +247,12 @@ public class LoadBalancerConfigService {
     private boolean isLoadBalancerEnabledForDatalake(StackType type, DetailedEnvironmentResponse environment) {
         return StackType.DATALAKE.equals(type) && environment != null &&
             (entitlementService.datalakeLoadBalancerEnabled(ThreadBasedUserCrnProvider.getAccountId()) ||
+                isLoadBalancerEntitlementNotRequiredForCloudProvider(environment.getCloudPlatform()) ||
                 isEndpointGatewayEnabled(environment.getNetwork()));
+    }
+
+    private boolean isLoadBalancerEntitlementNotRequiredForCloudProvider(String cloudPlatform) {
+        return AWS.equalsIgnoreCase(cloudPlatform);
     }
 
     private boolean isLoadBalancerEnabledForDatahub(StackType type, DetailedEnvironmentResponse environment) {


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-10577

This is meant to remove the check for the CDP_MEDIUM_DUTY_SDX and CDP_DATA_LAKE_LOAD_BALANCER entitlements during the datalake provisioning process if the cloud provider is AWS, it still checks for these entitlements otherwise.

Specifically, this will result in all AWS datalake provisions being set up with an accompanying loadbalancer, and globally enable medium duty setups for everyone.

I went through and added some unit tests to make sure this is working as expected.
