### PR TITLE
CB-11646: Fixed YCloud in-place load balancer update.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/update/loadbalancer/StackLoadBalancerUpdateActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/update/loadbalancer/StackLoadBalancerUpdateActions.java
@@ -259,6 +259,7 @@ public class StackLoadBalancerUpdateActions {
                 .withVariant(stack.getPlatformVariant())
                 .withLocation(location)
                 .withUserId(stack.getCreator().getUserId())
+                .withUserName(stack.getCreator().getUserName())
                 .withAccountId(stack.getWorkspace().getId())
                 .build();
             CloudCredential cloudCredential = stackUtil.getCloudCredential(stack);


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-11646

I had to make two primary changes for this to work:

- Adding the stack creator username to the Cloud Context object created for the load balancer update flow
    - We were running into null pointer exceptions because the YCloud load balancer logic requires the user name field in the Cloud Context object to be present for the creation of the load balancer and application name

- Adding a polling process for the load balancer resources to the load balancer creation logic in the update flow
    - Basically when this is not present the load balancer creation will be initiated but by the time the load balancer metadata is being retrieved, the load balancer application will not have been finished
    - This polling process is identical to the one present in the LaunchStackHandler so this should not affect any other Cloud provider and better mirror the initial creation process

This has been tested with both LD and MD YCloud datalakes and is working as expected.