### PR TITLE
CDPCP-4195. Allow invoking user sync against non-existent users

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncRequestFilter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncRequestFilter.java
@@ -14,10 +14,13 @@ public class UserSyncRequestFilter {
 
     private final Optional<String> deletedWorkloadUser;
 
+    private final boolean fullSync;
+
     public UserSyncRequestFilter(Set<String> userCrnFilter, Set<String> machineUserCrnFilter, Optional<String> deletedWorkloadUser) {
         this.userCrnFilter = ImmutableSet.copyOf(userCrnFilter);
         this.machineUserCrnFilter = ImmutableSet.copyOf(machineUserCrnFilter);
         this.deletedWorkloadUser = deletedWorkloadUser;
+        fullSync = userCrnFilter.isEmpty() && machineUserCrnFilter.isEmpty();
     }
 
     public static UserSyncRequestFilter newFullSync() {
@@ -25,7 +28,7 @@ public class UserSyncRequestFilter {
     }
 
     public boolean isFullSync() {
-        return userCrnFilter.isEmpty() && machineUserCrnFilter.isEmpty();
+        return fullSync;
     }
 
     public ImmutableSet<String> getUserCrnFilter() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/MachineUserRetriever.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/MachineUserRetriever.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.freeipa.service.freeipa.user.ums;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+@Component
+public class MachineUserRetriever {
+    @VisibleForTesting
+    static final boolean DONT_INCLUDE_INTERNAL_MACHINE_USERS = false;
+
+    @VisibleForTesting
+    static final boolean INCLUDE_WORKLOAD_MACHINE_USERS = true;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MachineUserRetriever.class);
+
+    @Inject
+    private GrpcUmsClient grpcUmsClient;
+
+    public List<UserManagementProto.MachineUser> getMachineUsers(
+            String actorCrn, String accountId, Optional<String> requestIdOptional,
+            boolean fullSync, Set<String> machineUserCrns,
+            BiConsumer<String, String> warnings) {
+        if (fullSync) {
+            return grpcUmsClient.listAllMachineUsers(actorCrn, accountId,
+                    DONT_INCLUDE_INTERNAL_MACHINE_USERS, INCLUDE_WORKLOAD_MACHINE_USERS,
+                    requestIdOptional);
+        } else if (!machineUserCrns.isEmpty()) {
+            return getRequestedMachineUsers(actorCrn, accountId, machineUserCrns, requestIdOptional, warnings);
+        } else {
+            return List.of();
+        }
+    }
+
+    private List<UserManagementProto.MachineUser> getRequestedMachineUsers(
+            String actorCrn, String accountId,
+            Set<String> machineUserCrns, Optional<String> requestIdOptional,
+            BiConsumer<String, String> warnings) {
+        try {
+            return grpcUmsClient.listMachineUsers(actorCrn, accountId, List.copyOf(machineUserCrns),
+                    DONT_INCLUDE_INTERNAL_MACHINE_USERS, INCLUDE_WORKLOAD_MACHINE_USERS,
+                    requestIdOptional);
+        } catch (StatusRuntimeException e) {
+            if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
+                LOGGER.warn("Some requested machine user not found in UMS. " +
+                                "Attempting to retrieve machine users individually.",
+                        e.getLocalizedMessage());
+                return getRequestedMachineUsersIndividually(
+                        actorCrn, accountId, machineUserCrns, requestIdOptional, warnings);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    private List<UserManagementProto.MachineUser> getRequestedMachineUsersIndividually(
+            String actorCrn, String accountId,
+            Set<String> machineUserCrns, Optional<String> requestIdOptional,
+            BiConsumer<String, String> warnings) {
+        List<UserManagementProto.MachineUser> machineUsers = Lists.newArrayListWithCapacity(machineUserCrns.size());
+        for (String machineUserCrn : machineUserCrns) {
+            try {
+                machineUsers.addAll(grpcUmsClient.listMachineUsers(actorCrn, accountId, List.of(machineUserCrn),
+                        DONT_INCLUDE_INTERNAL_MACHINE_USERS, INCLUDE_WORKLOAD_MACHINE_USERS,
+                        requestIdOptional));
+            } catch (StatusRuntimeException e) {
+                if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
+                    LOGGER.warn("Machine user CRN {} not found in UMS. Machine user will not be added to the UMS Users State. {}",
+                            machineUserCrn, e.getLocalizedMessage());
+                    warnings.accept(machineUserCrn, String.format("Machine User %s not found.", machineUserCrn));
+                } else {
+                    throw e;
+                }
+            }
+        }
+        return machineUsers;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/UserRetriever.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/ums/UserRetriever.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.freeipa.service.freeipa.user.ums;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.google.common.collect.Lists;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+@Component
+public class UserRetriever {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserRetriever.class);
+
+    @Inject
+    private GrpcUmsClient grpcUmsClient;
+
+    public List<UserManagementProto.User> getUsers(
+            String actorCrn, String accountId,
+            Optional<String> requestIdOptional,
+            boolean fullSync, Set<String> userCrns,
+            BiConsumer<String, String> warnings) {
+        if (fullSync) {
+            return grpcUmsClient.listAllUsers(actorCrn, accountId, requestIdOptional);
+        } else if (!userCrns.isEmpty()) {
+            return getRequestedUsers(actorCrn, accountId, userCrns, requestIdOptional, warnings);
+        } else {
+            return List.of();
+        }
+    }
+
+    private List<UserManagementProto.User> getRequestedUsers(
+            String actorCrn, String accountId,
+            Set<String> userCrns, Optional<String> requestIdOptional,
+            BiConsumer<String, String> warnings) {
+        try {
+            return grpcUmsClient.listUsers(actorCrn, accountId, List.copyOf(userCrns),
+                    requestIdOptional);
+        } catch (StatusRuntimeException e) {
+            if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
+                LOGGER.warn("Some requested user was not found in UMS. " +
+                                "Attempting to retrieve users individually.",
+                        e.getLocalizedMessage());
+                return getRequestedUsersIndividually(actorCrn, accountId, userCrns, requestIdOptional, warnings);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    private List<UserManagementProto.User> getRequestedUsersIndividually(
+            String actorCrn, String accountId,
+            Set<String> userCrns, Optional<String> requestIdOptional,
+            BiConsumer<String, String> warnings) {
+        List<UserManagementProto.User> users = Lists.newArrayListWithCapacity(userCrns.size());
+        for (String userCrn : userCrns) {
+            try {
+                users.addAll(grpcUmsClient.listUsers(actorCrn, accountId, List.of(userCrn),
+                        requestIdOptional));
+            } catch (StatusRuntimeException e) {
+                if (e.getStatus().getCode() == Status.Code.NOT_FOUND) {
+                    LOGGER.warn("User CRN {} not found in UMS. User will not be added to the UMS Users State. {}",
+                            userCrn, e.getLocalizedMessage());
+                    warnings.accept(userCrn, String.format("User %s not found.", userCrn));
+                } else {
+                    throw e;
+                }
+            }
+        }
+        return users;
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
@@ -4,7 +4,6 @@ import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anySet;
@@ -176,12 +175,12 @@ class UserSyncServiceTest {
             assertEquals(INTERNAL_ACTOR_CRN, ThreadBasedUserCrnProvider.getUserCrn());
             return null;
         })
-                .when(spyService).asyncSynchronizeUsers(anyString(), anyString(), anyString(), anyList(), any(), anyBoolean());
+                .when(spyService).asyncSynchronizeUsers(anyString(), anyString(), anyString(), anyList(), any(UserSyncRequestFilter.class));
 
         spyService.synchronizeUsers("accountId", "actorCrn",
                 Set.of(), Set.of(), Set.of());
 
-        verify(spyService).asyncSynchronizeUsers(anyString(), anyString(), anyString(), anyList(), any(), anyBoolean());
+        verify(spyService).asyncSynchronizeUsers(anyString(), anyString(), anyString(), anyList(), any(UserSyncRequestFilter.class));
     }
 
     @Test

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/BaseUmsUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/BaseUmsUsersStateProviderTest.java
@@ -10,30 +10,22 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import java.security.SecureRandom;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
-import com.sequenceiq.cloudbreak.auth.altus.Crn;
-import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.freeipa.service.freeipa.user.UserSyncConstants;
 import com.sequenceiq.freeipa.service.freeipa.user.model.FmsGroup;
@@ -46,18 +38,6 @@ import com.sequenceiq.freeipa.service.freeipa.user.model.WorkloadCredential;
 @ExtendWith(MockitoExtension.class)
 class BaseUmsUsersStateProviderTest {
 
-    protected static final SecureRandom RANDOM = new SecureRandom();
-
-    protected static final String ACCOUNT_ID = UUID.randomUUID().toString();
-
-    protected static final String ACTOR_CRN = Crn.builder(CrnResourceDescriptor.USER)
-            .setAccountId(ACCOUNT_ID)
-            .setResource(UUID.randomUUID().toString())
-            .build()
-            .toString();
-
-    protected static final String ENVIRONMENT_CRN = createEnvironmentCrn();
-
     @Mock
     protected GrpcUmsClient grpcUmsClient;
 
@@ -65,36 +45,36 @@ class BaseUmsUsersStateProviderTest {
 
     protected void setupServicePrincipals() {
         when(grpcUmsClient.listServicePrincipalCloudIdentities(
-                eq(INTERNAL_ACTOR_CRN), eq(ACCOUNT_ID), eq(ENVIRONMENT_CRN), any(Optional.class)))
-                .thenReturn(testData.servicePrincipalCloudIdentities);
+                eq(INTERNAL_ACTOR_CRN), eq(testData.getAccountId()), eq(testData.getEnvironmentCrn()), any(Optional.class)))
+                .thenReturn(testData.getServicePrincipalCloudIdentities());
     }
 
     protected void verifyUmsUsersStateBuilderMap(Map<String, UmsUsersState> umsUsersStateMap) {
         assertEquals(1, umsUsersStateMap.size());
-        UmsUsersState state = umsUsersStateMap.get(ENVIRONMENT_CRN);
+        UmsUsersState state = umsUsersStateMap.get(testData.getEnvironmentCrn());
         assertNotNull(state);
 
         // Add the internal group to the expected groups and wags
-        assertEquals(testData.groups.size() + testData.wagsForThisEnvironment.size() + 1,
+        assertEquals(testData.getGroups().size() + testData.getWagsForThisEnvironment().size() + 1,
                 state.getUsersState().getGroups().size());
         List<String> groupNames = state.getUsersState().getGroups()
                 .stream().map(FmsGroup::getName).collect(Collectors.toList());
         assertTrue(groupNames.containsAll(
-                testData.groups.stream().map(UserManagementProto.Group::getGroupName).collect(Collectors.toList())));
+                testData.getGroups().stream().map(UserManagementProto.Group::getGroupName).collect(Collectors.toList())));
         assertTrue(groupNames.containsAll(
-                testData.wagsForThisEnvironment.stream()
+                testData.getWagsForThisEnvironment().stream()
                         .map(UserManagementProto.WorkloadAdministrationGroup::getWorkloadAdministrationGroupName)
                         .collect(Collectors.toList())));
         assertEquals(
-                testData.allWags.stream()
+                testData.getAllWags().stream()
                         .map(UserManagementProto.WorkloadAdministrationGroup::getWorkloadAdministrationGroupName)
                         .collect(Collectors.toSet()),
                 state.getWorkloadAdministrationGroups().stream()
                         .map(FmsGroup::getName)
                         .collect(Collectors.toSet()));
 
-        assertEquals(Stream.concat(testData.users.stream().map(UserManagementProto.User::getWorkloadUsername),
-                testData.machineUsers.stream()
+        assertEquals(Stream.concat(testData.getUsers().stream().map(UserManagementProto.User::getWorkloadUsername),
+                testData.getMachineUsers().stream()
                         .map(UserManagementProto.MachineUser::getWorkloadUsername))
                         .collect(Collectors.toSet()),
                 state.getRequestedWorkloadUsernames());
@@ -107,18 +87,18 @@ class BaseUmsUsersStateProviderTest {
                 .collect(Collectors.toSet());
         Multimap<String, String> groupsPerMember = Multimaps.invertFrom(usersState.getGroupMembership(),
                 ArrayListMultimap.<String, String>create());
-        testData.users.forEach(u ->
+        testData.getUsers().forEach(u ->
                 verifyActor(u.getCrn(), u.getWorkloadUsername(), workloadUsersWithAccess,
                         groupsPerMember.get(u.getWorkloadUsername()),
                         state.getUsersWorkloadCredentialMap().get(u.getWorkloadUsername()),
                         usersState.getUserMetadataMap().get(u.getWorkloadUsername())));
-        testData.machineUsers.forEach(u ->
+        testData.getMachineUsers().forEach(u ->
                 verifyActor(u.getCrn(), u.getWorkloadUsername(), workloadUsersWithAccess,
                         groupsPerMember.get(u.getWorkloadUsername()),
                         state.getUsersWorkloadCredentialMap().get(u.getWorkloadUsername()),
                         usersState.getUserMetadataMap().get(u.getWorkloadUsername())));
 
-        assertEquals(testData.servicePrincipalCloudIdentities, state.getServicePrincipalCloudIdentities());
+        assertEquals(testData.getServicePrincipalCloudIdentities(), state.getServicePrincipalCloudIdentities());
     }
 
     private void verifyActor(
@@ -127,25 +107,25 @@ class BaseUmsUsersStateProviderTest {
             Collection<String> actualGroups,
             WorkloadCredential workloadCredential,
             UserMetadata userMetadata) {
-        if (testData.memberCrnToActorRights.get(actorCrn).get(UserSyncConstants.RIGHTS.get(0))) {
+        if (testData.getMemberCrnToActorRights().get(actorCrn).get(UserSyncConstants.RIGHTS.get(0))) {
             assertTrue(workloadUsersWithAccess.contains(workloadUsername));
-            Map<String, Boolean> expectedGroupMembership = testData.memberCrnToGroupMembership.get(actorCrn);
-            testData.groups.forEach(g -> {
+            Map<String, Boolean> expectedGroupMembership = testData.getMemberCrnToGroupMembership().get(actorCrn);
+            testData.getGroups().forEach(g -> {
                 if (expectedGroupMembership.get(g.getCrn())) {
                     assertTrue(actualGroups.contains(g.getGroupName()));
                 } else {
                     assertFalse(actualGroups.contains(g.getGroupName()));
                 }
             });
-            Map<String, Boolean> expectedWagMembership = testData.memberCrnToWagMembership.get(actorCrn);
-            testData.wagsForThisEnvironment.forEach(wag -> {
+            Map<String, Boolean> expectedWagMembership = testData.getMemberCrnToWagMembership().get(actorCrn);
+            testData.getWagsForThisEnvironment().forEach(wag -> {
                 if (expectedWagMembership.get(wag.getWorkloadAdministrationGroupName())) {
                     assertTrue(actualGroups.contains(wag.getWorkloadAdministrationGroupName()));
                 } else {
                     assertFalse(actualGroups.contains(wag.getWorkloadAdministrationGroupName()));
                 }
             });
-            testData.wagsForOtherEnvironment.forEach(wag ->
+            testData.getWagsForOtherEnvironment().forEach(wag ->
                     assertFalse(actualGroups.contains(wag.getWorkloadAdministrationGroupName())));
             verifyWorkloadCredential(actorCrn, workloadCredential);
             assertEquals(actorCrn, userMetadata.getCrn());
@@ -160,223 +140,10 @@ class BaseUmsUsersStateProviderTest {
     private void verifyWorkloadCredential(String actorCrn, WorkloadCredential workloadCredential) {
         assertNotNull(workloadCredential);
         UserManagementProto.GetActorWorkloadCredentialsResponse expected =
-                testData.memberCrnToWorkloadCredentials.get(actorCrn);
+                testData.getMemberCrnToWorkloadCredentials().get(actorCrn);
         assertEquals(expected.getPasswordHash(), workloadCredential.getHashedPassword());
         assertEquals(expected.getKerberosKeysList(), workloadCredential.getKeys());
         assertEquals(expected.getSshPublicKeyList(), workloadCredential.getSshPublicKeys());
         assertEquals(expected.getWorkloadCredentialsVersion(), workloadCredential.getVersion());
-    }
-
-    private static String createEnvironmentCrn() {
-        return Crn.builder(CrnResourceDescriptor.ENVIRONMENT)
-                .setAccountId(ACCOUNT_ID)
-                .setResource(UUID.randomUUID().toString())
-                .build()
-                .toString();
-    }
-
-    public static class UserSyncTestData {
-        // groups
-        List<UserManagementProto.Group> groups = createGroups("testGroup", 10);
-
-        // wags
-        List<UserManagementProto.WorkloadAdministrationGroup> wagsForThisEnvironment =
-                createWags(ENVIRONMENT_CRN, 10);
-
-        List<UserManagementProto.WorkloadAdministrationGroup> wagsForOtherEnvironment =
-                createWags(createEnvironmentCrn(), 10);
-
-        List<UserManagementProto.WorkloadAdministrationGroup> allWags = Stream.concat(
-                wagsForThisEnvironment.stream(),
-                wagsForOtherEnvironment.stream())
-                .collect(Collectors.toList());
-
-        // users and machine users
-        List<UserManagementProto.User> users = createUsers("testUser", 10);
-
-        List<UserManagementProto.MachineUser> machineUsers = createMachineUsers(10);
-
-        List<String> allActorCrns = Stream.concat(users.stream().map(UserManagementProto.User::getCrn),
-                machineUsers.stream().map(UserManagementProto.MachineUser::getCrn))
-                .collect(Collectors.toList());
-
-        // mappings from actor to rights, group memberships, wag memberships, and credentials
-        Map<String, Map<String, Boolean>> memberCrnToActorRights = createActorRights(allActorCrns);
-
-        Map<String, Map<String, Boolean>> memberCrnToGroupMembership = createGroupMembership(allActorCrns);
-
-        Map<String, Map<String, Boolean>> memberCrnToWagMembership = createWagMembership(allActorCrns);
-
-        // credentials
-        Map<String, UserManagementProto.GetActorWorkloadCredentialsResponse> memberCrnToWorkloadCredentials =
-                createCredentials(allActorCrns);
-
-        // service principals cloud identities
-        List<UserManagementProto.ServicePrincipalCloudIdentities> servicePrincipalCloudIdentities =
-                createServicePrincipalCloudIdentities(5);
-
-        private Map<String, UserManagementProto.GetActorWorkloadCredentialsResponse> createCredentials(
-                List<String> allActorCrns) {
-            Map<String, String> actorCrnToWorkloadUsername = Maps.newHashMap();
-            actorCrnToWorkloadUsername.putAll(users.stream()
-                    .collect(Collectors.toMap(UserManagementProto.User::getCrn,
-                            UserManagementProto.User::getWorkloadUsername)));
-            actorCrnToWorkloadUsername.putAll(machineUsers.stream()
-                    .collect(Collectors.toMap(UserManagementProto.MachineUser::getCrn,
-                            UserManagementProto.MachineUser::getWorkloadUsername)));
-            return allActorCrns.stream()
-                    .collect(Collectors.toMap(
-                            Function.identity(),
-                            actorCrn -> createActorCredentials(actorCrnToWorkloadUsername.get(actorCrn))));
-        }
-
-        private UserManagementProto.GetActorWorkloadCredentialsResponse createActorCredentials(
-                String workloadUsername) {
-            return UserManagementProto.GetActorWorkloadCredentialsResponse.newBuilder()
-                    .setWorkloadUsername(workloadUsername)
-                    .setPasswordHash(RandomStringUtils.randomAlphabetic(50))
-                    .setPasswordHashExpirationDate(RANDOM.nextLong())
-                    .addKerberosKeys(UserManagementProto.ActorKerberosKey.newBuilder()
-                            .setKeyType(RANDOM.nextInt())
-                            .setKeyValue(RandomStringUtils.randomAlphabetic(10))
-                            .setSaltType(RANDOM.nextInt())
-                            .setSaltValue(RandomStringUtils.randomAlphabetic(10))
-                            .build())
-                    .addSshPublicKey(UserManagementProto.SshPublicKey.newBuilder()
-                            .setPublicKey(RandomStringUtils.randomAlphabetic(50))
-                            .setPublicKeyFingerprint(RandomStringUtils.randomAlphabetic(10))
-                            .setDescription(RandomStringUtils.randomAlphabetic(10))
-                            .build())
-                    .setWorkloadCredentialsVersion(randomNonNegativeLong())
-                    .build();
-        }
-
-        private Map<String, Map<String, Boolean>> createActorRights(List<String> allActorCrns) {
-            return allActorCrns.stream()
-                    .collect(Collectors.toMap(
-                            Function.identity(),
-                            actor -> createRandomBooleans(UserSyncConstants.RIGHTS)));
-        }
-
-        private Map<String, Map<String, Boolean>> createGroupMembership(List<String> allActorCrns) {
-            List<String> groupCrns = groups.stream()
-                    .map(UserManagementProto.Group::getCrn)
-                    .collect(Collectors.toList());
-            return allActorCrns.stream()
-                    .collect(Collectors.toMap(
-                            Function.identity(),
-                            actor -> createRandomBooleans(groupCrns)));
-        }
-
-        private Map<String, Map<String, Boolean>> createWagMembership(List<String> allActorCrns) {
-            List<String> wagNames = allWags.stream()
-                    .map(UserManagementProto.WorkloadAdministrationGroup::getWorkloadAdministrationGroupName)
-                    .collect(Collectors.toList());
-            return allActorCrns.stream()
-                    .collect(Collectors.toMap(
-                            Function.identity(),
-                            actor -> createRandomBooleans(wagNames)));
-        }
-
-        private <U> Map<U, Boolean> createRandomBooleans(List<U> keys) {
-            return keys.stream()
-                    .collect(Collectors.toMap(
-                            Function.identity(),
-                            right -> RANDOM.nextBoolean()));
-        }
-
-        private List<UserManagementProto.User> createUsers(String userNameBasis, int numUsers) {
-            return IntStream.range(0, numUsers)
-                    .mapToObj(i -> {
-                        return UserManagementProto.User.newBuilder()
-                                .setFirstName(RandomStringUtils.randomAlphabetic(10))
-                                .setLastName(RandomStringUtils.randomAlphabetic(10))
-                                .setCrn(Crn.builder(CrnResourceDescriptor.USER)
-                                        .setAccountId(ACCOUNT_ID)
-                                        .setResource(UUID.randomUUID().toString())
-                                        .build()
-                                        .toString())
-                                .setWorkloadUsername(userNameBasis + i)
-                                .addCloudIdentities(createCloudIdentity())
-                                .build();
-                    })
-                    .collect(Collectors.toList());
-        }
-
-        private List<UserManagementProto.MachineUser> createMachineUsers(int numUsers) {
-            return IntStream.range(0, numUsers)
-                    .mapToObj(i -> {
-                        String id = UUID.randomUUID().toString();
-                        return UserManagementProto.MachineUser.newBuilder()
-                                .setMachineUserId(id)
-                                .setMachineUserName(RandomStringUtils.randomAlphabetic(10))
-                                .setCrn(Crn.builder(CrnResourceDescriptor.MACHINE_USER)
-                                        .setAccountId(ACCOUNT_ID)
-                                        .setResource(UUID.randomUUID().toString())
-                                        .build()
-                                        .toString())
-                                .setWorkloadUsername(RandomStringUtils.randomAlphabetic(10))
-                                .addCloudIdentities(createCloudIdentity())
-                                .build();
-                    })
-                    .collect(Collectors.toList());
-        }
-
-        private List<UserManagementProto.Group> createGroups(String groupNameBasis, int numGroups) {
-            return IntStream.range(0, numGroups)
-                    .mapToObj(i -> {
-                        String name = groupNameBasis + i;
-                        String id = UUID.randomUUID().toString();
-                        return UserManagementProto.Group.newBuilder()
-                                .setGroupName(name)
-                                .setCrn(Crn.builder(CrnResourceDescriptor.GROUP)
-                                        .setAccountId(ACCOUNT_ID)
-                                        .setResource(name + "/" + id)
-                                        .build()
-                                        .toString())
-                                .build();
-                    })
-                    .collect(Collectors.toList());
-        }
-
-        private List<UserManagementProto.WorkloadAdministrationGroup> createWags(String environmentCrn, int numWags) {
-            return IntStream.range(0, numWags)
-                    .mapToObj(i -> UserManagementProto.WorkloadAdministrationGroup.newBuilder()
-                            .setResource(environmentCrn)
-                            .setRightName(UUID.randomUUID().toString())
-                            .setWorkloadAdministrationGroupName(UUID.randomUUID().toString())
-                            .build())
-                    .collect(Collectors.toList());
-        }
-
-        private List<UserManagementProto.ServicePrincipalCloudIdentities> createServicePrincipalCloudIdentities(int numSP) {
-            return IntStream.range(0, numSP)
-                    .mapToObj(i -> UserManagementProto.ServicePrincipalCloudIdentities.newBuilder()
-                            .setServicePrincipal(UUID.randomUUID().toString())
-                            .addCloudIdentities(createCloudIdentity())
-                            .build())
-                    .collect(Collectors.toList());
-        }
-
-        private UserManagementProto.CloudIdentity createCloudIdentity() {
-            return UserManagementProto.CloudIdentity.newBuilder()
-                    .setCloudIdentityName(UserManagementProto.CloudIdentityName.newBuilder()
-                            .setAzureCloudIdentityName(UserManagementProto.AzureCloudIdentityName.newBuilder()
-                                    .setObjectId(UUID.randomUUID().toString())
-                                    .build())
-                            .build())
-                    .setCloudIdentityDomain(UserManagementProto.CloudIdentityDomain.newBuilder()
-                            .setEnvironmentCrn(ENVIRONMENT_CRN)
-                            .setAzureCloudIdentityDomain(UserManagementProto.AzureCloudIdentityDomain.newBuilder()
-                                    .setAzureAdIdentifier(UUID.randomUUID().toString())
-                                    .build())
-                            .build())
-                    .build();
-        }
-
-        private static long randomNonNegativeLong() {
-            long val = RANDOM.nextLong();
-            return val == Long.MIN_VALUE ? Long.MAX_VALUE : Math.abs(val);
-        }
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/BulkUmsUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/BulkUmsUsersStateProviderTest.java
@@ -52,7 +52,7 @@ public class BulkUmsUsersStateProviderTest  extends BaseUmsUsersStateProviderTes
         setupMocksForBulk();
 
         Map<String, UmsUsersState> umsUsersStateMap = underTest.get(
-                ACCOUNT_ID, List.of(ENVIRONMENT_CRN), Optional.empty());
+                testData.getAccountId(), List.of(testData.getEnvironmentCrn()), Optional.empty());
 
         verifyUmsUsersStateBuilderMap(umsUsersStateMap);
     }
@@ -60,20 +60,20 @@ public class BulkUmsUsersStateProviderTest  extends BaseUmsUsersStateProviderTes
     private void setupMocksForBulk() {
         List<UserManagementProto.RightsCheck> expectedRightsChecks =
                 List.of(UserManagementProto.RightsCheck.newBuilder()
-                        .setResourceCrn(ENVIRONMENT_CRN)
+                        .setResourceCrn(testData.getEnvironmentCrn())
                         .addAllRight(UserSyncConstants.RIGHTS)
                         .build());
 
         UserManagementProto.GetUserSyncStateModelResponse.Builder builder =
                 UserManagementProto.GetUserSyncStateModelResponse.newBuilder();
 
-        builder.addAllGroup(testData.groups);
-        builder.addAllWorkloadAdministrationGroup(testData.allWags);
+        builder.addAllGroup(testData.getGroups());
+        builder.addAllWorkloadAdministrationGroup(testData.getAllWags());
         builder.addAllActor(Stream.concat(
-                testData.users.stream()
+                testData.getUsers().stream()
                         .map(u ->  {
-                            Map<String, Boolean> groupMembership = testData.memberCrnToGroupMembership.get(u.getCrn());
-                            Map<String, Boolean> wagMembership = testData.memberCrnToWagMembership.get(u.getCrn());
+                            Map<String, Boolean> groupMembership = testData.getMemberCrnToGroupMembership().get(u.getCrn());
+                            Map<String, Boolean> wagMembership = testData.getMemberCrnToWagMembership().get(u.getCrn());
                             return UserManagementProto.UserSyncActor.newBuilder()
                                     .setActorDetails(UserManagementProto.UserSyncActorDetails.newBuilder()
                                             .setCrn(u.getCrn())
@@ -84,26 +84,26 @@ public class BulkUmsUsersStateProviderTest  extends BaseUmsUsersStateProviderTes
                                             .build())
                                     .addRightsCheckResult(UserManagementProto.RightsCheckResult.newBuilder()
                                             .addAllHasRight(UserSyncConstants.RIGHTS.stream()
-                                                    .map(right -> testData.memberCrnToActorRights.get(u.getCrn()).get(right))
+                                                    .map(right -> testData.getMemberCrnToActorRights().get(u.getCrn()).get(right))
                                                     .collect(Collectors.toList()))
                                             .build())
-                                    .addAllGroupIndex(IntStream.range(0, testData.groups.size())
-                                            .filter(i -> groupMembership.get(testData.groups.get(i).getCrn()))
+                                    .addAllGroupIndex(IntStream.range(0, testData.getGroups().size())
+                                            .filter(i -> groupMembership.get(testData.getGroups().get(i).getCrn()))
                                             .boxed()
                                             .collect(Collectors.toList()))
-                                    .addAllWorkloadAdministrationGroupIndex(IntStream.range(0, testData.allWags.size())
+                                    .addAllWorkloadAdministrationGroupIndex(IntStream.range(0, testData.getAllWags().size())
                                             .filter(i -> wagMembership
-                                                    .get(testData.allWags.get(i).getWorkloadAdministrationGroupName()))
+                                                    .get(testData.getAllWags().get(i).getWorkloadAdministrationGroupName()))
                                             .boxed()
                                             .collect(Collectors.toList()))
                                     .setCredentials(toActorWorkloadCredentials(
-                                            testData.memberCrnToWorkloadCredentials.get(u.getCrn())))
+                                            testData.getMemberCrnToWorkloadCredentials().get(u.getCrn())))
                                     .build();
                         }),
-                testData.machineUsers.stream()
+                testData.getMachineUsers().stream()
                         .map(u -> {
-                            Map<String, Boolean> groupMembership = testData.memberCrnToGroupMembership.get(u.getCrn());
-                            Map<String, Boolean> wagMembership = testData.memberCrnToWagMembership.get(u.getCrn());
+                            Map<String, Boolean> groupMembership = testData.getMemberCrnToGroupMembership().get(u.getCrn());
+                            Map<String, Boolean> wagMembership = testData.getMemberCrnToWagMembership().get(u.getCrn());
                             return UserManagementProto.UserSyncActor.newBuilder()
                                     .setActorDetails(UserManagementProto.UserSyncActorDetails.newBuilder()
                                             .setCrn(u.getCrn())
@@ -114,26 +114,26 @@ public class BulkUmsUsersStateProviderTest  extends BaseUmsUsersStateProviderTes
                                             .build())
                                     .addRightsCheckResult(UserManagementProto.RightsCheckResult.newBuilder()
                                             .addAllHasRight(UserSyncConstants.RIGHTS.stream()
-                                                    .map(right -> testData.memberCrnToActorRights.get(u.getCrn()).get(right))
+                                                    .map(right -> testData.getMemberCrnToActorRights().get(u.getCrn()).get(right))
                                                     .collect(Collectors.toList()))
                                             .build())
-                                    .addAllGroupIndex(IntStream.range(0, testData.groups.size())
-                                            .filter(i -> groupMembership.get(testData.groups.get(i).getCrn()))
+                                    .addAllGroupIndex(IntStream.range(0, testData.getGroups().size())
+                                            .filter(i -> groupMembership.get(testData.getGroups().get(i).getCrn()))
                                             .boxed()
                                             .collect(Collectors.toList()))
-                                    .addAllWorkloadAdministrationGroupIndex(IntStream.range(0, testData.allWags.size())
+                                    .addAllWorkloadAdministrationGroupIndex(IntStream.range(0, testData.getAllWags().size())
                                             .filter(i -> wagMembership
-                                                    .get(testData.allWags.get(i).getWorkloadAdministrationGroupName()))
+                                                    .get(testData.getAllWags().get(i).getWorkloadAdministrationGroupName()))
                                             .boxed()
                                             .collect(Collectors.toList()))
                                     .setCredentials(toActorWorkloadCredentials(
-                                            testData.memberCrnToWorkloadCredentials.get(u.getCrn())))
+                                            testData.getMemberCrnToWorkloadCredentials().get(u.getCrn())))
                                     .build();
                         }))
                 .collect(Collectors.toList()));
 
         when(grpcUmsClient.getUserSyncStateModel(
-                eq(INTERNAL_ACTOR_CRN), eq(ACCOUNT_ID), eq(expectedRightsChecks), any(Optional.class)))
+                eq(INTERNAL_ACTOR_CRN), eq(testData.getAccountId()), eq(expectedRightsChecks), any(Optional.class)))
                 .thenReturn(builder.build());
         setupServicePrincipals();
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/MachineUserRetrieverTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/MachineUserRetrieverTest.java
@@ -1,0 +1,200 @@
+package com.sequenceiq.freeipa.service.freeipa.user.ums;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MachineUserRetrieverTest {
+
+    @Mock
+    private GrpcUmsClient grpcUmsClient;
+
+    @InjectMocks
+    private MachineUserRetriever underTest;
+
+    private UserSyncTestData testData = new UserSyncTestData();
+
+    @Test
+    void getMachineUsersFull() {
+        Optional<String> requestId = Optional.of(UUID.randomUUID().toString());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
+
+        when(grpcUmsClient.listAllMachineUsers(anyString(), anyString(), anyBoolean(), anyBoolean(), any(Optional.class)))
+                .thenReturn(testData.getMachineUsers());
+
+        List<UserManagementProto.MachineUser> machineUsers = underTest.getMachineUsers(
+                INTERNAL_ACTOR_CRN, testData.getAccountId(), requestId, true, ImmutableSet.of(), warnings::put);
+
+        assertEquals(testData.getMachineUsers(), machineUsers);
+        assertTrue(warnings.isEmpty());
+    }
+
+    @Test
+    void getMachineUsersSingle() {
+        setupListMachineUsersMock();
+        Optional<String> requestId = Optional.of(UUID.randomUUID().toString());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
+        UserManagementProto.MachineUser expectedMachineUser = testData.getMachineUsers().get(0);
+
+        List<UserManagementProto.MachineUser> machineUsers = underTest.getMachineUsers(
+                INTERNAL_ACTOR_CRN, testData.getAccountId(), requestId, false,
+                ImmutableSet.of(expectedMachineUser.getCrn()), warnings::put);
+
+        assertEquals(1, machineUsers.size());
+        assertEquals(expectedMachineUser, machineUsers.get(0));
+        verify(grpcUmsClient).listMachineUsers(eq(INTERNAL_ACTOR_CRN), eq(testData.getAccountId()),
+                eq(List.of(expectedMachineUser.getCrn())),
+                eq(MachineUserRetriever.DONT_INCLUDE_INTERNAL_MACHINE_USERS),
+                eq(MachineUserRetriever.INCLUDE_WORKLOAD_MACHINE_USERS),
+                eq(requestId));
+        assertTrue(warnings.isEmpty());
+    }
+
+    @Test
+    void getMachineUsersMultiple() {
+        setupListMachineUsersMock();
+        Optional<String> requestId = Optional.of(UUID.randomUUID().toString());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
+        List<UserManagementProto.MachineUser> expectedMachineUsers = testData.getMachineUsers()
+                .subList(0, 3);
+
+        Set<String> requestedCrns = expectedMachineUsers.stream()
+                .map(UserManagementProto.MachineUser::getCrn)
+                .collect(Collectors.toSet());
+
+        List<UserManagementProto.MachineUser> machineUsers = underTest.getMachineUsers(
+                INTERNAL_ACTOR_CRN, testData.getAccountId(), requestId, false,
+                requestedCrns, warnings::put);
+
+        assertEquals(expectedMachineUsers.size(), machineUsers.size());
+        assertTrue(expectedMachineUsers.containsAll(machineUsers));
+        assertTrue(machineUsers.containsAll(expectedMachineUsers));
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        verify(grpcUmsClient).listMachineUsers(eq(INTERNAL_ACTOR_CRN), eq(testData.getAccountId()),
+                captor.capture(),
+                eq(MachineUserRetriever.DONT_INCLUDE_INTERNAL_MACHINE_USERS),
+                eq(MachineUserRetriever.INCLUDE_WORKLOAD_MACHINE_USERS),
+                eq(requestId));
+        List<String> capturedCrns = captor.getValue();
+        assertTrue(requestedCrns.containsAll(capturedCrns));
+        assertTrue(capturedCrns.containsAll(requestedCrns));
+        assertTrue(warnings.isEmpty());
+    }
+
+    @Test
+    void getMachineUsersMultipleWithMissing() {
+        setupListMachineUsersMock();
+        Optional<String> requestId = Optional.of(UUID.randomUUID().toString());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
+        List<UserManagementProto.MachineUser> expectedMachineUsers = testData.getMachineUsers()
+                .subList(0, 3);
+
+        Set<String> requestedCrns = expectedMachineUsers.stream()
+                .map(UserManagementProto.MachineUser::getCrn)
+                .collect(Collectors.toSet());
+
+        String extraCrn = Crn.builder(CrnResourceDescriptor.MACHINE_USER)
+                .setAccountId(testData.getAccountId())
+                .setResource(UUID.randomUUID().toString())
+                .build()
+                .toString();
+        requestedCrns.add(extraCrn);
+
+        List<UserManagementProto.MachineUser> machineUsers = underTest.getMachineUsers(
+                INTERNAL_ACTOR_CRN, testData.getAccountId(), requestId, false,
+                requestedCrns, warnings::put);
+
+        assertEquals(expectedMachineUsers.size(), machineUsers.size());
+        assertTrue(expectedMachineUsers.containsAll(machineUsers));
+        assertTrue(machineUsers.containsAll(expectedMachineUsers));
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        verify(grpcUmsClient, times(requestedCrns.size() + 1)).listMachineUsers(
+                eq(INTERNAL_ACTOR_CRN),
+                eq(testData.getAccountId()),
+                captor.capture(),
+                eq(MachineUserRetriever.DONT_INCLUDE_INTERNAL_MACHINE_USERS),
+                eq(MachineUserRetriever.INCLUDE_WORKLOAD_MACHINE_USERS),
+                eq(requestId));
+        List<List<String>> capturedArguments = captor.getAllValues();
+        assertEquals(requestedCrns.size() + 1, capturedArguments.size());
+        List<String> capturedCrns = capturedArguments.get(0);
+        assertTrue(requestedCrns.containsAll(capturedCrns));
+        assertTrue(capturedCrns.containsAll(requestedCrns));
+        capturedArguments.subList(1, capturedArguments.size()).forEach(capturedCrn -> {
+            assertEquals(1, capturedCrn.size());
+            assertTrue(requestedCrns.contains(capturedCrn.get(0)));
+        });
+        assertEquals(1, warnings.size());
+        assertTrue(warnings.containsKey(extraCrn));
+    }
+
+    @Test
+    void getMachineUsersEmpty() {
+        Optional<String> requestId = Optional.of(UUID.randomUUID().toString());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
+
+        List<UserManagementProto.MachineUser> machineUsers = underTest.getMachineUsers(
+                INTERNAL_ACTOR_CRN, testData.getAccountId(), requestId, false, ImmutableSet.of(), warnings::put);
+
+        assertEquals(ImmutableList.of(), machineUsers);
+        assertTrue(warnings.isEmpty());
+    }
+
+    private void setupListMachineUsersMock() {
+        doAnswer(new Answer<List<UserManagementProto.MachineUser>>() {
+            @Override
+            public List<UserManagementProto.MachineUser> answer(InvocationOnMock invocation) throws Throwable {
+                List<UserManagementProto.MachineUser> answer;
+
+                List<String> requestedMachineUserCrns = invocation.getArgument(2);
+                if (requestedMachineUserCrns.isEmpty()) {
+                    answer = testData.getMachineUsers();
+                } else {
+                    answer = testData.getMachineUsers().stream()
+                            .filter(machineUser -> requestedMachineUserCrns.contains(machineUser.getCrn()))
+                            .collect(Collectors.toList());
+                    if (requestedMachineUserCrns.size() > answer.size()) {
+                        throw new StatusRuntimeException(Status.NOT_FOUND);
+                    }
+                }
+                return answer;
+            }
+        }).when(grpcUmsClient).listMachineUsers(anyString(), anyString(), anyList(),
+                anyBoolean(), anyBoolean(), any(Optional.class));
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/UmsUsersStateProviderDispatcherTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/UmsUsersStateProviderDispatcherTest.java
@@ -3,7 +3,6 @@ package com.sequenceiq.freeipa.service.freeipa.user.ums;
 import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -13,9 +12,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.sequenceiq.freeipa.service.freeipa.user.UserSyncRequestFilter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -55,6 +58,8 @@ class UmsUsersStateProviderDispatcherTest {
     void testFullSync() {
         Set<String> userCrns = Set.of();
         Set<String> machineUserCrns = Set.of();
+        UserSyncRequestFilter requestFilter = new UserSyncRequestFilter(userCrns, machineUserCrns, Optional.empty());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
 
         Map<String, UmsUsersState> expected = createExpectedResponse();
         when(bulkUmsUsersStateProvider.get(anyString(), any(Set.class), any(Optional.class)))
@@ -63,56 +68,62 @@ class UmsUsersStateProviderDispatcherTest {
         Optional<String> requestIdOptional = Optional.of(UUID.randomUUID().toString());
         Map<String, UmsUsersState> response = underTest.getEnvToUmsUsersStateMap(
                 ACCOUNT_ID, INTERNAL_ACTOR_CRN, ENVIRONMENT_CRNS,
-                userCrns, machineUserCrns, requestIdOptional);
+                requestFilter, requestIdOptional, warnings::put);
 
         assertEquals(expected, response);
         verify(bulkUmsUsersStateProvider).get(ACCOUNT_ID, ENVIRONMENT_CRNS, requestIdOptional);
         verify(defaultUmsUsersStateProvider, never()).get(anyString(), anyString(), any(Set.class),
-                any(Set.class), any(Set.class), any(Optional.class), anyBoolean());
+                any(UserSyncRequestFilter.class), any(Optional.class), any(BiConsumer.class));
     }
 
     @Test
     void testBulkFallsBackToDefault() {
         Set<String> userCrns = Set.of();
         Set<String> machineUserCrns = Set.of();
+        UserSyncRequestFilter requestFilter = new UserSyncRequestFilter(userCrns, machineUserCrns, Optional.empty());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
 
         when(bulkUmsUsersStateProvider.get(anyString(), any(Set.class), any(Optional.class)))
                 .thenThrow(StatusRuntimeException.class);
         Map<String, UmsUsersState> expected = createExpectedResponse();
         when(defaultUmsUsersStateProvider.get(anyString(), anyString(), any(Set.class),
-                any(Set.class), any(Set.class), any(Optional.class), anyBoolean()))
+                any(UserSyncRequestFilter.class), any(Optional.class), any(BiConsumer.class)))
                 .thenReturn(expected);
 
         Optional<String> requestIdOptional = Optional.of(UUID.randomUUID().toString());
+        BiConsumer<String, String> biConsumer = warnings::put;
         Map<String, UmsUsersState> response = underTest.getEnvToUmsUsersStateMap(
                 ACCOUNT_ID, INTERNAL_ACTOR_CRN, ENVIRONMENT_CRNS,
-                userCrns, machineUserCrns, requestIdOptional);
+                requestFilter, requestIdOptional, biConsumer);
 
         assertEquals(expected, response);
         verify(bulkUmsUsersStateProvider).get(ACCOUNT_ID, ENVIRONMENT_CRNS, requestIdOptional);
         verify(defaultUmsUsersStateProvider).get(ACCOUNT_ID, INTERNAL_ACTOR_CRN, ENVIRONMENT_CRNS,
-                userCrns, machineUserCrns, requestIdOptional, true);
+                requestFilter, requestIdOptional, biConsumer);
     }
 
     @Test
     void testPartialSync() {
         Set<String> userCrns = Set.of(createActorCrn(CrnResourceDescriptor.USER));
         Set<String> machineUserCrns = Set.of(createActorCrn(CrnResourceDescriptor.MACHINE_USER));
+        UserSyncRequestFilter requestFilter = new UserSyncRequestFilter(userCrns, machineUserCrns, Optional.empty());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
 
         Map<String, UmsUsersState> expected = createExpectedResponse();
         when(defaultUmsUsersStateProvider.get(anyString(), anyString(), any(Set.class),
-                any(Set.class), any(Set.class), any(Optional.class), anyBoolean()))
+                any(UserSyncRequestFilter.class), any(Optional.class), any(BiConsumer.class)))
                 .thenReturn(expected);
 
         Optional<String> requestIdOptional = Optional.of(UUID.randomUUID().toString());
+        BiConsumer<String, String> biConsumer = warnings::put;
         Map<String, UmsUsersState> response = underTest.getEnvToUmsUsersStateMap(
                 ACCOUNT_ID, INTERNAL_ACTOR_CRN, ENVIRONMENT_CRNS,
-                userCrns, machineUserCrns, requestIdOptional);
+                requestFilter, requestIdOptional, biConsumer);
 
         assertEquals(expected, response);
         verify(bulkUmsUsersStateProvider, never()).get(ACCOUNT_ID, ENVIRONMENT_CRNS, requestIdOptional);
         verify(defaultUmsUsersStateProvider).get(ACCOUNT_ID, INTERNAL_ACTOR_CRN, ENVIRONMENT_CRNS,
-                userCrns, machineUserCrns, requestIdOptional, false);
+                requestFilter, requestIdOptional, biConsumer);
     }
 
     private Map<String, UmsUsersState> createExpectedResponse() {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/UserRetrieverTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/UserRetrieverTest.java
@@ -1,0 +1,192 @@
+package com.sequenceiq.freeipa.service.freeipa.user.ums;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserRetrieverTest {
+
+    @Mock
+    private GrpcUmsClient grpcUmsClient;
+
+    @InjectMocks
+    private UserRetriever underTest;
+
+    private UserSyncTestData testData = new UserSyncTestData();
+
+    @Test
+    void getUsersFull() {
+        Optional<String> requestId = Optional.of(UUID.randomUUID().toString());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
+
+        when(grpcUmsClient.listAllUsers(anyString(), anyString(), any(Optional.class)))
+                .thenReturn(testData.getUsers());
+
+        List<UserManagementProto.User> users = underTest.getUsers(
+                INTERNAL_ACTOR_CRN, testData.getAccountId(), requestId, true, ImmutableSet.of(), warnings::put);
+
+        assertEquals(testData.getUsers(), users);
+        assertTrue(warnings.isEmpty());
+    }
+
+    @Test
+    void getUsersSingle() {
+        setupListUsersMock();
+        Optional<String> requestId = Optional.of(UUID.randomUUID().toString());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
+        UserManagementProto.User expectedUser = testData.getUsers().get(0);
+
+        List<UserManagementProto.User> users = underTest.getUsers(
+                INTERNAL_ACTOR_CRN, testData.getAccountId(), requestId, false,
+                ImmutableSet.of(expectedUser.getCrn()), warnings::put);
+
+        assertEquals(1, users.size());
+        assertEquals(expectedUser, users.get(0));
+        verify(grpcUmsClient).listUsers(eq(INTERNAL_ACTOR_CRN), eq(testData.getAccountId()),
+                eq(List.of(expectedUser.getCrn())),
+                eq(requestId));
+        assertTrue(warnings.isEmpty());
+    }
+
+    @Test
+    void getUsersMultiple() {
+        setupListUsersMock();
+        Optional<String> requestId = Optional.of(UUID.randomUUID().toString());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
+        List<UserManagementProto.User> expectedUsers = testData.getUsers()
+                .subList(0, 3);
+
+        Set<String> requestedCrns = expectedUsers.stream()
+                .map(UserManagementProto.User::getCrn)
+                .collect(Collectors.toSet());
+
+        List<UserManagementProto.User> users = underTest.getUsers(
+                INTERNAL_ACTOR_CRN, testData.getAccountId(), requestId, false,
+                requestedCrns, warnings::put);
+
+        assertEquals(expectedUsers.size(), users.size());
+        assertTrue(expectedUsers.containsAll(users));
+        assertTrue(users.containsAll(expectedUsers));
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        verify(grpcUmsClient).listUsers(eq(INTERNAL_ACTOR_CRN), eq(testData.getAccountId()),
+                captor.capture(),
+                eq(requestId));
+        List<String> capturedCrns = captor.getValue();
+        assertTrue(requestedCrns.containsAll(capturedCrns));
+        assertTrue(capturedCrns.containsAll(requestedCrns));
+        assertTrue(warnings.isEmpty());
+    }
+
+    @Test
+    void getUsersMultipleWithMissing() {
+        setupListUsersMock();
+        Optional<String> requestId = Optional.of(UUID.randomUUID().toString());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
+        List<UserManagementProto.User> expectedUsers = testData.getUsers()
+                .subList(0, 3);
+
+        Set<String> requestedCrns = expectedUsers.stream()
+                .map(UserManagementProto.User::getCrn)
+                .collect(Collectors.toSet());
+
+        String extraCrn = Crn.builder(CrnResourceDescriptor.USER)
+                .setAccountId(testData.getAccountId())
+                .setResource(UUID.randomUUID().toString())
+                .build()
+                .toString();
+        requestedCrns.add(extraCrn);
+
+        List<UserManagementProto.User> users = underTest.getUsers(
+                INTERNAL_ACTOR_CRN, testData.getAccountId(), requestId, false,
+                requestedCrns, warnings::put);
+
+        assertEquals(expectedUsers.size(), users.size());
+        assertTrue(expectedUsers.containsAll(users));
+        assertTrue(users.containsAll(expectedUsers));
+        ArgumentCaptor<List<String>> captor = ArgumentCaptor.forClass(List.class);
+        verify(grpcUmsClient, times(requestedCrns.size() + 1)).listUsers(
+                eq(INTERNAL_ACTOR_CRN),
+                eq(testData.getAccountId()),
+                captor.capture(),
+                eq(requestId));
+        List<List<String>> capturedArguments = captor.getAllValues();
+        assertEquals(requestedCrns.size() + 1, capturedArguments.size());
+        List<String> capturedCrns = capturedArguments.get(0);
+        assertTrue(requestedCrns.containsAll(capturedCrns));
+        assertTrue(capturedCrns.containsAll(requestedCrns));
+        capturedArguments.subList(1, capturedArguments.size()).forEach(capturedCrn -> {
+            assertEquals(1, capturedCrn.size());
+            assertTrue(requestedCrns.contains(capturedCrn.get(0)));
+        });
+        assertEquals(1, warnings.size());
+        assertTrue(warnings.containsKey(extraCrn));
+    }
+
+    @Test
+    void getUsersEmpty() {
+        Optional<String> requestId = Optional.of(UUID.randomUUID().toString());
+        Multimap<String, String> warnings = ArrayListMultimap.create();
+
+        List<UserManagementProto.User> users = underTest.getUsers(
+                INTERNAL_ACTOR_CRN, testData.getAccountId(), requestId, false, ImmutableSet.of(), warnings::put);
+
+        assertEquals(ImmutableList.of(), users);
+        assertTrue(warnings.isEmpty());
+    }
+
+    private void setupListUsersMock() {
+        doAnswer(new Answer<List<UserManagementProto.User>>() {
+            @Override
+            public List<UserManagementProto.User> answer(InvocationOnMock invocation) throws Throwable {
+                List<UserManagementProto.User> answer;
+
+                List<String> requestedUserCrns = invocation.getArgument(2);
+                if (requestedUserCrns.isEmpty()) {
+                    answer = testData.getUsers();
+                } else {
+                    answer = testData.getUsers().stream()
+                            .filter(user -> requestedUserCrns.contains(user.getCrn()))
+                            .collect(Collectors.toList());
+                    if (requestedUserCrns.size() > answer.size()) {
+                        throw new StatusRuntimeException(Status.NOT_FOUND);
+                    }
+                }
+                return answer;
+            }
+        }).when(grpcUmsClient).listUsers(anyString(), anyString(), anyList(), any(Optional.class));
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/UserSyncTestData.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/UserSyncTestData.java
@@ -1,0 +1,309 @@
+package com.sequenceiq.freeipa.service.freeipa.user.ums;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
+import com.sequenceiq.freeipa.service.freeipa.user.UserSyncConstants;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class UserSyncTestData {
+    private final SecureRandom random = new SecureRandom();
+
+    private final String accountId = UUID.randomUUID().toString();
+
+    private final String actorCrn = Crn.builder(CrnResourceDescriptor.USER)
+            .setAccountId(accountId)
+            .setResource(UUID.randomUUID().toString())
+            .build()
+            .toString();
+
+    private final String environmentCrn = createEnvironmentCrn();
+
+    // groups
+    private final ImmutableList<UserManagementProto.Group> groups =
+            createGroups("testGroup", 10);
+
+    // wags
+    private final ImmutableList<UserManagementProto.WorkloadAdministrationGroup> wagsForThisEnvironment =
+            createWags(environmentCrn, 10);
+
+    private final ImmutableList<UserManagementProto.WorkloadAdministrationGroup> wagsForOtherEnvironment =
+            createWags(createEnvironmentCrn(), 10);
+
+    private final ImmutableList<UserManagementProto.WorkloadAdministrationGroup> allWags =
+            ImmutableList.copyOf(Stream.concat(
+                    wagsForThisEnvironment.stream(),
+                    wagsForOtherEnvironment.stream())
+                    .collect(Collectors.toList()));
+
+    // users and machine users
+    private final ImmutableList<UserManagementProto.User> users = createUsers("testUser", 10);
+
+    private final ImmutableList<UserManagementProto.MachineUser> machineUsers = createMachineUsers(10);
+
+    private final ImmutableList<String> allActorCrns = ImmutableList.copyOf(Stream.concat(users.stream().map(UserManagementProto.User::getCrn),
+            machineUsers.stream().map(UserManagementProto.MachineUser::getCrn))
+            .collect(Collectors.toList()));
+
+    // mappings from actor to rights, group memberships, wag memberships, and credentials
+    private final ImmutableMap<String, ImmutableMap<String, Boolean>> memberCrnToActorRights =
+            createActorRights(allActorCrns);
+
+    private final ImmutableMap<String, ImmutableMap<String, Boolean>> memberCrnToGroupMembership =
+            createGroupMembership(allActorCrns);
+
+    private final ImmutableMap<String, ImmutableMap<String, Boolean>> memberCrnToWagMembership =
+            createWagMembership(allActorCrns);
+
+    // credentials
+    private final ImmutableMap<String, UserManagementProto.GetActorWorkloadCredentialsResponse> memberCrnToWorkloadCredentials =
+            createCredentials(allActorCrns);
+
+    // service principals cloud identities
+    private final ImmutableList<UserManagementProto.ServicePrincipalCloudIdentities> servicePrincipalCloudIdentities =
+            createServicePrincipalCloudIdentities(5);
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public String getActorCrn() {
+        return actorCrn;
+    }
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public ImmutableList<UserManagementProto.Group> getGroups() {
+        return groups;
+    }
+
+    public ImmutableList<UserManagementProto.WorkloadAdministrationGroup> getWagsForThisEnvironment() {
+        return wagsForThisEnvironment;
+    }
+
+    public ImmutableList<UserManagementProto.WorkloadAdministrationGroup> getWagsForOtherEnvironment() {
+        return wagsForOtherEnvironment;
+    }
+
+    public ImmutableList<UserManagementProto.WorkloadAdministrationGroup> getAllWags() {
+        return allWags;
+    }
+
+    public ImmutableList<UserManagementProto.User> getUsers() {
+        return users;
+    }
+
+    public ImmutableList<UserManagementProto.MachineUser> getMachineUsers() {
+        return machineUsers;
+    }
+
+    public ImmutableList<String> getAllActorCrns() {
+        return allActorCrns;
+    }
+
+    public ImmutableMap<String, ImmutableMap<String, Boolean>> getMemberCrnToActorRights() {
+        return memberCrnToActorRights;
+    }
+
+    public ImmutableMap<String, ImmutableMap<String, Boolean>> getMemberCrnToGroupMembership() {
+        return memberCrnToGroupMembership;
+    }
+
+    public ImmutableMap<String, ImmutableMap<String, Boolean>> getMemberCrnToWagMembership() {
+        return memberCrnToWagMembership;
+    }
+
+    public ImmutableMap<String, UserManagementProto.GetActorWorkloadCredentialsResponse> getMemberCrnToWorkloadCredentials() {
+        return memberCrnToWorkloadCredentials;
+    }
+
+    public ImmutableList<UserManagementProto.ServicePrincipalCloudIdentities> getServicePrincipalCloudIdentities() {
+        return servicePrincipalCloudIdentities;
+    }
+
+    private String createEnvironmentCrn() {
+        return Crn.builder(CrnResourceDescriptor.ENVIRONMENT)
+                .setAccountId(accountId)
+                .setResource(UUID.randomUUID().toString())
+                .build()
+                .toString();
+    }
+
+    private ImmutableMap<String, UserManagementProto.GetActorWorkloadCredentialsResponse> createCredentials(
+            List<String> allActorCrns) {
+        Map<String, String> actorCrnToWorkloadUsername = Maps.newHashMap();
+        actorCrnToWorkloadUsername.putAll(users.stream()
+                .collect(Collectors.toMap(UserManagementProto.User::getCrn,
+                        UserManagementProto.User::getWorkloadUsername)));
+        actorCrnToWorkloadUsername.putAll(machineUsers.stream()
+                .collect(Collectors.toMap(UserManagementProto.MachineUser::getCrn,
+                        UserManagementProto.MachineUser::getWorkloadUsername)));
+        return ImmutableMap.copyOf(allActorCrns.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        actorCrn -> createActorCredentials(actorCrnToWorkloadUsername.get(actorCrn)))));
+    }
+
+    private UserManagementProto.GetActorWorkloadCredentialsResponse createActorCredentials(
+            String workloadUsername) {
+        return UserManagementProto.GetActorWorkloadCredentialsResponse.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setPasswordHash(RandomStringUtils.randomAlphabetic(50))
+                .setPasswordHashExpirationDate(random.nextLong())
+                .addKerberosKeys(UserManagementProto.ActorKerberosKey.newBuilder()
+                        .setKeyType(random.nextInt())
+                        .setKeyValue(RandomStringUtils.randomAlphabetic(10))
+                        .setSaltType(random.nextInt())
+                        .setSaltValue(RandomStringUtils.randomAlphabetic(10))
+                        .build())
+                .addSshPublicKey(UserManagementProto.SshPublicKey.newBuilder()
+                        .setPublicKey(RandomStringUtils.randomAlphabetic(50))
+                        .setPublicKeyFingerprint(RandomStringUtils.randomAlphabetic(10))
+                        .setDescription(RandomStringUtils.randomAlphabetic(10))
+                        .build())
+                .setWorkloadCredentialsVersion(randomNonNegativeLong())
+                .build();
+    }
+
+    private ImmutableMap<String, ImmutableMap<String, Boolean>> createActorRights(List<String> allActorCrns) {
+        return ImmutableMap.copyOf(allActorCrns.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        actor -> createRandomBooleans(UserSyncConstants.RIGHTS))));
+    }
+
+    private ImmutableMap<String, ImmutableMap<String, Boolean>> createGroupMembership(List<String> allActorCrns) {
+        List<String> groupCrns = groups.stream()
+                .map(UserManagementProto.Group::getCrn)
+                .collect(Collectors.toList());
+        return ImmutableMap.copyOf(allActorCrns.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        actor -> createRandomBooleans(groupCrns))));
+    }
+
+    private ImmutableMap<String, ImmutableMap<String, Boolean>> createWagMembership(List<String> allActorCrns) {
+        List<String> wagNames = allWags.stream()
+                .map(UserManagementProto.WorkloadAdministrationGroup::getWorkloadAdministrationGroupName)
+                .collect(Collectors.toList());
+        return ImmutableMap.copyOf(allActorCrns.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        actor -> createRandomBooleans(wagNames))));
+    }
+
+    private <U> ImmutableMap<U, Boolean> createRandomBooleans(List<U> keys) {
+        return ImmutableMap.copyOf(keys.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        right -> random.nextBoolean())));
+    }
+
+    private ImmutableList<UserManagementProto.User> createUsers(String userNameBasis, int numUsers) {
+        return ImmutableList.copyOf(IntStream.range(0, numUsers)
+                .mapToObj(i -> {
+                    return UserManagementProto.User.newBuilder()
+                            .setFirstName(RandomStringUtils.randomAlphabetic(10))
+                            .setLastName(RandomStringUtils.randomAlphabetic(10))
+                            .setCrn(Crn.builder(CrnResourceDescriptor.USER)
+                                    .setAccountId(accountId)
+                                    .setResource(UUID.randomUUID().toString())
+                                    .build()
+                                    .toString())
+                            .setWorkloadUsername(userNameBasis + i)
+                            .addCloudIdentities(createCloudIdentity())
+                            .build();
+                })
+                .collect(Collectors.toList()));
+    }
+
+    private ImmutableList<UserManagementProto.MachineUser> createMachineUsers(int numUsers) {
+        return ImmutableList.copyOf(IntStream.range(0, numUsers)
+                .mapToObj(i -> {
+                    String id = UUID.randomUUID().toString();
+                    return UserManagementProto.MachineUser.newBuilder()
+                            .setMachineUserId(id)
+                            .setMachineUserName(RandomStringUtils.randomAlphabetic(10))
+                            .setCrn(Crn.builder(CrnResourceDescriptor.MACHINE_USER)
+                                    .setAccountId(accountId)
+                                    .setResource(UUID.randomUUID().toString())
+                                    .build()
+                                    .toString())
+                            .setWorkloadUsername(RandomStringUtils.randomAlphabetic(10))
+                            .addCloudIdentities(createCloudIdentity())
+                            .build();
+                })
+                .collect(Collectors.toList()));
+    }
+
+    private ImmutableList<UserManagementProto.Group> createGroups(String groupNameBasis, int numGroups) {
+        return ImmutableList.copyOf(IntStream.range(0, numGroups)
+                .mapToObj(i -> {
+                    String name = groupNameBasis + i;
+                    String id = UUID.randomUUID().toString();
+                    return UserManagementProto.Group.newBuilder()
+                            .setGroupName(name)
+                            .setCrn(Crn.builder(CrnResourceDescriptor.GROUP)
+                                    .setAccountId(accountId)
+                                    .setResource(name + "/" + id)
+                                    .build()
+                                    .toString())
+                            .build();
+                })
+                .collect(Collectors.toList()));
+    }
+
+    private ImmutableList<UserManagementProto.WorkloadAdministrationGroup> createWags(String environmentCrn, int numWags) {
+        return ImmutableList.copyOf(IntStream.range(0, numWags)
+                .mapToObj(i -> UserManagementProto.WorkloadAdministrationGroup.newBuilder()
+                        .setResource(environmentCrn)
+                        .setRightName(UUID.randomUUID().toString())
+                        .setWorkloadAdministrationGroupName(UUID.randomUUID().toString())
+                        .build())
+                .collect(Collectors.toList()));
+    }
+
+    private ImmutableList<UserManagementProto.ServicePrincipalCloudIdentities> createServicePrincipalCloudIdentities(int numSP) {
+        return ImmutableList.copyOf(IntStream.range(0, numSP)
+                .mapToObj(i -> UserManagementProto.ServicePrincipalCloudIdentities.newBuilder()
+                        .setServicePrincipal(UUID.randomUUID().toString())
+                        .addCloudIdentities(createCloudIdentity())
+                        .build())
+                .collect(Collectors.toList()));
+    }
+
+    private UserManagementProto.CloudIdentity createCloudIdentity() {
+        return UserManagementProto.CloudIdentity.newBuilder()
+                .setCloudIdentityName(UserManagementProto.CloudIdentityName.newBuilder()
+                        .setAzureCloudIdentityName(UserManagementProto.AzureCloudIdentityName.newBuilder()
+                                .setObjectId(UUID.randomUUID().toString())
+                                .build())
+                        .build())
+                .setCloudIdentityDomain(UserManagementProto.CloudIdentityDomain.newBuilder()
+                        .setEnvironmentCrn(environmentCrn)
+                        .setAzureCloudIdentityDomain(UserManagementProto.AzureCloudIdentityDomain.newBuilder()
+                                .setAzureAdIdentifier(UUID.randomUUID().toString())
+                                .build())
+                        .build())
+                .build();
+    }
+
+    private long randomNonNegativeLong() {
+        long val = random.nextLong();
+        return val == Long.MIN_VALUE ? Long.MAX_VALUE : Math.abs(val);
+    }
+}


### PR DESCRIPTION
Partial user sync failed to retrieve the UMS state if a specified
user or machineUser does not exist in UMS. This could be a problem
if a user sync invocation races against deletion of the actor. This
commit fixes this issue by reverting to retrieving users and
machineUsers individually if we receive a NOT_FOUND exception retrieving
the actors as a group. The missing actor will be recorded in the
warnings for the user sync.

Along with this change, parameter lists for some methods have been
simplified. Whether a user sync is a full sync or partial sync is dependent
upon the parameters in the UserSyncRequestFilter. I've removed
the "full sync" boolean parameter from methods that include the
request filter as a parameter. I've also changed methods that
include user and machine user crn lists to include the request
filter instead.

See detailed description in the commit message.