### PR TITLE
CB-11722 after Refresh Cluster CM command failure CB throws NPE

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRoleRefreshService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRoleRefreshService.java
@@ -23,7 +23,6 @@ import com.cloudera.api.swagger.model.ApiCommandList;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
-import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.polling.PollingResult;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
@@ -54,12 +53,8 @@ class ClouderaManagerRoleRefreshService {
         PollingResult pollingResult = PollingResult.SUCCESS;
         try {
             pollingResult = clouderaManagerPollingServiceProvider.startPollingCmConfigurationRefresh(stack, client, command.getId());
-        } catch (CloudbreakServiceException e) {
-            if (ClouderaManagerOperationFailedException.class.equals(e.getCause().getClass())) {
-                LOGGER.warn("Ignored failed refresh command. Upscale will continue.", e);
-            } else {
-                throw e;
-            }
+        } catch (ClouderaManagerOperationFailedException e) {
+            LOGGER.warn("Ignored failed refresh command. Upscale will continue.", e);
         }
         if (isExited(pollingResult)) {
             throw new CancellationException("Cluster was terminated while waiting for cluster refresh");

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRoleRefreshServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerRoleRefreshServiceTest.java
@@ -1,17 +1,17 @@
 package com.sequenceiq.cloudbreak.cm;
 
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.util.Collections;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.ClouderaManagerResourceApi;
 import com.cloudera.api.swagger.ClustersResourceApi;
@@ -21,12 +21,13 @@ import com.cloudera.api.swagger.model.ApiCommand;
 import com.cloudera.api.swagger.model.ApiCommandList;
 import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.polling.PollingResult;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ClouderaManagerRoleRefreshServiceTest {
 
     private static final String CLUSTER_NAME = "myCluster";
@@ -42,26 +43,58 @@ public class ClouderaManagerRoleRefreshServiceTest {
     @Mock
     private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;
 
+    @Mock
+    private ClustersResourceApi clustersResourceApi;
+
+    @Mock
+    private ClouderaManagerResourceApi clouderaManagerResourceApi;
+
+    @Mock
+    private ApiClient apiClient;
+
     @Test
     public void testRestartClusterRolesShouldUpdateTheRoles() throws ApiException, CloudbreakException {
-        ApiClient apiClient = mock(ApiClient.class);
         Stack stack = createStack();
-        ClustersResourceApi clustersResourceApi = mock(ClustersResourceApi.class);
-        ClouderaManagerResourceApi clouderaManagerResourceApi = mock(ClouderaManagerResourceApi.class);
-        ApiCommand apiCommand = createApiCommand();
-        ApiCommandList apiCommandList = createApiCommandList();
-
-        when(clouderaManagerApiFactory.getClouderaManagerResourceApi(apiClient)).thenReturn(clouderaManagerResourceApi);
-        when(clouderaManagerResourceApi.listActiveCommands(DataView.SUMMARY.name())).thenReturn(apiCommandList);
-        when(clouderaManagerApiFactory.getClustersResourceApi(apiClient)).thenReturn(clustersResourceApi);
-        when(clustersResourceApi.refresh(CLUSTER_NAME)).thenReturn(apiCommand);
+        setupMocks();
         when(clouderaManagerPollingServiceProvider.startPollingCmConfigurationRefresh(stack, apiClient, COMMAND_ID)).thenReturn(PollingResult.SUCCESS);
 
         underTest.refreshClusterRoles(apiClient, stack);
 
-        verify(clouderaManagerPollingServiceProvider).startPollingCmConfigurationRefresh(stack, apiClient, COMMAND_ID);
         verify(clustersResourceApi).refresh(CLUSTER_NAME);
         verify(clouderaManagerPollingServiceProvider).startPollingCmConfigurationRefresh(stack, apiClient, COMMAND_ID);
+    }
+
+    @Test
+    public void testRestartClusterRolesCmFailure() throws ApiException, CloudbreakException {
+        Stack stack = createStack();
+        setupMocks();
+        when(clouderaManagerPollingServiceProvider.startPollingCmConfigurationRefresh(stack, apiClient, COMMAND_ID)).
+                thenThrow(new ClouderaManagerOperationFailedException("Refresh cluster failed."));
+
+        underTest.refreshClusterRoles(apiClient, stack);
+
+        verify(clustersResourceApi).refresh(CLUSTER_NAME);
+        verify(clouderaManagerPollingServiceProvider).startPollingCmConfigurationRefresh(stack, apiClient, COMMAND_ID);
+    }
+
+    @Test
+    public void testRestartClusterRolesOtherFailure() throws ApiException {
+        Stack stack = createStack();
+        setupMocks();
+        when(clouderaManagerPollingServiceProvider.startPollingCmConfigurationRefresh(stack, apiClient, COMMAND_ID)).
+                thenThrow(new CloudbreakServiceException("Refresh cluster failed."));
+
+        assertThrows(CloudbreakServiceException.class, () -> underTest.refreshClusterRoles(apiClient, stack));
+
+        verify(clustersResourceApi).refresh(CLUSTER_NAME);
+        verify(clouderaManagerPollingServiceProvider).startPollingCmConfigurationRefresh(stack, apiClient, COMMAND_ID);
+    }
+
+    private void setupMocks() throws ApiException {
+        when(clouderaManagerApiFactory.getClouderaManagerResourceApi(apiClient)).thenReturn(clouderaManagerResourceApi);
+        when(clouderaManagerResourceApi.listActiveCommands(DataView.SUMMARY.name())).thenReturn(createApiCommandList());
+        when(clouderaManagerApiFactory.getClustersResourceApi(apiClient)).thenReturn(clustersResourceApi);
+        when(clustersResourceApi.refresh(CLUSTER_NAME)).thenReturn(createApiCommand());
     }
 
     private ApiCommand createApiCommand() {


### PR DESCRIPTION
- fixing NPE issue, thus error message `New node(s) could not be added to the cluster. Reason null` will not occur again
- ensure best effort behavior and ignore CM failure

See detailed description in the commit message.