### PR TITLE
CB-11417 Replace DefaultRestartAction for flows in cb core service

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrenew/ClusterCertificateRenewState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrenew/ClusterCertificateRenewState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.certrenew;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum  ClusterCertificateRenewState implements FlowState {
     INIT_STATE,
@@ -9,4 +11,9 @@ public enum  ClusterCertificateRenewState implements FlowState {
     CLUSTER_CERTIFICATE_RENEWAL_FINISHED_STATE,
     CLUSTER_CERTIFICATE_RENEW_FAILED_STATE,
     FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/certrotate/ClusterCertificatesRotationState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.certrotate;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum ClusterCertificatesRotationState implements FlowState {
     INIT_STATE,
@@ -11,4 +13,9 @@ public enum ClusterCertificatesRotationState implements FlowState {
     CLUSTER_CERTIFICATES_ROTATION_FINISHED_STATE,
     CLUSTER_CERTIFICATES_ROTATION_FAILED_STATE,
     FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/PillarConfigUpdateState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.config.update;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum PillarConfigUpdateState implements FlowState {
     INIT_STATE,
@@ -8,4 +10,9 @@ public enum PillarConfigUpdateState implements FlowState {
     PILLAR_CONFIG_UPDATE_FINISHED_STATE,
     FINAL_STATE,
     PILLAR_CONFIG_UPDATE_FAILED_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/backup/DatabaseBackupState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/backup/DatabaseBackupState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.backup;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum DatabaseBackupState implements FlowState {
     INIT_STATE,
@@ -8,4 +10,9 @@ public enum DatabaseBackupState implements FlowState {
     DATABASE_BACKUP_FAILED_STATE,
     DATABASE_BACKUP_FINISHED_STATE,
     FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/restore/DatabaseRestoreState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/restore/DatabaseRestoreState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr.restore;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum DatabaseRestoreState implements FlowState {
     INIT_STATE,
@@ -8,4 +10,9 @@ public enum DatabaseRestoreState implements FlowState {
     DATABASE_RESTORE_FAILED_STATE,
     DATABASE_RESTORE_FINISHED_STATE,
     FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeState.java
@@ -1,15 +1,20 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum ClusterUpgradeState implements FlowState {
     INIT_STATE,
     CLUSTER_UPGRADE_FAILED_STATE,
-
     CLUSTER_UPGRADE_INIT_STATE,
     CLUSTER_MANAGER_UPGRADE_STATE,
     CLUSTER_UPGRADE_STATE,
     CLUSTER_UPGRADE_FINISHED_STATE,
+    FINAL_STATE;
 
-    FINAL_STATE
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/maintenance/MaintenanceModeValidationState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/maintenance/MaintenanceModeValidationState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.maintenance;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum MaintenanceModeValidationState implements FlowState {
 
@@ -11,5 +13,10 @@ public enum MaintenanceModeValidationState implements FlowState {
     VALIDATE_IMAGE_COMPATIBILITY_STATE,
     VALIDATION_FINISHED_STATE,
     VALIDATION_FAILED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/update/SaltUpdateState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/salt/update/SaltUpdateState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.salt.update;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum SaltUpdateState implements FlowState {
     INIT_STATE,
@@ -11,4 +13,9 @@ public enum SaltUpdateState implements FlowState {
     SALT_UPDATE_FINISHED_STATE,
     FINAL_STATE,
     SALT_UPDATE_FAILED_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/start/ClusterStartState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/start/ClusterStartState.java
@@ -17,7 +17,7 @@ public enum ClusterStartState implements FlowState {
 
     FINAL_STATE;
 
-    private Class<? extends DefaultRestartAction> restartAction = DefaultRestartAction.class;
+    private Class<? extends DefaultRestartAction> restartAction = FillInMemoryStateStoreRestartAction.class;
 
     ClusterStartState() {
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stop/ClusterStopState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/stop/ClusterStopState.java
@@ -14,7 +14,7 @@ public enum ClusterStopState implements FlowState {
 
     FINAL_STATE;
 
-    private Class<? extends DefaultRestartAction> restartAction = DefaultRestartAction.class;
+    private Class<? extends DefaultRestartAction> restartAction = FillInMemoryStateStoreRestartAction.class;
 
     ClusterStopState() {
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/termination/ClusterTerminationState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/termination/ClusterTerminationState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.termination;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum ClusterTerminationState implements FlowState {
     INIT_STATE,
@@ -12,5 +14,10 @@ public enum ClusterTerminationState implements FlowState {
     CLUSTER_TERMINATING_STATE,
     CLUSTER_TERMINATION_FINISH_STATE,
 
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/userpasswd/ClusterCredentialChangeState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/userpasswd/ClusterCredentialChangeState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.userpasswd;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum ClusterCredentialChangeState implements FlowState {
     INIT_STATE,
@@ -9,5 +11,10 @@ public enum ClusterCredentialChangeState implements FlowState {
     CLUSTER_CREDENTIALCHANGE_STATE,
     CLUSTER_CREDENTIALCHANGE_FINISHED_STATE,
 
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/CmDiagnosticsCollectionState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/CmDiagnosticsCollectionState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.cmdiagnostics;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum CmDiagnosticsCollectionState implements FlowState {
     INIT_STATE,
@@ -10,5 +12,10 @@ public enum CmDiagnosticsCollectionState implements FlowState {
     CM_DIAGNOSTICS_CLEANUP_STATE,
     CM_DIAGNOSTICS_COLLECTION_FINISHED_STATE,
     CM_DIAGNOSTICS_COLLECTION_FAILED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionsState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsCollectionsState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.diagnostics;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum DiagnosticsCollectionsState implements FlowState {
     INIT_STATE,
@@ -12,5 +14,10 @@ public enum DiagnosticsCollectionsState implements FlowState {
     DIAGNOSTICS_CLEANUP_STATE,
     DIAGNOSTICS_COLLECTION_FINISHED_STATE,
     DIAGNOSTICS_COLLECTION_FAILED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/config/ExternalDatabaseCreationState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/provision/config/ExternalDatabaseCreationState.java
@@ -1,11 +1,18 @@
 package com.sequenceiq.cloudbreak.core.flow2.externaldatabase.provision.config;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.InitializeMDCContextRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum ExternalDatabaseCreationState implements FlowState {
     INIT_STATE,
     WAIT_FOR_EXTERNAL_DATABASE_STATE,
     EXTERNAL_DATABASE_CREATION_FAILED_STATE,
     EXTERNAL_DATABASE_CREATION_FINISHED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return InitializeMDCContextRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/start/config/ExternalDatabaseStartState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/start/config/ExternalDatabaseStartState.java
@@ -1,11 +1,18 @@
 package com.sequenceiq.cloudbreak.core.flow2.externaldatabase.start.config;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.InitializeMDCContextRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum ExternalDatabaseStartState implements FlowState {
     INIT_STATE,
     EXTERNAL_DATABASE_STARTING_STATE,
     EXTERNAL_DATABASE_START_FAILED_STATE,
     EXTERNAL_DATABASE_START_FINISHED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return InitializeMDCContextRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/stop/config/ExternalDatabaseStopState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/stop/config/ExternalDatabaseStopState.java
@@ -1,11 +1,18 @@
 package com.sequenceiq.cloudbreak.core.flow2.externaldatabase.stop.config;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.InitializeMDCContextRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum ExternalDatabaseStopState implements FlowState {
     INIT_STATE,
     EXTERNAL_DATABASE_STOPPING_STATE,
     EXTERNAL_DATABASE_STOP_FAILED_STATE,
     EXTERNAL_DATABASE_STOP_FINISHED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return InitializeMDCContextRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/config/ExternalDatabaseTerminationState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/terminate/config/ExternalDatabaseTerminationState.java
@@ -1,11 +1,18 @@
 package com.sequenceiq.cloudbreak.core.flow2.externaldatabase.terminate.config;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.InitializeMDCContextRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum ExternalDatabaseTerminationState implements FlowState {
     INIT_STATE,
     WAIT_FOR_EXTERNAL_DATABASE_TERMINATION_STATE,
     EXTERNAL_DATABASE_TERMINATION_FAILED_STATE,
     EXTERNAL_DATABASE_TERMINATION_FINISHED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return InitializeMDCContextRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/restart/InitializeMDCContextRestartAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/restart/InitializeMDCContextRestartAction.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.core.flow2.restart;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
+
+@Component("InitializeMDCContextRestartAction")
+public class InitializeMDCContextRestartAction extends DefaultRestartAction {
+
+    @Inject
+    private StackService stackService;
+
+    @Override
+    public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
+        Payload stackPayload = (Payload) payload;
+        Stack stack = stackService.getById(stackPayload.getResourceId());
+        MDCBuilder.buildMdcContext(stack);
+        super.restart(flowParameters, flowChainId, event, payload);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/restart/WaitForSyncRestartAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/restart/WaitForSyncRestartAction.java
@@ -9,6 +9,7 @@ import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionRuntimeExecutionException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.core.FlowLogService;
@@ -31,6 +32,7 @@ public class WaitForSyncRestartAction extends DefaultRestartAction {
     public void restart(FlowParameters flowParameters, String flowChainId, String event, Object payload) {
         Payload stackPayload = (Payload) payload;
         Stack stack = stackService.getByIdWithListsInTransaction(stackPayload.getResourceId());
+        MDCBuilder.buildMdcContext(stack);
         stackUpdater.updateStackStatus(stack.getId(), DetailedStackStatus.WAIT_FOR_SYNC, stack.getStatusReason());
         try {
             flowLogService.terminate(stackPayload.getResourceId(), flowParameters.getFlowId());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateState.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack.image.update;
 
 import com.sequenceiq.cloudbreak.core.flow2.AbstractStackAction;
+import com.sequenceiq.cloudbreak.core.flow2.restart.InitializeMDCContextRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum StackImageUpdateState implements FlowState {
     INIT_STATE,
@@ -27,5 +29,10 @@ public enum StackImageUpdateState implements FlowState {
     @Override
     public Class<? extends AbstractStackAction<?, ?, ?, ?>> action() {
         return action;
+    }
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return InitializeMDCContextRestartAction.class;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationState.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack.instance.termination;
 
 import com.sequenceiq.cloudbreak.core.flow2.AbstractStackAction;
+import com.sequenceiq.cloudbreak.core.flow2.restart.InitializeMDCContextRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 enum InstanceTerminationState implements FlowState {
 
@@ -23,5 +25,10 @@ enum InstanceTerminationState implements FlowState {
     @Override
     public Class<? extends AbstractStackAction<?, ?, ?, ?>> action() {
         return action;
+    }
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return InitializeMDCContextRestartAction.class;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/start/StackStartState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/start/StackStartState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack.start;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.InitializeMDCContextRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum StackStartState implements FlowState {
     INIT_STATE,
@@ -8,5 +10,10 @@ public enum StackStartState implements FlowState {
     START_STATE,
     COLLECTING_METADATA,
     START_FINISHED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return InitializeMDCContextRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/stop/StackStopState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/stop/StackStopState.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack.stop;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.InitializeMDCContextRestartAction;
 import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.RestartAction;
 import com.sequenceiq.flow.core.restart.DefaultRestartAction;
@@ -11,7 +12,7 @@ public enum StackStopState implements FlowState {
     STOP_FINISHED_STATE,
     FINAL_STATE;
 
-    private Class<? extends DefaultRestartAction> restartAction = DefaultRestartAction.class;
+    private Class<? extends DefaultRestartAction> restartAction = InitializeMDCContextRestartAction.class;
 
     StackStopState() {
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationState.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack.termination;
 
 import com.sequenceiq.cloudbreak.core.flow2.AbstractStackAction;
+import com.sequenceiq.cloudbreak.core.flow2.restart.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum StackTerminationState implements FlowState {
     INIT_STATE,
@@ -25,5 +27,10 @@ public enum StackTerminationState implements FlowState {
     @Override
     public Class<? extends AbstractStackAction<?, ?, ?, ?>> action() {
         return action;
+    }
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/config/CloudConfigValidationState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/cloud/config/CloudConfigValidationState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.validate.cloud.config;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.InitializeMDCContextRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum CloudConfigValidationState implements FlowState {
 
@@ -8,5 +10,10 @@ public enum CloudConfigValidationState implements FlowState {
     VALIDATE_CLOUD_CONFIG_STATE,
     VALIDATE_CLOUD_CONFIG_FAILED_STATE,
     VALIDATE_CLOUD_CONFIG_FINISHED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return InitializeMDCContextRestartAction.class;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/kerberosconfig/config/KerberosConfigValidationState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/validate/kerberosconfig/config/KerberosConfigValidationState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.validate.kerberosconfig.config;
 
+import com.sequenceiq.cloudbreak.core.flow2.restart.InitializeMDCContextRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum KerberosConfigValidationState implements FlowState {
 
@@ -8,5 +10,10 @@ public enum KerberosConfigValidationState implements FlowState {
     VALIDATE_KERBEROS_CONFIG_STATE,
     VALIDATE_KERBEROS_CONFIG_FAILED_STATE,
     VALIDATE_KERBEROS_CONFIG_FINISHED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return InitializeMDCContextRestartAction.class;
+    }
 }


### PR DESCRIPTION
Replace default restartaction for flows to
- `FillInMemoryStateStoreRestartAction` if it's using `InMemoryStore` for polling
- `InitializeMDCContextRestartAction` otherwise to ensure MDCContext is set

`WaitForSyncRestartAction` will also st MDCContext

See detailed description in the commit message.