### PR TITLE
CB-11368 - [Knox] Add replayBufferSize to HIVE and RANGERUI services

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -452,6 +452,10 @@
         {% for hostloc in salt['pillar.get']('gateway:location')['RANGER_ADMIN'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['RANGER'] }}</url>
         {%- endfor %}
+        <param>
+             <name>replayBufferSize</name>
+             <value>128</value>
+        </param>
     </service>
     {%- endif %}
     {%- endif %}
@@ -463,6 +467,10 @@
         {% for hostloc in salt['pillar.get']('gateway:location')['HIVESERVER2'] -%}
         <url>{{ protocol }}://{{ hostloc }}:{{ ports['HIVE'] }}/cliservice</url>
         {%- endfor %}
+        <param>
+            <name>replayBufferSize</name>
+            <value>128</value>
+        </param>
     </service>
     {%- endif %}
     {%- endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -312,6 +312,10 @@
             <name>httpclient.socketTimeout</name>
             <value>5m</value>
         </param>
+        <param>
+             <name>replayBufferSize</name>
+             <value>128</value>
+        </param>
     </service>
     {%- endif %}
     {%- endif %}


### PR DESCRIPTION
This is related to https://jira.cloudera.com/browse/CB-11368
This fix will increase the buffer size for HIVE and RANGERUI services.