### PR TITLE
CB-11660 Log more info for Cloudformation stack when it's failing or …

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/client/AmazonCloudFormationClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/client/AmazonCloudFormationClient.java
@@ -5,6 +5,8 @@ import com.amazonaws.services.cloudformation.model.CreateStackRequest;
 import com.amazonaws.services.cloudformation.model.CreateStackResult;
 import com.amazonaws.services.cloudformation.model.DeleteStackRequest;
 import com.amazonaws.services.cloudformation.model.DeleteStackResult;
+import com.amazonaws.services.cloudformation.model.DescribeStackEventsRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStackEventsResult;
 import com.amazonaws.services.cloudformation.model.DescribeStackResourceRequest;
 import com.amazonaws.services.cloudformation.model.DescribeStackResourceResult;
 import com.amazonaws.services.cloudformation.model.DescribeStackResourcesRequest;
@@ -49,6 +51,10 @@ public class AmazonCloudFormationClient extends AmazonClient {
 
     public DescribeStackResourcesResult describeStackResources(DescribeStackResourcesRequest request) {
         return retry.testWith2SecDelayMax15Times(() -> client.describeStackResources(request));
+    }
+
+    public DescribeStackEventsResult describeStackEvents(DescribeStackEventsRequest request) {
+        return retry.testWith2SecDelayMax15Times(() -> client.describeStackEvents(request));
     }
 
     public UpdateStackResult updateStack(UpdateStackRequest request) {

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/AwsCloudFormationErrorMessageProvider.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/util/AwsCloudFormationErrorMessageProvider.java
@@ -8,11 +8,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.amazonaws.services.cloudformation.model.DescribeStackEventsRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStackEventsResult;
 import com.amazonaws.services.cloudformation.model.DescribeStackResourcesRequest;
 import com.amazonaws.services.cloudformation.model.DescribeStackResourcesResult;
 import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
 import com.amazonaws.services.cloudformation.model.DescribeStacksResult;
 import com.amazonaws.services.cloudformation.model.ResourceStatus;
+import com.amazonaws.services.cloudformation.model.StackEvent;
 import com.amazonaws.services.cloudformation.model.StackResource;
 import com.sequenceiq.cloudbreak.cloud.aws.AwsClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationClient;
@@ -41,22 +44,38 @@ public class AwsCloudFormationErrorMessageProvider {
         LOGGER.debug("Getting error reason in Cloudformation stack {} for resources with {} status", stackName, resourceErrorStatus);
 
         AmazonCloudFormationClient cfClient = awsClient.createCloudFormationClient(credentialView, region);
-        DescribeStacksRequest describeStacksRequest = new DescribeStacksRequest().withStackName(stackName);
-        DescribeStacksResult describeStacksResult = cfClient.describeStacks(describeStacksRequest);
-        LOGGER.debug("Cloudformation stack {} describe result: {}", stackName, describeStacksResult);
-        String stackStatusReason = describeStacksResult.getStacks().get(0).getStackStatusReason();
-        LOGGER.debug("Cloudformation stack {} has the error status reason: {}", stackName, stackStatusReason);
+        String stackStatusReason = getStackStatusReason(stackName, cfClient);
+        String cfEvents = getCfEvents(stackName, cfClient);
+        String stackResourceStatusReasons = getStackResourceStatusReasons(credentialView, region, stackName, resourceErrorStatus, cfClient);
 
+        String errorReason = stackStatusReason + " " + stackResourceStatusReasons;
+        LOGGER.debug("Cloudformation stack {} has the following error reason: {}. Events: {}", stackName, errorReason, cfEvents);
+        return errorReason;
+    }
+
+    private String getCfEvents(String stackName, AmazonCloudFormationClient cfClient) {
+        DescribeStackEventsResult eventsResult = cfClient.describeStackEvents(new DescribeStackEventsRequest().withStackName(stackName));
+        return eventsResult.getStackEvents().stream().map(StackEvent::toString).collect(Collectors.joining("; "));
+    }
+
+    private String getStackResourceStatusReasons(AwsCredentialView credentialView, String region, String stackName, ResourceStatus resourceErrorStatus,
+            AmazonCloudFormationClient cfClient) {
         DescribeStackResourcesRequest describeStackResourcesRequest = new DescribeStackResourcesRequest().withStackName(stackName);
         DescribeStackResourcesResult describeStackResourcesResult = cfClient.describeStackResources(describeStackResourcesRequest);
         String stackResourceStatusReasons = describeStackResourcesResult.getStackResources().stream()
                 .filter(stackResource -> ResourceStatus.fromValue(stackResource.getResourceStatus()).equals(resourceErrorStatus))
                 .map(stackResource -> getStackResourceMessage(credentialView, region, stackResource))
                 .collect(Collectors.joining(", "));
+        return stackResourceStatusReasons;
+    }
 
-        String errorReason = stackStatusReason + " " + stackResourceStatusReasons;
-        LOGGER.debug("Cloudformation stack {} has the following error reason: {}", stackName, errorReason);
-        return errorReason;
+    private String getStackStatusReason(String stackName, AmazonCloudFormationClient cfClient) {
+        DescribeStacksRequest describeStacksRequest = new DescribeStacksRequest().withStackName(stackName);
+        DescribeStacksResult describeStacksResult = cfClient.describeStacks(describeStacksRequest);
+        LOGGER.debug("Cloudformation stack {} describe result: {}", stackName, describeStacksResult);
+        String stackStatusReason = describeStacksResult.getStacks().get(0).getStackStatusReason();
+        LOGGER.debug("Cloudformation stack {} has the error status reason: {}", stackName, stackStatusReason);
+        return stackStatusReason;
     }
 
     private String getStackResourceMessage(AwsCredentialView credentialView, String region, StackResource stackResource) {

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/util/AwsCloudFormationErrorMessageProviderTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/util/AwsCloudFormationErrorMessageProviderTest.java
@@ -15,6 +15,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.amazonaws.services.cloudformation.model.DescribeStackEventsRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStackEventsResult;
 import com.amazonaws.services.cloudformation.model.DescribeStackResourcesResult;
 import com.amazonaws.services.cloudformation.model.DescribeStacksResult;
 import com.amazonaws.services.cloudformation.model.ResourceStatus;
@@ -69,6 +71,7 @@ class AwsCloudFormationErrorMessageProviderTest {
                         .withResourceStatus(ResourceStatus.CREATE_COMPLETE.toString())
                         .withResourceStatusReason("Created")
         ));
+        when(cfRetryClient.describeStackEvents(any(DescribeStackEventsRequest.class))).thenReturn(new DescribeStackEventsResult());
 
         String result = underTest.getErrorReason(credentialView, REGION, STACK_NAME, ResourceStatus.CREATE_FAILED);
 
@@ -89,6 +92,7 @@ class AwsCloudFormationErrorMessageProviderTest {
                         .withResourceStatusReason(resourceStatusReason)));
         when(awsEncodedAuthorizationFailureMessageDecoder.decodeAuthorizationFailureMessageIfNeeded(any(), eq(REGION), anyString()))
                 .thenReturn("Decoded auth error");
+        when(cfRetryClient.describeStackEvents(any(DescribeStackEventsRequest.class))).thenReturn(new DescribeStackEventsResult());
 
         String result = underTest.getErrorReason(credentialView, REGION, STACK_NAME, ResourceStatus.CREATE_FAILED);
 


### PR DESCRIPTION
…timing out

In this commit in case of Cloudformation timeout or error we will collect the CF related events and log it.
This will help us to investigate if the template has been modified from outside.

