### PR TITLE
CB-11527 Fix cannot find class listfiltering.ImageCatalogListFiltering

### DIFF
--- a/integration-test/src/main/resources/testsuites/v4/mock/real-ums-mock-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/v4/mock/real-ums-mock-tests.yaml
@@ -14,5 +14,5 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.authorization.listfiltering.DataLakeListFilteringTest
       - name: com.sequenceiq.it.cloudbreak.testcase.authorization.listfiltering.EnvironmentListFilteringTest
       - name: com.sequenceiq.it.cloudbreak.testcase.authorization.listfiltering.FreeIpaListFilteringTest
-      - name: com.sequenceiq.it.cloudbreak.testcase.authorization.listfiltering.ImageCatalogListFiltering
+      - name: com.sequenceiq.it.cloudbreak.testcase.authorization.listfiltering.ImageCatalogListFilteringTest
       - name: com.sequenceiq.it.cloudbreak.testcase.authorization.listfiltering.RecipeListFilteringTest


### PR DESCRIPTION
Test ApplicationContext cannot be started at [cloudbreak-real-ums-authz-tests](http://ci-cloudbreak.eng.hortonworks.com/job/cloudbreak-real-ums-authz-tests/), because of: `Cannot find class in classpath: com.sequenceiq.it.cloudbreak.testcase.authorization.listfiltering.ImageCatalogListFiltering`.

ImageCatalogListFiltering reference is present at the test suite: [cloudbreak/integration-test/src/main/resources/testsuites/v4/mock/real-ums-mock-tests.yaml](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/resources/testsuites/v4/mock/real-ums-mock-tests.yaml). However the correct file name is [cloudbreak/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/listfiltering/ImageCatalogListFilteringTest.java](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/authorization/listfiltering/ImageCatalogListFilteringTest.java)
So the
```
- name: com.sequenceiq.it.cloudbreak.testcase.authorization.listfiltering.ImageCatalogListFiltering
```
should be fixed by the correct name
```
- name: com.sequenceiq.it.cloudbreak.testcase.authorization.listfiltering.ImageCatalogListFilteringTest
```