### PR TITLE
CB-11070 CDP PC missing firewall for egress/ingress

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudSubnet.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudSubnet.java
@@ -28,23 +28,26 @@ public class CloudSubnet extends DynamicModel implements Serializable {
 
     private boolean igwAvailable;
 
+    private boolean routableToInternet;
+
     public CloudSubnet() {
     }
 
     public CloudSubnet(String id, String name) {
-        this.id = id;
-        this.name = name;
+        this(id, name, null, null);
     }
 
     public CloudSubnet(String id, String name, String availabilityZone, String cidr) {
-        this.id = id;
-        this.name = name;
-        this.availabilityZone = availabilityZone;
-        this.cidr = cidr;
+        this(id, name, availabilityZone, cidr, false, false, false, null);
     }
 
     public CloudSubnet(String id, String name, String availabilityZone, String cidr, boolean privateSubnet, boolean mapPublicIpOnLaunch, boolean igwAvailable,
             SubnetType type) {
+        this(id, name, availabilityZone, cidr, privateSubnet, mapPublicIpOnLaunch, igwAvailable, type, false);
+    }
+
+    public CloudSubnet(String id, String name, String availabilityZone, String cidr, boolean privateSubnet, boolean mapPublicIpOnLaunch, boolean igwAvailable,
+            SubnetType type, boolean routableToInternet) {
         this.id = id;
         this.name = name;
         this.availabilityZone = availabilityZone;
@@ -53,6 +56,7 @@ public class CloudSubnet extends DynamicModel implements Serializable {
         this.mapPublicIpOnLaunch = mapPublicIpOnLaunch;
         this.igwAvailable = igwAvailable;
         this.type = type;
+        this.routableToInternet = routableToInternet;
     }
 
     public String getId() {
@@ -119,10 +123,19 @@ public class CloudSubnet extends DynamicModel implements Serializable {
         this.type = type;
     }
 
-    public CloudSubnet withId(String newId) {
-        return new CloudSubnet(newId, name, availabilityZone, cidr, privateSubnet, mapPublicIpOnLaunch, igwAvailable, type);
+    public boolean isRoutableToInternet() {
+        return routableToInternet;
     }
 
+    public void setRoutableToInternet(boolean routableToInternet) {
+        this.routableToInternet = routableToInternet;
+    }
+
+    public CloudSubnet withId(String newId) {
+        return new CloudSubnet(newId, name, availabilityZone, cidr, privateSubnet, mapPublicIpOnLaunch, igwAvailable, type, routableToInternet);
+    }
+
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -138,7 +151,8 @@ public class CloudSubnet extends DynamicModel implements Serializable {
                 Objects.equals(id, that.id) &&
                 Objects.equals(name, that.name) &&
                 Objects.equals(availabilityZone, that.availabilityZone) &&
-                Objects.equals(cidr, that.cidr);
+                Objects.equals(cidr, that.cidr) &&
+                Objects.equals(routableToInternet, that.routableToInternet);
     }
 
     @Override
@@ -156,6 +170,7 @@ public class CloudSubnet extends DynamicModel implements Serializable {
                 + ", privateSubnet=" + privateSubnet
                 + ", mapPublicIpOnLaunch=" + mapPublicIpOnLaunch
                 + ", igwAvailable=" + igwAvailable
+                + ", routableToInternet=" + routableToInternet
                 + ", parameters=" + getParameters()
                 + '}';
     }

--- a/cloud-aws/build.gradle
+++ b/cloud-aws/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   compile group: 'com.amazonaws',                 name: 'aws-java-sdk-cloudwatch',        version: awsSdkVersion
   compile group: 'com.amazonaws',                 name: 'aws-java-sdk-elasticloadbalancingv2',  version: awsSdkVersion
   compile group: 'com.amazonaws',                 name: 'aws-java-sdk-efs',               version: awsSdkVersion
+  compile group: 'com.amazonaws',                 name: 'aws-java-sdk-networkfirewall',   version: awsSdkVersion
 
   compile group: 'org.freemarker',                name: 'freemarker',                     version: freemarkerVersion
   compile group: 'commons-net',                   name: 'commons-net',                    version: '3.6'

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
@@ -35,6 +35,8 @@ import com.amazonaws.services.identitymanagement.AmazonIdentityManagement;
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementClientBuilder;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClientBuilder;
+import com.amazonaws.services.networkfirewall.AWSNetworkFirewall;
+import com.amazonaws.services.networkfirewall.AWSNetworkFirewallClient;
 import com.amazonaws.services.rds.AmazonRDS;
 import com.amazonaws.services.rds.AmazonRDSClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
@@ -52,6 +54,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonEfsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonElasticLoadBalancingClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonIdentityManagementClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonKmsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonNetworkFirewallClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonRdsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonS3Client;
 import com.sequenceiq.cloudbreak.cloud.aws.mapper.SdkClientExceptionMapper;
@@ -213,6 +216,15 @@ public class AwsClient {
                 .withClientConfiguration(getDefaultClientConfiguration())
                 .build(), awsCredential, regionName);
         return new AmazonElasticLoadBalancingClient(client);
+    }
+
+    public AmazonNetworkFirewallClient createNetworkFirewallClient(AwsCredentialView awsCredential, String regionName) {
+        AWSNetworkFirewall client = AWSNetworkFirewallClient.builder()
+            .withCredentials(getCredentialProvider(awsCredential))
+            .withClientConfiguration(getDefaultClientConfiguration())
+            .withRegion(regionName)
+            .build();
+        return new AmazonNetworkFirewallClient(client, retry);
     }
 
     public AmazonEfsClient createElasticFileSystemClient(AwsCredentialView awsCredential, String regionName) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsFirewall.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsFirewall.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.cloud.aws;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.services.networkfirewall.model.FirewallStatus;
+import com.amazonaws.services.networkfirewall.model.SyncState;
+
+public class AwsFirewall {
+
+    private final String name;
+
+    private final FirewallStatus firewallStatus;
+
+    public AwsFirewall(String name, FirewallStatus firewallStatus) {
+        this.name = name;
+        this.firewallStatus = firewallStatus;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public FirewallStatus getFirewallStatus() {
+        return firewallStatus;
+    }
+
+    public List<SyncState> getAllSyncStates() {
+        return new ArrayList<>(firewallStatus.getSyncStates().values());
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsPlatformResources.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsPlatformResources.java
@@ -93,6 +93,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonDynamoDBClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonIdentityManagementClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonKmsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonNetworkFirewallClient;
 import com.sequenceiq.cloudbreak.cloud.aws.util.AwsPageCollector;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
@@ -324,6 +325,7 @@ public class AwsPlatformResources implements PlatformResources {
     @Override
     public CloudNetworks networks(CloudCredential cloudCredential, Region region, Map<String, String> filters) {
         AmazonEc2Client ec2Client = awsClient.createEc2Client(new AwsCredentialView(cloudCredential), region.value());
+        AmazonNetworkFirewallClient nfwClient = awsClient.createNetworkFirewallClient(new AwsCredentialView(cloudCredential), region.value());
         try {
             LOGGER.debug("Describing route tables in region {}", region.getRegionName());
             List<RouteTable> allRouteTables = AwsPageCollector.getAllRouteTables(ec2Client, new DescribeRouteTablesRequest());
@@ -337,7 +339,7 @@ public class AwsPlatformResources implements PlatformResources {
                 first = false;
                 describeVpcsRequest.setNextToken(describeVpcsResult == null ? null : describeVpcsResult.getNextToken());
                 describeVpcsResult = ec2Client.describeVpcs(describeVpcsRequest);
-                Set<CloudNetwork> partialNetworks = getCloudNetworks(ec2Client, allRouteTables, describeVpcsResult);
+                Set<CloudNetwork> partialNetworks = getCloudNetworks(ec2Client, nfwClient, allRouteTables, describeVpcsResult);
                 cloudNetworks.addAll(partialNetworks);
             }
             Map<String, Set<CloudNetwork>> result = new HashMap<>();
@@ -360,14 +362,14 @@ public class AwsPlatformResources implements PlatformResources {
         return describeVpcsRequest;
     }
 
-    private Set<CloudNetwork> getCloudNetworks(AmazonEc2Client ec2Client,
+    private Set<CloudNetwork> getCloudNetworks(AmazonEc2Client ec2Client, AmazonNetworkFirewallClient nfwClient,
             List<RouteTable> describeRouteTablesResult, DescribeVpcsResult describeVpcsResult) {
 
         Set<CloudNetwork> cloudNetworks = new HashSet<>();
         LOGGER.debug("Processing VPCs");
         for (Vpc vpc : describeVpcsResult.getVpcs()) {
             List<Subnet> awsSubnets = getSubnets(ec2Client, vpc);
-            Set<CloudSubnet> subnets = convertAwsSubnetsToCloudSubnets(describeRouteTablesResult, awsSubnets);
+            Set<CloudSubnet> subnets = convertAwsSubnetsToCloudSubnets(nfwClient, describeRouteTablesResult, awsSubnets);
 
             Map<String, Object> properties = prepareNetworkProperties(vpc);
             Optional<String> name = getName(vpc.getTags());
@@ -396,11 +398,15 @@ public class AwsPlatformResources implements PlatformResources {
         return awsSubnets;
     }
 
-    private Set<CloudSubnet> convertAwsSubnetsToCloudSubnets(List<RouteTable> describeRouteTablesResult, List<Subnet> awsSubnets) {
+    private Set<CloudSubnet> convertAwsSubnetsToCloudSubnets(AmazonNetworkFirewallClient nfwClient,
+            List<RouteTable> describeRouteTablesResult, List<Subnet> awsSubnets) {
         Set<CloudSubnet> subnets = new HashSet<>();
         for (Subnet subnet : awsSubnets) {
             boolean hasInternetGateway = awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(describeRouteTablesResult, subnet.getSubnetId(), subnet.getVpcId());
+            boolean routableToInternet = awsSubnetIgwExplorer.isRoutableToInternet(nfwClient, describeRouteTablesResult, awsSubnets,
+                subnet.getSubnetId(), subnet.getVpcId());
             LOGGER.info("The subnet {} has internetGateway value is '{}'", subnet, hasInternetGateway);
+            LOGGER.info("The subnet {} routableToInternet value is '{}'", subnet, routableToInternet);
             Optional<String> subnetName = getName(subnet.getTags());
             subnets.add(
                     new CloudSubnet(
@@ -411,7 +417,8 @@ public class AwsPlatformResources implements PlatformResources {
                             !hasInternetGateway,
                             subnet.getMapPublicIpOnLaunch(),
                             hasInternetGateway,
-                            hasInternetGateway ? PUBLIC : PRIVATE)
+                            hasInternetGateway ? PUBLIC : PRIVATE,
+                            routableToInternet)
             );
         }
         return subnets;
@@ -640,7 +647,7 @@ public class AwsPlatformResources implements PlatformResources {
                 .collect(Collectors.toList());
 
         Set<VmType> awsInstances = new HashSet<>();
-        for (int actualSegment = 0; actualSegment < instanceTypes.size(); actualSegment = actualSegment + SEGMENT) {
+        for (int actualSegment = 0; actualSegment < instanceTypes.size(); actualSegment += SEGMENT) {
             DescribeInstanceTypesRequest request = new DescribeInstanceTypesRequest();
             request.setInstanceTypes(getInstanceTypes(instanceTypes, actualSegment));
             getVmTypesWithAwsCall(awsInstances, ec2Client.describeInstanceTypes(request));

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSubnetIgwExplorer.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSubnetIgwExplorer.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.aws;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -11,15 +12,32 @@ import org.springframework.stereotype.Component;
 
 import com.amazonaws.services.ec2.model.Route;
 import com.amazonaws.services.ec2.model.RouteTable;
+import com.amazonaws.services.ec2.model.Subnet;
+import com.amazonaws.services.ec2.model.Tag;
+import com.amazonaws.services.networkfirewall.model.AWSNetworkFirewallException;
+import com.amazonaws.services.networkfirewall.model.DescribeFirewallRequest;
+import com.amazonaws.services.networkfirewall.model.FirewallMetadata;
+import com.amazonaws.services.networkfirewall.model.ListFirewallsRequest;
+import com.amazonaws.services.networkfirewall.model.SyncState;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonNetworkFirewallClient;
+import com.sequenceiq.cloudbreak.cloud.aws.util.AwsPageCollector;
 
 @Component
 public class AwsSubnetIgwExplorer {
+
+    static final String ENDPOINT_GATEWAY_OVERRIDE_KEY = "cdp-public-endpoint-gateway-lb";
+
+    static final String ENDPOINT_GATEWAY_OVERRIDE_VALUE = "override";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsSubnetIgwExplorer.class);
 
     private static final String OPEN_CIDR_BLOCK = "0.0.0.0/0";
 
     private static final String IGW_PREFIX = "igw-";
+
+    private static final String FW_PREFIX = "vpce-";
+
+    private static final String ACCESS_DENIED = "AccessDeniedException";
 
     public boolean hasInternetGatewayOfSubnet(List<RouteTable> routeTables, String subnetId, String vpcId) {
         Optional<RouteTable> routeTable = getRouteTableForSubnet(routeTables, subnetId, vpcId);
@@ -41,7 +59,7 @@ public class AwsSubnetIgwExplorer {
         LOGGER.debug("Explicit route table for subnet '{}' (VPC is '{}'): {}", subnetId, vpcId, explicitRouteTable);
 
         return explicitRouteTable.or(() -> {
-            LOGGER.debug("There is no explicit route table for subnet '{}' (VPC is '{}') so we should look for the implicit one.");
+            LOGGER.debug("There is no explicit route table for subnet '{}' (VPC is '{}') so looking for the implicit one.", subnetId, vpcId);
             Optional<RouteTable> implicitRouteTable = getImplicitRouteTable(routeTables);
             LOGGER.debug("Implicit route table for subnet '{}' (VPC is '{}'): {}", subnetId, vpcId, implicitRouteTable);
             return implicitRouteTable;
@@ -67,5 +85,141 @@ public class AwsSubnetIgwExplorer {
                         route.getGatewayId().startsWith(IGW_PREFIX) &&
                         OPEN_CIDR_BLOCK.equals(route.getDestinationCidrBlock()))
                 .findFirst();
+    }
+
+    public boolean isRoutableToInternet(AmazonNetworkFirewallClient nfwClient, List<RouteTable> routeTables, List<Subnet> awsSubnets,
+            String subnetId, String vpcId) {
+        boolean result = false;
+        if (StringUtils.isNotEmpty(subnetId)) {
+            LOGGER.info("Checking if subnet {} has the {} override tag.", subnetId, ENDPOINT_GATEWAY_OVERRIDE_KEY);
+            result = isEndpointGatewayOverrideTagSet(awsSubnets, subnetId);
+            if (!result) {
+                LOGGER.info("{} tag not set. Checking if subnet has internet gateway explicitly defined in route table.", ENDPOINT_GATEWAY_OVERRIDE_KEY);
+                result = hasInternetGatewayOfSubnet(routeTables, subnetId, vpcId);
+            }
+            if (!result) {
+                LOGGER.info("No internet gateway defined in subnet route table. Checking if subnet has route to network firewall with internet gateway.");
+                result = isRoutableToFirewallWithInternetGateway(routeTables, subnetId, vpcId, nfwClient);
+            }
+            if (!result) {
+                LOGGER.info("No route to internet found for subnet {}. Subnet cannot be used for Public Endpoint Gateway.", subnetId);
+            }
+        } else {
+            LOGGER.info("No subnet id provided. Skipping internet routing check.");
+        }
+        return result;
+    }
+
+    private boolean isEndpointGatewayOverrideTagSet(List<Subnet> awsSubnets, String subnetId) {
+        List<Tag> tags = awsSubnets.stream()
+            .filter(subnet -> subnetId.equalsIgnoreCase(subnet.getSubnetId()))
+            .flatMap(subnet -> subnet.getTags().stream())
+            .collect(Collectors.toList());
+        LOGGER.debug("Found tags {} for subnet {}", tags, subnetId);
+        return tags.stream()
+            .anyMatch(tag ->
+                ENDPOINT_GATEWAY_OVERRIDE_KEY.equalsIgnoreCase(tag.getKey()) &&
+                    ENDPOINT_GATEWAY_OVERRIDE_VALUE.equalsIgnoreCase(tag.getValue())
+            );
+    }
+
+    private boolean isRoutableToFirewallWithInternetGateway(List<RouteTable> routeTables, String subnetId, String vpcId,
+            AmazonNetworkFirewallClient nfwClient) {
+        boolean result = false;
+        try {
+            List<String> gatewayIds = getPotentialFirewallEndpointIds(routeTables, subnetId, vpcId);
+            if (!gatewayIds.isEmpty()) {
+                LOGGER.info("Found gateway ids {} in route table for subnet {}", gatewayIds, subnetId);
+                List<FirewallMetadata> firewallMetadata = getAllFirewallMetadataForVpc(nfwClient, vpcId);
+                if (!firewallMetadata.isEmpty()) {
+                    LOGGER.info("Found firewalls {} in VPC {}", firewallMetadata.stream().map(FirewallMetadata::getFirewallName), vpcId);
+                    result = hasRouteToPublicFirewall(firewallMetadata, routeTables, subnetId, vpcId, nfwClient, gatewayIds);
+                } else {
+                    LOGGER.info("Did not find any firewalls in VPC {}", vpcId);
+                }
+            } else {
+                LOGGER.info("Did not find any potential firewall routing paths for subnet {}", subnetId);
+            }
+        } catch (AWSNetworkFirewallException e) {
+            if (ACCESS_DENIED.equals(e.getErrorCode())) {
+                LOGGER.info("User does not have permission to query firewall resources: {}. Skipping firewall IGW check.",
+                    e.getMessage());
+            } else {
+                LOGGER.warn("Unexpected exception while fetching firewall information. Skipping firewall IGW check.", e);
+            }
+        }
+        return result;
+    }
+
+    private List<String> getPotentialFirewallEndpointIds(List<RouteTable> routeTables, String subnetId, String vpcId) {
+        List<String> gatewayIds = new ArrayList<>();
+        LOGGER.info("Searching subnet {} route table for potential firewall routing", subnetId);
+        Optional<RouteTable> subnetRouteTable = getRouteTableForSubnet(routeTables, subnetId, vpcId);
+        LOGGER.info("Searching subnet route table for any routes that start with the firewall gateway prefix ({})", FW_PREFIX);
+        subnetRouteTable.ifPresent(
+            routeTable ->
+                gatewayIds.addAll(subnetRouteTable.get().getRoutes().stream()
+                    .filter(route -> StringUtils.isNotEmpty(route.getGatewayId()) && route.getGatewayId().startsWith(FW_PREFIX))
+                    .map(Route::getGatewayId)
+                    .collect(Collectors.toList())));
+        return gatewayIds;
+    }
+
+    private List<FirewallMetadata> getAllFirewallMetadataForVpc(AmazonNetworkFirewallClient nfwClient, String vpcId) {
+        ListFirewallsRequest request = new ListFirewallsRequest()
+            .withVpcIds(vpcId);
+        return AwsPageCollector.getAllFirewallMetadata(nfwClient, request);
+    }
+
+    private boolean hasRouteToPublicFirewall(List<FirewallMetadata> firewallMetadata, List<RouteTable> routeTables,
+            String subnetId, String vpcId, AmazonNetworkFirewallClient nfwClient, List<String> gatewayIds) {
+        LOGGER.info("Searching firewalls for gateway id in subnet {} route table.", subnetId);
+        boolean result = false;
+        List<AwsFirewall> firewalls = getFirewalls(firewallMetadata, nfwClient);
+        List<SyncState> syncStates = getStateForRoutedFirewalls(firewalls, nfwClient, gatewayIds, subnetId);
+        if (!syncStates.isEmpty()) {
+            LOGGER.info("Found {} firewall status states that match gateway ids in the subnet {} route table",
+                syncStates.size(), subnetId);
+            Optional<SyncState> syncStateOptional = syncStates.stream()
+                .filter(syncState -> hasInternetGatewayOfSubnet(routeTables, syncState.getAttachment().getSubnetId(), vpcId))
+                .findFirst();
+            result = syncStateOptional.isPresent();
+            if (result) {
+                String firewallName = firewalls.stream()
+                    .filter(fw -> fw.getAllSyncStates().contains(syncStateOptional.get()) && fw.getName() != null)
+                    .map(AwsFirewall::getName)
+                    .findAny().orElse("[could not find name]");
+                LOGGER.info("Found routed firewall {} with attached internet gateway for subnet {}", firewallName, subnetId);
+            } else {
+                LOGGER.info("The firewalls used by subnet {} do not have an internet gateway attached.", subnetId);
+            }
+        } else {
+            LOGGER.info("Did not find any firewall metadata that matched the route table for subnet {}", subnetId);
+        }
+        return result;
+    }
+
+    private List<AwsFirewall> getFirewalls(List<FirewallMetadata> firewallMetadata, AmazonNetworkFirewallClient nfwClient) {
+        List<String> firewallArns = firewallMetadata.stream()
+            .map(FirewallMetadata::getFirewallArn)
+            .collect(Collectors.toList());
+        LOGGER.debug("Issuing DescribeFirewallRequest for firewalls with arns {}", firewallArns);
+        return firewallArns.stream()
+            .map(arn -> nfwClient.describeFirewall(new DescribeFirewallRequest().withFirewallArn(arn)))
+            .map(result -> new AwsFirewall(result.getFirewall().getFirewallName(), result.getFirewallStatus()))
+            .collect(Collectors.toList());
+    }
+
+    private List<SyncState> getStateForRoutedFirewalls(List<AwsFirewall> firewalls, AmazonNetworkFirewallClient nfwClient,
+            List<String> gatewayIds, String subnetId) {
+        LOGGER.info("Searching firewall status for gateway id that matches subnet {} route table.", subnetId);
+        return firewalls.stream()
+            .flatMap(fw -> fw.getAllSyncStates().stream())
+            .filter(syncState -> doesEndpointMatchSubnetGatewayList(syncState, gatewayIds))
+            .collect(Collectors.toList());
+    }
+
+    private boolean doesEndpointMatchSubnetGatewayList(SyncState syncState, List<String> gatewayids) {
+        return gatewayids.contains(syncState.getAttachment().getEndpointId());
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/client/AmazonNetworkFirewallClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/client/AmazonNetworkFirewallClient.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.cloud.aws.client;
+
+import com.amazonaws.services.networkfirewall.AWSNetworkFirewall;
+import com.amazonaws.services.networkfirewall.model.DescribeFirewallRequest;
+import com.amazonaws.services.networkfirewall.model.DescribeFirewallResult;
+import com.amazonaws.services.networkfirewall.model.ListFirewallsRequest;
+import com.amazonaws.services.networkfirewall.model.ListFirewallsResult;
+import com.sequenceiq.cloudbreak.service.Retry;
+
+public class AmazonNetworkFirewallClient extends AmazonClient {
+
+    private final AWSNetworkFirewall client;
+
+    private final Retry retry;
+
+    public AmazonNetworkFirewallClient(AWSNetworkFirewall client, Retry retry) {
+        this.client = client;
+        this.retry = retry;
+    }
+
+    public ListFirewallsResult listFirewalls(ListFirewallsRequest request) {
+        return retry.testWith2SecDelayMax15Times(() -> client.listFirewalls(request));
+    }
+
+    public DescribeFirewallResult describeFirewall(DescribeFirewallRequest request) {
+        return retry.testWith2SecDelayMax15Times(() -> client.describeFirewall(request));
+    }
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLoadBalancerLaunchService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLoadBalancerLaunchService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
 
+import static com.amazonaws.util.StringUtils.isNullOrEmpty;
 import static com.sequenceiq.cloudbreak.cloud.aws.scheduler.WaiterRunner.run;
 
 import java.util.ArrayList;
@@ -22,8 +23,11 @@ import com.amazonaws.services.cloudformation.model.ListStackResourcesResult;
 import com.amazonaws.services.cloudformation.model.ResourceStatus;
 import com.amazonaws.services.cloudformation.model.StackResourceSummary;
 import com.amazonaws.services.ec2.model.DescribeRouteTablesRequest;
+import com.amazonaws.services.ec2.model.DescribeSubnetsRequest;
+import com.amazonaws.services.ec2.model.DescribeSubnetsResult;
 import com.amazonaws.services.ec2.model.Filter;
 import com.amazonaws.services.ec2.model.RouteTable;
+import com.amazonaws.services.ec2.model.Subnet;
 import com.amazonaws.waiters.Waiter;
 import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.cloud.aws.AwsClient;
@@ -35,6 +39,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.CloudFormationTemplateBuilder.ModelCo
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonAutoScalingClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonEc2Client;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonNetworkFirewallClient;
 import com.sequenceiq.cloudbreak.cloud.aws.loadbalancer.AwsListener;
 import com.sequenceiq.cloudbreak.cloud.aws.loadbalancer.AwsLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.aws.loadbalancer.AwsLoadBalancerScheme;
@@ -102,6 +107,7 @@ public class AwsLoadBalancerLaunchService {
             AmazonAutoScalingClient amazonASClient = awsClient.createAutoScalingClient(credentialView, regionName);
             List<CloudResource> instances = cfStackUtil.getInstanceCloudResources(ac, cfRetryClient, amazonASClient, stack.getGroups());
             AmazonEc2Client amazonEC2Client = awsClient.createEc2Client(credentialView, regionName);
+            AmazonNetworkFirewallClient nfwClient = awsClient.createNetworkFirewallClient(credentialView, regionName);
             Network network = stack.getNetwork();
             AwsNetworkView awsNetworkView = new AwsNetworkView(network);
 
@@ -110,7 +116,8 @@ public class AwsLoadBalancerLaunchService {
                 modelContext = awsModelService.buildDefaultModelContext(ac, stack, resourceNotifier);
             }
 
-            List<AwsLoadBalancer> awsLoadBalancers = getAwsLoadBalancers(cloudLoadBalancers, instances, awsNetworkView, amazonEC2Client);
+            List<AwsLoadBalancer> awsLoadBalancers = getAwsLoadBalancers(cloudLoadBalancers, instances, awsNetworkView,
+                amazonEC2Client, nfwClient);
 
             modelContext.withLoadBalancers(awsLoadBalancers);
             LOGGER.debug("Starting CloudFormation update to create load balancer and target groups.");
@@ -143,12 +150,13 @@ public class AwsLoadBalancerLaunchService {
     }
 
     private List<AwsLoadBalancer> getAwsLoadBalancers(List<CloudLoadBalancer> cloudLoadBalancers, List<CloudResource> instances,
-            AwsNetworkView awsNetworkView, AmazonEc2Client amazonEC2Client) {
+            AwsNetworkView awsNetworkView, AmazonEc2Client amazonEC2Client, AmazonNetworkFirewallClient nfwClient) {
         LOGGER.debug("Converting internal load balancer model to AWS cloud provider model.");
         List<AwsLoadBalancer> awsLoadBalancers = new ArrayList<>();
         for (CloudLoadBalancer cloudLoadBalancer : cloudLoadBalancers) {
             LOGGER.debug("Found load balancer model of type {}", cloudLoadBalancer.getType());
-            AwsLoadBalancer loadBalancer = convertLoadBalancer(cloudLoadBalancer, instances, awsNetworkView, amazonEC2Client, awsLoadBalancers);
+            AwsLoadBalancer loadBalancer = convertLoadBalancer(cloudLoadBalancer, instances, awsNetworkView, amazonEC2Client,
+                nfwClient, awsLoadBalancers);
             if (loadBalancer != null && !awsLoadBalancers.contains(loadBalancer)) {
                 awsLoadBalancers.add(loadBalancer);
             }
@@ -207,13 +215,13 @@ public class AwsLoadBalancerLaunchService {
     }
 
     @VisibleForTesting
-    AwsLoadBalancer convertLoadBalancer(CloudLoadBalancer cloudLoadBalancer, List<CloudResource> instances,
-            AwsNetworkView awsNetworkView, AmazonEc2Client amazonEC2Client, List<AwsLoadBalancer> awsLoadBalancers) {
+    AwsLoadBalancer convertLoadBalancer(CloudLoadBalancer cloudLoadBalancer, List<CloudResource> instances, AwsNetworkView awsNetworkView,
+            AmazonEc2Client amazonEC2Client, AmazonNetworkFirewallClient nfwClient, List<AwsLoadBalancer> awsLoadBalancers) {
         // Check and see if we already have a load balancer whose scheme matches this one.
         AwsLoadBalancer currentLoadBalancer = null;
         LoadBalancerType cloudLbType = cloudLoadBalancer.getType();
         Set<String> subnetIds = selectLoadBalancerSubnetIds(cloudLbType, awsNetworkView);
-        AwsLoadBalancerScheme scheme = determinePublicVsPrivateSchema(subnetIds, awsNetworkView.getExistingVpc(), amazonEC2Client);
+        AwsLoadBalancerScheme scheme = determinePublicVsPrivateSchema(subnetIds, awsNetworkView.getExistingVpc(), amazonEC2Client, nfwClient);
 
         if ((AwsLoadBalancerScheme.INTERNAL.equals(scheme) && LoadBalancerType.PUBLIC.equals(cloudLbType)) ||
             (AwsLoadBalancerScheme.INTERNET_FACING.equals(scheme) && LoadBalancerType.PRIVATE.equals(cloudLbType))) {
@@ -257,13 +265,35 @@ public class AwsLoadBalancerLaunchService {
         return new HashSet<>(subnetIds);
     }
 
-    private AwsLoadBalancerScheme determinePublicVsPrivateSchema(Set<String> subnetIds, String vpcId, AmazonEc2Client amazonEC2Client) {
+    private AwsLoadBalancerScheme determinePublicVsPrivateSchema(Set<String> subnetIds, String vpcId, AmazonEc2Client amazonEC2Client,
+            AmazonNetworkFirewallClient nfwClient) {
         DescribeRouteTablesRequest describeRouteTablesRequest = new DescribeRouteTablesRequest()
             .withFilters(new Filter().withName("vpc-id").withValues(vpcId));
         List<RouteTable> routeTableList = AwsPageCollector.getAllRouteTables(amazonEC2Client, describeRouteTablesRequest);
+        List<Subnet> subnets = getSubnets(amazonEC2Client, subnetIds);
         return subnetIds.stream()
-            .anyMatch(subnetId -> awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(routeTableList, subnetId, vpcId))
+            .anyMatch(subnetId -> awsSubnetIgwExplorer.isRoutableToInternet(nfwClient, routeTableList, subnets, subnetId, vpcId))
             ? AwsLoadBalancerScheme.INTERNET_FACING : AwsLoadBalancerScheme.INTERNAL;
+    }
+
+    private List<Subnet> getSubnets(AmazonEc2Client ec2Client, Set<String> subnetIds) {
+        List<Subnet> awsSubnets = new ArrayList<>();
+        DescribeSubnetsResult describeSubnetsResult = null;
+        do {
+            LOGGER.debug("Describing subnets {}{}", subnetIds, describeSubnetsResult == null ? "" : " (continuation)");
+            DescribeSubnetsRequest describeSubnetsRequest = createSubnetsDescribeRequest(subnetIds, describeSubnetsResult == null
+                ? null
+                : describeSubnetsResult.getNextToken());
+            describeSubnetsResult = ec2Client.describeSubnets(describeSubnetsRequest);
+            awsSubnets.addAll(describeSubnetsResult.getSubnets());
+        } while (!isNullOrEmpty(describeSubnetsResult.getNextToken()));
+        return awsSubnets;
+    }
+
+    private DescribeSubnetsRequest createSubnetsDescribeRequest(Set<String> subnetIds, String nextToken) {
+        return new DescribeSubnetsRequest()
+            .withSubnetIds(subnetIds)
+            .withNextToken(nextToken);
     }
 
     private void setupLoadBalancer(CloudLoadBalancer cloudLoadBalancer, List<CloudResource> instances,

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/AwsPageCollector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/AwsPageCollector.java
@@ -10,7 +10,11 @@ import java.util.function.Function;
 import com.amazonaws.services.ec2.model.DescribeRouteTablesRequest;
 import com.amazonaws.services.ec2.model.DescribeRouteTablesResult;
 import com.amazonaws.services.ec2.model.RouteTable;
+import com.amazonaws.services.networkfirewall.model.FirewallMetadata;
+import com.amazonaws.services.networkfirewall.model.ListFirewallsRequest;
+import com.amazonaws.services.networkfirewall.model.ListFirewallsResult;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonEc2Client;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonNetworkFirewallClient;
 
 public class AwsPageCollector {
     private AwsPageCollector() {
@@ -22,6 +26,14 @@ public class AwsPageCollector {
                 DescribeRouteTablesResult::getNextToken,
                 DescribeRouteTablesRequest::setNextToken);
         return routeTableList;
+    }
+
+    public static List<FirewallMetadata> getAllFirewallMetadata(AmazonNetworkFirewallClient nfwClient, ListFirewallsRequest request) {
+        List<FirewallMetadata> firewallMetadataList = collectPages(nfwClient::listFirewalls, request,
+                ListFirewallsResult::getFirewalls,
+                ListFirewallsResult::getNextToken,
+                ListFirewallsRequest::setNextToken);
+        return firewallMetadataList;
     }
 
     public static <S, P, R> List<S> collectPages(Function<P, R> resultProvider, P request, Function<R, List<S>> listFromResultGetter,

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSubnetIgwExplorerTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSubnetIgwExplorerTest.java
@@ -1,17 +1,34 @@
 package com.sequenceiq.cloudbreak.cloud.aws;
 
-
+import static com.sequenceiq.cloudbreak.cloud.aws.AwsSubnetIgwExplorer.ENDPOINT_GATEWAY_OVERRIDE_KEY;
+import static com.sequenceiq.cloudbreak.cloud.aws.AwsSubnetIgwExplorer.ENDPOINT_GATEWAY_OVERRIDE_VALUE;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import com.amazonaws.services.ec2.model.Route;
 import com.amazonaws.services.ec2.model.RouteTable;
 import com.amazonaws.services.ec2.model.RouteTableAssociation;
+import com.amazonaws.services.ec2.model.Subnet;
+import com.amazonaws.services.ec2.model.Tag;
+import com.amazonaws.services.networkfirewall.model.Attachment;
+import com.amazonaws.services.networkfirewall.model.DescribeFirewallResult;
+import com.amazonaws.services.networkfirewall.model.Firewall;
+import com.amazonaws.services.networkfirewall.model.FirewallMetadata;
+import com.amazonaws.services.networkfirewall.model.FirewallStatus;
+import com.amazonaws.services.networkfirewall.model.ListFirewallsResult;
+import com.amazonaws.services.networkfirewall.model.SyncState;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonNetworkFirewallClient;
 
 public class AwsSubnetIgwExplorerTest {
 
@@ -28,6 +45,15 @@ public class AwsSubnetIgwExplorerTest {
     private static final String OPEN_CIDR_BLOCK = "0.0.0.0/0";
 
     private static final String INTERNAL_DESTINATION_CIDR_BLOCK = "172.17.0.0/16";
+
+    private static final String FW_SUBNET_ID = "fwSubnetId";
+
+    private static final String FW_GATEWAY_ID = "vpce-4a6s5d4fsadf";
+
+    private static final String FW_ARN = "arn:firewall";
+
+    @Mock
+    private final AmazonNetworkFirewallClient nfwClient = mock(AmazonNetworkFirewallClient.class);
 
     private final AwsSubnetIgwExplorer awsSubnetIgwExplorer = new AwsSubnetIgwExplorer();
 
@@ -267,5 +293,190 @@ public class AwsSubnetIgwExplorerTest {
         boolean hasInternetGateway = awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(routeTables, SUBNET_ID, VPC_ID);
 
         assertTrue(hasInternetGateway);
+    }
+
+    @Test
+    public void testInternetRoutableWithIgw() {
+        RouteTable routeTable = new RouteTable().withVpcId(VPC_ID);
+        Route route = new Route();
+        route.setGatewayId(GATEWAY_ID);
+        route.setDestinationCidrBlock(OPEN_CIDR_BLOCK);
+        routeTable.setRoutes(List.of(route));
+        RouteTableAssociation routeTableAssociation = new RouteTableAssociation();
+        routeTableAssociation.setSubnetId(SUBNET_ID);
+        routeTable.setAssociations(List.of(routeTableAssociation));
+        setupFirewallClientMocks();
+
+        boolean routableToInternet = awsSubnetIgwExplorer.isRoutableToInternet(nfwClient, List.of(routeTable),
+            createSubnets(null, null), SUBNET_ID, VPC_ID);
+
+        assertTrue(routableToInternet);
+    }
+
+    @Test
+    public void testInternetRoutableWithoutIgw() {
+        RouteTable routeTable = new RouteTable().withVpcId(VPC_ID);
+        Route route = new Route();
+        route.setDestinationCidrBlock(OPEN_CIDR_BLOCK);
+        routeTable.setRoutes(List.of(route));
+        RouteTableAssociation routeTableAssociation = new RouteTableAssociation();
+        routeTableAssociation.setSubnetId(SUBNET_ID);
+        routeTable.setAssociations(List.of(routeTableAssociation));
+        setupFirewallClientMocks();
+
+        boolean routableToInternet = awsSubnetIgwExplorer.isRoutableToInternet(nfwClient, List.of(routeTable),
+            createSubnets(null, null), SUBNET_ID, VPC_ID);
+
+        assertFalse(routableToInternet);
+    }
+
+    @Test
+    public void testFirewallRoutingWithIgw() {
+        setupFirewallClientMocks();
+        List<RouteTable> routeTables = setupFirewallRoutes(true);
+
+        boolean routableToInternet = awsSubnetIgwExplorer.isRoutableToInternet(nfwClient, routeTables,
+            createSubnets(null, null), SUBNET_ID, VPC_ID);
+
+        assertTrue(routableToInternet);
+    }
+
+    @Test
+    public void testFirewallRoutingWithoutIgw() {
+        setupFirewallClientMocks();
+        List<RouteTable> routeTables = setupFirewallRoutes(false);
+
+        boolean routableToInternet = awsSubnetIgwExplorer.isRoutableToInternet(nfwClient, routeTables,
+            createSubnets(null, null), SUBNET_ID, VPC_ID);
+
+        assertFalse(routableToInternet);
+    }
+
+    @Test
+    public void testEndpointGatewayTagOverride() {
+        RouteTable routeTable = new RouteTable().withVpcId(VPC_ID);
+        Route route = new Route();
+        route.setDestinationCidrBlock(OPEN_CIDR_BLOCK);
+        routeTable.setRoutes(List.of(route));
+        RouteTableAssociation routeTableAssociation = new RouteTableAssociation();
+        routeTableAssociation.setSubnetId(SUBNET_ID);
+        routeTable.setAssociations(List.of(routeTableAssociation));
+        List<Subnet> subnets = createSubnets(ENDPOINT_GATEWAY_OVERRIDE_KEY, ENDPOINT_GATEWAY_OVERRIDE_VALUE);
+
+        setupFirewallClientMocks();
+
+        boolean routableToInternet = awsSubnetIgwExplorer.isRoutableToInternet(nfwClient, List.of(routeTable),
+            subnets, SUBNET_ID, VPC_ID);
+
+        assertTrue(routableToInternet);
+    }
+
+    @Test
+    public void testEndpointGatewayTagOverrideBadValue() {
+        RouteTable routeTable = new RouteTable().withVpcId(VPC_ID);
+        Route route = new Route();
+        route.setDestinationCidrBlock(OPEN_CIDR_BLOCK);
+        routeTable.setRoutes(List.of(route));
+        RouteTableAssociation routeTableAssociation = new RouteTableAssociation();
+        routeTableAssociation.setSubnetId(SUBNET_ID);
+        routeTable.setAssociations(List.of(routeTableAssociation));
+
+        List<Subnet> subnets = createSubnets(ENDPOINT_GATEWAY_OVERRIDE_KEY, "something else");
+        setupFirewallClientMocks();
+
+        boolean routableToInternet = awsSubnetIgwExplorer.isRoutableToInternet(nfwClient, List.of(routeTable),
+            subnets, SUBNET_ID, VPC_ID);
+
+        assertFalse(routableToInternet);
+    }
+
+    @Test
+    public void testEndpointGatewayTagNonOverrideTag() {
+        RouteTable routeTable = new RouteTable().withVpcId(VPC_ID);
+        Route route = new Route();
+        route.setDestinationCidrBlock(OPEN_CIDR_BLOCK);
+        routeTable.setRoutes(List.of(route));
+        RouteTableAssociation routeTableAssociation = new RouteTableAssociation();
+        routeTableAssociation.setSubnetId(SUBNET_ID);
+        routeTable.setAssociations(List.of(routeTableAssociation));
+
+        List<Subnet> subnets = createSubnets("another tag", ENDPOINT_GATEWAY_OVERRIDE_VALUE);
+        setupFirewallClientMocks();
+
+        boolean routableToInternet = awsSubnetIgwExplorer.isRoutableToInternet(nfwClient, List.of(routeTable),
+            subnets, SUBNET_ID, VPC_ID);
+
+        assertFalse(routableToInternet);
+    }
+
+    private List<RouteTable> setupFirewallRoutes(boolean withIgw) {
+        Route subnetRoute = new Route();
+        subnetRoute.setGatewayId(FW_GATEWAY_ID);
+        subnetRoute.setDestinationCidrBlock(OPEN_CIDR_BLOCK);
+        RouteTableAssociation subnetRouteTableAssociation = new RouteTableAssociation();
+        subnetRouteTableAssociation.setSubnetId(SUBNET_ID);
+
+        Route fwRoute = new Route();
+        if (withIgw) {
+            fwRoute.setGatewayId(GATEWAY_ID);
+        }
+        fwRoute.setDestinationCidrBlock(OPEN_CIDR_BLOCK);
+        RouteTableAssociation fwRouteTableAssociation = new RouteTableAssociation();
+        fwRouteTableAssociation.setSubnetId(FW_SUBNET_ID);
+
+        RouteTable subnetRouteTable = new RouteTable().withVpcId(VPC_ID);
+        subnetRouteTable.setAssociations(List.of(subnetRouteTableAssociation));
+        subnetRouteTable.setRoutes(List.of(subnetRoute));
+        subnetRouteTable.setVpcId(VPC_ID);
+
+        RouteTable fwRouteTable = new RouteTable().withVpcId(VPC_ID);
+        fwRouteTable.setAssociations(List.of(fwRouteTableAssociation));
+        fwRouteTable.setRoutes(List.of(fwRoute));
+        fwRouteTable.setVpcId(VPC_ID);
+
+        return List.of(subnetRouteTable, fwRouteTable);
+    }
+
+    private void setupFirewallClientMocks() {
+        FirewallMetadata firewallMetadata = new FirewallMetadata();
+        firewallMetadata.setFirewallArn(FW_ARN);
+
+        ListFirewallsResult listFirewallsResult = new ListFirewallsResult();
+        listFirewallsResult.setFirewalls(List.of(firewallMetadata));
+
+        Attachment attachment = new Attachment();
+        attachment.setEndpointId(FW_GATEWAY_ID);
+        attachment.setSubnetId(FW_SUBNET_ID);
+
+        SyncState syncState = new SyncState();
+        syncState.setAttachment(attachment);
+
+        FirewallStatus firewallStatus = new FirewallStatus();
+        firewallStatus.setSyncStates(Map.of("key", syncState));
+
+        Firewall firewall = new Firewall();
+        firewall.setFirewallName("name");
+
+        DescribeFirewallResult describeFirewallResult = new DescribeFirewallResult();
+        describeFirewallResult.setFirewallStatus(firewallStatus);
+        describeFirewallResult.setFirewall(firewall);
+
+        when(nfwClient.listFirewalls(any())).thenReturn(listFirewallsResult);
+        when(nfwClient.describeFirewall(any())).thenReturn(describeFirewallResult);
+    }
+
+    private List<Subnet> createSubnets(String tagKey, String tagValue) {
+        Subnet subnet = new Subnet();
+        subnet.setSubnetId(SUBNET_ID);
+        subnet.setVpcId(VPC_ID);
+
+        if (StringUtils.isNotEmpty(tagKey) && StringUtils.isNotEmpty(tagValue)) {
+            Tag tag = new Tag();
+            tag.setKey(tagKey);
+            tag.setValue(tagValue);
+            subnet.setTags(List.of(tag));
+        }
+
+        return List.of(subnet);
     }
 }

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchServiceLoadBalancerTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLaunchServiceLoadBalancerTest.java
@@ -40,6 +40,7 @@ import com.amazonaws.services.cloudformation.model.ListStackResourcesResult;
 import com.amazonaws.services.cloudformation.model.ResourceStatus;
 import com.amazonaws.services.cloudformation.model.StackResourceSummary;
 import com.amazonaws.services.cloudformation.waiters.AmazonCloudFormationWaiters;
+import com.amazonaws.services.ec2.model.DescribeSubnetsResult;
 import com.amazonaws.waiters.Waiter;
 import com.sequenceiq.cloudbreak.cloud.aws.AwsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.AwsStackRequestHelper;
@@ -49,6 +50,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.CloudFormationTemplateBuilder;
 import com.sequenceiq.cloudbreak.cloud.aws.CloudFormationTemplateBuilder.ModelContext;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonEc2Client;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonNetworkFirewallClient;
 import com.sequenceiq.cloudbreak.cloud.aws.loadbalancer.AwsListener;
 import com.sequenceiq.cloudbreak.cloud.aws.loadbalancer.AwsLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.aws.loadbalancer.AwsLoadBalancerScheme;
@@ -102,6 +104,9 @@ public class AwsLaunchServiceLoadBalancerTest {
 
     @Mock
     private AmazonEc2Client amazonEC2Client;
+
+    @Mock
+    private AmazonNetworkFirewallClient amazonNfwClient;
 
     @Mock
     private AwsSubnetIgwExplorer awsSubnetIgwExplorer;
@@ -180,7 +185,7 @@ public class AwsLaunchServiceLoadBalancerTest {
         AwsNetworkView awsNetworkView = createNetworkView(null, null);
         String expectedError = "Unable to configure load balancer: Could not identify subnets.";
         CloudConnectorException exception =
-                assertThrows(CloudConnectorException.class, () -> underTest.selectLoadBalancerSubnetIds(LoadBalancerType.PRIVATE, awsNetworkView));
+            assertThrows(CloudConnectorException.class, () -> underTest.selectLoadBalancerSubnetIds(LoadBalancerType.PRIVATE, awsNetworkView));
         assertEquals(expectedError, exception.getMessage());
     }
 
@@ -189,7 +194,7 @@ public class AwsLaunchServiceLoadBalancerTest {
         AwsNetworkView awsNetworkView = createNetworkView(null, null);
         String expectedError = "Unable to configure load balancer: Could not identify subnets.";
         CloudConnectorException exception =
-                assertThrows(CloudConnectorException.class, () -> underTest.selectLoadBalancerSubnetIds(LoadBalancerType.PUBLIC, awsNetworkView));
+            assertThrows(CloudConnectorException.class, () -> underTest.selectLoadBalancerSubnetIds(LoadBalancerType.PUBLIC, awsNetworkView));
         assertEquals(expectedError, exception.getMessage());
     }
 
@@ -203,7 +208,8 @@ public class AwsLaunchServiceLoadBalancerTest {
     @Test
     public void testConvertLoadBalancerNewPrivate() {
         // Returning false - private subnet
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), anyString(), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), anyString(), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
 
         AwsLoadBalancer awsLoadBalancer = setupAndRunConvertLoadBalancer(List.of(), LoadBalancerType.PRIVATE, PRIVATE_ID_1);
 
@@ -222,7 +228,8 @@ public class AwsLaunchServiceLoadBalancerTest {
     @Test
     public void testConvertLoadBalancerExistingPrivate() {
         // Returning false - private subnet
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), anyString(), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), anyString(), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         PowerMockito.mockStatic(AwsPageCollector.class);
         PowerMockito.when(AwsPageCollector.getAllRouteTables(any(), any())).thenReturn(List.of());
 
@@ -245,7 +252,8 @@ public class AwsLaunchServiceLoadBalancerTest {
     @Test
     public void testConvertLoadBalancerNewPublic() {
         // Returning true - public subnet
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), anyString(), anyString())).thenReturn(true);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), anyString(), anyString())).thenReturn(true);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         PowerMockito.mockStatic(AwsPageCollector.class);
         PowerMockito.when(AwsPageCollector.getAllRouteTables(any(), any())).thenReturn(List.of());
 
@@ -266,7 +274,8 @@ public class AwsLaunchServiceLoadBalancerTest {
     @Test
     public void testConvertLoadBalancerExistingPublic() {
         // Returning true - public subnet
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), anyString(), anyString())).thenReturn(true);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), anyString(), anyString())).thenReturn(true);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         PowerMockito.mockStatic(AwsPageCollector.class);
         PowerMockito.when(AwsPageCollector.getAllRouteTables(any(), any())).thenReturn(List.of());
 
@@ -289,7 +298,8 @@ public class AwsLaunchServiceLoadBalancerTest {
     @Test
     public void testConvertLoadBalancerMismatchedTypes() {
         // Returning false - private subnet
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), anyString(), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), anyString(), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         PowerMockito.mockStatic(AwsPageCollector.class);
         PowerMockito.when(AwsPageCollector.getAllRouteTables(any(), any())).thenReturn(List.of());
 
@@ -298,7 +308,7 @@ public class AwsLaunchServiceLoadBalancerTest {
         assertNull(awsLoadBalancer);
 
         // Returning true - public subnet
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), anyString(), anyString())).thenReturn(true);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), anyString(), anyString())).thenReturn(true);
 
         awsLoadBalancer = setupAndRunConvertLoadBalancer(List.of(), LoadBalancerType.PRIVATE, PRIVATE_ID_1);
 
@@ -314,18 +324,19 @@ public class AwsLaunchServiceLoadBalancerTest {
         List<StackResourceSummary> firstUpdateSummaries = createFirstUpdateSummaries(types);
         List<StackResourceSummary> secondUpdateSummaries = createFullSummaries(types);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, Set.of(LoadBalancerType.PRIVATE));
         when(result.getStackResourceSummaries())
-                .thenReturn(List.of())
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(secondUpdateSummaries);
+            .thenReturn(List.of())
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(secondUpdateSummaries);
 
         underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
 
         verify(cfClient, times(2)).updateStack(any());
-        verify(awsSubnetIgwExplorer, times(1)).hasInternetGatewayOfSubnet(any(), anyString(), anyString());
+        verify(awsSubnetIgwExplorer, times(1)).isRoutableToInternet(any(), any(), any(), anyString(), anyString());
         verify(result, times(4)).getStackResourceSummaries();
     }
 
@@ -338,18 +349,19 @@ public class AwsLaunchServiceLoadBalancerTest {
         List<StackResourceSummary> firstUpdateSummaries = createFirstUpdateSummaries(types);
         List<StackResourceSummary> secondUpdateSummaries = createFullSummaries(types);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PUBLIC_ID_1), anyString())).thenReturn(true);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PUBLIC_ID_1), anyString())).thenReturn(true);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, Set.of(LoadBalancerType.PUBLIC));
         when(result.getStackResourceSummaries())
-                .thenReturn(List.of())
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(secondUpdateSummaries);
+            .thenReturn(List.of())
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(secondUpdateSummaries);
 
         underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
 
         verify(cfClient, times(2)).updateStack(any());
-        verify(awsSubnetIgwExplorer, times(1)).hasInternetGatewayOfSubnet(any(), anyString(), anyString());
+        verify(awsSubnetIgwExplorer, times(1)).isRoutableToInternet(any(), any(), any(), anyString(), anyString());
         verify(result, times(4)).getStackResourceSummaries();
     }
 
@@ -362,19 +374,20 @@ public class AwsLaunchServiceLoadBalancerTest {
         List<StackResourceSummary> firstUpdateSummaries = createFirstUpdateSummaries(types);
         List<StackResourceSummary> secondUpdateSummaries = createFullSummaries(types);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PUBLIC_ID_1), anyString())).thenReturn(true);
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PUBLIC_ID_1), anyString())).thenReturn(true);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, Set.of(LoadBalancerType.PUBLIC, LoadBalancerType.PRIVATE));
         when(result.getStackResourceSummaries())
-                .thenReturn(List.of())
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(secondUpdateSummaries);
+            .thenReturn(List.of())
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(secondUpdateSummaries);
 
         underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
 
         verify(cfClient, times(2)).updateStack(any());
-        verify(awsSubnetIgwExplorer, times(2)).hasInternetGatewayOfSubnet(any(), anyString(), anyString());
+        verify(awsSubnetIgwExplorer, times(2)).isRoutableToInternet(any(), any(), any(), anyString(), anyString());
         verify(result, times(5)).getStackResourceSummaries();
     }
 
@@ -384,16 +397,17 @@ public class AwsLaunchServiceLoadBalancerTest {
         AwsNetworkView awsNetworkView = createNetworkView(PRIVATE_ID_1, PUBLIC_ID_1);
         Network network = createNetwork(PRIVATE_ID_1, PUBLIC_ID_1);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PUBLIC_ID_1), anyString())).thenReturn(false);
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PRIVATE_ID_1), anyString())).thenReturn(true);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PUBLIC_ID_1), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PRIVATE_ID_1), anyString())).thenReturn(true);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, Set.of(LoadBalancerType.PUBLIC, LoadBalancerType.PRIVATE));
 
         CloudConnectorException exception =
