### PR TITLE
CB-11682 cleanup clients in int test module

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakClient.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.auth.altus.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.client.ApiKeyRequestFilter;
 import com.sequenceiq.cloudbreak.client.CloudbreakApiKeyClient;
 import com.sequenceiq.cloudbreak.client.CloudbreakInternalCrnClient;
+import com.sequenceiq.cloudbreak.client.CloudbreakServiceCrnEndpoints;
 import com.sequenceiq.cloudbreak.client.CloudbreakServiceUserCrnClient;
 import com.sequenceiq.cloudbreak.client.CloudbreakUserCrnClientBuilder;
 import com.sequenceiq.cloudbreak.client.ConfigKey;
@@ -45,14 +46,12 @@ import com.sequenceiq.it.cloudbreak.dto.util.VersionCheckTestDto;
 import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.cloudbreak.CloudbreakWaitObject;
 
-public class CloudbreakClient extends MicroserviceClient {
+public class CloudbreakClient extends MicroserviceClient<com.sequenceiq.cloudbreak.client.CloudbreakClient, CloudbreakServiceCrnEndpoints> {
     public static final String CLOUDBREAK_CLIENT = "CLOUDBREAK_CLIENT";
 
     private static com.sequenceiq.cloudbreak.client.CloudbreakClient singletonCloudbreakClient;
 
     private static CloudbreakInternalCrnClient singletonCloudbreakInternalCrnClient;
-
-    private static String crn;
 
     private com.sequenceiq.cloudbreak.client.CloudbreakClient cloudbreakClient;
 
@@ -83,16 +82,17 @@ public class CloudbreakClient extends MicroserviceClient {
         return (T) new CloudbreakWaitObject(this, name, map, testContext.getActingUserCrn().getAccountId());
     }
 
+    @Override
+    public com.sequenceiq.cloudbreak.client.CloudbreakClient getDefaultClient() {
+        return cloudbreakClient;
+    }
+
     public static synchronized com.sequenceiq.cloudbreak.client.CloudbreakClient getSingletonCloudbreakClient() {
         return singletonCloudbreakClient;
     }
 
     public static Function<IntegrationTestContext, CloudbreakClient> getTestContextCloudbreakClient(String key) {
         return testContext -> testContext.getContextParam(key, CloudbreakClient.class);
-    }
-
-    public static Function<IntegrationTestContext, CloudbreakClient> getTestContextCloudbreakClient() {
-        return getTestContextCloudbreakClient(CLOUDBREAK_CLIENT);
     }
 
     public static CloudbreakClient created() {
@@ -150,18 +150,6 @@ public class CloudbreakClient extends MicroserviceClient {
         return new CloudbreakInternalCrnClient(cbUserCrnClient, new InternalCrnBuilder(Crn.Service.IAM));
     }
 
-    public com.sequenceiq.cloudbreak.client.CloudbreakClient getCloudbreakClient() {
-        return cloudbreakClient;
-    }
-
-    public CloudbreakInternalCrnClient getCloudbreakInternalCrnClient() {
-        return cloudbreakInternalCrnClient;
-    }
-
-    public void setCloudbreakClient(com.sequenceiq.cloudbreak.client.CloudbreakClient cloudbreakClient) {
-        this.cloudbreakClient = cloudbreakClient;
-    }
-
     public Long getWorkspaceId() {
         return workspaceId;
     }
@@ -193,6 +181,12 @@ public class CloudbreakClient extends MicroserviceClient {
                 CheckResourceRightTestDto.class.getSimpleName(),
                 RenewDistroXCertificateTestDto.class.getSimpleName(),
                 ImageCatalogTestDto.class.getSimpleName());
+    }
+
+    @Override
+    public CloudbreakServiceCrnEndpoints getInternalClient(TestContext testContext) {
+        checkIfInternalClientAllowed(testContext);
+        return cloudbreakInternalCrnClient.withInternalCrn();
     }
 }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/EnvironmentClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/EnvironmentClient.java
@@ -10,6 +10,7 @@ import com.sequenceiq.cloudbreak.client.ConfigKey;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.environment.client.EnvironmentInternalCrnClient;
 import com.sequenceiq.environment.client.EnvironmentServiceApiKeyClient;
+import com.sequenceiq.environment.client.EnvironmentServiceCrnEndpoints;
 import com.sequenceiq.environment.client.EnvironmentServiceUserCrnClient;
 import com.sequenceiq.environment.client.EnvironmentServiceUserCrnClientBuilder;
 import com.sequenceiq.flow.api.FlowPublicEndpoint;
@@ -24,7 +25,7 @@ import com.sequenceiq.it.cloudbreak.dto.proxy.ProxyTestDto;
 import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.environment.EnvironmentWaitObject;
 
-public class EnvironmentClient extends MicroserviceClient {
+public class EnvironmentClient extends MicroserviceClient<com.sequenceiq.environment.client.EnvironmentClient, EnvironmentServiceCrnEndpoints> {
 
     public static final String ENVIRONMENT_CLIENT = "ENVIRONMENT_CLIENT";
 
@@ -42,10 +43,6 @@ public class EnvironmentClient extends MicroserviceClient {
 
     public static Function<IntegrationTestContext, EnvironmentClient> getTestContextEnvironmentClient(String key) {
         return testContext -> testContext.getContextParam(key, EnvironmentClient.class);
-    }
-
-    public static Function<IntegrationTestContext, EnvironmentClient> getTestContextEnvironmentClient() {
-        return getTestContextEnvironmentClient(ENVIRONMENT_CLIENT);
     }
 
     @Override
@@ -80,27 +77,22 @@ public class EnvironmentClient extends MicroserviceClient {
         return new EnvironmentInternalCrnClient(userCrnClient, new InternalCrnBuilder(Crn.Service.IAM));
     }
 
-    public com.sequenceiq.environment.client.EnvironmentClient getEnvironmentClient() {
-        return environmentClient;
-    }
-
-    public void setEnvironmentClient(com.sequenceiq.environment.client.EnvironmentClient environmentClient) {
-        this.environmentClient = environmentClient;
-    }
-
-    public EnvironmentInternalCrnClient getEnvironmentInternalCrnClient() {
-        return environmentInternalCrnClient;
-    }
-
-    public void setEnvironmentInternalCrnClient(EnvironmentInternalCrnClient environmentInternalCrnClient) {
-        this.environmentInternalCrnClient = environmentInternalCrnClient;
-    }
-
     @Override
     public Set<String> supportedTestDtos() {
         return Set.of(EnvironmentTestDto.class.getSimpleName(),
                 EnvironmentClient.class.getSimpleName(),
                 ProxyTestDto.class.getSimpleName(),
                 CredentialTestDto.class.getSimpleName());
+    }
+
+    @Override
+    public com.sequenceiq.environment.client.EnvironmentClient getDefaultClient() {
+        return environmentClient;
+    }
+
+    @Override
+    public EnvironmentServiceCrnEndpoints getInternalClient(TestContext testContext) {
+        checkIfInternalClientAllowed(testContext);
+        return environmentInternalCrnClient.withInternalCrn();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/FreeIpaClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/FreeIpaClient.java
@@ -11,6 +11,7 @@ import com.sequenceiq.flow.api.FlowPublicEndpoint;
 import com.sequenceiq.freeipa.api.client.FreeIpaApiKeyClient;
 import com.sequenceiq.freeipa.api.client.FreeIpaApiUserCrnClient;
 import com.sequenceiq.freeipa.api.client.FreeIpaApiUserCrnClientBuilder;
+import com.sequenceiq.freeipa.api.client.FreeIpaApiUserCrnEndpoint;
 import com.sequenceiq.freeipa.api.client.FreeipaInternalCrnClient;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.UserSyncState;
@@ -31,10 +32,8 @@ import com.sequenceiq.it.cloudbreak.util.wait.service.freeipa.FreeIpaOperationWa
 import com.sequenceiq.it.cloudbreak.util.wait.service.freeipa.FreeIpaUserSyncWaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.freeipa.FreeIpaWaitObject;
 
-public class FreeIpaClient extends MicroserviceClient {
+public class FreeIpaClient extends MicroserviceClient<com.sequenceiq.freeipa.api.client.FreeIpaClient, FreeIpaApiUserCrnEndpoint> {
     public static final String FREEIPA_CLIENT = "FREEIPA_CLIENT";
-
-    private static String crn;
 
     private com.sequenceiq.freeipa.api.client.FreeIpaClient freeIpaClient;
 
@@ -71,12 +70,13 @@ public class FreeIpaClient extends MicroserviceClient {
         }
     }
 
-    public static Function<IntegrationTestContext, FreeIpaClient> getTestContextFreeIpaClient(String key) {
-        return testContext -> testContext.getContextParam(key, FreeIpaClient.class);
+    @Override
+    public com.sequenceiq.freeipa.api.client.FreeIpaClient getDefaultClient() {
+        return freeIpaClient;
     }
 
-    public static Function<IntegrationTestContext, FreeIpaClient> getTestContextFreeIpaClient() {
-        return getTestContextFreeIpaClient(FREEIPA_CLIENT);
+    public static Function<IntegrationTestContext, FreeIpaClient> getTestContextFreeIpaClient(String key) {
+        return testContext -> testContext.getContextParam(key, FreeIpaClient.class);
     }
 
     public static synchronized FreeIpaClient createProxyFreeIpaClient(TestParameter testParameter, CloudbreakUser cloudbreakUser) {
@@ -98,22 +98,6 @@ public class FreeIpaClient extends MicroserviceClient {
         return new FreeipaInternalCrnClient(freeIpaApiUserCrnClient, new InternalCrnBuilder(Crn.Service.IAM));
     }
 
-    public com.sequenceiq.freeipa.api.client.FreeIpaClient getFreeIpaClient() {
-        return freeIpaClient;
-    }
-
-    public void setFreeIpaClient(com.sequenceiq.freeipa.api.client.FreeIpaClient freeIpaClient) {
-        this.freeIpaClient = freeIpaClient;
-    }
-
-    public FreeipaInternalCrnClient getFreeipaInternalCrnClient() {
-        return freeipaInternalCrnClient;
-    }
-
-    public void setFreeipaInternalCrnClient(FreeipaInternalCrnClient freeipaInternalCrnClient) {
-        this.freeipaInternalCrnClient = freeipaInternalCrnClient;
-    }
-
     @Override
     public Set<String> supportedTestDtos() {
         return Set.of(FreeIpaTestDto.class.getSimpleName(),
@@ -122,5 +106,11 @@ public class FreeIpaClient extends MicroserviceClient {
                 FreeIpaChildEnvironmentTestDto.class.getSimpleName(),
                 KerberosTestDto.class.getSimpleName(),
                 FreeIpaUserSyncStatusDto.class.getSimpleName());
+    }
+
+    @Override
+    public FreeIpaApiUserCrnEndpoint getInternalClient(TestContext testContext) {
+        checkIfInternalClientAllowed(testContext);
+        return freeipaInternalCrnClient.withInternalCrn();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/MicroserviceClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/MicroserviceClient.java
@@ -5,12 +5,14 @@ import java.util.Set;
 
 import com.sequenceiq.flow.api.FlowPublicEndpoint;
 import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
 import com.sequenceiq.it.cloudbreak.util.wait.service.WaitService;
 
-public abstract class MicroserviceClient extends Entity {
+public abstract class MicroserviceClient<C, I> extends Entity {
 
     protected static final int TIMEOUT = 60 * 1000;
 
@@ -45,4 +47,16 @@ public abstract class MicroserviceClient extends Entity {
 
     public abstract <E extends Enum<E>, W extends WaitObject> W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
             TestContext testContext);
+
+    public abstract C getDefaultClient();
+
+    public I getInternalClient(TestContext testContext) {
+        throw new TestFailException("There is no internal client for this microservice");
+    }
+
+    public void checkIfInternalClientAllowed(TestContext testContext) {
+        if (!(testContext instanceof MockedTestContext)) {
+            throw new TestFailException("You can use internal client only for mock tests!");
+        }
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RedbeamsClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RedbeamsClient.java
@@ -19,15 +19,13 @@ import com.sequenceiq.it.cloudbreak.util.wait.service.redbeams.RedbeamsWaitObjec
 import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.redbeams.client.RedbeamsApiKeyClient;
 
-public class RedbeamsClient extends MicroserviceClient {
+public class RedbeamsClient extends MicroserviceClient<com.sequenceiq.redbeams.client.RedbeamsClient, Void> {
 
     public static final String REDBEAMS_CLIENT = "REDBEAMS_CLIENT";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RedbeamsClient.class);
 
-    private com.sequenceiq.redbeams.client.RedbeamsClient endpoints;
-
-    private String environmentCrn;
+    private com.sequenceiq.redbeams.client.RedbeamsClient redbeamsClient;
 
     private RedbeamsClient() {
         super(REDBEAMS_CLIENT);
@@ -36,23 +34,11 @@ public class RedbeamsClient extends MicroserviceClient {
     public static synchronized RedbeamsClient createProxyRedbeamsClient(TestParameter testParameter, CloudbreakUser cloudbreakUser) {
         RedbeamsClient clientEntity = new RedbeamsClient();
         clientEntity.setActing(cloudbreakUser);
-        clientEntity.endpoints = new RedbeamsApiKeyClient(
+        clientEntity.redbeamsClient = new RedbeamsApiKeyClient(
                 testParameter.get(RedBeamsTest.REDBEAMS_SERVER_ROOT),
                 new ConfigKey(false, true, true, TIMEOUT))
                 .withKeys(cloudbreakUser.getAccessKey(), cloudbreakUser.getSecretKey());
         return clientEntity;
-    }
-
-    public com.sequenceiq.redbeams.client.RedbeamsClient getEndpoints() {
-        return endpoints;
-    }
-
-    public String getEnvironmentCrn() {
-        return environmentCrn;
-    }
-
-    public void setEnvironmentCrn(String environmentCrn) {
-        this.environmentCrn = environmentCrn;
     }
 
     @Override
@@ -65,6 +51,11 @@ public class RedbeamsClient extends MicroserviceClient {
     public <E extends Enum<E>, W extends WaitObject> W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
             TestContext testContext) {
         return (W) new RedbeamsWaitObject(this, entity.getCrn(), (Status) desiredStatuses.get("status"));
+    }
+
+    @Override
+    public com.sequenceiq.redbeams.client.RedbeamsClient getDefaultClient() {
+        return redbeamsClient;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RepositoryConfigsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RepositoryConfigsAction.java
@@ -13,7 +13,7 @@ public class RepositoryConfigsAction {
                 CloudbreakClient.class);
 
         repositoryConfigsEntity.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .utilV4Endpoint()
                         .repositoryConfigValidationRequest(repositoryConfigsEntity.getRequest()));
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SdxClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SdxClient.java
@@ -20,12 +20,10 @@ import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 import com.sequenceiq.sdx.client.SdxServiceApiKeyClient;
 import com.sequenceiq.sdx.client.SdxServiceApiKeyEndpoints;
 
-public class SdxClient extends MicroserviceClient {
+public class SdxClient extends MicroserviceClient<SdxServiceApiKeyEndpoints, Void> {
     public static final String SDX_CLIENT = "SDX_CLIENT";
 
     private SdxServiceApiKeyEndpoints sdxClient;
-
-    private String name;
 
     SdxClient() {
         super(SDX_CLIENT);
@@ -42,12 +40,13 @@ public class SdxClient extends MicroserviceClient {
         return (W) new DatalakeWaitObject(this, entity.getName(), (SdxClusterStatusResponse) desiredStatuses.get("status"));
     }
 
-    public static Function<IntegrationTestContext, SdxClient> getTestContextSdxClient(String key) {
-        return testContext -> testContext.getContextParam(key, SdxClient.class);
+    @Override
+    public SdxServiceApiKeyEndpoints getDefaultClient() {
+        return sdxClient;
     }
 
-    public static Function<IntegrationTestContext, SdxClient> getTestContextSdxClient() {
-        return getTestContextSdxClient(SDX_CLIENT);
+    public static Function<IntegrationTestContext, SdxClient> getTestContextSdxClient(String key) {
+        return testContext -> testContext.getContextParam(key, SdxClient.class);
     }
 
     public static synchronized SdxClient createProxySdxClient(TestParameter testParameter, CloudbreakUser cloudbreakUser) {
@@ -58,14 +57,6 @@ public class SdxClient extends MicroserviceClient {
                 new ConfigKey(false, true, true, TIMEOUT))
                 .withKeys(cloudbreakUser.getAccessKey(), cloudbreakUser.getSecretKey());
         return clientEntity;
-    }
-
-    public com.sequenceiq.sdx.client.SdxClient getSdxClient() {
-        return sdxClient;
-    }
-
-    public void setSdxClient(SdxServiceApiKeyEndpoints sdxClient) {
-        this.sdxClient = sdxClient;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SecurityRulesAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SecurityRulesAction.java
@@ -15,7 +15,7 @@ public class SecurityRulesAction {
         CloudbreakClient client = integrationTestContext.getContextParam(CloudbreakClient.CLOUDBREAK_CLIENT, CloudbreakClient.class);
 
         Log.log(" get Security Rules to");
-        securityRulesEntity.setResponse(client.getCloudbreakClient().utilV4Endpoint().getDefaultSecurityRules());
+        securityRulesEntity.setResponse(client.getDefaultClient().utilV4Endpoint().getDefaultSecurityRules());
         Log.whenJson(" get Security Rules response: ", securityRulesEntity.getResponse());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
@@ -16,7 +16,7 @@ import com.sequenceiq.it.cloudbreak.util.wait.service.WaitService;
 
 import io.opentracing.Tracer;
 
-public class UmsClient extends MicroserviceClient {
+public class UmsClient extends MicroserviceClient<GrpcUmsClient, Void> {
 
     public static final String UMS_CLIENT = "UMS_CLIENT";
 
@@ -46,16 +46,17 @@ public class UmsClient extends MicroserviceClient {
         throw new TestFailException("Wait object does not support by ums client");
     }
 
+    @Override
+    public GrpcUmsClient getDefaultClient() {
+        return umsClient;
+    }
+
     public static synchronized UmsClient createProxyUmsClient(Tracer tracer) {
         UmsClient clientEntity = new UmsClient();
         UmsClientConfig clientConfig = new UmsClientConfig();
         clientEntity.umsClient = GrpcUmsClient.createClient(
                 UmsChannelConfig.newManagedChannelWrapper("ums.thunderhead-dev.cloudera.com", 8982), clientConfig, tracer);
         return clientEntity;
-    }
-
-    public GrpcUmsClient getUmsClient() {
-        return umsClient;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ClusterRepairAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ClusterRepairAction.java
@@ -26,7 +26,7 @@ public class ClusterRepairAction implements Action<StackTestDto, CloudbreakClien
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws IOException {
         Log.whenJson(LOGGER, "cluster repair request:\n", getClusterRepairRequest(testDto));
 
-        client.getCloudbreakClient()
+        client.getDefaultClient()
                 .stackV4Endpoint()
                 .repairCluster(client.getWorkspaceId(), testDto.getName(), getClusterRepairRequest(testDto),
                         testContext.getActingUserCrn().getAccountId());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaAttachChildEnvironmentAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaAttachChildEnvironmentAction.java
@@ -18,7 +18,7 @@ public class FreeIpaAttachChildEnvironmentAction implements Action<FreeIpaChildE
     @Override
     public FreeIpaChildEnvironmentTestDto action(TestContext testContext, FreeIpaChildEnvironmentTestDto testDto, FreeIpaClient client) throws Exception {
         Log.whenJson(LOGGER, format(" FreeIPA attach child environment:%n"), testDto.getRequest());
-        client.getFreeIpaClient()
+        client.getDefaultClient()
                 .getFreeIpaV1Endpoint()
                 .attachChildEnvironment(testDto.getRequest());
         Log.when(LOGGER, " FreeIPA attached child environment successfully.");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaCollectDiagnosticsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaCollectDiagnosticsAction.java
@@ -17,11 +17,11 @@ public class FreeIpaCollectDiagnosticsAction implements Action<FreeIpaDiagnostic
     @Override
     public FreeIpaDiagnosticsTestDto action(TestContext testContext, FreeIpaDiagnosticsTestDto testDto, FreeIpaClient client) throws Exception {
         Log.whenJson(LOGGER, " FreeIPA collect diagnostics request: ", testDto.getRequest());
-        FlowIdentifier flowIdentifier = client.getFreeIpaClient()
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .getDiagnosticsEndpoint()
                 .collectDiagnostics(testDto.getRequest());
         testDto.setFlow("FreeIPA diagnostic collection", flowIdentifier);
-        Log.log(LOGGER, " FreeIPA name: %s", client.getFreeIpaClient().getFreeIpaV1Endpoint()
+        Log.log(LOGGER, " FreeIPA name: %s", client.getDefaultClient().getFreeIpaV1Endpoint()
                 .describe(testDto.getRequest().getEnvironmentCrn()).getName());
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaCreateAction.java
@@ -18,7 +18,7 @@ public class FreeIpaCreateAction implements Action<FreeIpaTestDto, FreeIpaClient
     public FreeIpaTestDto action(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient client) throws Exception {
         Log.whenJson(LOGGER, format(" FreeIPA post request:%n"), testDto.getRequest());
         testDto.setResponse(
-                client.getFreeIpaClient()
+                client.getDefaultClient()
                         .getFreeIpaV1Endpoint()
                         .create(testDto.getRequest()));
         Log.whenJson(LOGGER, format(" FreeIPA created  successfully:%n"), testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDeleteAction.java
@@ -18,11 +18,11 @@ public class FreeIpaDeleteAction implements Action<FreeIpaTestDto, FreeIpaClient
     public FreeIpaTestDto action(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient client) throws Exception {
         Log.when(LOGGER, String.format(" FreeIPA crn: %s", testDto.getRequest().getEnvironmentCrn()));
         Log.whenJson(LOGGER, format(" FreeIPA delete:%n"), testDto.getRequest());
-        client.getFreeIpaClient()
+        client.getDefaultClient()
                 .getFreeIpaV1Endpoint()
                 .delete(testDto.getRequest().getEnvironmentCrn(), false);
         testDto.setResponse(
-                client.getFreeIpaClient()
+                client.getDefaultClient()
                         .getFreeIpaV1Endpoint()
                         .describe(testDto.getRequest().getEnvironmentCrn())
         );

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDescribeAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDescribeAction.java
@@ -19,7 +19,7 @@ public class FreeIpaDescribeAction implements Action<FreeIpaTestDto, FreeIpaClie
         Log.when(LOGGER, format(" FreeIPA crn: %s", testDto.getRequest().getEnvironmentCrn()));
         Log.whenJson(LOGGER, format(" FreeIPA get request:%n"), testDto.getRequest());
         testDto.setResponse(
-                client.getFreeIpaClient()
+                client.getDefaultClient()
                         .getFreeIpaV1Endpoint()
                         .describe(testDto.getRequest().getEnvironmentCrn()));
         Log.whenJson(LOGGER, format(" FreeIPA get successfully: %n"), testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDetachChildEnvironmentAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaDetachChildEnvironmentAction.java
@@ -21,7 +21,7 @@ public class FreeIpaDetachChildEnvironmentAction implements Action<FreeIpaChildE
     public FreeIpaChildEnvironmentTestDto action(TestContext testContext, FreeIpaChildEnvironmentTestDto testDto, FreeIpaClient client) throws Exception {
         DetachChildEnvironmentRequest request = convertRequest(testDto.getRequest());
         Log.whenJson(LOGGER, format(" FreeIPA detach child environment:%n"), request);
-        client.getFreeIpaClient()
+        client.getDefaultClient()
                 .getFreeIpaV1Endpoint()
                 .detachChildEnvironment(request);
         Log.when(LOGGER, " FreeIPA detached child environment successfully.");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaGetLastSyncOperationStatus.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaGetLastSyncOperationStatus.java
@@ -19,7 +19,7 @@ public class FreeIpaGetLastSyncOperationStatus extends AbstractFreeIpaAction<Fre
     protected FreeIpaUserSyncTestDto freeIpaAction(TestContext testContext, FreeIpaUserSyncTestDto testDto, FreeIpaClient client) throws Exception {
         Log.when(LOGGER, format(" Environment Crn: [%s], freeIpa Crn: %s", testDto.getEnvironmentCrn(), testDto.getRequest().getEnvironments()));
         Log.whenJson(LOGGER, format(" FreeIPA get last sync status request: %n"), testDto.getRequest());
-        SyncOperationStatus syncOperationStatus = client.getFreeIpaClient()
+        SyncOperationStatus syncOperationStatus = client.getDefaultClient()
                 .getUserV1Endpoint()
                 .getLastSyncOperationStatus(testDto.getEnvironmentCrn());
         testDto.setOperationId(syncOperationStatus.getOperationId());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaRefreshAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaRefreshAction.java
@@ -16,7 +16,7 @@ public class FreeIpaRefreshAction implements Action<FreeIpaTestDto, FreeIpaClien
     @Override
     public FreeIpaTestDto action(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient client) throws Exception {
         testDto.setResponse(
-                client.getFreeIpaClient().getFreeIpaV1Endpoint().describe(testDto.getRequest().getEnvironmentCrn())
+                client.getDefaultClient().getFreeIpaV1Endpoint().describe(testDto.getRequest().getEnvironmentCrn())
         );
         Log.whenJson(LOGGER, " FreeIPA get response: ", testDto.getResponse());
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaRepairAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaRepairAction.java
@@ -42,7 +42,7 @@ public class FreeIpaRepairAction implements Action<FreeIpaTestDto, FreeIpaClient
                 .collect(Collectors.toList());
         request.setInstanceIds(instanceIds);
         Log.whenJson(LOGGER, format(" FreeIPA repair request: %n"), request);
-        client.getFreeIpaClient()
+        client.getDefaultClient()
                 .getFreeIpaV1Endpoint()
                 .repairInstances(request);
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaStartAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaStartAction.java
@@ -18,7 +18,7 @@ public class FreeIpaStartAction extends AbstractFreeIpaAction<FreeIpaTestDto> {
     protected FreeIpaTestDto freeIpaAction(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient client) throws Exception {
         Log.when(LOGGER, format(" FreeIPA CRN: %s", testDto.getRequest().getEnvironmentCrn()));
         Log.whenJson(LOGGER, format(" FreeIPA start request: %n"), testDto.getRequest());
-        client.getFreeIpaClient()
+        client.getDefaultClient()
                 .getFreeIpaV1Endpoint()
                 .start(testDto.getRequest().getEnvironmentCrn());
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaStopAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaStopAction.java
@@ -18,7 +18,7 @@ public class FreeIpaStopAction extends AbstractFreeIpaAction<FreeIpaTestDto> {
     protected FreeIpaTestDto freeIpaAction(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient client) throws Exception {
         Log.when(LOGGER, format(" FreeIPA CRN: %s", testDto.getRequest().getEnvironmentCrn()));
         Log.whenJson(LOGGER, format(" FreeIPA stop request: %n"), testDto.getRequest());
-        client.getFreeIpaClient()
+        client.getDefaultClient()
                 .getFreeIpaV1Endpoint()
                 .stop(testDto.getRequest().getEnvironmentCrn());
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaSynchronizeAllUsersAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeIpaSynchronizeAllUsersAction.java
@@ -19,7 +19,7 @@ public class FreeIpaSynchronizeAllUsersAction extends AbstractFreeIpaAction<Free
     protected FreeIpaUserSyncTestDto freeIpaAction(TestContext testContext, FreeIpaUserSyncTestDto testDto, FreeIpaClient client) throws Exception {
         Log.when(LOGGER, format(" Environment Crn: [%s], freeIpa Crn: %s", testDto.getEnvironmentCrn(), testDto.getRequest().getEnvironments()));
         Log.whenJson(LOGGER, format(" FreeIPA sync request: %n"), testDto.getRequest());
-        SyncOperationStatus syncOperationStatus = client.getFreeipaInternalCrnClient().withInternalCrn()
+        SyncOperationStatus syncOperationStatus = client.getInternalClient(testContext)
                 .getUserV1Endpoint()
                 .synchronizeAllUsers(testDto.getRequest());
         testDto.setOperationId(syncOperationStatus.getOperationId());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxAutotlsCertRotationAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxAutotlsCertRotationAction.java
@@ -20,12 +20,12 @@ public class SdxAutotlsCertRotationAction implements Action<SdxTestDto, SdxClien
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         CertificatesRotationV4Request certificatesRotationV4Request = new CertificatesRotationV4Request();
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX autotls cert rotation request: ", certificatesRotationV4Request);
-        FlowIdentifier flowIdentifier = client.getSdxClient().sdxEndpoint()
+        FlowIdentifier flowIdentifier = client.getDefaultClient().sdxEndpoint()
                 .rotateAutoTlsCertificatesByName(testDto.getName(), new CertificatesRotationV4Request());
         testDto.setFlow("SDX autotls cert rotation", flowIdentifier);
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient().sdxEndpoint()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient().sdxEndpoint()
                 .getDetail(testDto.getName(), Collections.emptySet());
         testDto.setResponse(detailedResponse);
         Log.whenJson(LOGGER, " SDX response after autotls cert rotation: ", detailedResponse);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCheckForUpgradeAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCheckForUpgradeAction.java
@@ -23,11 +23,11 @@ public class SdxCheckForUpgradeAction implements Action<SdxTestDto, SdxClient> {
         Log.whenJson(LOGGER, " SDX check for upgrade request: ", testDto.getRequest());
         SdxUpgradeRequest request = new SdxUpgradeRequest();
         request.setDryRun(true);
-        SdxUpgradeResponse upgradeResponse = client.getSdxClient()
+        SdxUpgradeResponse upgradeResponse = client.getDefaultClient()
                 .sdxUpgradeEndpoint()
                 .upgradeClusterByName(testDto.getName(), request);
         Log.whenJson(LOGGER, " SDX check for upgrade response: ", upgradeResponse);
-        Log.log(LOGGER, " SDX name: %s", client.getSdxClient().sdxEndpoint().get(testDto.getName()).getName());
+        Log.log(LOGGER, " SDX name: %s", client.getDefaultClient().sdxEndpoint().get(testDto.getName()).getName());
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCollectCMDiagnosticsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCollectCMDiagnosticsAction.java
@@ -17,11 +17,11 @@ public class SdxCollectCMDiagnosticsAction implements Action<SdxCMDiagnosticsTes
     @Override
     public SdxCMDiagnosticsTestDto action(TestContext testContext, SdxCMDiagnosticsTestDto testDto, SdxClient client) throws Exception {
         Log.whenJson(LOGGER, " SDX collect CM based diagnostics request: ", testDto.getRequest());
-        FlowIdentifier flowIdentifier = client.getSdxClient()
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .diagnosticsEndpoint()
                 .collectCmDiagnostics(testDto.getRequest());
         testDto.setFlow("SDX CM based diagnostic collection", flowIdentifier);
-        Log.log(LOGGER, " SDX name: %s", client.getSdxClient().sdxEndpoint().get(testDto.getName()).getName());
+        Log.log(LOGGER, " SDX name: %s", client.getDefaultClient().sdxEndpoint().get(testDto.getName()).getName());
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCollectDiagnosticsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCollectDiagnosticsAction.java
@@ -17,11 +17,11 @@ public class SdxCollectDiagnosticsAction implements Action<SdxDiagnosticsTestDto
     @Override
     public SdxDiagnosticsTestDto action(TestContext testContext, SdxDiagnosticsTestDto testDto, SdxClient client) throws Exception {
         Log.whenJson(LOGGER, " SDX collect diagnostics request: ", testDto.getRequest());
-        FlowIdentifier flowIdentifier = client.getSdxClient()
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .diagnosticsEndpoint()
                 .collectDiagnostics(testDto.getRequest());
         testDto.setFlow("SDX diagnostic collection", flowIdentifier);
-        Log.log(LOGGER, " SDX name: %s", client.getSdxClient().sdxEndpoint().get(testDto.getName()).getName());
+        Log.log(LOGGER, " SDX name: %s", client.getDefaultClient().sdxEndpoint().get(testDto.getName()).getName());
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCreateAction.java
@@ -19,17 +19,17 @@ public class SdxCreateAction implements Action<SdxTestDto, SdxClient> {
 
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX create request: ", testDto.getRequest());
-        SdxClusterResponse sdxClusterResponse = client.getSdxClient()
+        SdxClusterResponse sdxClusterResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .create(testDto.getName(), testDto.getRequest());
         testDto.setFlow("SDX create", sdxClusterResponse.getFlowIdentifier());
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetailByCrn(sdxClusterResponse.getCrn(), Collections.emptySet());
         testDto.setResponse(detailedResponse);
-        Log.whenJson(LOGGER, " SDX create response: ", client.getSdxClient().sdxEndpoint().get(testDto.getName()));
+        Log.whenJson(LOGGER, " SDX create response: ", client.getDefaultClient().sdxEndpoint().get(testDto.getName()));
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCreateInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxCreateInternalAction.java
@@ -19,17 +19,17 @@ public class SdxCreateInternalAction implements Action<SdxInternalTestDto, SdxCl
 
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX create request: ", testDto.getRequest());
-        SdxClusterResponse sdxClusterResponse = client.getSdxClient()
+        SdxClusterResponse sdxClusterResponse = client.getDefaultClient()
                 .sdxInternalEndpoint()
                 .create(testDto.getName(), testDto.getRequest());
         testDto.setFlow("SDX create internal", sdxClusterResponse.getFlowIdentifier());
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetailByCrn(sdxClusterResponse.getCrn(), Collections.emptySet());
         testDto.setResponse(detailedResponse);
-        Log.whenJson(LOGGER, " SDX create response: ", client.getSdxClient().sdxEndpoint().get(testDto.getName()));
+        Log.whenJson(LOGGER, " SDX create response: ", client.getDefaultClient().sdxEndpoint().get(testDto.getName()));
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteAction.java
@@ -19,13 +19,13 @@ public class SdxDeleteAction implements Action<SdxTestDto, SdxClient> {
 
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX delete request: ", testDto.getRequest());
-        FlowIdentifier flowIdentifier = client.getSdxClient()
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .sdxEndpoint()
                 .delete(testDto.getName(), false);
         testDto.setFlow("SDX delete", flowIdentifier);
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(testDto.getName(), Collections.emptySet());
         testDto.setResponse(detailedResponse);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDeleteInternalAction.java
@@ -19,13 +19,13 @@ public class SdxDeleteInternalAction implements Action<SdxInternalTestDto, SdxCl
 
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX Internal delete request: ", testDto.getRequest());
-        FlowIdentifier flowIdentifier = client.getSdxClient()
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .sdxEndpoint()
                 .delete(testDto.getName(), false);
         testDto.setFlow("SDX delete", flowIdentifier);
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(testDto.getName(), Collections.emptySet());
         testDto.setResponse(detailedResponse);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDescribeAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDescribeAction.java
@@ -15,12 +15,12 @@ public class SdxDescribeAction implements Action<SdxTestDto, SdxClient> {
 
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX describe request: ", testDto.getRequest());
-        client.getSdxClient()
+        client.getDefaultClient()
                 .sdxEndpoint()
                 .get(testDto.getName());
-        Log.whenJson(LOGGER, " SDX describe response: ", client.getSdxClient().sdxEndpoint().get(testDto.getName()));
+        Log.whenJson(LOGGER, " SDX describe response: ", client.getDefaultClient().sdxEndpoint().get(testDto.getName()));
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDescribeInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDescribeInternalAction.java
@@ -17,12 +17,12 @@ public class SdxDescribeInternalAction implements Action<SdxInternalTestDto, Sdx
 
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX describe internal request: ", testDto.getRequest());
-        testDto.setResponse(client.getSdxClient()
+        testDto.setResponse(client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(testDto.getName(), new HashSet<>()));
-        Log.whenJson(LOGGER, " SDX describe internal response: ", client.getSdxClient().sdxEndpoint().get(testDto.getName()));
+        Log.whenJson(LOGGER, " SDX describe internal response: ", client.getDefaultClient().sdxEndpoint().get(testDto.getName()));
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDetailedDescribeInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxDetailedDescribeInternalAction.java
@@ -17,12 +17,12 @@ public class SdxDetailedDescribeInternalAction implements Action<SdxInternalTest
 
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX describe internal request: ", testDto.getRequest());
-        testDto.setResponse(client.getSdxClient()
+        testDto.setResponse(client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(testDto.getName(), new HashSet<>()));
-        Log.whenJson(LOGGER, " SDX describe internal response: ", client.getSdxClient().sdxEndpoint().getDetail(testDto.getName(), null));
+        Log.whenJson(LOGGER, " SDX describe internal response: ", client.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), null));
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxForceDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxForceDeleteAction.java
@@ -19,13 +19,13 @@ public class SdxForceDeleteAction implements Action<SdxTestDto, SdxClient> {
 
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX force delete request: ", testDto.getRequest());
-        FlowIdentifier flowIdentifier = client.getSdxClient()
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .sdxEndpoint()
                 .delete(testDto.getName(), true);
         testDto.setFlow("SDX force delete", flowIdentifier);
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(testDto.getName(), Collections.emptySet());
         testDto.setResponse(detailedResponse);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxForceDeleteInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxForceDeleteInternalAction.java
@@ -19,12 +19,12 @@ public class SdxForceDeleteInternalAction implements Action<SdxInternalTestDto, 
 
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
-        FlowIdentifier flowIdentifier = client.getSdxClient()
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .sdxEndpoint()
                 .delete(testDto.getName(), true);
         testDto.setFlow("SDX Internal force delete", flowIdentifier);
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(testDto.getName(), Collections.emptySet());
         testDto.setResponse(detailedResponse);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxListAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxListAction.java
@@ -16,12 +16,12 @@ public class SdxListAction implements Action<SdxTestDto, SdxClient> {
 
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX list request: ", testDto.getRequest());
-        client.getSdxClient()
+        client.getDefaultClient()
                 .sdxEndpoint()
                 .list(testDto.getName());
-        Log.whenJson(LOGGER, " SDX list response: ", client.getSdxClient().sdxEndpoint().list(testContext.get(EnvironmentTestDto.class).getName()));
+        Log.whenJson(LOGGER, " SDX list response: ", client.getDefaultClient().sdxEndpoint().list(testContext.get(EnvironmentTestDto.class).getName()));
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRefreshAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRefreshAction.java
@@ -18,7 +18,7 @@ public class SdxRefreshAction implements Action<SdxTestDto, SdxClient> {
     @Override
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         testDto.setResponse(
-                client.getSdxClient().sdxEndpoint().getDetail(testDto.getName(), Collections.emptySet())
+                client.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), Collections.emptySet())
         );
         Log.whenJson(LOGGER, " SDX get detail response: ", testDto.getResponse());
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRefreshInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRefreshInternalAction.java
@@ -18,7 +18,7 @@ public class SdxRefreshInternalAction implements Action<SdxInternalTestDto, SdxC
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         testDto.setResponse(
-                client.getSdxClient().sdxEndpoint().getDetail(testDto.getName(), Collections.emptySet())
+                client.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), Collections.emptySet())
         );
         Log.whenJson(LOGGER, " SDX Internal get detail response: ", testDto.getResponse());
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairAction.java
@@ -23,11 +23,11 @@ public class SdxRepairAction implements Action<SdxTestDto, SdxClient> {
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         Log.when(LOGGER, format(" Starting repair on SDX: %s ", testDto.getName()));
         Log.whenJson(LOGGER, " SDX repair request: ", testDto.getSdxRepairRequest());
-        FlowIdentifier flowIdentifier = client.getSdxClient()
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .sdxEndpoint()
                 .repairCluster(testDto.getName(), testDto.getSdxRepairRequest());
         testDto.setFlow("SDX repair", flowIdentifier);
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(testDto.getName(), Collections.emptySet());
         testDto.setResponse(detailedResponse);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRepairInternalAction.java
@@ -23,11 +23,11 @@ public class SdxRepairInternalAction implements Action<SdxInternalTestDto, SdxCl
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         Log.when(LOGGER, format(" Starting repair on SDX Internal: %s ", testDto.getName()));
         Log.whenJson(LOGGER, " SDX Internal repair request: ", testDto.getSdxRepairRequest());
-        FlowIdentifier flowIdentifier = client.getSdxClient()
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .sdxEndpoint()
                 .repairCluster(testDto.getName(), testDto.getSdxRepairRequest());
         testDto.setFlow("SDX Internal repair", flowIdentifier);
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(testDto.getName(), Collections.emptySet());
         testDto.setResponse(detailedResponse);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStartAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStartAction.java
@@ -23,9 +23,9 @@ public class SdxStartAction implements Action<SdxInternalTestDto, SdxClient> {
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         Log.when(LOGGER, format(" Starting SDX: %s ", testDto.getName()));
         Log.whenJson(LOGGER, " SDX start request: ", testDto.getRequest());
-        FlowIdentifier flowIdentifier = client.getSdxClient().sdxEndpoint().startByName(testDto.getName());
+        FlowIdentifier flowIdentifier = client.getDefaultClient().sdxEndpoint().startByName(testDto.getName());
         testDto.setFlow("SDX start", flowIdentifier);
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(testDto.getName(), Collections.emptySet());
         testDto.setResponse(detailedResponse);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStopAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxStopAction.java
@@ -23,9 +23,9 @@ public class SdxStopAction implements Action<SdxInternalTestDto, SdxClient> {
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         Log.when(LOGGER, format(" Stop SDX: %s ", testDto.getName()));
         Log.whenJson(LOGGER, " SDX stop request: ", testDto.getRequest());
-        FlowIdentifier flowIdentifier = client.getSdxClient().sdxEndpoint().stopByName(testDto.getName());
+        FlowIdentifier flowIdentifier = client.getDefaultClient().sdxEndpoint().stopByName(testDto.getName());
         testDto.setFlow("SDX stop", flowIdentifier);
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(testDto.getName(), Collections.emptySet());
         testDto.setResponse(detailedResponse);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncAction.java
@@ -19,7 +19,7 @@ public class SdxSyncAction implements Action<SdxTestDto, SdxClient> {
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         Log.when(LOGGER, format(" SDX's environment: %s ", testDto.getRequest().getEnvironment()));
         Log.whenJson(LOGGER, " SDX sync request: ", testDto.getRequest());
-        client.getSdxClient()
+        client.getDefaultClient()
                 .sdxEndpoint()
                 .sync(testDto.getName());
         Log.when(LOGGER, " SDX sync have been initiated. ");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncInternalAction.java
@@ -19,7 +19,7 @@ public class SdxSyncInternalAction implements Action<SdxInternalTestDto, SdxClie
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         Log.when(LOGGER, format(" SDX's environment: %s ", testDto.getRequest().getEnvironment()));
         Log.whenJson(LOGGER, " SDX sync request: ", testDto.getRequest());
-        client.getSdxClient()
+        client.getDefaultClient()
                 .sdxEndpoint()
                 .sync(testDto.getName());
         Log.when(LOGGER, " SDX sync have been initiated. ");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxUpgradeAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxUpgradeAction.java
@@ -21,13 +21,13 @@ public class SdxUpgradeAction implements Action<SdxTestDto, SdxClient> {
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         SdxUpgradeRequest upgradeRequest = testDto.getSdxUpgradeRequest();
 
-        Log.when(LOGGER, " SDX endpoint: %s" + client.getSdxClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
         Log.whenJson(LOGGER, " SDX upgrade request: ", upgradeRequest);
-        SdxUpgradeResponse upgradeResponse = client.getSdxClient()
+        SdxUpgradeResponse upgradeResponse = client.getDefaultClient()
                 .sdxUpgradeEndpoint()
                 .upgradeClusterByName(testDto.getName(), upgradeRequest);
         testDto.setFlow("SDX upgrade", upgradeResponse.getFlowIdentifier());
-        SdxClusterDetailResponse detailedResponse = client.getSdxClient()
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(testDto.getName(), Collections.emptySet());
         testDto.setResponse(detailedResponse);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/stack/StackTestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/stack/StackTestAction.java
@@ -24,7 +24,7 @@ public class StackTestAction {
 
     public static StackTestDto delete(TestContext testContext, StackTestDto entity, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, " Stack delete request:\n", entity.getRequest());
-        client.getCloudbreakClient()
+        client.getDefaultClient()
                 .stackV4Endpoint()
                 .delete(client.getWorkspaceId(), entity.getName(), false, testContext.getActingUserCrn().getAccountId());
         Log.whenJson(LOGGER, " Stack deletion was successful:\n", entity.getResponse());
@@ -35,7 +35,7 @@ public class StackTestAction {
     public static StackTestDto create(TestContext testContext, StackTestDto entity, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, " Stack post request:\n", entity.getRequest());
         entity.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .stackV4Endpoint()
                         .post(client.getWorkspaceId(), entity.getRequest(), testContext.getActingUserCrn().getAccountId()));
         Log.whenJson(LOGGER, " Stack created was successful:\n", entity.getResponse());
@@ -47,7 +47,7 @@ public class StackTestAction {
     public static StackTestDto get(TestContext testContext, StackTestDto entity, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, " Stack get request:\n", entity.getRequest());
         entity.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .stackV4Endpoint()
                         .get(client.getWorkspaceId(), entity.getName(), new HashSet<>(),
                                 testContext.getActingUserCrn().getAccountId()));
@@ -59,7 +59,7 @@ public class StackTestAction {
 
     public static StackTestDto refresh(TestContext testContext, StackTestDto entity, CloudbreakClient client) throws IOException {
         entity.setResponse(
-                client.getCloudbreakClient().stackV4Endpoint().get(client.getWorkspaceId(), entity.getName(), Collections.emptySet(),
+                client.getDefaultClient().stackV4Endpoint().get(client.getWorkspaceId(), entity.getName(), Collections.emptySet(),
                         testContext.getActingUserCrn().getAccountId())
         );
         Log.whenJson(LOGGER, " Stack refresh (get) was successful:\n", entity.getResponse());
@@ -68,7 +68,7 @@ public class StackTestAction {
 
     public static StackTestDto start(TestContext testContext, StackTestDto entity, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, " Stack post request:\n", entity.getRequest());
-        client.getCloudbreakClient().stackV4Endpoint().putStart(client.getWorkspaceId(), entity.getName(),
+        client.getDefaultClient().stackV4Endpoint().putStart(client.getWorkspaceId(), entity.getName(),
                 testContext.getActingUserCrn().getAccountId());
         Log.whenJson(LOGGER, " Stack was started successful:\n", entity.getResponse());
         Log.log(LOGGER, format(" CRN: %s", entity.getResponse().getCrn()));
@@ -77,7 +77,7 @@ public class StackTestAction {
 
     public static StackTestDto stop(TestContext testContext, StackTestDto entity, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, " Stack post request:\n", entity.getRequest());
-        client.getCloudbreakClient().stackV4Endpoint().putStop(client.getWorkspaceId(), entity.getName(),
+        client.getDefaultClient().stackV4Endpoint().putStop(client.getWorkspaceId(), entity.getName(),
                 testContext.getActingUserCrn().getAccountId());
         Log.whenJson(LOGGER, " Stack was stopped successful:\n", entity.getResponse());
         Log.when(LOGGER, format(" CRN: %s", entity.getResponse().getCrn()));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignUmsRoleAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignUmsRoleAction.java
@@ -26,7 +26,7 @@ public class AssignUmsRoleAction implements Action<UmsTestDto, UmsClient> {
         CloudbreakUser user = testContext.getRealUmsUserByKey(userKey);
         LOGGER.info(String.format("Assigning resourceRole %s over resource %s for user ",
                 testDto.getRequest().getRoleCrn(), testDto.getRequest().getResourceCrn()), user.getCrn());
-        client.getUmsClient().assignResourceRole(user.getCrn(), testDto.getRequest().getResourceCrn(), testDto.getRequest().getRoleCrn(), Optional.of(""));
+        client.getDefaultClient().assignResourceRole(user.getCrn(), testDto.getRequest().getResourceCrn(), testDto.getRequest().getRoleCrn(), Optional.of(""));
         // wait for UmsRightsCache to expire
         Thread.sleep(7000);
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXBlueprintRequestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXBlueprintRequestAction.java
@@ -17,7 +17,7 @@ public class DistroXBlueprintRequestAction implements Action<DistroXTestDto, Clo
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, " Stack get generated blueprint.");
-        GeneratedBlueprintV4Response bp = client.getCloudbreakClient().distroXV1Endpoint().postStackForBlueprint(testDto.getRequest());
+        GeneratedBlueprintV4Response bp = client.getDefaultClient().distroXV1Endpoint().postStackForBlueprint(testDto.getRequest());
         testDto.withGeneratedBlueprint(bp);
         Log.whenJson(LOGGER, " get generated blueprint was successful:\n", testDto.getGeneratedBlueprint());
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXCreateAction.java
@@ -17,7 +17,7 @@ public class DistroXCreateAction implements Action<DistroXTestDto, CloudbreakCli
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, " Distrox create request: ", testDto.getRequest());
-        StackV4Response stackV4Response = client.getCloudbreakClient()
+        StackV4Response stackV4Response = client.getDefaultClient()
                         .distroXV1Endpoint()
                         .post(testDto.getRequest());
         testDto.setFlow("Distrox create", stackV4Response.getFlowIdentifier());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXDeleteAction.java
@@ -15,7 +15,7 @@ public class DistroXDeleteAction implements Action<DistroXTestDto, CloudbreakCli
 
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
-        client.getCloudbreakClient()
+        client.getDefaultClient()
                 .distroXV1Endpoint()
                 .deleteByName(testDto.getName(), false);
         Log.when(LOGGER, " Stack deletion was successful.");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXForceDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXForceDeleteAction.java
@@ -17,11 +17,11 @@ public class DistroXForceDeleteAction implements Action<DistroXTestDto, Cloudbre
 
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
-        client.getCloudbreakClient()
+        client.getDefaultClient()
                 .distroXV1Endpoint()
                 .deleteByName(testDto.getName(), true);
         testDto.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .distroXV1Endpoint()
                         .getByName(testDto.getName(), new HashSet<>()));
         Log.when(LOGGER, " Stack deletion was successful.");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXGetAction.java
@@ -18,7 +18,7 @@ public class DistroXGetAction implements Action<DistroXTestDto, CloudbreakClient
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
         testDto.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .distroXV1Endpoint()
                         .getByName(testDto.getName(), new HashSet<>()));
         Log.whenJson(LOGGER, " Stack get was successful:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXInternalGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXInternalGetAction.java
@@ -21,8 +21,7 @@ public class DistroXInternalGetAction implements Action<DistroXTestDto, Cloudbre
         String distroXCrn = testDto.getResponse().getCrn();
         Log.when(LOGGER, " Internal actor CRN used for distrox get request: " + distroXCrn);
         testDto.withInternalStackResponse(
-                client.getCloudbreakInternalCrnClient()
-                        .withInternalCrn()
+                client.getInternalClient(testContext)
                         .distroXInternalV1Endpoint()
                         .getByCrn(distroXCrn));
         Log.whenJson(LOGGER, "Internal actor CRN used for distrox, response:", testDto.getInternalStackResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRefreshAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRefreshAction.java
@@ -18,7 +18,7 @@ public class DistroXRefreshAction implements Action<DistroXTestDto, CloudbreakCl
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
         testDto.setResponse(
-                client.getCloudbreakClient().distroXV1Endpoint().getByName(testDto.getName(), Collections.emptySet())
+                client.getDefaultClient().distroXV1Endpoint().getByName(testDto.getName(), Collections.emptySet())
         );
         Log.whenJson(LOGGER, " Distrox get response: ", testDto.getResponse());
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRemoveInstanceAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRemoveInstanceAction.java
@@ -16,7 +16,7 @@ public class DistroXRemoveInstanceAction implements Action<DistroXTestDto, Cloud
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
         if (testDto.getRemovableInstanceId().isPresent()) {
-            client.getCloudbreakClient()
+            client.getDefaultClient()
                     .distroXV1Endpoint()
                     .deleteInstanceByCrn(testDto.getCrn(), false, testDto.getRemovableInstanceId().get());
             return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRepairAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRepairAction.java
@@ -32,10 +32,10 @@ public class DistroXRepairAction implements Action<DistroXTestDto, CloudbreakCli
         DistroXRepairV1Request distroXRepairV1Request = createRepairRequest();
         Log.when(LOGGER, format(" Starting repair on DistroX: %s ", testDto.getName()));
         Log.whenJson(LOGGER, " DistroX  repair request: ", distroXRepairV1Request);
-        client.getCloudbreakClient()
+        client.getDefaultClient()
                 .distroXV1Endpoint()
                 .repairClusterByName(testDto.getName(), distroXRepairV1Request);
-        StackV4Response stackV4Response = client.getCloudbreakClient()
+        StackV4Response stackV4Response = client.getDefaultClient()
                 .distroXV1Endpoint()
                 .getByName(testDto.getName(), Collections.emptySet());
         testDto.setResponse(stackV4Response);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXScaleAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXScaleAction.java
@@ -35,10 +35,10 @@ public class DistroXScaleAction implements Action<DistroXTestDto, CloudbreakClie
         DistroXScaleV1Request scaleRequest = new DistroXScaleV1Request();
         scaleRequest.setGroup(hostGroup);
         scaleRequest.setDesiredCount(count);
-        FlowIdentifier flowIdentifier = client.getCloudbreakClient()
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .distroXV1Endpoint()
                 .putScalingByName(testDto.getName(), scaleRequest);
-        StackV4Response stackV4Response = client.getCloudbreakClient()
+        StackV4Response stackV4Response = client.getDefaultClient()
                 .distroXV1Endpoint()
                 .getByName(testDto.getName(), new HashSet<>(Arrays.asList("hardware_info", "events")));
         testDto.setFlow("Distrox scale", flowIdentifier);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXShowBlueprintAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXShowBlueprintAction.java
@@ -17,7 +17,7 @@ public class DistroXShowBlueprintAction implements Action<DistroXTestDto, Cloudb
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, " Stack start request on: " + testDto.getName());
-        GeneratedBlueprintV4Response generatedBlueprintV4Response = client.getCloudbreakClient()
+        GeneratedBlueprintV4Response generatedBlueprintV4Response = client.getDefaultClient()
                 .distroXV1Endpoint()
                 .postStackForBlueprint(testDto.getRequest());
         testDto.withGeneratedBlueprintV4Response(generatedBlueprintV4Response);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXStartAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXStartAction.java
@@ -23,11 +23,11 @@ public class DistroXStartAction implements Action<DistroXTestDto, CloudbreakClie
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, format(" Starting Distrox: %s ", testDto.getName()));
         Log.whenJson(LOGGER, " Distrox start request: ", testDto.getRequest());
-        FlowIdentifier flowIdentifier = client.getCloudbreakClient()
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .distroXV1Endpoint()
                 .putStartByName(testDto.getName());
         testDto.setFlow("DistroX start", flowIdentifier);
-        StackV4Response stackV4Response = client.getCloudbreakClient()
+        StackV4Response stackV4Response = client.getDefaultClient()
                 .distroXV1Endpoint().getByName(testDto.getName(), Collections.emptySet());
         testDto.setResponse(stackV4Response);
         Log.whenJson(LOGGER, " Distrox start response: ", stackV4Response);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXStopAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXStopAction.java
@@ -23,11 +23,11 @@ public class DistroXStopAction implements Action<DistroXTestDto, CloudbreakClien
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, format(" Stop Distrox: %s ", testDto.getName()));
         Log.whenJson(LOGGER, " Distrox stop request: ", testDto.getRequest());
-        FlowIdentifier flow = client.getCloudbreakClient()
+        FlowIdentifier flow = client.getDefaultClient()
                 .distroXV1Endpoint()
                 .putStopByName(testDto.getName());
         testDto.setFlow("Distrox stop", flow);
-        StackV4Response stackV4Response = client.getCloudbreakClient()
+        StackV4Response stackV4Response = client.getDefaultClient()
                 .distroXV1Endpoint().getByName(testDto.getName(), Collections.emptySet());
         testDto.setResponse(stackV4Response);
         Log.whenJson(LOGGER, " Distrox stop response: ", stackV4Response);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/audit/AuditGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/audit/AuditGetAction.java
@@ -16,7 +16,7 @@ public class AuditGetAction implements Action<AuditTestDto, CloudbreakClient> {
 
     @Override
     public AuditTestDto action(TestContext testContext, AuditTestDto testDto, CloudbreakClient client) throws Exception {
-        AuditEventV4Response response = client.getCloudbreakClient()
+        AuditEventV4Response response = client.getDefaultClient()
                 .auditV4Endpoint()
                 .getAuditEventById(client.getWorkspaceId(), testDto.getAuditId());
         testDto.setResponse(response);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/audit/AuditListAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/audit/AuditListAction.java
@@ -19,7 +19,7 @@ public class AuditListAction implements Action<AuditTestDto, CloudbreakClient> {
 
     @Override
     public AuditTestDto action(TestContext testContext, AuditTestDto testDto, CloudbreakClient client) throws Exception {
-        Collection<AuditEventV4Response> responses = client.getCloudbreakClient()
+        Collection<AuditEventV4Response> responses = client.getDefaultClient()
                 .auditV4Endpoint()
                 .getAuditEvents(client.getWorkspaceId(), testDto.getResourceType(), testDto.getResourceId(), null)
                 .getResponses();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/audit/AuditListZipAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/audit/AuditListZipAction.java
@@ -17,7 +17,7 @@ public class AuditListZipAction implements Action<AuditTestDto, CloudbreakClient
 
     @Override
     public AuditTestDto action(TestContext testContext, AuditTestDto testDto, CloudbreakClient client) throws Exception {
-        Response auditEventsZip = client.getCloudbreakClient()
+        Response auditEventsZip = client.getDefaultClient()
                 .auditV4Endpoint()
                 .getAuditEventsZip(client.getWorkspaceId(), testDto.getResourceType(), testDto.getResourceId(), null);
         testDto.setZipResponse(auditEventsZip);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/blueprint/BlueprintCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/blueprint/BlueprintCreateAction.java
@@ -19,7 +19,7 @@ public class BlueprintCreateAction implements Action<BlueprintTestDto, Cloudbrea
     public BlueprintTestDto action(TestContext testContext, BlueprintTestDto testDto, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, format(" Blueprint post request:%n"), testDto.getRequest());
         testDto.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .blueprintV4Endpoint()
                         .post(client.getWorkspaceId(), testDto.getRequest()));
         Log.whenJson(LOGGER, format(" Blueprint created  successfully:%n"), testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/blueprint/BlueprintDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/blueprint/BlueprintDeleteAction.java
@@ -19,7 +19,7 @@ public class BlueprintDeleteAction implements Action<BlueprintTestDto, Cloudbrea
     public BlueprintTestDto action(TestContext testContext, BlueprintTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, format(" Blueprint deleteByName request: %n", testDto.getRequest().getName()));
         testDto.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .blueprintV4Endpoint()
                         .deleteByName(client.getWorkspaceId(), testDto.getName()));
         Log.whenJson(LOGGER, format(" Blueprint deleted successfully:%n"), testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/blueprint/BlueprintGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/blueprint/BlueprintGetAction.java
@@ -19,7 +19,7 @@ public class BlueprintGetAction implements Action<BlueprintTestDto, CloudbreakCl
     public BlueprintTestDto action(TestContext testContext, BlueprintTestDto testDto, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, format(" Blueprint getByName request: %n"), testDto.getName());
         testDto.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .blueprintV4Endpoint()
                         .getByName(client.getWorkspaceId(), testDto.getName()));
         Log.whenJson(LOGGER, format(" Blueprint getByName successfully:%n"), testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/blueprint/BlueprintListAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/blueprint/BlueprintListAction.java
@@ -19,7 +19,7 @@ public class BlueprintListAction implements Action<BlueprintTestDto, CloudbreakC
     public BlueprintTestDto action(TestContext testContext, BlueprintTestDto testDto, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, format(" Blueprint list by workspace request, workspace:%n"), client.getWorkspaceId());
         testDto.setViewResponses(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .blueprintV4Endpoint()
                         .list(client.getWorkspaceId(), true).getResponses());
         Log.whenJson(LOGGER, format(" Blueprint list has executed successfully:%n"), testDto.getViewResponses());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateCreateAction.java
@@ -17,7 +17,7 @@ public class ClusterTemplateCreateAction implements Action<ClusterTemplateTestDt
     public ClusterTemplateTestDto action(TestContext testContext, ClusterTemplateTestDto testDto, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, " ClusterTemplateEntity post request:\n", testDto.getRequest());
         testDto.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .clusterTemplateV4EndPoint()
                         .post(client.getWorkspaceId(), testDto.getRequest()));
         Log.whenJson(LOGGER, " ClusterTemplateEntity created  successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateDeleteAction.java
@@ -16,7 +16,7 @@ public class ClusterTemplateDeleteAction implements Action<ClusterTemplateTestDt
     @Override
     public ClusterTemplateTestDto action(TestContext testContext, ClusterTemplateTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, "ClusterTemplateEntity delete, name: " + testDto.getRequest().getName());
-        client.getCloudbreakClient()
+        client.getDefaultClient()
                 .clusterTemplateV4EndPoint()
                 .deleteByName(client.getWorkspaceId(), testDto.getRequest().getName());
         Log.when(LOGGER, "ClusterTemplateEntity deleted successfully: " + testDto.getResponse().getId());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateGetAction.java
@@ -18,7 +18,7 @@ public class ClusterTemplateGetAction implements Action<ClusterTemplateTestDto, 
     @Override
     public ClusterTemplateTestDto action(TestContext testContext, ClusterTemplateTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, " ClusterTemplateEntity get request: " + testDto.getName());
-        ClusterTemplateV4Response response = client.getCloudbreakClient()
+        ClusterTemplateV4Response response = client.getDefaultClient()
                 .clusterTemplateV4EndPoint()
                 .getByName(client.getWorkspaceId(), testDto.getName());
         testDto.setResponses(Sets.newHashSet(response));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateListAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/clustertemplate/ClusterTemplateListAction.java
@@ -33,7 +33,7 @@ public class ClusterTemplateListAction implements Action<ClusterTemplateTestDto,
         boolean success = false;
         while (run && count < maxRetry) {
             try {
-                Collection<ClusterTemplateViewV4Response> responses = client.getCloudbreakClient()
+                Collection<ClusterTemplateViewV4Response> responses = client.getDefaultClient()
                         .clusterTemplateV4EndPoint()
                         .list(client.getWorkspaceId()).getResponses();
                 testDto.setResponses(ClusterTemplateUtil.getResponseFromViews(responses));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialCreateAction.java
@@ -19,7 +19,7 @@ public class CredentialCreateAction implements Action<CredentialTestDto, Environ
     public CredentialTestDto action(TestContext testContext, CredentialTestDto testDto, EnvironmentClient environmentClient) throws Exception {
         Log.when(LOGGER, "Credential create request: " + testDto.getRequest());
         testDto.setResponse(
-                environmentClient.getEnvironmentClient()
+                environmentClient.getDefaultClient()
                         .credentialV1Endpoint()
                         .post(testDto.getRequest()));
         Log.whenJson(LOGGER, " Credential created successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialCreateIfNotExistAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialCreateIfNotExistAction.java
@@ -19,14 +19,14 @@ public class CredentialCreateIfNotExistAction implements Action<CredentialTestDt
         Log.when(LOGGER, "Credential create request: " + testDto.getRequest());
         try {
             testDto.setResponse(
-                    environmentClient.getEnvironmentClient().credentialV1Endpoint().post(testDto.getRequest())
+                    environmentClient.getDefaultClient().credentialV1Endpoint().post(testDto.getRequest())
             );
             Log.whenJson(LOGGER, "Credential created successfully: ", testDto.getRequest());
         } catch (ProxyMethodInvocationException e) {
             Log.when(LOGGER, "Cannot create Credential, fetch existed one: " + testDto.getRequest());
 
             testDto.setResponse(
-                    environmentClient.getEnvironmentClient().credentialV1Endpoint()
+                    environmentClient.getDefaultClient().credentialV1Endpoint()
                             .getByName(testDto.getRequest().getName()));
         }
         if (testDto.getResponse() == null) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialDeleteAction.java
@@ -17,7 +17,7 @@ public class CredentialDeleteAction implements Action<CredentialTestDto, Environ
     public CredentialTestDto action(TestContext testContext, CredentialTestDto testDto, EnvironmentClient environmentClient) throws Exception {
         Log.when(LOGGER, " Credential delete request, name:" + testDto.getName());
         testDto.setResponse(
-                environmentClient.getEnvironmentClient()
+                environmentClient.getDefaultClient()
                         .credentialV1Endpoint()
                         .deleteByName(testDto.getName()));
         Log.whenJson(LOGGER, " Credential deleted successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialGetAction.java
@@ -17,7 +17,7 @@ public class CredentialGetAction implements Action<CredentialTestDto, Environmen
     public CredentialTestDto action(TestContext testContext, CredentialTestDto testDto, EnvironmentClient environmentClient) throws Exception {
         Log.when(LOGGER, " Credential get request: " + testDto.getName());
         testDto.setResponse(
-                environmentClient.getEnvironmentClient()
+                environmentClient.getDefaultClient()
                         .credentialV1Endpoint()
                         .getByName(testDto.getName()));
         Log.whenJson(LOGGER, " Credential get successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialListAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialListAction.java
@@ -19,7 +19,7 @@ public class CredentialListAction implements Action<CredentialTestDto, Environme
 
     @Override
     public CredentialTestDto action(TestContext testContext, CredentialTestDto testDto, EnvironmentClient environmentClient) throws Exception {
-        Collection<CredentialResponse> responses = environmentClient.getEnvironmentClient()
+        Collection<CredentialResponse> responses = environmentClient.getDefaultClient()
                 .credentialV1Endpoint()
                 .list()
                 .getResponses();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialModifyAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/credential/CredentialModifyAction.java
@@ -17,7 +17,7 @@ public class CredentialModifyAction implements Action<CredentialTestDto, Environ
     public CredentialTestDto action(TestContext testContext, CredentialTestDto testDto, EnvironmentClient cloudbreakClient) throws Exception {
         Log.whenJson(LOGGER, " Credential modifyV4 request:\n", testDto.getRequest());
         testDto.setResponse(
-                cloudbreakClient.getEnvironmentClient()
+                cloudbreakClient.getDefaultClient()
                         .credentialV1Endpoint()
                         .put(testDto.modifyRequest()));
         Log.whenJson(LOGGER, " Credential modified successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseCreateAction.java
@@ -17,7 +17,7 @@ public class RedbeamsDatabaseCreateAction implements Action<RedbeamsDatabaseTest
     public RedbeamsDatabaseTestDto action(TestContext testContext, RedbeamsDatabaseTestDto testDto, RedbeamsClient client) throws Exception {
         Log.whenJson(LOGGER, " Database register request:\n", testDto.getRequest());
         testDto.setResponse(
-                client.getEndpoints()
+                client.getDefaultClient()
                         .databaseV4Endpoint()
                         .register(testDto.getRequest()));
         Log.whenJson(LOGGER, " Database registered successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseCreateIfNotExistsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseCreateIfNotExistsAction.java
@@ -17,15 +17,15 @@ public class RedbeamsDatabaseCreateIfNotExistsAction implements Action<RedbeamsD
         Log.when(LOGGER, "Register Database with name: " + testDto.getName());
         try {
             testDto.setResponse(
-                    client.getEndpoints().databaseV4Endpoint().register(testDto.getRequest())
+                    client.getDefaultClient().databaseV4Endpoint().register(testDto.getRequest())
             );
             Log.whenJson(LOGGER, "Database registered successfully: ", testDto.getResponse());
         } catch (Exception e) {
             Log.when(LOGGER, "Cannot register Database, fetch existing one: " + testDto.getName());
 
             testDto.setResponse(
-                    client.getEndpoints().databaseV4Endpoint()
-                            .getByName(client.getEnvironmentCrn(), testDto.getRequest().getName()));
+                    client.getDefaultClient().databaseV4Endpoint()
+                            .getByName(testDto.getRequest().getEnvironmentCrn(), testDto.getRequest().getName()));
             Log.whenJson(LOGGER, "Database fetched successfully: ", testDto.getResponse());
         }
         if (testDto.getResponse() == null) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseDeleteAction.java
@@ -17,9 +17,9 @@ public class RedbeamsDatabaseDeleteAction implements Action<RedbeamsDatabaseTest
     public RedbeamsDatabaseTestDto action(TestContext testContext, RedbeamsDatabaseTestDto testDto, RedbeamsClient client) throws Exception {
         Log.when(LOGGER, String.format("Database delete request Name: %s", testDto.getRequest().getName()));
         testDto.setResponse(
-                client.getEndpoints()
+                client.getDefaultClient()
                         .databaseV4Endpoint()
-                        .deleteByName(client.getEnvironmentCrn(), testDto.getName()));
+                        .deleteByName(testDto.getRequest().getEnvironmentCrn(), testDto.getName()));
         Log.whenJson(LOGGER, " Database deleted successfully:\n", testDto.getResponse());
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseListAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseListAction.java
@@ -19,9 +19,9 @@ public class RedbeamsDatabaseListAction implements Action<RedbeamsDatabaseTestDt
 
     @Override
     public RedbeamsDatabaseTestDto action(TestContext testContext, RedbeamsDatabaseTestDto testDto, RedbeamsClient client) throws Exception {
-        Collection<DatabaseV4Response> responses = client.getEndpoints()
+        Collection<DatabaseV4Response> responses = client.getDefaultClient()
                 .databaseV4Endpoint()
-                .list(client.getEnvironmentCrn())
+                .list(testDto.getRequest().getEnvironmentCrn())
                 .getResponses();
         testDto.setResponses(responses.stream().collect(Collectors.toSet()));
         Log.whenJson(LOGGER, " Databases listed successfully:\n", testDto.getResponses());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseServerCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseServerCreateAction.java
@@ -17,7 +17,7 @@ public class RedbeamsDatabaseServerCreateAction implements Action<RedbeamsDataba
     public RedbeamsDatabaseServerTestDto action(TestContext testContext, RedbeamsDatabaseServerTestDto testDto, RedbeamsClient client) throws Exception {
         Log.whenJson(LOGGER, " Database register request:\n", testDto.getRequest());
         testDto.setResponse(
-                client.getEndpoints()
+                client.getDefaultClient()
                         .databaseServerV4Endpoint()
                         .create(testDto.getRequest()));
         Log.whenJson(LOGGER, " Database registered successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseServerDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/database/RedbeamsDatabaseServerDeleteAction.java
@@ -18,7 +18,7 @@ public class RedbeamsDatabaseServerDeleteAction implements Action<RedbeamsDataba
     public RedbeamsDatabaseServerTestDto action(TestContext testContext, RedbeamsDatabaseServerTestDto testDto, RedbeamsClient client) throws Exception {
         Log.as(LOGGER, " Database server delete request:\n");
         //can't set response because it's not the same type
-        DatabaseServerV4Response response = client.getEndpoints()
+        DatabaseServerV4Response response = client.getDefaultClient()
                 .databaseServerV4Endpoint()
                 .deleteByCrn(testDto.getResponse().getResourceCrn(), false);
         Log.whenJson(LOGGER, " Database deleted successfully:\n", response);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentCascadingDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentCascadingDeleteAction.java
@@ -17,7 +17,7 @@ public class EnvironmentCascadingDeleteAction implements Action<EnvironmentTestD
     @Override
     public EnvironmentTestDto action(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient environmentClient) throws Exception {
         Log.when(LOGGER, "Environment cascading delete request, crn: " +  testDto.getResponse().getCrn());
-        SimpleEnvironmentResponse delete = environmentClient.getEnvironmentClient()
+        SimpleEnvironmentResponse delete = environmentClient.getDefaultClient()
                 .environmentV1Endpoint()
                 .deleteByCrn(testDto.getResponse().getCrn(), true, false);
         testDto.setResponseSimpleEnv(delete);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentChangeAuthenticationAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentChangeAuthenticationAction.java
@@ -22,7 +22,7 @@ public class EnvironmentChangeAuthenticationAction implements Action<Environment
         environmentAuthenticationRequest.setPublicKey(testDto.getRequest().getAuthentication().getPublicKey());
         environmentAuthenticationRequest.setPublicKeyId(testDto.getRequest().getAuthentication().getPublicKeyId());
         request.setAuthentication(environmentAuthenticationRequest);
-        testDto.setResponse(environmentClient.getEnvironmentClient()
+        testDto.setResponse(environmentClient.getDefaultClient()
                 .environmentV1Endpoint()
                 .editByCrn(testDto.getResponse().getCrn(), request));
         Log.when(LOGGER, "Environment edit authentication action posted");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentChangeCredentialAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentChangeCredentialAction.java
@@ -11,7 +11,7 @@ public class EnvironmentChangeCredentialAction implements Action<EnvironmentTest
     @Override
     public EnvironmentTestDto action(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient environmentClient) throws Exception {
         testDto.setResponse(
-                environmentClient.getEnvironmentClient()
+                environmentClient.getDefaultClient()
                         .environmentV1Endpoint()
                         .changeCredentialByEnvironmentName(testDto.getName(), testDto.getEnviornmentChangeCredentialRequest()));
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentChangeSecurityAccessAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentChangeSecurityAccessAction.java
@@ -21,7 +21,7 @@ public class EnvironmentChangeSecurityAccessAction implements Action<Environment
         SecurityAccessRequest securityAccess = testDto.getRequest().getSecurityAccess();
         SecurityAccessRequest clone = cloneSecurityAccessRequest(securityAccess);
         request.setSecurityAccess(clone);
-        testDto.setResponse(environmentClient.getEnvironmentClient()
+        testDto.setResponse(environmentClient.getDefaultClient()
                 .environmentV1Endpoint()
                 .editByCrn(testDto.getResponse().getCrn(), request));
         Log.when(LOGGER, "Environment edit authentication action posted");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentCreateAction.java
@@ -11,7 +11,7 @@ public class EnvironmentCreateAction extends AbstractEnvironmentAction {
     protected EnvironmentTestDto environmentAction(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) throws Exception {
         Log.whenJson("Environment post request: ", testDto.getRequest());
         testDto.setResponse(
-                client.getEnvironmentClient()
+                client.getDefaultClient()
                         .environmentV1Endpoint()
                         .post(testDto.getRequest()));
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteAction.java
@@ -11,7 +11,7 @@ public class EnvironmentDeleteAction implements Action<EnvironmentTestDto, Envir
 
     @Override
     public EnvironmentTestDto action(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient environmentClient) throws Exception {
-        SimpleEnvironmentResponse delete = environmentClient.getEnvironmentClient()
+        SimpleEnvironmentResponse delete = environmentClient.getDefaultClient()
                 .environmentV1Endpoint()
                 .deleteByCrn(testDto.getResponse().getCrn(), true, false);
         testDto.setResponseSimpleEnv(delete);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteByNameAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteByNameAction.java
@@ -20,7 +20,7 @@ public class EnvironmentDeleteByNameAction extends AbstractEnvironmentAction {
 
     @Override
     protected EnvironmentTestDto environmentAction(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) throws Exception {
-        SimpleEnvironmentResponse delete = client.getEnvironmentClient()
+        SimpleEnvironmentResponse delete = client.getDefaultClient()
                 .environmentV1Endpoint()
                 .deleteByName(testDto.getName(), cascading, false);
         testDto.setResponseSimpleEnv(delete);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteMultipleByCrnsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteMultipleByCrnsAction.java
@@ -18,7 +18,7 @@ public class EnvironmentDeleteMultipleByCrnsAction extends AbstractEnvironmentAc
 
     @Override
     protected EnvironmentTestDto environmentAction(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) throws Exception {
-        SimpleEnvironmentResponses delete = client.getEnvironmentClient()
+        SimpleEnvironmentResponses delete = client.getDefaultClient()
                 .environmentV1Endpoint()
                 .deleteMultipleByCrns(crns, true, false);
         testDto.setResponseSimpleEnvSet(delete.getResponses());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteMultipleByNamesAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentDeleteMultipleByNamesAction.java
@@ -18,7 +18,7 @@ public class EnvironmentDeleteMultipleByNamesAction extends AbstractEnvironmentA
 
     @Override
     protected EnvironmentTestDto environmentAction(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) throws Exception {
-        SimpleEnvironmentResponses delete = client.getEnvironmentClient()
+        SimpleEnvironmentResponses delete = client.getDefaultClient()
                 .environmentV1Endpoint()
                 .deleteMultipleByNames(envNames, true, false);
         testDto.setResponseSimpleEnvSet(delete.getResponses());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentGetAction.java
@@ -11,7 +11,7 @@ public class EnvironmentGetAction implements Action<EnvironmentTestDto, Environm
     @Override
     public EnvironmentTestDto action(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient environmentClient) throws Exception {
         testDto.setResponse(
-                environmentClient.getEnvironmentClient()
+                environmentClient.getDefaultClient()
                         .environmentV1Endpoint()
                         .getByName(testDto.getName()));
         Log.whenJson("Environment get response: ", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentGetByCrnAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentGetByCrnAction.java
@@ -11,7 +11,7 @@ public class EnvironmentGetByCrnAction implements Action<EnvironmentTestDto, Env
     @Override
     public EnvironmentTestDto action(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient environmentClient) throws Exception {
         testDto.setResponse(
-                environmentClient.getEnvironmentClient()
+                environmentClient.getDefaultClient()
                         .environmentV1Endpoint()
                         .getByCrn(testDto.getCrn()));
         Log.whenJson("Environment get response: ", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentInternalGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentInternalGetAction.java
@@ -15,8 +15,7 @@ public class EnvironmentInternalGetAction implements Action<EnvironmentTestDto, 
             throw new IllegalArgumentException("Environment get action with internal actor requires a Environment response first.");
         }
         testDto.setResponse(
-                environmentClient.getEnvironmentInternalCrnClient()
-                        .withInternalCrn()
+                environmentClient.getInternalClient(testContext)
                         .environmentV1Endpoint()
                         .getByCrn(testDto.getResponse().getCrn()));
         Log.whenJson("Environment get response with internal actor: ", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentListAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentListAction.java
@@ -11,7 +11,7 @@ public class EnvironmentListAction implements Action<EnvironmentTestDto, Environ
     @Override
     public EnvironmentTestDto action(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient environmentClient) throws Exception {
         testDto.setResponseSimpleEnvSet(
-                environmentClient.getEnvironmentClient()
+                environmentClient.getDefaultClient()
                         .environmentV1Endpoint()
                         .list().getResponses());
         Log.whenJson("Environment list response: ", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentRefreshAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentRefreshAction.java
@@ -16,7 +16,7 @@ public class EnvironmentRefreshAction implements Action<EnvironmentTestDto, Envi
     @Override
     public EnvironmentTestDto action(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) throws Exception {
         testDto.setResponse(
-                client.getEnvironmentClient().environmentV1Endpoint().getByName(testDto.getName())
+                client.getDefaultClient().environmentV1Endpoint().getByName(testDto.getName())
         );
         Log.whenJson(LOGGER, " Environment get response: ", testDto.getResponse());
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentStartAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentStartAction.java
@@ -15,7 +15,7 @@ public class EnvironmentStartAction extends AbstractEnvironmentAction {
 
     @Override
     protected EnvironmentTestDto environmentAction(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) throws Exception {
-        client.getEnvironmentClient()
+        client.getDefaultClient()
                 .environmentV1Endpoint()
                 .postStartByCrn(testDto.getResponse().getCrn(), DataHubStartAction.START_ALL);
         Log.when(LOGGER, "Environment start action posted");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentStopAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/environment/EnvironmentStopAction.java
@@ -14,7 +14,7 @@ public class EnvironmentStopAction extends AbstractEnvironmentAction {
 
     @Override
     protected EnvironmentTestDto environmentAction(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) {
-        client.getEnvironmentClient()
+        client.getDefaultClient()
                 .environmentV1Endpoint()
                 .postStopByCrn(testDto.getResponse().getCrn());
         Log.when(LOGGER, "Environment stop action posted");

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogCreateAction.java
@@ -20,7 +20,7 @@ public class ImageCatalogCreateAction implements Action<ImageCatalogTestDto, Clo
         Log.whenJson(LOGGER, format(" Image catalog post request:%n"), testDto.getRequest());
         try {
             testDto.setResponse(
-                    client.getCloudbreakClient()
+                    client.getDefaultClient()
                             .imageCatalogV4Endpoint()
                             .create(client.getWorkspaceId(), testDto.getRequest()));
         } catch (Exception e) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogCreateIfNotExistsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogCreateIfNotExistsAction.java
@@ -20,13 +20,13 @@ public class ImageCatalogCreateIfNotExistsAction implements Action<ImageCatalogT
         Log.when(LOGGER, "Create Imagecatalog with name: " + testDto.getRequest().getName());
         try {
             testDto.setResponse(
-                    client.getCloudbreakClient().imageCatalogV4Endpoint().create(client.getWorkspaceId(), testDto.getRequest())
+                    client.getDefaultClient().imageCatalogV4Endpoint().create(client.getWorkspaceId(), testDto.getRequest())
             );
             Log.whenJson(LOGGER, "Imagecatalog created successfully: ", testDto.getRequest());
         } catch (Exception e) {
             Log.when(LOGGER, "Cannot create Imagecatalog, fetch existed one: " + testDto.getRequest().getName());
             testDto.setResponse(
-                    client.getCloudbreakClient().imageCatalogV4Endpoint()
+                    client.getDefaultClient().imageCatalogV4Endpoint()
                             .getByName(client.getWorkspaceId(), testDto.getRequest().getName(), Boolean.FALSE));
             Log.whenJson(LOGGER, "Imagecatalog fetched successfully: ", testDto.getRequest());
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogCreateRetryAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogCreateRetryAction.java
@@ -26,7 +26,7 @@ public class ImageCatalogCreateRetryAction implements Action<ImageCatalogTestDto
         do {
             try {
                 response =
-                        client.getCloudbreakClient()
+                        client.getDefaultClient()
                                 .imageCatalogV4Endpoint()
                                 .create(client.getWorkspaceId(), testDto.getRequest());
             } catch (Exception e) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogCreateWithoutNameLoggingAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogCreateWithoutNameLoggingAction.java
@@ -19,7 +19,7 @@ public class ImageCatalogCreateWithoutNameLoggingAction implements Action<ImageC
     public ImageCatalogTestDto action(TestContext testContext, ImageCatalogTestDto testDto, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, format(" Image catalog post request:%n"), testDto.getRequest());
         testDto.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .imageCatalogV4Endpoint()
                         .create(client.getWorkspaceId(), testDto.getRequest()));
         Log.whenJson(LOGGER, format(" Image catalog created  successfully:%n"), testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogDeleteAction.java
@@ -18,7 +18,7 @@ public class ImageCatalogDeleteAction implements Action<ImageCatalogTestDto, Clo
     public ImageCatalogTestDto action(TestContext testContext, ImageCatalogTestDto testDto, CloudbreakClient cloudbreakClient) throws Exception {
         Log.when(LOGGER, format(" Image catalog DELETE request:%n", testDto.getRequest().getName()));
         testDto.setResponse(
-                cloudbreakClient.getCloudbreakClient()
+                cloudbreakClient.getDefaultClient()
                         .imageCatalogV4Endpoint()
                         .deleteByName(cloudbreakClient.getWorkspaceId(), testDto.getName()));
         Log.whenJson(LOGGER, format(" Image catalog has been deleted successfully:%n"), testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogGetAction.java
@@ -27,7 +27,7 @@ public class ImageCatalogGetAction implements Action<ImageCatalogTestDto, Cloudb
         Log.when(LOGGER, "Get Imagecatalog by name: " + testDto.getRequest().getName());
         try {
             testDto.setResponse(
-                    cloudbreakClient.getCloudbreakClient().imageCatalogV4Endpoint().getByName(cloudbreakClient.getWorkspaceId(), testDto.getName(), withImages)
+                    cloudbreakClient.getDefaultClient().imageCatalogV4Endpoint().getByName(cloudbreakClient.getWorkspaceId(), testDto.getName(), withImages)
             );
             Log.whenJson(LOGGER, "Imagecatalog has been fetched successfully: ", testDto.getRequest());
         } catch (Exception e) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogGetImagesByNameAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogGetImagesByNameAction.java
@@ -37,7 +37,7 @@ public class ImageCatalogGetImagesByNameAction implements Action<ImageCatalogTes
         Log.when(LOGGER, "Get Imagecatalog by name: " + testDto.getRequest().getName());
         try {
             ImageCatalogV4Endpoint imageCatalogV4Endpoint = cloudbreakClient
-                    .getCloudbreakClient()
+                    .getDefaultClient()
                     .imageCatalogV4Endpoint();
 
             testDto.setResponseByProvider(getImagesV4Response(testDto, cloudbreakClient, imageCatalogV4Endpoint));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogGetImagesFromDefaultCatalogAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/imagecatalog/ImageCatalogGetImagesFromDefaultCatalogAction.java
@@ -29,7 +29,7 @@ public class ImageCatalogGetImagesFromDefaultCatalogAction implements Action<Ima
         try {
             testDto.setResponseByProvider(
                     cloudbreakClient
-                            .getCloudbreakClient()
+                            .getDefaultClient()
                             .imageCatalogV4Endpoint()
                             .getImages(cloudbreakClient.getWorkspaceId(), null, platform.name())
             );

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/kerberos/KerberosCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/kerberos/KerberosCreateAction.java
@@ -18,7 +18,7 @@ public class KerberosCreateAction implements Action<KerberosTestDto, FreeIpaClie
     public KerberosTestDto action(TestContext testContext, KerberosTestDto testDto, FreeIpaClient client) throws Exception {
         Log.whenJson(LOGGER, format(" Kerberos post request:%n"), testDto.getRequest());
         testDto.setResponse(
-                client.getFreeIpaClient()
+                client.getDefaultClient()
                         .getKerberosConfigV1Endpoint()
                         .create(testDto.getRequest()));
         Log.whenJson(LOGGER, format(" Kerberos created  successfully:%n"), testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/kerberos/KerberosDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/kerberos/KerberosDeleteAction.java
@@ -19,12 +19,12 @@ public class KerberosDeleteAction implements Action<KerberosTestDto, FreeIpaClie
 
     public KerberosTestDto action(TestContext testContext, KerberosTestDto testDto, FreeIpaClient client) throws Exception {
         Log.whenJson(LOGGER, format(" Kerberos config delete: %n"), testDto.getName());
-        client.getFreeIpaClient()
+        client.getDefaultClient()
                 .getKerberosConfigV1Endpoint()
                 .delete(testDto.getName());
         try {
             testDto.setResponse(
-                    client.getFreeIpaClient()
+                    client.getDefaultClient()
                             .getKerberosConfigV1Endpoint()
                             .describe(testDto.getName()));
         } catch (NotFoundException e) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/kerberos/KerberosGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/kerberos/KerberosGetAction.java
@@ -18,7 +18,7 @@ public class KerberosGetAction implements Action<KerberosTestDto, FreeIpaClient>
     public KerberosTestDto action(TestContext testContext, KerberosTestDto testDto, FreeIpaClient client) throws Exception {
         Log.when(LOGGER, format(" Kerberos get request by env crn:%n", testDto.getName()));
         testDto.setResponse(
-                client.getFreeIpaClient()
+                client.getDefaultClient()
                         .getKerberosConfigV1Endpoint()
                         .describe(testDto.getName()));
         Log.whenJson(LOGGER, format(" Kerberos get successfully:%n"), testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/ldap/LdapCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/ldap/LdapCreateAction.java
@@ -16,7 +16,7 @@ public class LdapCreateAction implements Action<LdapTestDto, FreeIpaClient> {
     public LdapTestDto action(TestContext testContext, LdapTestDto testDto, FreeIpaClient client) throws Exception {
         Log.whenJson(LOGGER, " Ldap post request:\n", testDto.getRequest());
         testDto.setResponse(
-                client.getFreeIpaClient()
+                client.getDefaultClient()
                         .getLdapConfigV1Endpoint()
                         .create(testDto.getRequest()));
         Log.whenJson(LOGGER, " Ldap was created successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/ldap/LdapCreateIfNotExistsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/ldap/LdapCreateIfNotExistsAction.java
@@ -17,13 +17,13 @@ public class LdapCreateIfNotExistsAction implements Action<LdapTestDto, FreeIpaC
         Log.whenJson(LOGGER, " Ldap post request:\n", testDto.getRequest());
         try {
             testDto.setResponse(
-                    client.getFreeIpaClient().getLdapConfigV1Endpoint().create(testDto.getRequest())
+                    client.getDefaultClient().getLdapConfigV1Endpoint().create(testDto.getRequest())
             );
             Log.whenJson(LOGGER, "LdapConfig created successfully: ", testDto.getRequest());
         } catch (Exception e) {
             Log.when(LOGGER, "Cannot create LdapConfig, fetch existed one: " + testDto.getRequest().getName());
             testDto.setResponse(
-                    client.getFreeIpaClient().getLdapConfigV1Endpoint()
+                    client.getDefaultClient().getLdapConfigV1Endpoint()
                             .describe(testDto.getRequest().getEnvironmentCrn()));
             Log.whenJson(LOGGER, "LdapConfig fetched successfully: ", testDto.getRequest());
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/ldap/LdapDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/ldap/LdapDeleteAction.java
@@ -17,12 +17,12 @@ public class LdapDeleteAction implements Action<LdapTestDto, FreeIpaClient> {
     @Override
     public LdapTestDto action(TestContext testContext, LdapTestDto testDto, FreeIpaClient client) throws Exception {
         Log.when(LOGGER, " LDAP config delete request: " + testDto.getName());
-        client.getFreeIpaClient()
+        client.getDefaultClient()
             .getLdapConfigV1Endpoint()
             .delete(testDto.getName());
         try {
             testDto.setResponse(
-                    client.getFreeIpaClient()
+                    client.getDefaultClient()
                             .getLdapConfigV1Endpoint()
                             .describe(testDto.getName()));
         } catch (NotFoundException e) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/ldap/LdapGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/ldap/LdapGetAction.java
@@ -16,7 +16,7 @@ public class LdapGetAction implements Action<LdapTestDto, FreeIpaClient> {
     public LdapTestDto action(TestContext testContext, LdapTestDto testDto, FreeIpaClient client) throws Exception {
         Log.when(LOGGER, " Ldap get: " + testDto.getName());
         testDto.setResponse(
-                client.getFreeIpaClient()
+                client.getDefaultClient()
                         .getLdapConfigV1Endpoint()
                         .describe(testDto.getName()));
         Log.whenJson(LOGGER, " Ldap get was successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/notificationtest/NotificationTestingAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/notificationtest/NotificationTestingAction.java
@@ -16,7 +16,7 @@ public class NotificationTestingAction implements Action<NotificationTestingTest
     public NotificationTestingTestDto action(TestContext testContext, NotificationTestingTestDto testDto, CloudbreakClient cloudbreakClient) throws Exception {
         String logInitMessage = "Posting notification test";
         LOGGER.info("{}", logInitMessage);
-        cloudbreakClient.getCloudbreakClient().utilV4Endpoint().postNotificationTest();
+        cloudbreakClient.getDefaultClient().utilV4Endpoint().postNotificationTest();
         LOGGER.info("{} was successful", logInitMessage);
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/proxy/ProxyConfigCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/proxy/ProxyConfigCreateAction.java
@@ -17,7 +17,7 @@ public class ProxyConfigCreateAction implements Action<ProxyTestDto, Environment
     public ProxyTestDto action(TestContext testContext, ProxyTestDto testDto, EnvironmentClient client) throws Exception {
         Log.whenJson(LOGGER, " Proxy config post request:\n", testDto.getRequest());
         testDto.setResponse(
-                client.getEnvironmentClient()
+                client.getDefaultClient()
                         .proxyV1Endpoint()
                         .post(testDto.getRequest()));
         Log.whenJson(LOGGER, " Proxy config was created successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/proxy/ProxyConfigCreateIfNotExistsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/proxy/ProxyConfigCreateIfNotExistsAction.java
@@ -17,13 +17,13 @@ public class ProxyConfigCreateIfNotExistsAction implements Action<ProxyTestDto, 
         Log.whenJson(LOGGER, " Proxy config post request:\n", testDto.getRequest());
         try {
             testDto.setResponse(
-                    client.getEnvironmentClient().proxyV1Endpoint().post(testDto.getRequest())
+                    client.getDefaultClient().proxyV1Endpoint().post(testDto.getRequest())
             );
             Log.whenJson(LOGGER, "ProxyConfig created successfully, response: ", testDto.getResponse());
         } catch (Exception e) {
             Log.when(LOGGER, "Cannot create ProxyConfig, fetch existed one: " + testDto.getRequest().getName());
             testDto.setResponse(
-                    client.getEnvironmentClient().proxyV1Endpoint()
+                    client.getDefaultClient().proxyV1Endpoint()
                             .getByName(testDto.getRequest().getName()));
             Log.whenJson(LOGGER, "ProxyConfig fetched successfully, response: ", testDto.getResponse());
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/proxy/ProxyConfigDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/proxy/ProxyConfigDeleteAction.java
@@ -17,7 +17,7 @@ public class ProxyConfigDeleteAction implements Action<ProxyTestDto, Environment
     public ProxyTestDto action(TestContext testContext, ProxyTestDto testDto, EnvironmentClient client) throws Exception {
         Log.when(LOGGER, " Proxy config delete request: " + testDto.getName());
         testDto.setResponse(
-                client.getEnvironmentClient()
+                client.getDefaultClient()
                         .proxyV1Endpoint()
                         .deleteByName(testDto.getName()));
         Log.whenJson(LOGGER, " Proxy config was deleted successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/proxy/ProxyConfigGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/proxy/ProxyConfigGetAction.java
@@ -17,7 +17,7 @@ public class ProxyConfigGetAction implements Action<ProxyTestDto, EnvironmentCli
     public ProxyTestDto action(TestContext testContext, ProxyTestDto testDto, EnvironmentClient client) throws Exception {
         Log.when(LOGGER, " Proxy config get request: " + testDto.getName());
         testDto.setResponse(
-                client.getEnvironmentClient()
+                client.getDefaultClient()
                         .proxyV1Endpoint()
                         .getByName(testDto.getName()));
         Log.whenJson(LOGGER, " Proxy config get successfully:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/recipe/RecipeCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/recipe/RecipeCreateAction.java
@@ -19,7 +19,7 @@ public class RecipeCreateAction implements Action<RecipeTestDto, CloudbreakClien
     public RecipeTestDto action(TestContext testContext, RecipeTestDto testDto, CloudbreakClient cloudbreakClient) throws Exception {
         Log.whenJson(LOGGER, format(" Recipe post request:%n"), testDto.getRequest());
         testDto.setResponse(
-                cloudbreakClient.getCloudbreakClient()
+                cloudbreakClient.getDefaultClient()
                         .recipeV4Endpoint()
                         .post(cloudbreakClient.getWorkspaceId(), testDto.getRequest()));
         Log.whenJson(LOGGER, format(" Recipe created  successfully:%n"), testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/recipe/RecipeDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/recipe/RecipeDeleteAction.java
@@ -19,7 +19,7 @@ public class RecipeDeleteAction implements Action<RecipeTestDto, CloudbreakClien
     public RecipeTestDto action(TestContext testContext, RecipeTestDto testDto, CloudbreakClient cloudbreakClient) throws Exception {
         Log.when(LOGGER, format(" Recipe delete request:%n", testDto.getName()));
         testDto.setResponse(
-                cloudbreakClient.getCloudbreakClient()
+                cloudbreakClient.getDefaultClient()
                         .recipeV4Endpoint()
                         .deleteByName(cloudbreakClient.getWorkspaceId(), testDto.getName()));
         Log.whenJson(LOGGER, format(" Recipe deleted successfully:%n"), testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/recipe/RecipeGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/recipe/RecipeGetAction.java
@@ -18,7 +18,7 @@ public class RecipeGetAction implements Action<RecipeTestDto, CloudbreakClient> 
     @Override
     public RecipeTestDto action(TestContext testContext, RecipeTestDto testDto, CloudbreakClient cloudbreakClient) throws Exception {
         testDto.setResponse(
-                cloudbreakClient.getCloudbreakClient().recipeV4Endpoint().getByName(cloudbreakClient.getWorkspaceId(), testDto.getName())
+                cloudbreakClient.getDefaultClient().recipeV4Endpoint().getByName(cloudbreakClient.getWorkspaceId(), testDto.getName())
         );
         Log.whenJson(LOGGER, format(" Recipe get successfully:%n"), testDto.getResponse());
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/recipe/RecipeListAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/recipe/RecipeListAction.java
@@ -17,7 +17,7 @@ public class RecipeListAction implements Action<RecipeTestDto, CloudbreakClient>
     @Override
     public RecipeTestDto action(TestContext testContext, RecipeTestDto testDto, CloudbreakClient cloudbreakClient) throws Exception {
         testDto.setSimpleResponses(
-                cloudbreakClient.getCloudbreakClient().recipeV4Endpoint().list(cloudbreakClient.getWorkspaceId())
+                cloudbreakClient.getDefaultClient().recipeV4Endpoint().list(cloudbreakClient.getWorkspaceId())
         );
         Log.whenJson(LOGGER, format(" Recipe list successfully:%n"), testDto.getSimpleResponses());
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackBlueprintRequestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackBlueprintRequestAction.java
@@ -17,7 +17,7 @@ public class StackBlueprintRequestAction implements Action<StackTestDto, Cloudbr
     @Override
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, " Stack get generated blueprint:\n", testDto.getRequest());
-        GeneratedBlueprintV4Response bp = client.getCloudbreakClient().stackV4Endpoint().postStackForBlueprint(
+        GeneratedBlueprintV4Response bp = client.getDefaultClient().stackV4Endpoint().postStackForBlueprint(
                 client.getWorkspaceId(),
                 testDto.getName(),
                 testDto.getRequest(),

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackCreateAction.java
@@ -17,7 +17,7 @@ public class StackCreateAction implements Action<StackTestDto, CloudbreakClient>
     @Override
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
         Log.whenJson(LOGGER, " Stack create request: ", testDto.getRequest());
-        StackV4Response response = client.getCloudbreakClient()
+        StackV4Response response = client.getDefaultClient()
                         .stackV4Endpoint()
                         .post(client.getWorkspaceId(), testDto.getRequest(), testContext.getActingUserCrn().getAccountId());
         testDto.setResponse(response);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackDeleteAction.java
@@ -20,7 +20,7 @@ public class StackDeleteAction implements Action<StackTestDto, CloudbreakClient>
     @Override
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, format("Stack delete request: %s", testDto.getRequest().getName()));
-        client.getCloudbreakClient()
+        client.getDefaultClient()
                 .stackV4Endpoint()
                 .delete(client.getWorkspaceId(), testDto.getName(), false, testContext.getActingUserCrn().getAccountId());
         Log.whenJson(LOGGER, " Stack deletion was successful:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackDeleteInstanceAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackDeleteInstanceAction.java
@@ -20,7 +20,7 @@ public class StackDeleteInstanceAction implements Action<StackTestDto, Cloudbrea
         String instanceId = testContext.getRequiredSelected(INSTANCE_ID);
         Log.when(LOGGER, " Stack delete instance request: " + testDto.getName() + " instance id: " + instanceId);
         Boolean forced = testContext.getSelected("forced");
-        client.getCloudbreakClient()
+        client.getDefaultClient()
                 .stackV4Endpoint()
                 .deleteInstance(client.getWorkspaceId(), testDto.getName(), forced != null && forced, instanceId,
                         testContext.getActingUserCrn().getAccountId());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackForceDeleteAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackForceDeleteAction.java
@@ -22,11 +22,11 @@ public class StackForceDeleteAction implements Action<StackTestDto, CloudbreakCl
     @Override
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, format("Stack delete request: %s", testDto.getRequest().getName()));
-        client.getCloudbreakClient()
+        client.getDefaultClient()
                 .stackV4Endpoint()
                 .delete(client.getWorkspaceId(), testDto.getName(), true, testContext.getActingUserCrn().getAccountId());
         testDto.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .stackV4Endpoint()
                         .get(client.getWorkspaceId(), testDto.getName(), new HashSet<>(), testContext.getActingUserCrn().getAccountId()));
         Log.whenJson(LOGGER, " Stack deletion was successful: ", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackGetAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackGetAction.java
@@ -19,7 +19,7 @@ public class StackGetAction implements Action<StackTestDto, CloudbreakClient> {
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, "Stack get request: " + testDto.getRequest().getName());
         testDto.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .stackV4Endpoint()
                         .get(client.getWorkspaceId(), testDto.getName(), new HashSet<>(), testContext.getActingUserCrn().getAccountId()));
         Log.whenJson(LOGGER, " Stack get was successful:\n", testDto.getResponse());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackRefreshAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackRefreshAction.java
@@ -17,7 +17,7 @@ public class StackRefreshAction implements Action<StackTestDto, CloudbreakClient
     @Override
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
         testDto.setResponse(
-                client.getCloudbreakClient().stackV4Endpoint().get(client.getWorkspaceId(), testDto.getName(), Collections.emptySet(),
+                client.getDefaultClient().stackV4Endpoint().get(client.getWorkspaceId(), testDto.getName(), Collections.emptySet(),
                         testContext.getActingUserCrn().getAccountId())
         );
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackRequestAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackRequestAction.java
@@ -17,7 +17,7 @@ public class StackRequestAction implements Action<StackTestDto, CloudbreakClient
     @Override
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, " Stack get cli skeleton:" + testDto.getName());
-        StackV4Request request = client.getCloudbreakClient().stackV4Endpoint().getRequestfromName(
+        StackV4Request request = client.getDefaultClient().stackV4Endpoint().getRequestfromName(
                 client.getWorkspaceId(),
                 testDto.getName(),
                 testContext.getActingUserCrn().getAccountId());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackScalePostAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackScalePostAction.java
@@ -44,12 +44,12 @@ public class StackScalePostAction implements Action<StackTestDto, CloudbreakClie
         Log.when(LOGGER, String.format("Stack scale request on: %s. Hostgroup: %s, desiredCount: %d", testDto.getName(), request.getGroup(),
                 request.getDesiredCount()));
         Log.whenJson(LOGGER, " Stack scale request: ", testDto.getRequest());
-        FlowIdentifier flowIdentifier = client.getCloudbreakClient()
+        FlowIdentifier flowIdentifier = client.getDefaultClient()
                 .stackV4Endpoint()
                 .putScaling(client.getWorkspaceId(), testDto.getName(), request,
                         testContext.getActingUserCrn().getAccountId());
         testDto.setFlow("Stack scale", flowIdentifier);
-        StackV4Response stackV4Response = client.getCloudbreakClient()
+        StackV4Response stackV4Response = client.getDefaultClient()
                 .stackV4Endpoint()
                 .get(client.getWorkspaceId(), testDto.getName(), new HashSet<>(), testContext.getActingUserCrn().getAccountId());
         testDto.setResponse(stackV4Response);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackStartAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackStartAction.java
@@ -16,7 +16,7 @@ public class StackStartAction implements Action<StackTestDto, CloudbreakClient> 
     @Override
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, String.format(" Stack start request: %s", testDto.getRequest().getName()));
-        client.getCloudbreakClient().stackV4Endpoint().putStart(client.getWorkspaceId(), testDto.getName(),
+        client.getDefaultClient().stackV4Endpoint().putStart(client.getWorkspaceId(), testDto.getName(),
                 testContext.getActingUserCrn().getAccountId());
         Log.when(LOGGER, " Stack was start requested successfully");
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackStopAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackStopAction.java
@@ -16,7 +16,7 @@ public class StackStopAction implements Action<StackTestDto, CloudbreakClient> {
     @Override
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, String.format(" Stack stop request: %s", testDto.getRequest().getName()));
-        client.getCloudbreakClient().stackV4Endpoint().putStop(client.getWorkspaceId(), testDto.getName(),
+        client.getDefaultClient().stackV4Endpoint().putStop(client.getWorkspaceId(), testDto.getName(),
                 testContext.getActingUserCrn().getAccountId());
         Log.when(LOGGER, " Stack was stop requested successfully");
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackSyncAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/stack/StackSyncAction.java
@@ -16,7 +16,7 @@ public class StackSyncAction implements Action<StackTestDto, CloudbreakClient> {
     @Override
     public StackTestDto action(TestContext testContext, StackTestDto testDto, CloudbreakClient client) throws Exception {
         Log.when(LOGGER, String.format(" Stack sync request: %s", testDto.getRequest().getName()));
-        client.getCloudbreakClient().stackV4Endpoint().sync(client.getWorkspaceId(), testDto.getName(),
+        client.getDefaultClient().stackV4Endpoint().sync(client.getWorkspaceId(), testDto.getName(),
                 testContext.getActingUserCrn().getAccountId());
         Log.when(LOGGER, " Stack was sync requested successfully");
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/CheckResourceRightAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/CheckResourceRightAction.java
@@ -26,7 +26,7 @@ public class CheckResourceRightAction implements Action<CheckResourceRightTestDt
             resourceRightsV4.setRights(entry.getValue());
             return resourceRightsV4;
         }).collect(Collectors.toList()));
-        testDto.setResponse(cloudbreakClient.getCloudbreakClient().authorizationUtilEndpoint().checkRightByCrn(checkRightByCrnV4Request));
+        testDto.setResponse(cloudbreakClient.getDefaultClient().authorizationUtilEndpoint().checkRightByCrn(checkRightByCrnV4Request));
         Log.whenJson(LOGGER, "checking right on resources response:\n", testDto.getResponse());
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/CheckRightAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/CheckRightAction.java
@@ -18,7 +18,7 @@ public class CheckRightAction implements Action<CheckRightTestDto, CloudbreakCli
     public CheckRightTestDto action(TestContext testContext, CheckRightTestDto testDto, CloudbreakClient cloudbreakClient) throws Exception {
         CheckRightV4Request checkRightV4Request = new CheckRightV4Request();
         checkRightV4Request.setRights(testDto.getRightsToCheck());
-        testDto.setResponse(cloudbreakClient.getCloudbreakClient().authorizationUtilEndpoint().checkRightInAccount(checkRightV4Request));
+        testDto.setResponse(cloudbreakClient.getDefaultClient().authorizationUtilEndpoint().checkRightInAccount(checkRightV4Request));
         Log.whenJson(LOGGER, "check rights in account response:\n", testDto.getResponse());
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/CloudStorageMatrixAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/CloudStorageMatrixAction.java
@@ -17,7 +17,7 @@ public class CloudStorageMatrixAction implements Action<CloudStorageMatrixTestDt
 
     @Override
     public CloudStorageMatrixTestDto action(TestContext testContext, CloudStorageMatrixTestDto testDto, CloudbreakClient client) throws Exception {
-        testDto.setResponses(new HashSet<>(client.getCloudbreakClient().utilV4Endpoint().getCloudStorageMatrix(testDto.getStackVersion()).getResponses()));
+        testDto.setResponses(new HashSet<>(client.getDefaultClient().utilV4Endpoint().getCloudStorageMatrix(testDto.getStackVersion()).getResponses()));
         Log.whenJson(LOGGER, "Cloud storage matrix response:\n", testDto.getResponses());
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/DeploymentPreferencesAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/DeploymentPreferencesAction.java
@@ -15,7 +15,7 @@ public class DeploymentPreferencesAction implements Action<DeploymentPreferences
 
     @Override
     public DeploymentPreferencesTestDto action(TestContext testContext, DeploymentPreferencesTestDto testDto, CloudbreakClient client) throws Exception {
-        testDto.setResponse(client.getCloudbreakClient().utilV4Endpoint().deployment());
+        testDto.setResponse(client.getDefaultClient().utilV4Endpoint().deployment());
         Log.whenJson(LOGGER, "Deployment preferences response:\n", testDto.getResponse());
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/RenewDatalakeCertificateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/RenewDatalakeCertificateAction.java
@@ -15,7 +15,7 @@ public class RenewDatalakeCertificateAction implements Action<RenewDatalakeCerti
     @Override
     public RenewDatalakeCertificateTestDto action(TestContext testContext, RenewDatalakeCertificateTestDto renewCertificateTestDto, SdxClient sdxClient)
             throws Exception {
-        sdxClient.getSdxClient().sdxEndpoint().renewCertificate(renewCertificateTestDto.getStackCrn());
+        sdxClient.getDefaultClient().sdxEndpoint().renewCertificate(renewCertificateTestDto.getStackCrn());
         return renewCertificateTestDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/RenewDistroXCertificateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/RenewDistroXCertificateAction.java
@@ -15,7 +15,7 @@ public class RenewDistroXCertificateAction implements Action<RenewDistroXCertifi
     @Override
     public RenewDistroXCertificateTestDto action(TestContext testContext, RenewDistroXCertificateTestDto renewCertificateTestDto,
             CloudbreakClient cloudbreakClient) throws Exception {
-        cloudbreakClient.getCloudbreakClient().distroXV1Endpoint().renewCertificate(renewCertificateTestDto.getStackCrn());
+        cloudbreakClient.getDefaultClient().distroXV1Endpoint().renewCertificate(renewCertificateTestDto.getStackCrn());
         return renewCertificateTestDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/RepoConfigValidationAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/RepoConfigValidationAction.java
@@ -16,7 +16,7 @@ public class RepoConfigValidationAction implements Action<RepoConfigValidationTe
     @Override
     public RepoConfigValidationTestDto action(TestContext testContext, RepoConfigValidationTestDto testDto, CloudbreakClient cloudbreakClient) throws Exception {
         Log.whenJson(LOGGER, "Posting repository config request:\n", testDto.getRequest());
-        testDto.setResponse(cloudbreakClient.getCloudbreakClient().utilV4Endpoint().repositoryConfigValidationRequest(testDto.getRequest()));
+        testDto.setResponse(cloudbreakClient.getDefaultClient().utilV4Endpoint().repositoryConfigValidationRequest(testDto.getRequest()));
         Log.whenJson(LOGGER, "Posting repository config response:\n", testDto.getResponse());
 
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/SdxRetryAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/SdxRetryAction.java
@@ -15,7 +15,7 @@ public class SdxRetryAction implements Action<SdxInternalTestDto, SdxClient> {
     @Override
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient sdxClient)
             throws Exception {
-        sdxClient.getSdxClient().sdxEndpoint().retryByCrn(testDto.getCrn());
+        sdxClient.getDefaultClient().sdxEndpoint().retryByCrn(testDto.getCrn());
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/SecurityRulesAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/SecurityRulesAction.java
@@ -15,7 +15,7 @@ public class SecurityRulesAction implements Action<SecurityRulesTestDto, Cloudbr
 
     @Override
     public SecurityRulesTestDto action(TestContext testContext, SecurityRulesTestDto testDto, CloudbreakClient cloudbreakClient) throws Exception {
-        testDto.setResponse(cloudbreakClient.getCloudbreakClient().utilV4Endpoint().getDefaultSecurityRules());
+        testDto.setResponse(cloudbreakClient.getDefaultClient().utilV4Endpoint().getDefaultSecurityRules());
         Log.whenJson(LOGGER, "default security rules response:\n", testDto.getResponse());
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/StackMatrixAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/StackMatrixAction.java
@@ -15,7 +15,7 @@ public class StackMatrixAction implements Action<StackMatrixTestDto, CloudbreakC
 
     @Override
     public StackMatrixTestDto action(TestContext testContext, StackMatrixTestDto testDto, CloudbreakClient cloudbreakClient) throws Exception {
-        testDto.setResponse(cloudbreakClient.getCloudbreakClient().utilV4Endpoint().getStackMatrix(null, testDto.getCloudPlatform().name()));
+        testDto.setResponse(cloudbreakClient.getDefaultClient().utilV4Endpoint().getStackMatrix(null, testDto.getCloudPlatform().name()));
         Log.whenJson(LOGGER, "Obtaining stack matrix response:\n", testDto.getResponse());
 
         return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/VersionCheckAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/VersionCheckAction.java
@@ -15,7 +15,7 @@ public class VersionCheckAction implements Action<VersionCheckTestDto, Cloudbrea
 
     @Override
     public VersionCheckTestDto action(TestContext testContext, VersionCheckTestDto testDto, CloudbreakClient cloudbreakClient) throws Exception {
-        testDto.setResponse(cloudbreakClient.getCloudbreakClient().utilV4Endpoint().checkClientVersion(testDto.getVersion()));
+        testDto.setResponse(cloudbreakClient.getDefaultClient().utilV4Endpoint().checkClientVersion(testDto.getVersion()));
         Log.whenJson(LOGGER, "Obtaining client version response:\n", testDto.getResponse());
 
         return testDto;    }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/credential/CredentialTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/credential/CredentialTestAssertion.java
@@ -22,7 +22,7 @@ public class CredentialTestAssertion {
 
     public Assertion<CredentialTestDto, EnvironmentClient> checkStructuredEvents() {
         return (testContext, entity, client) -> {
-            List<CDPStructuredEvent> auditEvents = client.getEnvironmentClient().structuredEventsV1Endpoint()
+            List<CDPStructuredEvent> auditEvents = client.getDefaultClient().structuredEventsV1Endpoint()
                     .getAuditEvents(entity.getCrn(), Collections.emptyList(), 0, 100);
             eventAssertionCommon.checkRestEvents(auditEvents, List.of("post-credential",
                     "put-credential",

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/datalake/SdxUpgradeTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/datalake/SdxUpgradeTestAssertion.java
@@ -22,7 +22,7 @@ public class SdxUpgradeTestAssertion {
             request.setLockComponents(true);
             request.setDryRun(true);
             SdxUpgradeResponse upgradeResponse =
-                    sdxClient.getSdxClient().sdxUpgradeEndpoint().upgradeClusterByName(entity.getName(), request);
+                    sdxClient.getDefaultClient().sdxUpgradeEndpoint().upgradeClusterByName(entity.getName(), request);
             assertNotNull(upgradeResponse);
             assertTrue("Expected: " + reason + " Actual: " + upgradeResponse.getReason(), upgradeResponse.getReason().contains(reason));
             return entity;
@@ -35,7 +35,7 @@ public class SdxUpgradeTestAssertion {
             request.setLockComponents(true);
             request.setDryRun(true);
             SdxUpgradeResponse upgradeResponse =
-                    sdxClient.getSdxClient().sdxUpgradeEndpoint().upgradeClusterByName(entity.getName(), request);
+                    sdxClient.getDefaultClient().sdxUpgradeEndpoint().upgradeClusterByName(entity.getName(), request);
             assertNotNull(upgradeResponse);
             assertEquals("aaa778fc-7f17-4535-9021-515351df3691", upgradeResponse.getCurrent().getImageId());
             assertEquals(1583391600L, upgradeResponse.getCurrent().getCreated());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/distrox/DistroXExternalDatabaseAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/distrox/DistroXExternalDatabaseAssertion.java
@@ -19,7 +19,7 @@ public final class DistroXExternalDatabaseAssertion extends BaseMicroserviceClie
             String extendedBlueprint = distroXTestDto.getResponse().getCluster().getExtendedBlueprintText();
             String databaseServerCrn = distroXTestDto.getResponse().getCluster().getDatabaseServerCrn();
             RedbeamsClient redbeamsClient = getClient(testContext, testContext.getActingUser(), RedbeamsClient.class);
-            DatabaseServerV4Response databaseServer = redbeamsClient.getEndpoints()
+            DatabaseServerV4Response databaseServer = redbeamsClient.getDefaultClient()
                     .databaseServerV4Endpoint()
                     .getByCrn(databaseServerCrn);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/environment/EnvironmentListStructuredEventAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/environment/EnvironmentListStructuredEventAssertions.java
@@ -137,7 +137,7 @@ public class EnvironmentListStructuredEventAssertions {
     private EventAssertionCommon eventAssertionCommon;
 
     public EnvironmentTestDto checkCreateEvents(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) {
-        List<CDPStructuredEvent> auditEvents = client.getEnvironmentClient()
+        List<CDPStructuredEvent> auditEvents = client.getDefaultClient()
                 .structuredEventsV1Endpoint()
                 .getAuditEvents(testDto.getCrn(), Collections.emptyList(), 0, 100);
         eventAssertionCommon.checkFlowEvents(auditEvents, ENV_CREATE_FLOW_STATES);
@@ -147,7 +147,7 @@ public class EnvironmentListStructuredEventAssertions {
     }
 
     public EnvironmentTestDto checkDeleteEvents(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) {
-        List<CDPStructuredEvent> auditEvents = client.getEnvironmentClient()
+        List<CDPStructuredEvent> auditEvents = client.getDefaultClient()
                 .structuredEventsV1Endpoint()
                 .getAuditEvents(testDto.getCrn(), Collections.emptyList(), 0, 100);
         eventAssertionCommon.checkFlowEvents(auditEvents, ENV_DELETE_FLOW_STATES);
@@ -157,7 +157,7 @@ public class EnvironmentListStructuredEventAssertions {
     }
 
     public EnvironmentTestDto checkStopEvents(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) {
-        List<CDPStructuredEvent> auditEvents = client.getEnvironmentClient()
+        List<CDPStructuredEvent> auditEvents = client.getDefaultClient()
                 .structuredEventsV1Endpoint()
                 .getAuditEvents(testDto.getCrn(), Collections.emptyList(), 0, 100);
         eventAssertionCommon.checkFlowEvents(auditEvents, ENV_STOP_FLOW_STATES);
@@ -167,7 +167,7 @@ public class EnvironmentListStructuredEventAssertions {
     }
 
     public EnvironmentTestDto checkStartEvents(TestContext testContext, EnvironmentTestDto testDto, EnvironmentClient client) {
-        List<CDPStructuredEvent> auditEvents = client.getEnvironmentClient()
+        List<CDPStructuredEvent> auditEvents = client.getDefaultClient()
                 .structuredEventsV1Endpoint()
                 .getAuditEvents(testDto.getCrn(), Collections.emptyList(), 0, 100);
         eventAssertionCommon.checkFlowEvents(auditEvents, ENV_START_FLOW_STATES);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/environment/EnvironmentNetworkTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/environment/EnvironmentNetworkTestAssertion.java
@@ -19,7 +19,7 @@ public class EnvironmentNetworkTestAssertion {
 
     public static Assertion<EnvironmentTestDto, EnvironmentClient> environmentContainsNeccessaryConfigs() {
         return (testContext, testDto, environmentClient) -> {
-            DetailedEnvironmentResponse environment = environmentClient.getEnvironmentClient().environmentV1Endpoint().getByName(testDto.getName());
+            DetailedEnvironmentResponse environment = environmentClient.getDefaultClient().environmentV1Endpoint().getByName(testDto.getName());
             if (CloudPlatform.AWS.name().equals(environment.getCloudPlatform())) {
                 containsRightNumberOfSubnetsOnAws(environment);
                 hasThreePrivateSubnet(environment);
@@ -110,7 +110,7 @@ public class EnvironmentNetworkTestAssertion {
 
     public static Assertion<EnvironmentTestDto, EnvironmentClient> environmentWithEndpointGatewayContainsNeccessaryConfigs(Set<String> subnetIds) {
         return (testContext, testDto, environmentClient) -> {
-            DetailedEnvironmentResponse environment = environmentClient.getEnvironmentClient().environmentV1Endpoint().getByName(testDto.getName());
+            DetailedEnvironmentResponse environment = environmentClient.getDefaultClient().environmentV1Endpoint().getByName(testDto.getName());
             isPublicEndpointAccessGatewayEnabled(environment);
             subnetIdsWerePropagatedCorrectly(environment, subnetIds);
             return testDto;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/freeipa/FreeIpaChildEnvironmentAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/freeipa/FreeIpaChildEnvironmentAssertion.java
@@ -39,7 +39,7 @@ public class FreeIpaChildEnvironmentAssertion {
     }
 
     private static DescribeFreeIpaResponse describeChildFreeipa(FreeIpaChildEnvironmentTestDto entity, FreeIpaClient client) {
-        return client.getFreeIpaClient().getFreeIpaV1Endpoint()
+        return client.getDefaultClient().getFreeIpaV1Endpoint()
                 .describe(entity.getRequest().getChildEnvironmentCrn());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/freeipa/FreeIpaKerberosTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/freeipa/FreeIpaKerberosTestAssertion.java
@@ -17,7 +17,7 @@ public class FreeIpaKerberosTestAssertion {
     public static Assertion<FreeIpaTestDto, FreeIpaClient> validate() {
         return (testContext, entity, freeIpaClient) -> {
             DescribeKerberosConfigResponse kerberosConfigResponse =
-                    freeIpaClient.getFreeIpaClient().getKerberosConfigV1Endpoint().describe(entity.getResponse().getEnvironmentCrn());
+                    freeIpaClient.getDefaultClient().getKerberosConfigV1Endpoint().describe(entity.getResponse().getEnvironmentCrn());
             assertNotNull(kerberosConfigResponse);
             assertEquals(entity.getRequest().getFreeIpa().getDomain().toUpperCase(), kerberosConfigResponse.getDomain().toUpperCase());
             assertEquals(entity.getRequest().getFreeIpa().getDomain().toUpperCase(), kerberosConfigResponse.getRealm().toUpperCase());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/freeipa/FreeIpaLdapTestAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/freeipa/FreeIpaLdapTestAssertion.java
@@ -17,7 +17,7 @@ public class FreeIpaLdapTestAssertion {
     public static Assertion<FreeIpaTestDto, FreeIpaClient> validate() {
         return (testContext, entity, freeIpaClient) -> {
             DescribeLdapConfigResponse ldapConfigResponse =
-                    freeIpaClient.getFreeIpaClient().getLdapConfigV1Endpoint().describe(entity.getResponse().getEnvironmentCrn());
+                    freeIpaClient.getDefaultClient().getLdapConfigV1Endpoint().describe(entity.getResponse().getEnvironmentCrn());
             assertNotNull(ldapConfigResponse);
             assertEquals(entity.getRequest().getFreeIpa().getDomain().toUpperCase(), ldapConfigResponse.getDomain().toUpperCase());
             return entity;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/freeipa/FreeIpaListStructuredEventAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/freeipa/FreeIpaListStructuredEventAssertions.java
@@ -66,7 +66,7 @@ public class FreeIpaListStructuredEventAssertions {
     private EventAssertionCommon eventAssertionCommon;
 
     public FreeIpaTestDto checkCreateEvents(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient client) {
-        List<CDPStructuredEvent> auditEvents = client.getFreeIpaClient()
+        List<CDPStructuredEvent> auditEvents = client.getDefaultClient()
                 .structuredEventsV1Endpoint()
                 .getAuditEvents(testDto.getCrn(), Collections.emptyList(), 0, 100);
         eventAssertionCommon.checkFlowEvents(auditEvents, FREEIPA_CREATE_FLOW_STATES);
@@ -75,7 +75,7 @@ public class FreeIpaListStructuredEventAssertions {
     }
 
     public FreeIpaTestDto checkDeleteEvents(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient client) {
-        List<CDPStructuredEvent> auditEvents = client.getFreeIpaClient()
+        List<CDPStructuredEvent> auditEvents = client.getDefaultClient()
                 .structuredEventsV1Endpoint()
                 .getAuditEvents(testDto.getCrn(), Collections.emptyList(), 0, 100);
         eventAssertionCommon.checkFlowEvents(auditEvents, FREEIPA_DELETE_FLOW_STATES);
@@ -84,7 +84,7 @@ public class FreeIpaListStructuredEventAssertions {
     }
 
     public FreeIpaTestDto checkStopEvents(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient client) {
-        List<CDPStructuredEvent> auditEvents = client.getFreeIpaClient()
+        List<CDPStructuredEvent> auditEvents = client.getDefaultClient()
                 .structuredEventsV1Endpoint()
                 .getAuditEvents(testDto.getCrn(), Collections.emptyList(), 0, 100);
         eventAssertionCommon.checkFlowEvents(auditEvents, FREEIPA_STOP_FLOW_STATES);
@@ -93,7 +93,7 @@ public class FreeIpaListStructuredEventAssertions {
     }
 
     public FreeIpaTestDto checkStartEvents(TestContext testContext, FreeIpaTestDto testDto, FreeIpaClient client) {
-        List<CDPStructuredEvent> auditEvents = client.getFreeIpaClient()
+        List<CDPStructuredEvent> auditEvents = client.getDefaultClient()
                 .structuredEventsV1Endpoint()
                 .getAuditEvents(testDto.getCrn(), Collections.emptyList(), 0, 100);
         eventAssertionCommon.checkFlowEvents(auditEvents, FREEIPA_START_FLOW_STATES);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/kerberos/KerberosConfigListStructuredEventAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/kerberos/KerberosConfigListStructuredEventAssertions.java
@@ -20,7 +20,7 @@ public class KerberosConfigListStructuredEventAssertions {
     private EventAssertionCommon eventAssertionCommon;
 
     public KerberosTestDto checkDeleteEvents(TestContext testContext, KerberosTestDto testDto, FreeIpaClient client) {
-        List<CDPStructuredEvent> auditEvents = client.getFreeIpaClient()
+        List<CDPStructuredEvent> auditEvents = client.getDefaultClient()
                 .structuredEventsV1Endpoint()
                 .getAuditEvents(testDto.getCrn(), Collections.emptyList(), 0, 100);
         eventAssertionCommon.checkRestEvents(auditEvents, Collections.singletonList("delete-kerberos"));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/ldap/LdapListStructuredEventAssertions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/ldap/LdapListStructuredEventAssertions.java
@@ -20,7 +20,7 @@ public class LdapListStructuredEventAssertions {
     private EventAssertionCommon eventAssertionCommon;
 
     public LdapTestDto checkCreateEvents(TestContext testContext, LdapTestDto testDto, FreeIpaClient client) {
-        List<CDPStructuredEvent> auditEvents = client.getFreeIpaClient()
+        List<CDPStructuredEvent> auditEvents = client.getDefaultClient()
                 .structuredEventsV1Endpoint()
                 .getAuditEvents(testDto.getCrn(), Collections.emptyList(), 0, 100);
         eventAssertionCommon.checkRestEvents(auditEvents, Collections.singletonList("post-ldap"));
@@ -28,7 +28,7 @@ public class LdapListStructuredEventAssertions {
     }
 
     public LdapTestDto checkDeleteEvents(TestContext testContext, LdapTestDto testDto, FreeIpaClient client) {
-        List<CDPStructuredEvent> auditEvents = client.getFreeIpaClient()
+        List<CDPStructuredEvent> auditEvents = client.getDefaultClient()
                 .structuredEventsV1Endpoint()
                 .getAuditEvents(testDto.getCrn(), Collections.emptyList(), 0, 100);
         eventAssertionCommon.checkRestEvents(auditEvents, Collections.singletonList("delete-ldap"));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/util/CloudProviderSideTagAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/util/CloudProviderSideTagAssertion.java
@@ -49,7 +49,7 @@ public class CloudProviderSideTagAssertion {
         return (testContext, testDto, client) -> {
             String envCrn = testDto.getResponse().getCrn();
             DescribeFreeIpaResponse freeIpaResponse = testContext.getMicroserviceClient(FreeIpaClient.class)
-                    .getFreeIpaClient()
+                    .getDefaultClient()
                     .getFreeIpaV1Endpoint()
                     .describe(envCrn);
 
@@ -69,7 +69,7 @@ public class CloudProviderSideTagAssertion {
         return (testContext, testDto, client) -> {
             String sdxCrn = testDto.getResponse().getCrn();
             SdxClusterDetailResponse sdxClusterDetailResponse = testContext.getMicroserviceClient(SdxClient.class)
-                    .getSdxClient()
+                    .getDefaultClient()
                     .sdxEndpoint()
                     .getDetailByCrn(sdxCrn, Collections.emptySet());
 
@@ -89,7 +89,7 @@ public class CloudProviderSideTagAssertion {
         return (testContext, testDto, client) -> {
             String distroxCrn = testDto.getResponse().getCrn();
             StackV4Response stackV4Response = testContext.getMicroserviceClient(CloudbreakClient.class)
-                    .getCloudbreakClient()
+                    .getDefaultClient()
                     .distroXV1Endpoint()
                     .getByCrn(distroxCrn, Collections.emptySet());
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
@@ -227,7 +227,7 @@ public abstract class AbstractCloudProvider implements CloudProvider {
     public String getLatestBaseImage(ImageCatalogTestDto imageCatalogTestDto, CloudbreakClient cloudbreakClient, String platform) {
         try {
             List<BaseImageV4Response> images = cloudbreakClient
-                    .getCloudbreakClient()
+                    .getDefaultClient()
                     .imageCatalogV4Endpoint()
                     .getImagesByName(cloudbreakClient.getWorkspaceId(), imageCatalogTestDto.getRequest().getName(), null,
                             platform).getBaseImages();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -336,7 +336,7 @@ public class AwsCloudProvider extends AbstractCloudProvider {
         if (awsProperties.getBaseimage().getImageId() == null || awsProperties.getBaseimage().getImageId().isEmpty()) {
             try {
                 List<ImageV4Response> images = cloudbreakClient
-                        .getCloudbreakClient()
+                        .getDefaultClient()
                         .imageCatalogV4Endpoint()
                         .getImagesByName(cloudbreakClient.getWorkspaceId(), imageCatalogTestDto.getRequest().getName(), null,
                                 CloudPlatform.AWS.name()).getCdhImages();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -359,7 +359,7 @@ public class AzureCloudProvider extends AbstractCloudProvider {
         if (azureProperties.getBaseimage().getImageId() == null || azureProperties.getBaseimage().getImageId().isEmpty()) {
             try {
                 List<ImageV4Response> images = cloudbreakClient
-                        .getCloudbreakClient()
+                        .getDefaultClient()
                         .imageCatalogV4Endpoint()
                         .getImagesByName(cloudbreakClient.getWorkspaceId(), imageCatalogTestDto.getRequest().getName(), null,
                                 CloudPlatform.AZURE.name()).getCdhImages();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -320,7 +320,7 @@ public class GcpCloudProvider extends AbstractCloudProvider {
         if (gcpProperties.getBaseimage().getImageId() == null || gcpProperties.getBaseimage().getImageId().isEmpty()) {
             try {
                 List<ImageV4Response> images = cloudbreakClient
-                        .getCloudbreakClient()
+                        .getDefaultClient()
                         .imageCatalogV4Endpoint()
                         .getImagesByName(cloudbreakClient.getWorkspaceId(), imageCatalogTestDto.getRequest().getName(), null,
                                 CloudPlatform.GCP.name()).getCdhImages();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
@@ -206,7 +206,7 @@ public class MockCloudProvider extends AbstractCloudProvider {
         if (mockProperties.getBaseimage().getRedhat7().getImageId() == null || mockProperties.getBaseimage().getRedhat7().getImageId().isEmpty()) {
             try {
                 List<ImageV4Response> images = cloudbreakClient
-                        .getCloudbreakClient()
+                        .getDefaultClient()
                         .imageCatalogV4Endpoint()
                         .getImagesByName(cloudbreakClient.getWorkspaceId(), imageCatalogTestDto.getRequest().getName(), null,
                                 CloudPlatform.MOCK.name()).getCdhImages();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -28,7 +28,6 @@ import org.testng.ITestResult;
 import org.testng.Reporter;
 
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
-import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.it.TestParameter;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
@@ -401,10 +400,6 @@ public abstract class TestContext implements ApplicationContextAware {
                     UmsClient.class, umsClient);
             clients.put(cloudbreakUser.getAccessKey(), clientMap);
             cloudbreakClient.setWorkspaceId(0L);
-            redbeamsClient.setEnvironmentCrn(Crn.builder(CrnResourceDescriptor.ENVIRONMENT)
-                    .setAccountId("it")
-                    .setResource("test-environment")
-                    .build().toString());
         }
         return this;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/clustertemplate/ClusterTemplateTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/clustertemplate/ClusterTemplateTestDto.java
@@ -98,7 +98,7 @@ public class ClusterTemplateTestDto extends DeletableTestDto<ClusterTemplateV4Re
 
     @Override
     public Collection<ClusterTemplateV4Response> getAll(CloudbreakClient client) {
-        return ClusterTemplateUtil.getResponseFromViews(client.getCloudbreakClient().clusterTemplateV4EndPoint().list(client.getWorkspaceId()).getResponses());
+        return ClusterTemplateUtil.getResponseFromViews(client.getDefaultClient().clusterTemplateV4EndPoint().list(client.getWorkspaceId()).getResponses());
     }
 
     @Override
@@ -109,7 +109,7 @@ public class ClusterTemplateTestDto extends DeletableTestDto<ClusterTemplateV4Re
     @Override
     public void delete(TestContext testContext, ClusterTemplateV4Response entity, CloudbreakClient client) {
         try {
-            client.getCloudbreakClient().clusterTemplateV4EndPoint().deleteByName(client.getWorkspaceId(), entity.getName());
+            client.getDefaultClient().clusterTemplateV4EndPoint().deleteByName(client.getWorkspaceId(), entity.getName());
         } catch (Exception e) {
             LOGGER.warn("Something went wrong on {} purge. {}", entity.getName(), ResponseUtil.getErrorMessage(e), e);
         }
@@ -127,7 +127,7 @@ public class ClusterTemplateTestDto extends DeletableTestDto<ClusterTemplateV4Re
 
     public Long count() {
         CloudbreakClient client = getTestContext().getMicroserviceClient(CloudbreakClient.class);
-        return (long) client.getCloudbreakClient()
+        return (long) client.getDefaultClient()
                 .clusterTemplateV4EndPoint()
                 .list(client.getWorkspaceId()).getResponses().size();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/credential/CredentialTestDto.java
@@ -128,7 +128,7 @@ public class CredentialTestDto extends DeletableEnvironmentTestDto<CredentialReq
 
     @Override
     public Collection<CredentialResponse> getAll(EnvironmentClient client) {
-        return client.getEnvironmentClient().credentialV1Endpoint().list().getResponses();
+        return client.getDefaultClient().credentialV1Endpoint().list().getResponses();
     }
 
     @Override
@@ -139,7 +139,7 @@ public class CredentialTestDto extends DeletableEnvironmentTestDto<CredentialReq
     @Override
     public void delete(TestContext testContext, CredentialResponse entity, EnvironmentClient client) {
         try {
-            client.getEnvironmentClient().credentialV1Endpoint().deleteByName(entity.getName());
+            client.getDefaultClient().credentialV1Endpoint().deleteByName(entity.getName());
             LOGGER.info("DELETE :: Credential with name: [{}] has been deleted successfully.", entity.getName());
         } catch (Exception e) {
             LOGGER.warn("DELETE :: Something went wrong during [{}] credential delete: {}", entity.getName(), ResponseUtil.getErrorMessage(e), e);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/RedbeamsDatabaseTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/database/RedbeamsDatabaseTestDto.java
@@ -7,6 +7,7 @@ import com.sequenceiq.it.cloudbreak.Prototype;
 import com.sequenceiq.it.cloudbreak.RedbeamsClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.DeletableRedbeamsTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.search.Searchable;
 import com.sequenceiq.it.cloudbreak.util.ResponseUtil;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.DatabaseV4Endpoint;
@@ -31,7 +32,7 @@ public class RedbeamsDatabaseTestDto extends DeletableRedbeamsTestDto<DatabaseV4
         if (testContext == null) {
             throw new IllegalStateException("Cannot create valid instance, test context is not available");
         }
-        String environmentCrn = testContext.getMicroserviceClient(RedbeamsClient.class).getEnvironmentCrn();
+        String environmentCrn = testContext.given(EnvironmentTestDto.class).getCrn();
         return withName(getResourcePropertyProvider().getName(getCloudPlatform()))
                 .withDescription(getResourcePropertyProvider().getDescription("database"))
                 .withConnectionUserName("user")
@@ -89,8 +90,8 @@ public class RedbeamsDatabaseTestDto extends DeletableRedbeamsTestDto<DatabaseV4
 
     @Override
     public List<DatabaseV4Response> getAll(RedbeamsClient client) {
-        DatabaseV4Endpoint databaseV4Endpoint = client.getEndpoints().databaseV4Endpoint();
-        return databaseV4Endpoint.list(client.getEnvironmentCrn()).getResponses().stream()
+        DatabaseV4Endpoint databaseV4Endpoint = client.getDefaultClient().databaseV4Endpoint();
+        return databaseV4Endpoint.list(getTestContext().given(EnvironmentTestDto.class).getCrn()).getResponses().stream()
                 .filter(s -> s.getName() != null)
                 .collect(Collectors.toList());
     }
@@ -103,7 +104,7 @@ public class RedbeamsDatabaseTestDto extends DeletableRedbeamsTestDto<DatabaseV4
     @Override
     public void delete(TestContext testContext, DatabaseV4Response entity, RedbeamsClient client) {
         try {
-            client.getEndpoints().databaseV4Endpoint().deleteByName(client.getEnvironmentCrn(), entity.getName());
+            client.getDefaultClient().databaseV4Endpoint().deleteByName(testContext.given(EnvironmentTestDto.class).getCrn(), entity.getName());
         } catch (Exception e) {
             LOGGER.warn("Something went wrong on {} purge. {}", entity.getName(), ResponseUtil.getErrorMessage(e), e);
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
@@ -89,7 +89,7 @@ public class DistroXTestDto extends DistroXTestDtoBase<DistroXTestDto> implement
 
     @Override
     public List<StackV4Response> getAll(CloudbreakClient client) {
-        DistroXV1Endpoint distroXV1Endpoint = client.getCloudbreakClient().distroXV1Endpoint();
+        DistroXV1Endpoint distroXV1Endpoint = client.getDefaultClient().distroXV1Endpoint();
         return distroXV1Endpoint.list(null, null).getResponses().stream()
                 .filter(s -> s.getName() != null)
                 .map(s -> {
@@ -107,7 +107,7 @@ public class DistroXTestDto extends DistroXTestDtoBase<DistroXTestDto> implement
     @Override
     public void delete(TestContext testContext, StackV4Response entity, CloudbreakClient client) {
         try {
-            client.getCloudbreakClient().distroXV1Endpoint().deleteByName(entity.getName(), true);
+            client.getDefaultClient().distroXV1Endpoint().deleteByName(entity.getName(), true);
             testContext.await(this, STACK_DELETED, key("wait-purge-distrox-" + entity.getName()));
         } catch (Exception e) {
             LOGGER.warn("Something went wrong on {} purge. {}", entity.getName(), ResponseUtil.getErrorMessage(e), e);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/environment/EnvironmentTestDto.java
@@ -281,7 +281,7 @@ public class EnvironmentTestDto
 
     @Override
     public List<SimpleEnvironmentResponse> getAll(EnvironmentClient client) {
-        EnvironmentEndpoint environmentEndpoint = client.getEnvironmentClient().environmentV1Endpoint();
+        EnvironmentEndpoint environmentEndpoint = client.getDefaultClient().environmentV1Endpoint();
         return new ArrayList<>(environmentEndpoint.list().getResponses()).stream()
                 .filter(s -> s.getName() != null)
                 .map(s -> {
@@ -316,7 +316,7 @@ public class EnvironmentTestDto
     @Override
     public void delete(TestContext testContext, SimpleEnvironmentResponse entity, EnvironmentClient client) {
         LOGGER.info("Delete resource with name: {}", entity.getName());
-        EnvironmentEndpoint credentialEndpoint = client.getEnvironmentClient().environmentV1Endpoint();
+        EnvironmentEndpoint credentialEndpoint = client.getDefaultClient().environmentV1Endpoint();
         credentialEndpoint.deleteByName(entity.getName(), true, false);
         setName(entity.getName());
         testContext.await(this, Map.of("status", ARCHIVED));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -299,7 +299,7 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
 
     @Override
     public Collection<ListFreeIpaResponse> getAll(FreeIpaClient client) {
-        return client.getFreeIpaClient().getFreeIpaV1Endpoint().list();
+        return client.getDefaultClient().getFreeIpaV1Endpoint().list();
     }
 
     @Override
@@ -309,7 +309,7 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
 
     @Override
     public void delete(TestContext testContext, ListFreeIpaResponse entity, FreeIpaClient client) {
-        client.getFreeIpaClient().getFreeIpaV1Endpoint().delete(entity.getEnvironmentCrn(), false);
+        client.getDefaultClient().getFreeIpaV1Endpoint().delete(entity.getEnvironmentCrn(), false);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/imagecatalog/ImageCatalogTestDto.java
@@ -99,7 +99,7 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
 
     @Override
     public Collection<ImageCatalogV4Response> getAll(CloudbreakClient client) {
-        return client.getCloudbreakClient().imageCatalogV4Endpoint().list(client.getWorkspaceId()).getResponses();
+        return client.getDefaultClient().imageCatalogV4Endpoint().list(client.getWorkspaceId()).getResponses();
     }
 
     @Override
@@ -110,7 +110,7 @@ public class ImageCatalogTestDto extends AbstractCloudbreakTestDto<ImageCatalogV
     @Override
     public void delete(TestContext testContext, ImageCatalogV4Response entity, CloudbreakClient client) {
         try {
-            client.getCloudbreakClient().imageCatalogV4Endpoint().deleteByName(client.getWorkspaceId(), entity.getName());
+            client.getDefaultClient().imageCatalogV4Endpoint().deleteByName(client.getWorkspaceId(), entity.getName());
         } catch (Exception e) {
             LOGGER.warn("Something went wrong on {} purge. {}", entity.getName(), ResponseUtil.getErrorMessage(e), e);
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/recipe/RecipeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/recipe/RecipeTestDto.java
@@ -87,7 +87,7 @@ public class RecipeTestDto extends DeletableTestDto<RecipeV4Request, RecipeV4Res
 
     @Override
     public List<RecipeViewV4Response> getAll(CloudbreakClient client) {
-        RecipeV4Endpoint recipeV4Endpoint = client.getCloudbreakClient().recipeV4Endpoint();
+        RecipeV4Endpoint recipeV4Endpoint = client.getDefaultClient().recipeV4Endpoint();
         return recipeV4Endpoint.list(client.getWorkspaceId()).getResponses().stream()
                 .filter(s -> s.getName() != null)
                 .collect(Collectors.toList());
@@ -101,7 +101,7 @@ public class RecipeTestDto extends DeletableTestDto<RecipeV4Request, RecipeV4Res
     @Override
     public void delete(TestContext testContext, RecipeViewV4Response entity, CloudbreakClient client) {
         try {
-            client.getCloudbreakClient().recipeV4Endpoint().deleteByName(client.getWorkspaceId(), entity.getName());
+            client.getDefaultClient().recipeV4Endpoint().deleteByName(client.getWorkspaceId(), entity.getName());
         } catch (Exception e) {
             LOGGER.warn("Something went wrong on {} purge. {}", entity.getName(), ResponseUtil.getErrorMessage(e), e);
         }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -340,7 +340,7 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
 
     @Override
     public List<SdxClusterResponse> getAll(SdxClient client) {
-        SdxEndpoint sdxEndpoint = client.getSdxClient().sdxEndpoint();
+        SdxEndpoint sdxEndpoint = client.getDefaultClient().sdxEndpoint();
         return sdxEndpoint.list(null).stream()
                 .filter(s -> s.getName() != null)
                 .map(s -> {
@@ -359,7 +359,7 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
     public void delete(TestContext testContext, SdxClusterResponse entity, SdxClient client) {
         String sdxName = entity.getName();
         try {
-            client.getSdxClient().sdxEndpoint().delete(getName(), false);
+            client.getDefaultClient().sdxEndpoint().delete(getName(), false);
             testContext.await(this, Map.of("status", DELETED), key("wait-purge-sdx-" + getName()));
         } catch (Exception e) {
             LOGGER.warn("Something went wrong on {} purge. {}", sdxName, ResponseUtil.getErrorMessage(e), e);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -91,7 +91,7 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
 
     @Override
     public List<SdxClusterResponse> getAll(SdxClient client) {
-        SdxEndpoint sdxEndpoint = client.getSdxClient().sdxEndpoint();
+        SdxEndpoint sdxEndpoint = client.getDefaultClient().sdxEndpoint();
         return sdxEndpoint.list(null).stream()
                 .filter(s -> s.getName() != null)
                 .map(s -> {
@@ -110,7 +110,7 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
     public void delete(TestContext testContext, SdxClusterResponse entity, SdxClient client) {
         String sdxName = entity.getName();
         try {
-            client.getSdxClient().sdxEndpoint().delete(sdxName, true);
+            client.getDefaultClient().sdxEndpoint().delete(sdxName, true);
             testContext.await(this, Map.of("status", DELETED), key("wait-purge-sdx-" + entity.getName()));
         } catch (Exception e) {
             LOGGER.warn("Something went wrong on SDX {} purge. {}", sdxName, ResponseUtil.getErrorMessage(e), e);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/stack/StackTestDto.java
@@ -84,7 +84,7 @@ public class StackTestDto extends StackTestDtoBase<StackTestDto> implements Purg
 
     @Override
     public List<StackV4Response> getAll(CloudbreakClient client) {
-        StackV4Endpoint stackEndpoint = client.getCloudbreakClient().stackV4Endpoint();
+        StackV4Endpoint stackEndpoint = client.getDefaultClient().stackV4Endpoint();
         return stackEndpoint.list(client.getWorkspaceId(), null, false).getResponses().stream()
                 .filter(s -> s.getName() != null)
                 .map(s -> {
@@ -102,7 +102,7 @@ public class StackTestDto extends StackTestDtoBase<StackTestDto> implements Purg
     @Override
     public void delete(TestContext testContext, StackV4Response entity, CloudbreakClient client) {
         try {
-            client.getCloudbreakClient().stackV4Endpoint().delete(client.getWorkspaceId(), entity.getName(), true,
+            client.getDefaultClient().stackV4Endpoint().delete(client.getWorkspaceId(), entity.getName(), true,
                     Crn.fromString(entity.getCrn()).getAccountId());
             testContext.await(this, STACK_DELETED, key("wait-purge-stack-" + entity.getName()));
         } catch (Exception e) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
@@ -210,7 +210,7 @@ public class AwsYcloudHybridCloudTest extends AbstractE2ETest {
                 .awaitForInstance(INSTANCES_HEALTHY)
                 .then((tc, dto, client) -> {
                     String environmentCrn = dto.getResponse().getEnvironmentCrn();
-                    com.sequenceiq.freeipa.api.client.FreeIpaClient freeIpaClient = tc.getMicroserviceClient(FreeIpaClient.class).getFreeIpaClient();
+                    com.sequenceiq.freeipa.api.client.FreeIpaClient freeIpaClient = tc.getMicroserviceClient(FreeIpaClient.class).getDefaultClient();
                     checkUserSyncState(environmentCrn, freeIpaClient);
 
                     String username = testContext.getActingUserCrn().getResource();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -371,7 +371,7 @@ public class ClusterTemplateTest extends AbstractMockTest {
     }
 
     private ClusterTemplateTestDto clusterTemplateHasDeletedAlongTheEnvironment(ClusterTemplateTestDto entity, CloudbreakClient client, String templateName) {
-        client.getCloudbreakClient()
+        client.getDefaultClient()
                 .clusterTemplateV4EndPoint()
                 .listByEnv(client.getWorkspaceId(), entity.getResponse().getEnvironmentCrn())
                 .getResponses()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentClusterTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/EnvironmentClusterTest.java
@@ -18,9 +18,7 @@ import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
-import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
@@ -76,24 +74,6 @@ public class EnvironmentClusterTest extends AbstractMockTest {
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
     @Description(
-            given = "there is an environment and a database which in not attached to the environment",
-            when = "a cluster is created in the environment and with the non-attached database",
-            then = "the cluster create should succeed")
-    public void testClusterWithRdsWithoutEnvironment(MockedTestContext testContext) {
-        createDefaultRdsConfig(testContext);
-        testContext
-                .given(EnvironmentTestDto.class)
-                .when(environmentTestClient.create())
-                .given(StackTestDto.class)
-                .withEnvironmentClass(EnvironmentTestDto.class)
-                .withCluster(setResources(testContext, testContext.get(RedbeamsDatabaseTestDto.class).getName(),
-                        null, null))
-                .when(stackTestClient.createV4())
-                .validate();
-    }
-
-    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
-    @Description(
             given = "there is an environment with a cluster in it",
             when = "a change credential request is sent for the environment",
             then = "the credential of the cluster should be changed too")
@@ -144,15 +124,6 @@ public class EnvironmentClusterTest extends AbstractMockTest {
                 .when(stackTestClient.getV4())
                 .then(EnvironmentClusterTest::checkNewCredentialInStack)
                 .validate();
-    }
-
-    private ClusterTestDto setResources(MockedTestContext testContext, String rdsName, String ldapName, String proxyName) {
-        ClusterTestDto cluster = testContext.given(ClusterTestDto.class)
-                .valid();
-        if (rdsName != null) {
-            cluster.withProxyConfigName(proxyName);
-        }
-        return cluster;
     }
 
     private static StackTestDto checkNewCredentialInStack(TestContext testContext, StackTestDto stack, CloudbreakClient client) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ImageCatalogTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ImageCatalogTest.java
@@ -315,7 +315,7 @@ public class ImageCatalogTest extends AbstractMockTest {
                 .select(ImageCatalogTestDto::getRequest, key(imgCatalogName))
                 .when((testContext1, entity, cloudbreakClient) -> {
                     ImageCatalogV4Request request = cloudbreakClient
-                            .getCloudbreakClient()
+                            .getDefaultClient()
                             .imageCatalogV4Endpoint()
                             .getRequest(cloudbreakClient.getWorkspaceId(), imgCatalogName);
                     entity.setRequest(request);
@@ -353,7 +353,7 @@ public class ImageCatalogTest extends AbstractMockTest {
                     updateRequest.setUrl(IMG_CATALOG_URL);
 
                     ImageCatalogV4Response updateResponse = cloudbreakClient
-                            .getCloudbreakClient()
+                            .getDefaultClient()
                             .imageCatalogV4Endpoint()
                             .update(cloudbreakClient.getWorkspaceId(), updateRequest);
                     entity.setResponse(updateResponse);
@@ -382,7 +382,7 @@ public class ImageCatalogTest extends AbstractMockTest {
                 .withName(CB_DEFAULT_IMG_CATALOG_NAME)
                 .when((testContext1, entity, cloudbreakClient) -> {
                     ImageCatalogV4Responses list = cloudbreakClient
-                            .getCloudbreakClient()
+                            .getDefaultClient()
                             .imageCatalogV4Endpoint()
                             .list(cloudbreakClient.getWorkspaceId());
                     return entity;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/AuditUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/AuditUtil.java
@@ -16,7 +16,7 @@ public class AuditUtil {
     }
 
     public static AuditEventV4Responses getAuditEvents(CloudbreakClient cloudbreakClient, String resourceType, Long id, String crn) {
-        AuditEventV4Endpoint endpoint = cloudbreakClient.getCloudbreakClient().auditV4Endpoint();
+        AuditEventV4Endpoint endpoint = cloudbreakClient.getDefaultClient().auditV4Endpoint();
         return endpoint.getAuditEvents(0L, resourceType, id, crn);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ClouderaManagerUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ClouderaManagerUtil.java
@@ -38,7 +38,7 @@ public class ClouderaManagerUtil {
     private static ClouderaManagerStackDescriptorV4Response getCMDescriptor(TestContext testContext) throws Exception {
         StackMatrixV4Response stackMatrix = testContext
                 .getMicroserviceClient(CloudbreakClient.class)
-                .getCloudbreakClient()
+                .getDefaultClient()
                 .utilV4Endpoint().getStackMatrix(null, null);
         return stackMatrix.getCdh().get(CDH_VERSION);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/DistroxUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/DistroxUtil.java
@@ -12,7 +12,7 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 @Component
 public class DistroxUtil {
     public List<String> getInstanceIds(DistroXTestDto testDto, CloudbreakClient cloudbreakClient, String hostGroupName) {
-        List<InstanceGroupV4Response> instanceGroups = cloudbreakClient.getCloudbreakClient().distroXV1Endpoint()
+        List<InstanceGroupV4Response> instanceGroups = cloudbreakClient.getDefaultClient().distroXV1Endpoint()
                 .getByName(testDto.getName(), new HashSet<>()).getInstanceGroups();
         return InstanceUtil.getInstanceIds(instanceGroups, hostGroupName);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxUtil.java
@@ -13,7 +13,7 @@ import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
 public class SdxUtil {
 
     public List<String> getInstanceIds(AbstractSdxTestDto testDto, SdxClient sdxClient, String hostGroupName) {
-        List<InstanceGroupV4Response> instanceGroups = sdxClient.getSdxClient().sdxEndpoint().getDetail(testDto.getName(), new HashSet<>())
+        List<InstanceGroupV4Response> instanceGroups = sdxClient.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), new HashSet<>())
                 .getStackV4Response().getInstanceGroups();
         return InstanceUtil.getInstanceIds(instanceGroups, hostGroupName);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshEnaDriverCheckActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshEnaDriverCheckActions.java
@@ -58,7 +58,7 @@ public class SshEnaDriverCheckActions extends SshJClient {
     }
 
     private InstanceMetaDataV4Response getInstanceMetadata(String name, CloudbreakClient cloudbreakClient, String group) {
-        InstanceMetaDataV4Response instanceMetaDataResponse = cloudbreakClient.getCloudbreakClient().distroXV1Endpoint()
+        InstanceMetaDataV4Response instanceMetaDataResponse = cloudbreakClient.getDefaultClient().distroXV1Endpoint()
                 .getByName(name, Collections.emptySet())
                 .getInstanceGroups()
                 .stream()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshJClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshJClientActions.java
@@ -36,7 +36,7 @@ public class SshJClientActions extends SshJClient {
         List<String> instanceIPs = new ArrayList<>();
 
         hostGroupNames.forEach(hostGroupName -> {
-            InstanceMetaDataV4Response instanceMetaDataV4Response = Objects.requireNonNull(sdxClient.getSdxClient().sdxEndpoint().getDetail(sdxName,
+            InstanceMetaDataV4Response instanceMetaDataV4Response = Objects.requireNonNull(sdxClient.getDefaultClient().sdxEndpoint().getDetail(sdxName,
                     new HashSet<>()).getStackV4Response().getInstanceGroups().stream().filter(instanceGroup -> instanceGroup.getName().equals(hostGroupName))
                     .findFirst().orElse(null)).getMetadata().stream().findFirst().orElse(null);
             assert instanceMetaDataV4Response != null;
@@ -52,7 +52,7 @@ public class SshJClientActions extends SshJClient {
     private List<String> getFreeIpaInstanceGroupIps(String environmentCrn, FreeIpaClient freeipaClient, boolean publicIp) {
         List<String> instanceIPs = new ArrayList<>();
 
-        freeipaClient.getFreeIpaClient().getFreeIpaV1Endpoint()
+        freeipaClient.getDefaultClient().getFreeIpaV1Endpoint()
                 .describe(environmentCrn).getInstanceGroups().stream()
                 .forEach(ig -> {
                     InstanceMetaDataResponse instanceMetaDataResponse = ig.getMetaData().stream().findFirst().orElse(null);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakWaitObject.java
@@ -52,11 +52,11 @@ public class CloudbreakWaitObject implements WaitObject {
     }
 
     public DistroXV1Endpoint getDistroxEndpoint() {
-        return client.getCloudbreakClient().distroXV1Endpoint();
+        return client.getDefaultClient().distroXV1Endpoint();
     }
 
     public StackV4Endpoint getStackEndpoint() {
-        return client.getCloudbreakClient().stackV4Endpoint();
+        return client.getDefaultClient().stackV4Endpoint();
     }
 
     public Long getWorkspaceId() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeWaitObject.java
@@ -38,7 +38,7 @@ public class DatalakeWaitObject implements WaitObject {
     }
 
     public SdxEndpoint getEndpoint() {
-        return client.getSdxClient().sdxEndpoint();
+        return client.getDefaultClient().sdxEndpoint();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentWaitObject.java
@@ -32,7 +32,7 @@ public class EnvironmentWaitObject implements WaitObject {
     }
 
     public EnvironmentEndpoint getEndpoint() {
-        return client.getEnvironmentClient().environmentV1Endpoint();
+        return client.getDefaultClient().environmentV1Endpoint();
     }
 
     public String getCrn() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaOperationWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaOperationWaitObject.java
@@ -26,7 +26,7 @@ public class FreeIpaOperationWaitObject extends FreeIpaWaitObject {
     public void fetchData() {
         super.fetchData();
         if (operationId != null) {
-            operationStatus = getClient().getFreeIpaClient().getOperationV1Endpoint().getOperationStatus(operationId);
+            operationStatus = getClient().getDefaultClient().getOperationV1Endpoint().getOperationStatus(operationId);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaUserSyncWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaUserSyncWaitObject.java
@@ -22,7 +22,7 @@ public class FreeIpaUserSyncWaitObject extends FreeIpaWaitObject {
     @Override
     public void fetchData() {
         super.fetchData();
-        environmentUserSyncState = getClient().getFreeIpaClient().getUserV1Endpoint().getUserSyncState(getEnvironmentCrn());
+        environmentUserSyncState = getClient().getDefaultClient().getUserV1Endpoint().getUserSyncState(getEnvironmentCrn());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java
@@ -32,7 +32,7 @@ public class FreeIpaWaitObject implements WaitObject {
     }
 
     public FreeIpaV1Endpoint getEndpoint() {
-        return client.getFreeIpaClient().getFreeIpaV1Endpoint();
+        return client.getDefaultClient().getFreeIpaV1Endpoint();
     }
 
     protected FreeIpaClient getClient() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceWaitObject.java
@@ -51,10 +51,10 @@ public class InstanceWaitObject implements WaitObject {
     public void fetchData() {
         try {
             instanceGroups = testContext.getMicroserviceClient(CloudbreakClient.class)
-                    .getCloudbreakClient().distroXV1Endpoint().getByName(name, Set.of()).getInstanceGroups();
+                    .getDefaultClient().distroXV1Endpoint().getByName(name, Set.of()).getInstanceGroups();
         } catch (NotFoundException e) {
             LOGGER.info("SDX '{}' instance groups are present for validation.", getName());
-            instanceGroups = testContext.getSdxClient().getSdxClient().sdxEndpoint().getDetail(name, Set.of()).getStackV4Response().getInstanceGroups();
+            instanceGroups = testContext.getSdxClient().getDefaultClient().sdxEndpoint().getDetail(name, Set.of()).getStackV4Response().getInstanceGroups();
         } catch (Exception e) {
             LOGGER.error("Instance groups cannot be determined, because of: {}", e.getMessage(), e);
             throw new TestFailException("Instance groups cannot be determined", e);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/redbeams/RedbeamsWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/redbeams/RedbeamsWaitObject.java
@@ -37,7 +37,7 @@ public class RedbeamsWaitObject implements WaitObject {
     }
 
     public DatabaseServerV4Endpoint getEndpoint() {
-        return client.getEndpoints().databaseServerV4Endpoint();
+        return client.getDefaultClient().databaseServerV4Endpoint();
     }
 
     public String getCrn() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v4/BlueprintV4Action.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v4/BlueprintV4Action.java
@@ -28,7 +28,7 @@ public class BlueprintV4Action {
                 .concat(blueprintEntity.getName())
                 .concat(" private blueprint. "));
         blueprintEntity.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .blueprintV4Endpoint()
                         .post(workspaceId, blueprintEntity.getRequest()));
 
@@ -45,7 +45,7 @@ public class BlueprintV4Action {
                 .concat(blueprintEntity.getName())
                 .concat(" private blueprint by Name. "));
         blueprintEntity.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .blueprintV4Endpoint().getByName(workspaceId, blueprintEntity.getName()));
         Log.whenJson(" getByName "
                 .concat(blueprintEntity.getName())
@@ -60,10 +60,10 @@ public class BlueprintV4Action {
                 CloudbreakClient.class);
         Long workspaceId = integrationTestContext.getContextParam(CloudbreakTest.WORKSPACE_ID, Long.class);
         Log.log(" getByName all private blueprints. ");
-        Collection<BlueprintV4ViewResponse> blueprints = client.getCloudbreakClient().blueprintV4Endpoint()
+        Collection<BlueprintV4ViewResponse> blueprints = client.getDefaultClient().blueprintV4Endpoint()
                 .list(workspaceId, true).getResponses();
         Set<BlueprintV4Response> detailedBlueprints = blueprints.stream()
-                .map(bp -> client.getCloudbreakClient().blueprintV4Endpoint()
+                .map(bp -> client.getDefaultClient().blueprintV4Endpoint()
                         .getByName(workspaceId, bp.getName())).collect(Collectors.toSet());
         blueprintEntity.setResponses(detailedBlueprints);
     }
@@ -77,7 +77,7 @@ public class BlueprintV4Action {
         Log.log(" deleteByName "
                 .concat(blueprintEntity.getName())
                 .concat(" private blueprint with Name. "));
-        client.getCloudbreakClient().blueprintV4Endpoint().deleteByName(workspaceId, blueprintEntity.getName());
+        client.getDefaultClient().blueprintV4Endpoint().deleteByName(workspaceId, blueprintEntity.getName());
     }
 
     public static void createInGiven(IntegrationTestContext integrationTestContext, Entity entity) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v4/ClusterTemplateV4Action.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/v4/ClusterTemplateV4Action.java
@@ -23,7 +23,7 @@ public class ClusterTemplateV4Action {
         Long workspaceId = integrationTestContext.getContextParam(CloudbreakTest.WORKSPACE_ID, Long.class);
         Log.log(String.format(" post %s cluster template. ", clusterTemplateV4Entity.getName()));
         clusterTemplateV4Entity.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .clusterTemplateV4EndPoint()
                         .post(workspaceId, clusterTemplateV4Entity.getRequest()));
 
@@ -38,7 +38,7 @@ public class ClusterTemplateV4Action {
         Long workspaceId = integrationTestContext.getContextParam(CloudbreakTest.WORKSPACE_ID, Long.class);
         Log.log(String.format(" get %s cluster template by Name. ", clusterTemplateV4Entity.getName()));
         clusterTemplateV4Entity.setResponse(
-                client.getCloudbreakClient()
+                client.getDefaultClient()
                         .clusterTemplateV4EndPoint()
                         .getByName(workspaceId, clusterTemplateV4Entity.getName()));
         Log.whenJson(String.format(" get %s cluster template response: ", clusterTemplateV4Entity.getName()),
@@ -53,7 +53,7 @@ public class ClusterTemplateV4Action {
         Long workspaceId = integrationTestContext.getContextParam(CloudbreakTest.WORKSPACE_ID, Long.class);
         Log.log(" get all cluster templates. ");
         clusterTemplateV4Entity.setResponses(
-                ClusterTemplateUtil.getResponseFromViews(client.getCloudbreakClient()
+                ClusterTemplateUtil.getResponseFromViews(client.getDefaultClient()
                         .clusterTemplateV4EndPoint()
                         .list(workspaceId).getResponses()));
     }
@@ -66,7 +66,7 @@ public class ClusterTemplateV4Action {
         Long workspaceId = integrationTestContext.getContextParam(CloudbreakTest.WORKSPACE_ID, Long.class);
         Log.log(String.format(" delete %s cluster template with Name. ", clusterTemplateV4Entity.getName()));
 
-        client.getCloudbreakClient().clusterTemplateV4EndPoint().deleteByName(workspaceId, clusterTemplateV4Entity.getName());
+        client.getDefaultClient().clusterTemplateV4EndPoint().deleteByName(workspaceId, clusterTemplateV4Entity.getName());
     }
 
     public static void createInGiven(IntegrationTestContext integrationTestContext, Entity entity) {


### PR DESCRIPTION
- prevent internal client usage for e2e tests
- cleanup integration test clients
- generalize integration test client usage
- remove unnecessary codes from affected classes