### PR TITLE
ENGESC-7626 XOM is unable to deploy CDP env using "Public Endpoint Access Gateway"

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/SubnetSelector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/SubnetSelector.java
@@ -51,7 +51,7 @@ public class SubnetSelector {
                     subnetsToParse = source.getGatewayEndpointSubnetMetas();
                 }
                 Map<String, CloudSubnet> publicSubnetMetas = subnetsToParse.entrySet().stream()
-                    .filter(entry -> !entry.getValue().isPrivateSubnet())
+                    .filter(entry -> !entry.getValue().isPrivateSubnet() || entry.getValue().isRoutableToInternet())
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
                 endpointGatewayCloudSubnet = chooseSubnet(null, publicSubnetMetas, selectedAZ, false);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
@@ -221,7 +221,7 @@ public class LoadBalancerConfigService {
         return isSelectedSubnetAvailableAndRequestedType(network, envNetwork, false);
     }
 
-    private boolean isSelectedSubnetAvailableAndRequestedType(Network network, EnvironmentNetworkResponse envNetwork, boolean privateType) {
+    private boolean isSelectedSubnetAvailableAndRequestedType(Network network, EnvironmentNetworkResponse envNetwork, boolean requestPrivate) {
         if (network != null) {
             Json attributes = network.getAttributes();
             Map<String, Object> params = attributes == null ? Collections.emptyMap() : attributes.getMap();
@@ -230,8 +230,9 @@ public class LoadBalancerConfigService {
                 LOGGER.debug("Found selected stack subnet {}", subnetId);
                 Optional<CloudSubnet> selectedSubnet = subnetSelector.findSubnetById(envNetwork.getSubnetMetas(), subnetId);
                 if (selectedSubnet.isPresent()) {
-                    LOGGER.debug("Subnet {} type {}", subnetId, selectedSubnet.get().isPrivateSubnet() ? "private" : "public");
-                    return privateType == selectedSubnet.get().isPrivateSubnet();
+                    boolean privateSubnet = selectedSubnet.get().isPrivateSubnet() && !selectedSubnet.get().isRoutableToInternet();
+                    LOGGER.debug("Subnet {} type {}", subnetId, privateSubnet ? "private" : "public");
+                    return requestPrivate == privateSubnet;
                 }
             }
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/SubnetSelectorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/SubnetSelectorTest.java
@@ -104,6 +104,36 @@ public class SubnetSelectorTest extends SubnetTest {
         assert subnet.isEmpty();
     }
 
+    @Test
+    public void testChooseEndpointGatewaySubnetFromEndpointSubnetstRoutableToInternet() {
+        EnvironmentNetworkResponse source = setupResponse();
+        source.setSubnetMetas(Map.of("key", getCloudSubnet(AZ_1)));
+        source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+        source.setGatewayEndpointSubnetMetas(Map.of("public-key", getRoutableToInternetCloudSubnet(PRIVATE_ID_1, AZ_1)));
+
+        Optional<CloudSubnet> subnet =
+            underTest.chooseSubnetForEndpointGateway(source, PRIVATE_ID_1);
+
+        assert subnet.isPresent();
+        assertEquals(PRIVATE_ID_1, subnet.get().getId());
+    }
+
+    @Test
+    public void testChooseEndpointGatewaySubnetFromEnvironmentSubnetstRoutableToInternet() {
+        EnvironmentNetworkResponse source = setupResponse();
+        source.setSubnetMetas(Map.of(
+            "key1", getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1),
+            "key2", getRoutableToInternetCloudSubnet(PUBLIC_ID_1, AZ_1)
+        ));
+        source.setPublicEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED);
+
+        Optional<CloudSubnet> subnet =
+            underTest.chooseSubnetForEndpointGateway(source, PRIVATE_ID_1);
+
+        assert subnet.isPresent();
+        assertEquals(PUBLIC_ID_1, subnet.get().getId());
+    }
+
     private CloudSubnet getCloudSubnet(String availabilityZone) {
         return new CloudSubnet(PRIVATE_ID_1, "name", availabilityZone, "cidr");
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/network/SubnetTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/network/SubnetTest.java
@@ -20,4 +20,8 @@ public class SubnetTest {
     protected CloudSubnet getPrivateCloudSubnet(String id, String availabilityZone) {
         return new CloudSubnet(id, "name", availabilityZone, "cidr", true, false, false, SubnetType.PRIVATE);
     }
+
+    protected CloudSubnet getRoutableToInternetCloudSubnet(String id, String availabilityZone) {
+        return new CloudSubnet(id, "name", availabilityZone, "cidr", false, true, true, SubnetType.PRIVATE, true);
+    }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigServiceTest.java
@@ -179,6 +179,23 @@ public class LoadBalancerConfigServiceTest extends SubnetTest {
     }
 
     @Test
+    public void testCreateLoadBalancerForDataLakeInternetRoutableSubnets() {
+        Stack stack = createStack(StackType.DATALAKE, PUBLIC_ID_1);
+        CloudSubnet subnet = getRoutableToInternetCloudSubnet(PUBLIC_ID_1, AZ_1);
+        DetailedEnvironmentResponse environment = createEnvironment(subnet, false);
+
+        when(entitlementService.datalakeLoadBalancerEnabled(anyString())).thenReturn(true);
+        when(blueprint.getBlueprintText()).thenReturn(getBlueprintText("input/clouderamanager-knox.bp"));
+        when(subnetSelector.findSubnetById(any(), anyString())).thenReturn(Optional.of(subnet));
+
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
+            Set<LoadBalancer> loadBalancers = underTest.createLoadBalancers(stack, environment, false);
+            assertEquals(1, loadBalancers.size());
+            assertEquals(LoadBalancerType.PUBLIC, loadBalancers.iterator().next().getType());
+        });
+    }
+
+    @Test
     public void testCreateLoadBalancerForDatahubWithDatalakeEntitlement() {
         Stack stack = createStack(StackType.WORKLOAD, PRIVATE_ID_1);
         DetailedEnvironmentResponse environment = createEnvironment(getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1), false);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/network/NetworkMetadataValidationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/network/NetworkMetadataValidationService.java
@@ -105,7 +105,7 @@ public class NetworkMetadataValidationService {
             .map(CloudSubnet::getAvailabilityZone)
             .collect(Collectors.toSet());
         Set<String> publicAZs = subnetMetas.values().stream()
-            .filter(subnet -> !subnet.isPrivateSubnet())
+            .filter(subnet -> subnet.isRoutableToInternet())
             .map(CloudSubnet::getAvailabilityZone)
             .collect(Collectors.toSet());
         if (!privateAZs.equals(publicAZs)) {


### PR DESCRIPTION
Expands the logic that processes subnets for the endpoint gateway to always account for the routableToInternet field. Adds new units tests to classes that process endpoint gateway subnets.

Tested with new unit tests and by successfully creating an environment with endpoint gateway enabled using private subnets tagged with override tag.
