### PR TITLE
CB-11694 - Corrected topology name

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
@@ -4,7 +4,7 @@
 {# They have to be the same except the authentication/federation provider they use #}
 
 <topology>
-    <name>{{ topology_name }}-api</name>
+    <name>{{ topology_name }}-token</name>
     <gateway>
 
         <provider>


### PR DESCRIPTION
Corrected the new topology name (it was accidentally left as `cdp-proxy-api` instead of `cdp-proxy-token`)