### PR TITLE
CB-7557 configure entry_cache_timeout for SSSD on FreeIPA

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
@@ -80,3 +80,16 @@ restart_httpd:
     - watch:
       - file: /etc/httpd/conf.d/ipa-rewrite.conf
       - file: /etc/httpd/conf/httpd.conf
+
+/etc/sssd/sssd.conf:
+  file.line:
+    - mode: ensure
+    - content: "entry_cache_timeout = 30"
+    - after: "cache_credentials.*"
+
+restart_sssd_if_reconfigured:
+  service.running:
+    - enable: True
+    - name: sssd
+    - watch:
+      - file: /etc/sssd/sssd.conf


### PR DESCRIPTION
The default value of entry_cache_timeout is 90 mins and once a
user is cached it may not be able to SSH to the FreeIPA node with
the provided SSH key that is stored in UMS. This config is already
set to 30 seconds on the Data Lake and Data Hub clusters. As part
of this PR I'm making it consistent with the other clusters. It
should not cause any performance issues since users are not expected
to SSH to the FreeIPA instances that often. Mostly never.

After this change the sssd.conf will look like this:
```
[domain/test-env.xcu2-8y8x.wl.cloudera.site]

cache_credentials = True
entry_cache_timeout = 30
krb5_store_password_if_offline = True
ipa_domain = test-env.xcu2-8y8x.wl.cloudera.site
id_provider = ipa
auth_provider = ipa
access_provider = ipa
ipa_hostname = ipaserver2.test-env.xcu2-8y8x.wl.cloudera.site
chpass_provider = ipa
ipa_server = ipaserver2.test-env.xcu2-8y8x.wl.cloudera.site
ldap_tls_cacert = /etc/ipa/ca.crt
ipa_server_mode = True
[sssd]
services = nss, sudo, pam, ssh

domains = test-env.xcu2-8y8x.wl.cloudera.site
[nss]
homedir_substring = /home

[pam]

[sudo]

[autofs]

[ssh]

[pac]

[ifp]

[secrets]

[session_recording]
```
