### PR TITLE
DISTX-588 Rationalize DE HA Template for GCP,AWS,AZURE

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-ha.json
@@ -44,6 +44,9 @@
         "template": {
           "aws": {},
           "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
             "size": 150,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-ha.json
@@ -18,11 +18,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -34,11 +37,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -50,11 +56,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -66,11 +75,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 500,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -82,11 +94,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -98,11 +113,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-ha.json
@@ -18,11 +18,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -34,11 +37,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -50,11 +56,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -66,11 +75,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 500,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -82,11 +94,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -98,11 +113,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-ha.json
@@ -44,6 +44,9 @@
         "template": {
           "aws": {},
           "instanceType": "m5.4xlarge",
+          "rootVolume": {
+            "size": 150
+          },
           "attachedVolumes": [{
             "size": 150,
             "count": 1,

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-ha.json
@@ -18,11 +18,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -34,11 +37,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 2,
         "type": "CORE",
@@ -50,11 +56,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -66,11 +75,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 500,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 3,
         "type": "CORE",
@@ -82,11 +94,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 0,
         "type": "CORE",
@@ -98,11 +113,14 @@
           "attachedVolumes": [
             {
               "count": 1,
-              "size": 100,
-              "type": "pd-standard"
+              "size": 150,
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "rootVolume": {
+            "size": 150
+          },
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "CORE",


### PR DESCRIPTION
GCP 7.2.8, 7.2.9, 7.2.10 template root and attached volume increased.
GCP hostgroups vm updated to 64 gb machines.
AWS 7.2.9, 7.2.10 compute hostGroup root volume increased.

See detailed description in the commit message.