-                assertThrows(CloudConnectorException.class, () ->
-                        underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null));
+            assertThrows(CloudConnectorException.class, () ->
+                underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null));
 
         verify(cfClient, times(0)).updateStack(any());
-        verify(awsSubnetIgwExplorer, times(2)).hasInternetGatewayOfSubnet(any(), anyString(), anyString());
+        verify(awsSubnetIgwExplorer, times(2)).isRoutableToInternet(any(), any(), any(), anyString(), anyString());
         verify(result, times(0)).getStackResourceSummaries();
         assert exception.getMessage().startsWith("Can not create all requested AWS load balancers.");
     }
@@ -404,26 +418,27 @@ public class AwsLaunchServiceLoadBalancerTest {
         AwsNetworkView awsNetworkView = createNetworkView(PRIVATE_ID_1, null);
         Network network = createNetwork(PRIVATE_ID_1, null);
         String expectedError = String.format("Could not create load balancer listeners: target group %s not found.",
-                AwsTargetGroup.getTargetGroupName(PORT, AwsLoadBalancerScheme.INTERNAL));
+            AwsTargetGroup.getTargetGroupName(PORT, AwsLoadBalancerScheme.INTERNAL));
         Set<LoadBalancerType> types = Set.of(LoadBalancerType.PRIVATE);
         List<StackResourceSummary> firstUpdateSummaries = createFirstUpdateSummaries(types);
         firstUpdateSummaries.remove(TG_INDEX);
         List<StackResourceSummary> secondUpdateSummaries = createFullSummaries(types);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, types);
         when(result.getStackResourceSummaries())
