### PR TITLE
CB-11419 Fix waiting edge cases in integration tests

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerApiCheckerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerApiCheckerTask.java
@@ -83,12 +83,12 @@ public abstract class AbstractClouderaManagerApiCheckerTask<T extends ClouderaMa
         if (toleratedErrorCounter < TOLERATED_ERROR_LIMIT) {
             toleratedErrorCounter++;
             LOGGER.warn("Command [{}] with id [{}] failed with a tolerated error '{}' for the {}. time(s). Tolerating till {} occasions.",
-                    getCommandName(), getOperationIdentifier(pollerObject), e.getMessage(), toleratedErrorCounter, TOLERATED_ERROR_LIMIT);
+                    getCommandName(), getOperationIdentifier(pollerObject), e.getMessage(), toleratedErrorCounter, TOLERATED_ERROR_LIMIT, e);
             return false;
         } else {
             throw new ClouderaManagerOperationFailedException(
                     String.format("Command [%s] with id [%s] failed with a tolerated error '%s' for %s times. Operation is considered failed.",
-                            getCommandName(), getOperationIdentifier(pollerObject), e.getMessage(), TOLERATED_ERROR_LIMIT));
+                            getCommandName(), getOperationIdentifier(pollerObject), e.getMessage(), TOLERATED_ERROR_LIMIT), e);
         }
     }
 

--- a/integration-test/scripts/fetch-secrets.sh
+++ b/integration-test/scripts/fetch-secrets.sh
@@ -16,7 +16,7 @@ fi
 mkdir -p ./src/main/resources/ums-users
 
 echo "Executing secret fetching from Azure 'jenkins-secret' store"
-az keyvault secret show --name "real-ums-users-dev" --vault-name "jenkins-secret" --version $secret_version --query 'value' -o tsv | jq > $USER_JSON_LOCATION
+az keyvault secret show --name "real-ums-users-dev" --vault-name "jenkins-secret" --version $secret_version --query 'value' -o tsv | jq '.' > $USER_JSON_LOCATION
 
 echo "Checking if valid json file was fetched: $USER_JSON_LOCATION"
 cat $USER_JSON_LOCATION | jq type

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/yarn/YarnCloudProvider.java
@@ -18,6 +18,7 @@ import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.Instan
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.YarnInstanceTemplateV1Parameters;
 import com.sequenceiq.environment.api.v1.credential.model.parameters.yarn.YarnParameters;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkYarnParams;
