### PR TITLE
DISTX-584 Move CM to its own hostgroup in DE HA Template

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
@@ -496,7 +496,7 @@
         ]
       },
       {
-        "refName": "manager",
+        "refName": "masterx",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "hdfs-BALANCER-BASE",
@@ -535,6 +535,13 @@
         "cardinality": 0,
         "roleConfigGroupsRefNames": [
           "yarn-NODEMANAGER-COMPUTE"
+        ]
+      },
+      {
+        "refName": "manager",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "knox-KNOX_GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
@@ -496,7 +496,7 @@
         ]
       },
       {
-        "refName": "manager",
+        "refName": "masterx",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "hdfs-BALANCER-BASE",
@@ -535,6 +535,13 @@
         "cardinality": 0,
         "roleConfigGroupsRefNames": [
           "yarn-NODEMANAGER-COMPUTE"
+        ]
+      },
+      {
+        "refName": "manager",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "knox-KNOX_GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
@@ -496,7 +496,7 @@
         ]
       },
       {
-        "refName": "manager",
+        "refName": "masterx",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "hdfs-BALANCER-BASE",
@@ -535,6 +535,13 @@
         "cardinality": 0,
         "roleConfigGroupsRefNames": [
           "yarn-NODEMANAGER-COMPUTE"
+        ]
+      },
+      {
+        "refName": "manager",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "knox-KNOX_GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-ha.json
@@ -119,6 +119,30 @@
           "cloudPlatform": "AWS"
         },
         "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering-ha.json
@@ -149,6 +149,35 @@
         },
         "recipeNames": [],
         "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 150,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-ha.json
@@ -91,6 +91,22 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "masterx",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-standard"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/yarn/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/yarn/dataengineering-ha.json
@@ -90,6 +90,22 @@
           }
         },
         "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "recipeNames": []
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering-ha.json
@@ -15,7 +15,7 @@
     "instanceGroups": [{
       "nodeCount": 1,
       "name": "manager",
-      "type": "CORE",
+      "type": "GATEWAY",
       "recoveryMode": "MANUAL",
       "template": {
         "aws": {
@@ -103,7 +103,31 @@
       {
         "nodeCount": 2,
         "name": "master",
-        "type": "GATEWAY",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
         "recoveryMode": "MANUAL",
         "template": {
           "aws": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering-ha.json
@@ -149,6 +149,35 @@
         },
         "recipeNames": [],
         "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 150,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-ha.json
@@ -91,6 +91,22 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "masterx",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-standard"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/dataengineering-ha.json
@@ -75,6 +75,19 @@
           }
         },
         "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "recipeNames": []
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-ha.json
@@ -119,6 +119,30 @@
           "cloudPlatform": "AWS"
         },
         "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "aws": {
+            "placementGroup" : {
+              "strategy" : "PARTITION"
+            }
+          },
+          "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [{
+            "size": 150,
+            "count": 1,
+            "type": "gp2"
+          }],
+          "cloudPlatform": "AWS"
+        },
+        "recipeNames": []
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering-ha.json
@@ -149,6 +149,35 @@
         },
         "recipeNames": [],
         "cloudPlatform": "AZURE"
+      },
+      {
+        "nodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D16_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 150,
+              "count": 1,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "cloudPlatform": "AZURE"
+        },
+        "recipeNames": [],
+        "cloudPlatform": "AZURE"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-ha.json
@@ -91,6 +91,22 @@
         "nodeCount": 0,
         "type": "CORE",
         "recoveryMode": "MANUAL"
+      },
+      {
+        "name": "masterx",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "pd-standard"
+            }
+          ],
+          "instanceType": "e2-standard-8"
+        },
+        "nodeCount": 1,
+        "type": "CORE",
+        "recoveryMode": "MANUAL"
       }
     ]
   }

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/yarn/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/yarn/dataengineering-ha.json
@@ -90,6 +90,22 @@
           }
         },
         "recipeNames": []
+      },
+      {
+        "nodeCount": 1,
+        "name": "masterx",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 32768
+          }
+        },
+        "recipeNames": []
       }
     ]
   }


### PR DESCRIPTION
1. Manager HostGroup to contain only CM.
2. Old manager HostGroup renamed to masterx.
3. Manager HostGroup made Gateway type.
4. The change is applied to 7.2.8, 7.2.9 and 7.2.10 DE HA Templates

See detailed description in the commit message.