### PR TITLE
ENGESC-7598 DataHub creation is failing in "ca-central-1" region

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSubnetIgwExplorer.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSubnetIgwExplorer.java
@@ -147,6 +147,8 @@ public class AwsSubnetIgwExplorer {
             } else {
                 LOGGER.warn("Unexpected exception while fetching firewall information. Skipping firewall IGW check.", e);
             }
+        } catch (Exception e) {
+            LOGGER.warn("Unexpected exception while fetching firewall information. Skipping firewall IGW check.", e);
         }
         return result;
     }

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSubnetIgwExplorerTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsSubnetIgwExplorerTest.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.ec2.model.Route;
 import com.amazonaws.services.ec2.model.RouteTable;
 import com.amazonaws.services.ec2.model.RouteTableAssociation;
@@ -405,6 +406,19 @@ public class AwsSubnetIgwExplorerTest {
 
         boolean routableToInternet = awsSubnetIgwExplorer.isRoutableToInternet(nfwClient, List.of(routeTable),
             subnets, SUBNET_ID, VPC_ID);
+
+        assertFalse(routableToInternet);
+    }
+
+    @Test
+    public void testHandleFirewallException() {
+        setupFirewallClientMocks();
+        List<RouteTable> routeTables = setupFirewallRoutes(true);
+
+        when(nfwClient.listFirewalls(any())).thenThrow(new SdkClientException("error"));
+
+        boolean routableToInternet = awsSubnetIgwExplorer.isRoutableToInternet(nfwClient, routeTables,
+            createSubnets(null, null), SUBNET_ID, VPC_ID);
 
         assertFalse(routableToInternet);
     }


### PR DESCRIPTION
Catch all exceptions thrown when calling the AWS network firewall client, and if any are caught,
handle them gracefully and allow operations to continue.

Tested with new unit test.