### PR TITLE
DISTX-571:set hive.server2.idle.session.timeout to 4h

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
@@ -165,6 +165,10 @@
               {
                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
                 "value": 20
+              },
+              {
+                "name": "hiveserver2_idle_session_timeout",
+                "value": 14400000
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
@@ -315,6 +315,10 @@
               {
                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
                 "value": 20
+              },
+              {
+                "name": "hiveserver2_idle_session_timeout",
+                "value": 14400000
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
@@ -305,6 +305,10 @@
               {
                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
                 "value": 20
+              },
+              {
+                "name": "hiveserver2_idle_session_timeout",
+                "value": 14400000
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
@@ -165,6 +165,10 @@
               {
                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
                 "value": 20
+              },
+              {
+                "name": "hiveserver2_idle_session_timeout",
+                "value": 14400000
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-spark3.bp
@@ -315,6 +315,10 @@
               {
                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
                 "value": 20
+              },
+              {
+                "name": "hiveserver2_idle_session_timeout",
+                "value": 14400000
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering.bp
@@ -305,6 +305,10 @@
               {
                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
                 "value": 20
+              },
+              {
+                "name": "hiveserver2_idle_session_timeout",
+                "value": 14400000
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
@@ -165,6 +165,10 @@
               {
                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
                 "value": 20
+              },
+              {
+                "name": "hiveserver2_idle_session_timeout",
+                "value": 14400000
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-spark3.bp
@@ -315,6 +315,10 @@
               {
                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
                 "value": 20
+              },
+              {
+                "name": "hiveserver2_idle_session_timeout",
+                "value": 14400000
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering.bp
@@ -305,6 +305,10 @@
               {
                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
                 "value": 20
+              },
+              {
+                "name": "hiveserver2_idle_session_timeout",
+                "value": 14400000
               }
             ]
           }


### PR DESCRIPTION
The setting "hiveserver2_idle_session_timeout" used to be 1 day by default for DE clusters and now the default value is changed to 4 hours and the screenshots attached for the same:
 
before change:
<img width="1212" alt="Screenshot 2021-03-17 at 4 47 27 PM" src="https://user-images.githubusercontent.com/7271603/111459423-a886df00-8740-11eb-8c47-4c9e7ff0f4e3.png">

Post the change:
<img width="695" alt="Screenshot 2021-03-17 at 4 03 23 PM" src="https://user-images.githubusercontent.com/7271603/111459462-b50b3780-8740-11eb-81d1-67c587f6b071.png">
<img width="1212" alt="Screenshot 2021-03-17 at 4 47 27 PM" src="https://user-images.githubusercontent.com/7271603/111459466-b63c6480-8740-11eb-9e0b-f9a16b64ed8a.png">
