### PR TITLE
DISTX-397 Use the default setting for HS2 transport mode which is all…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
@@ -155,10 +155,6 @@
             "base": true,
             "configs": [
               {
-                "name": "hive_server2_transport_mode",
-                "value": "http"
-              },
-              {
                 "name": "hiveserver2_mv_files_thread",
                 "value": 20
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
@@ -305,10 +305,6 @@
             "base": true,
             "configs": [
               {
-                "name": "hive_server2_transport_mode",
-                "value": "http"
-              },
-              {
                 "name": "hiveserver2_mv_files_thread",
                 "value": 20
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
@@ -295,10 +295,6 @@
             "base": true,
             "configs": [
               {
-                "name": "hive_server2_transport_mode",
-                "value": "http"
-              },
-              {
                 "name": "hiveserver2_mv_files_thread",
                 "value": 20
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
@@ -155,10 +155,6 @@
             "base": true,
             "configs": [
               {
-                "name": "hive_server2_transport_mode",
-                "value": "http"
-              },
-              {
                 "name": "hiveserver2_mv_files_thread",
                 "value": 20
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-spark3.bp
@@ -305,10 +305,6 @@
             "base": true,
             "configs": [
               {
-                "name": "hive_server2_transport_mode",
-                "value": "http"
-              },
-              {
                 "name": "hiveserver2_mv_files_thread",
                 "value": 20
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering.bp
@@ -295,10 +295,6 @@
             "base": true,
             "configs": [
               {
-                "name": "hive_server2_transport_mode",
-                "value": "http"
-              },
-              {
                 "name": "hiveserver2_mv_files_thread",
                 "value": 20
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
@@ -155,10 +155,6 @@
             "base": true,
             "configs": [
               {
-                "name": "hive_server2_transport_mode",
-                "value": "http"
-              },
-              {
                 "name": "hiveserver2_mv_files_thread",
                 "value": 20
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-spark3.bp
@@ -305,10 +305,6 @@
             "base": true,
             "configs": [
               {
-                "name": "hive_server2_transport_mode",
-                "value": "http"
-              },
-              {
                 "name": "hiveserver2_mv_files_thread",
                 "value": 20
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering.bp
@@ -295,10 +295,6 @@
             "base": true,
             "configs": [
               {
-                "name": "hive_server2_transport_mode",
-                "value": "http"
-              },
-              {
                 "name": "hiveserver2_mv_files_thread",
                 "value": 20
               },


### PR DESCRIPTION
… (both HTTP and binary)

1. OPSAPS-54505 made all as the default transport mode for 7.2.7+ clusters.
2. This is needed if we want to enable load-balancer from Hue to HS2 integration.
3. Tested this in a cluster by reverting the setting to default in CM in 7.2.8 cluster, and made sure both beeline and Hue worked.