### PR TITLE
CB-11675 - Added Knox's own KNOXTOKEN service and the new tokengen application into the cdp-proxy topology

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -811,4 +811,32 @@
         {%- endif %}
     {%- endif %}
 
+    <service>
+      <role>KNOXTOKEN</role>
+      <param>
+         <name>knox.token.ttl</name>
+         <value>31540000000</value> <!-- 1 year -->
+      </param>
+      <param>
+         <name>knox.token.exp.server-managed</name>
+         <value>true</value>
+      </param>
+      <param>
+         <name>knox.token.audiences</name>
+         <value>cdp-proxy-token</value>
+      </param>
+      <param>
+         <name>knox.token.target.url</name>
+         <value>cdp-proxy-token</value>
+      </param>
+      <param>
+         <name>knox.token.client.data</name>
+         <value>homepage_url=homepage/home/</value>
+      </param>
+    </service>
+
+    <application>
+      <name>tokengen</name>
+    </application>
+
 </topology>


### PR DESCRIPTION
Two new artifacts have to be added in cdp-proxy topology:
- Knox's own KNOXTOKEN service (it's proprietary to Knox, not like a regular service such Hive, YARN, ATLAS,...) with a custom configuration that is not meant to be changed from the UI
- A new Knox application called `tokengen`. It's 100% guaranteed that all versions after CDH 7.2.9 will have it