### PR TITLE
CB-11675 - Added Knox's own KNOXTOKEN service and the new tokengen ap…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -811,4 +811,34 @@
         {%- endif %}
     {%- endif %}
 
+{%- if salt['pillar.get']('gateway:enable_token_gen_application') == True -%}
+    <service>
+      <role>KNOXTOKEN</role>
+      <param>
+         <name>knox.token.ttl</name>
+         <value>31540000000</value> <!-- 1 year -->
+      </param>
+      <param>
+         <name>knox.token.exp.server-managed</name>
+         <value>true</value>
+      </param>
+      <param>
+         <name>knox.token.audiences</name>
+         <value>cdp-proxy-token</value>
+      </param>
+      <param>
+         <name>knox.token.target.url</name>
+         <value>cdp-proxy-token</value>
+      </param>
+      <param>
+         <name>knox.token.client.data</name>
+         <value>homepage_url=homepage/home/</value>
+      </param>
+    </service>
+
+    <application>
+      <name>tokengen</name>
+    </application>
+{% endif %}
+
 </topology>

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -38,6 +38,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_2_8 = () -> "7.2.8";
 
+    public static final Versioned CDP_VERSION_7_2_9 = () -> "7.2.9";
+
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CMRepositoryVersionUtil.class);


### PR DESCRIPTION
…plication into the cdp-proxy topology

Two new artifacts have to be added in cdp-proxy topology:

Knox's own KNOXTOKEN service (it's proprietary to Knox, not like a regular service such Hive, YARN, ATLAS,...) with a custom configuration that is not meant to be changed from the UI
A new Knox application called tokengen. It's 100% guaranteed that all versions after CDH 7.2.9 will have it