### PR TITLE
CB-10092: Adding an internal loadbalancer to YCloud datalake setups.

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
@@ -63,6 +63,20 @@ public interface ResourceConnector<R> {
             AdjustmentType adjustmentType, Long threshold) throws Exception;
 
     /**
+     * Updates an existing stack with one or more load balancers, if the load balances do not already exist. This method will initiate the
+     * creation of load balancers on the Cloud platform, and will configure the load balancer routing in accordance with the specified
+     * target group configuration. It returns a list of CloudResourceStatus for any created load balancers.
+     *
+     * @param authenticatedContext the authenticated context which holds the client object
+     * @param stack                contains the full description of infrastructure
+     * @param persistenceNotifier  Cloud platform notifies the Cloudbreak over this interface if a resource is allocated on the Cloud platfrom
+     * @return the status of load balancers allocated on Cloud platform
+     * @throws Exception in case of any error
+     */
+    List<CloudResourceStatus> launchLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack, PersistenceNotifier persistenceNotifier)
+            throws Exception;
+
+    /**
      * Launches a database stack on a cloud platform. The stack consists of the following resources:
      * - a single database server instance
      * - depending on the platform, other associated, required resources (e.g., a DB subnet group for RDS)
@@ -248,19 +262,4 @@ public interface ResourceConnector<R> {
      * @throws TemplatingNotSupportedException if templating is not supported by provider
      */
     String getDBStackTemplate() throws TemplatingNotSupportedException;
-
-    /**
-     * Updates an existing stack with one or more load balancers, if the load balances do not already exist. This method will initiate the
-     * creation of load balancers on the Cloud platform, and will configure the load balancer routing in accordance with the specified
-     * target group configuration. It returns a list of CloudResourceStatus for any created load balancers.
-     *
-     * @param authenticatedContext the authenticated context which holds the client object
-     * @param stack                contains the full description of infrastructure
-     * @param persistenceNotifier  Cloud platform notifies the Cloudbreak over this interface if a resource is allocated on the Cloud platfrom
-     * @return the status of load balancers allocated on Cloud platform
-     * @throws Exception in case of any error
-     */
-    List<CloudResourceStatus> updateLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack,
-            PersistenceNotifier persistenceNotifier) throws Exception;
-
 }

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/ResourceConnectorTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/ResourceConnectorTest.java
@@ -83,7 +83,7 @@ class ResourceConnectorTest {
         }
 
         @Override
-        public List<CloudResourceStatus> updateLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack,
+        public List<CloudResourceStatus> launchLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack,
                 PersistenceNotifier persistenceNotifier) {
             return null;
         }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetadataCollector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetadataCollector.java
@@ -187,7 +187,7 @@ public class AwsMetadataCollector implements MetadataCollector {
         List<CloudLoadBalancerMetadata> cloudLoadBalancerMetadata = new ArrayList<>();
         for (LoadBalancerType type : loadBalancerTypes) {
             String loadBalancerName = AwsLoadBalancer.getLoadBalancerName(loadBalancerTypeConverter.convert(type));
-            LOGGER.debug("Attempting to collected metadata for load balancer {}, type {}", loadBalancerName, type);
+            LOGGER.debug("Attempting to collect metadata for load balancer {}, type {}", loadBalancerName, type);
             try {
                 LoadBalancer loadBalancer = cloudFormationStackUtil.getLoadBalancerByLogicalId(ac, loadBalancerName);
                 CloudLoadBalancerMetadata loadBalancerMetadata = new CloudLoadBalancerMetadata.Builder()
@@ -197,7 +197,7 @@ public class AwsMetadataCollector implements MetadataCollector {
                     .withName(loadBalancerName)
                     .build();
                 cloudLoadBalancerMetadata.add(loadBalancerMetadata);
-                LOGGER.debug("Saved metdata for load balancer {}: DNS {}, zone id {}", loadBalancerName, loadBalancer.getDNSName(),
+                LOGGER.debug("Saved metadata for load balancer {}: DNS {}, zone id {}", loadBalancerName, loadBalancer.getDNSName(),
                     loadBalancer.getCanonicalHostedZoneId());
             } catch (RuntimeException e) {
                 LOGGER.debug("Unable to find metadata for load balancer " + loadBalancerName, e);

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -104,6 +104,11 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
+    public List<CloudResourceStatus> launchLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack, PersistenceNotifier persistenceNotifier) {
+        return awsLoadBalancerLaunchService.updateCloudformationWithLoadBalancers(authenticatedContext, stack, persistenceNotifier);
+    }
+
+    @Override
     public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext ac, DatabaseStack stack,
             PersistenceNotifier persistenceNotifier) throws Exception {
         return awsRdsLaunchService.launch(ac, stack, persistenceNotifier);
@@ -200,11 +205,5 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
         } catch (IOException e) {
             throw new CloudConnectorException("can't get freemarker template", e);
         }
-    }
-
-    @Override
-    public List<CloudResourceStatus> updateLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack,
-            PersistenceNotifier persistenceNotifier) {
-        return awsLoadBalancerLaunchService.updateCloudformationWithLoadBalancers(authenticatedContext, stack, persistenceNotifier);
     }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -138,6 +138,12 @@ public class AzureResourceConnector extends AbstractResourceConnector {
         return resources;
     }
 
+    @Override
+    public List<CloudResourceStatus> launchLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack, PersistenceNotifier persistenceNotifier)
+            throws Exception {
+        throw new UnsupportedOperationException("Load balancers are not supported for Azure.");
+    }
+
     private List<CloudResource> persistCloudResources(
             AuthenticatedContext ac, CloudStack stack, PersistenceNotifier notifier, CloudContext cloudContext, String stackName,
             String resourceGroupName, Deployment templateDeployment) {
@@ -323,11 +329,5 @@ public class AzureResourceConnector extends AbstractResourceConnector {
     @Override
     public String getDBStackTemplate() {
         return azureDatabaseResourceService.getDBStackTemplate();
-    }
-
-    @Override
-    public List<CloudResourceStatus> updateLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack,
-            PersistenceNotifier persistenceNotifier) {
-        throw new UnsupportedOperationException("Azure load balancers are not currently supported.");
     }
 }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.cloud.gcp;
 