-                .thenReturn(List.of())
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(secondUpdateSummaries);
+            .thenReturn(List.of())
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(secondUpdateSummaries);
 
         CloudConnectorException exception =
-                assertThrows(CloudConnectorException.class, () ->
-                        underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null));
+            assertThrows(CloudConnectorException.class, () ->
+                underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null));
 
         verify(cfClient, times(1)).updateStack(any());
-        verify(awsSubnetIgwExplorer, times(1)).hasInternetGatewayOfSubnet(any(), anyString(), anyString());
+        verify(awsSubnetIgwExplorer, times(1)).isRoutableToInternet(any(), any(), any(), anyString(), anyString());
         verify(result, times(2)).getStackResourceSummaries();
         assertEquals(expectedError, exception.getMessage());
     }
@@ -434,27 +449,28 @@ public class AwsLaunchServiceLoadBalancerTest {
         AwsNetworkView awsNetworkView = createNetworkView(PRIVATE_ID_1, null);
         Network network = createNetwork(PRIVATE_ID_1, null);
         String expectedError = String.format("Could not create load balancer listeners: target group %s arn not found.",
-                AwsTargetGroup.getTargetGroupName(PORT, AwsLoadBalancerScheme.INTERNAL));
+            AwsTargetGroup.getTargetGroupName(PORT, AwsLoadBalancerScheme.INTERNAL));
         Set<LoadBalancerType> types = Set.of(LoadBalancerType.PRIVATE);
         List<StackResourceSummary> firstUpdateSummaries = createFirstUpdateSummaries(types);
         StackResourceSummary tgSummary = firstUpdateSummaries.get(TG_INDEX);
         tgSummary.setPhysicalResourceId(null);
         List<StackResourceSummary> secondUpdateSummaries = createFullSummaries(types);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, types);
         when(result.getStackResourceSummaries())
