### PR TITLE
CB-11415 Replace DefaultRestartAction for flows in redbeams service

### DIFF
--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/FillInMemoryStateStoreRestartAction.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/common/FillInMemoryStateStoreRestartAction.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.redbeams.flow.redbeams.common;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
+import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.redbeams.domain.stack.DatabaseServer;
+import com.sequenceiq.redbeams.service.stack.DBStackService;
+import com.sequenceiq.redbeams.service.store.RedbeamsInMemoryStateStoreUpdaterService;
+
+@Component("FillInMemoryStateStoreRestartAction")
+public class FillInMemoryStateStoreRestartAction extends DefaultRestartAction {
+
+    @Inject
+    private DBStackService dbStackService;
+
+    @Inject
+    private RedbeamsInMemoryStateStoreUpdaterService redbeamsInMemoryStateStoreUpdaterService;
+
+    @Override
+    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
+        Payload redbeamsPayload = (Payload) payload;
+        DBStack dbStack = dbStackService.getById(redbeamsPayload.getResourceId());
+        if (dbStack != null) {
+            redbeamsInMemoryStateStoreUpdaterService.update(dbStack.getId(), dbStack.getStatus());
+            MDCBuilder.buildMdcContext(dbStack);
+            MDCBuilder.addEnvironmentCrn(dbStack.getEnvironmentId());
+            MDCBuilder.addAccountId(getAccountId(dbStack));
+        }
+        super.restart(flowParameters, flowChainId, event, payload);
+    }
+
+    private String getAccountId(DBStack dbStack) {
+        return Optional.ofNullable(dbStack.getDatabaseServer()).map(DatabaseServer::getAccountId).orElse("");
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/RedbeamsProvisionState.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/RedbeamsProvisionState.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.redbeams.flow.redbeams.provision;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
+import com.sequenceiq.redbeams.flow.redbeams.common.FillInMemoryStateStoreRestartAction;
 
 public enum RedbeamsProvisionState implements FlowState {
     INIT_STATE,
@@ -8,5 +11,13 @@ public enum RedbeamsProvisionState implements FlowState {
     ALLOCATE_DATABASE_SERVER_STATE,
     UPDATE_DATABASE_SERVER_REGISTRATION_STATE,
     REDBEAMS_PROVISION_FINISHED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    private Class<? extends DefaultRestartAction> restartAction = FillInMemoryStateStoreRestartAction.class;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return restartAction;
+    }
+
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/RedbeamsStartState.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/start/RedbeamsStartState.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.redbeams.flow.redbeams.start;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
+import com.sequenceiq.redbeams.flow.redbeams.common.FillInMemoryStateStoreRestartAction;
 
 public enum RedbeamsStartState implements FlowState {
     INIT_STATE,
@@ -8,4 +11,12 @@ public enum RedbeamsStartState implements FlowState {
     START_DATABASE_SERVER_STATE,
     REDBEAMS_START_FINISHED_STATE,
     FINAL_STATE;
+
+    private Class<? extends DefaultRestartAction> restartAction = FillInMemoryStateStoreRestartAction.class;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return restartAction;
+    }
+
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/RedbeamsStopState.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/stop/RedbeamsStopState.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.redbeams.flow.redbeams.stop;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
+import com.sequenceiq.redbeams.flow.redbeams.common.FillInMemoryStateStoreRestartAction;
 
 public enum RedbeamsStopState implements FlowState {
     INIT_STATE,
@@ -8,4 +11,12 @@ public enum RedbeamsStopState implements FlowState {
     STOP_DATABASE_SERVER_STATE,
     REDBEAMS_STOP_FINISHED_STATE,
     FINAL_STATE;
+
+    private Class<? extends DefaultRestartAction> restartAction = FillInMemoryStateStoreRestartAction.class;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return restartAction;
+    }
+
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/RedbeamsTerminationState.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/RedbeamsTerminationState.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.redbeams.flow.redbeams.termination;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
+import com.sequenceiq.redbeams.flow.redbeams.common.FillInMemoryStateStoreRestartAction;
 
 public enum RedbeamsTerminationState implements FlowState {
     INIT_STATE,
@@ -8,5 +11,13 @@ public enum RedbeamsTerminationState implements FlowState {
     TERMINATE_DATABASE_SERVER_STATE,
     DEREGISTER_DATABASE_SERVER_STATE,
     REDBEAMS_TERMINATION_FINISHED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    private Class<? extends DefaultRestartAction> restartAction = FillInMemoryStateStoreRestartAction.class;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return restartAction;
+    }
+
 }


### PR DESCRIPTION
Upon restart the DBStack of running flows is not loaded into the in memory store, causing possible problems in the heartbeatService when all deleting flows are queried.
A restart action was added that fills the in memory store with currently executing flow's DBStack, if present (at the final step of the delete flow DBStack is deleted, thus after a restart at that place there is be no more DBStack).

See detailed description in the commit message.