### PR TITLE
CB-11457 validate the resource CRNs on Credential and Environment related platform resources endpoints

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/CredentialPlatformResourceController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/CredentialPlatformResourceController.java
@@ -23,6 +23,8 @@ import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.authorization.service.CommonPermissionCheckingUtils;
 import com.sequenceiq.authorization.service.CustomCheckUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.CrnParseException;
 import com.sequenceiq.cloudbreak.cloud.PlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.model.CloudAccessConfigs;
 import com.sequenceiq.cloudbreak.cloud.model.CloudEncryptionKeys;
@@ -396,6 +398,7 @@ public class CredentialPlatformResourceController implements CredentialPlatformR
             commonPermissionCheckingUtils.checkPermissionForUserOnResource(AuthorizationResourceAction.DESCRIBE_CREDENTIAL,
                     ThreadBasedUserCrnProvider.getUserCrn(), platformParameterService.getCredentialCrnByName(credentialName));
         } else if (!Strings.isNullOrEmpty(credentialCrn)) {
+            validateCredentialCrnPattern(credentialCrn);
             commonPermissionCheckingUtils.checkPermissionForUserOnResource(AuthorizationResourceAction.DESCRIBE_CREDENTIAL,
                     ThreadBasedUserCrnProvider.getUserCrn(), credentialCrn);
         } else {
@@ -403,4 +406,11 @@ public class CredentialPlatformResourceController implements CredentialPlatformR
         }
     }
 
+    private void validateCredentialCrnPattern(String credentialCrn) {
+        try {
+            Crn.safeFromString(credentialCrn);
+        } catch (CrnParseException e) {
+            throw new BadRequestException(String.format("The 'credentialCrn' field value is not a valid CRN: '%s'", e));
+        }
+    }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/EnvironmentPlatformResourceController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/EnvironmentPlatformResourceController.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
+import javax.ws.rs.BadRequestException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +18,8 @@ import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.CrnParseException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudAccessConfigs;
 import com.sequenceiq.cloudbreak.cloud.model.CloudEncryptionKeys;
 import com.sequenceiq.cloudbreak.cloud.model.CloudGateWays;
@@ -68,6 +71,7 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
             String availabilityZone,
             CdpResourceType cdpResourceType) {
         String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
         PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
                 accountId,
                 environmentCrn,
@@ -93,6 +97,7 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
             String availabilityZone,
             boolean availabilityZonesNeeded) {
         String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
         PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
                 accountId,
                 environmentCrn,
@@ -116,6 +121,7 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
             String availabilityZone,
             String sharedProjectId) {
         String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
         PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
                 accountId,
                 environmentCrn,
@@ -139,6 +145,7 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
             String platformVariant,
             String availabilityZone) {
         String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
         PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
                 accountId,
                 environmentCrn,
@@ -161,6 +168,7 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
             String platformVariant,
             String availabilityZone) {
         String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
         PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
                 accountId,
                 environmentCrn,
@@ -184,6 +192,7 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
             String platformVariant,
             String availabilityZone) {
         String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
         PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
                 accountId,
                 environmentCrn,
@@ -207,6 +216,7 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
             String availabilityZone,
             String sharedProjectId) {
         String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
         PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
                 accountId,
                 environmentCrn,
@@ -229,6 +239,7 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
             String platformVariant,
             String availabilityZone) {
         String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
         PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
                 accountId,
                 environmentCrn,
@@ -252,6 +263,7 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
             String availabilityZone,
             AccessConfigTypeQueryParam accessConfigType) {
         String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
         PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
                 accountId,
                 environmentCrn,
@@ -275,6 +287,7 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
             String platformVariant,
             String availabilityZone) {
         String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
         PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
                 accountId,
                 environmentCrn,
@@ -297,6 +310,7 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
             String platformVariant,
             String availabilityZone) {
         String accountId = getAccountId();
+        validateEnvironmentCrnPattern(environmentCrn);
         PlatformResourceRequest request = platformParameterService.getPlatformResourceRequestByEnvironment(
                 accountId,
                 environmentCrn,
@@ -316,5 +330,13 @@ public class EnvironmentPlatformResourceController implements EnvironmentPlatfor
 
     private String getAccountId() {
         return ThreadBasedUserCrnProvider.getAccountId();
+    }
+
+    private void validateEnvironmentCrnPattern(String environmentCrn) {
+        try {
+            Crn.safeFromString(environmentCrn);
+        } catch (CrnParseException e) {
+            throw new BadRequestException(String.format("The 'environmentCrn' field value is not a valid CRN: '%s'", e));
+        }
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/platformresource/v1/CredentialPlatformResourceControllerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/platformresource/v1/CredentialPlatformResourceControllerTest.java
@@ -6,6 +6,9 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import javax.ws.rs.BadRequestException;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,6 +27,8 @@ import com.sequenceiq.environment.platformresource.PlatformResourceRequest;
 class CredentialPlatformResourceControllerTest {
 
     private static final String USER_CRN = "crn:cdp:iam:us-west-1:123:user:123";
+
+    private static final String CREDENTIAL_CRN = "crn:cdp:environments:us-west-1:123:credential:123";
 
     @Mock
     private ConversionService convertersionService;
@@ -48,11 +53,18 @@ class CredentialPlatformResourceControllerTest {
         doNothing().when(commonPermissionCheckingUtils).checkPermissionForUserOnResource(any(), any(), any());
 
         PlatformNoSqlTablesResponse result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.getNoSqlTables(null,
-                    "crn", "region", "aws", "az"));
+                    CREDENTIAL_CRN, "region", "aws", "az"));
 
         verify(platformParameterService).getNoSqlTables(platformResourceRequest);
         verify(convertersionService).convert(noSqlTables, PlatformNoSqlTablesResponse.class);
         assertEquals(response, result);
+
+    }
+
+    @Test
+    void testGetNoSqlTablesShouldThrowBadRequestExceptionWhenTheSpecifiedCredentialCrnIsInvalid() {
+        Assertions.assertThrows(BadRequestException.class, () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.getNoSqlTables(null,
+                "new", "region", "aws", "az")));
 
     }
 }


### PR DESCRIPTION
**Changes:**
 - validate the resource CRNs on Credential and Environment related platform resources endpoints
 - handle empty network id during environment deletion as it could be empty when the deletion flow is restarted due to any reason before finalisation, but after network resource deletion