### PR TITLE
CB-11626 Fix integration-test project check-results failure conditions

### DIFF
--- a/integration-test/scripts/check-results.sh
+++ b/integration-test/scripts/check-results.sh
@@ -4,19 +4,29 @@
 
 status_code=0
 
+set -ex
+
 if [[ "$CIRCLECI" ]]; then
 
     # Check integration test results
     date
     if [[ ! -d test-output ]]; then
-        echo -e "\033[0;91m--- !!! NO test-output DIRECTORY !!! ---\n"; status_code=1;
+        echo -e "\033[0;91m--- !!! NO test-output DIRECTORY !!! ---\n";
+        status_code=1;
     else
         if grep -r '<failure ' test-output; then
-          echo -e "\033[0;91m--- !!! INTEGRATION TEST FAILED, CHECK \033[1;93mtest-output\033[0;91m DIR FOR RESULTS !!! ---\n"; status_code=1;
+          echo -e "\033[0;91m--- !!! INTEGRATION TEST FAILED, CHECK \033[1;93mtest-output\033[0;91m DIR FOR RESULTS !!! ---\n";
+          status_code=1;
         fi
         if grep -r '<skipped' test-output; then
-          echo -e "\033[0;91m--- !!! INTEGRATION TEST SKIPPED, CHECK \033[1;93mtest-output\033[0;91m DIR FOR RESULTS !!! ---\n"; status_code=1;
+          echo -e "\033[0;91m--- !!! INTEGRATION TEST SKIPPED, CHECK \033[1;93mtest-output\033[0;91m DIR FOR RESULTS !!! ---\n";
+          status_code=1;
         fi
+    fi
+
+    if [[ $(find suites_log -maxdepth 1 -name '*.log' | wc -l) -lt 3 ]]; then
+        echo -e "\033[0;91m--- !!! NO TEST HAS BEEN LAUNCHED !!! ---\n";
+        status_code=1;
     fi
 
     if [[ -z "${INTEGRATIONTEST_YARN_QUEUE}" ]] && [[ "$AWS" != true ]]; then
@@ -29,15 +39,17 @@ if [[ "$CIRCLECI" ]]; then
 
       pg_res=$(cat ./test-output/docker_stats/pg_stat_network_io_analysed.result);
       if [[ "$pg_res" == "POSTGRES>> OK" ]]; then
-        echo -e "\n\033[0;92m+++ Postgres traffic is below ${max_pg_network_output} limit.";
+        echo -e "\n\033[0;92m+++ POSTGRES TRAFFIC IS BELOW ${max_pg_network_output} LIMIT. +++\n";
       else
-        echo -e "\033[0;91m--- !!! Postgres trafic check failed: ${pg_res}"; status_code=1;
+        echo -e "\033[0;91m--- !!! POSTGRES TRAFIC CHECK FAILED: ${pg_res} !!! ---\n";
+        status_code=1;
       fi
     fi
 
     # Exit if there are failed tests
-    if [[ status_code -eq 1 ]];
-        then exit 1;
+    if [[ status_code -eq 1 ]]; then
+      echo -e "\033[0;91m--- !!! INTEGRATION TEST HAS BEEN FAILED !!! ---\n";
+      exit 1;
     fi
 
     echo -e "\n\033[0;92m+++ INTEGRATION TEST SUCCESSFULLY FINISHED +++\n";

--- a/integration-test/scripts/docker-compose.sh
+++ b/integration-test/scripts/docker-compose.sh
@@ -121,7 +121,7 @@ if [[ "$CIRCLECI" ]]; then
     export DOCKER_CLIENT_TIMEOUT=120
     export COMPOSE_HTTP_TIMEOUT=120
 
-    $INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility up --remove-orphans test | tee test.out
+    set -o pipefail ; $INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility up --remove-orphans --exit-code-from test test | tee test.out
     echo -e "\n\033[1;96m--- Test finished\033[0m\n"
 
     echo -e "\n\033[1;96m--- Collect docker stats:\033[0m\n"


### PR DESCRIPTION
We had error at starting ApplicationContext for Integration Test project, because of 
`Cannot find class in classpath: com.sequenceiq.it.cloudbreak.testcase.authorization.listfiltering.ImageCatalogListFiltering`.
So the related `artifact/integration-test` folder contains only the:
```
integcb
suites_log
```
sub folders. Beyond this the `suites_log` folder contains only the `spring.log` file with the above exception. Even the `integration-test_test_1 exited with code 1` the result was PASSED, because of:
```
./scripts/check-results.sh
Thu Mar 11 02:22:10 UTC 2021
Mar 11, 2021 2:22:12 AM java.util.prefs.FileSystemPreferences$1 run
INFO: Created user preferences directory.
[0;92m+++ Postgres traffic is below  limit.
[0;92m+++ INTEGRATION TEST SUCCESSFULLY FINISHED +++
RESULT=0
```
So we need to fix the `integration-test/scripts/check-results.sh` to handle this case correctly. Besides this the `integration-test/scripts/docker-compose.sh` was improved as well with:
```    
set -o pipefail ; $INTEGCB_LOCATION/.deps/bin/docker-compose --compatibility up --remove-orphans --exit-code-from test test | tee test.out
```