-import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -25,6 +24,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
+import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.service.CloudbreakResourceNameService;
 import com.sequenceiq.cloudbreak.cloud.template.AbstractResourceConnector;
 import com.sequenceiq.cloudbreak.cloud.template.compute.ComputeResourceService;
@@ -63,6 +63,12 @@ public class GcpResourceConnector extends AbstractResourceConnector {
     @Override
     public String getDBStackTemplate() throws TemplatingNotSupportedException {
         return "";
+    }
+
+    @Override
+    public List<CloudResourceStatus> launchLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack, PersistenceNotifier persistenceNotifier)
+            throws Exception {
+        throw new UnsupportedOperationException("Load balancers are not supported for GCP.");
     }
 
     @Override
@@ -138,12 +144,5 @@ public class GcpResourceConnector extends AbstractResourceConnector {
     @Override
     public List<CloudResourceStatus> check(AuthenticatedContext authenticatedContext, List<CloudResource> resources) {
         return List.of();
-    }
-
-    @Override
-    public List<CloudResourceStatus> updateLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack,
-            PersistenceNotifier persistenceNotifier) {
-
-        throw new UnsupportedOperationException("GCP load balancers are not currently supported.");
     }
 }

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
@@ -77,6 +77,12 @@ public class MockResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
+    public List<CloudResourceStatus> launchLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack, PersistenceNotifier persistenceNotifier)
+            throws Exception {
+        throw new UnsupportedOperationException("Load balancers are not supported for the mock resource connector.");
+    }
+
+    @Override
     public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
             PersistenceNotifier persistenceNotifier) {
         List<CloudResource> cloudResources = List.of(
@@ -207,11 +213,5 @@ public class MockResourceConnector implements ResourceConnector<Object> {
     @Override
     public ExternalDatabaseStatus getDatabaseServerStatus(AuthenticatedContext authenticatedContext, DatabaseStack stack) throws Exception {
         throw new UnsupportedOperationException("Database server status lookup is not supported for " + getClass().getName());
-    }
-
-    @Override
-    public List<CloudResourceStatus> updateLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack,
-            PersistenceNotifier persistenceNotifier) {
-        throw new UnsupportedOperationException("Load balancers updates are not supported for " + getClass().getName());
     }
 }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
@@ -121,6 +121,12 @@ public class OpenStackResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
+    public List<CloudResourceStatus> launchLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack, PersistenceNotifier persistenceNotifier)
+            throws Exception {
+        throw new UnsupportedOperationException("Load balancers are not supported for the open stack resource connector.");
+    }
+
+    @Override
     public List<CloudResourceStatus> launchDatabaseServer(AuthenticatedContext authenticatedContext, DatabaseStack stack,
         PersistenceNotifier persistenceNotifier) {
         throw new UnsupportedOperationException("Database server launch is not supported for " + getClass().getName());
@@ -399,12 +405,6 @@ public class OpenStackResourceConnector implements ResourceConnector<Object> {
         Map<String, String> parameters = heatTemplateBuilder.buildParameters(
                 authenticatedContext, stack, existingNetwork, existingSubnetCidr);
         return updateHeatStack(authenticatedContext, resources, heatTemplate, parameters);
-    }
-
-    @Override
-    public List<CloudResourceStatus> updateLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack,
-            PersistenceNotifier persistenceNotifier) {
-        throw new UnsupportedOperationException("OpenStack load balancers are not currently supported.");
     }
 
     private List<CloudResourceStatus> updateHeatStack(AuthenticatedContext authenticatedContext, List<CloudResource> resources, String heatTemplate,

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeResourceConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeResourceConnector.java
@@ -39,8 +39,8 @@ public class OpenStackNativeResourceConnector extends AbstractResourceConnector 
     }
 
     @Override
