### PR TITLE
CB-11394. Provide generated sha256 password for cdp-nodestatus-monito…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/nodestatus/NodeStatusConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/nodestatus/NodeStatusConfigService.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.telemetry.nodestatus;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NodeStatusConfigService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NodeStatusConfigService.class);
+
+    public NodeStatusConfigView createNodeStatusConfig(String cdpNodeStatusUser, char[] cdpNodeStatusPassword) {
+        NodeStatusConfigView.Builder builder = new NodeStatusConfigView.Builder();
+        if (cdpNodeStatusPassword != null && StringUtils.isNoneBlank(cdpNodeStatusUser, new String(cdpNodeStatusPassword))) {
+            LOGGER.debug("Filling authentication settings for nodestatus monitor.");
+            builder.withServerUsername(cdpNodeStatusUser);
+            builder.withServerPassword(cdpNodeStatusPassword);
+        } else {
+            LOGGER.debug("Authentication settings are missing from nodestatus monitor.");
+        }
+        return builder.build();
+    }
+
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/nodestatus/NodeStatusConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/nodestatus/NodeStatusConfigView.java
@@ -1,0 +1,57 @@
+package com.sequenceiq.cloudbreak.telemetry.nodestatus;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.ObjectUtils;
+
+import com.sequenceiq.cloudbreak.telemetry.TelemetryConfigView;
+
+import io.micrometer.core.instrument.util.StringUtils;
+
+public class NodeStatusConfigView implements TelemetryConfigView {
+
+    private static final String EMPTY_CONFIG_DEFAULT = "";
+
+    private final String serverUsername;
+
+    private final char[] serverPassword;
+
+    private NodeStatusConfigView(Builder builder) {
+        this.serverUsername = builder.serverUsername;
+        this.serverPassword = builder.serverPassword;
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put("serverUsername", ObjectUtils.defaultIfNull(this.serverUsername, EMPTY_CONFIG_DEFAULT));
+        String serverSha256Password = EMPTY_CONFIG_DEFAULT;
+        if (this.serverPassword != null && StringUtils.isNotBlank(new String(this.serverPassword))) {
+            serverSha256Password = new String(this.serverPassword);
+        }
+        map.put("serverPassword", serverSha256Password);
+        return map;
+    }
+
+    public static final class Builder {
+
+        private String serverUsername;
+
+        private char[] serverPassword;
+
+        public NodeStatusConfigView build() {
+            return new NodeStatusConfigView(this);
+        }
+
+        public Builder withServerUsername(String serverUsername) {
+            this.serverUsername = serverUsername;
+            return this;
+        }
+
+        public Builder withServerPassword(char[] serverPassword) {
+            this.serverPassword = serverPassword;
+            return this;
+        }
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
@@ -127,6 +127,10 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
 
     @Convert(converter = SecretToString.class)
     @SecretValue
+    private Secret cdpNodeStatusMonitorUser = Secret.EMPTY;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
     private Secret cloudbreakAmbariPassword = Secret.EMPTY;
 
     @Convert(converter = SecretToString.class)
@@ -136,6 +140,10 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
     @Convert(converter = SecretToString.class)
     @SecretValue
     private Secret cloudbreakClusterManagerMonitoringPassword = Secret.EMPTY;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret cdpNodeStatusMonitorPassword = Secret.EMPTY;
 
     @Convert(converter = SecretToString.class)
     @SecretValue
@@ -517,6 +525,10 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
         return getIfNotNull(cloudbreakClusterManagerMonitoringUser, Secret::getRaw);
     }
 
+    public String getCdpNodeStatusMonitorUser() {
+        return getIfNotNull(cdpNodeStatusMonitorUser, Secret::getRaw);
+    }
+
     public void setCloudbreakAmbariUser(String cloudbreakAmbariUser) {
         this.cloudbreakAmbariUser = new Secret(cloudbreakAmbariUser);
     }
@@ -532,6 +544,10 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
 
     public void setCloudbreakClusterManagerMonitoringUser(String cloudbreakClusterManagerMonitoringUser) {
         this.cloudbreakClusterManagerMonitoringUser = new Secret(cloudbreakClusterManagerMonitoringUser);
+    }
+
+    public void setCdpNodeStatusMonitorUser(String cdpNodeStatusMonitorUser) {
+        this.cdpNodeStatusMonitorUser = new Secret(cdpNodeStatusMonitorUser);
     }
 
     public String getCloudbreakAmbariPassword() {
@@ -554,6 +570,10 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
         return getIfNotNull(cloudbreakClusterManagerMonitoringPassword, Secret::getRaw);
     }
 
+    public String getCdpNodeStatusMonitorPassword() {
+        return getIfNotNull(cdpNodeStatusMonitorPassword, Secret::getRaw);
+    }
+
     public void setCloudbreakAmbariPassword(String cloudbreakAmbariPassword) {
         this.cloudbreakAmbariPassword = new Secret(cloudbreakAmbariPassword);
     }
@@ -569,6 +589,10 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
 
     public void setCloudbreakClusterManagerMonitoringPassword(String cloudbreakClusterManagerMonitoringPassword) {
         this.cloudbreakClusterManagerMonitoringPassword = new Secret(cloudbreakClusterManagerMonitoringPassword);
+    }
+
+    public void setCdpNodeStatusMonitorPassword(String cdpNodeStatusMonitorPassword) {
+        this.cdpNodeStatusMonitorPassword = new Secret(cdpNodeStatusMonitorPassword);
     }
 
     public String getDpAmbariUser() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
@@ -365,6 +365,8 @@ public class StackV4RequestToStackConverter extends AbstractConversionServiceAwa
             cluster.setCloudbreakPassword(PasswordUtil.generatePassword());
             cluster.setCloudbreakClusterManagerMonitoringUser(cmMonitoringUser);
             cluster.setCloudbreakClusterManagerMonitoringPassword(PasswordUtil.generatePassword());
+            cluster.setCdpNodeStatusMonitorUser(UUID.randomUUID().toString());
+            cluster.setCdpNodeStatusMonitorPassword(PasswordUtil.generatePassword());
             cluster.setDpUser(cmMgmtUsername);
             cluster.setDpPassword(PasswordUtil.generatePassword());
             cluster.setKeyStorePwd(PasswordUtil.generatePassword());

--- a/core/src/main/resources/schema/app/20210402130824_CB-11394_add_cdp_nodestatus_monitor_user_password.sql
+++ b/core/src/main/resources/schema/app/20210402130824_CB-11394_add_cdp_nodestatus_monitor_user_password.sql
@@ -1,0 +1,11 @@
+-- // CB-11394 Store cdp nodestatus monitor user/password in cluster
+-- Migration SQL that makes the change goes here.
+
+alter table cluster add COLUMN cdpnodestatusmonitoruser text;
+alter table cluster add COLUMN cdpnodestatusmonitorpassword text;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+alter table cluster drop COLUMN cdpnodestatusmonitoruser;
+alter table cluster drop COLUMN cdpnodestatusmonitorpassword;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientFactory.java
@@ -49,12 +49,8 @@ public abstract class FreeIpaClientFactory<T> {
         return client;
     }
 
-    public T getClientWithBasicAuth(Stack stack, InstanceMetaData instance)
+    public T getClientWithBasicAuth(Stack stack, InstanceMetaData instance, Optional<String> username, Optional<String> password)
             throws FreeIpaClientException, MalformedURLException {
-        //TODO get username/password from stack object
-        Optional<String> username = Optional.empty();
-        Optional<String> password = Optional.empty();
-
         T client;
         if (clusterProxyService.isCreateConfigForClusterProxy(stack)) {
             client = buildClientForClusterProxy(stack, instance, username, password);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/CreateFreeIpaRequestToStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/CreateFreeIpaRequestToStackConverter.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +37,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
 import com.sequenceiq.cloudbreak.tag.request.CDPTagGenerationRequest;
+import com.sequenceiq.cloudbreak.util.PasswordUtil;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
@@ -125,6 +127,8 @@ public class CreateFreeIpaRequestToStackConverter {
         } else {
             stack.setBackup(backupConverter.convert(source.getTelemetry()));
         }
+        stack.setCdpNodeStatusMonitorUser(UUID.randomUUID().toString());
+        stack.setCdpNodeStatusMonitorPassword(PasswordUtil.generatePassword());
         decorateStackWithTunnelAndCcm(stack, source);
         updateOwnerRelatedFields(source, accountId, ownerFuture, userCrn, stack);
         extendGatewaySecurityGroupWithDefaultGatewayCidrs(stack);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.entity;
 
+import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
 import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE;
 import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETE_COMPLETED;
 import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.DELETE_IN_PROGRESS;
@@ -117,6 +118,14 @@ public class Stack implements AccountAwareResource {
     @Convert(converter = SecretToString.class)
     @SecretValue
     private Secret databusCredential = Secret.EMPTY;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret cdpNodeStatusMonitorUser = Secret.EMPTY;
+
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret cdpNodeStatusMonitorPassword = Secret.EMPTY;
 
     private String template;
 
@@ -323,6 +332,22 @@ public class Stack implements AccountAwareResource {
 
     public void setDatabusCredential(String databusCredential) {
         this.databusCredential = new Secret(databusCredential);
+    }
+
+    public String getCdpNodeStatusMonitorUser() {
+        return getIfNotNull(cdpNodeStatusMonitorUser, Secret::getRaw);
+    }
+
+    public void setCdpNodeStatusMonitorUser(String cdpNodeStatusMonitorUser) {
+        this.cdpNodeStatusMonitorUser = new Secret(cdpNodeStatusMonitorUser);
+    }
+
+    public String getCdpNodeStatusMonitorPassword() {
+        return getIfNotNull(cdpNodeStatusMonitorPassword, Secret::getRaw);
+    }
+
+    public void setCdpNodeStatusMonitorPassword(String cdpNodeStatusMonitorPassword) {
+        this.cdpNodeStatusMonitorPassword = new Secret(cdpNodeStatusMonitorPassword);
     }
 
     public String getOwner() {

--- a/freeipa/src/main/resources/freeipa-salt/pillar/top.sls
+++ b/freeipa/src/main/resources/freeipa-salt/pillar/top.sls
@@ -4,6 +4,7 @@ base:
     - tags
     - databus
     - fluent
+    - nodestatus
     - discovery
     - proxy.proxy
     - freeipa

--- a/freeipa/src/main/resources/schema/app/20210402130732_CB-11394_add_cdp_nodestatus_monitor_user_password.sql
+++ b/freeipa/src/main/resources/schema/app/20210402130732_CB-11394_add_cdp_nodestatus_monitor_user_password.sql
@@ -1,0 +1,11 @@
+-- // CB-11394 Store cdp nodestatus monitor user/password in stack
+-- Migration SQL that makes the change goes here.
+
+alter table stack add COLUMN IF NOT EXISTS cdpnodestatusmonitoruser text;
+alter table stack add COLUMN IF NOT EXISTS cdpnodestatusmonitorpassword text;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+alter table stack drop COLUMN IF EXISTS cdpnodestatusmonitoruser;
+alter table stack drop COLUMN IF EXISTS cdpnodestatusmonitorpassword;

--- a/orchestrator-salt/src/main/resources/salt-common/pillar/nodestatus/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/pillar/nodestatus/init.sls
@@ -1,0 +1,3 @@
+nodestatus:
+  serverUsername:
+  serverPassword:

--- a/orchestrator-salt/src/main/resources/salt-common/salt/nodestatus/template/nodestatus-monitor.yaml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/nodestatus/template/nodestatus-monitor.yaml.j2
@@ -5,7 +5,7 @@ server:
   folder: /var/lib/cdp-nodestatus/report{% if nodestatus.serverUsername and nodestatus.serverPassword %}
   auth:
     username: {{ nodestatus.serverUsername }}
-    password: {{ nodestatus.serverPassword }}
+    password: {{ nodestatus.serverPassword | sha256 }}
     hash: sha256{% endif %}
 commands:{% if telemetry.databusEndpoint %}
   - "cdp-nodestatus collect --databus-url {{ telemetry.databusEndpoint }}"{% else %}

--- a/orchestrator-salt/src/main/resources/salt/pillar/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/top.sls
@@ -14,6 +14,7 @@ base:
     - proxy.proxy
     - telemetry.init
     - databus
+    - nodestatus
     - cloudera-manager.csd
     - cloudera-manager.settings
     - fluent


### PR DESCRIPTION
…r server.

- add 2 new fields (user + pwd) for freeipa stack and core cluster model -> that will store the ndoestatus monitor username / password.
- add new salt decorators to pass the values
- use sha256 on salt side to hide the real passwords in the config files.
- update clients to provide basic authentication.

See detailed description in the commit message.