### PR TITLE
CDPD-23526:Add abfs and gs to hive.blobstore.supported.schemes

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
@@ -140,7 +140,8 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
@@ -290,7 +290,8 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
@@ -280,7 +280,8 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
@@ -140,7 +140,8 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-spark3.bp
@@ -290,7 +290,8 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering.bp
@@ -280,7 +280,8 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
@@ -140,7 +140,8 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-spark3.bp
@@ -290,7 +290,8 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering.bp
@@ -280,7 +280,8 @@
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>"
+            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property>"
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
 the default value for "hive.blobstore.supported.schemes" is  "s3,s3a,s3n" and its updated to "s3,s3a,s3n,abfs" now. Screenshot attached below:

![image](https://user-images.githubusercontent.com/7271603/112191248-d4680000-8c2b-11eb-9e25-412c61e82d82.png)