-                .thenReturn(List.of())
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(secondUpdateSummaries);
+            .thenReturn(List.of())
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(secondUpdateSummaries);
 
         CloudConnectorException exception =
-                assertThrows(CloudConnectorException.class, () ->
-                        underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null));
+            assertThrows(CloudConnectorException.class, () ->
+                underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null));
 
         verify(cfClient, times(1)).updateStack(any());
-        verify(awsSubnetIgwExplorer, times(1)).hasInternetGatewayOfSubnet(any(), anyString(), anyString());
+        verify(awsSubnetIgwExplorer, times(1)).isRoutableToInternet(any(), any(), any(), anyString(), anyString());
         verify(result, times(2)).getStackResourceSummaries();
         assertEquals(expectedError, exception.getMessage());
     }
@@ -465,26 +481,27 @@ public class AwsLaunchServiceLoadBalancerTest {
         AwsNetworkView awsNetworkView = createNetworkView(PRIVATE_ID_1, null);
         Network network = createNetwork(PRIVATE_ID_1, null);
         String expectedError = String.format("Could not create load balancer listeners: load balancer %s not found.",
-                AwsLoadBalancer.getLoadBalancerName(AwsLoadBalancerScheme.INTERNAL));
+            AwsLoadBalancer.getLoadBalancerName(AwsLoadBalancerScheme.INTERNAL));
         Set<LoadBalancerType> types = Set.of(LoadBalancerType.PRIVATE);
         List<StackResourceSummary> firstUpdateSummaries = createFirstUpdateSummaries(types);
         firstUpdateSummaries.remove(LB_INDEX);
         List<StackResourceSummary> secondUpdateSummaries = createFullSummaries(types);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, types);
         when(result.getStackResourceSummaries())
