### PR TITLE
DISTX-585 Autoscaling trigger failure should be made available in history events.

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/common/MessageCode.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/common/MessageCode.java
@@ -20,6 +20,8 @@ public class MessageCode {
 
     public static final String AUTOSCALING_ACTIVITY_SUCCESS = "autoscale.activity.success";
 
+    public static final String AUTOSCALING_TRIGGER_FAILURE = "autoscale.trigger.failure";
+
     public static final String SCHEDULE_CONFIG_OVERLAPS = "autoscale.schedule.config.overlap";
 
     public static final String CLUSTER_EXISTS_FOR_CRN = "autoscale.cluster.exists.for.crn";

--- a/autoscale-api/src/main/resources/messages/messages.properties
+++ b/autoscale-api/src/main/resources/messages/messages.properties
@@ -24,3 +24,5 @@ autoscale.validation.time.negative.adjustment=Schedule-Based Autoscaling Node Co
 
 autoscale.notification.history.update=Autoscaling History Updated
 autoscale.notification.config.update=Autoscaling Config Updated
+
+autoscale.trigger.failure=Autoscaling Trigger Failed. Please verify Cluster Connectivity and Environment User(s) Synchronization.


### PR DESCRIPTION
Autoscaling trigger failure should be made available in history events.