### PR TITLE
CB-10965 Missing retry - Read timed out for GCP

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpCloudKMSFactory.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpCloudKMSFactory.java
@@ -10,8 +10,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.cloudkms.v1.CloudKMS;
 import com.google.api.services.cloudkms.v1.CloudKMSScopes;
@@ -28,14 +27,16 @@ public class GcpCloudKMSFactory {
     @Inject
     private GcpCredentialFactory gcpCredentialFactory;
 
+    @Inject
+    private ApacheHttpTransport gcpApacheHttpTransport;
+
     public CloudKMS buildCloudKMS(CloudCredential cloudCredential) throws GeneralSecurityException, IOException {
-        HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-        GoogleCredential credential = gcpCredentialFactory.buildCredential(cloudCredential, httpTransport);
+        GoogleCredential credential = gcpCredentialFactory.buildCredential(cloudCredential, gcpApacheHttpTransport);
         if (credential.createScopedRequired()) {
             credential = credential.createScoped(CloudKMSScopes.all());
         }
 
-        return new CloudKMS.Builder(httpTransport, jsonFactory, credential)
+        return new CloudKMS.Builder(gcpApacheHttpTransport, jsonFactory, credential)
                 .setApplicationName(cloudCredential.getName())
                 .build();
     }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpCloudKMSFactory.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpCloudKMSFactory.java
@@ -10,14 +10,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.http.apache.ApacheHttpTransport;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.cloudkms.v1.CloudKMS;
 import com.google.api.services.cloudkms.v1.CloudKMSScopes;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 
 @Service
-public class GcpCloudKMSFactory {
+public class GcpCloudKMSFactory extends GcpServiceFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GcpCloudKMSFactory.class);
 
@@ -28,15 +28,15 @@ public class GcpCloudKMSFactory {
     private GcpCredentialFactory gcpCredentialFactory;
 
     @Inject
-    private ApacheHttpTransport gcpApacheHttpTransport;
+    private HttpTransport httpTransport;
 
     public CloudKMS buildCloudKMS(CloudCredential cloudCredential) throws GeneralSecurityException, IOException {
-        GoogleCredential credential = gcpCredentialFactory.buildCredential(cloudCredential, gcpApacheHttpTransport);
+        GoogleCredential credential = gcpCredentialFactory.buildCredential(cloudCredential, httpTransport);
         if (credential.createScopedRequired()) {
             credential = credential.createScoped(CloudKMSScopes.all());
         }
 
-        return new CloudKMS.Builder(gcpApacheHttpTransport, jsonFactory, credential)
+        return new CloudKMS.Builder(httpTransport, jsonFactory, requestInitializer(credential))
                 .setApplicationName(cloudCredential.getName())
                 .build();
     }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpComputeFactory.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpComputeFactory.java
@@ -7,8 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.compute.Compute;
 import com.sequenceiq.cloudbreak.cloud.event.credential.CredentialVerificationException;
@@ -25,12 +24,14 @@ public class GcpComputeFactory {
     @Inject
     private GcpCredentialFactory gcpCredentialFactory;
 
+    @Inject
+    private ApacheHttpTransport gcpApacheHttpTransport;
+
     public Compute buildCompute(CloudCredential cloudCredential) {
         try {
-            HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-            GoogleCredential credential = gcpCredentialFactory.buildCredential(cloudCredential, httpTransport);
+            GoogleCredential credential = gcpCredentialFactory.buildCredential(cloudCredential, gcpApacheHttpTransport);
             return new Compute.Builder(
-                    httpTransport, jsonFactory, null).setApplicationName(cloudCredential.getName())
+                    gcpApacheHttpTransport, jsonFactory, null).setApplicationName(cloudCredential.getName())
                     .setHttpRequestInitializer(credential)
                     .build();
         } catch (Exception e) {

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpComputeFactory.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpComputeFactory.java
@@ -7,14 +7,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.http.apache.ApacheHttpTransport;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.compute.Compute;
 import com.sequenceiq.cloudbreak.cloud.event.credential.CredentialVerificationException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 
 @Service
-public class GcpComputeFactory {
+public class GcpComputeFactory extends GcpServiceFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GcpComputeFactory.class);
 
@@ -25,19 +25,17 @@ public class GcpComputeFactory {
     private GcpCredentialFactory gcpCredentialFactory;
 
     @Inject
-    private ApacheHttpTransport gcpApacheHttpTransport;
+    private HttpTransport httpTransport;
 
     public Compute buildCompute(CloudCredential cloudCredential) {
         try {
-            GoogleCredential credential = gcpCredentialFactory.buildCredential(cloudCredential, gcpApacheHttpTransport);
-            return new Compute.Builder(
-                    gcpApacheHttpTransport, jsonFactory, null).setApplicationName(cloudCredential.getName())
-                    .setHttpRequestInitializer(credential)
+            GoogleCredential credential = gcpCredentialFactory.buildCredential(cloudCredential, httpTransport);
+            return new Compute.Builder(httpTransport, jsonFactory, requestInitializer(credential))
+                    .setApplicationName(cloudCredential.getName())
                     .build();
         } catch (Exception e) {
             LOGGER.warn("Error occurred while building Google Compute access.", e);
             throw new CredentialVerificationException("Error occurred while building Google Compute access.", e);
         }
     }
-
 }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpHttpClientConfig.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpHttpClientConfig.java
@@ -1,20 +1,19 @@
 package com.sequenceiq.cloudbreak.cloud.gcp.client;
 
-import org.apache.http.impl.client.DefaultHttpClient;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import com.google.api.client.http.apache.ApacheHttpTransport;
-import com.sequenceiq.cloudbreak.cloud.gcp.tracing.GcpTracingInterceptor;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
 
 @Configuration
 public class GcpHttpClientConfig {
 
     @Bean
-    public ApacheHttpTransport gcpApacheHttpTransport(GcpTracingInterceptor gcpTracingInterceptor) {
-        DefaultHttpClient defaultHttpClient = ApacheHttpTransport.newDefaultHttpClient();
-        defaultHttpClient.addRequestInterceptor(gcpTracingInterceptor);
-        defaultHttpClient.addResponseInterceptor(gcpTracingInterceptor);
-        return new ApacheHttpTransport(defaultHttpClient);
+    public HttpTransport httpTransport() throws GeneralSecurityException, IOException {
+        return GoogleNetHttpTransport.newTrustedTransport();
     }
 }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpHttpClientConfig.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpHttpClientConfig.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.client;
+
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.api.client.http.apache.ApacheHttpTransport;
+import com.sequenceiq.cloudbreak.cloud.gcp.tracing.GcpTracingInterceptor;
+
+@Configuration
+public class GcpHttpClientConfig {
+
+    @Bean
+    public ApacheHttpTransport gcpApacheHttpTransport(GcpTracingInterceptor gcpTracingInterceptor) {
+        DefaultHttpClient defaultHttpClient = ApacheHttpTransport.newDefaultHttpClient();
+        defaultHttpClient.addRequestInterceptor(gcpTracingInterceptor);
+        defaultHttpClient.addResponseInterceptor(gcpTracingInterceptor);
+        return new ApacheHttpTransport(defaultHttpClient);
+    }
+}

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpIamFactory.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpIamFactory.java
@@ -7,14 +7,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.http.apache.ApacheHttpTransport;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.iam.v1.Iam;
 import com.sequenceiq.cloudbreak.cloud.event.credential.CredentialVerificationException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 
 @Service
-public class GcpIamFactory {
+public class GcpIamFactory extends GcpServiceFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GcpIamFactory.class);
 
@@ -25,14 +25,13 @@ public class GcpIamFactory {
     private GcpCredentialFactory gcpCredentialFactory;
 
     @Inject
-    private ApacheHttpTransport gcpApacheHttpTransport;
+    private HttpTransport httpTransport;
 
     public Iam buildIam(CloudCredential gcpCredential) {
         try {
-            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, gcpApacheHttpTransport);
-            return new Iam.Builder(
-                    gcpApacheHttpTransport, jsonFactory, null).setApplicationName(gcpCredential.getName())
-                    .setHttpRequestInitializer(credential)
+            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, httpTransport);
+            return new Iam.Builder(httpTransport, jsonFactory, requestInitializer(credential))
+                    .setApplicationName(gcpCredential.getName())
                     .build();
         } catch (Exception e) {
             LOGGER.warn("Error occurred while building Google Compute access.", e);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpIamFactory.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpIamFactory.java
@@ -7,8 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.iam.v1.Iam;
 import com.sequenceiq.cloudbreak.cloud.event.credential.CredentialVerificationException;
@@ -25,12 +24,14 @@ public class GcpIamFactory {
     @Inject
     private GcpCredentialFactory gcpCredentialFactory;
 
+    @Inject
+    private ApacheHttpTransport gcpApacheHttpTransport;
+
     public Iam buildIam(CloudCredential gcpCredential) {
         try {
-            HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, httpTransport);
+            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, gcpApacheHttpTransport);
             return new Iam.Builder(
-                    httpTransport, jsonFactory, null).setApplicationName(gcpCredential.getName())
+                    gcpApacheHttpTransport, jsonFactory, null).setApplicationName(gcpCredential.getName())
                     .setHttpRequestInitializer(credential)
                     .build();
         } catch (Exception e) {

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpSQLAdminFactory.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpSQLAdminFactory.java
@@ -7,8 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.sqladmin.SQLAdmin;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
@@ -24,12 +23,14 @@ public class GcpSQLAdminFactory {
     @Inject
     private GcpCredentialFactory gcpCredentialFactory;
 
+    @Inject
+    private ApacheHttpTransport gcpApacheHttpTransport;
+
     public SQLAdmin buildSQLAdmin(CloudCredential gcpCredential, String name) {
         try {
-            HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, httpTransport);
+            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, gcpApacheHttpTransport);
             return new SQLAdmin.Builder(
-                    httpTransport, jsonFactory, null)
+                    gcpApacheHttpTransport, jsonFactory, null)
                     .setApplicationName(name)
                     .setHttpRequestInitializer(credential)
                     .build();

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpSQLAdminFactory.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpSQLAdminFactory.java
@@ -7,13 +7,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.http.apache.ApacheHttpTransport;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.sqladmin.SQLAdmin;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 
 @Service
-public class GcpSQLAdminFactory {
+public class GcpSQLAdminFactory extends GcpServiceFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GcpSQLAdminFactory.class);
 
@@ -24,15 +24,13 @@ public class GcpSQLAdminFactory {
     private GcpCredentialFactory gcpCredentialFactory;
 
     @Inject
-    private ApacheHttpTransport gcpApacheHttpTransport;
+    private HttpTransport httpTransport;
 
     public SQLAdmin buildSQLAdmin(CloudCredential gcpCredential, String name) {
         try {
-            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, gcpApacheHttpTransport);
-            return new SQLAdmin.Builder(
-                    gcpApacheHttpTransport, jsonFactory, null)
+            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, httpTransport);
+            return new SQLAdmin.Builder(httpTransport, jsonFactory, requestInitializer(credential))
                     .setApplicationName(name)
-                    .setHttpRequestInitializer(credential)
                     .build();
         } catch (Exception e) {
             LOGGER.warn("Error occurred while building Google Storage access.", e);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpServiceFactory.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpServiceFactory.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.client;
+
+import javax.inject.Inject;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.http.HttpExecuteInterceptor;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.sequenceiq.cloudbreak.cloud.gcp.tracing.GcpTracingInterceptor;
+
+public abstract class GcpServiceFactory {
+
+    @Inject
+    private GcpTracingInterceptor gcpTracingInterceptor;
+
+    protected HttpRequestInitializer requestInitializer(GoogleCredential credential) {
+        return request -> {
+            credential.initialize(request);
+            request.setInterceptor(requestInterceptor(credential));
+            request.setResponseInterceptor(gcpTracingInterceptor);
+        };
+    }
+
+    private HttpExecuteInterceptor requestInterceptor(GoogleCredential credential) {
+        return request -> {
+            credential.intercept(request);
+            gcpTracingInterceptor.intercept(request);
+        };
+    }
+}

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpStorageFactory.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpStorageFactory.java
@@ -9,8 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.storage.Storage;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
@@ -26,12 +25,14 @@ public class GcpStorageFactory {
     @Inject
     private GcpCredentialFactory gcpCredentialFactory;
 
+    @Inject
+    private ApacheHttpTransport gcpApacheHttpTransport;
+
     public Storage buildStorage(CloudCredential gcpCredential, String name) {
         try {
-            HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, httpTransport);
+            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, gcpApacheHttpTransport);
             return new Storage.Builder(
-                    httpTransport, jsonFactory, setHttpTimeout(credential)).setApplicationName(name)
+                    gcpApacheHttpTransport, jsonFactory, setHttpTimeout(credential)).setApplicationName(name)
                     .setHttpRequestInitializer(setHttpTimeout(credential))
                     .build();
         } catch (Exception e) {

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpStorageFactory.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/client/GcpStorageFactory.java
@@ -9,13 +9,13 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.api.client.http.apache.ApacheHttpTransport;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.storage.Storage;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 
 @Service
-public class GcpStorageFactory {
+public class GcpStorageFactory extends GcpServiceFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GcpStorageFactory.class);
 
@@ -26,14 +26,13 @@ public class GcpStorageFactory {
     private GcpCredentialFactory gcpCredentialFactory;
 
     @Inject
-    private ApacheHttpTransport gcpApacheHttpTransport;
+    private HttpTransport httpTransport;
 
     public Storage buildStorage(CloudCredential gcpCredential, String name) {
         try {
-            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, gcpApacheHttpTransport);
-            return new Storage.Builder(
-                    gcpApacheHttpTransport, jsonFactory, setHttpTimeout(credential)).setApplicationName(name)
-                    .setHttpRequestInitializer(setHttpTimeout(credential))
+            GoogleCredential credential = gcpCredentialFactory.buildCredential(gcpCredential, httpTransport);
+            return new Storage.Builder(httpTransport, jsonFactory, setHttpTimeout(requestInitializer(credential)))
+                    .setApplicationName(name)
                     .build();
         } catch (Exception e) {
             LOGGER.warn("Error occurred while building Google Storage access.", e);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/tracing/GcpTracingInterceptor.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/tracing/GcpTracingInterceptor.java
@@ -1,0 +1,121 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.tracing;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpResponseInterceptor;
+import org.apache.http.RequestLine;
+import org.apache.http.StatusLine;
+import org.apache.http.protocol.HttpContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.tracing.TracingUtil;
+import com.sequenceiq.cloudbreak.util.Benchmark;
+
+import io.opentracing.References;
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+
+@Component
+public class GcpTracingInterceptor implements HttpRequestInterceptor, HttpResponseInterceptor {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GcpTracingInterceptor.class);
+
+    private static final String JAVA_GCP_SDK = "java-gcp-sdk";
+
+    private static final int MIN_OK_STATUS_CODE = 200;
+
+    private static final int MAX_OK_STATUS_CODE = 300;
+
+    private static final ThreadLocal<Pair<Scope, Span>> DATA = new ThreadLocal<>();
+
+    @Inject
+    private Tracer tracer;
+
+    @Override
+    public void process(HttpRequest request, HttpContext context) {
+        StackWalker stackWalker = StackWalker.getInstance();
+        StringBuilder apiOperation = new StringBuilder();
+        Benchmark.measure(() -> getApiOperationFromStackTrace(stackWalker, apiOperation),
+                LOGGER, "STACK WALKING TOOK: {}ms");
+        activateNewTracingSpan(request, context, apiOperation);
+    }
+
+    @Override
+    public void process(HttpResponse response, HttpContext context) {
+        Scope scope = DATA.get().getLeft();
+        Span span = DATA.get().getRight();
+        StatusLine statusLine = response.getStatusLine();
+        if (requestSucceeded(statusLine)) {
+            span.setTag(TracingUtil.ERROR, false);
+        } else {
+            span.setTag(TracingUtil.ERROR, true);
+            span.log(Map.of(TracingUtil.RESPONSE_CODE, statusLine.getStatusCode(), TracingUtil.MESSAGE, statusLine.getReasonPhrase()));
+        }
+        span.finish();
+        scope.close();
+    }
+
+    private void getApiOperationFromStackTrace(StackWalker stackWalker, StringBuilder apiOperation) {
+        stackWalker.forEach(stackFrame -> {
+            try {
+                if (isFirstGcpApiMethod(apiOperation, stackFrame)) {
+                    String className = extractClassName(stackFrame);
+                    apiOperation.append(className).append(" # ").append(stackFrame.getMethodName());
+                }
+            } catch (Exception e) {
+                LOGGER.warn("Exception occurred during stack walking.", e);
+            }
+        });
+    }
+
+    private boolean isFirstGcpApiMethod(StringBuilder apiOperation, StackWalker.StackFrame stackFrame) {
+        return stackFrame.getClassName().startsWith("com.sequenceiq.cloudbreak.cloud.gcp")
+                && !stackFrame.getClassName().contains("tracing") && apiOperation.length() == 0;
+    }
+
+    private String extractClassName(StackWalker.StackFrame stackFrame) {
+        return StringUtils.substringBefore(
+                StringUtils.substringAfterLast(stackFrame.getClassName(), "."),
+                "$");
+    }
+
+    private void activateNewTracingSpan(HttpRequest request, HttpContext context, StringBuilder apiOperation) {
+        RequestLine requestLine = request.getRequestLine();
+        String operationName = createOperationName(context, apiOperation, requestLine);
+        Span span = initSpan(requestLine, operationName);
+        Scope scope = tracer.activateSpan(span);
+        DATA.set(Pair.of(scope, span));
+    }
+
+    private String createOperationName(HttpContext context, StringBuilder apiOperation, RequestLine requestLine) {
+        String hostName = ((HttpHost) context.getAttribute("http.target_host")).getHostName();
+        return "GCP - [" + requestLine.getMethod().toUpperCase() + "] " +
+                apiOperation +
+                " (" + hostName + ')';
+    }
+
+    private Span initSpan(RequestLine requestLine, String operationName) {
+        Span span = tracer.buildSpan(operationName)
+                .addReference(References.FOLLOWS_FROM, tracer.activeSpan() != null ? tracer.activeSpan().context() : null)
+                .start();
+        span.setTag(TracingUtil.COMPONENT, JAVA_GCP_SDK);
+        span.setTag(TracingUtil.URL, requestLine.getUri());
+        span.setTag(TracingUtil.HTTP_METHOD, requestLine.getMethod());
+        return span;
+    }
+
+    private boolean requestSucceeded(StatusLine statusLine) {
+        return statusLine.getStatusCode() >= MIN_OK_STATUS_CODE && statusLine.getStatusCode() < MAX_OK_STATUS_CODE;
+    }
+}


### PR DESCRIPTION
Use the original NetHttpTransport for GCP tracing. This implementation can retry with backoff and has timeout. With wrapper classes, the interceptors were added to the requests, the interceptor implementation changed to the Google HTTP API.