-                .thenReturn(List.of())
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(secondUpdateSummaries);
+            .thenReturn(List.of())
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(secondUpdateSummaries);
 
         CloudConnectorException exception =
-                assertThrows(CloudConnectorException.class, () ->
-                        underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null));
+            assertThrows(CloudConnectorException.class, () ->
+                underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null));
 
         verify(cfClient, times(1)).updateStack(any());
-        verify(awsSubnetIgwExplorer, times(1)).hasInternetGatewayOfSubnet(any(), anyString(), anyString());
+        verify(awsSubnetIgwExplorer, times(1)).isRoutableToInternet(any(), any(), any(), anyString(), anyString());
         verify(result, times(2)).getStackResourceSummaries();
         assertEquals(expectedError, exception.getMessage());
     }
@@ -495,27 +512,28 @@ public class AwsLaunchServiceLoadBalancerTest {
         AwsNetworkView awsNetworkView = createNetworkView(PRIVATE_ID_1, null);
         Network network = createNetwork(PRIVATE_ID_1, null);
         String expectedError = String.format("Could not create load balancer listeners: load balancer %s arn not found.",
-                AwsLoadBalancer.getLoadBalancerName(AwsLoadBalancerScheme.INTERNAL));
+            AwsLoadBalancer.getLoadBalancerName(AwsLoadBalancerScheme.INTERNAL));
         Set<LoadBalancerType> types = Set.of(LoadBalancerType.PRIVATE);
         List<StackResourceSummary> firstUpdateSummaries = createFirstUpdateSummaries(types);
         StackResourceSummary lbSummary = firstUpdateSummaries.get(LB_INDEX);
         lbSummary.setPhysicalResourceId(null);
         List<StackResourceSummary> secondUpdateSummaries = createFullSummaries(types);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, types);
         when(result.getStackResourceSummaries())
