### PR TITLE
CB-11667 Use ListBucket action instead of HeadBucket action in AWS IAM policy

### DIFF
--- a/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-bucket-access-policy.json
+++ b/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-bucket-access-policy.json
@@ -6,7 +6,7 @@
       "Action": [
         "s3:CreateJob",
         "s3:GetAccountPublicAccessBlock",
-        "s3:HeadBucket",
+        "s3:ListBucket",
         "s3:ListJobs"
       ],
       "Resource": "*"


### PR DESCRIPTION
s3:HeadBucket is not a valid IAM action. s3:ListBucket is the IAM action
which grants access to call the HeadBucket API on S3.