### PR TITLE
CB-11664 set-endpoint-access-gateway on existing environment fails

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/update/loadbalancer/StackLoadBalancerUpdateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/update/loadbalancer/StackLoadBalancerUpdateService.java
@@ -83,6 +83,6 @@ public class StackLoadBalancerUpdateService {
         clusterService.updateClusterStatusByStackId(stackId, AVAILABLE);
         stackUpdater.updateStackStatus(stackId, DetailedStackStatus.LOAD_BALANCER_UPDATE_FAILED,
             "Load balancer creation failed failed " + exception.getMessage());
-        flowMessageService.fireEventAndLog(stackId, UPDATE_FAILED.name(), STACK_LB_UPDATE_FAILED);
+        flowMessageService.fireEventAndLog(stackId, UPDATE_FAILED.name(), STACK_LB_UPDATE_FAILED, exception.getMessage());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateLoadBalancerEntityHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateLoadBalancerEntityHandler.java
@@ -4,7 +4,6 @@ import static com.sequenceiq.cloudbreak.cloud.model.CloudInstance.SUBNET_ID;
 import static com.sequenceiq.cloudbreak.common.network.NetworkConstants.ENDPOINT_GATEWAY_SUBNET_ID;
 import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
 
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -24,6 +23,7 @@ import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.converter.v4.environment.network.SubnetSelector;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.CreateLoadBalancerEntityFailure;
 import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.CreateLoadBalancerEntityRequest;
@@ -89,7 +89,7 @@ public class CreateLoadBalancerEntityHandler extends ExceptionCatcherEventHandle
                 enableEndpointGateway(stack, environment);
             }
 
-            Set<InstanceGroup> instanceGroups = instanceGroupService.findByStackId(stack.getId());
+            Set<InstanceGroup> instanceGroups = instanceGroupService.getByStackAndFetchTemplates(stack.getId());
             instanceGroups.forEach(ig -> ig.setTargetGroups(targetGroupPersistenceService.findByIntanceGroupId(ig.getId())));
             Set<LoadBalancer> existingLoadBalancers = loadBalancerPersistenceService.findByStackId(stack.getId());
             stack.setInstanceGroups(instanceGroups);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/RegisterPublicDnsHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/RegisterPublicDnsHandler.java
@@ -62,8 +62,9 @@ public class RegisterPublicDnsHandler extends ExceptionCatcherEventHandler<Regis
                 InstanceGroup instanceGroup = instanceGroupService.getPrimaryGatewayInstanceGroupByStackId(stack.getId());
                 Optional<InstanceMetaData> instanceMetaDataOptional = instanceMetaDataService.getPrimaryGatewayInstanceMetadata(stack.getId());
                 if (instanceMetaDataOptional.isPresent()) {
-                    instanceGroup.setInstanceMetaData(Set.of(instanceMetaDataOptional.get()));
-                    stack.setInstanceGroups(Set.of(instanceGroup));
+                    stack.getInstanceGroups().stream()
+                        .filter(ig -> ig.getId().equals(instanceGroup.getId()))
+                        .forEach(ig -> ig.setInstanceMetaData(Set.of(instanceMetaDataOptional.get())));
                     LOGGER.debug("Registering load balancer public DNS entry");
                     boolean success = clusterPublicEndpointManagementService.provisionLoadBalancer(stack);
                     if (!success) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
@@ -39,4 +39,7 @@ public interface InstanceGroupRepository extends CrudRepository<InstanceGroup, L
     @Query("SELECT i.instanceGroup FROM InstanceMetaData i WHERE i.instanceMetadataType = 'GATEWAY_PRIMARY' AND i.instanceStatus <> 'TERMINATED' "
             + "AND i.instanceGroup.stack.id= :stackId")
     Optional<InstanceGroup> getPrimaryGatewayInstanceGroupByStackId(@Param("stackId") Long stackId);
+
+    @Query("SELECT i FROM InstanceGroup i JOIN FETCH i.template WHERE i.stack.id = :stackId")
+    Set<InstanceGroup> getByStackAndFetchTemplates(@Param("stackId") Long stackId);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
@@ -169,7 +169,7 @@ public class LoadBalancerConfigService {
         }
         Set<LoadBalancer> loadBalancers = new HashSet<>();
 
-        if ((loadBalancerFlagEnabled || isLoadBalancerEnabled(stack.getType(), environment)) && getSupportedPlatforms().contains(stack.getCloudPlatform())) {
+        if (isLoadBalancerEnabled(stack.getType(), stack.getCloudPlatform(), environment, loadBalancerFlagEnabled)) {
             if (!loadBalancerFlagEnabled) {
                 LOGGER.debug("Load balancers are enabled for data lake and data hub stacks.");
             } else {
@@ -239,9 +239,9 @@ public class LoadBalancerConfigService {
         return false;
     }
 
-    private boolean isLoadBalancerEnabled(StackType type, DetailedEnvironmentResponse environment) {
-        return environment != null &&
-            (isLoadBalancerEnabledForDatalake(type, environment) || isLoadBalancerEnabledForDatahub(type, environment));
+    private boolean isLoadBalancerEnabled(StackType type, String cloudPlatform, DetailedEnvironmentResponse environment, boolean flagEnabled) {
+        return getSupportedPlatforms().contains(cloudPlatform) &&
+            (flagEnabled || isLoadBalancerEnabledForDatalake(type, environment) || isLoadBalancerEnabledForDatahub(type, environment));
     }
 
     private boolean isLoadBalancerEnabledForDatalake(StackType type, DetailedEnvironmentResponse environment) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceGroupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceGroupService.java
@@ -95,4 +95,8 @@ public class InstanceGroupService {
     public InstanceGroup getPrimaryGatewayInstanceGroupByStackId(Long stackId) {
         return repository.getPrimaryGatewayInstanceGroupByStackId(stackId).orElseThrow(notFound("Gateway Instance Group for Stack", stackId));
     }
+
+    public Set<InstanceGroup> getByStackAndFetchTemplates(Long stackId) {
+        return repository.getByStackAndFetchTemplates(stackId);
+    }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/network/NetworkMetadataValidationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/network/NetworkMetadataValidationService.java
@@ -93,7 +93,7 @@ public class NetworkMetadataValidationService {
         Set<String> endpointGatewaySubnetAZs = endpointGatewaySubnetMetas.values().stream()
             .map(CloudSubnet::getAvailabilityZone)
             .collect(Collectors.toSet());
-        if (!subnetAZs.equals(endpointGatewaySubnetAZs)) {
+        if (!endpointGatewaySubnetAZs.containsAll(subnetAZs)) {
             throw new BadRequestException(String.format(UNMATCHED_AZ, subnetAZs));
         }
     }
@@ -108,7 +108,7 @@ public class NetworkMetadataValidationService {
             .filter(subnet -> !subnet.isPrivateSubnet())
             .map(CloudSubnet::getAvailabilityZone)
             .collect(Collectors.toSet());
-        if (!privateAZs.equals(publicAZs)) {
+        if (!publicAZs.containsAll(privateAZs)) {
             throw new BadRequestException(String.format(UNMATCHED_AZ, privateAZs));
         }
     }


### PR DESCRIPTION
Fetches the instance group templates during the initial database fetch. These are required if the
cluster has an embedded database. Fixes the stack information being passed to the
"clusterHostServiceRunner.updateClusterConfigs" call, which was updated in PR #10223. And now
correctly passes the exception during failures to the UI output, so it should show up correctly.

Tested on local CB environments.