### PR TITLE
CB-11700. Zookeeper should not be on the 'worker' nodes in the Spark3

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.0/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.0/cdp-data-engineering-spark3.bp
@@ -240,6 +240,7 @@
           "hms-HIVEMETASTORE-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "zookeeper-SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
@@ -256,7 +257,6 @@
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
-          "zookeeper-SERVER-BASE",
           "yarn-GATEWAY-BASE"
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.1/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.1/cdp-data-engineering-spark3.bp
@@ -240,6 +240,7 @@
           "hms-HIVEMETASTORE-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
+          "zookeeper-SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
@@ -256,7 +257,6 @@
           "hms-GATEWAY-BASE",
           "spark3_on_yarn-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
-          "zookeeper-SERVER-BASE",
           "yarn-GATEWAY-BASE"
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
@@ -365,6 +365,7 @@
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "livy_for_spark3-LIVY_SERVER-BASE",
+          "zookeeper-SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
@@ -384,7 +385,6 @@
           "spark3_on_yarn-GATEWAY-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
-          "zookeeper-SERVER-BASE",
           "yarn-GATEWAY-BASE"
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-data-engineering-spark3.bp
@@ -355,6 +355,7 @@
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "livy_for_spark3-LIVY_SERVER-BASE",
+          "zookeeper-SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
@@ -374,7 +375,6 @@
           "spark3_on_yarn-GATEWAY-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
-          "zookeeper-SERVER-BASE",
           "yarn-GATEWAY-BASE"
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-data-engineering-spark3.bp
@@ -355,6 +355,7 @@
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "livy_for_spark3-LIVY_SERVER-BASE",
+          "zookeeper-SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
@@ -374,7 +375,6 @@
           "spark3_on_yarn-GATEWAY-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
-          "zookeeper-SERVER-BASE",
           "yarn-GATEWAY-BASE"
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-data-engineering-spark3.bp
@@ -355,6 +355,7 @@
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "livy_for_spark3-LIVY_SERVER-BASE",
+          "zookeeper-SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
@@ -374,7 +375,6 @@
           "spark3_on_yarn-GATEWAY-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
-          "zookeeper-SERVER-BASE",
           "yarn-GATEWAY-BASE"
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-spark3.bp
@@ -365,6 +365,7 @@
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "livy_for_spark3-LIVY_SERVER-BASE",
+          "zookeeper-SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
@@ -384,7 +385,6 @@
           "spark3_on_yarn-GATEWAY-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
-          "zookeeper-SERVER-BASE",
           "yarn-GATEWAY-BASE"
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-spark3.bp
@@ -365,6 +365,7 @@
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "livy_for_spark3-LIVY_SERVER-BASE",
+          "zookeeper-SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
@@ -384,7 +385,6 @@
           "spark3_on_yarn-GATEWAY-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "yarn-NODEMANAGER-WORKER",
-          "zookeeper-SERVER-BASE",
           "yarn-GATEWAY-BASE"
         ]
       },


### PR DESCRIPTION
template.
- Moves Zookeeper over to the 'master' node.

See detailed description in the commit message.