### PR TITLE
CB-11418 Remove DefaultRestartAction from Flowstate as default

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/SdxCertRotationState.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/SdxCertRotationState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.datalake.flow.cert.rotation;
 
+import com.sequenceiq.datalake.flow.FillInMemoryStateStoreRestartAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 
 public enum SdxCertRotationState implements FlowState {
     INIT_STATE,
@@ -9,4 +11,9 @@ public enum SdxCertRotationState implements FlowState {
     CERT_ROTATION_FINISHED_STATE,
     CERT_ROTATION_FAILED_STATE,
     FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowState.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowState.java
@@ -1,15 +1,11 @@
 package com.sequenceiq.flow.core;
 
-import com.sequenceiq.flow.core.restart.DefaultRestartAction;
-
 public interface FlowState {
     default Class<? extends AbstractAction<?, ?, ?, ?>> action() {
         return null;
     }
 
-    default Class<? extends RestartAction> restartAction() {
-        return DefaultRestartAction.class;
-    }
+    Class<? extends RestartAction> restartAction();
 
     String name();
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/config/FlowChainFinalizeState.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/finalize/config/FlowChainFinalizeState.java
@@ -1,10 +1,17 @@
 package com.sequenceiq.flow.core.chain.finalize.config;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 
 public enum FlowChainFinalizeState implements FlowState {
     INIT_STATE,
     FLOWCHAIN_FINALIZE_FINISHED_STATE,
     FLOWCHAIN_FINALIZE_FAILED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return DefaultRestartAction.class;
+    }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/init/config/FlowChainInitState.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/init/config/FlowChainInitState.java
@@ -1,10 +1,17 @@
 package com.sequenceiq.flow.core.chain.init.config;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 
 public enum FlowChainInitState implements FlowState {
     INIT_STATE,
     FLOWCHAIN_INIT_FINISHED_STATE,
     FLOWCHAIN_INIT_FAILED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return DefaultRestartAction.class;
+    }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/helloworld/config/HelloWorldState.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/helloworld/config/HelloWorldState.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.flow.core.helloworld.config;
 
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 
 public enum HelloWorldState implements FlowState {
     INIT_STATE,
@@ -9,5 +11,10 @@ public enum HelloWorldState implements FlowState {
     HELLO_WORLD_SECOND_STEP_STATE,
     HELLO_WORLD_FINISHED_STATE,
     HELLO_WORLD_FAILED_STATE,
-    FINAL_STATE
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return DefaultRestartAction.class;
+    }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/restart/DefaultRestartAction.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/restart/DefaultRestartAction.java
@@ -14,6 +14,10 @@ import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
 
 import reactor.bus.EventBus;
 
+/**
+ * Please consider using a different, service specific one which sets the MdcContext
+ * See: FillInMemoryStateStoreRestartAction or InitializeMDCContextRestartAction
+ */
 @Component("DefaultRestartAction")
 public class DefaultRestartAction implements RestartAction {
 

--- a/flow/src/test/java/com/sequenceiq/flow/core/AbstractActionTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/AbstractActionTest.java
@@ -32,6 +32,7 @@ import org.springframework.statemachine.config.common.annotation.ObjectPostProce
 
 import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -137,6 +138,11 @@ public class AbstractActionTest {
         @Override
         public Class<? extends AbstractAction<?, ?, ?, ?>> action() {
             return TestAction.class;
+        }
+
+        @Override
+        public Class<? extends RestartAction> restartAction() {
+            return DefaultRestartAction.class;
         }
     }
 

--- a/flow/src/test/java/com/sequenceiq/flow/core/Flow2HandlerTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/Flow2HandlerTest.java
@@ -538,5 +538,10 @@ public class Flow2HandlerTest {
         public String name() {
             return null;
         }
+
+        @Override
+        public Class<? extends RestartAction> restartAction() {
+            return DefaultRestartAction.class;
+        }
     }
 }

--- a/flow/src/test/java/com/sequenceiq/flow/core/StateConverterAdapterTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/StateConverterAdapterTest.java
@@ -3,6 +3,8 @@ package com.sequenceiq.flow.core;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
+
 public class StateConverterAdapterTest {
     private final StateConverterAdapter<TestState> stateConverterAdapter = new StateConverterAdapter<>(TestState.class);
 
@@ -13,6 +15,11 @@ public class StateConverterAdapterTest {
     }
 
     private enum TestState implements FlowState {
-        TEST_STATE
+        TEST_STATE;
+
+        @Override
+        public Class<? extends RestartAction> restartAction() {
+            return DefaultRestartAction.class;
+        }
     }
 }

--- a/flow/src/test/java/com/sequenceiq/flow/core/config/AbstractFlowConfigurationTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/config/AbstractFlowConfigurationTest.java
@@ -29,10 +29,12 @@ import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowEventListener;
 import com.sequenceiq.flow.core.FlowFinalizeAction;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.FlowEdgeConfig;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
 import com.sequenceiq.flow.core.config.AbstractFlowConfigurationTest.TestFlowConfiguration.NotAcceptedException;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 
 public class AbstractFlowConfigurationTest {
 
@@ -135,6 +137,11 @@ public class AbstractFlowConfigurationTest {
         @Override
         public Class<? extends AbstractAction<?, ?, ?, ?>> action() {
             return FlowFinalizeAction.class;
+        }
+
+        @Override
+        public Class<? extends RestartAction> restartAction() {
+            return DefaultRestartAction.class;
         }
     }
 

--- a/flow/src/test/java/com/sequenceiq/flow/core/config/TestFlowConfig.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/config/TestFlowConfig.java
@@ -4,6 +4,8 @@ import java.util.List;
 
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 
 public class TestFlowConfig extends AbstractFlowConfiguration<TestFlowConfig.TestFlowState, TestFlowConfig.TestFlowEvent>
         implements RetryableFlowConfiguration<TestFlowConfig.TestFlowEvent> {
@@ -61,6 +63,11 @@ public class TestFlowConfig extends AbstractFlowConfiguration<TestFlowConfig.Tes
         TEST_STATE,
         TEST_FINISHED_STATE,
         FINAL_STATE;
+
+        @Override
+        public Class<? extends RestartAction> restartAction() {
+            return DefaultRestartAction.class;
+        }
     }
 
     public enum TestFlowEvent implements FlowEvent {

--- a/flow/src/test/java/com/sequenceiq/flow/service/flowlog/FlowLogDBServiceTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/service/flowlog/FlowLogDBServiceTest.java
@@ -41,7 +41,9 @@ import com.sequenceiq.flow.core.ApplicationFlowInformation;
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowState;
 import com.sequenceiq.flow.core.ResourceIdProvider;
+import com.sequenceiq.flow.core.RestartAction;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.restart.DefaultRestartAction;
 import com.sequenceiq.flow.domain.FlowLog;
 import com.sequenceiq.flow.domain.FlowLogIdWithTypeAndTimestamp;
 import com.sequenceiq.flow.domain.StateStatus;
@@ -305,6 +307,10 @@ public class FlowLogDBServiceTest {
             return null;
         }
 
+        @Override
+        public Class<? extends RestartAction> restartAction() {
+            return DefaultRestartAction.class;
+        }
     }
 
     public static class MockFlowEvent implements FlowEvent {


### PR DESCRIPTION
Remove `DefaultRestartAction` from `FlowState` as default implementation for `restartAction` to enforce developers to think about it when creating new flows
