### PR TITLE
Merge remote-tracking branch 'origin/CB-2.40.0' into master

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionWrapper.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionWrapper.java
@@ -2,7 +2,7 @@ package com.sequenceiq.freeipa.client;
 
 public class FreeIpaClientExceptionWrapper extends RuntimeException {
     public FreeIpaClientExceptionWrapper(FreeIpaClientException e) {
-        super(e);
+        super(e.getMessage(), e);
     }
 
     public FreeIpaClientException getWrappedException() {

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/RetryableFreeIpaClientException.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/RetryableFreeIpaClientException.java
@@ -38,6 +38,7 @@ public class RetryableFreeIpaClientException extends FreeIpaClientException {
 
     @Override
     public String toString() {
-        return super.toString() + System.lineSeparator() + "ExceptionForRestApi: "  + exceptionForRestApi.toString();
+        String exceptionForRestApiMsg = exceptionForRestApi == null ? "not set" : exceptionForRestApi.toString();
+        return super.toString() + System.lineSeparator() + "ExceptionForRestApi: " + exceptionForRestApiMsg;
     }
 }

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/RetryableFreeIpaClientExceptionTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/RetryableFreeIpaClientExceptionTest.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.freeipa.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class RetryableFreeIpaClientExceptionTest {
+
+    @Test
+    public void testToStringWhenExceptionForRestApiPresent() {
+        RetryableFreeIpaClientException underTest =
+                new RetryableFreeIpaClientException("testMsg",
+                        new RetryableFreeIpaClientException("testMsg1", new Exception("testMsg2")),
+                        new Exception("testMsg3"));
+        String result = underTest.toString();
+        assertEquals("com.sequenceiq.freeipa.client.RetryableFreeIpaClientException: testMsg\n"
+                + "ExceptionForRestApi: java.lang.Exception: testMsg3", result);
+    }
+
+    @Test
+    public void testToStringWhenExceptionForRestApiMissing() {
+        RetryableFreeIpaClientException underTest =
+                new RetryableFreeIpaClientException("testMsg",
+                        new RetryableFreeIpaClientException("testMsg1", new Exception("testMsg2")));
+        String result = underTest.toString();
+        assertEquals("com.sequenceiq.freeipa.client.RetryableFreeIpaClientException: testMsg\n"
+                + "ExceptionForRestApi: not set", result);
+    }
+}


### PR DESCRIPTION
When `exceptionForRestApi` is not set `toString` could cause exception. This is fixed by handling null gracefully.
Also `FreeIpaClientExceptionWrapper` contructor has been edited to include the message, so it won't call `toString` on the wrapped exception.See detailed description in the commit message.