### PR TITLE
CB-11491 Optimize springboot and kubernetes graceful shutdown timeouts

### DIFF
--- a/autoscale/src/main/resources/application.yml
+++ b/autoscale/src/main/resources/application.yml
@@ -88,6 +88,8 @@ spring:
     prefer-file-system-access: false
   datasource:
       maxActive: 30
+  lifecycle:
+    timeout-per-shutdown-phase: 60
 
 secret:
   application: as/shared

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -50,6 +50,8 @@ spring:
       hibernate:
         jdbc.batch_size: 50
         order_inserts: true
+  lifecycle:
+    timeout-per-shutdown-phase: 60
 
 rest:
   debug: false

--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -6,6 +6,8 @@ server:
 spring:
   application:
     name: DatalakeService
+  lifecycle:
+    timeout-per-shutdown-phase: 60
 
 opentracing:
   jaeger:

--- a/environment/src/main/resources/application.yml
+++ b/environment/src/main/resources/application.yml
@@ -206,6 +206,8 @@ spring:
     prefer-file-system-access: false
   datasource:
     maxActive: 30
+  lifecycle:
+    timeout-per-shutdown-phase: 60
 
 notification:
   urls: http://localhost:3000/notifications

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -138,6 +138,8 @@ spring:
     prefer-file-system-access: false
   datasource:
     maxActive: 30
+  lifecycle:
+    timeout-per-shutdown-phase: 60
 
 rest:
   debug: false

--- a/redbeams/src/main/resources/application.yml
+++ b/redbeams/src/main/resources/application.yml
@@ -146,6 +146,8 @@ spring:
   freemarker:
     template-loader-path: file:/etc/redbeams,classpath:/
     prefer-file-system-access: false
+  lifecycle:
+    timeout-per-shutdown-phase: 60
 
 rest:
   debug: false


### PR DESCRIPTION
Increase spring graceful shutdown timeout from the default 30 sec to 60 sec.

See detailed description in the commit message.