### PR TITLE
CB-11839 Cloudwatch alarms are not deleted in case of sdx delete

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsDownscaleService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsDownscaleService.java
@@ -73,6 +73,7 @@ public class AwsDownscaleService {
             AwsCredentialView credentialView = new AwsCredentialView(auth.getCloudCredential());
             AuthenticatedContextView authenticatedContextView = new AuthenticatedContextView(auth);
             String regionName = authenticatedContextView.getRegion();
+            LOGGER.debug("Calling deleteCloudWatchAlarmsForSystemFailures from AwsDownscaleService");
             awsCloudWatchService.deleteCloudWatchAlarmsForSystemFailures(stack, regionName, credentialView, instanceIds);
 
             List<CloudResource> resourcesToDownscale = resources.stream()

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsTerminateService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsTerminateService.java
@@ -76,6 +76,7 @@ public class AwsTerminateService {
         AmazonEc2Client amazonEC2Client = authenticatedContextView.getAmazonEC2Client();
         AmazonCloudFormationClient amazonCloudFormationClient = awsClient.createCloudFormationClient(credentialView, regionName);
 
+        LOGGER.debug("Calling deleteCloudWatchAlarmsForSystemFailures from AwsTerminateService");
         awsCloudWatchService.deleteCloudWatchAlarmsForSystemFailures(stack, regionName, credentialView);
         waitAndDeleteCloudformationStack(ac, stack, resources, amazonCloudFormationClient);
         awsComputeResourceService.deleteComputeResources(ac, stack, resources);


### PR DESCRIPTION
Adding additional logging to try and trace the cloudwatch SDX deletion failures.

I wasn't able to recreate a failure to delete the cloudwatch alarms in my local CB environment, nor was I able to find a clear code path that would lead to deletion being skipped. I also don't see any "Unable to delete cloudwatch alarms" in Kibana at all over the last 30 days, which makes me think deletion is being skipped, not failing. This change adds more logging to the full call stack, so that we can better identify why deletion isn't always happening.