### PR TITLE
CB-11420 Handle ContextClosedEvent event and shutdown eventBusThreadP…

### DIFF
--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/testcontext/TestApplicationContext.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/testcontext/TestApplicationContext.java
@@ -57,12 +57,13 @@ import com.sequenceiq.cloudbreak.cloud.service.ResourceRetriever;
 import com.sequenceiq.cloudbreak.grpc.ManagedChannelWrapper;
 import com.sequenceiq.common.api.type.ResourceType;
 import com.sequenceiq.flow.core.ApplicationFlowInformation;
+import com.sequenceiq.flow.core.FlowRegister;
 import com.sequenceiq.flow.service.flowlog.FlowLogDBService;
 
 import io.opentracing.Tracer;
 import reactor.Environment;
 
-@MockBeans({@MockBean(ApplicationFlowInformation.class), @MockBean(FlowLogDBService.class)})
+@MockBeans({@MockBean(ApplicationFlowInformation.class), @MockBean(FlowLogDBService.class), @MockBean(FlowRegister.class)})
 @Configuration
 @ComponentScans({ @ComponentScan("com.sequenceiq.cloudbreak.cloud"), @ComponentScan("com.sequenceiq.flow.reactor"),
         @ComponentScan("com.sequenceiq.cloudbreak.auth"), @ComponentScan("com.sequenceiq.cloudbreak.client")})

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/AppConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/AppConfig.java
@@ -63,8 +63,6 @@ import io.opentracing.Tracer;
 public class AppConfig implements ResourceLoaderAware {
     private static final Logger LOGGER = LoggerFactory.getLogger(AppConfig.class);
 
-    private static final int AWAIT_TERMINATION_SECONDS = 60;
-
     @Value("${cb.etc.config.dir:}")
     private String etcConfigDir;
 
@@ -77,11 +75,17 @@ public class AppConfig implements ResourceLoaderAware {
     @Value("${cb.threadpool.capacity.size:}")
     private int queueCapacity;
 
+    @Value("${cb.threadpool.termination.seconds:60}")
+    private int awaitTerminationSeconds;
+
     @Value("${cb.intermediate.threadpool.core.size:}")
     private int intermediateCorePoolSize;
 
     @Value("${cb.intermediate.threadpool.capacity.size:}")
     private int intermediateQueueCapacity;
+
+    @Value("${cb.intermediate.threadpool.termination.seconds:60}")
+    private int intermediateAwaitTerminationSeconds;
 
     @Value("${rest.debug}")
     private boolean restDebug;
@@ -186,7 +190,7 @@ public class AppConfig implements ResourceLoaderAware {
         executor.setThreadNamePrefix("intermediateBuilderExecutor-");
         executor.setTaskDecorator(new TracingAndMdcCopyingTaskDecorator(tracer));
         executor.setWaitForTasksToCompleteOnShutdown(true);
-        executor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS);
+        executor.setAwaitTerminationSeconds(intermediateAwaitTerminationSeconds);
         executor.initialize();
         return executor;
     }
@@ -199,7 +203,7 @@ public class AppConfig implements ResourceLoaderAware {
         executor.setThreadNamePrefix("resourceBuilderExecutor-");
         executor.setTaskDecorator(new TracingAndMdcCopyingTaskDecorator(tracer));
         executor.setWaitForTasksToCompleteOnShutdown(true);
-        executor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS);
+        executor.setAwaitTerminationSeconds(awaitTerminationSeconds);
         executor.initialize();
         return executor;
     }

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/ContextClosedEventHandler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/ContextClosedEventHandler.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.flow.reactor;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.logger.concurrent.MDCCleanerThreadPoolExecutor;
+import com.sequenceiq.flow.core.FlowRegister;
+
+@Component
+public class ContextClosedEventHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContextClosedEventHandler.class);
+
+    @Value("${cb.eventbus.threadpool.shutdown.timeout.seconds:15}")
+    private long eventBusThreadpoolShutdownTimeout;
+
+    @Inject
+    private FlowRegister flowRegister;
+
+    @Inject
+    @Named("eventBusThreadPoolExecutor")
+    private MDCCleanerThreadPoolExecutor executor;
+
+    @EventListener
+    public void handleContextClosedEvent(ContextClosedEvent event) {
+        LOGGER.info("ContextClosedEvent received, shutdown eventBusThreadPoolExecutor. Running flows: {}", flowRegister.getRunningFlowIds());
+        shutdownEventBusThreadPoolExecutor();
+    }
+
+    private void shutdownEventBusThreadPoolExecutor() {
+        executor.shutdownNow();
+        try {
+            if (!executor.awaitTermination(eventBusThreadpoolShutdownTimeout, TimeUnit.SECONDS)) {
+                LOGGER.warn("eventBusThreadPoolExecutor shutdown timed out.");
+            }
+        } catch (InterruptedException e) {
+            LOGGER.warn("eventBusThreadPoolExecutor shutdown is interrupted.", e);
+            Thread.currentThread().interrupt();
+        }
+    }
+
+}

--- a/flow/src/test/java/com/sequenceiq/flow/reactor/ContextClosedEventHandlerTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/reactor/ContextClosedEventHandlerTest.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.flow.reactor;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import com.sequenceiq.cloudbreak.common.metrics.AbstractMetricService;
+import com.sequenceiq.cloudbreak.logger.concurrent.MDCCleanerThreadPoolExecutor;
+import com.sequenceiq.flow.core.FlowRegister;
+import com.sequenceiq.flow.reactor.config.EventBusConfig;
+
+class ContextClosedEventHandlerTest {
+
+    @Test
+    public void tetsHandleContextClosedEventShouldStopExecutor() {
+        ConfigurableApplicationContext applicationContext = new AnnotationConfigApplicationContext(EventBusConfig.class, ContextClosedEventHandler.class,
+                FlowRegister.class, TestMetricService.class);
+
+        MDCCleanerThreadPoolExecutor eventBusThreadPoolExecutor = applicationContext.getBean("eventBusThreadPoolExecutor", MDCCleanerThreadPoolExecutor.class);
+        Assertions.assertFalse(eventBusThreadPoolExecutor.isShutdown());
+
+        applicationContext.close();
+
+        Assertions.assertTrue(eventBusThreadPoolExecutor.isShutdown());
+    }
+
+    @TestComponent
+    public static class TestMetricService extends AbstractMetricService {
+
+        @Override
+        protected String getMetricPrefix() {
+            return "test";
+        }
+    }
+
+}


### PR DESCRIPTION
…oolExecutor before Spring starts to destroy beans during shutdown.

Without this commit, Spring could destroy beans before reactor threads stops which can lead to an exception and the fail handler of the flow would set flow state to FAILED.

See detailed description in the commit message.