### PR TITLE
CB-11645: Added Yarn to the supported load balancer cloud platform list.

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -670,7 +670,7 @@ cb:
     readTimeoutMs: 5000
 
   loadBalancer:
-    supportedPlatforms: AWS
+    supportedPlatforms: AWS,YARN
 
 clusterProxy:
   url: http://localhost:10180/cluster-proxy


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-11645

Copying extended commit message here:

This change was originally meant to track upscale/downscale support for YCloud load balancers, however as upscale and downscale operations are not supported for Yarn stacks, this just tracks the official support for YCloud load balancers. All other load balancer logic for YCloud has been implemented and tested.