### PR TITLE
CB-11170 EDH integration to measure how many customers used Data Hub repair

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactoryTest.java
@@ -92,9 +92,11 @@ public class ClusterRepairFlowEventChainFactoryTest {
         FlowTriggerEventQueue eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedPrimaryGateway().build());
 
         List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
-        assertEquals(List.of("STACK_DOWNSCALE_TRIGGER_EVENT",
+        assertEquals(List.of("FLOWCHAIN_INIT_TRIGGER_EVENT",
+                "STACK_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
-                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT"), triggeredOperations);
+                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT",
+                "FLOWCHAIN_FINALIZE_TRIGGER_EVENT"), triggeredOperations);
     }
 
     @Test
@@ -106,10 +108,12 @@ public class ClusterRepairFlowEventChainFactoryTest {
         FlowTriggerEventQueue eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedPrimaryGateway().build());
 
         List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
-        assertEquals(List.of("STACK_DOWNSCALE_TRIGGER_EVENT",
+        assertEquals(List.of("FLOWCHAIN_INIT_TRIGGER_EVENT",
+                "STACK_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
                 "EPHEMERAL_CLUSTERS_UPDATE_TRIGGER_EVENT",
-                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT"), triggeredOperations);
+                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT",
+                "FLOWCHAIN_FINALIZE_TRIGGER_EVENT"), triggeredOperations);
     }
 
     @Test
@@ -127,11 +131,13 @@ public class ClusterRepairFlowEventChainFactoryTest {
                 new TriggerEventBuilder(stack).withFailedPrimaryGateway().withFailedCore().build());
 
         List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
-        assertEquals(List.of("STACK_DOWNSCALE_TRIGGER_EVENT",
+        assertEquals(List.of("FLOWCHAIN_INIT_TRIGGER_EVENT",
+                "STACK_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
                 "FULL_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
-                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT"),
+                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT",
+                "FLOWCHAIN_FINALIZE_TRIGGER_EVENT"),
                 triggeredOperations);
     }
 
@@ -145,10 +151,12 @@ public class ClusterRepairFlowEventChainFactoryTest {
 
         List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of(
+                "FLOWCHAIN_INIT_TRIGGER_EVENT",
                 "CHANGE_PRIMARY_GATEWAY_TRIGGER_EVENT",
                 "FULL_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
-                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT"), triggeredOperations);
+                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT",
+                "FLOWCHAIN_FINALIZE_TRIGGER_EVENT"), triggeredOperations);
     }
 
     @Test
@@ -161,11 +169,13 @@ public class ClusterRepairFlowEventChainFactoryTest {
 
         List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of(
+                "FLOWCHAIN_INIT_TRIGGER_EVENT",
                 "CHANGE_PRIMARY_GATEWAY_TRIGGER_EVENT",
                 "FULL_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
                 "EPHEMERAL_CLUSTERS_UPDATE_TRIGGER_EVENT",
-                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT"), triggeredOperations);
+                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT",
+                "FLOWCHAIN_FINALIZE_TRIGGER_EVENT"), triggeredOperations);
     }
 
     @Test
@@ -177,9 +187,11 @@ public class ClusterRepairFlowEventChainFactoryTest {
         FlowTriggerEventQueue eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedCore().build());
 
         List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
-        assertEquals(List.of("FULL_DOWNSCALE_TRIGGER_EVENT",
+        assertEquals(List.of("FLOWCHAIN_INIT_TRIGGER_EVENT",
+                "FULL_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
-                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT"), triggeredOperations);
+                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT",
+                "FLOWCHAIN_FINALIZE_TRIGGER_EVENT"), triggeredOperations);
     }
 
     @Test
@@ -191,9 +203,11 @@ public class ClusterRepairFlowEventChainFactoryTest {
         FlowTriggerEventQueue eventQueues = underTest.createFlowTriggerEventQueue(new TriggerEventBuilder(stack).withFailedCore().build());
 
         List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
-        assertEquals(List.of("FULL_DOWNSCALE_TRIGGER_EVENT",
+        assertEquals(List.of("FLOWCHAIN_INIT_TRIGGER_EVENT",
+                "FULL_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
-                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT"), triggeredOperations);
+                "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT",
+                "FLOWCHAIN_FINALIZE_TRIGGER_EVENT"), triggeredOperations);
     }
 
     private void setupHostGroup(boolean gatewayInstanceGroup) {

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowChains.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowChains.java
@@ -38,10 +38,15 @@ public class FlowChains {
     private final Map<String, String> flowChainParentMap = new ConcurrentHashMap<>();
 
     public void putFlowChain(String flowChainId, String parentFlowChainId, FlowTriggerEventQueue flowChain) {
-        flowChainMap.put(flowChainId, flowChain);
         if (parentFlowChainId != null) {
             flowChainParentMap.put(flowChainId, parentFlowChainId);
+            FlowTriggerEventQueue parentFlowChain = flowChainMap.get(parentFlowChainId);
+            if (parentFlowChain != null) {
+                flowChain = new FlowTriggerEventQueue(parentFlowChain.getFlowChainName() + "/" + flowChain.getFlowChainName(),
+                        flowChain.getQueue());
+            }
         }
+        flowChainMap.put(flowChainId, flowChain);
     }
 
     public void removeFlowChain(String flowChainId) {

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/FlowChainFinalizeActions.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/FlowChainFinalizeActions.java
@@ -1,0 +1,66 @@
+package com.sequenceiq.flow.core.chain.finalize;
+
+import static com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeEvent.FLOWCHAIN_FINALIZE_FAILHANDLED_EVENT;
+import static com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeEvent.FLOWCHAIN_FINALIZE_FINISHED_EVENT;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.CommonContext;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeEvent;
+import com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeState;
+import com.sequenceiq.flow.core.chain.finalize.flowevents.FlowChainFinalizeFailedPayload;
+import com.sequenceiq.flow.core.chain.finalize.flowevents.FlowChainFinalizePayload;
+
+@Configuration
+public class FlowChainFinalizeActions {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowChainFinalizeActions.class);
+
+    @Bean(name = "FLOWCHAIN_FINALIZE_FINISHED_STATE")
+    public Action<?, ?> finalizeAction() {
+        return new AbstractFlowChainFinalizeAction<>(FlowChainFinalizePayload.class) {
+            @Override
+            protected void doExecute(CommonContext context, FlowChainFinalizePayload payload, Map<Object, Object> variables) {
+                LOGGER.info("Flow chain {} finalized", payload.getFlowChainName());
+                sendEvent(context, FLOWCHAIN_FINALIZE_FINISHED_EVENT.event(), payload);
+            }
+        };
+    }
+
+    @Bean(name = "FLOWCHAIN_FINALIZE_FAILED_STATE")
+    public Action<?, ?> failedAction() {
+        return new AbstractFlowChainFinalizeAction<>(FlowChainFinalizeFailedPayload.class) {
+            @Override
+            protected void doExecute(CommonContext context, FlowChainFinalizeFailedPayload payload, Map<Object, Object> variables) {
+                sendEvent(context, FLOWCHAIN_FINALIZE_FAILHANDLED_EVENT.event(), payload);
+            }
+        };
+    }
+
+    private abstract static class AbstractFlowChainFinalizeAction<P extends FlowChainFinalizePayload>
+            extends AbstractAction<FlowChainFinalizeState, FlowChainFinalizeEvent, CommonContext, P> {
+        protected AbstractFlowChainFinalizeAction(Class<P> payloadClass) {
+            super(payloadClass);
+        }
+
+        @Override
+        protected CommonContext createFlowContext(FlowParameters flowParameters, StateContext<FlowChainFinalizeState, FlowChainFinalizeEvent> stateContext,
+                P payload) {
+            return new CommonContext(flowParameters);
+        }
+
+        @Override
+        protected Object getFailurePayload(P payload, Optional<CommonContext> flowContext, Exception ex) {
+            return new FlowChainFinalizeFailedPayload(payload.getFlowChainName(), payload.getResourceId(), ex);
+        }
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/config/FlowChainFinalizeEvent.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/config/FlowChainFinalizeEvent.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.flow.core.chain.finalize.config;
+
+import com.sequenceiq.flow.core.FlowEvent;
+
+public enum FlowChainFinalizeEvent implements FlowEvent {
+    FLOWCHAIN_FINALIZE_TRIGGER_EVENT,
+    FLOWCHAIN_FINALIZE_FINISHED_EVENT,
+    FLOWCHAIN_FINALIZE_FAILED_EVENT,
+    FLOWCHAIN_FINALIZE_FAILHANDLED_EVENT;
+
+    private String selector;
+
+    FlowChainFinalizeEvent() {
+        this.selector = name();
+    }
+
+    @Override
+    public String event() {
+        return selector;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/config/FlowChainFinalizeFlowConfig.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/config/FlowChainFinalizeFlowConfig.java
@@ -1,0 +1,76 @@
+package com.sequenceiq.flow.core.chain.finalize.config;
+
+import static com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeEvent.FLOWCHAIN_FINALIZE_FAILED_EVENT;
+import static com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeEvent.FLOWCHAIN_FINALIZE_FAILHANDLED_EVENT;
+import static com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeEvent.FLOWCHAIN_FINALIZE_FINISHED_EVENT;
+import static com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeEvent.FLOWCHAIN_FINALIZE_TRIGGER_EVENT;
+import static com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeState.FINAL_STATE;
+import static com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeState.FLOWCHAIN_FINALIZE_FAILED_STATE;
+import static com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeState.FLOWCHAIN_FINALIZE_FINISHED_STATE;
+import static com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeState.INIT_STATE;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
+
+@Component
+public class FlowChainFinalizeFlowConfig extends AbstractFlowConfiguration<FlowChainFinalizeState, FlowChainFinalizeEvent>
+        implements RetryableFlowConfiguration<FlowChainFinalizeEvent> {
+    private static final List<Transition<FlowChainFinalizeState, FlowChainFinalizeEvent>> TRANSITIONS =
+            new Transition.Builder<FlowChainFinalizeState, FlowChainFinalizeEvent>()
+                    .defaultFailureEvent(FLOWCHAIN_FINALIZE_FAILED_EVENT)
+
+                    .from(INIT_STATE)
+                    .to(FLOWCHAIN_FINALIZE_FINISHED_STATE)
+                    .event(FLOWCHAIN_FINALIZE_TRIGGER_EVENT)
+                    .noFailureEvent()
+
+                    .from(FLOWCHAIN_FINALIZE_FINISHED_STATE)
+                    .to(FINAL_STATE)
+                    .event(FLOWCHAIN_FINALIZE_FINISHED_EVENT)
+                    .defaultFailureEvent()
+
+                    .build();
+
+    private static final FlowEdgeConfig<FlowChainFinalizeState, FlowChainFinalizeEvent> EDGE_CONFIG =
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, FLOWCHAIN_FINALIZE_FAILED_STATE, FLOWCHAIN_FINALIZE_FAILHANDLED_EVENT);
+
+    public FlowChainFinalizeFlowConfig() {
+        super(FlowChainFinalizeState.class, FlowChainFinalizeEvent.class);
+    }
+
+    @Override
+    public FlowChainFinalizeEvent[] getEvents() {
+        return FlowChainFinalizeEvent.values();
+    }
+
+    @Override
+    public FlowChainFinalizeEvent[] getInitEvents() {
+        return new FlowChainFinalizeEvent[]{
+                FLOWCHAIN_FINALIZE_TRIGGER_EVENT
+        };
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Flowchain finalizer";
+    }
+
+    @Override
+    public FlowChainFinalizeEvent getRetryableEvent() {
+        return FLOWCHAIN_FINALIZE_FAILHANDLED_EVENT;
+    }
+
+    @Override
+    protected List<Transition<FlowChainFinalizeState, FlowChainFinalizeEvent>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<FlowChainFinalizeState, FlowChainFinalizeEvent> getEdgeConfig() {
+        return EDGE_CONFIG;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/config/FlowChainFinalizeState.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/config/FlowChainFinalizeState.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.flow.core.chain.finalize.config;
+
+import com.sequenceiq.flow.core.FlowState;
+
+public enum FlowChainFinalizeState implements FlowState {
+    INIT_STATE,
+    FLOWCHAIN_FINALIZE_FINISHED_STATE,
+    FLOWCHAIN_FINALIZE_FAILED_STATE,
+    FINAL_STATE
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/flowevents/FlowChainFinalizeFailedPayload.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/flowevents/FlowChainFinalizeFailedPayload.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.flow.core.chain.finalize.flowevents;
+
+import reactor.rx.Promise;
+
+public class FlowChainFinalizeFailedPayload extends FlowChainFinalizePayload {
+
+    private Exception exception;
+
+    public FlowChainFinalizeFailedPayload(String flowChainName, Long resourceId, Exception exception) {
+        super(flowChainName, resourceId, new Promise<>());
+        this.exception = exception;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/flowevents/FlowChainFinalizePayload.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/flowevents/FlowChainFinalizePayload.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.flow.core.chain.finalize.flowevents;
+
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.core.chain.finalize.config.FlowChainFinalizeEvent;
+
+import reactor.rx.Promise;
+
+public class FlowChainFinalizePayload implements Selectable, Acceptable {
+
+    private Long resourceId;
+
+    private String flowChainName;
+
+    private final Promise<AcceptResult> accepted;
+
+    public FlowChainFinalizePayload(String flowChainName, Long resourceId, Promise<AcceptResult> accepted) {
+        this.flowChainName = flowChainName;
+        this.resourceId = resourceId;
+        this.accepted = accepted;
+    }
+
+    @Override
+    public Long getResourceId() {
+        return resourceId;
+    }
+
+    @Override
+    public Promise<AcceptResult> accepted() {
+        return accepted;
+    }
+
+    @Override
+    public String selector() {
+        return FlowChainFinalizeEvent.FLOWCHAIN_FINALIZE_TRIGGER_EVENT.event();
+    }
+
+    public String getFlowChainName() {
+        return flowChainName;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/init/FlowChainInitActions.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/init/FlowChainInitActions.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.flow.core.chain.init;
+
+import static com.sequenceiq.flow.core.chain.init.config.FlowChainInitEvent.FLOWCHAIN_INIT_FAILHANDLED_EVENT;
+import static com.sequenceiq.flow.core.chain.init.config.FlowChainInitEvent.FLOWCHAIN_INIT_FINISHED_EVENT;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.StateContext;
+import org.springframework.statemachine.action.Action;
+
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.CommonContext;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.chain.init.config.FlowChainInitEvent;
+import com.sequenceiq.flow.core.chain.init.config.FlowChainInitState;
+import com.sequenceiq.flow.core.chain.init.flowevents.FlowChainInitFailedPayload;
+import com.sequenceiq.flow.core.chain.init.flowevents.FlowChainInitPayload;
+
+@Configuration
+public class FlowChainInitActions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowChainInitActions.class);
+
+    @Bean(name = "FLOWCHAIN_INIT_FINISHED_STATE")
+    public Action<?, ?> initAction() {
+        return new AbstractFlowChainInitAction<>(FlowChainInitPayload.class) {
+            @Override
+            protected void doExecute(CommonContext context, FlowChainInitPayload payload, Map<Object, Object> variables) {
+                LOGGER.info("Flow chain {} initialized", payload.getFlowChainName());
+                sendEvent(context, FLOWCHAIN_INIT_FINISHED_EVENT.event(), payload);
+            }
+        };
+    }
+
+    @Bean(name = "FLOWCHAIN_INIT_FAILED_STATE")
+    public Action<?, ?> failedAction() {
+        return new AbstractFlowChainInitAction<>(FlowChainInitFailedPayload.class) {
+            @Override
+            protected void doExecute(CommonContext context, FlowChainInitFailedPayload payload, Map<Object, Object> variables) {
+                sendEvent(context, FLOWCHAIN_INIT_FAILHANDLED_EVENT.event(), payload);
+            }
+        };
+    }
+
+    private abstract static class AbstractFlowChainInitAction<P extends FlowChainInitPayload>
+            extends AbstractAction<FlowChainInitState, FlowChainInitEvent, CommonContext, P> {
+
+        protected AbstractFlowChainInitAction(Class<P> payloadClass) {
+            super(payloadClass);
+        }
+
+        @Override
+        protected CommonContext createFlowContext(FlowParameters flowParameters, StateContext<FlowChainInitState, FlowChainInitEvent> stateContext, P payload) {
+            return new CommonContext(flowParameters);
+        }
+
+        @Override
+        protected Object getFailurePayload(P payload, Optional<CommonContext> flowContext, Exception ex) {
+            return new FlowChainInitFailedPayload(payload.getFlowChainName(), payload.getResourceId(), ex);
+        }
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/init/config/FlowChainInitEvent.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/init/config/FlowChainInitEvent.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.flow.core.chain.init.config;
+
+import com.sequenceiq.flow.core.FlowEvent;
+
+public enum FlowChainInitEvent implements FlowEvent {
+    FLOWCHAIN_INIT_TRIGGER_EVENT,
+    FLOWCHAIN_INIT_FINISHED_EVENT,
+    FLOWCHAIN_INIT_FAILED_EVENT,
+    FLOWCHAIN_INIT_FAILHANDLED_EVENT;
+
+    private String selector;
+
+    FlowChainInitEvent() {
+        this.selector = name();
+    }
+
+    @Override
+    public String event() {
+        return selector;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/init/config/FlowChainInitFlowConfig.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/init/config/FlowChainInitFlowConfig.java
@@ -1,0 +1,76 @@
+package com.sequenceiq.flow.core.chain.init.config;
+
+import static com.sequenceiq.flow.core.chain.init.config.FlowChainInitEvent.FLOWCHAIN_INIT_FAILED_EVENT;
+import static com.sequenceiq.flow.core.chain.init.config.FlowChainInitEvent.FLOWCHAIN_INIT_FAILHANDLED_EVENT;
+import static com.sequenceiq.flow.core.chain.init.config.FlowChainInitEvent.FLOWCHAIN_INIT_FINISHED_EVENT;
+import static com.sequenceiq.flow.core.chain.init.config.FlowChainInitEvent.FLOWCHAIN_INIT_TRIGGER_EVENT;
+import static com.sequenceiq.flow.core.chain.init.config.FlowChainInitState.FINAL_STATE;
+import static com.sequenceiq.flow.core.chain.init.config.FlowChainInitState.FLOWCHAIN_INIT_FAILED_STATE;
+import static com.sequenceiq.flow.core.chain.init.config.FlowChainInitState.FLOWCHAIN_INIT_FINISHED_STATE;
+import static com.sequenceiq.flow.core.chain.init.config.FlowChainInitState.INIT_STATE;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
+
+@Component
+public class FlowChainInitFlowConfig extends AbstractFlowConfiguration<FlowChainInitState, FlowChainInitEvent>
+        implements RetryableFlowConfiguration<FlowChainInitEvent> {
+    private static final List<Transition<FlowChainInitState, FlowChainInitEvent>> TRANSITIONS =
+            new Transition.Builder<FlowChainInitState, FlowChainInitEvent>()
+                    .defaultFailureEvent(FLOWCHAIN_INIT_FAILED_EVENT)
+
+                    .from(INIT_STATE)
+                    .to(FLOWCHAIN_INIT_FINISHED_STATE)
+                    .event(FLOWCHAIN_INIT_TRIGGER_EVENT)
+                    .noFailureEvent()
+
+                    .from(FLOWCHAIN_INIT_FINISHED_STATE)
+                    .to(FINAL_STATE)
+                    .event(FLOWCHAIN_INIT_FINISHED_EVENT)
+                    .defaultFailureEvent()
+
+                    .build();
+
+    private static final FlowEdgeConfig<FlowChainInitState, FlowChainInitEvent> EDGE_CONFIG =
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, FLOWCHAIN_INIT_FAILED_STATE, FLOWCHAIN_INIT_FAILHANDLED_EVENT);
+
+    public FlowChainInitFlowConfig() {
+        super(FlowChainInitState.class, FlowChainInitEvent.class);
+    }
+
+    @Override
+    public FlowChainInitEvent[] getEvents() {
+        return FlowChainInitEvent.values();
+    }
+
+    @Override
+    public FlowChainInitEvent[] getInitEvents() {
+        return new FlowChainInitEvent[]{
+                FLOWCHAIN_INIT_TRIGGER_EVENT
+        };
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Flowchain initializer";
+    }
+
+    @Override
+    public FlowChainInitEvent getRetryableEvent() {
+        return FLOWCHAIN_INIT_FAILHANDLED_EVENT;
+    }
+
+    @Override
+    protected List<Transition<FlowChainInitState, FlowChainInitEvent>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<FlowChainInitState, FlowChainInitEvent> getEdgeConfig() {
+        return EDGE_CONFIG;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/init/config/FlowChainInitState.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/init/config/FlowChainInitState.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.flow.core.chain.init.config;
+
+import com.sequenceiq.flow.core.FlowState;
+
+public enum FlowChainInitState implements FlowState {
+    INIT_STATE,
+    FLOWCHAIN_INIT_FINISHED_STATE,
+    FLOWCHAIN_INIT_FAILED_STATE,
+    FINAL_STATE
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/init/flowevents/FlowChainInitFailedPayload.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/init/flowevents/FlowChainInitFailedPayload.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.flow.core.chain.init.flowevents;
+
+import reactor.rx.Promise;
+
+public class FlowChainInitFailedPayload extends FlowChainInitPayload {
+
+    private Exception exception;
+
+    public FlowChainInitFailedPayload(String flowChainName, Long resourceId, Exception exception) {
+        super(flowChainName, resourceId, new Promise<>());
+        this.exception = exception;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/init/flowevents/FlowChainInitPayload.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/init/flowevents/FlowChainInitPayload.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.flow.core.chain.init.flowevents;
+
+import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.core.chain.init.config.FlowChainInitEvent;
+
+import reactor.rx.Promise;
+
+public class FlowChainInitPayload implements Selectable, Acceptable {
+
+    private Long resourceId;
+
+    private String flowChainName;
+
+    private final Promise<AcceptResult> accepted;
+
+    public FlowChainInitPayload(String flowChainName, Long resourceId, Promise<AcceptResult> accepted) {
+        this.flowChainName = flowChainName;
+        this.resourceId = resourceId;
+        this.accepted = accepted;
+    }
+
+    @Override
+    public Long getResourceId() {
+        return resourceId;
+    }
+
+    @Override
+    public Promise<AcceptResult> accepted() {
+        return accepted;
+    }
+
+    @Override
+    public String selector() {
+        return FlowChainInitEvent.FLOWCHAIN_INIT_TRIGGER_EVENT.event();
+    }
+
+    public String getFlowChainName() {
+        return flowChainName;
+    }
+}

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/log/cluster/ClusterRequestedLogger.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/log/cluster/ClusterRequestedLogger.java
@@ -5,6 +5,8 @@ import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPCluste
 import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.CREATE_STARTED;
 import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DOWNSCALE_FAILED;
 import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.DOWNSCALE_FINISHED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.REPAIR_FAILED;
+import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.REPAIR_FINISHED;
 import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPGRADE_FAILED;
 import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPGRADE_FINISHED;
 import static com.cloudera.thunderhead.service.common.usage.UsageProto.CDPClusterStatus.Value.UPSCALE_FAILED;
@@ -35,7 +37,8 @@ public class ClusterRequestedLogger implements LegacyTelemetryEventLogger {
     private static final EnumSet<UsageProto.CDPClusterStatus.Value> TRIGGER_CASES = EnumSet.of(CREATE_STARTED, CREATE_FINISHED, CREATE_FAILED,
             UPGRADE_FINISHED, UPGRADE_FAILED,
             UPSCALE_FINISHED, UPSCALE_FAILED,
-            DOWNSCALE_FINISHED, DOWNSCALE_FAILED);
+            DOWNSCALE_FINISHED, DOWNSCALE_FAILED,
+            REPAIR_FINISHED, REPAIR_FAILED);
 
     @Inject
     private UsageReporter usageReporter;

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/mapper/ClusterUseCaseMapper.java
@@ -1,7 +1,13 @@
 package com.sequenceiq.cloudbreak.structuredevent.service.telemetry.mapper;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -11,139 +17,126 @@ import com.sequenceiq.cloudbreak.structuredevent.event.FlowDetails;
 
 @Component
 public class ClusterUseCaseMapper {
-
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterUseCaseMapper.class);
+
+    private static final String DISTROX_UPGRADE_REPAIR_FLOWCHAIN = "UpgradeDistroxFlowEventChainFactory/ClusterRepairFlowEventChainFactory";
 
     @Inject
     private ClusterRequestProcessingStepMapper clusterRequestProcessingStepMapper;
 
+    private Map<Pair, UsageProto.CDPClusterStatus.Value> firstStepUseCaseMap;
+
+    @PostConstruct
+    private void initUseCaseMaps() {
+        firstStepUseCaseMap = new HashMap<>();
+        firstStepUseCaseMap.put(Pair.of("ProvisionFlowEventChainFactory", "CloudConfigValidationFlowConfig"), UsageProto.CDPClusterStatus.Value.CREATE_STARTED);
+        firstStepUseCaseMap.put(Pair.of("ProperTerminationFlowEventChainFactory", "ClusterTerminationFlowConfig"),
+                UsageProto.CDPClusterStatus.Value.DELETE_STARTED);
+        firstStepUseCaseMap.put(Pair.of("UpscaleFlowEventChainFactory", "StackUpscaleConfig"), UsageProto.CDPClusterStatus.Value.UPSCALE_STARTED);
+        firstStepUseCaseMap.put(Pair.of("DownscaleFlowEventChainFactory", "ClusterDownscaleFlowConfig"), UsageProto.CDPClusterStatus.Value.DOWNSCALE_STARTED);
+        firstStepUseCaseMap.put(Pair.of("StartFlowEventChainFactory", "StackStartFlowConfig"), UsageProto.CDPClusterStatus.Value.RESUME_STARTED);
+        firstStepUseCaseMap.put(Pair.of("StopFlowEventChainFactory", "ClusterStopFlowConfig"), UsageProto.CDPClusterStatus.Value.SUSPEND_STARTED);
+        firstStepUseCaseMap.put(Pair.of("ClusterRepairFlowEventChainFactory", "FlowChainInitFlowConfig"), UsageProto.CDPClusterStatus.Value.REPAIR_STARTED);
+        firstStepUseCaseMap.put(Pair.of(DISTROX_UPGRADE_REPAIR_FLOWCHAIN, "FlowChainInitFlowConfig"), UsageProto.CDPClusterStatus.Value.REPAIR_STARTED);
+        firstStepUseCaseMap.put(Pair.of("UpgradeDatalakeFlowEventChainFactory", "SaltUpdateFlowConfig"), UsageProto.CDPClusterStatus.Value.UPGRADE_STARTED);
+        firstStepUseCaseMap.put(Pair.of("UpgradeDistroxFlowEventChainFactory", "SaltUpdateFlowConfig"), UsageProto.CDPClusterStatus.Value.UPGRADE_STARTED);
+        firstStepUseCaseMap.put(Pair.of("", "ClusterCertificateRenewFlowConfig"), UsageProto.CDPClusterStatus.Value.RENEW_PUBLIC_CERT_STARTED);
+        firstStepUseCaseMap.put(Pair.of("", "CertRotationFlowConfig"), UsageProto.CDPClusterStatus.Value.RENEW_CLUSTER_INTERNAL_CERT_STARTED);
+    }
+
     // At the moment we need to introduce a complex logic to figure out the use case
     public UsageProto.CDPClusterStatus.Value useCase(FlowDetails flow) {
         UsageProto.CDPClusterStatus.Value useCase = UsageProto.CDPClusterStatus.Value.UNSET;
+        String rootFlowChainType = getRootFlowChainType(flow.getFlowChainType());
         if (clusterRequestProcessingStepMapper.isFirstStep(flow)) {
-            useCase = firstStepToUseCaseMapping(flow.getFlowType());
+            useCase = firstStepToUseCaseMapping(rootFlowChainType, flow.getFlowType());
         } else if (clusterRequestProcessingStepMapper.isLastStep(flow)) {
-            useCase = lastStepToUseCaseMapping(flow.getFlowState());
+            useCase = lastStepToUseCaseMapping(rootFlowChainType, flow.getFlowType(), flow.getFlowState());
         }
         LOGGER.debug("FlowDetails: {}, Usecase: {}", flow, useCase);
         return useCase;
     }
 
-    //CHECKSTYLE:OFF: CyclomaticComplexity
-    private UsageProto.CDPClusterStatus.Value firstStepToUseCaseMapping(String flowType) {
-        UsageProto.CDPClusterStatus.Value useCase = UsageProto.CDPClusterStatus.Value.UNSET;
-        switch (flowType) {
-            case "CloudConfigValidationFlowConfig":
-                useCase = UsageProto.CDPClusterStatus.Value.CREATE_STARTED;
-                break;
-            case "ClusterTerminationFlowConfig":
-                useCase = UsageProto.CDPClusterStatus.Value.DELETE_STARTED;
-                break;
-            case "StackUpscaleConfig":
-                useCase = UsageProto.CDPClusterStatus.Value.UPSCALE_STARTED;
-                break;
-            case "ClusterDownscaleFlowConfig":
-                useCase = UsageProto.CDPClusterStatus.Value.DOWNSCALE_STARTED;
-                break;
-            case "StackStartFlowConfig":
-                useCase = UsageProto.CDPClusterStatus.Value.RESUME_STARTED;
-                break;
-            case "ClusterStopFlowConfig":
-                useCase = UsageProto.CDPClusterStatus.Value.SUSPEND_STARTED;
-                break;
-            case "SaltUpdateFlowConfig":
-                useCase = UsageProto.CDPClusterStatus.Value.UPGRADE_STARTED;
-                break;
-            case "ClusterCertificateRenewFlowConfig":
-                useCase = UsageProto.CDPClusterStatus.Value.RENEW_PUBLIC_CERT_STARTED;
-                break;
-            case "CertRotationFlowConfig":
-                useCase = UsageProto.CDPClusterStatus.Value.RENEW_CLUSTER_INTERNAL_CERT_STARTED;
-                break;
-            default:
-                LOGGER.debug("Flow type: {}", flowType);
-        }
-        LOGGER.debug("Mapping flow type to use-case: {}, {}", flowType, useCase);
+    private UsageProto.CDPClusterStatus.Value firstStepToUseCaseMapping(String rootFlowChainType, String flowType) {
+        UsageProto.CDPClusterStatus.Value useCase =
+                firstStepUseCaseMap.getOrDefault(Pair.of(rootFlowChainType, flowType), UsageProto.CDPClusterStatus.Value.UNSET);
+        LOGGER.debug("Mapping flow type to use-case: [flowchain: {}, flow: {}]: usecase: {}", rootFlowChainType, flowType, useCase);
         return useCase;
     }
-    //CHECKSTYLE:ON
 
     //CHECKSTYLE:OFF: CyclomaticComplexity
-    private UsageProto.CDPClusterStatus.Value lastStepToUseCaseMapping(String flowState) {
+    private UsageProto.CDPClusterStatus.Value lastStepToUseCaseMapping(String rootFlowChainType, String flowType, String flowState) {
         UsageProto.CDPClusterStatus.Value useCase = UsageProto.CDPClusterStatus.Value.UNSET;
-        switch (flowState) {
-            case "CLUSTER_CREATION_FINISHED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.CREATE_FINISHED;
+        String rootFlowType = StringUtils.isNotEmpty(rootFlowChainType) ? rootFlowChainType : flowType;
+        switch (rootFlowType) {
+            case "ProvisionFlowEventChainFactory":
+                useCase = getClusterStatus(flowState, "CLUSTER_CREATION_FINISHED_STATE",
+                        UsageProto.CDPClusterStatus.Value.CREATE_FINISHED, UsageProto.CDPClusterStatus.Value.CREATE_FAILED);
                 break;
-            case "VALIDATE_CLOUD_CONFIG_FAILED_STATE":
-            case "VALIDATE_KERBEROS_CONFIG_FAILED_STATE":
-            case "EXTERNAL_DATABASE_CREATION_FAILED_STATE":
-            case "CLUSTER_CREATION_FAILED_STATE":
-            case "STACK_CREATION_FAILED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.CREATE_FAILED;
+            case "ProperTerminationFlowEventChainFactory":
+                useCase = getClusterStatus(flowState, "TERMINATION_FINISHED_STATE",
+                        UsageProto.CDPClusterStatus.Value.DELETE_FINISHED, UsageProto.CDPClusterStatus.Value.DELETE_FAILED);
                 break;
-            case "TERMINATION_FINISHED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.DELETE_FINISHED;
+            case "UpscaleFlowEventChainFactory":
+                useCase = getClusterStatus(flowState, "FINALIZE_UPSCALE_STATE",
+                        UsageProto.CDPClusterStatus.Value.UPSCALE_FINISHED, UsageProto.CDPClusterStatus.Value.UPSCALE_FAILED);
                 break;
-            case "CLUSTER_TERMINATION_FAILED_STATE":
-            case "EXTERNAL_DATABASE_TERMINATION_FAILED_STATE":
-            case "TERMINATION_FAILED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.DELETE_FAILED;
+            case "DownscaleFlowEventChainFactory":
+                useCase = getClusterStatus(flowState, "DOWNSCALE_FINISHED_STATE",
+                        UsageProto.CDPClusterStatus.Value.DOWNSCALE_FINISHED, UsageProto.CDPClusterStatus.Value.DOWNSCALE_FAILED);
                 break;
-            case "FINALIZE_UPSCALE_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.UPSCALE_FINISHED;
+            case "StartFlowEventChainFactory":
+                useCase = getClusterStatus(flowState, "CLUSTER_START_FINISHED_STATE",
+                        UsageProto.CDPClusterStatus.Value.RESUME_FINISHED, UsageProto.CDPClusterStatus.Value.RESUME_FAILED);
                 break;
-            case "CLUSTER_UPSCALE_FAILED_STATE":
-            case "UPSCALE_FAILED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.UPSCALE_FAILED;
+            case "StopFlowEventChainFactory":
+                useCase = getClusterStatus(flowState, "STOP_FINISHED_STATE",
+                        UsageProto.CDPClusterStatus.Value.SUSPEND_FINISHED, UsageProto.CDPClusterStatus.Value.SUSPEND_FAILED);
                 break;
-            case "DOWNSCALE_FINISHED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.DOWNSCALE_FINISHED;
+            case DISTROX_UPGRADE_REPAIR_FLOWCHAIN:
+            case "ClusterRepairFlowEventChainFactory":
+                useCase = getClusterStatus(flowState, "FLOWCHAIN_FINALIZE_FINISHED_STATE",
+                        UsageProto.CDPClusterStatus.Value.REPAIR_FINISHED, UsageProto.CDPClusterStatus.Value.REPAIR_FAILED);
                 break;
-            case "CLUSTER_DOWNSCALE_FAILED_STATE":
-            case "DOWNSCALE_FAILED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.DOWNSCALE_FAILED;
+            case "UpgradeDatalakeFlowEventChainFactory":
+            case "UpgradeDistroxFlowEventChainFactory":
+                useCase = getClusterStatus(flowState, "CLUSTER_UPGRADE_FINISHED_STATE",
+                        UsageProto.CDPClusterStatus.Value.UPGRADE_FINISHED, UsageProto.CDPClusterStatus.Value.UPGRADE_FAILED);
                 break;
-            case "START_FINISHED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.RESUME_FINISHED;
+            case "ClusterCertificateRenewFlowConfig":
+                useCase = getClusterStatus(flowState, "CLUSTER_CERTIFICATE_RENEWAL_FINISHED_STATE",
+                        UsageProto.CDPClusterStatus.Value.RENEW_PUBLIC_CERT_FINISHED, UsageProto.CDPClusterStatus.Value.RENEW_PUBLIC_CERT_FAILED);
                 break;
-            case "CLUSTER_START_FAILED_STATE":
-            case "EXTERNAL_DATABASE_START_FAILED_STATE":
-            case "START_FAILED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.RESUME_FAILED;
-                break;
-            case "STOP_FINISHED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.SUSPEND_FINISHED;
-                break;
-            case "CLUSTER_STOP_FAILED_STATE":
-            case "EXTERNAL_DATABASE_STOP_FAILED_STATE":
-            case "STOP_FAILED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.SUSPEND_FAILED;
-                break;
-            case "CLUSTER_UPGRADE_FINISHED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.UPGRADE_FINISHED;
-                break;
-            case "SALT_UPDATE_FAILED_STATE":
-            case "CLUSTER_UPGRADE_FAILED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.UPGRADE_FAILED;
-                break;
-            case "CLUSTER_CERTIFICATE_RENEWAL_FINISHED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.RENEW_PUBLIC_CERT_FINISHED;
-                break;
-            case "CLUSTER_CERTIFICATE_RENEW_FAILED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.RENEW_PUBLIC_CERT_FAILED;
-                break;
-            case "CERT_ROTATION_FINISHED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.RENEW_CLUSTER_INTERNAL_CERT_FINISHED;
-                break;
-            case "CERT_ROTATION_FAILED_STATE":
-                useCase = UsageProto.CDPClusterStatus.Value.RENEW_CLUSTER_INTERNAL_CERT_FAILED;
+            case "CertRotationFlowConfig":
+                useCase = getClusterStatus(flowState, "CERT_ROTATION_FINISHED_STATE", UsageProto.CDPClusterStatus.Value.RENEW_CLUSTER_INTERNAL_CERT_FINISHED,
+                        UsageProto.CDPClusterStatus.Value.RENEW_CLUSTER_INTERNAL_CERT_FAILED);
                 break;
             default:
                 LOGGER.debug("Flow state: {}", flowState);
         }
-        LOGGER.debug("Mapping last flow state to use-case: {}, {}", flowState, useCase);
+        LOGGER.debug("Mapping last flow state to use-case: [flowchain: {}, flow:{}, flowstate: {}]: {}", rootFlowChainType, flowType, flowState, useCase);
         return useCase;
     }
     //CHECKSTYLE:ON
+
+    private String getRootFlowChainType(String flowChainTypes) {
+        if (StringUtils.isNotEmpty(flowChainTypes)) {
+            // In case of Distrox Upgrade the upgrade report and the optional repair report will be separated
+            if (flowChainTypes.startsWith(DISTROX_UPGRADE_REPAIR_FLOWCHAIN)) {
+                return DISTROX_UPGRADE_REPAIR_FLOWCHAIN;
+            }
+            return flowChainTypes.split("/")[0];
+        }
+        return "";
+    }
+
+    private UsageProto.CDPClusterStatus.Value getClusterStatus(String flowState, String finishedFlowState, UsageProto.CDPClusterStatus.Value finishedStatus,
+            UsageProto.CDPClusterStatus.Value failedStatus) {
+        if (flowState.equals(finishedFlowState)) {
+            return finishedStatus;
+        } else if (flowState.contains("_FAIL")) {
+            return failedStatus;
+        }
+        return UsageProto.CDPClusterStatus.Value.UNSET;
+    }
 }


### PR DESCRIPTION
CB-11170 EDH integration to measure how many customers used Data Hub repair

* New flows are introduced for flow chain init and flow chain finish
* To identify the repair start / finish steps, the repair flowchain is extended with these new flows
* The type of the flow chains will follow the following pattern flowchain1/flowchain2/flowchain3/flow in the flowlog table
* ClusterUseCaseMapper will make decision about the mapping based on the root flowchain
* report will be sent about repair flows
* Distrox upgrade will be reported as an upgrade report and a separated repair report
