### PR TITLE
CB-11416 Replace DefaultRestartAction for flows in freeipa service

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/FillInMemoryStateStoreRestartAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/FillInMemoryStateStoreRestartAction.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.freeipa.flow;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
+import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Component("FillInMemoryStateStoreRestartAction")
+public class FillInMemoryStateStoreRestartAction extends DefaultRestartAction {
+
+    @Inject
+    private StackService stackService;
+
+    @Override
+    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
+        Payload stackPayload = (Payload) payload;
+        Stack stack = stackService.getByIdWithListsInTransaction(stackPayload.getResourceId());
+        restart(flowParameters, flowChainId, event, payload, stack);
+    }
+
+    protected void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload, Stack stack) {
+        PollGroup pollGroup = Status.DELETE_COMPLETED == stack.getStackStatus().getStatus() ? PollGroup.CANCELLED : PollGroup.POLLABLE;
+        InMemoryStateStore.putStack(stack.getId(), pollGroup);
+        MDCBuilder.buildMdcContext(stack);
+        super.restart(flowParameters, flowChainId, event, payload);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/InitializeMDCContextRestartAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/InitializeMDCContextRestartAction.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.freeipa.flow;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Component("InitializeMDCContextRestartAction")
+public class InitializeMDCContextRestartAction extends DefaultRestartAction {
+
+    @Inject
+    private StackService stackService;
+
+    @Override
+    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
+        Payload stackPayload = (Payload) payload;
+        Stack stack = stackService.getStackById(stackPayload.getResourceId());
+        MDCBuilder.buildMdcContext(stack);
+        super.restart(flowParameters, flowChainId, event, payload);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/CleanupEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/CleanupEvent.java
@@ -6,23 +6,27 @@ import com.sequenceiq.freeipa.flow.stack.StackEvent;
 
 public class CleanupEvent extends StackEvent {
 
-    private final Set<String> users;
+    private Set<String> users;
 
-    private final Set<String> hosts;
+    private Set<String> hosts;
 
-    private final Set<String> roles;
+    private Set<String> roles;
 
-    private final Set<String> ips;
+    private Set<String> ips;
 
-    private final Set<String> statesToSkip;
+    private Set<String> statesToSkip;
 
-    private final String accountId;
+    private String accountId;
 
-    private final String operationId;
+    private String operationId;
 
-    private final String clusterName;
+    private String clusterName;
 
-    private final String environmentCrn;
+    private String environmentCrn;
+
+    protected CleanupEvent(Long stackId) {
+        super(stackId);
+    }
 
     @SuppressWarnings("ExecutableStatementCount")
     public CleanupEvent(Long stackId, Set<String> users, Set<String> hosts, Set<String> roles, Set<String> ips, Set<String> statesToSkip, String accountId,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/FreeIpaCleanupState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.freeipa.flow.freeipa.cleanup;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.InitializeMDCContextRestartAction;
 
 public enum FreeIpaCleanupState implements FlowState {
     INIT_STATE,
@@ -13,4 +15,11 @@ public enum FreeIpaCleanupState implements FlowState {
     CLEANUP_FINISHED_STATE,
     CLEANUP_FAILED_STATE,
     FINAL_STATE;
+
+    private Class<? extends RestartAction> restartAction = InitializeMDCContextRestartAction.class;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return restartAction;
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/AbstractCleanupEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/AbstractCleanupEvent.java
@@ -4,6 +4,10 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.CleanupEvent;
 
 public abstract class AbstractCleanupEvent extends CleanupEvent {
 
+    protected AbstractCleanupEvent(Long stackId) {
+        super(stackId);
+    }
+
     public AbstractCleanupEvent(CleanupEvent cleanupEvent) {
         super(cleanupEvent.getResourceId(), cleanupEvent.getUsers(), cleanupEvent.getHosts(), cleanupEvent.getRoles(), cleanupEvent.getIps(),
                 cleanupEvent.getStatesToSkip(), cleanupEvent.getAccountId(), cleanupEvent.getOperationId(), cleanupEvent.getClusterName(),

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/cert/RevokeCertsRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/cert/RevokeCertsRequest.java
@@ -8,6 +8,10 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RevokeCertsRequest extends AbstractCleanupEvent {
 
+    protected RevokeCertsRequest(Long stackId) {
+        super(stackId);
+    }
+
     public RevokeCertsRequest(CleanupEvent cleanupEvent, Stack stack) {
         super(cleanupEvent);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/cert/RevokeCertsResponse.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/cert/RevokeCertsResponse.java
@@ -8,9 +8,13 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RevokeCertsResponse extends AbstractCleanupEvent {
 
-    private final Set<String> certCleanupSuccess;
+    private Set<String> certCleanupSuccess;
 
-    private final Map<String, String> certCleanupFailed;
+    private Map<String, String> certCleanupFailed;
+
+    protected RevokeCertsResponse(Long stackId) {
+        super(stackId);
+    }
 
     public RevokeCertsResponse(CleanupEvent cleanupEvent, Set<String> certCleanupSuccess, Map<String, String> certCleanupFailed) {
         super(cleanupEvent);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/dns/RemoveDnsRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/dns/RemoveDnsRequest.java
@@ -6,6 +6,11 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.CleanupEvent;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveDnsRequest extends AbstractCleanupEvent {
+
+    protected RemoveDnsRequest(Long stackId) {
+        super(stackId);
+    }
+
     public RemoveDnsRequest(CleanupEvent cleanupEvent) {
         super(cleanupEvent);    }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/dns/RemoveDnsResponse.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/dns/RemoveDnsResponse.java
@@ -8,9 +8,13 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveDnsResponse extends AbstractCleanupEvent {
 
-    private final Set<String> dnsCleanupSuccess;
+    private Set<String> dnsCleanupSuccess;
 
-    private final Map<String, String> dnsCleanupFailed;
+    private Map<String, String> dnsCleanupFailed;
+
+    public RemoveDnsResponse(Long stackId) {
+        super(stackId);
+    }
 
     public RemoveDnsResponse(CleanupEvent cleanupEvent, Set<String> dnsCleanupSuccess, Map<String, String> dnsCleanupFailed) {
         super(cleanupEvent);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/failure/CleanupFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/failure/CleanupFailureEvent.java
@@ -8,11 +8,15 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class CleanupFailureEvent extends AbstractCleanupEvent {
 
-    private final String failedPhase;
+    private String failedPhase;
 
-    private final Map<String, String> failureDetails;
+    private Map<String, String> failureDetails;
 
-    private final Set<String> success;
+    private Set<String> success;
+
+    protected CleanupFailureEvent(Long stackId) {
+        super(stackId);
+    }
 
     public CleanupFailureEvent(CleanupEvent cleanupEvent, String failedPhase, Map<String, String> failureDetails,
             Set<String> success) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/host/RemoveHostsRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/host/RemoveHostsRequest.java
@@ -6,6 +6,10 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveHostsRequest extends AbstractCleanupEvent {
 
+    protected RemoveHostsRequest(Long stackId) {
+        super(stackId);
+    }
+
     public RemoveHostsRequest(CleanupEvent cleanupEvent, Stack stack) {
         super(cleanupEvent);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/host/RemoveHostsResponse.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/host/RemoveHostsResponse.java
@@ -8,9 +8,13 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveHostsResponse extends AbstractCleanupEvent {
 
-    private final Set<String> hostCleanupSuccess;
+    private Set<String> hostCleanupSuccess;
 
-    private final Map<String, String> hostCleanupFailed;
+    private Map<String, String> hostCleanupFailed;
+
+    protected RemoveHostsResponse(Long stackId) {
+        super(stackId);
+    }
 
     public RemoveHostsResponse(CleanupEvent cleanupEvent, Set<String> hostCleanupSuccess, Map<String, String> hostCleanupFailed) {
         super(cleanupEvent);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/roles/RemoveRolesRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/roles/RemoveRolesRequest.java
@@ -5,6 +5,11 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.CleanupEvent;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveRolesRequest extends AbstractCleanupEvent {
+
+    protected RemoveRolesRequest(Long stackId) {
+        super(stackId);
+    }
+
     public RemoveRolesRequest(CleanupEvent cleanupEvent, Stack stack) {
         super(cleanupEvent);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/roles/RemoveRolesResponse.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/roles/RemoveRolesResponse.java
@@ -8,9 +8,13 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveRolesResponse extends AbstractCleanupEvent {
 
-    private final Set<String> roleCleanupSuccess;
+    private Set<String> roleCleanupSuccess;
 
-    private final Map<String, String> roleCleanupFailed;
+    private Map<String, String> roleCleanupFailed;
+
+    protected RemoveRolesResponse(Long stackId) {
+        super(stackId);
+    }
 
     public RemoveRolesResponse(CleanupEvent cleanupEvent, Set<String> roleCleanupSuccess, Map<String, String> roleCleanupFailed) {
         super(cleanupEvent);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/users/RemoveUsersRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/users/RemoveUsersRequest.java
@@ -6,6 +6,10 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveUsersRequest extends AbstractCleanupEvent {
 
+    protected RemoveUsersRequest(Long stackId) {
+        super(stackId);
+    }
+
     public RemoveUsersRequest(CleanupEvent cleanupEvent, Stack stack) {
         super(cleanupEvent);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/users/RemoveUsersResponse.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/users/RemoveUsersResponse.java
@@ -8,9 +8,13 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveUsersResponse extends AbstractCleanupEvent {
 
-    private final Set<String> userCleanupSuccess;
+    private Set<String> userCleanupSuccess;
 
-    private final Map<String, String> userCleanupFailed;
+    private Map<String, String> userCleanupFailed;
+
+    protected RemoveUsersResponse(Long stackId) {
+        super(stackId);
+    }
 
     public RemoveUsersResponse(CleanupEvent cleanupEvent, Set<String> userCleanupSuccess, Map<String, String> userCleanupFailed) {
         super(cleanupEvent);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/vault/RemoveVaultEntriesRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/vault/RemoveVaultEntriesRequest.java
@@ -7,6 +7,11 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.CleanupEvent;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveVaultEntriesRequest extends AbstractCleanupEvent {
+
+    protected RemoveVaultEntriesRequest(Long stackId) {
+        super(stackId);
+    }
+
     public RemoveVaultEntriesRequest(CleanupEvent cleanupEvent, Stack stack) {
         super(cleanupEvent);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/vault/RemoveVaultEntriesResponse.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/event/vault/RemoveVaultEntriesResponse.java
@@ -8,9 +8,13 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveVaultEntriesResponse extends AbstractCleanupEvent {
 
-    private final Set<String> vaultCleanupSuccess;
+    private Set<String> vaultCleanupSuccess;
 
-    private final Map<String, String> vaultCleanupFailed;
+    private Map<String, String> vaultCleanupFailed;
+
+    protected RemoveVaultEntriesResponse(Long stackId) {
+        super(stackId);
+    }
 
     public RemoveVaultEntriesResponse(CleanupEvent cleanupEvent, Set<String> vaultCleanupSuccess,
             Map<String, String> vaultCleanupFailed) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionsState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/DiagnosticsCollectionsState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.freeipa.flow.freeipa.diagnostics;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
 
 public enum DiagnosticsCollectionsState implements FlowState {
     INIT_STATE,
@@ -12,5 +14,10 @@ public enum DiagnosticsCollectionsState implements FlowState {
     DIAGNOSTICS_CLEANUP_STATE,
     DIAGNOSTICS_COLLECTION_FINISHED_STATE,
     DIAGNOSTICS_COLLECTION_FAILED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/DownscaleState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/DownscaleState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.freeipa.flow.freeipa.downscale;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
 
 public enum DownscaleState implements FlowState {
     INIT_STATE,
@@ -21,4 +23,9 @@ public enum DownscaleState implements FlowState {
     DOWNSCALE_FINISHED_STATE,
     DOWNSCALE_FAIL_STATE,
     FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/dnssoarecords/UpdateDnsSoaRecordsRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/dnssoarecords/UpdateDnsSoaRecordsRequest.java
@@ -5,6 +5,10 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class UpdateDnsSoaRecordsRequest extends AbstractCleanupEvent {
 
+    protected UpdateDnsSoaRecordsRequest(Long stackId) {
+        super(stackId);
+    }
+
     public UpdateDnsSoaRecordsRequest(CleanupEvent cleanupEvent) {
         super(cleanupEvent);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/removehosts/RemoveHostsFromOrchestrationRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/removehosts/RemoveHostsFromOrchestrationRequest.java
@@ -5,6 +5,10 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveHostsFromOrchestrationRequest extends AbstractCleanupEvent {
 
+    protected RemoveHostsFromOrchestrationRequest(Long stackId) {
+        super(stackId);
+    }
+
     public RemoveHostsFromOrchestrationRequest(CleanupEvent cleanupEvent) {
         super(cleanupEvent);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/removeserver/RemoveServersRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/removeserver/RemoveServersRequest.java
@@ -5,6 +5,10 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveServersRequest extends AbstractCleanupEvent {
 
+    protected RemoveServersRequest(Long stackId) {
+        super(stackId);
+    }
+
     public RemoveServersRequest(CleanupEvent cleanupEvent) {
         super(cleanupEvent);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/removeserver/RemoveServersResponse.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/event/removeserver/RemoveServersResponse.java
@@ -8,9 +8,13 @@ import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.AbstractCleanupEvent;
 
 public class RemoveServersResponse extends AbstractCleanupEvent {
 
-    private final Set<String> serverCleanupSuccess;
+    private Set<String> serverCleanupSuccess;
 
-    private final Map<String, String> serverCleanupFailed;
+    private Map<String, String> serverCleanupFailed;
+
+    protected RemoveServersResponse(Long stackId) {
+        super(stackId);
+    }
 
     public RemoveServersResponse(CleanupEvent cleanupEvent, Set<String> serverCleanupSuccess, Map<String, String> serverCleanupFailed) {
         super(cleanupEvent);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/FreeIpaProvisionState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/FreeIpaProvisionState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.freeipa.flow.freeipa.provision;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
 
 public enum FreeIpaProvisionState implements FlowState {
     INIT_STATE,
@@ -14,4 +16,9 @@ public enum FreeIpaProvisionState implements FlowState {
     FREEIPA_POST_INSTALL_STATE,
     FREEIPA_PROVISION_FINISHED_STATE,
     FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/ChangePrimaryGatewayState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/ChangePrimaryGatewayState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
 
 public enum ChangePrimaryGatewayState implements FlowState {
     INIT_STATE,
@@ -11,4 +13,9 @@ public enum ChangePrimaryGatewayState implements FlowState {
     CHANGE_PRIMARY_GATEWAY_FINISHED_STATE,
     CHANGE_PRIMARY_GATEWAY_FAIL_STATE,
     FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/UpscaleState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upscale/UpscaleState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.freeipa.flow.freeipa.upscale;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
 
 public enum UpscaleState implements FlowState {
     INIT_STATE,
@@ -23,4 +25,9 @@ public enum UpscaleState implements FlowState {
     UPSCALE_FINISHED_STATE,
     UPSCALE_FAIL_STATE,
     FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/RebootState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.freeipa.flow.instance.reboot;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
 
 public enum RebootState implements FlowState {
     INIT_STATE,
@@ -9,6 +11,8 @@ public enum RebootState implements FlowState {
     REBOOT_FINISHED_STATE,
     FINAL_STATE;
 
-    RebootState() {
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/StackEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/StackEvent.java
@@ -47,4 +47,12 @@ public class StackEvent implements Selectable, Acceptable {
         return accepted;
     }
 
+    @Override
+    public String toString() {
+        return "StackEvent{" +
+                "selector='" + selector + '\'' +
+                ", stackId=" + stackId +
+                ", accepted=" + accepted +
+                '}';
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/StackProvisionState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/provision/StackProvisionState.java
@@ -2,6 +2,7 @@ package com.sequenceiq.freeipa.flow.stack.provision;
 
 import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.freeipa.flow.stack.AbstractStackAction;
 import com.sequenceiq.freeipa.flow.stack.provision.action.CheckImageAction;
 
@@ -39,6 +40,6 @@ public enum StackProvisionState implements FlowState {
 
     @Override
     public Class<? extends RestartAction> restartAction() {
-        return null;
+        return FillInMemoryStateStoreRestartAction.class;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/start/StackStartState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/start/StackStartState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.freeipa.flow.stack.start;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
 
 public enum StackStartState implements FlowState {
     INIT_STATE,
@@ -8,5 +10,10 @@ public enum StackStartState implements FlowState {
     START_STATE,
     COLLECTING_METADATA,
     START_FINISHED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/stop/StackStopState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/stop/StackStopState.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.flow.stack.stop;
 import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.RestartAction;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
 
 public enum StackStopState implements FlowState {
     INIT_STATE,
@@ -11,7 +12,7 @@ public enum StackStopState implements FlowState {
     STOP_FINISHED_STATE,
     FINAL_STATE;
 
-    private Class<? extends DefaultRestartAction> restartAction = DefaultRestartAction.class;
+    private Class<? extends DefaultRestartAction> restartAction = FillInMemoryStateStoreRestartAction.class;
 
     StackStopState() {
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/termination/StackTerminationState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.freeipa.flow.stack.termination;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.freeipa.flow.stack.AbstractStackAction;
 import com.sequenceiq.freeipa.flow.stack.termination.action.DeregisterCcmKeyAction;
 import com.sequenceiq.freeipa.flow.stack.termination.action.DeregisterClusterProxyAction;
@@ -33,5 +35,10 @@ public enum StackTerminationState implements FlowState {
     @Override
     public Class<? extends AbstractStackAction<?, ?, ?, ?>> action() {
         return action;
+    }
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
     }
 }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
@@ -145,7 +145,7 @@ public class SaltStates {
     }
 
     private static Multimap<String, Map<String, String>> highStateJidInfo(SaltConnector sc, String jid) {
-        Map<String, List<Map<String, Object>>> jidInfo = sc.run("jobs.lookup_jid", RUNNER, Map.class, "jid", jid);
+        Map<String, List<Map<String, Object>>> jidInfo = sc.run("jobs.lookup_jid", RUNNER, Map.class, "jid", jid, "missing", "True");
         Map<String, List<RunnerInfo>> states = JidInfoResponseTransformer.getHighStates(jidInfo);
         return collectMissingTargets(states);
     }

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStatesTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStatesTest.java
@@ -138,10 +138,10 @@ public class SaltStatesTest {
         String response = IOUtils.toString(responseStream, Charset.defaultCharset());
         responseStream.close();
         Map<?, ?> responseMap = new ObjectMapper().readValue(response, Map.class);
-        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), any())).thenReturn(responseMap);
+        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), any(), eq("missing"), eq("True"))).thenReturn(responseMap);
 
         Multimap<String, Map<String, String>> jidInfo = SaltStates.jidInfo(saltConnector, jobId, StateType.HIGH);
-        verify(saltConnector, times(1)).run("jobs.lookup_jid", RUNNER, Map.class, "jid", jobId);
+        verify(saltConnector, times(1)).run("jobs.lookup_jid", RUNNER, Map.class, "jid", jobId, "missing", "True");
 
         assertThat(jidInfo.keySet(), hasSize(1));
         assertThat(jidInfo.entries(), hasSize(4));
@@ -169,7 +169,7 @@ public class SaltStatesTest {
         String runningJid = "20201116101144197633";
         String jobId = "2";
 
-        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), eq("2"))).thenThrow(
+        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), eq("2"), eq("missing"), eq("True"))).thenThrow(
                 new SaltExecutionWentWrongException("The function \"state.highstate\" is running as PID 100789 and was started at 2020, " +
                         "Nov 16 10:11:44.197633 with jid " + runningJid));
 
@@ -177,11 +177,11 @@ public class SaltStatesTest {
         String response = IOUtils.toString(responseStream, Charset.defaultCharset());
         responseStream.close();
         Map<?, ?> responseMap = new ObjectMapper().readValue(response, Map.class);
-        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), eq(runningJid))).thenReturn(responseMap);
+        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), eq(runningJid), eq("missing"), eq("True"))).thenReturn(responseMap);
 
         Multimap<String, Map<String, String>> jidInfo = SaltStates.jidInfo(saltConnector, jobId, StateType.HIGH);
-        verify(saltConnector, times(1)).run("jobs.lookup_jid", RUNNER, Map.class, "jid", runningJid);
-        verify(saltConnector, times(1)).run("jobs.lookup_jid", RUNNER, Map.class, "jid", jobId);
+        verify(saltConnector, times(1)).run("jobs.lookup_jid", RUNNER, Map.class, "jid", runningJid, "missing", "True");
+        verify(saltConnector, times(1)).run("jobs.lookup_jid", RUNNER, Map.class, "jid", jobId, "missing", "True");
 
         assertThat(jidInfo.keySet(), hasSize(1));
         assertThat(jidInfo.entries(), hasSize(4));
@@ -209,11 +209,11 @@ public class SaltStatesTest {
         String runningJid = "20201116101144197633";
         String jobId = "2";
 
-        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), eq("2"))).thenThrow(
+        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), eq("2"), eq("missing"), eq("True"))).thenThrow(
                 new SaltExecutionWentWrongException("The function \"state.highstate\" is running as PID 100789 and was started at 2020, " +
                         "Nov 16 10:11:44.197633 with jid " + runningJid));
 
-        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), eq("20201116101144197633"))).thenThrow(
+        when(saltConnector.run(eq("jobs.lookup_jid"), any(), any(), eq("jid"), eq("20201116101144197633"), eq("missing"), eq("True"))).thenThrow(
                 new SaltExecutionWentWrongException("other error"));
 
         try {
@@ -221,8 +221,8 @@ public class SaltStatesTest {
         } catch (SaltExecutionWentWrongException e) {
             assertEquals("other error", e.getMessage());
         }
-        verify(saltConnector, times(1)).run("jobs.lookup_jid", RUNNER, Map.class, "jid", runningJid);
-        verify(saltConnector, times(1)).run("jobs.lookup_jid", RUNNER, Map.class, "jid", jobId);
+        verify(saltConnector, times(1)).run("jobs.lookup_jid", RUNNER, Map.class, "jid", runningJid, "missing", "True");
+        verify(saltConnector, times(1)).run("jobs.lookup_jid", RUNNER, Map.class, "jid", jobId, "missing", "True");
     }
 
     @Test


### PR DESCRIPTION
- created and set `FillInMemoryStateStoreRestartAction` for flows running salt. It will set MDCContext and make the the `Stack` pollable if not deleted/terminated
- created and set `InitializeMDCContextRestartAction` for flows which doesn't use `InMemoryStore`
- Ensured events can be recreated from DB after service restart
- Fixed salt related issue where reading the highstate returned empty result when minion didn't return. Now missing minions are in the response causing exception/failure as it should.

Tested:
- FreeIPA provision with service restart. HA tested too
- FreeIPA termination with service restart
- FreeIPA running cleanup flow with service restart
- DL creation
- DH creation, scaling, termination

See detailed description in the commit message.