### PR TITLE
CB-11659 Add logrotate config for /pki/pki-tomcat/ca/debug on FreeIPA

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/pkidebug
+++ b/freeipa/src/main/resources/freeipa-salt/salt/logrotate/conf/pkidebug
@@ -1,0 +1,10 @@
+/var/log/pki/pki-tomcat/ca/debug {
+    missingok
+    notifempty
+    copytruncate
+    daily
+    size 128M
+    rotate 6
+    su pkiuser pkiuser
+    nocompress
+}

--- a/freeipa/src/main/resources/freeipa-salt/salt/logrotate/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/logrotate/init.sls
@@ -13,3 +13,11 @@ logrotate-ipabackup:
     - user: root
     - group: root
     - mode: 644
+
+logrotate-pkidebug:
+  file.managed:
+    - name: /etc/logrotate.d/pkidebug
+    - source: salt://logrotate/conf/pkidebug
+    - user: root
+    - group: root
+    - mode: 644


### PR DESCRIPTION
Currently /pki/pki-tomcat/ca/debug doesn't have logrotate configuration. It should have similarly to ipabackup.log. We add logrotate rule to avoid the log to fill the disk space.

See detailed description in the commit message.