### PR TITLE
CB-11682 Remove internal actor from integration-test

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeipaInternalCrnClient.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeipaInternalCrnClient.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.freeipa.api.client;
+
+import com.sequenceiq.cloudbreak.auth.altus.InternalCrnBuilder;
+
+public class FreeipaInternalCrnClient {
+
+    private FreeIpaApiUserCrnClient client;
+
+    private InternalCrnBuilder internalCrnBuilder;
+
+    public FreeipaInternalCrnClient(FreeIpaApiUserCrnClient crnClient, InternalCrnBuilder builder) {
+        client = crnClient;
+        internalCrnBuilder = builder;
+    }
+
+    public FreeIpaApiUserCrnEndpoint withInternalCrn() {
+        return client.withCrn(internalCrnBuilder.getInternalCrnForServiceAsString());
+    }
+
+    public FreeIpaApiUserCrnEndpoint withUserCrn(String userCrn) {
+        return client.withCrn(userCrn);
+    }
+}

--- a/integration-test/docker-compose_template.yml
+++ b/integration-test/docker-compose_template.yml
@@ -44,6 +44,7 @@ services:
       - MOCK_INFRASTRUCTURE_HOST=mock-infrastructure
       - CLOUDBREAK_URL=cloudbreak:8080
       - ENVIRONMENT_URL=environment:8088
+      - FREEIPA_URL=freeipa:8080
       - SPRING_CONFIG_LOCATION=classpath:/application.yml,/it/it-application.yml
       - INTEGRATIONTEST_SUITEFILES
       - INTEGRATIONTEST_OPENSTACKV3CREDENTIAL_TENANTNAME

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/FreeIpaTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/FreeIpaTest.java
@@ -4,6 +4,8 @@ public class FreeIpaTest extends GherkinTest {
 
     public static final String FREEIPA_SERVER_ROOT = "FREEIPA_SERVER_ROOT";
 
+    public static final String FREEIPA_SERVER_INTERNAL_ROOT = "FREEIPA_SERVER_INTERNAL_ROOT";
+
     public static final String ACCESS_KEY = "ACCESS_KEY";
 
     public static final String SECRET_KEY = "SECRET_KEY";

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaSynchronizeAllUsersAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaSynchronizeAllUsersAction.java
@@ -19,7 +19,7 @@ public class FreeIpaSynchronizeAllUsersAction extends AbstractFreeIpaAction<Free
     protected FreeIpaUserSyncTestDto freeIpaAction(TestContext testContext, FreeIpaUserSyncTestDto testDto, FreeIpaClient client) throws Exception {
         Log.when(LOGGER, format(" Environment Crn: [%s], freeIpa Crn: %s", testDto.getEnvironmentCrn(), testDto.getRequest().getEnvironments()));
         Log.whenJson(LOGGER, format(" FreeIPA sync request: %n"), testDto.getRequest());
-        SyncOperationStatus syncOperationStatus = client.getFreeIpaClient()
+        SyncOperationStatus syncOperationStatus = client.getFreeipaInternalCrnClient().withInternalCrn()
                 .getUserV1Endpoint()
                 .synchronizeAllUsers(testDto.getRequest());
         testDto.setOperationId(syncOperationStatus.getOperationId());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/server/FreeIpaServer.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/config/server/FreeIpaServer.java
@@ -23,8 +23,13 @@ public class FreeIpaServer {
 
     private static final String WARNING_TEXT_FORMAT = "Following variable must be set whether as environment variables or (test) application.yaml: %s";
 
+    private static final int DEFAULT_FREEIPA_PORT = 8090;
+
     @Value("${integrationtest.freeipa.server}")
     private String server;
+
+    @Value("${freeipa.url:localhost:" + DEFAULT_FREEIPA_PORT + "}")
+    private String freeipaUrl;
 
     @Value("${freeipa.server.contextPath:/freeipa}")
     private String freeIpaRootContextPath;
@@ -60,6 +65,7 @@ public class FreeIpaServer {
         checkNonEmpty("integrationtest.user.privatekey", secretKey);
 
         testParameter.put(FreeIpaTest.FREEIPA_SERVER_ROOT, server + freeIpaRootContextPath);
+        testParameter.put(FreeIpaTest.FREEIPA_SERVER_INTERNAL_ROOT, "http://" + freeipaUrl + freeIpaRootContextPath);
         testParameter.put(FreeIpaTest.ACCESS_KEY, accessKey);
         testParameter.put(FreeIpaTest.SECRET_KEY, secretKey);
         testParameter.put(CloudbreakTest.USER_CRN, userCrn);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaUserSyncTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaUserSyncTestDto.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunning
 import java.util.Collections;
 import java.util.Map;
 
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeAllUsersRequest;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
@@ -26,6 +27,7 @@ public class FreeIpaUserSyncTestDto extends AbstractFreeIpaTestDto<SynchronizeAl
     @Override
     public FreeIpaUserSyncTestDto valid() {
         getRequest().setEnvironments(Collections.singleton(getEnvironmentCrn()));
+        getRequest().setAccountId(Crn.fromString(getEnvironmentCrn()).getAccountId());
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaSyncTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/FreeIpaSyncTest.java
@@ -7,7 +7,6 @@ import org.testng.annotations.Test;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
 import com.sequenceiq.it.cloudbreak.actor.CloudbreakActor;
-import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
 import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
@@ -45,18 +44,10 @@ public class FreeIpaSyncTest extends AbstractMockTest {
                 .given(FreeIpaUserSyncTestDto.class)
                 .when(freeIpaTestClient.getLastSyncOperationStatus())
                 .await(OperationState.COMPLETED)
-                .validate();
-
-        CloudbreakUser internalActor = cloudbreakActor.create(testContext.getActingUserCrn().getAccountId(), "__internal__actor__");
-
-        testContext
-                .as(internalActor)
                 .given(FreeIpaUserSyncTestDto.class)
                 .when(freeIpaTestClient.syncAll())
                 .await(OperationState.COMPLETED)
-                .validate();
-
-        testContext.given(FreeIpaTestDto.class)
+                .given(FreeIpaTestDto.class)
                 .when(freeIpaTestClient.delete())
                 .await(Status.DELETE_COMPLETED)
                 .validate();


### PR DESCRIPTION
- removing explicit internal actor usage from integration tests
- only using internal crn client for specific actions