### PR TITLE
CB-11790 FreeIPA cleanup can cause missing DNS records

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/downscale/StackDownscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/downscale/StackDownscaleService.java
@@ -92,7 +92,7 @@ public class StackDownscaleService {
 
     private void cleanupDnsRecords(Stack stack, Collection<InstanceMetaData> instanceMetaDatas) {
         Set<String> fqdns = instanceMetadataProcessor.extractFqdn(instanceMetaDatas);
-        Set<String> ips = instanceMetadataProcessor.extractIps(instanceMetaDatas);
+        Set<String> ips = Set.of();
         try {
             LOGGER.info("Cleanup DNS records for FQDNS: {} and IPs {}", fqdns, ips);
             freeIpaCleanupService.cleanupDnsOnly(stack, fqdns, ips);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/DecommissionHandler.java
@@ -155,8 +155,7 @@ public class DecommissionHandler implements EventHandler<DecommissionRequest> {
 
     private void cleanUpFreeIpa(Stack stack, Map<String, InstanceMetaData> hostsToRemove) {
         try {
-            Set<String> ips = hostsToRemove.values().stream().map(InstanceMetaData::getPrivateIp).filter(StringUtils::isNotBlank).collect(Collectors.toSet());
-            freeIpaCleanupService.cleanupOnScale(stack, hostsToRemove.keySet(), ips);
+            freeIpaCleanupService.cleanupOnScale(stack, hostsToRemove.keySet(), Set.of());
         } catch (FreeIpaOperationFailedException | CloudbreakServiceException e) {
             LOGGER.warn("FreeIPA cleanup has failed during decommission, ignoring error", e);
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeIpaCleanupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeIpaCleanupService.java
@@ -81,9 +81,9 @@ public class FreeIpaCleanupService {
     @Inject
     private InstanceMetadataProcessor instanceMetadataProcessor;
 
-    public void cleanup(Stack stack) {
+    public void cleanupButIp(Stack stack) {
         Set<String> hostNames = instanceMetadataProcessor.extractFqdn(stack);
-        Set<String> ips = instanceMetadataProcessor.extractIps(stack);
+        Set<String> ips = Set.of();
         LOGGER.info("Full cleanup invoked with hostnames {} and IPs {}", hostNames, ips);
         cleanup(stack, Set.of(), hostNames, ips);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TerminationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TerminationService.java
@@ -99,7 +99,7 @@ public class TerminationService {
 
     private void cleanupFreeIpa(Stack stack) {
         try {
-            freeIpaCleanupService.cleanup(stack);
+            freeIpaCleanupService.cleanupButIp(stack);
         } catch (Exception e) {
             LOGGER.warn("FreeIPA cleanup has failed during termination finalization, ignoring error", e);
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/freeipa/FreeIpaCleanupServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/freeipa/FreeIpaCleanupServiceTest.java
@@ -103,7 +103,7 @@ public class FreeIpaCleanupServiceTest {
         when(freeIpaV1Endpoint.internalCleanup(any(CleanupRequest.class), anyString())).thenReturn(operationStatus);
         when(freeIpaOperationChecker.pollWithAbsoluteTimeout(any(), any(), anyLong(), anyLong(), anyInt())).thenReturn(pollingResult);
 
-        victim.cleanup(stack);
+        victim.cleanupButIp(stack);
 
         verify(freeIpaV1Endpoint).internalCleanup(any(), anyString());
     }
@@ -117,7 +117,7 @@ public class FreeIpaCleanupServiceTest {
         when(environmentConfigProvider.isChildEnvironment(ENVIRONMENT_CRN)).thenReturn(true);
         when(kerberosDetailService.keytabsShouldBeUpdated(CLOUD_PLATFORM, true, kerberosConfig)).thenReturn(false);
 
-        victim.cleanup(stack);
+        victim.cleanupButIp(stack);
 
         verifyNoMoreInteractions(freeIpaV1Endpoint);
     }
@@ -136,7 +136,7 @@ public class FreeIpaCleanupServiceTest {
         when(freeIpaV1Endpoint.internalCleanup(captor.capture(), anyString())).thenReturn(operationStatus);
         when(freeIpaOperationChecker.pollWithAbsoluteTimeout(any(), any(), anyLong(), anyLong(), anyInt())).thenReturn(pollingResult);
 
-        victim.cleanup(stack);
+        victim.cleanupButIp(stack);
 
         CleanupRequest cleanupRequest = captor.getValue();
         assertEquals(STACK_NAME, cleanupRequest.getClusterName());
@@ -145,7 +145,7 @@ public class FreeIpaCleanupServiceTest {
         assertEquals(Set.of(KERBEROS_USER_PREFIX + stack.getName(), KEYTAB_USER_PREFIX + stack.getName(), LDAP_USER_PREFIX + stack.getName()),
                 cleanupRequest.getUsers());
         assertEquals(Set.of(ROLE_NAME_PREFIX + stack.getName()), cleanupRequest.getRoles());
-        assertEquals(Set.of("1.1.1.1", "1.1.1.2"), cleanupRequest.getIps());
+        assertTrue(cleanupRequest.getIps().isEmpty());
         assertEquals(Set.of("asdf", "qwer"), cleanupRequest.getHosts());
     }
 
@@ -164,7 +164,7 @@ public class FreeIpaCleanupServiceTest {
         Pair<PollingResult, Exception> pollingResult = new ImmutablePair<>(PollingResult.FAILURE, new Exception("message"));
         when(freeIpaOperationChecker.pollWithAbsoluteTimeout(any(), any(), anyLong(), anyLong(), anyInt())).thenReturn(pollingResult);
 
-        assertThrows(FreeIpaOperationFailedException.class, () -> victim.cleanup(stack));
+        assertThrows(FreeIpaOperationFailedException.class, () -> victim.cleanupButIp(stack));
 
         CleanupRequest cleanupRequest = captor.getValue();
         assertEquals(STACK_NAME, cleanupRequest.getClusterName());
@@ -173,7 +173,7 @@ public class FreeIpaCleanupServiceTest {
         assertEquals(Set.of(KERBEROS_USER_PREFIX + stack.getName(), KEYTAB_USER_PREFIX + stack.getName(), LDAP_USER_PREFIX + stack.getName()),
                 cleanupRequest.getUsers());
         assertEquals(Set.of(ROLE_NAME_PREFIX + stack.getName()), cleanupRequest.getRoles());
-        assertEquals(Set.of("1.1.1.1", "1.1.1.2"), cleanupRequest.getIps());
+        assertTrue(cleanupRequest.getIps().isEmpty());
         assertEquals(Set.of("asdf", "qwer"), cleanupRequest.getHosts());
     }
 


### PR DESCRIPTION
FreeIPA cleanup (which runs during cluster scaling, creation, termination) in an edge case can cause missing DNS records in FreeIPA:
- create a cluster: CL1
- delete the nodes on provider (but leave it in place on the controlplane side)
- create another cluster: CL2 (some of it's nodes will get the same IP as CL1)
- delete CL1 using control plane
- this will invoke cleanup process which deletes records based on IP too, removing entries used by CL2

The fix is to remove IP based cleanup when downscaling and terminating. On the ideal path it should not cause an issue and leave residue as FQDN/name based cleanup should clean everything.
The reason we need IP based cleanup if something cause sideways during downscale/terminate cleanup as we ignore those results. In that case on creation/upscale we must cleanup records based on IPs.

Tested in small subnet with playing the same scenario which caused the issue. Also tested the modification don't cause regression issues.

See detailed description in the commit message.