### PR TITLE
CB-9717 FreeIPA should log X-CDP-Request-ID to /var/log/httpd/error_log

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
@@ -17,6 +17,15 @@ one_week_next_update_grace_period:
       - service pki-tomcatd@pki-tomcat start
     - unless: grep "^ca[.]crl[.]MasterCRL[.]nextUpdateGracePeriod=10080$" /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
 
+add-httpd-x-cdp-trace-id:
+   file.line:
+     - name: /usr/lib/python2.7/site-packages/ipaserver/rpcserver.py
+     - mode: ensure
+     - content: "        logger.info('X-cdp-request-ID : %s', environ.get('HTTP_X_CDP_REQUEST_ID'))"
+     - after: "return self.marshal(result, RefererError(referer=environ['HTTP_REFERER']), _id)"
+     - indent: False
+     - backup: False
+
 /usr/lib/python2.7/site-packages/ipaserver/plugins/getkeytab.py:
   file.managed:
     - makedirs: True
@@ -32,6 +41,7 @@ restart_freeipa_after_plugin_change:
     - onlyif: test -f /etc/ipa/default.conf
     - watch:
       - file: /usr/lib/python2.7/site-packages/ipaserver/plugins/getkeytab.py
+      - file: /usr/lib/python2.7/site-packages/ipaserver/rpcserver.py
 
 set_number_of_krb5kdc_workers:
   file.replace:


### PR DESCRIPTION
As described in https://docs.google.com/document/d/1krz-82-wY9PwUcJcof2SH9EtF7KkYcPVmWGIzN2akkA/edit#, the header X-CDP-Request-ID should be logged by FreeIPA into /var/log/httpd/error_log

This can be done by adding logging of environ.get('HTTP_X_CDP_Request_ID') to the info level logs statemetns in /usr/lib/python2.7/site-packages/ipaserver/rpcserver.py
WSGIExecutioner::wsgi_execute(). Salt to distribute update this file and restart ipa.

See detailed description in the commit message.