### PR TITLE
CB-11672 GCP: Mark the existing 7.2.8 datahub templates as GA

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-spark3.json
@@ -2,7 +2,7 @@
   "name": "7.2.10 - Data Engineering Spark3 for Google Cloud",
   "description": "",
   "type": "DATAENGINEERING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering.json
@@ -2,7 +2,7 @@
   "name": "7.2.10 - Data Engineering for Google Cloud",
   "description": "",
   "type": "DATAENGINEERING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/flow-management-small.json
@@ -2,7 +2,7 @@
   "name": "7.2.10 - Flow Management Light Duty for Google Cloud",
   "description": "",
   "type": "FLOW_MANAGEMENT",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/flow-management.json
@@ -2,7 +2,7 @@
   "name": "7.2.10 - Flow Management Heavy Duty for Google Cloud",
   "description": "",
   "type": "FLOW_MANAGEMENT",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/streaming-small.json
@@ -2,7 +2,7 @@
   "name": "7.2.10 - Streams Messaging Light Duty for Google Cloud",
   "description": "",
   "type": "STREAMING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/streaming.json
@@ -2,7 +2,7 @@
   "name": "7.2.10 - Streams Messaging Heavy Duty for Google Cloud",
   "description": "",
   "type": "STREAMING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-spark3.json
@@ -2,7 +2,7 @@
   "name": "7.2.8 - Data Engineering Spark3 for Google Cloud",
   "description": "",
   "type": "DATAENGINEERING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering.json
@@ -2,7 +2,7 @@
   "name": "7.2.8 - Data Engineering for Google Cloud",
   "description": "",
   "type": "DATAENGINEERING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/flow-management-small.json
@@ -2,7 +2,7 @@
   "name": "7.2.8 - Flow Management Light Duty for Google Cloud",
   "description": "",
   "type": "FLOW_MANAGEMENT",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/flow-management.json
@@ -2,7 +2,7 @@
   "name": "7.2.8 - Flow Management Heavy Duty for Google Cloud",
   "description": "",
   "type": "FLOW_MANAGEMENT",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/streaming-small.json
@@ -2,7 +2,7 @@
   "name": "7.2.8 - Streams Messaging Light Duty for Google Cloud",
   "description": "",
   "type": "STREAMING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/streaming.json
@@ -2,7 +2,7 @@
   "name": "7.2.8 - Streams Messaging Heavy Duty for Google Cloud",
   "description": "",
   "type": "STREAMING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-spark3.json
@@ -2,7 +2,7 @@
   "name": "7.2.9 - Data Engineering Spark3 for Google Cloud",
   "description": "",
   "type": "DATAENGINEERING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering.json
@@ -2,7 +2,7 @@
   "name": "7.2.9 - Data Engineering for Google Cloud",
   "description": "",
   "type": "DATAENGINEERING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/flow-management-small.json
@@ -2,7 +2,7 @@
   "name": "7.2.9 - Flow Management Light Duty for Google Cloud",
   "description": "",
   "type": "FLOW_MANAGEMENT",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/flow-management.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/flow-management.json
@@ -2,7 +2,7 @@
   "name": "7.2.9 - Flow Management Heavy Duty for Google Cloud",
   "description": "",
   "type": "FLOW_MANAGEMENT",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/streaming-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/streaming-small.json
@@ -2,7 +2,7 @@
   "name": "7.2.9 - Streams Messaging Light Duty for Google Cloud",
   "description": "",
   "type": "STREAMING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/streaming.json
@@ -2,7 +2,7 @@
   "name": "7.2.9 - Streams Messaging Heavy Duty for Google Cloud",
   "description": "",
   "type": "STREAMING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "GCP",
   "distroXTemplate": {
     "cluster": {


### PR DESCRIPTION
1. Mark all the templates except for DE HA, DM and RTDM as released from 7.2.8
2. If 7.2.8 gets released before GCP is GA, customers with GCP entitlement will see this version as released before the announcement.
3. But marking it as released before, knocks out one item to track from the launch checklist.

See detailed description in the commit message.