### PR TITLE
CB-11561 - removing the usage of Inject annotation from EnvDeleteClustersFlowEventChainFactory

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/chain/EnvDeleteClustersFlowEventChainFactory.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/chain/EnvDeleteClustersFlowEventChainFactory.java
@@ -7,8 +7,6 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import javax.inject.Inject;
-
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
@@ -25,8 +23,11 @@ import reactor.rx.Promise;
 @Component
 public class EnvDeleteClustersFlowEventChainFactory implements FlowEventChainFactory<EnvDeleteEvent> {
 
-    @Inject
     private EnvironmentService environmentService;
+
+    public EnvDeleteClustersFlowEventChainFactory(EnvironmentService environmentService) {
+        this.environmentService = environmentService;
+    }
 
     @Override
     public String initEvent() {


### PR DESCRIPTION
Removing the usage of Inject annotation from EnvDeleteClustersFlowEventChainFactory