### PR TITLE
CB-11432 Datalake cannot go to delete_failed from delete_in_progress

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/entity/DatalakeStatusEnum.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/entity/DatalakeStatusEnum.java
@@ -54,7 +54,8 @@ public enum DatalakeStatusEnum {
                 || STACK_DELETED.equals(this)
                 || STACK_DELETION_IN_PROGRESS.equals(this)
                 || DELETE_REQUESTED.equals(this)
-                || DELETED.equals(this);
+                || DELETED.equals(this)
+                || DELETE_FAILED.equals(this);
     }
 
     @SuppressWarnings("checkstyle:CyclomaticComplexity")


### PR DESCRIPTION
SDX stuck in DELETE_IN_PROGRESS when the termination failed but the flow finished.

See detailed description in the commit message.