### PR TITLE
CB-11808: Removed Yarn from the Load Balancer supported platforms.

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -667,7 +667,7 @@ cb:
   paywall.url: "https://archive.cloudera.com/p/cdp-public/"
 
   loadBalancer:
-    supportedPlatforms: AWS,YARN
+    supportedPlatforms: AWS
 
 clusterProxy:
   url: http://localhost:10180/cluster-proxy


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-11808

Want to wait for repair with upscale/downscale to work before adding this.