### PR TITLE
CB-11716 Distrox repair test fix.

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
@@ -80,6 +80,8 @@ import com.sequenceiq.flow.api.model.FlowProgressResponse;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @RetryAndMetrics
 @Path("/v1/distrox")
@@ -228,13 +230,21 @@ public interface DistroXV1Endpoint {
     @Path("name/{name}/manual_repair")
     @ApiOperation(value = REPAIR_CLUSTER_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.CLUSTER_REPAIR_NOTES,
             nickname = "repairDistroXV1ByName")
-    void repairClusterByName(@PathParam("name") String name, @Valid DistroXRepairV1Request clusterRepairRequest);
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "successful operation", response = FlowIdentifier.class),
+        @ApiResponse(code = 0, message = "unsuccessful operation", response = Void.class)
+    })
+    FlowIdentifier repairClusterByName(@PathParam("name") String name, @Valid DistroXRepairV1Request clusterRepairRequest);
 
     @POST
     @Path("crn/{crn}/manual_repair")
     @ApiOperation(value = REPAIR_CLUSTER_BY_CRN, produces = MediaType.APPLICATION_JSON, notes = Notes.CLUSTER_REPAIR_NOTES,
             nickname = "repairDistroXV1ByCrn")
-    void repairClusterByCrn(@PathParam("crn") String crn, @Valid DistroXRepairV1Request clusterRepairRequest);
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "successful operation", response = FlowIdentifier.class),
+            @ApiResponse(code = 0, message = "unsuccessful operation", response = Void.class)
+    })
+    FlowIdentifier repairClusterByCrn(@PathParam("crn") String crn, @Valid DistroXRepairV1Request clusterRepairRequest);
 
     @GET
     @Path("name/{name}/cli_create")

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
@@ -325,8 +325,8 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.REPAIR_DATAHUB)
-    public void repairClusterByName(@ResourceName String name, @Valid DistroXRepairV1Request clusterRepairRequest) {
-        stackOperations.repairCluster(
+    public FlowIdentifier repairClusterByName(@ResourceName String name, @Valid DistroXRepairV1Request clusterRepairRequest) {
+        return stackOperations.repairCluster(
                 NameOrCrn.ofName(name),
                 workspaceService.getForCurrentUser().getId(),
                 clusterRepairRequestConverter.convert(clusterRepairRequest));
@@ -334,8 +334,8 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.REPAIR_DATAHUB)
-    public void repairClusterByCrn(@ResourceCrn String crn, @Valid DistroXRepairV1Request clusterRepairRequest) {
-        stackOperations.repairCluster(
+    public FlowIdentifier repairClusterByCrn(@ResourceCrn String crn, @Valid DistroXRepairV1Request clusterRepairRequest) {
+        return stackOperations.repairCluster(
                 NameOrCrn.ofCrn(crn),
                 workspaceService.getForCurrentUser().getId(),
                 clusterRepairRequestConverter.convert(clusterRepairRequest));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRepairAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXRepairAction.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.distrox.api.v1.distrox.model.DistroXRepairV1Request;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
@@ -32,9 +33,10 @@ public class DistroXRepairAction implements Action<DistroXTestDto, CloudbreakCli
         DistroXRepairV1Request distroXRepairV1Request = createRepairRequest();
         Log.when(LOGGER, format(" Starting repair on DistroX: %s ", testDto.getName()));
         Log.whenJson(LOGGER, " DistroX  repair request: ", distroXRepairV1Request);
-        client.getCloudbreakClient()
+        FlowIdentifier flowIdentifier = client.getCloudbreakClient()
                 .distroXV1Endpoint()
                 .repairClusterByName(testDto.getName(), distroXRepairV1Request);
+        testDto.setFlow("DistroX repair flow identifier", flowIdentifier);
         StackV4Response stackV4Response = client.getCloudbreakClient()
                 .distroXV1Endpoint()
                 .getByName(testDto.getName(), Collections.emptySet());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -980,24 +980,25 @@ public abstract class TestContext implements ApplicationContextAware {
         }
         if (!getExceptionMap().isEmpty() && runningParameter.isSkipOnFail()) {
             Log.await(LOGGER, "Cloudbreak await for flow should be skipped because of previous error.");
-            return entity;
-        }
-        LOGGER.info(String.format(" Cloudbreak await for flow on resource: %s at account: %s - for entity: %s ", awaitEntity.getCrn(),
-                Objects.requireNonNull(Crn.fromString(awaitEntity.getCrn())).getAccountId(), awaitEntity));
-        Log.await(LOGGER, String.format(" Cloudbreak await for flow on resource: %s at account: %s - for entity: %s ", awaitEntity.getCrn(),
-                Objects.requireNonNull(Crn.fromString(awaitEntity.getCrn())).getAccountId(), awaitEntity));
-        try {
-            MicroserviceClient msClient = getAdminMicroserviceClient(awaitEntity.getClass(), Objects.requireNonNull(Crn.fromString(awaitEntity.getCrn()))
-                    .getAccountId());
-            flowUtilSingleStatus.waitBasedOnLastKnownFlow(awaitEntity, msClient);
-        } catch (Exception e) {
-            if (runningParameter.isLogError()) {
-                LOGGER.error("Cloudbreak await for flow '{}' is failed for: '{}', because of {}", awaitEntity, awaitEntity.getName(), e.getMessage(), e);
-                Log.await(LOGGER, String.format(" Cloudbreak await for flow '%s' is failed for '%s', because of %s",
-                        awaitEntity, awaitEntity.getName(), e.getMessage()));
+        } else {
+            LOGGER.info(String.format(" Cloudbreak await for flow on resource: %s at account: %s - for entity: %s ", awaitEntity.getCrn(),
+                    Objects.requireNonNull(Crn.fromString(awaitEntity.getCrn())).getAccountId(), awaitEntity));
+            Log.await(LOGGER, String.format(" Cloudbreak await for flow on resource: %s at account: %s - for entity: %s ", awaitEntity.getCrn(),
+                    Objects.requireNonNull(Crn.fromString(awaitEntity.getCrn())).getAccountId(), awaitEntity));
+            try {
+                MicroserviceClient msClient = getAdminMicroserviceClient(awaitEntity.getClass(), Objects.requireNonNull(Crn.fromString(awaitEntity.getCrn()))
+                        .getAccountId());
+                flowUtilSingleStatus.waitBasedOnLastKnownFlow(awaitEntity, msClient);
+            } catch (Exception e) {
+                if (runningParameter.isLogError()) {
+                    LOGGER.error("Cloudbreak await for flow '{}' is failed for: '{}', because of {}", awaitEntity, awaitEntity.getName(), e.getMessage(), e);
+                    Log.await(LOGGER, String.format(" Cloudbreak await for flow '%s' is failed for '%s', because of %s",
+                            awaitEntity, awaitEntity.getName(), e.getMessage()));
+                }
+                getExceptionMap().put("Cloudbreak await for flow " + awaitEntity, e);
             }
-            getExceptionMap().put("Cloudbreak await for flow " + awaitEntity, e);
         }
+        entity.setLastKnownFlowId(null);
         return entity;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractTestDto.java
@@ -138,6 +138,7 @@ public abstract class AbstractTestDto<R, S, T extends CloudbreakTestDto, U exten
         return lastKnownFlowId;
     }
 
+    @Override
     public void setLastKnownFlowId(String lastKnownFlowId) {
         this.lastKnownFlowId = lastKnownFlowId;
         this.lastKnownFlowChainId = null;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
@@ -21,6 +21,8 @@ public interface CloudbreakTestDto extends Orderable, Assignable {
 
     String getLastKnownFlowId();
 
+    void setLastKnownFlowId(String lastKnownFlowId);
+
     CloudbreakTestDto valid();
 
     String getName();


### PR DESCRIPTION
DistroXRepair test considers the repair flow's identifier at repair and remove flow identifier from test context at the end of flow polling
