### PR TITLE
CB-11694 - Added a new Knox topology called cdp-proxy-token

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-{# If you update this file, please add the same changes into topology_token.xml.j2 too #}
+{# If you update this file, please add the same changes into topology_api.xml.j2 too #}
 {# They have to be the same except the authentication/federation provider they use #}
 
 <topology>
@@ -8,24 +8,16 @@
     <gateway>
 
         <provider>
-           <role>authentication</role>
-           <name>ShiroProvider</name>
+           <role>federation</role>
+           <name>JWTProvider</name>
            <enabled>true</enabled>
            <param>
-              <name>sessionTimeout</name>
-              <value>30</value>
+               <name>knox.token.exp.server-managed</name>
+               <value>true</value>
            </param>
            <param>
-              <name>main.pamRealm</name>
-              <value>org.apache.hadoop.gateway.shirorealm.KnoxPamRealm</value>
-           </param>
-           <param>
-              <name>main.pamRealm.service</name>
-              <value>login</value>
-           </param>
-           <param>
-              <name>urls./**</name>
-              <value>authcBasic</value>
+               <name>knox.token.audiences</name>
+               <value>cdp-proxy-token</value>
            </param>
         </provider>
 

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/knox.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/knox.sls
@@ -61,6 +61,17 @@
       protocol: {{ salt['pillar.get']('gateway:protocol') }}
     - mode: 644
 
+{{ gateway.knox_data_root }}/topologies/{{ topology.name }}-token.xml:
+  file.managed:
+    - source: salt://gateway/config/cm/topology_token.xml.j2
+    - template: jinja
+    - context:
+      exposed: {{ topology.exposed }}
+      ports: {{ salt['pillar.get']('gateway:ports') }}
+      topology_name: {{ topology.name }}
+      protocol: {{ salt['pillar.get']('gateway:protocol') }}
+    - mode: 644
+
 {% endfor %}
 
 {{ gateway.knox_data_root }}/security/keystores/signkey.pem:


### PR DESCRIPTION
This new topology must be in synch with `cdp-proxy-api` in terms of services and gateway providers except for the authentication/federation provider they use.
