### PR TITLE
CB-11379 subscriptionRequired flag for notifications

### DIFF
--- a/notification-sender/build.gradle
+++ b/notification-sender/build.gradle
@@ -9,6 +9,7 @@ repositories {
 dependencies {
   compile project(":common")
   compile project(":structuredevent-model")
+  compile project(":auth-connector")
 
   implementation group: 'org.glassfish.jersey.core',     name: 'jersey-client',                  version: jerseyCoreVersion
   implementation group: 'org.slf4j',                     name: 'slf4j-api',                      version: slf4jApiVersion

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/CloudbreakNotification.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/CloudbreakNotification.java
@@ -38,6 +38,8 @@ public class CloudbreakNotification extends CloudbreakNotificationBase {
 
     private String tenantName;
 
+    private Boolean subscriptionRequired;
+
     private JsonNode payload;
 
     private String payloadType;
@@ -181,5 +183,13 @@ public class CloudbreakNotification extends CloudbreakNotificationBase {
 
     public void setTenantName(String tenantName) {
         this.tenantName = tenantName;
+    }
+
+    public Boolean getSubscriptionRequired() {
+        return subscriptionRequired;
+    }
+
+    public void setSubscriptionRequired(Boolean subscriptionRequired) {
+        this.subscriptionRequired = subscriptionRequired;
     }
 }


### PR DESCRIPTION
Extend CloudbreakNotification class with an optional subscriptionRequired boolean property, set based on PERSONAL_VIEW_CB_BY_RIGHT entitlement.
The flag will be used by Uluwatu to determine if notification filtering is enabled for the tenant.

See detailed description in the commit message.