### PR TITLE
CB-11697. Use Exception mapper for FlowsAlreadyRunningException (free…

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/mapper/FlowsAlreadyRunningExceptionMapper.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/mapper/FlowsAlreadyRunningExceptionMapper.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.freeipa.controller.mapper;
+
+import javax.ws.rs.core.Response.Status;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.exception.FlowsAlreadyRunningException;
+
+@Component
+public class FlowsAlreadyRunningExceptionMapper extends BaseExceptionMapper<FlowsAlreadyRunningException> {
+
+    @Override
+    Status getResponseStatus(FlowsAlreadyRunningException exception) {
+        return Status.CONFLICT;
+    }
+
+    @Override
+    Class<FlowsAlreadyRunningException> getExceptionType() {
+        return FlowsAlreadyRunningException.class;
+    }
+}


### PR DESCRIPTION
…ipa).

- seems like this one is covered by CloudbreakApiExceptionMapper by datalake or the core code.
- use mapper only for FlowsAlreadyRunningException, not on all cloudbreak api eexception (to not break any test that could be built around that etc.)

See detailed description in the commit message.