### PR TITLE
CB-11530 Upload freeipa-client dependencies to nexus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -225,7 +225,7 @@ subprojects {
   task('buildInfo', type: BuildInfoTask, dependsOn: processResources)
 
   afterEvaluate { Project project ->
-    if (project.name in ['core', 'autoscale', 'freeipa', 'redbeams', 'environment', 'datalake', 'integration-test'] && project.plugins.hasPlugin('org.springframework.boot')) {
+    if (project.name in ['core', 'autoscale', 'freeipa', 'redbeams', 'environment', 'datalake', 'integration-test', 'common'] && project.plugins.hasPlugin('org.springframework.boot')) {
       buildInfo.configure {
         destination = file("$project.buildDir")
         basename = project.bootJar.baseName

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,6 +11,17 @@ repositories {
   maven { url "https://plugins.gradle.org/m2/" }
 }
 
+uploadBootArchives {
+  repositories {
+    mavenDeployer {
+      configuration = configurations.deployerJars
+      repository(url: "$System.env.NEXUS_URL") {
+        authentication(userName: "$System.env.NEXUS_USER", password: "$System.env.NEXUS_PASSWORD")
+      }
+    }
+  }
+}
+
 jar {
   baseName = 'common'
 }

--- a/freeipa-client/build.gradle
+++ b/freeipa-client/build.gradle
@@ -35,5 +35,4 @@ dependencies {
   compile            group: 'org.springframework.boot',         name: 'spring-boot-starter-web',     version: springBootVersion
 
   implementation project(':common')
-  implementation project(':cluster-proxy')
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -17,14 +17,14 @@ import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.sequenceiq.freeipa.client.clusterproxy.ClusterProxyError;
+import com.sequenceiq.freeipa.client.clusterproxy.ClusterProxyException;
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
 import com.googlecode.jsonrpc4j.JsonRpcHttpClient;
-import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyError;
-import com.sequenceiq.cloudbreak.clusterproxy.ClusterProxyException;
 import com.sequenceiq.cloudbreak.tracing.TracingUtil;
 import com.sequenceiq.freeipa.client.model.Ca;
 import com.sequenceiq.freeipa.client.model.Cert;

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/clusterproxy/ClusterProxyError.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/clusterproxy/ClusterProxyError.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.freeipa.client.clusterproxy;
+
+public interface ClusterProxyError {
+    String getStatus();
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/clusterproxy/ClusterProxyException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/clusterproxy/ClusterProxyException.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.freeipa.client.clusterproxy;
+
+import java.util.Optional;
+
+public abstract class ClusterProxyException extends RuntimeException {
+    public abstract Optional<ClusterProxyError> getClusterProxyError();
+}


### PR DESCRIPTION
Previously, in CDPSDX-2788, the build scripts were updated to upload
freeipa-client as a jar into nexus. However, freeipa-client has two
dependencies: common, and cluster-proxy. We need to upload these
also to nexus so that thunderhead can use the freeipa-client.

Verified that common and cluster-proxy do not have any further
dependencies.

See detailed description in the commit message.