### PR TITLE
CB-11621 There are cases when we remove less node than demanded node count at downscale

### DIFF
--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissionerTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecomissionerTest.java
@@ -1,18 +1,22 @@
 package com.sequenceiq.cloudbreak.cm;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -28,11 +32,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.cloudera.api.swagger.ClouderaManagerResourceApi;
 import com.cloudera.api.swagger.ClustersResourceApi;
 import com.cloudera.api.swagger.CommandsResourceApi;
+import com.cloudera.api.swagger.HostTemplatesResourceApi;
+import com.cloudera.api.swagger.HostsResourceApi;
 import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiCommand;
+import com.cloudera.api.swagger.model.ApiHealthSummary;
+import com.cloudera.api.swagger.model.ApiHost;
 import com.cloudera.api.swagger.model.ApiHostRef;
 import com.cloudera.api.swagger.model.ApiHostRefList;
+import com.cloudera.api.swagger.model.ApiHostTemplateList;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
@@ -131,6 +140,54 @@ class ClouderaManagerDecomissionerTest {
                         createRunningInstanceMetadata().getDiscoveryFQDN());
     }
 
+    @Test
+    public void testDecommissionForNodesNowKnownByCM() throws ApiException {
+        ApiHostRefList apiHostRefList = new ApiHostRefList();
+        apiHostRefList.setItems(List.of(createApiHostRef("host1.example.com"), createApiHostRef("host2.example.com"),
+                createApiHostRef("host5.example.com")));
+        when(clustersResourceApi.listHosts(STACK_NAME, null, null)).thenReturn(apiHostRefList);
+        when(clouderaManagerApiFactory.getClustersResourceApi(client)).thenReturn(clustersResourceApi);
+        HostTemplatesResourceApi hostTemplatesResourceApi = mock(HostTemplatesResourceApi.class);
+        ApiHostTemplateList apiHostTemplateList = new ApiHostTemplateList();
+        apiHostTemplateList.setItems(new ArrayList<>());
+        when(hostTemplatesResourceApi.readHostTemplates(any())).thenReturn(apiHostTemplateList);
+        when(clouderaManagerApiFactory.getHostTemplatesResourceApi(client)).thenReturn(hostTemplatesResourceApi);
+
+        HostGroup compute = new HostGroup();
+        compute.setName("compute");
+
+        HostsResourceApi hostsResourceApi = mock(HostsResourceApi.class);
+        when(clouderaManagerApiFactory.getHostsResourceApi(client)).thenReturn(hostsResourceApi);
+        ApiHost apiHost1 = new ApiHost();
+        apiHost1.setHealthSummary(ApiHealthSummary.GOOD);
+        apiHost1.setHostname("host1.example.com");
+        when(hostsResourceApi.readHost(eq("host1.example.com"), any())).thenReturn(apiHost1);
+        ApiHost apiHost2 = new ApiHost();
+        apiHost2.setHealthSummary(ApiHealthSummary.BAD);
+        apiHost2.setHostname("host2.example.com");
+        when(hostsResourceApi.readHost(eq("host2.example.com"), any())).thenReturn(apiHost2);
+        ApiHost apiHost3 = new ApiHost();
+        apiHost3.setHealthSummary(ApiHealthSummary.GOOD);
+        apiHost3.setHostname("host5.example.com");
+        when(hostsResourceApi.readHost(eq("host5.example.com"), any())).thenReturn(apiHost3);
+
+        InstanceMetaData healthy1 = createInstanceMetadata(InstanceStatus.SERVICES_HEALTHY, "host1.example.com", "compute");
+        InstanceMetaData bad1 = createInstanceMetadata(InstanceStatus.SERVICES_HEALTHY, "host2.example.com", "compute");
+        InstanceMetaData failed1 = createInstanceMetadata(InstanceStatus.ORCHESTRATION_FAILED, "host3.example.com", "compute");
+        InstanceMetaData failed2 = createInstanceMetadata(InstanceStatus.ORCHESTRATION_FAILED, "host4.example.com", "compute");
+        InstanceMetaData healthy2 = createInstanceMetadata(InstanceStatus.SERVICES_HEALTHY, "host5.example.com", "compute");
+
+        Set<InstanceMetaData> instanceMetaDataSet = Set.of(failed1, failed2, healthy1, healthy2, bad1);
+        Stack stack = getStack();
+        stack.setPlatformVariant("AWS");
+        Set<InstanceMetaData> removableInstances = underTest.collectDownscaleCandidates(client, stack, compute, 4, 0, instanceMetaDataSet);
+        assertEquals(4, removableInstances.size());
+        assertTrue(removableInstances.contains(failed1));
+        assertTrue(removableInstances.contains(failed2));
+        assertTrue(removableInstances.contains(healthy2));
+        assertTrue(removableInstances.contains(bad1));
+    }
+
     private HostGroup createHostGroup() {
         HostGroup hostGroup = new HostGroup();
         InstanceGroup instanceGroup = new InstanceGroup();
@@ -162,26 +219,27 @@ class ClouderaManagerDecomissionerTest {
     }
 
     private InstanceMetaData createRunningInstanceMetadata() {
-        return createInstanceMetadata(InstanceStatus.SERVICES_HEALTHY, RUNNING_INSTANCE_FQDN);
+        return createInstanceMetadata(InstanceStatus.SERVICES_HEALTHY, RUNNING_INSTANCE_FQDN, "compute");
     }
 
     private InstanceMetaData createDeletedInstanceMetadata() {
-        return createInstanceMetadata(InstanceStatus.DELETED_ON_PROVIDER_SIDE, DELETED_INSTANCE_FQDN);
+        return createInstanceMetadata(InstanceStatus.DELETED_ON_PROVIDER_SIDE, DELETED_INSTANCE_FQDN, "compute");
     }
 
-    private InstanceMetaData createInstanceMetadata(InstanceStatus servicesHealthy, String runningInstanceFqdn) {
+    private InstanceMetaData createInstanceMetadata(InstanceStatus servicesHealthy, String runningInstanceFqdn, String instanceGroupName) {
         InstanceMetaData instanceMetaData = new InstanceMetaData();
         instanceMetaData.setInstanceStatus(servicesHealthy);
         instanceMetaData.setDiscoveryFQDN(runningInstanceFqdn);
         InstanceGroup instanceGroup = new InstanceGroup();
-        instanceGroup.setGroupName("instanceGroup");
+        instanceGroup.setGroupName(instanceGroupName);
         instanceMetaData.setInstanceGroup(instanceGroup);
         return instanceMetaData;
     }
 
-    private ApiHostRef createApiHostRef(String deletedInstanceFqd) {
+    private ApiHostRef createApiHostRef(String instanceFqd) {
         ApiHostRef deletedInstanceHostRef = new ApiHostRef();
-        deletedInstanceHostRef.setHostname(deletedInstanceFqd);
+        deletedInstanceHostRef.setHostname(instanceFqd);
+        deletedInstanceHostRef.setHostId(instanceFqd);
         return deletedInstanceHostRef;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
@@ -125,8 +125,8 @@ public class DecommissionHandler implements EventHandler<DecommissionRequest> {
             Set<Node> decommissionedNodes = stackUtil.collectNodesFromHostnames(stack, decommissionedHostNames);
             GatewayConfig gatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
             boolean forced = request.getDetails() != null && request.getDetails().isForced();
-            hostOrchestrator.stopClusterManagerAgent(gatewayConfig, decommissionedNodes, clusterDeletionBasedModel(stack.getId(), cluster.getId()),
-                    kerberosDetailService.isAdJoinable(kerberosConfig), kerberosDetailService.isIpaJoinable(kerberosConfig), forced);
+            hostOrchestrator.stopClusterManagerAgent(gatewayConfig, stackUtil.collectNodes(stack), decommissionedNodes, clusterDeletionBasedModel(stack.getId(),
+                    cluster.getId()), kerberosDetailService.isAdJoinable(kerberosConfig), kerberosDetailService.isIpaJoinable(kerberosConfig), forced);
             cleanUpFreeIpa(stack, hostsToRemove);
             List<InstanceMetaData> decommissionedInstances = decommissionedHostNames.stream()
                     .map(hostsToRemove::get)

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxRetryService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxRetryService.java
@@ -3,6 +3,8 @@ package com.sequenceiq.datalake.service.sdx;
 import static com.sequenceiq.datalake.flow.create.SdxCreateEvent.SDX_STACK_CREATION_IN_PROGRESS_EVENT;
 import static com.sequenceiq.datalake.flow.datalake.upgrade.DatalakeUpgradeEvent.DATALAKE_UPGRADE_IN_PROGRESS_EVENT;
 import static com.sequenceiq.datalake.flow.repair.SdxRepairEvent.SDX_REPAIR_IN_PROGRESS_EVENT;
+import static com.sequenceiq.datalake.flow.start.SdxStartEvent.SDX_START_IN_PROGRESS_EVENT;
+import static com.sequenceiq.datalake.flow.stop.SdxStopEvent.SDX_STOP_IN_PROGRESS_EVENT;
 
 import java.util.Arrays;
 import java.util.List;
@@ -80,7 +82,9 @@ public class SdxRetryService {
         return Arrays.asList(
                 SDX_STACK_CREATION_IN_PROGRESS_EVENT,
                 DATALAKE_UPGRADE_IN_PROGRESS_EVENT,
-                SDX_REPAIR_IN_PROGRESS_EVENT
+                SDX_REPAIR_IN_PROGRESS_EVENT,
+                SDX_START_IN_PROGRESS_EVENT,
+                SDX_STOP_IN_PROGRESS_EVENT
         );
     }
 

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -88,8 +88,8 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     Map<String, Map<String, String>> formatAndMountDisksOnNodes(List<GatewayConfig> allGateway, Set<Node> targets, Set<Node> allNodes,
             ExitCriteriaModel exitModel, String platformVariant) throws CloudbreakOrchestratorFailedException;
 
-    void stopClusterManagerAgent(GatewayConfig gatewayConfig, Set<Node> nodes, ExitCriteriaModel exitCriteriaModel, boolean adJoinable, boolean ipaJoinable,
-            boolean forced)
+    void stopClusterManagerAgent(GatewayConfig gatewayConfig, Set<Node> allNodes, Set<Node> stoppedNodes, ExitCriteriaModel exitCriteriaModel,
+            boolean adJoinable, boolean ipaJoinable, boolean forced)
             throws CloudbreakOrchestratorFailedException;
 
     void uploadKeytabs(List<GatewayConfig> allGatewayConfigs, Set<KeytabModel> keytabModels, ExitCriteriaModel exitModel)


### PR DESCRIPTION
eg: customer select 3 nodes for downscale but we removed 0 nodes

It can happen because we collect nodes in the following way:

 - collect nodes without FQDN (so they are not registered to CM)
 - collect nodes from CM by some ordering algorithm if we don't have enough nodes from the first step

Problem: there are nodes with FQDN but not registered into CM. It can happen because we assign FQDN to them, but somehow we were not able to join them to the CM cluster.

Solution: we have to collect them also, so the downscale collection will happen in the following way:

 - collect nodes without FQDN
 - collect nodes with FQDN but not registered into CM
 - collect nodes from CM by some ordering algorithm if we don't have enough nodes from the 1. and 2. step