### PR TITLE
CB-11528 Set HBase umask overrides in the data lake to 007

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx-medium-ha.bp
@@ -285,6 +285,10 @@
           {
             "name": "service_config_suppression_hadoop_secure_web_ui",
             "value": "true"
+          },
+          {
+            "name": "hbase_service_config_safety_valve",
+            "value": "<property><name>hbase.data.umask.enable</name><value>true</value></property><property><name>hbase.data.umask</name><value>007</value></property>"
           }
         ],
         "serviceType": "HBASE"

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx.bp
@@ -229,6 +229,10 @@
           {
             "name": "service_config_suppression_hadoop_secure_web_ui",
             "value": "true"
+          },
+          {
+            "name": "hbase_service_config_safety_valve",
+            "value": "<property><name>hbase.data.umask.enable</name><value>true</value></property><property><name>hbase.data.umask</name><value>007</value></property>"
           }
         ],
         "serviceType": "HBASE"


### PR DESCRIPTION
HBase data in the datalake is stored on HDFS. However, by default
the HDFS data is readable by the world! This presents a security risk.
This change overrides the HBase umask value to 007 which sets the
HBase file permissions to rwx------ by default.

See detailed description in the commit message.