### PR TITLE
CB-10926: Use larger instance types for Datamart and Realtime Datamar…

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/datamart.json
@@ -1,12 +1,12 @@
 {
-  "name": "7.2.9 - Data Mart for Google Cloud",
+  "name": "7.2.10 - Data Mart for Google Cloud",
   "description": "",
   "type": "DATAMART",
   "featureState": "PREVIEW",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {
-      "blueprintName": "7.2.9 - Data Mart: Apache Impala, Hue"
+      "blueprintName": "7.2.10 - Data Mart: Apache Impala, Hue"
     },
     "instanceGroups": [
       {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/rt-datamart.json
@@ -67,7 +67,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16"
+          "instanceType": "e2-highmem-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -83,7 +83,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16"
+          "instanceType": "e2-highmem-16"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/rt-datamart.json
@@ -67,7 +67,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16"
+          "instanceType": "e2-highmem-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -83,7 +83,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16"
+          "instanceType": "e2-highmem-16"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/rt-datamart.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/rt-datamart.json
@@ -67,7 +67,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16"
+          "instanceType": "e2-highmem-16"
         },
         "nodeCount": 1,
         "type": "CORE",
@@ -83,7 +83,7 @@
               "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-16"
+          "instanceType": "e2-highmem-16"
         },
         "nodeCount": 3,
         "type": "CORE",

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -362,7 +362,7 @@ public class ClusterTemplateTest extends AbstractMockTest {
             assertNotNull(entity);
             assertNotNull(entity.getResponses());
             long defaultCount = entity.getResponses().stream().filter(template -> ResourceStatus.DEFAULT.equals(template.getStatus())).count();
-            long expectedCount = 393;
+            long expectedCount = 394;
             assertEquals("Should have " + expectedCount + " of default cluster templates.", expectedCount, defaultCount);
         } catch (Exception e) {
             throw new TestFailException(String.format("Failed to validate default count of cluster templates: %s", e.getMessage()), e);


### PR DESCRIPTION
CB-10926: Use larger instance types for Datamart and Realtime Datamart templates on GCP

    Aligns GCP instance type sizes with the sizes used on AWS and Azure

See detailed description in the commit message.