### PR TITLE
CB-11680 Improve root cause detection after a complex operation fails

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/ConclusionChecker.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/ConclusionChecker.java
@@ -1,0 +1,57 @@
+package com.sequenceiq.cloudbreak.conclusion;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.conclusion.step.ConclusionStep;
+import com.sequenceiq.cloudbreak.conclusion.step.ConclusionStepResult;
+
+public class ConclusionChecker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConclusionChecker.class);
+
+    private final List<ConclusionStep> conclusionSteps;
+
+    private int actualStep;
+
+    private boolean doNext = true;
+
+    public ConclusionChecker(List<ConclusionStep> conclusionSteps) {
+        this.conclusionSteps = conclusionSteps;
+    }
+
+    public ConclusionResult doCheck(Long resourceId) {
+        LOGGER.info("Conclusion checker started, steps: {}, resourceId: {}", conclusionSteps, resourceId);
+        List<String> conclusions = new ArrayList<>();
+        try {
+            while (hasMoreSteps() && doNext()) {
+                ConclusionStep conclusionStep = conclusionSteps.get(actualStep++);
+                LOGGER.debug("Conclusion step: {}", conclusionStep);
+
+                ConclusionStepResult stepResult = conclusionStep.check(resourceId);
+                LOGGER.debug("Conclusion step {}, conclusion: {}", stepResult.isStepFailed() ? "failed" : "succeeded", stepResult.getConclusion());
+                if (stepResult.getConclusion() != null) {
+                    conclusions.add(stepResult.getConclusion());
+                }
+                doNext = stepResult.isStepFailed();
+            }
+            return new ConclusionResult(conclusions);
+        } catch (RuntimeException e) {
+            LOGGER.error("Conclusion checker error: {}", e.getMessage(), e);
+            throw e;
+        } finally {
+            LOGGER.info("Conclusion checker finished, conclusions: {}", conclusions);
+        }
+    }
+
+    private boolean hasMoreSteps() {
+        return actualStep < conclusionSteps.size();
+    }
+
+    private boolean doNext() {
+        return doNext;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/ConclusionCheckerFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/ConclusionCheckerFactory.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.cloudbreak.conclusion;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.conclusion.step.ConclusionStep;
+
+@Component
+public class ConclusionCheckerFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConclusionCheckerFactory.class);
+
+    @Inject
+    private List<ConclusionStep> conclusionSteps;
+
+    private Map<Class<? extends ConclusionStep>, ConclusionStep> conclusionStepMapByType;
+
+    @PostConstruct
+    public void init() {
+        conclusionStepMapByType = conclusionSteps.stream().collect(Collectors.toMap(ConclusionStep::getClass, step -> step));
+    }
+
+    public ConclusionChecker getConclusionChecker(ConclusionCheckerType conclusionCheckerType) {
+        List<Class<? extends ConclusionStep>> stepClasses = conclusionCheckerType.getSteps();
+        List<ConclusionStep> actualConclusionSteps = getActualConclusionSteps(stepClasses);
+        return new ConclusionChecker(actualConclusionSteps);
+    }
+
+    private List<ConclusionStep> getActualConclusionSteps(List<Class<? extends ConclusionStep>> stepClasses) {
+        List<ConclusionStep> actualConclusionSteps = new ArrayList<>();
+        for (Class<? extends ConclusionStep> stepClass : stepClasses) {
+            if (!conclusionStepMapByType.containsKey(stepClass)) {
+                String message = "Unknown conclusion step class: " + stepClass;
+                LOGGER.error(message);
+                throw new IllegalArgumentException(message);
+            } else {
+                actualConclusionSteps.add(conclusionStepMapByType.get(stepClass));
+            }
+        }
+        return actualConclusionSteps;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/ConclusionCheckerType.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/ConclusionCheckerType.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.conclusion;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.sequenceiq.cloudbreak.conclusion.step.ConclusionStep;
+import com.sequenceiq.cloudbreak.conclusion.step.SaltMinionCheckerConclusionStep;
+
+public enum ConclusionCheckerType {
+
+    DEFAULT(SaltMinionCheckerConclusionStep.class);
+
+    private List<Class<? extends ConclusionStep>> steps;
+
+    ConclusionCheckerType(Class<? extends ConclusionStep>... steps) {
+        if (steps != null) {
+            this.steps = Arrays.asList(steps);
+        } else {
+            this.steps = Collections.emptyList();
+        }
+    }
+
+    public List<Class<? extends ConclusionStep>> getSteps() {
+        return steps;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/ConclusionResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/ConclusionResult.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.conclusion;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ConclusionResult {
+
+    private List<String> conclusions;
+
+    public ConclusionResult(List<String> conclusions) {
+        if (conclusions != null) {
+            this.conclusions = conclusions;
+        } else {
+            this.conclusions = Collections.emptyList();
+        }
+    }
+
+    public List<String> getConclusions() {
+        return conclusions;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/step/ConclusionStep.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/step/ConclusionStep.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.conclusion.step;
+
+public interface ConclusionStep {
+
+    ConclusionStepResult check(Long resourceId);
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/step/ConclusionStepResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/step/ConclusionStepResult.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.conclusion.step;
+
+public class ConclusionStepResult {
+
+    private final boolean stepFailed;
+
+    private final String conclusion;
+
+    public ConclusionStepResult(boolean stepFailed, String conclusion) {
+        this.stepFailed = stepFailed;
+        this.conclusion = conclusion;
+    }
+
+    public static ConclusionStepResult succeeded() {
+        return new ConclusionStepResult(false, null);
+    }
+
+    public static ConclusionStepResult failed(String conclusion) {
+        return new ConclusionStepResult(true, conclusion);
+    }
+
+    public boolean isStepFailed() {
+        return stepFailed;
+    }
+
+    public String getConclusion() {
+        return conclusion;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/step/SaltMinionCheckerConclusionStep.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conclusion/step/SaltMinionCheckerConclusionStep.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.cloudbreak.conclusion.step;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.util.NodesUnreachableException;
+import com.sequenceiq.cloudbreak.util.StackUtil;
+
+@Component
+public class SaltMinionCheckerConclusionStep implements ConclusionStep {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaltMinionCheckerConclusionStep.class);
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private StackUtil stackUtil;
+
+    @Override
+    public ConclusionStepResult check(Long resourceId) {
+        Stack stack = stackService.getByIdWithListsInTransaction(resourceId);
+        Set<String> allNodes = stackUtil.collectNodes(stack).stream().map(Node::getHostname).collect(Collectors.toSet());
+        try {
+            stackUtil.collectAndCheckReachableNodes(stack, allNodes);
+        } catch (NodesUnreachableException e) {
+            Set<String> unreachableNodes = e.getUnreachableNodes();
+            LOGGER.error("Unreachable salt minions: {}", unreachableNodes);
+            String conclusion = String.format("Unreachable nodes: %s. Please check the instances on your cloud provider for further details.",
+                    unreachableNodes);
+            return ConclusionStepResult.failed(conclusion);
+        }
+        return ConclusionStepResult.succeeded();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/downscale/ClusterDownscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/downscale/ClusterDownscaleActions.java
@@ -30,6 +30,7 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterDownscaleFailedConclusionRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.RemoveHostsFailed;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.RemoveHostsRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.RemoveHostsSuccess;
@@ -161,12 +162,8 @@ public class ClusterDownscaleActions {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) {
                 clusterDownscaleService.handleClusterDownscaleFailure(context.getStackView().getId(), payload.getException());
-                sendEvent(context);
-            }
-
-            @Override
-            protected Selectable createRequest(StackFailureContext context) {
-                return new StackEvent(ClusterDownscaleEvent.FAIL_HANDLED_EVENT.event(), context.getStackView().getId());
+                ClusterDownscaleFailedConclusionRequest request = new ClusterDownscaleFailedConclusionRequest(context.getStackView().getId());
+                sendEvent(context, request.selector(), request);
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleActions.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.upscale;
 
-import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.FAIL_HANDLED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent.FINALIZED_EVENT;
 
 import java.util.Map;
@@ -48,6 +47,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StartServerAndAgentRe
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.StopClusterComponentsResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.UpscaleClusterRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.UpscaleClusterResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterUpscaleFailedConclusionRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.kerberos.KeytabConfigurationRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.kerberos.KeytabConfigurationSuccess;
 import com.sequenceiq.cloudbreak.reactor.api.event.orchestration.UpscaleClusterManagerRequest;
@@ -405,7 +405,8 @@ public class ClusterUpscaleActions {
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) {
                 clusterUpscaleFlowService.clusterUpscaleFailed(context.getStackView().getId(), payload.getException());
                 getMetricService().incrementMetricCounter(MetricType.CLUSTER_UPSCALE_FAILED, context.getStackView(), payload.getException());
-                sendEvent(context, FAIL_HANDLED_EVENT.event(), payload);
+                ClusterUpscaleFailedConclusionRequest request = new ClusterUpscaleFailedConclusionRequest(context.getStackView().getId());
+                sendEvent(context, request.selector(), request);
             }
         };
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterDownscaleFailedConclusionRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterDownscaleFailedConclusionRequest.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class ClusterDownscaleFailedConclusionRequest extends StackEvent  {
+
+    public ClusterDownscaleFailedConclusionRequest(Long stackId) {
+        super(stackId);
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterUpscaleFailedConclusionRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/ClusterUpscaleFailedConclusionRequest.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class ClusterUpscaleFailedConclusionRequest extends StackEvent {
+
+    public ClusterUpscaleFailedConclusionRequest(Long stackId) {
+        super(stackId);
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterDownscaleFailedConclusionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterDownscaleFailedConclusionHandler.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_FAILED;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_FAILED;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.conclusion.ConclusionChecker;
+import com.sequenceiq.cloudbreak.conclusion.ConclusionCheckerFactory;
+import com.sequenceiq.cloudbreak.conclusion.ConclusionCheckerType;
+import com.sequenceiq.cloudbreak.conclusion.ConclusionResult;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.downscale.ClusterDownscaleEvent;
+import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterDownscaleFailedConclusionRequest;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+
+import reactor.bus.Event;
+
+@Component
+public class ClusterDownscaleFailedConclusionHandler extends ExceptionCatcherEventHandler<ClusterDownscaleFailedConclusionRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterDownscaleFailedConclusionHandler.class);
+
+    @Inject
+    private ConclusionCheckerFactory conclusionCheckerFactory;
+
+    @Inject
+    private CloudbreakFlowMessageService flowMessageService;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(ClusterDownscaleFailedConclusionRequest.class);
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<ClusterDownscaleFailedConclusionRequest> event) {
+        return new StackEvent(ClusterDownscaleEvent.FAIL_HANDLED_EVENT.event(), resourceId);
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent event) {
+        ClusterDownscaleFailedConclusionRequest request = event.getData();
+        LOGGER.info("Handle ClusterDownscaleFailedConclusionRequest, stackId: {}", request.getResourceId());
+        try {
+            ConclusionChecker conclusionChecker = conclusionCheckerFactory.getConclusionChecker(ConclusionCheckerType.DEFAULT);
+            ConclusionResult conclusionResult = conclusionChecker.doCheck(request.getResourceId());
+            flowMessageService.fireEventAndLog(request.getResourceId(), UPDATE_FAILED.name(), CLUSTER_SCALING_FAILED,
+                    "removed from", conclusionResult.getConclusions().toString());
+        } catch (Exception e) {
+            LOGGER.error("Error happened during conclusion check", e);
+        }
+        return new StackEvent(ClusterDownscaleEvent.FAIL_HANDLED_EVENT.event(), request.getResourceId());
+
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterUpscaleFailedConclusionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterUpscaleFailedConclusionHandler.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_FAILED;
+import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_SCALING_FAILED;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.conclusion.ConclusionChecker;
+import com.sequenceiq.cloudbreak.conclusion.ConclusionCheckerFactory;
+import com.sequenceiq.cloudbreak.conclusion.ConclusionCheckerType;
+import com.sequenceiq.cloudbreak.conclusion.ConclusionResult;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleEvent;
+import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterUpscaleFailedConclusionRequest;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+
+import reactor.bus.Event;
+
+@Component
+public class ClusterUpscaleFailedConclusionHandler extends ExceptionCatcherEventHandler<ClusterUpscaleFailedConclusionRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterUpscaleFailedConclusionHandler.class);
+
+    @Inject
+    private ConclusionCheckerFactory conclusionCheckerFactory;
+
+    @Inject
+    private CloudbreakFlowMessageService flowMessageService;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(ClusterUpscaleFailedConclusionRequest.class);
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<ClusterUpscaleFailedConclusionRequest> event) {
+        return new StackEvent(ClusterUpscaleEvent.FAIL_HANDLED_EVENT.event(), resourceId);
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent event) {
+        ClusterUpscaleFailedConclusionRequest request = event.getData();
+        LOGGER.info("Handle ClusterUpscaleFailedConclusionRequest, stackId: {}", request.getResourceId());
+        try {
+            ConclusionChecker conclusionChecker = conclusionCheckerFactory.getConclusionChecker(ConclusionCheckerType.DEFAULT);
+            ConclusionResult conclusionResult = conclusionChecker.doCheck(request.getResourceId());
+            flowMessageService.fireEventAndLog(request.getResourceId(), UPDATE_FAILED.name(), CLUSTER_SCALING_FAILED,
+                    "added to", conclusionResult.getConclusions().toString());
+        } catch (Exception e) {
+            LOGGER.error("Error happened during conclusion check", e);
+        }
+        return new StackEvent(ClusterUpscaleEvent.FAIL_HANDLED_EVENT.event(), request.getResourceId());
+
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/conclusion/ConclusionCheckerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/conclusion/ConclusionCheckerTest.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.cloudbreak.conclusion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.conclusion.step.ConclusionStep;
+import com.sequenceiq.cloudbreak.conclusion.step.ConclusionStepResult;
+
+class ConclusionCheckerTest {
+
+    @Test
+    public void doCheckShouldCallNextStepAfterFailedStep() {
+        ConclusionStep firstStep = mock(ConclusionStep.class);
+        when(firstStep.check(anyLong())).thenReturn(ConclusionStepResult.failed("failed"));
+        ConclusionStep secondStep = mock(ConclusionStep.class);
+        when(secondStep.check(anyLong())).thenReturn(ConclusionStepResult.failed("failed"));
+        ConclusionChecker conclusionChecker = new ConclusionChecker(List.of(firstStep, secondStep));
+        ConclusionResult conclusionResult = conclusionChecker.doCheck(1L);
+
+        assertEquals(2, conclusionResult.getConclusions().size());
+        verify(firstStep, times(1)).check(eq(1L));
+        verify(secondStep, times(1)).check(eq(1L));
+    }
+
+    @Test
+    public void doCheckShouldStopAfterSuccessfulStep() {
+        ConclusionStep firstStep = mock(ConclusionStep.class);
+        when(firstStep.check(anyLong())).thenReturn(ConclusionStepResult.succeeded());
+        ConclusionStep secondStep = mock(ConclusionStep.class);
+        ConclusionChecker conclusionChecker = new ConclusionChecker(List.of(firstStep, secondStep));
+        ConclusionResult conclusionResult = conclusionChecker.doCheck(1L);
+
+        assertTrue(conclusionResult.getConclusions().isEmpty());
+        verify(firstStep, times(1)).check(eq(1L));
+        verify(secondStep, never()).check(eq(1L));
+    }
+
+    @Test
+    public void doCheckShouldThrowExceptionIfStepThrowsException() {
+        ConclusionStep firstStep = mock(ConclusionStep.class);
+        when(firstStep.check(anyLong())).thenThrow(new RuntimeException("Something wrong happened!"));
+        ConclusionStep secondStep = mock(ConclusionStep.class);
+        ConclusionChecker conclusionChecker = new ConclusionChecker(List.of(firstStep, secondStep));
+
+        RuntimeException runtimeException = Assertions.assertThrows(RuntimeException.class, () -> conclusionChecker.doCheck(1L));
+
+        verify(firstStep, times(1)).check(eq(1L));
+        verify(secondStep, never()).check(eq(1L));
+        assertEquals("Something wrong happened!", runtimeException.getMessage());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/conclusion/step/SaltMinionCheckerConclusionStepTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/conclusion/step/SaltMinionCheckerConclusionStepTest.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.cloudbreak.conclusion.step;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.util.NodesUnreachableException;
+import com.sequenceiq.cloudbreak.util.StackUtil;
+
+@ExtendWith(MockitoExtension.class)
+class SaltMinionCheckerConclusionStepTest {
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private StackUtil stackUtil;
+
+    @InjectMocks
+    private SaltMinionCheckerConclusionStep underTest;
+
+    @Test
+    public void checkShouldBeSuccessfulIfNoUnreachableNodeFound() throws NodesUnreachableException {
+        when(stackService.getByIdWithListsInTransaction(eq(1L))).thenReturn(new Stack());
+        Set<Node> nodes = Set.of(createNode("host1"), createNode("host2"));
+        when(stackUtil.collectNodes(any())).thenReturn(nodes);
+        when(stackUtil.collectAndCheckReachableNodes(any(), anyCollection())).thenReturn(nodes);
+        ConclusionStepResult stepResult = underTest.check(1L);
+
+        assertFalse(stepResult.isStepFailed());
+        assertNull(stepResult.getConclusion());
+        verify(stackService, times(1)).getByIdWithListsInTransaction(eq(1L));
+        verify(stackUtil, times(1)).collectNodes(any());
+        verify(stackUtil, times(1)).collectAndCheckReachableNodes(any(), any());
+    }
+
+    @Test
+    public void checkShouldFailAndReturnConclusionIfUnreachableNodeFound() throws NodesUnreachableException {
+        when(stackService.getByIdWithListsInTransaction(eq(1L))).thenReturn(new Stack());
+        when(stackUtil.collectNodes(any())).thenReturn(Set.of(createNode("host1"), createNode("host2")));
+        when(stackUtil.collectAndCheckReachableNodes(any(), anyCollection())).thenThrow(new NodesUnreachableException("error", Set.of("host1")));
+        ConclusionStepResult stepResult = underTest.check(1L);
+
+        assertTrue(stepResult.isStepFailed());
+        assertEquals("Unreachable nodes: [host1]. Please check the instances on your cloud provider for further details.", stepResult.getConclusion());
+        verify(stackService, times(1)).getByIdWithListsInTransaction(eq(1L));
+        verify(stackUtil, times(1)).collectNodes(any());
+        verify(stackUtil, times(1)).collectAndCheckReachableNodes(any(), any());
+    }
+
+    private Node createNode(String fqdn) {
+        return new Node("privateIp", "publicIp", "instanceId", "instanceType",
+                fqdn, "hostGroup");
+    }
+
+}


### PR DESCRIPTION
If something wrong happens during flow execution (currently cluster upscale and cluster downscale), we should run some checks in order to find the root cause of the error.
Currently salt minion check is implemented.
If the conclusion checker finds something it will send an event to the UI.