### PR TITLE
CDPCP-3702 Add flag to force update of workload credentials by user sync

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/doc/UserModelDescriptions.java
@@ -18,6 +18,7 @@ public class UserModelDescriptions {
     public static final String FAILURE_ENVIRONMENTS = "details about environments where operation failed";
     public static final String USER_PASSWORD = "the user's password";
     public static final String USERSYNC_STATE = "state of user synchronization";
+    public static final String WORKLOAD_CREDENTIALS_UPDATE_TYPE = "Type of workload credentials update to perform";
 
     private UserModelDescriptions() {
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeAllUsersRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/SynchronizeAllUsersRequest.java
@@ -24,6 +24,9 @@ public class SynchronizeAllUsersRequest extends SynchronizeOperationRequestBase 
     @ApiModelProperty(value = UserModelDescriptions.USERSYNC_ACCOUNT_ID)
     private String accountId;
 
+    @ApiModelProperty(value = UserModelDescriptions.WORKLOAD_CREDENTIALS_UPDATE_TYPE)
+    private WorkloadCredentialsUpdateType workloadCredentialsUpdateType = WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED;
+
     public SynchronizeAllUsersRequest() {
     }
 
@@ -56,6 +59,14 @@ public class SynchronizeAllUsersRequest extends SynchronizeOperationRequestBase 
         this.accountId = accountId;
     }
 
+    public WorkloadCredentialsUpdateType getWorkloadCredentialsUpdateType() {
+        return workloadCredentialsUpdateType;
+    }
+
+    public void setWorkloadCredentialsUpdateType(WorkloadCredentialsUpdateType workloadCredentialsUpdateType) {
+        this.workloadCredentialsUpdateType = workloadCredentialsUpdateType;
+    }
+
     public Set<String> getDeletedWorkloadUsers() {
         return deletedWorkloadUsers;
     }
@@ -71,6 +82,7 @@ public class SynchronizeAllUsersRequest extends SynchronizeOperationRequestBase 
                 + ", users=" + users
                 + ", deletedWorkloadUsers=" + deletedWorkloadUsers
                 + ", accountId=" + accountId
+                + ", workloadCredentialsUpdateType=" + workloadCredentialsUpdateType
                 + ", " + super.fieldsToString()
                 + '}';
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/WorkloadCredentialsUpdateType.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/user/model/WorkloadCredentialsUpdateType.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.user.model;
+
+public enum WorkloadCredentialsUpdateType {
+    UPDATE_IF_CHANGED,
+    FORCE_UPDATE
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UserV1Controller.java
@@ -32,6 +32,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeAllUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUserRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.WorkloadCredentialsUpdateType;
 import com.sequenceiq.freeipa.controller.exception.SyncOperationAlreadyRunningException;
 import com.sequenceiq.freeipa.converter.freeipa.user.OperationToSyncOperationStatus;
 import com.sequenceiq.freeipa.entity.Operation;
@@ -83,7 +84,7 @@ public class UserV1Controller implements UserV1Endpoint {
         }
         UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(userCrnFilter, machineUserCrnFilter, Optional.empty());
         Operation syncOperation = userSyncService.synchronizeUsersWithCustomPermissionCheck(accountId, userCrn, environmentCrnFilter,
-                userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+                userSyncFilter, WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
         return checkOperationRejected(operationToSyncOperationStatus.convert(syncOperation));
     }
 
@@ -99,7 +100,8 @@ public class UserV1Controller implements UserV1Endpoint {
                 nullToEmpty(request.getMachineUsers()),
                 getOptionalDeletedWorkloadUser(request.getDeletedWorkloadUsers()));
         Operation syncOperation = userSyncService.synchronizeUsersWithCustomPermissionCheck(accountId, userCrn,
-                nullToEmpty(request.getEnvironments()), userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+                nullToEmpty(request.getEnvironments()), userSyncFilter, request.getWorkloadCredentialsUpdateType(),
+                AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
         return checkOperationRejected(operationToSyncOperationStatus.convert(syncOperation));
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.WorkloadCredentialsUpdateType;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.Permission;
@@ -89,7 +90,8 @@ public class FreeIpaPostInstallService {
         passwordPolicyService.updatePasswordPolicy(freeIpaClient);
         modifyAdminPasswordExpirationIfNeeded(freeIpaClient);
         userSyncService.synchronizeUsers(
-                ThreadBasedUserCrnProvider.getAccountId(), ThreadBasedUserCrnProvider.getUserCrn(), Set.of(stack.getEnvironmentCrn()), Set.of(), Set.of());
+                ThreadBasedUserCrnProvider.getAccountId(), ThreadBasedUserCrnProvider.getUserCrn(), Set.of(stack.getEnvironmentCrn()),
+                Set.of(), Set.of(), WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED);
     }
 
     private void modifyAdminPasswordExpirationIfNeeded(FreeIpaClient client) throws FreeIpaClientException {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UserSyncOptions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/UserSyncOptions.java
@@ -1,17 +1,23 @@
 package com.sequenceiq.freeipa.service.freeipa.user.model;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.WorkloadCredentialsUpdateType;
+
 public class UserSyncOptions {
 
     private final boolean fullSync;
 
     private final boolean fmsToFreeIpaBatchCallEnabled;
 
-    private final boolean credentialsUpdateOptimizationEnabled;
+    private final WorkloadCredentialsUpdateType workloadCredentialsUpdateType;
 
-    public UserSyncOptions(boolean fullSync, boolean fmsToFreeIpaBatchCallEnabled, boolean credentialsUpdateOptimizationEnabled) {
+    public UserSyncOptions(boolean fullSync, boolean fmsToFreeIpaBatchCallEnabled, WorkloadCredentialsUpdateType workloadCredentialsUpdateType) {
+        checkArgument(workloadCredentialsUpdateType == WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED ||
+                workloadCredentialsUpdateType == WorkloadCredentialsUpdateType.FORCE_UPDATE);
         this.fullSync = fullSync;
         this.fmsToFreeIpaBatchCallEnabled = fmsToFreeIpaBatchCallEnabled;
-        this.credentialsUpdateOptimizationEnabled = credentialsUpdateOptimizationEnabled;
+        this.workloadCredentialsUpdateType = workloadCredentialsUpdateType;
     }
 
     public boolean isFullSync() {
@@ -23,6 +29,6 @@ public class UserSyncOptions {
     }
 
     public boolean isCredentialsUpdateOptimizationEnabled() {
-        return credentialsUpdateOptimizationEnabled;
+        return workloadCredentialsUpdateType == WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPoller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPoller.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.WorkloadCredentialsUpdateType;
 import com.sequenceiq.freeipa.entity.Operation;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
@@ -121,7 +122,7 @@ public class UserSyncPoller {
                 LOGGER.debug("Environment {} in Account {} is not in sync.",
                         stack.getEnvironmentCrn(), stack.getAccountId());
                 Operation operation = userSyncService.synchronizeUsers(stack.getAccountId(), INTERNAL_ACTOR_CRN,
-                        Set.of(stack.getEnvironmentCrn()), Set.of(), Set.of());
+                        Set.of(stack.getEnvironmentCrn()), Set.of(), Set.of(), WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED);
                 LOGGER.debug("User Sync request resulted in operation {}", operation);
             } else {
                 LOGGER.debug("Environment {} in Account {} is in sync or has been synchronized recently.", stack.getEnvironmentCrn(), stack.getAccountId());

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/UserV1ControllerTest.java
@@ -29,6 +29,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizationStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeAllUsersRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeUserRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.WorkloadCredentialsUpdateType;
 import com.sequenceiq.freeipa.controller.exception.SyncOperationAlreadyRunningException;
 import com.sequenceiq.freeipa.converter.freeipa.user.OperationToSyncOperationStatus;
 import com.sequenceiq.freeipa.entity.Operation;
@@ -66,7 +67,7 @@ public class UserV1ControllerTest {
     @Test
     void synchronizeUser() {
         Operation operation = mock(Operation.class);
-        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any())).thenReturn(operation);
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
@@ -76,13 +77,13 @@ public class UserV1ControllerTest {
 
         UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(Set.of(USER_CRN), Set.of(), Optional.empty());
         verify(userSyncService, times(1)).synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, Set.of(),
-                userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+                userSyncFilter, WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
     }
 
     @Test
     void synchronizeUserMachineUser() {
         Operation operation = mock(Operation.class);
-        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any())).thenReturn(operation);
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
@@ -92,7 +93,7 @@ public class UserV1ControllerTest {
 
         UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(Set.of(), Set.of(MACHINE_USER_CRN), Optional.empty());
         verify(userSyncService, times(1)).synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, MACHINE_USER_CRN,
-                Set.of(), userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+                Set.of(), userSyncFilter, WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
     }
 
     @Test
@@ -100,7 +101,7 @@ public class UserV1ControllerTest {
         Operation operation = mock(Operation.class);
         UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(Set.of(USER_CRN), Set.of(), Optional.empty());
         when(userSyncService.synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, Set.of(), userSyncFilter,
-                AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)).thenReturn(operation);
+                WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(status.getStatus()).thenReturn(SynchronizationStatus.REJECTED);
         when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
@@ -119,9 +120,10 @@ public class UserV1ControllerTest {
         request.setEnvironments(environments);
         request.setUsers(users);
         request.setMachineUsers(machineUsers);
+        request.setWorkloadCredentialsUpdateType(WorkloadCredentialsUpdateType.FORCE_UPDATE);
 
         Operation operation = mock(Operation.class);
-        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any())).thenReturn(operation);
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
@@ -129,7 +131,7 @@ public class UserV1ControllerTest {
 
         UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(users, machineUsers, Optional.empty());
         verify(userSyncService, times(1)).synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, environments,
-                userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+                userSyncFilter, WorkloadCredentialsUpdateType.FORCE_UPDATE, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
     }
 
     @Test
@@ -142,7 +144,7 @@ public class UserV1ControllerTest {
         request.setDeletedWorkloadUsers(Set.of(deletedWorkloadUser));
 
         Operation operation = mock(Operation.class);
-        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any())).thenReturn(operation);
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
@@ -150,13 +152,12 @@ public class UserV1ControllerTest {
 
         UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(users, Set.of(), Optional.of(deletedWorkloadUser));
         verify(userSyncService, times(1)).synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, Set.of(),
-                userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+                userSyncFilter, WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
     }
 
     @Test
     void synchronizeAllUsersMultipleDeleteWorkloadUsers() {
         Set<String> users = Set.of(USER_CRN);
-        String deletedWorkloadUser = "workload-user";
         SynchronizeAllUsersRequest request = new SynchronizeAllUsersRequest();
         request.setEnvironments(Set.of());
         request.setUsers(users);
@@ -176,7 +177,7 @@ public class UserV1ControllerTest {
         request.setAccountId(ACCOUNT_ID);
 
         Operation operation = mock(Operation.class);
-        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any())).thenReturn(operation);
+        when(userSyncService.synchronizeUsersWithCustomPermissionCheck(any(), any(), any(), any(), any(), any())).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);
 
@@ -184,7 +185,7 @@ public class UserV1ControllerTest {
 
         UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(users, machineUsers, Optional.empty());
         verify(userSyncService, times(1)).synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, INTERNAL_ACTOR_CRN,
-                environments, userSyncFilter, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
+                environments, userSyncFilter, WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT);
     }
 
     @Test
@@ -206,7 +207,7 @@ public class UserV1ControllerTest {
         Operation operation = mock(Operation.class);
         UserSyncRequestFilter userSyncFilter = new UserSyncRequestFilter(users, Set.of(), Optional.empty());
         when(userSyncService.synchronizeUsersWithCustomPermissionCheck(ACCOUNT_ID, USER_CRN, environments, userSyncFilter,
-                AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)).thenReturn(operation);
+                WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED, AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)).thenReturn(operation);
         SyncOperationStatus status = mock(SyncOperationStatus.class);
         when(status.getStatus()).thenReturn(SynchronizationStatus.REJECTED);
         when(operationToSyncOperationStatus.convert(operation)).thenReturn(status);

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/WorkloadCredentialServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/WorkloadCredentialServiceTest.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Multimap;
 import com.googlecode.jsonrpc4j.JsonRpcClientException;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.WorkloadCredentialsUpdateType;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.cloudbreak.client.RPCResponse;
@@ -216,7 +217,9 @@ class WorkloadCredentialServiceTest {
         ImmutableSet<WorkloadCredentialUpdate> credentialUpdates = usersWithCredentialsToUpdate.stream()
                 .map(username -> new WorkloadCredentialUpdate(username, userToCrnMap.get(username), usersWorkloadCredentialMap.get(username)))
                 .collect(ImmutableSet.toImmutableSet());
-        underTest.setWorkloadCredentials(new UserSyncOptions(false, batchCallEnabled, updateOptimizationEnabled), ipaClient, credentialUpdates,
+        WorkloadCredentialsUpdateType credentialsUpdateType = updateOptimizationEnabled ?
+                WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED : WorkloadCredentialsUpdateType.FORCE_UPDATE;
+        underTest.setWorkloadCredentials(new UserSyncOptions(false, batchCallEnabled, credentialsUpdateType), ipaClient, credentialUpdates,
                 warnings);
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
@@ -4,7 +4,6 @@ import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -38,6 +37,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.WorkloadCredentialsUpdateType;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
 import com.sequenceiq.freeipa.configuration.BatchPartitionSizeProperties;
@@ -175,13 +175,11 @@ class UserSyncServiceTest {
         doAnswer(invocation -> {
             assertEquals(INTERNAL_ACTOR_CRN, ThreadBasedUserCrnProvider.getUserCrn());
             return null;
-        })
-                .when(spyService).asyncSynchronizeUsers(anyString(), anyString(), anyString(), anyList(), any(), anyBoolean());
+        }).when(spyService).asyncSynchronizeUsers(anyString(), anyString(), anyString(), anyList(), any(), any());
 
-        spyService.synchronizeUsers("accountId", "actorCrn",
-                Set.of(), Set.of(), Set.of());
+        spyService.synchronizeUsers("accountId", "actorCrn", Set.of(), Set.of(), Set.of(), WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED);
 
-        verify(spyService).asyncSynchronizeUsers(anyString(), anyString(), anyString(), anyList(), any(), anyBoolean());
+        verify(spyService).asyncSynchronizeUsers(anyString(), anyString(), anyString(), anyList(), any(), any());
     }
 
     @Test

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPollerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPollerTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.WorkloadCredentialsUpdateType;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.freeipa.user.EventGenerationIdsChecker;
@@ -72,7 +73,7 @@ class UserSyncPollerTest {
         underTest.syncAllFreeIpaStacks();
 
         verify(userSyncService).synchronizeUsers(UserSyncTestUtils.ACCOUNT_ID, INTERNAL_ACTOR_CRN,
-                Set.of(UserSyncTestUtils.ENVIRONMENT_CRN), Set.of(), Set.of());
+                Set.of(UserSyncTestUtils.ENVIRONMENT_CRN), Set.of(), Set.of(), WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED);
     }
 
     @Test
