### PR TITLE
CB-11535 it looks like that due to the circular dependency, Spring st…

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
@@ -77,6 +77,7 @@ public class AwsClient {
 
     private static final int MAX_CONSECUTIVE_RETRIES_BEFORE_THROTTLING = 200;
 
+    @Inject
     private AwsSessionCredentialClient credentialClient;
 
     @Inject

--- a/config/checkstyle/import-control.xml
+++ b/config/checkstyle/import-control.xml
@@ -12,6 +12,9 @@
         <file name="AwsClient">
             <allow pkg="(?!.*model)com\.amazonaws\.services.*" regex="true"/>
         </file>
+        <file name="AwsSessionCredentialClient">
+            <allow pkg="(?!.*model)com\.amazonaws\.services.*" regex="true"/>
+        </file>
         <subpackage name="client">
             <allow pkg="(?!.*model)com\.amazonaws\.services.*" regex="true"/>
         </subpackage>


### PR DESCRIPTION
…arts to initialise the AwsSessionCredentialClient bean very early in the process, even before it starts to initialise the caching system.Since the caching system is not initialised therefore the @Cacheable annotation is not going to have any effect.

This is not a proper fix, just a workaround and most probably it reverts the benefits of "CB-10938 Decode authorization errors"

See detailed description in the commit message.