+import com.sequenceiq.environment.api.v1.environment.model.request.AttachedFreeIpaRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProvider;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -66,8 +67,12 @@ public class YarnCloudProvider extends AbstractCloudProvider {
 
     @Override
     public EnvironmentTestDto environment(EnvironmentTestDto environment) {
+        final AttachedFreeIpaRequest attachedFreeIpaRequest = new AttachedFreeIpaRequest();
+        attachedFreeIpaRequest.setCreate(Boolean.FALSE);
+
         return environment
-                .withLocation(location());
+                .withLocation(location())
+                .withFreeIpa(attachedFreeIpaRequest);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitFailedChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitFailedChecker.java
@@ -44,7 +44,6 @@ public class WaitFailedChecker<T extends WaitObject> extends ExceptionChecker<T>
     public void handleTimeout(T waitObject) {
         String name = waitObject.getName();
         try {
-            waitObject.fetchData();
             Map<String, String> actualStatuses = waitObject.actualStatuses();
             Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
             throw new TestFailException(String.format("Wait operation timed out, '%s' %s has not been failed. Status: '%s' " +
@@ -64,7 +63,6 @@ public class WaitFailedChecker<T extends WaitObject> extends ExceptionChecker<T>
     @Override
     public boolean exitWaiting(T waitObject) {
         try {
-            waitObject.fetchData();
             String name = waitObject.getName();
             if (waitObject.actualStatuses().isEmpty()) {
                 LOGGER.info("'{}' {} was not found. Exit waiting!", waitObject.getClass().getSimpleName(), name);
@@ -81,7 +79,6 @@ public class WaitFailedChecker<T extends WaitObject> extends ExceptionChecker<T>
 
     @Override
     public Map<String, String> getStatuses(T waitObject) {
-        waitObject.fetchData();
         return waitObject.actualStatuses();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
@@ -49,7 +49,6 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
     @Override
     public void handleTimeout(T waitObject) {
         try {
-            waitObject.fetchData();
             String name = waitObject.getName();
             Map<String, String> actualStatuses = waitObject.actualStatuses();
             if (actualStatuses.isEmpty()) {
@@ -73,7 +72,6 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
     @Override
     public boolean exitWaiting(T waitObject) {
         try {
-            waitObject.fetchData();
             String name = waitObject.getName();
             Map<String, String> actualStatuses = waitObject.actualStatuses();
             if (actualStatuses.isEmpty()) {
@@ -84,6 +82,7 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
                 LOGGER.info("'{}' the polled resource entered into creation failed state. Exit waiting!", name);
                 return true;
             }
+            return waitObject.isFailed();
         } catch (ProcessingException clientException) {
             LOGGER.error("Exit waiting! Failed to get cluster due to API client exception: {}", clientException.getMessage(), clientException);
         } catch (Exception e) {
@@ -95,7 +94,6 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
 
     @Override
     public Map<String, String> getStatuses(T waitObject) {
-        waitObject.fetchData();
         return waitObject.actualStatuses();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitTerminationChecker.java
@@ -45,7 +45,6 @@ public class WaitTerminationChecker<T extends WaitObject> extends ExceptionCheck
     @Override
     public void handleTimeout(T waitObject) {
         try {
-            waitObject.fetchData();
             String name = waitObject.getName();
             Map<String, String> actualStatuses = waitObject.actualStatuses();
             Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
@@ -65,7 +64,6 @@ public class WaitTerminationChecker<T extends WaitObject> extends ExceptionCheck
     @Override
     public boolean exitWaiting(T waitObject) {
         try {
-            waitObject.fetchData();
             if (waitObject.isDeleteFailed()) {
                 return false;
             }
@@ -83,7 +81,6 @@ public class WaitTerminationChecker<T extends WaitObject> extends ExceptionCheck
     public Map<String, String> getStatuses(T waitObject) {
         String name = waitObject.getName();
         try {
-            waitObject.fetchData();
             return waitObject.actualStatuses();
         } catch (NotFoundException e) {
             LOGGER.warn("No cluster found with name '{}'! It has been deleted successfully.", name, e);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceFailedChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceFailedChecker.java
@@ -73,7 +73,6 @@ public class InstanceFailedChecker<T extends InstanceWaitObject> extends Excepti
     public boolean exitWaiting(T waitObject) {
         String hostGroup = waitObject.getHostGroup();
         try {
-            waitObject.fetchData();
             Optional<InstanceGroupV4Response> instanceGroup = waitObject.getInstanceGroup();
             if (instanceGroup.isEmpty()) {
                 LOGGER.info("'{}' instance group was not found. Exit waiting!", hostGroup);
@@ -95,7 +94,6 @@ public class InstanceFailedChecker<T extends InstanceWaitObject> extends Excepti
 
     @Override
     public Map<String, String> getStatuses(T waitObject) {
-        waitObject.fetchData();
         return waitObject.actualStatuses();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceOperationChecker.java
@@ -55,7 +55,6 @@ public class InstanceOperationChecker<T extends InstanceWaitObject> extends Exce
     @Override
     public void handleTimeout(T waitObject) {
         try {
-            waitObject.fetchData();
             InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
             InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
             String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
@@ -77,7 +76,6 @@ public class InstanceOperationChecker<T extends InstanceWaitObject> extends Exce
     @Override
     public boolean exitWaiting(T waitObject) {
         try {
-            waitObject.fetchData();
             InstanceStatus instanceStatus = waitObject.getInstanceStatus();
             if (instanceStatus.equals(ORCHESTRATION_FAILED)) {
                 return true;
@@ -95,7 +93,6 @@ public class InstanceOperationChecker<T extends InstanceWaitObject> extends Exce
 
     @Override
     public Map<String, String> getStatuses(T waitObject) {
-        waitObject.fetchData();
         return waitObject.actualStatuses();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceTerminationChecker.java
@@ -46,7 +46,6 @@ public class InstanceTerminationChecker<T extends InstanceWaitObject> extends Ex
     @Override
     public void handleTimeout(T waitObject) {
         try {
-            waitObject.fetchData();
             InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
             InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
             String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
@@ -69,7 +68,6 @@ public class InstanceTerminationChecker<T extends InstanceWaitObject> extends Ex
     @Override
     public boolean exitWaiting(T waitObject) {
         try {
-            waitObject.fetchData();
             if (waitObject.isDeleteFailed()) {
                 return false;
             }
@@ -86,7 +84,6 @@ public class InstanceTerminationChecker<T extends InstanceWaitObject> extends Ex
 
     @Override
     public Map<String, String> getStatuses(T waitObject) {
-        waitObject.fetchData();
         return waitObject.actualStatuses();
     }
 }


### PR DESCRIPTION
While WaitService waits for a certain criteria to be met (depedning on StatusChecker implementation), it should refresh its data only once per round. This way we can not encounter an edge case where a check runs on different data then the check before it, causing changes to not handled properly.

See detailed description in the commit message.