### PR TITLE
CB-11711 Open NGINX for VPC CIDR with CCMv2

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -628,6 +628,7 @@ public class ClusterHostServiceRunner {
         }
         serviceLocations.put(exposedServiceCollector.getClouderaManagerService().getServiceName(), asList(gatewayConfig.getHostname()));
         gateway.put("location", serviceLocations);
+        gateway.put("cidrBlocks", stack.getNetwork().getNetworkCidrs());
         servicePillar.put("gateway", new SaltPillarProperties("/gateway/init.sls", singletonMap("gateway", gateway)));
     }
 

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl.conf
@@ -1,7 +1,11 @@
 #curl --verbose --key ./key.pem --cert ./cert.pem -k --user "user:password" -H "Accept: application/json" https://104.155.27.67:9443/saltboot/health
 server {
     {%- if salt['pillar.get']('gateway:enable_ccmv2', False) %}
-        listen       127.0.0.1:9443;
+        listen       9443;
+        {% for cidr in salt['pillar.get']('gateway:cidrBlocks') %}
+        allow        {{ cidr }};
+        {% endfor %}
+        deny         all;
     {%- else %}
         listen       9443;
     {%- endif %}


### PR DESCRIPTION
Only on data hubs and data lakes.
This way all ingress traffic is enabled from within the VPC towards
NGINX port 9443 if CCMv2 is enabled.
This is achieved by adding CIDR list to gateway pillar and using it
with NGINX SSL config.