### PR TITLE
CB-11691 change the Datanode address and https address to a secure po…

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/KerberosConfig.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/KerberosConfig.java
@@ -31,6 +31,10 @@ public class KerberosConfig {
 
     private String nameServers;
 
+    private int datanodeSecurePort;
+
+    private int datanodeSecureHttpsPort;
+
     public KerberosType getType() {
         return type;
     }
@@ -87,6 +91,14 @@ public class KerberosConfig {
         return nameServers;
     }
 
+    public int getDatanodeSecurePort() {
+        return datanodeSecurePort;
+    }
+
+    public int getDatanodeSecureHttpsPort() {
+        return datanodeSecureHttpsPort;
+    }
+
     public static final class KerberosConfigBuilder {
         private KerberosType type;
 
@@ -115,6 +127,10 @@ public class KerberosConfig {
         private String domain;
 
         private String nameServers;
+
+        private int datanodeSecurePort;
+
+        private int datanodeSecureHttpsPort;
 
         private KerberosConfigBuilder() {
         }
@@ -193,6 +209,16 @@ public class KerberosConfig {
             return this;
         }
 
+        public KerberosConfigBuilder withDatanodeSecurePort(int datanodeSecurePort) {
+            this.datanodeSecurePort = datanodeSecurePort;
+            return this;
+        }
+
+        public KerberosConfigBuilder withDatanodeSecureHttpsPort(int datanodeSecureHttpsPort) {
+            this.datanodeSecureHttpsPort = datanodeSecureHttpsPort;
+            return this;
+        }
+
         public KerberosConfig build() {
             KerberosConfig kerberosConfig = new KerberosConfig();
             kerberosConfig.type = type;
@@ -209,6 +235,8 @@ public class KerberosConfig {
             kerberosConfig.verifyKdcTrust = verifyKdcTrust;
             kerberosConfig.domain = domain;
             kerberosConfig.nameServers = nameServers;
+            kerberosConfig.datanodeSecurePort = datanodeSecurePort;
+            kerberosConfig.datanodeSecureHttpsPort = datanodeSecureHttpsPort;
             return kerberosConfig;
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/kerberos/KerberosConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/kerberos/KerberosConfigService.java
@@ -8,6 +8,7 @@ import javax.ws.rs.WebApplicationException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.vault.VaultException;
 
@@ -24,6 +25,12 @@ import com.sequenceiq.freeipa.api.v1.kerberos.model.describe.DescribeKerberosCon
 @Service
 public class KerberosConfigService {
     private static final Logger LOGGER = LoggerFactory.getLogger(KerberosConfigService.class);
+
+    @Value("${cb.cm.datanode.secure.port:9866}")
+    private int secureDatanodePort;
+
+    @Value("${cb.cm.datanode.secure.https.port:9865}")
+    private int secureDatanodeHttpsPort;
 
     @Inject
     private KerberosConfigV1Endpoint kerberosConfigV1Endpoint;
@@ -77,6 +84,8 @@ public class KerberosConfigService {
                 .withType(KerberosType.valueOf(describeLdapConfigResponse.getType().name()))
                 .withUrl(describeLdapConfigResponse.getUrl())
                 .withVerifyKdcTrust(describeLdapConfigResponse.getVerifyKdcTrust())
+                .withDatanodeSecurePort(secureDatanodePort)
+                .withDatanodeSecureHttpsPort(secureDatanodeHttpsPort)
                 .build();
     }
 


### PR DESCRIPTION
…rt >=1024

By default when Kerberos is enabled the following ports are set by CM:
DataNode Transceiver Port              dfs.datanode.address         1004
Secure DataNode Web UI Port (TLS/SSL)  dfs.datanode.https.address   9865

In this case CM will show a warning that HDFS has invalid configurations:
Secure DataNode configuration is invalid. There are two recommended configurations:
(1) DataNode Transceiver Port and Secure DataNode Web UI Port (TLS/SSL) both >= 1024,
DataNode Data Transfer Protection set, Hadoop TLS/SSL enabled;
(2) DataNode Transceiver Port and DataNode HTTP Web UI Port both < 1024,
DataNode Data Transfer Protection not set, Hadoop TLS/SSL disabled.

To fix this warning we can se these 2 parameters in the instantiator section for Kerberos.
This config is valid with all the runtime version we have. Tested from 7.1.0+.

See detailed description in the commit message.