### PR TITLE
Revert "Revert "CB-11691 change the Datanode address and https addres…

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/KerberosConfig.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/dto/KerberosConfig.java
@@ -31,6 +31,10 @@ public class KerberosConfig {
 
     private String nameServers;
 
+    private int datanodeSecurePort;
+
+    private int datanodeSecureHttpsPort;
+
     public KerberosType getType() {
         return type;
     }
@@ -87,6 +91,14 @@ public class KerberosConfig {
         return nameServers;
     }
 
+    public int getDatanodeSecurePort() {
+        return datanodeSecurePort;
+    }
+
+    public int getDatanodeSecureHttpsPort() {
+        return datanodeSecureHttpsPort;
+    }
+
     public static final class KerberosConfigBuilder {
         private KerberosType type;
 
@@ -115,6 +127,10 @@ public class KerberosConfig {
         private String domain;
 
         private String nameServers;
+
+        private int datanodeSecurePort;
+
+        private int datanodeSecureHttpsPort;
 
         private KerberosConfigBuilder() {
         }
@@ -193,6 +209,16 @@ public class KerberosConfig {
             return this;
         }
 
+        public KerberosConfigBuilder withDatanodeSecurePort(int datanodeSecurePort) {
+            this.datanodeSecurePort = datanodeSecurePort;
+            return this;
+        }
+
+        public KerberosConfigBuilder withDatanodeSecureHttpsPort(int datanodeSecureHttpsPort) {
+            this.datanodeSecureHttpsPort = datanodeSecureHttpsPort;
+            return this;
+        }
+
         public KerberosConfig build() {
             KerberosConfig kerberosConfig = new KerberosConfig();
             kerberosConfig.type = type;
@@ -209,6 +235,8 @@ public class KerberosConfig {
             kerberosConfig.verifyKdcTrust = verifyKdcTrust;
             kerberosConfig.domain = domain;
             kerberosConfig.nameServers = nameServers;
+            kerberosConfig.datanodeSecurePort = datanodeSecurePort;
+            kerberosConfig.datanodeSecureHttpsPort = datanodeSecureHttpsPort;
             return kerberosConfig;
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/kerberos/KerberosConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/kerberos/KerberosConfigService.java
@@ -8,6 +8,7 @@ import javax.ws.rs.WebApplicationException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.vault.VaultException;
 
@@ -24,6 +25,12 @@ import com.sequenceiq.freeipa.api.v1.kerberos.model.describe.DescribeKerberosCon
 @Service
 public class KerberosConfigService {
     private static final Logger LOGGER = LoggerFactory.getLogger(KerberosConfigService.class);
+
+    @Value("${cb.cm.datanode.secure.port:9866}")
+    private int secureDatanodePort;
+
+    @Value("${cb.cm.datanode.secure.https.port:9865}")
+    private int secureDatanodeHttpsPort;
 
     @Inject
     private KerberosConfigV1Endpoint kerberosConfigV1Endpoint;
@@ -77,6 +84,8 @@ public class KerberosConfigService {
                 .withType(KerberosType.valueOf(describeLdapConfigResponse.getType().name()))
                 .withUrl(describeLdapConfigResponse.getUrl())
                 .withVerifyKdcTrust(describeLdapConfigResponse.getVerifyKdcTrust())
+                .withDatanodeSecurePort(secureDatanodePort)
+                .withDatanodeSecureHttpsPort(secureDatanodeHttpsPort)
                 .build();
     }
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
@@ -63,6 +63,7 @@ import com.sequenceiq.cloudbreak.common.type.ClusterManagerType;
 import com.sequenceiq.cloudbreak.dto.KerberosConfig;
 import com.sequenceiq.cloudbreak.template.BlueprintProcessingException;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.model.ServiceAttributes;
 import com.sequenceiq.cloudbreak.template.model.ServiceComponent;
 import com.sequenceiq.cloudbreak.template.processor.BlueprintTextProcessor;
@@ -450,7 +451,7 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
                 && kerberosConfigOpt.isPresent()) {
             KerberosConfig kerberosConfig = kerberosConfigOpt.get();
             ApiConfigureForKerberosArguments apiConfigureForKerberosArguments = new ApiConfigureForKerberosArguments();
-            if (kerberosConfig.getDatanodeSecurePort() > 0 && kerberosConfig.getDatanodeSecureHttpsPort() > 0) {
+            if (shouldConfigureSecureDatanode(templatePreparationObject.getGeneralClusterConfigs(), kerberosConfig)) {
                 LOGGER.debug("Add Kerberos Datanode port config to CM template, web port: {}, https port: {}",
                         kerberosConfig.getDatanodeSecurePort(), kerberosConfig.getDatanodeSecureHttpsPort());
                 apiConfigureForKerberosArguments
@@ -459,6 +460,13 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
             }
             instantiator.setEnableKerberos(apiConfigureForKerberosArguments);
         }
+    }
+
+    private boolean shouldConfigureSecureDatanode(GeneralClusterConfigs generalClusterConfigs, KerberosConfig kerberosConfig) {
+        return generalClusterConfigs != null
+                && generalClusterConfigs.getAutoTlsEnabled()
+                && kerberosConfig.getDatanodeSecurePort() > 0
+                && kerberosConfig.getDatanodeSecureHttpsPort() > 0;
     }
 
     public void addVariables(List<ApiClusterTemplateVariable> vars) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessorTest.java
@@ -34,7 +34,10 @@ import com.sequenceiq.cloudbreak.cloud.model.ResizeRecommendation;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.yarn.YarnConstants;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.yarn.YarnRoles;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.cloudbreak.dto.KerberosConfig;
+import com.sequenceiq.cloudbreak.dto.KerberosConfig.KerberosConfigBuilder;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
 import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.model.ServiceAttributes;
 import com.sequenceiq.cloudbreak.template.model.ServiceComponent;
@@ -82,8 +85,8 @@ public class CmTemplateProcessorTest {
         underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager-existing-conf.bp"));
         List<ApiClusterTemplateConfig> configs = new ArrayList<>();
         configs.add(new ApiClusterTemplateConfig()
-                            .name("hive_service_config_safety_valve")
-                            .value("<property><name>testkey</name><value>testvalue</value></property>"));
+                .name("hive_service_config_safety_valve")
+                .value("<property><name>testkey</name><value>testvalue</value></property>"));
 
         underTest.addServiceConfigs("HIVE", List.of("GATEWAY", "HIVEMETASTORE"), configs);
 
@@ -94,8 +97,8 @@ public class CmTemplateProcessorTest {
         assertTrue(serviceConfigs.get(0).getValue().startsWith("<property><name>testkey</name><value>testvalue</value></property>"));
         assertTrue(serviceConfigs.get(0).getValue().endsWith(
                 "<property><name>hive.metastore.server.filter.enabled</name><value>true</value></property> " +
-                "<property><name>hive.metastore.filter.hook</name>" +
-                "<value>org.apache.hadoop.hive.ql.security.authorization.plugin.metastore.HiveMetaStoreAuthorizer</value></property>"));
+                        "<property><name>hive.metastore.filter.hook</name>" +
+                        "<value>org.apache.hadoop.hive.ql.security.authorization.plugin.metastore.HiveMetaStoreAuthorizer</value></property>"));
         assertTrue(serviceConfigs.get(0).getValue().contains("\n"));
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = new HashMap<>();
@@ -262,6 +265,64 @@ public class CmTemplateProcessorTest {
 
         ApiClusterTemplateInstantiator instantiator = underTest.getTemplate().getInstantiator();
         assertEquals("kusztom", instantiator.getClusterName());
+    }
+
+    @Test
+    public void testAddInstantiatorWithBaseRolesAndSecureDataNodSettings() {
+        underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager.bp"));
+        ClouderaManagerRepo clouderaManagerRepoDetails = new ClouderaManagerRepo();
+        clouderaManagerRepoDetails.setVersion(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_8.getVersion());
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setClusterName("cluster");
+        generalClusterConfigs.setAutoTlsEnabled(true);
+        KerberosConfig kerberosConfig = KerberosConfigBuilder.aKerberosConfig()
+                .withDatanodeSecurePort(5001)
+                .withDatanodeSecureHttpsPort(5000).build();
+        Builder tpoBuilder = new Builder()
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withKerberosConfig(kerberosConfig);
+        TemplatePreparationObject templatePreparationObject = tpoBuilder.build();
+
+        underTest.addInstantiator(clouderaManagerRepoDetails, templatePreparationObject, "test-sdx");
+
+        ApiClusterTemplateInstantiator instantiator = underTest.getTemplate().getInstantiator();
+        List<ApiClusterTemplateRoleConfigGroupInfo> roleConfigGroups = instantiator.getRoleConfigGroups();
+        List<String> refNames = roleConfigGroups.stream().map(ApiClusterTemplateRoleConfigGroupInfo::getRcgRefName).collect(Collectors.toList());
+
+        assertEquals(2, refNames.size());
+        assertTrue(refNames.containsAll(List.of("yarn-NODEMANAGER-BASE", "hdfs-DATANODE-BASE")));
+        assertEquals("cluster", instantiator.getClusterName());
+        assertEquals(5000L, instantiator.getEnableKerberos().getDatanodeWebPort().longValue());
+        assertEquals(5001L, instantiator.getEnableKerberos().getDatanodeTransceiverPort().longValue());
+    }
+
+    @Test
+    public void testAddInstantiatorWithBaseRolesAndWithoutAutoTls() {
+        underTest = new CmTemplateProcessor(getBlueprintText("input/clouderamanager.bp"));
+        ClouderaManagerRepo clouderaManagerRepoDetails = new ClouderaManagerRepo();
+        clouderaManagerRepoDetails.setVersion(CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_6_3_0.getVersion());
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setClusterName("cluster");
+        generalClusterConfigs.setAutoTlsEnabled(false);
+        KerberosConfig kerberosConfig = KerberosConfigBuilder.aKerberosConfig()
+                .withDatanodeSecurePort(5001)
+                .withDatanodeSecureHttpsPort(5000).build();
+        Builder tpoBuilder = new Builder()
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .withKerberosConfig(kerberosConfig);
+        TemplatePreparationObject templatePreparationObject = tpoBuilder.build();
+
+        underTest.addInstantiator(clouderaManagerRepoDetails, templatePreparationObject, "test-sdx");
+
+        ApiClusterTemplateInstantiator instantiator = underTest.getTemplate().getInstantiator();
+        List<ApiClusterTemplateRoleConfigGroupInfo> roleConfigGroups = instantiator.getRoleConfigGroups();
+        List<String> refNames = roleConfigGroups.stream().map(ApiClusterTemplateRoleConfigGroupInfo::getRcgRefName).collect(Collectors.toList());
+
+        assertEquals(2, refNames.size());
+        assertTrue(refNames.containsAll(List.of("yarn-NODEMANAGER-BASE", "hdfs-DATANODE-BASE")));
+        assertEquals("cluster", instantiator.getClusterName());
+        assertNull(instantiator.getEnableKerberos().getDatanodeWebPort());
+        assertNull(instantiator.getEnableKerberos().getDatanodeTransceiverPort());
     }
 
     @Test


### PR DESCRIPTION
…s to a secure port >= 1024 By default when Kerberos is enabled the following ports are set by CM: DataNode Transceiver Port dfs.datanode.address 1004 Secure DataNode Web UI Port (TLS/SSL) dfs.datanode.https.address 9865""

This reverts commit 6e46eb09fdb079eb24b522641f0d0165aa1b8939.

See detailed description in the commit message.