-    public List<CloudResourceStatus> updateLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack,
-            PersistenceNotifier persistenceNotifier) {
-        throw new UnsupportedOperationException("OpenStackNativeResource load balancers are not currently supported.");
+    public List<CloudResourceStatus> launchLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack, PersistenceNotifier persistenceNotifier)
+            throws Exception {
+        throw new UnsupportedOperationException("Load balancers are not supported for the open stack native resource connector.");
     }
 }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/ApplicationNameUtil.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/ApplicationNameUtil.java
@@ -1,7 +1,13 @@
 package com.sequenceiq.cloudbreak.cloud.yarn;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.common.api.type.LoadBalancerType;
 
 @Component
 public class ApplicationNameUtil {
@@ -9,21 +15,53 @@ public class ApplicationNameUtil {
     @Value("${cb.max.yarn.resource.name.length:}")
     private int maxResourceNameLength;
 
+    public String createApplicationName(AuthenticatedContext authenticatedContext) {
+        List<String> applicationNameAndUser = initializeApplicationName(authenticatedContext.getCloudContext());
+        return decorateName(applicationNameAndUser.get(0), applicationNameAndUser.get(1));
+    }
+
+    public String createLoadBalancerName(AuthenticatedContext authenticatedContext) {
+        List<String> applicationNameAndUser = initializeApplicationName(authenticatedContext.getCloudContext());
+        return decorateLoadBalancerName(applicationNameAndUser.get(0), applicationNameAndUser.get(1));
+    }
+
     public String decorateName(String name, String userName) {
         if (name.endsWith("-cb")) {
-            name += "-" + userName;
+            name = name + "-" + userName;
         }
         if (!name.endsWith("-cb-" + userName)) {
             name = name + "-cb-" + userName;
         }
-        return cutToMaxLength(name, userName);
+        return cutToMaxLength(name, userName, "-cb-");
     }
 
-    private String cutToMaxLength(String name, String userName) {
+    public String decorateLoadBalancerName(String name, String userName) {
+        if (name.endsWith("-lb")) {
+            name = name + "-" + userName;
+        }
+        if (!name.endsWith("-lb-" + userName)) {
+            name = name + "-lb-" + userName;
+        }
+        return cutToMaxLength(name, userName, "-lb-");
+    }
+
+    public String createLoadBalancerComponentName(String applicationName, LoadBalancerType type) {
+        return applicationName + type.name();
+    }
+
+    private List<String> initializeApplicationName(CloudContext cloudContext) {
+        String name = cloudContext.getName();
+        String id = cloudContext.getId().toString();
+        name += "-" + id;
+        String user = cloudContext.getUserName().split("@")[0].replaceAll("[^a-z0-9-_]", "");
+        return List.of(name, user);
+    }
+
+    private String cutToMaxLength(String name, String userName, String postfixBeginning) {
         if (name.length() <= maxResourceNameLength) {
             return name;
         }
-        String postfix = "-cb-" + userName;
+        String postfix = postfixBeginning + userName;
         String clusterName = name.substring(0, name.indexOf(postfix));
         int newLength = maxResourceNameLength - postfix.length();
         clusterName = clusterName.substring(0, newLength);

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnApplicationCreationService.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnApplicationCreationService.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.cloudbreak.cloud.yarn;
+
+import java.net.MalformedURLException;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.YarnClient;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.api.YarnResourceConstants;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.request.ApplicationDetailRequest;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.request.CreateApplicationRequest;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.response.ApplicationErrorResponse;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.response.ResponseContext;
+
+@Service
+public class YarnApplicationCreationService {
+    public static final String ARTIFACT_TYPE_DOCKER = "DOCKER";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(YarnApplicationCreationService.class);
+
+    @Value("${cb.yarn.defaultQueue}")
+    private String defaultQueue;
+
+    /*
+     * Default lifetime in seconds.
+     */
+    @Value("${cb.yarn.defaultLifeTime:}")
+    private int defaultLifeTime;
+
+    /**
+     * Checks to see if the application described by applicationName already exists on the Yarn client.
+     */
+    public boolean checkApplicationAlreadyCreated(YarnClient yarnClient, String applicationName) throws MalformedURLException {
+        ApplicationDetailRequest applicationDetailRequest = new ApplicationDetailRequest();
+        applicationDetailRequest.setName(applicationName);
+        boolean created = yarnClient.getApplicationDetail(applicationDetailRequest).getStatusCode() == YarnResourceConstants.HTTP_SUCCESS;
+        LOGGER.debug("The yarn application " + applicationName + " already being created = " + created + ".");
+        return created;
+    }
+
+    /**
+     * Creates the application using the given application request by sending the request to the Yarn client, and ensuring that the request was
+     * correctly received.
+     */
+    public void createApplication(YarnClient yarnClient, CreateApplicationRequest createApplicationRequest) throws MalformedURLException {
+        LOGGER.info("Creating the Yarn application " + createApplicationRequest.getName() + ".");
+        ResponseContext responseContext = yarnClient.createApplication(createApplicationRequest);
+        if (Objects.nonNull(responseContext.getResponseError())) {
+            LOGGER.warn("Received a response error from the Yarn client when trying to create the application " + createApplicationRequest.getName() + ".");
+            ApplicationErrorResponse applicationErrorResponse = responseContext.getResponseError();
+            throw new CloudConnectorException(String.format("Yarn Application creation error: HTTP Return: %d Error: %s", responseContext.getStatusCode(),
+                    applicationErrorResponse.getDiagnostics()));
+        }
+    }
+
+    /**
+     * Returns a generic initial form for a Yarn {@link CreateApplicationRequest} which can be built upon to create
+     * more complex and specialized requests.
+     */
+    public CreateApplicationRequest initializeRequest(CloudStack stack, String applicationName) {
+        CreateApplicationRequest createApplicationRequest = new CreateApplicationRequest();
+        createApplicationRequest.setName(applicationName);
+        createApplicationRequest.setQueue(stack.getParameters().getOrDefault(YarnConstants.YARN_QUEUE_PARAMETER, defaultQueue));
+        String lifeTimeStr = stack.getParameters().get(YarnConstants.YARN_LIFETIME_PARAMETER);
+        createApplicationRequest.setLifetime(lifeTimeStr != null ? Integer.parseInt(lifeTimeStr) : defaultLifeTime);
+        LOGGER.debug("Created an initial application request for " + applicationName + ".");
+        return createApplicationRequest;
+    }
+}

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/Artifact.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/Artifact.java
@@ -17,11 +17,18 @@ public class Artifact implements Serializable {
     }
 
     public String getId() {
-
         return id;
     }
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "Artifact {"
+                + "id=" + id
+                + ", type=" + type
+                + '}';
     }
 }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/ConfigFile.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/ConfigFile.java
@@ -50,4 +50,14 @@ public class ConfigFile implements Serializable {
     public void setProps(Map<String, String> props) {
         this.props = props;
     }
+
+    @Override
+    public String toString() {
+        return "ConfigFile {"
+                + "type=" + type
+                + ", destFile=" + destFile
+                + ", srcFile=" + srcFile
+                + ", props=" + props
+                + '}';
+    }
 }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/Configuration.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/Configuration.java
@@ -38,4 +38,13 @@ public class Configuration  implements Serializable {
     public void setFiles(List<ConfigFile> files) {
         this.files = files;
     }
+
+    @Override
+    public String toString() {
+        return "Configuration {"
+                + "properties=" + properties
+                + ", env=" + env
+                + ", files=" + files
+                + '}';
+    }
 }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/Dependency.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/Dependency.java
@@ -13,4 +13,9 @@ public class Dependency implements Serializable {
     public void setItem(String item) {
         this.item = item;
     }
+
+    @Override
+    public String toString() {
+        return item;
+    }
 }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/Resource.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/Resource.java
@@ -23,4 +23,12 @@ public class Resource implements Serializable {
     public void setMemory(int memory) {
         this.memory = memory;
     }
+
+    @Override
+    public String toString() {
+        return "Resource {"
+                + "cpus=" + cpus
+                + ", memory=" + memory
+                + '}';
+    }
 }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/YarnComponent.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/client/model/core/YarnComponent.java
@@ -89,4 +89,18 @@ public class YarnComponent implements Serializable {
     public void setConfiguration(Configuration configuration) {
         this.configuration = configuration;
     }
+
+    @Override
+    public String toString() {
+        return "YarnComponent {"
+                + "name=" + name
+                + ", dependencies=" + dependencies
+                + ", numberOfContainers=" + numberOfContainers
+                + ", artifact=" + artifact
+                + ", launchCommand=" + launchCommand
+                + ", resource=" + resource
+                + ", runPrivilegedContainer=" + runPrivilegedContainer
+                + ", configuration=" + configuration
+                + '}';
+    }
 }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/component/YarnLoadBalancerComponentFactoryService.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/component/YarnLoadBalancerComponentFactoryService.java
@@ -1,0 +1,147 @@
+package com.sequenceiq.cloudbreak.cloud.yarn.loadbalancer.service.component;
+
+import static com.sequenceiq.cloudbreak.cloud.yarn.YarnApplicationCreationService.ARTIFACT_TYPE_DOCKER;
+
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.yarn.ApplicationNameUtil;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.core.Artifact;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.core.ConfigFile;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.core.ConfigFileType;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.core.Configuration;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.core.Resource;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.core.YarnComponent;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@Service
+public class YarnLoadBalancerComponentFactoryService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(YarnLoadBalancerComponentFactoryService.class);
+
+    private final ApplicationNameUtil applicationNameUtil;
+
+    /**
+     * Must match an existing Docker image in the primary Cloudbreak repository.
+     */
+    private final String loadBalancerImageName = "docker-sandbox.infra.cloudera.com/cloudbreak/yarn-loadbalancer:2021-03-23-12-02-09";
+
+    private final int loadBalancerNumCPUs = 1;
+
+    /**
+     * In megabytes.
+     */
+    private final int loadBalancerMemorySize = 1024;
+
+    YarnLoadBalancerComponentFactoryService(ApplicationNameUtil applicationNameUtil) {
+        Objects.requireNonNull(applicationNameUtil);
+        this.applicationNameUtil = applicationNameUtil;
+    }
+
+    /**
+     * Creates a Yarn component for each of the loadbalancers that are to be created, using a set of pre-defined
+     * constants for the various component parameters.
+     *
+     * Each container is pointed at a specific docker image which contains the loadbalancing service and logic.
+     */
+    public List<YarnComponent> create(CloudStack cloudStack, List<String> gatewayIPs, String applicationName) {
+        LOGGER.debug("Creating the loadbalancer components for application " + applicationName + " with gatewayIPs: " + gatewayIPs.toString() + ".");
+        Artifact artifact = createLoadBalancerArtifact();
+        Resource resource = createLoadBalancerResource();
+        String launchCommand = createLoadBalancerLaunchCommand(cloudStack);
+        Configuration configuration = createLoadBalancerConfiguration(gatewayIPs);
+
+        List<YarnComponent> loadBalancerComponents = Lists.newArrayList();
+        for (CloudLoadBalancer loadBalancer : cloudStack.getLoadBalancers()) {
+            String componentName = applicationNameUtil.createLoadBalancerComponentName(applicationName, loadBalancer.getType());
+            LOGGER.debug("Creating the load balancer Yarn component object for " + componentName + ".");
+            loadBalancerComponents.add(createLoadBalancerComponent(componentName, artifact, resource, launchCommand, configuration));
+        }
+
+        LOGGER.debug("Finished creating the Yarn load balancer components for application " + applicationName + ".");
+        return loadBalancerComponents;
+    }
+
+    /**
+     * Creates a YarnComponent, using specific parameters to set up the load balancer service on the designated
+     * docker image pointed to.
+     */
+    private YarnComponent createLoadBalancerComponent(String name, Artifact artifact, Resource resource, String launchCommand, Configuration configuration) {
+        YarnComponent component = new YarnComponent();
+        component.setName(name);
+        component.setArtifact(artifact);
+        component.setResource(resource);
+        component.setNumberOfContainers(1);
+        component.setDependencies(Collections.emptyList());
+        component.setRunPrivilegedContainer(true);
+        component.setLaunchCommand(launchCommand);
+        component.setConfiguration(configuration);
+        LOGGER.debug("Created Yarn load balancer component: " + component);
+        return component;
+    }
+
+    /**
+     * Creates the artifact object for the loadbalancer Yarn component, which points at the specific Docker image
+     * that will set up the actual service which will do the loadbalancing.
+     */
+    private Artifact createLoadBalancerArtifact() {
+        Artifact artifact = new Artifact();
+        artifact.setId(loadBalancerImageName);
+        artifact.setType(ARTIFACT_TYPE_DOCKER);
+        return artifact;
+    }
+
+    /**
+     * Creates the resource object for the loadbalancer Yarn component, which specifies the amount of
+     * CPUs to use and the amount of memory to use for the container.
+     */
+    private Resource createLoadBalancerResource() {
+        Resource resource = new Resource();
+        resource.setCpus(loadBalancerNumCPUs);
+        resource.setMemory(loadBalancerMemorySize);
+        return resource;
+    }
+
+    /**
+     * Creates the launch command for the loadbalancer Yarn component, which uses a custom start script.
+     */
+    private String createLoadBalancerLaunchCommand(CloudStack cloudStack) {
+        return String.format("/bootstrap/start-systemd '%s' '%s' '%s'",
+                Base64.getEncoder().encodeToString(cloudStack.getImage().getUserDataByType(InstanceGroupType.CORE).getBytes()),
+                cloudStack.getLoginUserName(), cloudStack.getPublicKey());
+    }
+
+    /**
+     * Creates the configuration object for the loadbalancer Yarn component, which specifies the backend servers
+     * the loadbalancer container will balance against, as well as any other custom properties for the
+     * Docker image to use.
+     *
+     * The name of the destination file must match the name of the properties file used for the Docker image.
+     */
+    private Configuration createLoadBalancerConfiguration(List<String> gatewayIPs) {
+        Map<String, String> propsMap = Maps.newHashMap();
+        propsMap.put("conf.cb-conf.per.component", "true");
+        propsMap.put("site.cb-conf.groupname", "'loadbalancer'");
+        propsMap.put("site.cb-conf.servers", '\'' + String.join(" ", gatewayIPs) + '\'');
+
+        ConfigFile configFileProps = new ConfigFile();
+        configFileProps.setType(ConfigFileType.PROPERTIES.name());
+        configFileProps.setSrcFile("cb-conf");
+        configFileProps.setDestFile("/etc/cloudbreak-loadbalancer.props");
+
+        Configuration configuration = new Configuration();
+        configuration.setProperties(propsMap);
+        configuration.setFiles(Collections.singletonList(configFileProps));
+        return configuration;
+    }
+}

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/launch/YarnLoadBalancerLaunchService.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/launch/YarnLoadBalancerLaunchService.java
@@ -1,0 +1,150 @@
+package com.sequenceiq.cloudbreak.cloud.yarn.loadbalancer.service.launch;
+
+import static com.sequenceiq.common.api.type.ResourceType.YARN_LOAD_BALANCER;
+
+import java.net.MalformedURLException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.google.common.collect.Lists;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource.Builder;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
+import com.sequenceiq.cloudbreak.cloud.yarn.ApplicationNameUtil;
+import com.sequenceiq.cloudbreak.cloud.yarn.YarnApplicationCreationService;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.YarnClient;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.api.YarnResourceConstants;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.core.Container;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.core.YarnComponent;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.request.ApplicationDetailRequest;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.request.CreateApplicationRequest;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.response.ApplicationDetailResponse;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.response.ApplicationErrorResponse;
+import com.sequenceiq.cloudbreak.cloud.yarn.client.model.response.ResponseContext;
+import com.sequenceiq.cloudbreak.cloud.yarn.loadbalancer.service.component.YarnLoadBalancerComponentFactoryService;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@Service
+public class YarnLoadBalancerLaunchService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(YarnLoadBalancerLaunchService.class);
+
+    private final ApplicationNameUtil applicationNameUtil;
+
+    private final YarnApplicationCreationService yarnApplicationCreationService;
+
+    private final YarnLoadBalancerComponentFactoryService componentFactory;
+
+    YarnLoadBalancerLaunchService(ApplicationNameUtil applicationNameUtil, YarnApplicationCreationService yarnApplicationCreationService,
+            YarnLoadBalancerComponentFactoryService componentFactory) {
+        Objects.requireNonNull(applicationNameUtil);
+        Objects.requireNonNull(yarnApplicationCreationService);
+        Objects.requireNonNull(componentFactory);
+        this.applicationNameUtil = applicationNameUtil;
+        this.yarnApplicationCreationService = yarnApplicationCreationService;
+        this.componentFactory = componentFactory;
+    }
+
+    public CloudResource launch(AuthenticatedContext authenticatedContext, CloudStack cloudStack, PersistenceNotifier persistenceNotifier, YarnClient yarnClient)
+            throws Exception {
+        String applicationName = applicationNameUtil.createLoadBalancerName(authenticatedContext);
+
+        if (!yarnApplicationCreationService.checkApplicationAlreadyCreated(yarnClient, applicationName)) {
+            LOGGER.debug("Creating the load balancer application for the Yarn datalake.");
+            CreateApplicationRequest createApplicationRequest = createLoadBalancerRequest(cloudStack, applicationName, authenticatedContext, yarnClient);
+            yarnApplicationCreationService.createApplication(yarnClient, createApplicationRequest);
+            LOGGER.info("Successfully created the Yarn load balancer application.");
+        }
+
+        // Create an object for the new loadbalancer application and persist it in the resources table.
+        CloudResource loadBalancerApplication = new Builder().type(YARN_LOAD_BALANCER).name(applicationName).build();
+        LOGGER.debug("Persisting the new Yarn load balancer resource in the resources table.");
+        persistenceNotifier.notifyAllocation(loadBalancerApplication, authenticatedContext.getCloudContext());
+        return loadBalancerApplication;
+    }
+
+    /**
+     * Creates a load balancer application request, specifically by:
+     *      - Getting the IP addresses of the gateway nodes that are already running
+     *      - Creating YarnComponent objects for each (if more than one) loadbalancer and pointing them to the gateway IPs.
+     */
+    private CreateApplicationRequest createLoadBalancerRequest(CloudStack cloudStack, String applicationName, AuthenticatedContext authenticatedContext,
+            YarnClient yarnClient) {
+        CreateApplicationRequest createApplicationRequest = yarnApplicationCreationService.initializeRequest(cloudStack, applicationName);
+        List<String> gatewayIPs = getGatewayIPs(authenticatedContext, yarnClient, cloudStack);
+        List<YarnComponent> loadBalancerComponents = componentFactory.create(cloudStack, gatewayIPs, applicationName);
+        createApplicationRequest.setComponents(loadBalancerComponents);
+        LOGGER.debug("Successfully created the Yarn laod balancer application request: " + createApplicationRequest);
+        return createApplicationRequest;
+    }
+
+    /**
+     * Uses the provided YarnClient to obtain information about the existing Yarn application. Takes advantage of the fact
+     * that the applicationNameUtil has the exact same logic for creating the name of the original application.
+     *
+     * Returns the extracted IPs of only the gateway nodes in the Yarn application.
+     */
+    private List<String> getGatewayIPs(AuthenticatedContext authenticatedContext, YarnClient yarnClient, CloudStack cloudStack) {
+        LOGGER.debug("Getting the IPs of the existing gateway Yarn containers for the loadbalancer.");
+        String applicationName = applicationNameUtil.createApplicationName(authenticatedContext);
+        Iterable<Container> foundContainers = getContainers(applicationName, yarnClient);
+        Set<String> gatewayGroupNames = getGatewayGroupNames(cloudStack);
+
+        List<String> gatewayIPs = Lists.newArrayList();
+        foundContainers.forEach(container -> {
+            if (gatewayGroupNames.contains(container.getComponentName())) {
+                gatewayIPs.add(container.getIp() + ":443");
+            }
+        });
+        LOGGER.info("Successfully found the following gateway IPs for the load balancer: " + gatewayIPs + ".");
+        return gatewayIPs;
+    }
+
+    /**
+     * Gets all of the containers currently running in the YCloud ecosystem within the application
+     * given by the application name provided.
+     */
+    public Iterable<Container> getContainers(String applicationName, YarnClient yarnClient) {
+        LOGGER.debug("Getting the Yarn containers for application " + applicationName + ".");
+        ApplicationDetailRequest applicationDetailRequest = new ApplicationDetailRequest();
+        applicationDetailRequest.setName(applicationName);
+        ResponseContext responseContext;
+
+        try {
+            responseContext = yarnClient.getApplicationDetail(applicationDetailRequest);
+            LOGGER.debug("Successfully for a response for Yarn application " + applicationName + " from the Yarn client.");
+        } catch (MalformedURLException ex) {
+            LOGGER.warn("Failed to get information for the Yarn loadbalancer! Application name: " + applicationName + " Error: " + ex.getMessage());
+            throw new CloudConnectorException("Failed to get information for the Yarn loadbalancer.", ex);
+        }
+
+        if (responseContext.getStatusCode() == YarnResourceConstants.HTTP_SUCCESS) {
+            LOGGER.info("Successfully retrieved container information for the Yarn application " + applicationName + ".");
+            ApplicationDetailResponse applicationDetailResponse = (ApplicationDetailResponse) responseContext.getResponseObject();
+            return applicationDetailResponse.getContainers();
+        } else {
+            LOGGER.warn("Failed to get yarn container! Application name: " + applicationName);
+            ApplicationErrorResponse errorResponse = responseContext.getResponseError();
+            throw new CloudConnectorException(String.format("Failed to get yarn container details: HTTP Return: %d Error: %s",
+                    responseContext.getStatusCode(), errorResponse == null ? "unknown" : errorResponse.getDiagnostics()));
+        }
+    }
+
+    /**
+     * Gets the names of the instance groups that are Gateway types, the names can then be compared against
+     * Yarn container names to check whether a container is a gateway container or not.
+     */
+    private Set<String> getGatewayGroupNames(CloudStack cloudStack) {
+        return cloudStack.getGroups().stream().filter(group -> InstanceGroupType.isGateway(group.getType()))
+                .map(Group::getName).collect(Collectors.toSet());
+    }
+}

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/ResourceType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/ResourceType.java
@@ -72,6 +72,7 @@ public enum ResourceType {
 
     // YARN
     YARN_APPLICATION(CommonResourceType.TEMPLATE),
+    YARN_LOAD_BALANCER(CommonResourceType.TEMPLATE),
 
     // MOCK
     MOCK_INSTANCE,

--- a/common-model/src/test/java/com/sequenceiq/common/api/type/ResourceTypeTest.java
+++ b/common-model/src/test/java/com/sequenceiq/common/api/type/ResourceTypeTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ResourceTypeTest {
 
     private static final Set<ResourceType> TEMPLATE_TYPES = EnumSet.of(ResourceType.CLOUDFORMATION_STACK, ResourceType.HEAT_STACK, ResourceType.ARM_TEMPLATE,
-            ResourceType.YARN_APPLICATION);
+            ResourceType.YARN_APPLICATION, ResourceType.YARN_LOAD_BALANCER);
 
     private static final Set<ResourceType> INSTANCE_TYPES = EnumSet.of(ResourceType.GCP_INSTANCE, ResourceType.OPENSTACK_INSTANCE, ResourceType.MOCK_INSTANCE);
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateCloudLoadBalancersHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateCloudLoadBalancersHandler.java
@@ -1,22 +1,20 @@
 package com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.handler;
 
-import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
-import com.sequenceiq.common.api.type.LoadBalancerType;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import reactor.bus.Event;
-
 import com.sequenceiq.cloudbreak.cloud.CloudConnector;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
@@ -27,8 +25,11 @@ import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.CreateClou
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.CreateCloudLoadBalancersRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.CreateCloudLoadBalancersSuccess;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+
+import reactor.bus.Event;
 
 @Component
 public class CreateCloudLoadBalancersHandler extends ExceptionCatcherEventHandler<CreateCloudLoadBalancersRequest> {
@@ -79,7 +80,7 @@ public class CreateCloudLoadBalancersHandler extends ExceptionCatcherEventHandle
             CloudConnector<Object> connector = cloudPlatformConnectors.get(cloudContext.getPlatformVariant());
             AuthenticatedContext ac = connector.authentication().authenticate(cloudContext, request.getCloudCredential());
             LOGGER.debug("Initiating cloud load balancer creation");
-            List<CloudResourceStatus> resourceStatus = connector.resources().updateLoadBalancers(ac, updatedCloudStack, persistenceNotifier);
+            List<CloudResourceStatus> resourceStatus = connector.resources().launchLoadBalancers(ac, updatedCloudStack, persistenceNotifier);
             if (resourceStatus.stream().anyMatch(CloudResourceStatus::isFailed)) {
                 Set<String> names = resourceStatus.stream()
                     .filter(CloudResourceStatus::isFailed)

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -667,7 +667,7 @@ cb:
   paywall.url: "https://archive.cloudera.com/p/cdp-public/"
 
   loadBalancer:
-    supportedPlatforms: AWS
+    supportedPlatforms: AWS,YARN
 
 clusterProxy:
   url: http://localhost:10180/cluster-proxy


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-10092

### Status

This has been tested fully, end-to-end, with additional verification that nothing has been broken for AWS/Azure LD/HA setups.

### Main Changes

- A launchLoadBalancer() method was added to the stack creation flow within the launchStack logic
- A new class called YarnLaunchLoadBalancerService was added which handles all of the launch logic
- The gateway nodes created before the launch loadbalancer steps have their IPs retrieved
- A new docker image (which will be hosted where the default YCloud image is hosted) was created and is being pointed to by the LoadBalancer container created, this image will install the haproxy service and point it at the provided servers
- The loadbalancer container's IP is retrieved in the same way as other YCloud container IPs, but we take advantage of the fact that we know what the loadbalancer application name is and use that instead of anything more complex