-                .thenReturn(List.of())
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(secondUpdateSummaries);
+            .thenReturn(List.of())
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(secondUpdateSummaries);
 
         CloudConnectorException exception =
-                assertThrows(CloudConnectorException.class, () ->
-                        underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null));
+            assertThrows(CloudConnectorException.class, () ->
+                underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null));
 
         verify(cfClient, times(1)).updateStack(any());
-        verify(awsSubnetIgwExplorer, times(1)).hasInternetGatewayOfSubnet(any(), anyString(), anyString());
+        verify(awsSubnetIgwExplorer, times(1)).isRoutableToInternet(any(), any(), any(), anyString(), anyString());
         verify(result, times(2)).getStackResourceSummaries();
         assertEquals(expectedError, exception.getMessage());
     }
@@ -545,13 +563,14 @@ public class AwsLaunchServiceLoadBalancerTest {
         List<StackResourceSummary> firstUpdateSummaries = createFirstUpdateSummaries(types);
         List<StackResourceSummary> secondUpdateSummaries = createFullSummaries(types);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, types);
         when(result.getStackResourceSummaries())
-                .thenReturn(List.of())
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(secondUpdateSummaries);
+            .thenReturn(List.of())
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(secondUpdateSummaries);
 
         List<CloudResourceStatus> statuses = underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
 