@@ -84,7 +85,7 @@ class UserSyncPollerTest {
         underTest.syncAllFreeIpaStacks();
 
         verify(userSyncService, times(0))
-                .synchronizeUsers(any(), any(), any(), any(), any());
+                .synchronizeUsers(any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -97,7 +98,7 @@ class UserSyncPollerTest {
         underTest.syncAllFreeIpaStacks();
 
         verify(userSyncService).synchronizeUsers(UserSyncTestUtils.ACCOUNT_ID, INTERNAL_ACTOR_CRN,
-                Set.of(UserSyncTestUtils.ENVIRONMENT_CRN), Set.of(), Set.of());
+                Set.of(UserSyncTestUtils.ENVIRONMENT_CRN), Set.of(), Set.of(), WorkloadCredentialsUpdateType.UPDATE_IF_CHANGED);
     }
 
     @Test
@@ -110,7 +111,7 @@ class UserSyncPollerTest {
         underTest.syncAllFreeIpaStacks();
 
         verify(userSyncService, times(0))
-                .synchronizeUsers(any(), any(), any(), any(), any());
+                .synchronizeUsers(any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -121,7 +122,7 @@ class UserSyncPollerTest {
         underTest.syncAllFreeIpaStacks();
 
         verify(userSyncService, times(0))
-                .synchronizeUsers(any(), any(), any(), any(), any());
+                .synchronizeUsers(any(), any(), any(), any(), any(), any());
     }
 
     private Stack setupMockStackService(Stack stack) {


### PR DESCRIPTION
Adds a flag to the SynchronizeAllUsers request that forces user sync to update
workload credentials for all users, whether or not they have changed. The flag
is a no-op when the CDP_USER_SYNC_CREDENTIALS_UPDATE_OPTIMIZATION entitlement
is not enabled.

The flag will be exposed as a '--force-workload-credentials-update' option to
the 'cdp environments sync-all-users' API. This is the backend implementation.

I added the flag to both public entry points to UserSyncService -- synchronizeUsers
and synchronizeUsersWithCustomPermissionCheck, even though callers of the former
always set it to false. It seemed inconsistent for this option to be accepted
when doing a custom permission check, but not otherwise.

I also moved the computation of UserSyncOptions up the call chain, to avoid
adding more parameters to lower-level methods, and to simplify adding new
options in the future.

See detailed description in the commit message.