### PR TITLE
DISTX-557 Overcome master memory overcommit problem with default DE d…

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering.json
@@ -25,7 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/dataengineering.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/dataengineering.json
@@ -25,7 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering.json
@@ -24,7 +24,7 @@
               "type": "NONE"
             }
           },
-          "instanceType": "m5.2xlarge"
+          "instanceType": "m5.4xlarge"
         },
         "nodeCount": 1,
         "type": "GATEWAY",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/dataengineering.json
@@ -25,7 +25,7 @@
               "updateDomainCount": 20
             }
           },
-          "instanceType": "Standard_D8_v3"
+          "instanceType": "Standard_D16_v3"
         },
         "nodeCount": 1,
         "type": "GATEWAY",


### PR DESCRIPTION
…efinition by using m5.4xlarge

1. There are 33 roles in master, and 32 GB is clearly not enough.
2. This will solve the memory overcommit problem.
3. This will give more memory for services like HS2.

Tested that memory overcommit is gone by creating a cluster with custom definition like this.