### PR TITLE
CB-11533 Fix AWS credential cache

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
@@ -4,7 +4,6 @@ import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import java.io.IOException;
-import java.util.Objects;
 
 import javax.inject.Inject;
 
@@ -43,7 +42,6 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.google.common.annotations.VisibleForTesting;
-import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonSecurityTokenServiceClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonAutoScalingClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonClientExceptionHandler;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationClient;
@@ -57,6 +55,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonKmsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonNetworkFirewallClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonRdsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonS3Client;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonSecurityTokenServiceClient;
 import com.sequenceiq.cloudbreak.cloud.aws.mapper.SdkClientExceptionMapper;
 import com.sequenceiq.cloudbreak.cloud.aws.tracing.AwsTracingRequestHandler;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AuthenticatedContextView;
@@ -80,6 +79,7 @@ public class AwsClient {
 
     private static final int MAX_CONSECUTIVE_RETRIES_BEFORE_THROTTLING = 200;
 
+    @Inject
     private AwsSessionCredentialClient credentialClient;
 
     @Inject
@@ -374,16 +374,12 @@ public class AwsClient {
     }
 
     private AwsSessionCredentialProvider createAwsSessionCredentialProvider(AwsCredentialView awsCredential) {
-        return new AwsSessionCredentialProvider(awsCredential, Objects.requireNonNull(credentialClient));
+        return new AwsSessionCredentialProvider(awsCredential, credentialClient);
     }
 
     private <T> T proxy(T client, AwsCredentialView awsCredentialView, String region) {
         AspectJProxyFactory proxyFactory = new AspectJProxyFactory(client);
         proxyFactory.addAspect(new AmazonClientExceptionHandler(awsCredentialView, region, sdkClientExceptionMapper));
         return proxyFactory.getProxy();
-    }
-
-    public void setAwsSessionCredentialClient(AwsSessionCredentialClient awsSessionCredentialClient) {
-        this.credentialClient = awsSessionCredentialClient;
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSessionCredentialClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSessionCredentialClient.java
@@ -2,7 +2,6 @@ package com.sequenceiq.cloudbreak.cloud.aws;
 
 import java.util.Date;
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
@@ -13,12 +12,14 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 
 import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import com.sequenceiq.cloudbreak.cloud.aws.cache.AwsCachingConfig;
-import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonSecurityTokenServiceClient;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
 
 @Component
@@ -35,16 +36,10 @@ public class AwsSessionCredentialClient {
     private String roleSessionName;
 
     @Inject
-    private AwsClient awsClient;
+    private AwsEnvironmentVariableChecker awsEnvironmentVariableChecker;
 
-    /**
-     * AWS clients should only be created by {@link AwsClient}, but it needs {@link AwsSessionCredentialClient} to create them,
-     * so this {@link PostConstruct} setter is used to resolve the circular dependency issue
-     */
-    @PostConstruct
-    public void passToAwsClient() {
-        awsClient.setAwsSessionCredentialClient(this);
-    }
+    @Inject
+    private AwsDefaultZoneProvider awsDefaultZoneProvider;
 
     @Cacheable(value = AwsCachingConfig.TEMPORARY_AWS_CREDENTIAL_CACHE, unless = "#awsCredential.getId() == null")
     public AwsSessionCredentials retrieveCachedSessionCredentials(AwsCredentialView awsCredential) {
@@ -95,8 +90,11 @@ public class AwsSessionCredentialClient {
         }
     }
 
-    private AmazonSecurityTokenServiceClient awsSecurityTokenServiceClient(AwsCredentialView awsCredential) {
-        return awsClient.createCdpSecurityTokenServiceClient(awsCredential);
+    private AWSSecurityTokenService awsSecurityTokenServiceClient(AwsCredentialView awsCredential) {
+        return AWSSecurityTokenServiceClientBuilder.standard()
+                .withRegion(awsDefaultZoneProvider.getDefaultZone(awsCredential))
+                .withCredentials(DefaultAWSCredentialsProviderChain.getInstance())
+                .build();
     }
 
 }

--- a/config/checkstyle/import-control.xml
+++ b/config/checkstyle/import-control.xml
@@ -12,6 +12,9 @@
         <file name="AwsClient">
             <allow pkg="(?!.*model)com\.amazonaws\.services.*" regex="true"/>
         </file>
+        <file name="AwsSessionCredentialClient">
+            <allow pkg="(?!.*model)com\.amazonaws\.services.*" regex="true"/>
+        </file>
         <subpackage name="client">
             <allow pkg="(?!.*model)com\.amazonaws\.services.*" regex="true"/>
         </subpackage>


### PR DESCRIPTION
AwsSessionCredentialClient was not caching credentials, because when setting it to AwsClient it did not have any proxies.
Fixed it by creating the sts client there instead and injecting it to AwsClient (so we do not have circular dependency issues), and disabled the checkstyle check to allow aws client class imports in that file.

See detailed description in the commit message.