@@ -571,13 +590,14 @@ public class AwsLaunchServiceLoadBalancerTest {
         List<StackResourceSummary> secondUpdateSummaries = createFullSummaries(types);
         secondUpdateSummaries.get(LB_INDEX).setResourceStatus(ResourceStatus.CREATE_FAILED);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, types);
         when(result.getStackResourceSummaries())
-                .thenReturn(List.of())
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(secondUpdateSummaries);
+            .thenReturn(List.of())
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(secondUpdateSummaries);
 
         List<CloudResourceStatus> statuses = underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
 
@@ -597,13 +617,14 @@ public class AwsLaunchServiceLoadBalancerTest {
         List<StackResourceSummary> secondUpdateSummaries = createFullSummaries(types);
         secondUpdateSummaries.get(LIS_INDEX).setResourceStatus(ResourceStatus.CREATE_FAILED);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, Set.of(LoadBalancerType.PRIVATE));
         when(result.getStackResourceSummaries())
-                .thenReturn(List.of())
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(secondUpdateSummaries);
+            .thenReturn(List.of())
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(secondUpdateSummaries);
 
         List<CloudResourceStatus> statuses = underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
 
@@ -623,13 +644,14 @@ public class AwsLaunchServiceLoadBalancerTest {
         List<StackResourceSummary> secondUpdateSummaries = createFullSummaries(types);
         secondUpdateSummaries.get(TG_INDEX).setResourceStatus(ResourceStatus.CREATE_FAILED);
 
-        when(awsSubnetIgwExplorer.hasInternetGatewayOfSubnet(any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(awsSubnetIgwExplorer.isRoutableToInternet(any(), any(), any(), eq(PRIVATE_ID_1), anyString())).thenReturn(false);
+        when(amazonEC2Client.describeSubnets(any())).thenReturn(new DescribeSubnetsResult());
         setupMocksForUpdate(awsNetworkView, network, instances, Set.of(LoadBalancerType.PRIVATE));
         when(result.getStackResourceSummaries())
-                .thenReturn(List.of())
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(firstUpdateSummaries)
-                .thenReturn(secondUpdateSummaries);
+            .thenReturn(List.of())
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(firstUpdateSummaries)
+            .thenReturn(secondUpdateSummaries);
 
         List<CloudResourceStatus> statuses = underTest.updateCloudformationWithLoadBalancers(ac, cloudStack, null, null);
 
@@ -712,7 +734,8 @@ public class AwsLaunchServiceLoadBalancerTest {
         PowerMockito.mockStatic(AwsPageCollector.class);
         PowerMockito.when(AwsPageCollector.getAllRouteTables(any(), any())).thenReturn(List.of());
 
-        return underTest.convertLoadBalancer(createCloudLoadBalancer(type), instances, awsNetworkView, amazonEC2Client, existingLoadBalancers);
+        return underTest.convertLoadBalancer(createCloudLoadBalancer(type), instances, awsNetworkView, amazonEC2Client,
+            amazonNfwClient, existingLoadBalancers);
     }
 
     private AwsNetworkView createNetworkView(String subnetId, String endpointGatewaSubnetId) {
@@ -731,13 +754,13 @@ public class AwsLaunchServiceLoadBalancerTest {
 
     private List<CloudResource> createInstances() {
         return List.of(CloudResource.builder()
-                .name(INSTANCE_NAME)
-                .instanceId(INSTANCE_ID)
-                .type(AWS_INSTANCE)
-                .status(CREATED)
-                .params(Map.of())
-                .group(INSTANCE_NAME)
-                .build());
+            .name(INSTANCE_NAME)
+            .instanceId(INSTANCE_ID)
+            .type(AWS_INSTANCE)
+            .status(CREATED)
+            .params(Map.of())
+            .group(INSTANCE_NAME)
+            .build());
     }
 
     private CloudLoadBalancer createCloudLoadBalancer(LoadBalancerType type) {
@@ -759,7 +782,7 @@ public class AwsLaunchServiceLoadBalancerTest {
         List<StackResourceSummary> summaries = new ArrayList<>();
         for (LoadBalancerType type : types) {
             AwsLoadBalancerScheme scheme = LoadBalancerType.PRIVATE.equals(type) ?
-                    AwsLoadBalancerScheme.INTERNAL : AwsLoadBalancerScheme.INTERNET_FACING;
+                AwsLoadBalancerScheme.INTERNAL : AwsLoadBalancerScheme.INTERNET_FACING;
             if (createLbAndTg) {
                 StackResourceSummary tgSummary = new StackResourceSummary();
                 tgSummary.setLogicalResourceId(AwsTargetGroup.getTargetGroupName(PORT, scheme));

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/NetworkCreationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/NetworkCreationHandler.java
@@ -41,8 +41,6 @@ public class NetworkCreationHandler extends EventSenderAwareHandler<EnvironmentD
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NetworkCreationHandler.class);
 
-    private static final String UNMATCHED_AZ = "Please provide public subnets in each of the following availability zones: %s";
-
     private final EnvironmentService environmentService;
 
     private final NetworkService networkService;

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/network/NetworkMetadataValidationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/network/NetworkMetadataValidationService.java
@@ -59,7 +59,7 @@ public class NetworkMetadataValidationService {
             return Map.of();
         }
         return endpointGatewaySubnetMetas.entrySet().stream()
-            .filter(entry -> !entry.getValue().isPrivateSubnet())
+            .filter(entry -> !entry.getValue().isPrivateSubnet() || entry.getValue().isRoutableToInternet())
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/network/NetworkMetadataValidationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/network/NetworkMetadataValidationServiceTest.java
@@ -148,4 +148,22 @@ public class NetworkMetadataValidationServiceTest extends NetworkTest {
         assertNull(subnetResult);
         assertEquals(PublicEndpointAccessGateway.DISABLED, environmentDto.getNetwork().getPublicEndpointAccessGateway());
     }
+
+    @Test
+    public void testWithEndpointGatewayAndFirewallRouting() {
+        EnvironmentDto environmentDto = createEnvironmentDto();
+        Environment environment = createEnvironment(createNetwork());
+
+        Map<String, CloudSubnet> subnets = createDefaultPrivateSubnets();
+        Map<String, CloudSubnet> endpointGatewaySubnets = createPrivateSubnetsWithInternetRouting();
+
+        when(cloudNetworkService.retrieveSubnetMetadata(any(EnvironmentDto.class), any())).thenReturn(subnets);
+        when(cloudNetworkService.retrieveEndpointGatewaySubnetMetadata(any(EnvironmentDto.class), any())).thenReturn(endpointGatewaySubnets);
+
+        Map<String, CloudSubnet> subnetResult =
+            ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.getEndpointGatewaySubnetMetadata(environment, environmentDto));
+
+        assertEquals(2, subnetResult.size());
+        assertEquals(Set.of(ID_1, ID_2), subnetResult.keySet());
+    }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/network/NetworkTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/network/NetworkTest.java
@@ -80,4 +80,15 @@ public class NetworkTest {
         subnets.put(PUBLIC_ID_2, createPublicSubnet(PUBLIC_ID_2, AZ_2));
         return subnets;
     }
+
+    protected Map<String, CloudSubnet> createPrivateSubnetsWithInternetRouting() {
+        Map<String, CloudSubnet> subnets = new HashMap<>();
+        CloudSubnet subnet1 = createPrivateSubnet(ID_1, AZ_1);
+        subnet1.setRoutableToInternet(true);
+        subnets.put(ID_1, subnet1);
+        CloudSubnet subnet2 = createPrivateSubnet(ID_2, AZ_2);
+        subnet2.setRoutableToInternet(true);
+        subnets.put(ID_2, subnet2);
+        return subnets;
+    }
 }


### PR DESCRIPTION
This is the second version of this change, which fixes a performance problem in the original commit. The
updated change no longer issues a DescribeSubnetRequest recursively on all subnets. Instead, a single
DescribeSubnetRequest is issued to fetch results for all relevant subnets, and the results are then iterated
over to find the description of each desired subnet. Original commit message is below:

Adds additional pass conditions to the logic that validates the AWS subnets provided for the public endpoint
gateway load balancer. Previously a subnet could only be used if it had an attached internet gateway. Now
it can be used if it passes one of the following three conditions:
  1. The subnet is tagged with "cdp-public-endpoint-gateway-lb" : "override".
  2. The subnet has an internet gateway attached.
  3. The subnet is routed through an AWS network firewall, and that firewall has an attached IGW.

Tested with unit tests and by enabling the feature with subnets with the override tag, and subnets routed
though a public network firewall.

Original PR for reference: https://github.com/hortonworks/cloudbreak/pull/10149