### PR TITLE
CB-11154 Use DES to enable SSE with CMK during Azure DH cluster creation

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceTemplate.java
@@ -38,7 +38,7 @@ public class InstanceTemplate extends DynamicModel {
      * when {@link #VOLUME_ENCRYPTION_KEY_TYPE} equals {@code "CUSTOM"}. Its value will be ignored otherwise.
      *
      * <p>
-     *     When set, the value shall be a {@link String} containing the ID of the customer-managed encryption key in a cloud provider specific syntax.
+     *     When set, the value shall be a nonempty {@link String} containing the ID of the customer-managed encryption key in a cloud provider specific syntax.
      * </p>
      *
      * @see #VOLUME_ENCRYPTION_KEY_TYPE

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
@@ -21,6 +21,10 @@ public class AwsInstanceTemplate extends InstanceTemplate {
      *     </ul>
      * </p>
      *
+     * If enabled, the encryption key to use is determined by {@link #VOLUME_ENCRYPTION_KEY_TYPE} and {@link #VOLUME_ENCRYPTION_KEY_ID}.
+     *
+     * @see #VOLUME_ENCRYPTION_KEY_ID
+     * @see #VOLUME_ENCRYPTION_KEY_TYPE
      * @see #putParameter(String, Object)
      * @see Boolean#parseBoolean(String)
      */

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AzureInstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AzureInstanceTemplate.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.cloud.model.instance;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.Volume;
+
+public class AzureInstanceTemplate extends InstanceTemplate {
+
+    /**
+     * Key of the optional dynamic parameter denoting whether managed disk encryption with a customer-managed encryption key is enabled or not. This applies
+     * to both root & attached (data) volumes.
+     *
+     * <p>
+     *     Permitted values:
+     *     <ul>
+     *         <li>{@code Boolean.TRUE} instance, {@code "true"} (ignoring case): Encryption with a customer-managed encryption key is enabled.</li>
+     *         <li>{@code Boolean.FALSE} instance, {@code "false"} (or any other {@code String} not equal to {@code "true"} ignoring case), {@code null}:
+     *         Encryption with a customer-managed encryption key is disabled. This implies that managed disks will be subject to the default Storage Service
+     *         Encryption with a platform managed key.</li>
+     *     </ul>
+     * </p>
+     *
+     * If enabled, the encryption key to use is determined by the disk encryption set specified by {@link #DISK_ENCRYPTION_SET_ID}. In particular,
+     * {@link #VOLUME_ENCRYPTION_KEY_TYPE} and {@link #VOLUME_ENCRYPTION_KEY_ID} are currently ignored for managed disk encryption.
+     *
+     * @see #DISK_ENCRYPTION_SET_ID
+     * @see #VOLUME_ENCRYPTION_KEY_ID
+     * @see #VOLUME_ENCRYPTION_KEY_TYPE
+     * @see #putParameter(String, Object)
+     * @see Boolean#parseBoolean(String)
+     */
+    public static final String MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED = "encryptionWithCustomKey";
+
+    /**
+     * Key of the dynamic parameter denoting the Resource ID of the disk encryption set to be used for managed disk encryption. Relevant and required only
+     * when {@link #MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED} is {@code true}. Its value will be ignored otherwise.
+     *
+     * <p>
+     *     When set, the value shall be a nonempty {@link String} containing the Resource ID of the disk encryption set.
+     * </p>
+     *
+     * @see #MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED
+     * @see #putParameter(String, Object)
+     */
+    public static final String DISK_ENCRYPTION_SET_ID = "diskEncryptionSetId";
+
+    public AzureInstanceTemplate(String flavor, String groupName, Long privateId, Collection<Volume> volumes, InstanceStatus status,
+            Map<String, Object> parameters, Long templateId, String imageId) {
+        super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId);
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureInstanceView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureInstanceView.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.azure.view;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -12,8 +14,9 @@ import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
-import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AzureInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 public class AzureInstanceView {
 
@@ -45,23 +48,21 @@ public class AzureInstanceView {
 
     private final String managedIdentity;
 
-    public AzureInstanceView(String stackName, int stackNamePrefixLength, CloudInstance instance, InstanceGroupType type, String attachedDiskStorage,
-            String attachedDiskStorageType, String groupName, String availabilitySetName, boolean managedDisk, String subnetId, int rootVolumeSize,
-            String customImageId, String managedIdentity) {
-        this.instance = instance;
+    private AzureInstanceView(Builder builder) {
+        instance = builder.instance;
         instanceTemplate = instance.getTemplate();
-        this.stackNamePrefixLength = stackNamePrefixLength;
-        this.type = type;
-        this.attachedDiskStorage = attachedDiskStorage;
-        this.attachedDiskStorageType = attachedDiskStorageType;
-        this.groupName = groupName;
-        this.stackName = stackName;
-        this.availabilitySetName = availabilitySetName;
-        this.managedDisk = managedDisk;
-        this.subnetId = subnetId;
-        this.rootVolumeSize = rootVolumeSize;
-        this.customImageId = customImageId;
-        this.managedIdentity = managedIdentity;
+        stackNamePrefixLength = builder.stackNamePrefixLength;
+        type = builder.type;
+        attachedDiskStorage = builder.attachedDiskStorage;
+        attachedDiskStorageType = builder.attachedDiskStorageType;
+        groupName = builder.groupName;
+        stackName = builder.stackName;
+        availabilitySetName = builder.availabilitySetName;
+        managedDisk = builder.managedDisk;
+        subnetId = builder.subnetId;
+        rootVolumeSize = builder.rootVolumeSize;
+        customImageId = builder.customImageId;
+        managedIdentity = builder.managedIdentity;
     }
 
     public CloudInstance getInstance() {
@@ -184,4 +185,126 @@ public class AzureInstanceView {
     public String getManagedIdentity() {
         return managedIdentity;
     }
+
+    public boolean isManagedDiskEncryptionWithCustomKeyEnabled() {
+        Object encryptedWithCustomKey = instanceTemplate.getParameter(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, Object.class);
+        if (encryptedWithCustomKey instanceof Boolean) {
+            return (Boolean) encryptedWithCustomKey;
+        } else if (encryptedWithCustomKey instanceof String) {
+            return Boolean.parseBoolean((String) encryptedWithCustomKey);
+        }
+        return false;
+    }
+
+    public String getDiskEncryptionSetId() {
+        return instanceTemplate.getStringParameter(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID);
+    }
+
+    public static Builder builder(CloudInstance instance) {
+        return new Builder(instance);
+    }
+
+    public static class Builder {
+
+        private CloudInstance instance;
+
+        private String stackName;
+
+        private int stackNamePrefixLength;
+
+        private InstanceGroupType type;
+
+        private String attachedDiskStorage;
+
+        private String attachedDiskStorageType;
+
+        private String groupName;
+
+        private String availabilitySetName;
+
+        private boolean managedDisk;
+
+        private String subnetId;
+
+        private int rootVolumeSize;
+
+        private String customImageId;
+
+        private String managedIdentity;
+
+        private Builder(CloudInstance instance) {
+            withInstance(instance);
+        }
+
+        public Builder withInstance(CloudInstance instance) {
+            this.instance = requireNonNull(instance);
+            return this;
+        }
+
+        public Builder withStackName(String stackName) {
+            this.stackName = stackName;
+            return this;
+        }
+
+        public Builder withStackNamePrefixLength(int stackNamePrefixLength) {
+            this.stackNamePrefixLength = stackNamePrefixLength;
+            return this;
+        }
+
+        public Builder withType(InstanceGroupType type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withAttachedDiskStorage(String attachedDiskStorage) {
+            this.attachedDiskStorage = attachedDiskStorage;
+            return this;
+        }
+
+        public Builder withAttachedDiskStorageType(String attachedDiskStorageType) {
+            this.attachedDiskStorageType = attachedDiskStorageType;
+            return this;
+        }
+
+        public Builder withGroupName(String groupName) {
+            this.groupName = groupName;
+            return this;
+        }
+
+        public Builder withAvailabilitySetName(String availabilitySetName) {
+            this.availabilitySetName = availabilitySetName;
+            return this;
+        }
+
+        public Builder withManagedDisk(boolean managedDisk) {
+            this.managedDisk = managedDisk;
+            return this;
+        }
+
+        public Builder withSubnetId(String subnetId) {
+            this.subnetId = subnetId;
+            return this;
+        }
+
+        public Builder withRootVolumeSize(int rootVolumeSize) {
+            this.rootVolumeSize = rootVolumeSize;
+            return this;
+        }
+
+        public Builder withCustomImageId(String customImageId) {
+            this.customImageId = customImageId;
+            return this;
+        }
+
+        public Builder withManagedIdentity(String managedIdentity) {
+            this.managedIdentity = managedIdentity;
+            return this;
+        }
+
+        public AzureInstanceView build() {
+            return new AzureInstanceView(this);
+        }
+
+    }
+
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureStackView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureStackView.java
@@ -51,10 +51,20 @@ public class AzureStackView {
                     String attachedDiskStorageName = armStorageView.getAttachedDiskStorageName(template);
                     String attachedDiskStorageType = template.getVolumes().isEmpty() ? AzurePlatformParameters.defaultDiskType().value()
                             : template.getVolumes().get(0).getType();
-                    AzureInstanceView azureInstance = new AzureInstanceView(stackName, stackNamePrefixLength, instance, group.getType(),
-                            attachedDiskStorageName, attachedDiskStorageType, group.getName(), instanceGroupView.getAvailabilitySetName(),
-                            true, getInstanceSubnetId(instance, subnetStrategy), group.getRootVolumeSize(),
-                            customImageNamePerInstance.get(instance.getInstanceId()), getManagedIdentity(group));
+                    AzureInstanceView azureInstance = AzureInstanceView.builder(instance)
+                            .withStackName(stackName)
+                            .withStackNamePrefixLength(stackNamePrefixLength)
+                            .withType(group.getType())
+                            .withAttachedDiskStorage(attachedDiskStorageName)
+                            .withAttachedDiskStorageType(attachedDiskStorageType)
+                            .withGroupName(group.getName())
+                            .withAvailabilitySetName(instanceGroupView.getAvailabilitySetName())
+                            .withManagedDisk(true)
+                            .withSubnetId(getInstanceSubnetId(instance, subnetStrategy))
+                            .withRootVolumeSize(group.getRootVolumeSize())
+                            .withCustomImageId(customImageNamePerInstance.get(instance.getInstanceId()))
+                            .withManagedIdentity(getManagedIdentity(group))
+                            .build();
                     existingInstances.add(azureInstance);
                 }
                 instanceGroupView.setManagedDisk(true);

--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -293,16 +293,17 @@
                    }
                  },
                  {
-                   "apiVersion": "2018-04-01",
+                   "apiVersion": "2019-07-01",
                    "type": "Microsoft.Compute/virtualMachines",
                    "name": "[concat(parameters('vmNamePrefix'), '${instance.instanceId}')]",
                    "location": "[parameters('region')]",
                     <#if instance.managedIdentity?? && instance.managedIdentity?has_content>
                     "identity": {
                         "type": "userAssigned",
-                        "identityIds": [
-                            "${instance.managedIdentity}"
-                        ]
+                        "userAssignedIdentities": {
+                            "${instance.managedIdentity}": {
+                            }
+                        }
                      },
                     </#if>
                    "dependsOn": [
@@ -358,6 +359,11 @@
                            "osDisk" : {
                                "diskSizeGB": "${instance.rootVolumeSize}",
                                "managedDisk": {
+                                    <#if instance.managedDiskEncryptionWithCustomKeyEnabled>
+                                    "diskEncryptionSet": {
+                                        "id": "${instance.diskEncryptionSetId}"
+                                    },
+                                    </#if>
                                     "storageAccountType": "${instance.attachedDiskStorageType}"
                                },
                                "name" : "[concat(parameters('vmNamePrefix'),'-osDisk', '${instance.instanceId}')]",

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientTest.java
@@ -1,0 +1,99 @@
+package com.sequenceiq.cloudbreak.cloud.azure.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.microsoft.azure.management.compute.Disk;
+import com.microsoft.azure.management.compute.Disks;
+import com.microsoft.azure.management.compute.Encryption;
+import com.microsoft.azure.management.compute.implementation.DiskInner;
+import com.microsoft.azure.management.resources.fluentcore.model.implementation.IndexableRefreshableWrapperImpl;
+import com.sequenceiq.cloudbreak.cloud.azure.util.AzureAuthExceptionHandler;
+
+@ExtendWith(MockitoExtension.class)
+class AzureClientTest {
+
+    private static final String DISK_ENCRYPTION_SET_ID = "diskEncryptionSetId";
+
+    @Mock
+    private AzureClientCredentials azureClientCredentials;
+
+    @Mock
+    private AzureAuthExceptionHandler azureAuthExceptionHandler;
+
+    @InjectMocks
+    private AzureClient underTest;
+
+    @Mock(extraInterfaces = Disk.DefinitionStages.WithCreate.class)
+    private IndexableRefreshableWrapperImpl withCreateIndexableRefreshableWrapperImpl;
+
+    @Mock
+    private DiskInner diskInner;
+
+    @Captor
+    private ArgumentCaptor<Encryption> encryptionCaptor;
+
+    static Object[][] setupDiskEncryptionWithDesIfNeededTestWhenDesAbsentDataProvider() {
+        return new Object[][]{
+                // testCaseName diskEncryptionSetId
+                {"diskEncryptionSetId=null", null},
+                {"diskEncryptionSetId=\"\"", ""},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("setupDiskEncryptionWithDesIfNeededTestWhenDesAbsentDataProvider")
+    void setupDiskEncryptionWithDesIfNeededTestWhenDesAbsent(String testCaseName, String diskEncryptionSetId) {
+        underTest.setupDiskEncryptionWithDesIfNeeded(diskEncryptionSetId, (Disk.DefinitionStages.WithCreate) withCreateIndexableRefreshableWrapperImpl);
+
+        verify(withCreateIndexableRefreshableWrapperImpl, never()).inner();
+    }
+
+    @Test
+    void setupDiskEncryptionWithDesIfNeededTestWhenDesGiven() {
+        when(withCreateIndexableRefreshableWrapperImpl.inner()).thenReturn(diskInner);
+
+        underTest.setupDiskEncryptionWithDesIfNeeded(DISK_ENCRYPTION_SET_ID, (Disk.DefinitionStages.WithCreate) withCreateIndexableRefreshableWrapperImpl);
+
+        verify(diskInner).withEncryption(encryptionCaptor.capture());
+        Encryption encryption = encryptionCaptor.getValue();
+        assertThat(encryption).isNotNull();
+        assertThat(encryption.diskEncryptionSetId()).isEqualTo(DISK_ENCRYPTION_SET_ID);
+    }
+
+    @Test
+    void setupDiskEncryptionWithDesIfNeededTestWhenAzureSdkInternalTypeChecks() throws ClassNotFoundException {
+        // This class is package private
+        Class<?> clazzDisksImpl = Class.forName("com.microsoft.azure.management.compute.implementation.DisksImpl");
+        assertThat(Disks.class.isAssignableFrom(clazzDisksImpl)).isTrue();
+
+        // This class is package private
+        Class<?> clazzDiskImpl = Class.forName("com.microsoft.azure.management.compute.implementation.DiskImpl");
+        assertThat(Disk.class.isAssignableFrom(clazzDiskImpl)).isTrue();
+        assertThat(Disk.DefinitionStages.WithCreate.class.isAssignableFrom(clazzDiskImpl)).isTrue();
+        assertThat(IndexableRefreshableWrapperImpl.class.isAssignableFrom(clazzDiskImpl)).isTrue();
+        Constructor<?>[] clazzDiskImplConstructors = clazzDiskImpl.getDeclaredConstructors();
+        assertThat(clazzDiskImplConstructors).isNotEmpty();
+        Optional<Constructor<?>> clazzDiskImplConstructorOptional = Arrays.stream(clazzDiskImplConstructors)
+                .filter(c -> Arrays.asList(c.getParameterTypes()).contains(DiskInner.class))
+                .findFirst();
+        assertThat(clazzDiskImplConstructorOptional).isPresent();
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureVirtualMachineTypeProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureVirtualMachineTypeProviderTest.java
@@ -1,13 +1,18 @@
 package com.sequenceiq.cloudbreak.cloud.azure.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureInstanceView;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureStackView;
@@ -24,7 +29,12 @@ public class AzureVirtualMachineTypeProviderTest {
 
     private static final String STANDARD_D15_V2 = "Standard_D15_v2";
 
-    private AzureVirtualMachineTypeProvider underTest = new AzureVirtualMachineTypeProvider();
+    private AzureVirtualMachineTypeProvider underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new AzureVirtualMachineTypeProvider();
+    }
 
     @Test
     public void testGetVmTypesShouldReturnsTheAvailableVmTypes() {
@@ -33,24 +43,24 @@ public class AzureVirtualMachineTypeProviderTest {
 
         Set<String> actual = underTest.getVmTypes(azureStackView);
 
-        Assert.assertEquals(4, actual.size());
-        Assert.assertTrue(actual.contains(STANDARD_DS_V2));
-        Assert.assertTrue(actual.contains(STANDARD_D3_V2));
-        Assert.assertTrue(actual.contains(STANDARD_E16A_V3));
-        Assert.assertTrue(actual.contains(STANDARD_D15_V2));
+        assertEquals(4, actual.size());
+        assertTrue(actual.contains(STANDARD_DS_V2));
+        assertTrue(actual.contains(STANDARD_D3_V2));
+        assertTrue(actual.contains(STANDARD_E16A_V3));
+        assertTrue(actual.contains(STANDARD_D15_V2));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testGetVmTypesShouldThrowExceptionWhenAFlavourIsMissing() {
         Map<String, List<AzureInstanceView>> instanceGroups = createInstanceGroupsWithAMissingFlavour();
         AzureStackView azureStackView = createAzureStackView(instanceGroups);
 
-        underTest.getVmTypes(azureStackView);
+        assertThrows(IllegalArgumentException.class, () -> underTest.getVmTypes(azureStackView));
     }
 
     private AzureStackView createAzureStackView(Map<String, List<AzureInstanceView>> instanceGroups) {
-        AzureStackView azureStackView = Mockito.mock(AzureStackView.class);
-        Mockito.when(azureStackView.getGroups()).thenReturn(instanceGroups);
+        AzureStackView azureStackView = mock(AzureStackView.class);
+        when(azureStackView.getGroups()).thenReturn(instanceGroups);
         return azureStackView;
     }
 
@@ -80,7 +90,7 @@ public class AzureVirtualMachineTypeProviderTest {
         InstanceTemplate instanceTemplate = new InstanceTemplate(flavour, groupName, null,
                 Collections.emptyList(), null, Collections.emptyMap(), null, null);
         CloudInstance cloudInstance = new CloudInstance(null, instanceTemplate, null);
-        return new AzureInstanceView(null, 0, cloudInstance, null, null, null,
-                null, null, false, null, 0, null, null);
+        return AzureInstanceView.builder(cloudInstance).build();
     }
+
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureInstanceViewTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureInstanceViewTest.java
@@ -1,0 +1,138 @@
+package com.sequenceiq.cloudbreak.cloud.azure.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AzureInstanceTemplate;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@ExtendWith(MockitoExtension.class)
+class AzureInstanceViewTest {
+
+    private static final int STACK_NAME_PREFIX_LENGTH = 12;
+
+    private static final InstanceGroupType TYPE = InstanceGroupType.CORE;
+
+    private static final String ATTACHED_DISK_STORAGE = "attachedDiskStorage";
+
+    private static final String ATTACHED_DISK_STORAGE_TYPE = "attachedDiskStorageType";
+
+    private static final String GROUP_NAME = "groupName";
+
+    private static final String STACK_NAME = "stackName";
+
+    private static final String AVAILABILITY_SET_NAME = "availabilitySetName";
+
+    private static final boolean MANAGED_DISK = true;
+
+    private static final String SUBNET_ID = "subnetId";
+
+    private static final int ROOT_VOLUME_SIZE = 34;
+
+    private static final String CUSTOM_IMAGE_ID = "customImageId";
+
+    private static final String MANAGED_IDENTITY = "managedIdentity";
+
+    private static final String DISK_ENCRYPTION_SET_ID = "diskEncryptionSetId";
+
+    @Mock
+    private CloudInstance cloudInstance;
+
+    @Mock
+    private InstanceTemplate instanceTemplate;
+
+    @BeforeEach
+    void setUp() {
+        when(cloudInstance.getTemplate()).thenReturn(instanceTemplate);
+    }
+
+    @Test
+    void builderTestMinimal() {
+        AzureInstanceView underTest = AzureInstanceView.builder(cloudInstance).build();
+
+        assertThat(underTest.getInstance()).isSameAs(cloudInstance);
+    }
+
+    @Test
+    void builderTestComplete() {
+        AzureInstanceView underTest = AzureInstanceView.builder(cloudInstance)
+                .withStackNamePrefixLength(STACK_NAME_PREFIX_LENGTH)
+                .withType(TYPE)
+                .withAttachedDiskStorage(ATTACHED_DISK_STORAGE)
+                .withAttachedDiskStorageType(ATTACHED_DISK_STORAGE_TYPE)
+                .withGroupName(GROUP_NAME)
+                .withStackName(STACK_NAME)
+                .withAvailabilitySetName(AVAILABILITY_SET_NAME)
+                .withManagedDisk(MANAGED_DISK)
+                .withSubnetId(SUBNET_ID)
+                .withRootVolumeSize(ROOT_VOLUME_SIZE)
+                .withCustomImageId(CUSTOM_IMAGE_ID)
+                .withManagedIdentity(MANAGED_IDENTITY)
+                .build();
+
+        assertThat(underTest.getInstance()).isSameAs(cloudInstance);
+        assertThat(ReflectionTestUtils.getField(underTest, "stackNamePrefixLength")).isEqualTo(STACK_NAME_PREFIX_LENGTH);
+        assertThat(underTest.getType()).isSameAs(TYPE);
+        assertThat(underTest.getAttachedDiskStorageName()).isEqualTo(ATTACHED_DISK_STORAGE);
+        assertThat(underTest.getAttachedDiskStorageType()).isEqualTo(ATTACHED_DISK_STORAGE_TYPE);
+        assertThat(underTest.getGroupName()).isEqualTo(GROUP_NAME);
+        assertThat(ReflectionTestUtils.getField(underTest, "stackName")).isEqualTo(STACK_NAME);
+        assertThat(underTest.getAvailabilitySetName()).isEqualTo(AVAILABILITY_SET_NAME);
+        assertThat(underTest.isManagedDisk()).isEqualTo(MANAGED_DISK);
+        assertThat(underTest.getSubnetId()).isEqualTo(SUBNET_ID);
+        assertThat(underTest.getRootVolumeSize()).isEqualTo(ROOT_VOLUME_SIZE);
+        assertThat(underTest.getCustomImageId()).isEqualTo(CUSTOM_IMAGE_ID);
+        assertThat(underTest.getManagedIdentity()).isEqualTo(MANAGED_IDENTITY);
+    }
+
+    static Object[][] isManagedDiskEncryptionWithCustomKeyEnabledDataProvider() {
+        return new Object[][]{
+                // testCaseName propertyValue expectedResult
+                {"null", null, false},
+                {"false", false, false},
+                {"true", true, true},
+                {"\"false\"", "false", false},
+                {"\"true\"", "true", true},
+                {"\"True\"", "True", true},
+                {"\"foo\"", "foo", false},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("isManagedDiskEncryptionWithCustomKeyEnabledDataProvider")
+    void isManagedDiskEncryptionWithCustomKeyEnabledTest(String testCaseName, Object propertyValue, boolean expectedResult) {
+        when(instanceTemplate.getParameter(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, Object.class)).thenReturn(propertyValue);
+
+        AzureInstanceView underTest = AzureInstanceView.builder(cloudInstance).build();
+
+        assertThat(underTest.isManagedDiskEncryptionWithCustomKeyEnabled()).isEqualTo(expectedResult);
+    }
+
+    @Test
+    void getDiskEncryptionSetIdTestWhenAbsent() {
+        AzureInstanceView underTest = AzureInstanceView.builder(cloudInstance).build();
+
+        assertThat(underTest.getDiskEncryptionSetId()).isNull();
+    }
+
+    @Test
+    void getDiskEncryptionSetIdTestWhenGiven() {
+        when(instanceTemplate.getStringParameter(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID)).thenReturn(DISK_ENCRYPTION_SET_ID);
+
+        AzureInstanceView underTest = AzureInstanceView.builder(cloudInstance).build();
+
+        assertThat(underTest.getDiskEncryptionSetId()).isEqualTo(DISK_ENCRYPTION_SET_ID);
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureStackViewTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureStackViewTest.java
@@ -1,0 +1,175 @@
+package com.sequenceiq.cloudbreak.cloud.azure.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.cloud.azure.subnetstrategy.AzureSubnetStrategy;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.Volume;
+import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudAdlsGen2View;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@ExtendWith(MockitoExtension.class)
+class AzureStackViewTest {
+
+    private static final String STACK_NAME = "stackName";
+
+    private static final int STACK_NAME_PREFIX_LENGTH = 12;
+
+    private static final String CUSTOM_IMAGE_NAME = "customImageName";
+
+    private static final String INSTANCE_ID = "instanceId";
+
+    private static final InstanceGroupType TYPE = InstanceGroupType.CORE;
+
+    private static final String GROUP_NAME = "groupName";
+
+    private static final int ROOT_VOLUME_SIZE = 12;
+
+    private static final String ATTACHED_DISK_STORAGE_NAME = "attachedDiskStorageName";
+
+    private static final String ATTACHED_DISK_STORAGE_TYPE = "attachedDiskStorageType";
+
+    private static final String INSTANCE_SUBNET_ID = "instanceSubnetId";
+
+    private static final String MANAGED_IDENTITY = "managedIdentity";
+
+    @Mock
+    private Group group;
+
+    @Mock
+    private AzureStorageView armStorageView;
+
+    @Mock
+    private AzureSubnetStrategy subnetStrategy;
+
+    @Mock
+    private CloudInstance instance;
+
+    @Mock
+    private InstanceTemplate template;
+
+    @Mock
+    private Volume volume;
+
+    @Mock
+    private CloudAdlsGen2View cloudAdlsGen2View;
+
+    @Test
+    void constructorTestWhenNoGroup() {
+        AzureStackView underTest = new AzureStackView(STACK_NAME, STACK_NAME_PREFIX_LENGTH, List.of(), armStorageView, subnetStrategy, Map.of());
+
+        Map<String, List<AzureInstanceView>> groups = underTest.getGroups();
+        assertThat(groups).isNotNull();
+        assertThat(groups).isEmpty();
+
+        List<AzureInstanceGroupView> instanceGroups = underTest.getInstanceGroups();
+        assertThat(instanceGroups).isNotNull();
+        assertThat(instanceGroups).isEmpty();
+
+        List<String> instanceGroupNames = underTest.getInstanceGroupNames();
+        assertThat(instanceGroupNames).isNotNull();
+        assertThat(instanceGroupNames).isEmpty();
+    }
+
+    @Test
+    void constructorTestWhenGroupGivenWithoutInstance() {
+        initGroupBasics();
+
+        AzureStackView underTest = new AzureStackView(STACK_NAME, STACK_NAME_PREFIX_LENGTH, List.of(group), armStorageView, subnetStrategy, Map.of());
+
+        Map<String, List<AzureInstanceView>> groups = underTest.getGroups();
+        assertThat(groups).isNotNull();
+        assertThat(groups).isEmpty();
+
+        verifyInstanceGroups(underTest.getInstanceGroups(), false);
+        verifyInstanceGroupNames(underTest.getInstanceGroupNames());
+    }
+
+    @Test
+    void constructorTestWhenGroupGivenWithInstance() {
+        initGroupBasics();
+        initInstances();
+
+        AzureStackView underTest = new AzureStackView(STACK_NAME, STACK_NAME_PREFIX_LENGTH, List.of(group), armStorageView, subnetStrategy,
+                Map.of(INSTANCE_ID, CUSTOM_IMAGE_NAME));
+
+        Map<String, List<AzureInstanceView>> groups = underTest.getGroups();
+        assertThat(groups).isNotNull();
+        assertThat(groups).hasSize(1);
+
+        List<AzureInstanceView> azureInstanceViews = groups.get(TYPE.name());
+        assertThat(azureInstanceViews).isNotNull();
+        assertThat(azureInstanceViews).hasSize(1);
+
+        AzureInstanceView azureInstanceView = azureInstanceViews.get(0);
+        assertThat(azureInstanceView).isNotNull();
+        assertThat(azureInstanceView.getInstance()).isSameAs(instance);
+        assertThat(ReflectionTestUtils.getField(azureInstanceView, "stackName")).isEqualTo(STACK_NAME);
+        assertThat(ReflectionTestUtils.getField(azureInstanceView, "stackNamePrefixLength")).isEqualTo(STACK_NAME_PREFIX_LENGTH);
+        assertThat(azureInstanceView.getType()).isEqualTo(TYPE);
+        assertThat(azureInstanceView.getAttachedDiskStorageName()).isEqualTo(ATTACHED_DISK_STORAGE_NAME);
+        assertThat(azureInstanceView.getAttachedDiskStorageType()).isEqualTo(ATTACHED_DISK_STORAGE_TYPE);
+        assertThat(azureInstanceView.getGroupName()).isEqualTo(GROUP_NAME);
+        assertThat(azureInstanceView.getAvailabilitySetName()).isNull();
+        assertThat(azureInstanceView.isManagedDisk()).isTrue();
+        assertThat(azureInstanceView.getSubnetId()).isEqualTo(INSTANCE_SUBNET_ID);
+        assertThat(azureInstanceView.getRootVolumeSize()).isEqualTo(ROOT_VOLUME_SIZE);
+        assertThat(azureInstanceView.getCustomImageId()).isEqualTo(CUSTOM_IMAGE_NAME);
+        assertThat(azureInstanceView.getManagedIdentity()).isEqualTo(MANAGED_IDENTITY);
+
+        verifyInstanceGroups(underTest.getInstanceGroups(), true);
+        verifyInstanceGroupNames(underTest.getInstanceGroupNames());
+    }
+
+    private void verifyInstanceGroups(List<AzureInstanceGroupView> instanceGroups, boolean managedDiskExpected) {
+        assertThat(instanceGroups).isNotNull();
+        assertThat(instanceGroups).hasSize(1);
+
+        AzureInstanceGroupView azureInstanceGroupView = instanceGroups.get(0);
+        assertThat(azureInstanceGroupView).isNotNull();
+        assertThat(azureInstanceGroupView.getName()).isEqualTo(GROUP_NAME);
+        assertThat(azureInstanceGroupView.getRootVolumeSize()).isEqualTo(ROOT_VOLUME_SIZE);
+        assertThat(azureInstanceGroupView.isManagedDisk()).isEqualTo(managedDiskExpected);
+    }
+
+    private void verifyInstanceGroupNames(List<String> instanceGroupNames) {
+        assertThat(instanceGroupNames).isNotNull();
+        assertThat(instanceGroupNames).hasSize(1);
+
+        assertThat(instanceGroupNames.get(0)).isEqualTo(GROUP_NAME);
+    }
+
+    private void initGroupBasics() {
+        when(group.getType()).thenReturn(TYPE);
+        when(group.getName()).thenReturn(GROUP_NAME);
+        when(group.getRootVolumeSize()).thenReturn(ROOT_VOLUME_SIZE);
+    }
+
+    private void initInstances() {
+        when(group.getInstances()).thenReturn(List.of(instance));
+        when(group.getIdentity()).thenReturn(Optional.of(cloudAdlsGen2View));
+
+        when(instance.getTemplate()).thenReturn(template);
+        when(instance.getInstanceId()).thenReturn(INSTANCE_ID);
+        when(armStorageView.getAttachedDiskStorageName(template)).thenReturn(ATTACHED_DISK_STORAGE_NAME);
+        when(template.getVolumes()).thenReturn(List.of(volume));
+        when(volume.getType()).thenReturn(ATTACHED_DISK_STORAGE_TYPE);
+        when(cloudAdlsGen2View.getManagedIdentity()).thenReturn(MANAGED_IDENTITY);
+
+        when(subnetStrategy.getNextSubnetId()).thenReturn(INSTANCE_SUBNET_ID);
+    }
+
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AwsInstanceTemplateV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AwsInstanceTemplateV4Parameters.java
@@ -71,9 +71,9 @@ public class AwsInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
             putIfValueNotNull(map, AwsInstanceTemplate.EC2_SPOT_MAX_PRICE, sp.getMaxPrice());
         });
         if (encryption != null) {
-            putIfValueNotNull(map, InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, encryption.getType());
-            putIfValueNotNull(map, AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, encryption != null &&
-                    encryption.getType() != EncryptionType.NONE);
+            EncryptionType encryptionType = encryption.getType();
+            putIfValueNotNull(map, InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, encryptionType);
+            putIfValueNotNull(map, AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED, encryptionType != null && encryptionType != EncryptionType.NONE);
         }
 
         putIfValueNotNull(map, AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, Optional.ofNullable(placementGroup)
@@ -127,4 +127,5 @@ public class AwsInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
             placementGroup.setStrategy(AwsPlacementGroupStrategy.NONE);
         }
     }
+
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AzureEncryptionV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AzureEncryptionV4Parameters.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.EncryptionParametersV4Base;
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AzureEncryptionV4Parameters extends EncryptionParametersV4Base {
+
+    @ApiModelProperty(value = ModelDescriptions.TemplateModelDescription.DISK_ENCRYPTION_SET_ID)
+    private String diskEncryptionSetId;
+
+    public String getDiskEncryptionSetId() {
+        return diskEncryptionSetId;
+    }
+
+    public void setDiskEncryptionSetId(String diskEncryptionSetId) {
+        this.diskEncryptionSetId = diskEncryptionSetId;
+    }
+
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AzureInstanceTemplateV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AzureInstanceTemplateV4Parameters.java
@@ -6,9 +6,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceTemplateV4ParameterBase;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AzureInstanceTemplate;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.TemplateModelDescription;
+import com.sequenceiq.common.api.type.EncryptionType;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -24,6 +26,9 @@ public class AzureInstanceTemplateV4Parameters extends InstanceTemplateV4Paramet
     @ApiModelProperty(notes = "by default false")
     private Boolean encrypted = Boolean.FALSE;
 
+    @ApiModelProperty(TemplateModelDescription.ENCRYPTION)
+    private AzureEncryptionV4Parameters encryption;
+
     @ApiModelProperty(notes = "by default true")
     private Boolean managedDisk = Boolean.TRUE;
 
@@ -33,6 +38,14 @@ public class AzureInstanceTemplateV4Parameters extends InstanceTemplateV4Paramet
 
     public void setEncrypted(Boolean encrypted) {
         this.encrypted = encrypted;
+    }
+
+    public AzureEncryptionV4Parameters getEncryption() {
+        return encryption;
+    }
+
+    public void setEncryption(AzureEncryptionV4Parameters encryption) {
+        this.encryption = encryption;
     }
 
     public Boolean getManagedDisk() {
@@ -55,6 +68,9 @@ public class AzureInstanceTemplateV4Parameters extends InstanceTemplateV4Paramet
     public void parse(Map<String, Object> parameters) {
         privateId = getParameterOrNull(parameters, "privateId");
         encrypted = getBoolean(parameters, "encrypted");
+        encryption = new AzureEncryptionV4Parameters();
+        encryption.setType(getBoolean(parameters, AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED) ? EncryptionType.CUSTOM : null);
+        encryption.setDiskEncryptionSetId(getParameterOrNull(parameters, AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID));
         managedDisk = getBoolean(parameters, "managedDisk");
     }
 
@@ -63,6 +79,9 @@ public class AzureInstanceTemplateV4Parameters extends InstanceTemplateV4Paramet
         Map<String, Object> map = super.asMap();
         putIfValueNotNull(map, "privateId", privateId);
         putIfValueNotNull(map, "encrypted", encrypted);
+        if (encryption != null) {
+            putIfValueNotNull(map, AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, encryption.getType() == EncryptionType.CUSTOM);
+        }
         putIfValueNotNull(map, "managedDisk", managedDisk);
         return map;
     }
@@ -73,4 +92,14 @@ public class AzureInstanceTemplateV4Parameters extends InstanceTemplateV4Paramet
     public CloudPlatform getCloudPlatform() {
         return CloudPlatform.AZURE;
     }
+
+    @Override
+    public Map<String, Object> asSecretMap() {
+        Map<String, Object> secretMap = super.asSecretMap();
+        if (encryption != null) {
+            putIfValueNotNull(secretMap, AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID, encryption.getDiskEncryptionSetId());
+        }
+        return secretMap;
+    }
+
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -84,6 +84,7 @@ public class ModelDescriptions {
         public static final String ENCRYPTION_KEY = "encryption key for vm";
         public static final String ENCRYPTED = "should encrypt the vm";
         public static final String ENCRYPTION_METHOD = "encryption method for the key (RAW|RSA)";
+        public static final String DISK_ENCRYPTION_SET_ID = "disk encryption set Resource ID";
         public static final String SECRET_PARAMETERS = "cloud specific secret parameters for template";
     }
 

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AwsInstanceTemplateV4ParametersTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AwsInstanceTemplateV4ParametersTest.java
@@ -1,0 +1,147 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
+import com.sequenceiq.common.api.type.EncryptionType;
+
+class AwsInstanceTemplateV4ParametersTest {
+
+    private static final String ENCRYPTION_KEY = "encryptionKey";
+
+    private AwsInstanceTemplateV4Parameters underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new AwsInstanceTemplateV4Parameters();
+    }
+
+    static Object[][] asMapTestWhenEncryptionDataProvider() {
+        return new Object[][]{
+                // testCaseName encryption expectedVolumeEncryptionKeyType expectedEbsEncryptionEnabled
+                {"encryption=null", null, null, null},
+                {"encryption=(null, null)", createAwsEncryptionV4Parameters(null, null), null, false},
+                {"encryption=(null, \"\")", createAwsEncryptionV4Parameters(null, ""), null, false},
+                {"encryption=(null, ENCRYPTION_KEY)", createAwsEncryptionV4Parameters(null, ENCRYPTION_KEY), null, false},
+                {"encryption=(EncryptionType.NONE, null)", createAwsEncryptionV4Parameters(EncryptionType.NONE, null), EncryptionType.NONE, false},
+                {"encryption=(EncryptionType.NONE, \"\")", createAwsEncryptionV4Parameters(EncryptionType.NONE, ""), EncryptionType.NONE, false},
+                {"encryption=(EncryptionType.NONE, ENCRYPTION_KEY)", createAwsEncryptionV4Parameters(EncryptionType.NONE, ENCRYPTION_KEY), EncryptionType.NONE,
+                        false},
+                {"encryption=(EncryptionType.DEFAULT, null)", createAwsEncryptionV4Parameters(EncryptionType.DEFAULT, null), EncryptionType.DEFAULT, true},
+                {"encryption=(EncryptionType.DEFAULT, \"\")", createAwsEncryptionV4Parameters(EncryptionType.DEFAULT, ""), EncryptionType.DEFAULT, true},
+                {"encryption=(EncryptionType.DEFAULT, ENCRYPTION_KEY)", createAwsEncryptionV4Parameters(EncryptionType.DEFAULT, ENCRYPTION_KEY),
+                        EncryptionType.DEFAULT, true},
+                {"encryption=(EncryptionType.CUSTOM, null)", createAwsEncryptionV4Parameters(EncryptionType.CUSTOM, null), EncryptionType.CUSTOM, true},
+                {"encryption=(EncryptionType.CUSTOM, \"\")", createAwsEncryptionV4Parameters(EncryptionType.CUSTOM, ""), EncryptionType.CUSTOM, true},
+                {"encryption=(EncryptionType.CUSTOM, ENCRYPTION_KEY)", createAwsEncryptionV4Parameters(EncryptionType.CUSTOM, ENCRYPTION_KEY),
+                        EncryptionType.CUSTOM, true},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("asMapTestWhenEncryptionDataProvider")
+    void asMapTestWhenEncryption(String testCaseName, AwsEncryptionV4Parameters encryption, EncryptionType expectedVolumeEncryptionKeyType,
+            Boolean expectedEbsEncryptionEnabled) {
+        underTest.setEncryption(encryption);
+
+        Map<String, Object> result = underTest.asMap();
+
+        assertThat(result).isNotNull();
+        assertThat(result.get(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).isEqualTo(expectedVolumeEncryptionKeyType);
+        assertThat(result.get(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED)).isEqualTo(expectedEbsEncryptionEnabled);
+    }
+
+    static Object[][] asSecretMapTestDataProvider() {
+        return new Object[][]{
+                // testCaseName encryption expectedVolumeEncryptionKeyId
+                {"encryption=null", null, null},
+                {"encryption=(null, null)", createAwsEncryptionV4Parameters(null, null), null},
+                {"encryption=(null, \"\")", createAwsEncryptionV4Parameters(null, ""), ""},
+                {"encryption=(null, ENCRYPTION_KEY)", createAwsEncryptionV4Parameters(null, ENCRYPTION_KEY), ENCRYPTION_KEY},
+                {"encryption=(EncryptionType.NONE, null)", createAwsEncryptionV4Parameters(EncryptionType.NONE, null), null},
+                {"encryption=(EncryptionType.NONE, \"\")", createAwsEncryptionV4Parameters(EncryptionType.NONE, ""), ""},
+                {"encryption=(EncryptionType.NONE, ENCRYPTION_KEY)", createAwsEncryptionV4Parameters(EncryptionType.NONE, ENCRYPTION_KEY), ENCRYPTION_KEY},
+                {"encryption=(EncryptionType.DEFAULT, null)", createAwsEncryptionV4Parameters(EncryptionType.DEFAULT, null), null},
+                {"encryption=(EncryptionType.DEFAULT, \"\")", createAwsEncryptionV4Parameters(EncryptionType.DEFAULT, ""), ""},
+                {"encryption=(EncryptionType.DEFAULT, ENCRYPTION_KEY)", createAwsEncryptionV4Parameters(EncryptionType.DEFAULT, ENCRYPTION_KEY),
+                        ENCRYPTION_KEY},
+                {"encryption=(EncryptionType.CUSTOM, null)", createAwsEncryptionV4Parameters(EncryptionType.CUSTOM, null), null},
+                {"encryption=(EncryptionType.CUSTOM, \"\")", createAwsEncryptionV4Parameters(EncryptionType.CUSTOM, ""), ""},
+                {"encryption=(EncryptionType.CUSTOM, ENCRYPTION_KEY)", createAwsEncryptionV4Parameters(EncryptionType.CUSTOM, ENCRYPTION_KEY), ENCRYPTION_KEY},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("asSecretMapTestDataProvider")
+    void asSecretMapTest(String testCaseName, AwsEncryptionV4Parameters encryption, String expectedVolumeEncryptionKeyId) {
+        underTest.setEncryption(encryption);
+
+        Map<String, Object> result = underTest.asSecretMap();
+        assertThat(result).isNotNull();
+        assertThat(result.get(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID)).isEqualTo(expectedVolumeEncryptionKeyId);
+    }
+
+    static Object[][] parseTestWhenEncryptionDataProvider() {
+        return new Object[][]{
+                // testCaseName parameters expectedVolumeEncryptionKeyType expectedVolumeEncryptionKeyId
+                {"parameters=null", null, null, null},
+                {"parameters={}", Map.of(), null, null},
+                {"parameters={VOLUME_ENCRYPTION_KEY_TYPE=\"NONE\"}", Map.ofEntries(entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, "NONE")),
+                        EncryptionType.NONE, null},
+                {"parameters={VOLUME_ENCRYPTION_KEY_TYPE=\"NONE\", VOLUME_ENCRYPTION_KEY_ID=\"\"}",
+                        Map.ofEntries(entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, "NONE"), entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "")),
+                        EncryptionType.NONE, ""},
+                {"parameters={VOLUME_ENCRYPTION_KEY_TYPE=\"NONE\", VOLUME_ENCRYPTION_KEY_ID=ENCRYPTION_KEY}",
+                        Map.ofEntries(entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, "NONE"),
+                                entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, ENCRYPTION_KEY)),
+                        EncryptionType.NONE, ENCRYPTION_KEY},
+                {"parameters={VOLUME_ENCRYPTION_KEY_TYPE=\"DEFAULT\"}", Map.ofEntries(entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, "DEFAULT")),
+                        EncryptionType.DEFAULT, null},
+                {"parameters={VOLUME_ENCRYPTION_KEY_TYPE=\"DEFAULT\", VOLUME_ENCRYPTION_KEY_ID=\"\"}",
+                        Map.ofEntries(entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, "DEFAULT"), entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "")),
+                        EncryptionType.DEFAULT, ""},
+                {"parameters={VOLUME_ENCRYPTION_KEY_TYPE=\"DEFAULT\", VOLUME_ENCRYPTION_KEY_ID=ENCRYPTION_KEY}",
+                        Map.ofEntries(entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, "DEFAULT"),
+                                entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, ENCRYPTION_KEY)),
+                        EncryptionType.DEFAULT, ENCRYPTION_KEY},
+                {"parameters={VOLUME_ENCRYPTION_KEY_TYPE=\"CUSTOM\"}", Map.ofEntries(entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, "CUSTOM")),
+                        EncryptionType.CUSTOM, null},
+                {"parameters={VOLUME_ENCRYPTION_KEY_TYPE=\"CUSTOM\", VOLUME_ENCRYPTION_KEY_ID=\"\"}",
+                        Map.ofEntries(entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, "CUSTOM"),
+                                entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "")),
+                        EncryptionType.CUSTOM, ""},
+                {"parameters={VOLUME_ENCRYPTION_KEY_TYPE=\"CUSTOM\", VOLUME_ENCRYPTION_KEY_ID=ENCRYPTION_KEY}",
+                        Map.ofEntries(entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, "CUSTOM"),
+                                entry(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, ENCRYPTION_KEY)),
+                        EncryptionType.CUSTOM, ENCRYPTION_KEY},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("parseTestWhenEncryptionDataProvider")
+    void parseTestWhenEncryption(String testCaseName, Map<String, Object> parameters, EncryptionType expectedVolumeEncryptionKeyType,
+            String expectedVolumeEncryptionKeyId) {
+        underTest.parse(parameters);
+
+        AwsEncryptionV4Parameters encryption = underTest.getEncryption();
+        assertThat(encryption).isNotNull();
+        assertThat(encryption.getType()).isEqualTo(expectedVolumeEncryptionKeyType);
+        assertThat(encryption.getKey()).isEqualTo(expectedVolumeEncryptionKeyId);
+    }
+
+    private static AwsEncryptionV4Parameters createAwsEncryptionV4Parameters(EncryptionType type, String key) {
+        AwsEncryptionV4Parameters result = new AwsEncryptionV4Parameters();
+        result.setType(type);
+        result.setKey(key);
+        return result;
+    }
+
+}

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AzureInstanceTemplateV4ParametersTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/AzureInstanceTemplateV4ParametersTest.java
@@ -1,0 +1,155 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.sequenceiq.cloudbreak.cloud.model.instance.AzureInstanceTemplate;
+import com.sequenceiq.common.api.type.EncryptionType;
+
+class AzureInstanceTemplateV4ParametersTest {
+
+    private static final String DISK_ENCRYPTION_SET_ID = "diskEncryptionSetId";
+
+    private AzureInstanceTemplateV4Parameters underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new AzureInstanceTemplateV4Parameters();
+    }
+
+    static Object[][] asMapTestWhenEncryptionDataProvider() {
+        return new Object[][]{
+                // testCaseName encryption expectedManagedDiskEncryptionWithCustomKeyEnabled
+                {"encryption=null", null, null},
+                {"encryption=(null, null)", createAzureEncryptionV4Parameters(null, null), false},
+                {"encryption=(null, \"\")", createAzureEncryptionV4Parameters(null, ""), false},
+                {"encryption=(null, DISK_ENCRYPTION_SET_ID)", createAzureEncryptionV4Parameters(null, DISK_ENCRYPTION_SET_ID), false},
+                {"encryption=(EncryptionType.NONE, null)", createAzureEncryptionV4Parameters(EncryptionType.NONE, null), false},
+                {"encryption=(EncryptionType.NONE, \"\")", createAzureEncryptionV4Parameters(EncryptionType.NONE, ""), false},
+                {"encryption=(EncryptionType.NONE, DISK_ENCRYPTION_SET_ID)", createAzureEncryptionV4Parameters(EncryptionType.NONE, DISK_ENCRYPTION_SET_ID),
+                        false},
+                {"encryption=(EncryptionType.DEFAULT, null)", createAzureEncryptionV4Parameters(EncryptionType.DEFAULT, null), false},
+                {"encryption=(EncryptionType.DEFAULT, \"\")", createAzureEncryptionV4Parameters(EncryptionType.DEFAULT, ""), false},
+                {"encryption=(EncryptionType.DEFAULT, DISK_ENCRYPTION_SET_ID)",
+                        createAzureEncryptionV4Parameters(EncryptionType.DEFAULT, DISK_ENCRYPTION_SET_ID), false},
+                {"encryption=(EncryptionType.CUSTOM, null)", createAzureEncryptionV4Parameters(EncryptionType.CUSTOM, null), true},
+                {"encryption=(EncryptionType.CUSTOM, \"\")", createAzureEncryptionV4Parameters(EncryptionType.CUSTOM, ""), true},
+                {"encryption=(EncryptionType.CUSTOM, DISK_ENCRYPTION_SET_ID)",
+                        createAzureEncryptionV4Parameters(EncryptionType.CUSTOM, DISK_ENCRYPTION_SET_ID), true},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("asMapTestWhenEncryptionDataProvider")
+    void asMapTestWhenEncryption(String testCaseName, AzureEncryptionV4Parameters encryption, Boolean expectedManagedDiskEncryptionWithCustomKeyEnabled) {
+        underTest.setEncryption(encryption);
+
+        Map<String, Object> result = underTest.asMap();
+        assertThat(result).isNotNull();
+        assertThat(result.get(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED))
+                .isEqualTo(expectedManagedDiskEncryptionWithCustomKeyEnabled);
+    }
+
+    static Object[][] asSecretMapTestDataProvider() {
+        return new Object[][]{
+                // testCaseName encryption expectedDiskEncryptionSetId
+                {"encryption=null", null, null},
+                {"encryption=(null, null)", createAzureEncryptionV4Parameters(null, null), null},
+                {"encryption=(null, \"\")", createAzureEncryptionV4Parameters(null, ""), ""},
+                {"encryption=(null, DISK_ENCRYPTION_SET_ID)", createAzureEncryptionV4Parameters(null, DISK_ENCRYPTION_SET_ID), DISK_ENCRYPTION_SET_ID},
+                {"encryption=(EncryptionType.NONE, null)", createAzureEncryptionV4Parameters(EncryptionType.NONE, null), null},
+                {"encryption=(EncryptionType.NONE, \"\")", createAzureEncryptionV4Parameters(EncryptionType.NONE, ""), ""},
+                {"encryption=(EncryptionType.NONE, DISK_ENCRYPTION_SET_ID)", createAzureEncryptionV4Parameters(EncryptionType.NONE, DISK_ENCRYPTION_SET_ID),
+                        DISK_ENCRYPTION_SET_ID},
+                {"encryption=(EncryptionType.DEFAULT, null)", createAzureEncryptionV4Parameters(EncryptionType.DEFAULT, null), null},
+                {"encryption=(EncryptionType.DEFAULT, \"\")", createAzureEncryptionV4Parameters(EncryptionType.DEFAULT, ""), ""},
+                {"encryption=(EncryptionType.DEFAULT, DISK_ENCRYPTION_SET_ID)",
+                        createAzureEncryptionV4Parameters(EncryptionType.DEFAULT, DISK_ENCRYPTION_SET_ID), DISK_ENCRYPTION_SET_ID},
+                {"encryption=(EncryptionType.CUSTOM, null)", createAzureEncryptionV4Parameters(EncryptionType.CUSTOM, null), null},
+                {"encryption=(EncryptionType.CUSTOM, \"\")", createAzureEncryptionV4Parameters(EncryptionType.CUSTOM, ""), ""},
+                {"encryption=(EncryptionType.CUSTOM, DISK_ENCRYPTION_SET_ID)",
+                        createAzureEncryptionV4Parameters(EncryptionType.CUSTOM, DISK_ENCRYPTION_SET_ID), DISK_ENCRYPTION_SET_ID},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("asSecretMapTestDataProvider")
+    void asSecretMapTest(String testCaseName, AzureEncryptionV4Parameters encryption, String expectedDiskEncryptionSetId) {
+        underTest.setEncryption(encryption);
+
+        Map<String, Object> result = underTest.asSecretMap();
+        assertThat(result).isNotNull();
+        assertThat(result.get(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID)).isEqualTo(expectedDiskEncryptionSetId);
+    }
+
+    static Object[][] parseTestWhenEncryptionDataProvider() {
+        return new Object[][]{
+                // testCaseName parameters expectedVolumeEncryptionKeyType expectedDiskEncryptionSetId
+                {"parameters=null", null, null, null},
+                {"parameters={}", Map.of(), null, null},
+                {"parameters={MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED=Boolean.FALSE}",
+                        Map.ofEntries(entry(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, Boolean.FALSE)),
+                        null, null},
+                {"parameters={MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED=\"false\"}",
+                        Map.ofEntries(entry(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, "false")),
+                        null, null},
+                {"parameters={MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED=\"False\"}",
+                        Map.ofEntries(entry(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, "False")),
+                        null, null},
+                {"parameters={MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED=\"foo\"}",
+                        Map.ofEntries(entry(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, "foo")),
+                        null, null},
+                {"parameters={MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED=Boolean.TRUE}",
+                        Map.ofEntries(entry(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, Boolean.TRUE)),
+                        EncryptionType.CUSTOM, null},
+                {"parameters={MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED=\"true\"}",
+                        Map.ofEntries(entry(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, "true")),
+                        EncryptionType.CUSTOM, null},
+                {"parameters={MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED=\"True\"}",
+                        Map.ofEntries(entry(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, "True")),
+                        EncryptionType.CUSTOM, null},
+                {"parameters={MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED=Boolean.FALSE, DISK_ENCRYPTION_SET_ID=\"\"}",
+                        Map.ofEntries(entry(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, Boolean.FALSE),
+                                entry(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID, "")),
+                        null, ""},
+                {"parameters={MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED=Boolean.FALSE, DISK_ENCRYPTION_SET_ID=DISK_ENCRYPTION_SET_ID}",
+                        Map.ofEntries(entry(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, Boolean.FALSE),
+                                entry(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID, DISK_ENCRYPTION_SET_ID)),
+                        null, DISK_ENCRYPTION_SET_ID},
+                {"parameters={MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED=Boolean.TRUE, DISK_ENCRYPTION_SET_ID=\"\"}",
+                        Map.ofEntries(entry(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, Boolean.TRUE),
+                                entry(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID, "")),
+                        EncryptionType.CUSTOM, ""},
+                {"parameters={MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED=Boolean.TRUE, DISK_ENCRYPTION_SET_ID=DISK_ENCRYPTION_SET_ID}",
+                        Map.ofEntries(entry(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, Boolean.TRUE),
+                                entry(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID, DISK_ENCRYPTION_SET_ID)),
+                        EncryptionType.CUSTOM, DISK_ENCRYPTION_SET_ID},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("parseTestWhenEncryptionDataProvider")
+    void parseTestWhenEncryption(String testCaseName, Map<String, Object> parameters, EncryptionType expectedVolumeEncryptionKeyType,
+            String expectedDiskEncryptionSetId) {
+        underTest.parse(parameters);
+
+        AzureEncryptionV4Parameters encryption = underTest.getEncryption();
+        assertThat(encryption).isNotNull();
+        assertThat(encryption.getType()).isEqualTo(expectedVolumeEncryptionKeyType);
+        assertThat(encryption.getDiskEncryptionSetId()).isEqualTo(expectedDiskEncryptionSetId);
+    }
+
+    private static AzureEncryptionV4Parameters createAzureEncryptionV4Parameters(EncryptionType type, String diskEncryptionSetId) {
+        AzureEncryptionV4Parameters result = new AzureEncryptionV4Parameters();
+        result.setType(type);
+        result.setDiskEncryptionSetId(diskEncryptionSetId);
+        return result;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceGroupV1ToInstanceGroupV4Converter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceGroupV1ToInstanceGroupV4Converter.java
@@ -48,7 +48,7 @@ public class InstanceGroupV1ToInstanceGroupV4Converter {
         response.setType(source.getType());
         response.setCloudPlatform(source.getCloudPlatform());
         response.setName(source.getName());
-        response.setTemplate(getIfNotNull(source.getTemplate(), instanceTemplateConverter::convert));
+        response.setTemplate(getIfNotNull(source.getTemplate(), environment, instanceTemplateConverter::convert));
         response.setRecoveryMode(source.getRecoveryMode());
         response.setSecurityGroup(createSecurityGroupFromEnvironment(source.getType(), environment));
         response.setRecipeNames(source.getRecipeNames());

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
@@ -2,15 +2,19 @@ package com.sequenceiq.distrox.v1.distrox.converter;
 
 import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsEncryptionV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4SpotParameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsPlacementGroupV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AzureEncryptionV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AzureInstanceTemplateV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.GcpInstanceTemplateV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.YarnInstanceTemplateV4Parameters;
+import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsEncryptionV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsInstanceTemplateV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsInstanceTemplateV1SpotParameters;
@@ -18,6 +22,9 @@ import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsPla
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AzureInstanceTemplateV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.GcpInstanceTemplateV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.YarnInstanceTemplateV1Parameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 @Component
 public class InstanceTemplateParameterConverter {
@@ -58,12 +65,27 @@ public class InstanceTemplateParameterConverter {
         return new GcpInstanceTemplateV1Parameters();
     }
 
-    public AzureInstanceTemplateV4Parameters convert(AzureInstanceTemplateV1Parameters source) {
+    public AzureInstanceTemplateV4Parameters convert(AzureInstanceTemplateV1Parameters source, DetailedEnvironmentResponse environment) {
         AzureInstanceTemplateV4Parameters response = new AzureInstanceTemplateV4Parameters();
         response.setEncrypted(source.getEncrypted());
+        initAzureEncryptionFromEnvironment(response, environment);
         response.setManagedDisk(source.getManagedDisk());
         response.setPrivateId(source.getPrivateId());
         return response;
+    }
+
+    private void initAzureEncryptionFromEnvironment(AzureInstanceTemplateV4Parameters response, DetailedEnvironmentResponse environment) {
+        String diskEncryptionSetId = Optional.of(environment)
+                .map(DetailedEnvironmentResponse::getAzure)
+                .map(AzureEnvironmentParameters::getResourceEncryptionParameters)
+                .map(AzureResourceEncryptionParameters::getDiskEncryptionSetId)
+                .orElse(null);
+        if (diskEncryptionSetId != null) {
+            AzureEncryptionV4Parameters encryption = new AzureEncryptionV4Parameters();
+            encryption.setType(EncryptionType.CUSTOM);
+            encryption.setDiskEncryptionSetId(diskEncryptionSetId);
+            response.setEncryption(encryption);
+        }
     }
 
     public YarnInstanceTemplateV4Parameters convert(YarnInstanceTemplateV1Parameters source) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateV1ToInstanceTemplateV4Converter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateV1ToInstanceTemplateV4Converter.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.InstanceTemplateV4Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 @Component
 public class InstanceTemplateV1ToInstanceTemplateV4Converter {
@@ -18,14 +19,13 @@ public class InstanceTemplateV1ToInstanceTemplateV4Converter {
     @Inject
     private InstanceTemplateParameterConverter instanceTemplateParameterConverter;
 
-    public InstanceTemplateV4Request convert(InstanceTemplateV1Request source) {
+    public InstanceTemplateV4Request convert(InstanceTemplateV1Request source, DetailedEnvironmentResponse environment) {
         InstanceTemplateV4Request response = new InstanceTemplateV4Request();
-        response.setRootVolume(getIfNotNull(source.getRootVolume(), volumeConverter::convert));
         response.setRootVolume(getIfNotNull(source.getRootVolume(), volumeConverter::convert));
         response.setAttachedVolumes(getIfNotNull(source.getAttachedVolumes(), volumeConverter::convertTo));
         response.setEphemeralVolume(getIfNotNull(source.getEphemeralVolume(), volumeConverter::convert));
         response.setAws(getIfNotNull(source.getAws(), instanceTemplateParameterConverter::convert));
-        response.setAzure(getIfNotNull(source.getAzure(), instanceTemplateParameterConverter::convert));
+        response.setAzure(getIfNotNull(source.getAzure(), environment, instanceTemplateParameterConverter::convert));
         response.setGcp(getIfNotNull(source.getGcp(), instanceTemplateParameterConverter::convert));
         response.setYarn(getIfNotNull(source.getYarn(), instanceTemplateParameterConverter::convert));
         response.setCloudPlatform(source.getCloudPlatform());
@@ -36,7 +36,6 @@ public class InstanceTemplateV1ToInstanceTemplateV4Converter {
     public InstanceTemplateV1Request convert(InstanceTemplateV4Request source) {
         InstanceTemplateV1Request response = new InstanceTemplateV1Request();
         response.setRootVolume(getIfNotNull(source.getRootVolume(), volumeConverter::convert));
-        response.setRootVolume(getIfNotNull(source.getRootVolume(), volumeConverter::convert));
         response.setAttachedVolumes(getIfNotNull(source.getAttachedVolumes(), volumeConverter::convertFrom));
         response.setEphemeralVolume(getIfNotNull(source.getEphemeralVolume(), volumeConverter::convert));
         response.setAws(getIfNotNull(source.getAws(), instanceTemplateParameterConverter::convert));
@@ -46,4 +45,5 @@ public class InstanceTemplateV1ToInstanceTemplateV4Converter {
         response.setInstanceType(source.getInstanceType());
         return response;
     }
+
 }

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXV1RequestToStackV4RequestConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXV1RequestToStackV4RequestConverterTest.java
@@ -1,11 +1,8 @@
 package com.sequenceiq.distrox.v1.distrox.converter;
 
-import static com.sequenceiq.cloudbreak.doc.ModelDescriptions.InstanceGroupModelDescription.INSTANCE_GROUP_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -28,9 +25,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AwsNetworkV4Parameters;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.AzureNetworkV4Parameters;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.network.GcpNetworkV4Parameters;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.RecoveryMode;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseRequest;
@@ -38,20 +32,14 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.network.NetworkV
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.TagsV4Request;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.TelemetryConverter;
 import com.sequenceiq.cloudbreak.service.datalake.SdxClientService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
-import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseAvailabilityType;
 import com.sequenceiq.distrox.api.v1.distrox.model.database.DistroXDatabaseRequest;
-import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.InstanceGroupV1Request;
-import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.tags.TagsV1Request;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams;
-import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
-import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkGcpParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.CompactRegionResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
@@ -133,82 +121,6 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         assertThat(convert.getExternalDatabase().getAvailabilityType()).isEqualTo(DatabaseAvailabilityType.HA);
     }
 
-    @Test
-    void convertAsTemplate() {
-        when(environmentClientService.getByName(anyString())).thenReturn(createAwsEnvironment());
-        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createAwsNetworkV4Request());
-        when(databaseRequestConverter.convert(any(DistroXDatabaseRequest.class))).thenReturn(createDatabaseRequest());
-
-        DistroXV1Request source = new DistroXV1Request();
-        source.setEnvironmentName("envname");
-        DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
-        databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
-        source.setExternalDatabase(databaseRequest);
-
-        StackV4Request convert = underTest.convertAsTemplate(source);
-
-        assertThat(convert.getExternalDatabase()).isNotNull();
-        assertThat(convert.getExternalDatabase().getAvailabilityType()).isEqualTo(DatabaseAvailabilityType.HA);
-    }
-
-    @Test
-    void gatewayIGMustContain1Node() {
-        when(environmentClientService.getByName(anyString())).thenReturn(createAwsEnvironment());
-        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createAwsNetworkV4Request());
-        when(databaseRequestConverter.convert(any(DistroXDatabaseRequest.class))).thenReturn(createDatabaseRequest());
-
-        Set<InstanceGroupV1Request> instanceGroups1 = prepareInstanceGroupV1Requests(InstanceGroupType.CORE);
-        Set<InstanceGroupV1Request> instanceGroups2 = prepareInstanceGroupV1Requests(InstanceGroupType.GATEWAY);
-
-
-        DistroXV1Request source = new DistroXV1Request();
-        source.setEnvironmentName("envname");
-        DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
-        databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
-        source.setExternalDatabase(databaseRequest);
-        source.setInstanceGroups(instanceGroups1);
-        source.setEnableLoadBalancer(true);
-        underTest.convertAsTemplate(source);
-
-        instanceGroups2.stream().findFirst().ifPresent(instanceGroup -> instanceGroup.setNodeCount(2));
-        source.setInstanceGroups(instanceGroups2);
-
-        underTest.convertAsTemplate(source);
-
-        instanceGroups2.stream().findFirst().ifPresent(instanceGroup -> instanceGroup.setNodeCount(0));
-
-        BadRequestException exception = Assertions.assertThrows(BadRequestException.class, () -> underTest.convertAsTemplate(source));
-        assertEquals("Instance group with GATEWAY type must contain at least 1 node!", exception.getMessage());
-
-        instanceGroups2.stream().findFirst().ifPresent(instanceGroup -> instanceGroup.setNodeCount(2));
-        source.setEnableLoadBalancer(false);
-
-        exception = Assertions.assertThrows(BadRequestException.class, () -> underTest.convertAsTemplate(source));
-        assertEquals("Instance group with GATEWAY type must contain 1 node!", exception.getMessage());
-
-        instanceGroups2.stream().findFirst().ifPresent(instanceGroup -> instanceGroup.setNodeCount(0));
-
-        exception = Assertions.assertThrows(BadRequestException.class, () -> underTest.convertAsTemplate(source));
-        assertEquals("Instance group with GATEWAY type must contain 1 node!", exception.getMessage());
-
-        instanceGroups2.stream().findFirst().ifPresent(instanceGroup -> instanceGroup.setNodeCount(1));
-        underTest.convertAsTemplate(source);
-    }
-
-    private Set<InstanceGroupV1Request> prepareInstanceGroupV1Requests(InstanceGroupType instanceGroupType) {
-        InstanceGroupV1Request instanceGroup = new InstanceGroupV1Request();
-        instanceGroup.setName(INSTANCE_GROUP_NAME);
-        if (InstanceGroupType.GATEWAY.equals(instanceGroupType)) {
-            instanceGroup.setNodeCount(1);
-        } else {
-            instanceGroup.setNodeCount(5);
-        }
-        instanceGroup.setRecoveryMode(RecoveryMode.AUTO);
-        instanceGroup.setTemplate(new InstanceTemplateV1Request());
-        instanceGroup.setType(instanceGroupType);
-        return Set.of(instanceGroup);
-    }
-
     @ParameterizedTest
     @EnumSource(EnvironmentStatus.class)
     void testStackV4RequestToDistroXV1RequestRegardlessOfTheStateOfTheEnvironment(EnvironmentStatus status) {
@@ -228,79 +140,6 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         verify(environmentClientService, times(1)).getByCrn(source.getEnvironmentCrn());
 
         Assertions.assertEquals(env.getName(), result.getEnvironmentName());
-    }
-
-    @Test
-    void testWhenEnvironmentStatusIsNotAvailableThenBadRequestExceptionComes() {
-        DistroXV1Request source = new DistroXV1Request();
-        source.setEnvironmentName("envname");
-        DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
-        databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
-        source.setExternalDatabase(databaseRequest);
-
-        DetailedEnvironmentResponse env = createAwsEnvironment();
-        env.setEnvironmentStatus(EnvironmentStatus.ENV_STOPPED);
-
-        when(environmentClientService.getByName(source.getEnvironmentName())).thenReturn(env);
-
-        assertThrows(BadRequestException.class, () -> underTest.convertAsTemplate(source));
-    }
-
-    @Test
-    void convertAsTemplateForAzure() {
-        DistroXV1Request source = new DistroXV1Request();
-        source.setEnvironmentName("envname");
-        DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
-        databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
-        source.setExternalDatabase(databaseRequest);
-
-        when(environmentClientService.getByName(source.getEnvironmentName())).thenReturn(createAzureEnvironment());
-        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createAzureNetworkV4Request());
-        when(databaseRequestConverter.convert(any(DistroXDatabaseRequest.class))).thenReturn(createDatabaseRequest());
-
-        StackV4Request result = underTest.convertAsTemplate(source);
-
-        assertNotNull(result.getExternalDatabase());
-        assertEquals(DatabaseAvailabilityType.HA, result.getExternalDatabase().getAvailabilityType());
-    }
-
-    @Test
-    void convertAsTemplateForGcp() {
-        DistroXV1Request source = new DistroXV1Request();
-        source.setEnvironmentName("envname");
-        DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
-        databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
-        source.setExternalDatabase(databaseRequest);
-
-        when(environmentClientService.getByName(source.getEnvironmentName())).thenReturn(createGcpEnvironment());
-        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createGcpNetworkV4Request());
-        when(databaseRequestConverter.convert(any(DistroXDatabaseRequest.class))).thenReturn(createDatabaseRequest());
-
-        StackV4Request result = underTest.convertAsTemplate(source);
-
-        assertNotNull(result.getExternalDatabase());
-        assertEquals(DatabaseAvailabilityType.HA, result.getExternalDatabase().getAvailabilityType());
-    }
-
-    @Test
-    void testWhenTagsProvidedForDistroxConversionTheyWillBePassed() {
-        DistroXV1Request source = new DistroXV1Request();
-        source.setEnvironmentName("envname");
-        DistroXDatabaseRequest databaseRequest = new DistroXDatabaseRequest();
-        databaseRequest.setAvailabilityType(DistroXDatabaseAvailabilityType.HA);
-        source.setExternalDatabase(databaseRequest);
-        TagsV1Request tags = createTagsV1Request();
-        source.setTags(tags);
-
-        when(environmentClientService.getByName(source.getEnvironmentName())).thenReturn(createGcpEnvironment());
-        when(networkConverter.convertToNetworkV4Request(any())).thenReturn(createGcpNetworkV4Request());
-        when(databaseRequestConverter.convert(any(DistroXDatabaseRequest.class))).thenReturn(createDatabaseRequest());
-
-        StackV4Request result = underTest.convertAsTemplate(source);
-
-        assertNotNull(result.getExternalDatabase());
-        assertEquals(DatabaseAvailabilityType.HA, result.getExternalDatabase().getAvailabilityType());
-        checkTagsV1WithV4(tags, result.getTags());
     }
 
     @Test
@@ -348,16 +187,6 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         checkTagsV4WithV1(tags, result.getTags());
     }
 
-    private void checkTagsV1WithV4(TagsV1Request input, TagsV4Request result) {
-        assertEquals(input.getUserDefined().size(), result.getUserDefined().size());
-        assertEquals(input.getApplication().size(), result.getApplication().size());
-        assertEquals(input.getDefaults().size(), result.getDefaults().size());
-
-        checkTagMap(input.getUserDefined(), result.getUserDefined());
-        checkTagMap(input.getApplication(), result.getApplication());
-        checkTagMap(input.getDefaults(), result.getDefaults());
-    }
-
     private void checkTagsV4WithV1(TagsV4Request input, TagsV1Request result) {
         assertEquals(input.getUserDefined().size(), result.getUserDefined().size());
         assertEquals(input.getApplication().size(), result.getApplication().size());
@@ -393,26 +222,6 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         return network;
     }
 
-    private NetworkV4Request createAzureNetworkV4Request() {
-        NetworkV4Request network = new NetworkV4Request();
-        network.setAzure(createAzureNetworkV4Parameters());
-        return network;
-    }
-
-    private NetworkV4Request createGcpNetworkV4Request() {
-        NetworkV4Request network = new NetworkV4Request();
-        network.setGcp(createGcpNetworkV4Parameters());
-        return network;
-    }
-
-    private TagsV1Request createTagsV1Request() {
-        TagsV1Request r = new TagsV1Request();
-        r.setUserDefined(Map.of("apple", "tree"));
-        r.setDefaults(Map.of("default", "fruit"));
-        r.setApplication(Map.of("peach", "tree"));
-        return r;
-    }
-
     private TagsV4Request createTagsV4Request() {
         TagsV4Request r = new TagsV4Request();
         r.setUserDefined(Map.of("apple", "tree"));
@@ -426,44 +235,6 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         awsNetwork.setSubnetId("mysubnetid");
         awsNetwork.setVpcId("myvpc");
         return awsNetwork;
-    }
-
-    private AzureNetworkV4Parameters createAzureNetworkV4Parameters() {
-        AzureNetworkV4Parameters params = new AzureNetworkV4Parameters();
-        params.setSubnetId("mysubnetid");
-        params.setNetworkId("networkId");
-        params.setNoPublicIp(false);
-        params.setResourceGroupName("resourceGroup");
-        return params;
-    }
-
-    private GcpNetworkV4Parameters createGcpNetworkV4Parameters() {
-        GcpNetworkV4Parameters params = new GcpNetworkV4Parameters();
-        params.setSubnetId("mysubnetid");
-        params.setNoFirewallRules(true);
-        params.setNoPublicIp(false);
-        params.setSharedProjectId("projectId");
-        return params;
-    }
-
-    private DetailedEnvironmentResponse createAzureEnvironment() {
-        DetailedEnvironmentResponse env = new DetailedEnvironmentResponse();
-        env.setEnvironmentStatus(EnvironmentStatus.AVAILABLE);
-        env.setCloudPlatform("AZURE");
-        env.setNetwork(createAzureNetwork());
-        env.setName("SomeAwesomeEnv");
-        env.setRegions(createCompactRegionResponse());
-        return env;
-    }
-
-    private DetailedEnvironmentResponse createGcpEnvironment() {
-        DetailedEnvironmentResponse env = new DetailedEnvironmentResponse();
-        env.setEnvironmentStatus(EnvironmentStatus.AVAILABLE);
-        env.setCloudPlatform("GCP");
-        env.setNetwork(createGcpNetwork());
-        env.setName("SomeAwesomeEnv");
-        env.setRegions(createCompactRegionResponse());
-        return env;
     }
 
     private DetailedEnvironmentResponse createAwsEnvironment() {
@@ -480,37 +251,6 @@ class DistroXV1RequestToStackV4RequestConverterTest {
         CompactRegionResponse regionResponse = new CompactRegionResponse();
         regionResponse.setNames(List.of("myregion"));
         return regionResponse;
-    }
-
-    private EnvironmentNetworkResponse createAzureNetwork() {
-        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
-        network.setAzure(createAzureNetworkParams());
-        network.setSubnetIds(Set.of("mysubnetid"));
-        return network;
-    }
-
-    private EnvironmentNetworkAzureParams createAzureNetworkParams() {
-        EnvironmentNetworkAzureParams azureParams = new EnvironmentNetworkAzureParams();
-        azureParams.setNetworkId("someNetworkId");
-        azureParams.setResourceGroupName("someResourceGroup");
-        azureParams.setNoPublicIp(false);
-        return azureParams;
-    }
-
-    private EnvironmentNetworkResponse createGcpNetwork() {
-        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
-        network.setGcp(createGcpNetworkParams());
-        network.setSubnetIds(Set.of("mysubnetid"));
-        return network;
-    }
-
-    private EnvironmentNetworkGcpParams createGcpNetworkParams() {
-        EnvironmentNetworkGcpParams gcpParams = new EnvironmentNetworkGcpParams();
-        gcpParams.setNetworkId("someNetworkId");
-        gcpParams.setNoPublicIp(false);
-        gcpParams.setNoFirewallRules(true);
-        gcpParams.setSharedProjectId("someSharedProjectId");
-        return gcpParams;
     }
 
     private EnvironmentNetworkResponse createAwsNetwork() {

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverterTest.java
@@ -1,0 +1,92 @@
+package com.sequenceiq.distrox.v1.distrox.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AzureEncryptionV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AzureInstanceTemplateV4Parameters;
+import com.sequenceiq.common.api.type.EncryptionType;
+import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AzureInstanceTemplateV1Parameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+
+class InstanceTemplateParameterConverterTest {
+
+    private static final String PRIVATE_ID = "privateId";
+
+    private static final String DISK_ENCRYPTION_SET_ID = "diskEncryptionSetId";
+
+    private InstanceTemplateParameterConverter underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new InstanceTemplateParameterConverter();
+    }
+
+    @Test
+    void convertTestAzureInstanceTemplateV1ParametersToAzureInstanceTemplateV4ParametersWhenBasicFields() {
+        AzureInstanceTemplateV1Parameters source = new AzureInstanceTemplateV1Parameters();
+        source.setPrivateId(PRIVATE_ID);
+        DetailedEnvironmentResponse environment = createDetailedEnvironmentResponseForAzureEncryption(false, false, null);
+
+        AzureInstanceTemplateV4Parameters azureInstanceTemplateV4Parameters = underTest.convert(source, environment);
+
+        assertThat(azureInstanceTemplateV4Parameters).isNotNull();
+        assertThat(azureInstanceTemplateV4Parameters.getEncrypted()).isEqualTo(Boolean.FALSE);
+        assertThat(azureInstanceTemplateV4Parameters.getManagedDisk()).isEqualTo(Boolean.TRUE);
+        assertThat(azureInstanceTemplateV4Parameters.getPrivateId()).isEqualTo(PRIVATE_ID);
+    }
+
+    static Object[][] convertTestAzureInstanceTemplateV1ParametersToAzureInstanceTemplateV4ParametersWhenEncryptionDataProvider() {
+        return new Object[][]{
+                // testCaseName withAzure withResourceEncryption diskEncryptionSetId expectedEncryption expectedDiskEncryptionSetId
+                {"withAzure=false", false, false, null, false, null},
+                {"withAzure=true, withResourceEncryption=false", true, false, null, false, null},
+                {"withAzure=true, withResourceEncryption=true, diskEncryptionSetId=null", true, true, null, false, null},
+                {"withAzure=true, withResourceEncryption=true, diskEncryptionSetId=DISK_ENCRYPTION_SET_ID", true, true, DISK_ENCRYPTION_SET_ID, true,
+                        DISK_ENCRYPTION_SET_ID},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("convertTestAzureInstanceTemplateV1ParametersToAzureInstanceTemplateV4ParametersWhenEncryptionDataProvider")
+    void convertTestAzureInstanceTemplateV1ParametersToAzureInstanceTemplateV4ParametersWhenEncryption(String testCaseName, boolean withAzure,
+            boolean withResourceEncryption, String diskEncryptionSetId, boolean expectedEncryption, String expectedDiskEncryptionSetId) {
+        AzureInstanceTemplateV1Parameters source = new AzureInstanceTemplateV1Parameters();
+        DetailedEnvironmentResponse environment = createDetailedEnvironmentResponseForAzureEncryption(withAzure, withResourceEncryption, diskEncryptionSetId);
+
+        AzureInstanceTemplateV4Parameters azureInstanceTemplateV4Parameters = underTest.convert(source, environment);
+
+        assertThat(azureInstanceTemplateV4Parameters).isNotNull();
+
+        AzureEncryptionV4Parameters encryption = azureInstanceTemplateV4Parameters.getEncryption();
+        if (expectedEncryption) {
+            assertThat(encryption).isNotNull();
+            assertThat(encryption.getType()).isEqualTo(EncryptionType.CUSTOM);
+            assertThat(encryption.getDiskEncryptionSetId()).isEqualTo(expectedDiskEncryptionSetId);
+        } else {
+            assertThat(encryption).isNull();
+        }
+    }
+
+    private DetailedEnvironmentResponse createDetailedEnvironmentResponseForAzureEncryption(boolean withAzure, boolean withResourceEncryption,
+            String diskEncryptionSetId) {
+        DetailedEnvironmentResponse environment = new DetailedEnvironmentResponse();
+        if (withAzure) {
+            AzureEnvironmentParameters parameters = new AzureEnvironmentParameters();
+            environment.setAzure(parameters);
+            if (withResourceEncryption) {
+                AzureResourceEncryptionParameters encryption = new AzureResourceEncryptionParameters();
+                parameters.setResourceEncryptionParameters(encryption);
+                encryption.setDiskEncryptionSetId(diskEncryptionSetId);
+            }
+        }
+        return  environment;
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateV1ToInstanceTemplateV4ConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateV1ToInstanceTemplateV4ConverterTest.java
@@ -1,0 +1,119 @@
+package com.sequenceiq.distrox.v1.distrox.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AzureInstanceTemplateV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.InstanceTemplateV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.volume.RootVolumeV4Request;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AzureInstanceTemplateV1Parameters;
+import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.volume.RootVolumeV1Request;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+
+@ExtendWith(MockitoExtension.class)
+class InstanceTemplateV1ToInstanceTemplateV4ConverterTest {
+
+    private static final String INSTANCE_TYPE = "instanceType";
+
+    @Mock
+    private VolumeConverter volumeConverter;
+
+    @Mock
+    private InstanceTemplateParameterConverter instanceTemplateParameterConverter;
+
+    @InjectMocks
+    private InstanceTemplateV1ToInstanceTemplateV4Converter underTest;
+
+    private DetailedEnvironmentResponse environment;
+
+    @BeforeEach
+    void setUp() {
+        environment = new DetailedEnvironmentResponse();
+    }
+
+    @Test
+    void convertTestInstanceTemplateV1RequestToInstanceTemplateV4RequestWhenMinimal() {
+        InstanceTemplateV1Request source = new InstanceTemplateV1Request();
+        source.setInstanceType(INSTANCE_TYPE);
+
+        InstanceTemplateV4Request instanceTemplateV4Request = underTest.convert(source, environment);
+
+        assertThat(instanceTemplateV4Request).isNotNull();
+        assertThat(instanceTemplateV4Request.getRootVolume()).isNull();
+        assertThat(instanceTemplateV4Request.getAzure()).isNull();
+        assertThat(instanceTemplateV4Request.getCloudPlatform()).isNull();
+        assertThat(instanceTemplateV4Request.getInstanceType()).isEqualTo(INSTANCE_TYPE);
+    }
+
+    @Test
+    void convertTestInstanceTemplateV1RequestToInstanceTemplateV4RequestWhenAzure() {
+        InstanceTemplateV1Request source = new InstanceTemplateV1Request();
+        RootVolumeV1Request rootVolumeV1Request = new RootVolumeV1Request();
+        source.setRootVolume(rootVolumeV1Request);
+        AzureInstanceTemplateV1Parameters azureInstanceTemplateV1Parameters = new AzureInstanceTemplateV1Parameters();
+        source.setAzure(azureInstanceTemplateV1Parameters);
+        source.setInstanceType(INSTANCE_TYPE);
+
+        RootVolumeV4Request rootVolumeV4Request = new RootVolumeV4Request();
+        when(volumeConverter.convert(rootVolumeV1Request)).thenReturn(rootVolumeV4Request);
+
+        AzureInstanceTemplateV4Parameters azureInstanceTemplateV4Parameters = new AzureInstanceTemplateV4Parameters();
+        when(instanceTemplateParameterConverter.convert(azureInstanceTemplateV1Parameters, environment)).thenReturn(azureInstanceTemplateV4Parameters);
+
+        InstanceTemplateV4Request instanceTemplateV4Request = underTest.convert(source, environment);
+
+        assertThat(instanceTemplateV4Request).isNotNull();
+        assertThat(instanceTemplateV4Request.getRootVolume()).isSameAs(rootVolumeV4Request);
+        assertThat(instanceTemplateV4Request.getAzure()).isSameAs(azureInstanceTemplateV4Parameters);
+        assertThat(instanceTemplateV4Request.getCloudPlatform()).isEqualTo(CloudPlatform.AZURE);
+        assertThat(instanceTemplateV4Request.getInstanceType()).isEqualTo(INSTANCE_TYPE);
+    }
+
+    @Test
+    void convertTestInstanceTemplateV4RequestToInstanceTemplateV1RequestWhenMinimal() {
+        InstanceTemplateV4Request source = new InstanceTemplateV4Request();
+        source.setInstanceType(INSTANCE_TYPE);
+
+        InstanceTemplateV1Request instanceTemplateV1Request = underTest.convert(source);
+
+        assertThat(instanceTemplateV1Request).isNotNull();
+        assertThat(instanceTemplateV1Request.getRootVolume()).isNull();
+        assertThat(instanceTemplateV1Request.getAzure()).isNull();
+        assertThat(instanceTemplateV1Request.getCloudPlatform()).isNull();
+        assertThat(instanceTemplateV1Request.getInstanceType()).isEqualTo(INSTANCE_TYPE);
+    }
+
+    @Test
+    void convertTestInstanceTemplateV4RequestToInstanceTemplateV1RequestWhenAzure() {
+        InstanceTemplateV4Request source = new InstanceTemplateV4Request();
+        RootVolumeV4Request rootVolumeV4Request = new RootVolumeV4Request();
+        source.setRootVolume(rootVolumeV4Request);
+        AzureInstanceTemplateV4Parameters azureInstanceTemplateV4Parameters = new AzureInstanceTemplateV4Parameters();
+        source.setAzure(azureInstanceTemplateV4Parameters);
+        source.setInstanceType(INSTANCE_TYPE);
+
+        RootVolumeV1Request rootVolumeV1Request = new RootVolumeV1Request();
+        when(volumeConverter.convert(rootVolumeV4Request)).thenReturn(rootVolumeV1Request);
+
+        AzureInstanceTemplateV1Parameters azureInstanceTemplateV1Parameters = new AzureInstanceTemplateV1Parameters();
+        when(instanceTemplateParameterConverter.convert(azureInstanceTemplateV4Parameters)).thenReturn(azureInstanceTemplateV1Parameters);
+
+        InstanceTemplateV1Request instanceTemplateV1Request = underTest.convert(source);
+
+        assertThat(instanceTemplateV1Request).isNotNull();
+        assertThat(instanceTemplateV1Request.getRootVolume()).isSameAs(rootVolumeV1Request);
+        assertThat(instanceTemplateV1Request.getAzure()).isSameAs(azureInstanceTemplateV1Parameters);
+        assertThat(instanceTemplateV1Request.getCloudPlatform()).isEqualTo(CloudPlatform.AZURE);
+        assertThat(instanceTemplateV1Request.getInstanceType()).isEqualTo(INSTANCE_TYPE);
+    }
+
+}


### PR DESCRIPTION
* When present in `DetailedEnvironmentResponse` (`getDiskEncryptionSetId()`), associate the provided Disk Encryption Set (DES) Resource ID with all the Managed Disks of the DH cluster being created. This applies to the OS disks as well as data (attached) disks, and will make all such disks encrypted by SSE using the customer-managed CMK linked to the DES.
  * `cloud-api` receives the SSE with CMK and DES Resource ID as two new dynamic parameters in `InstanceTemplate`. The parameter name constants are defined in the new class `AzureInstanceTemplate`.
* No entitlement check (regarding `EntitlementService.isAzureDiskSSEWithCMKEnabled()`) is made; the DES Resource ID will be always used and applied to all new DH VM disks when present in `DetailedEnvironmentResponse`.
* StackV4 API has been extended with `AzureEncryptionV4Parameters` that encompasses the `diskEncryptionSetId`. These parameters are contained by the new property `AzureInstanceTemplateV4Parameters.encryption`.
* A small bug has been fixed in `AwsInstanceTemplateV4Parameters.asMap()` around how `AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED` gets populated. This also undoes the related (and ineffective) change of #9378.
* `DistroXV1RequestToStackV4RequestConverter.convertAsTemplate()` was a dead code so has been removed to avoid confusion. The related defunct tests in `DistroXV1RequestToStackV4RequestConverterTest` have been also cleaned up.
* `InstanceTemplateV1ToInstanceTemplateV4Converter` contained duplicated statements `response.setRootVolume(getIfNotNull(source.getRootVolume(), volumeConverter::convert));` in both `convert()` methods. The superfluous invocations have been dropped.
* The `apiVersion` of the `Microsoft.Compute/virtualMachines` resource in `arm-v2.ftl` has been updated from `2018-04-01` to `2019-07-01`; the latter is the earliest version supporting DES for VM disks. (Only the OS disk is created via ARM deployments in our case.) Unfortunately, this version bump came with a backward incompatible change around user-assigned MSIs; see `identity.identityIds` (array of strings) being changed to `identity.userAssignedIdentities` (object of empty objects).
* The legacy Azure Java SDK (`com.microsoft.azure:azure-mgmt-compute:1.38.0`) does not expose DES related functionality for VM disks. Not even the (currently) latest version 1.40.0 does so. We, therefore, have to rely on SDK internal implementation classes to apply the DES Resource ID to newly created attached disks. See `AzureClient.setupDiskEncryptionWithDesIfNeeded()` (called from `AzureClient.createManagedDisk()`).
* Testing:
  * Manually verified with local CB, brand new env, DH with and without DES Resource ID, with simple DES as well as double-encryption DES.
  * Added unit tests and updated existing ones, using JUnit 5 and AssertJ whenever possible. Since the Azure Java SDK has some `final` classes (e.g. `com.microsoft.azure.management.Azure`) that cannot be easily mocked, `AzureClient` validations in `AzureClientTest` are rather limited. Moreover, there are some reflection-based checks in `AzureClientTest.setupDiskEncryptionWithDesIfNeededTestWhenAzureSdkInternalTypeChecks()` that aim to guard against unexpected API changes in case of a future SDK version upgrade.
