### PR TITLE
CB-11839 Cloudwatch alarms are not deleted in case of sdx delete

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Group.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/Group.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,24 +34,32 @@ public class Group extends DynamicModel {
 
     private final Optional<CloudFileSystemView> identity;
 
+    private final List<CloudInstance> deletedInstances;
+
     public Group(String name, InstanceGroupType type, Collection<CloudInstance> instances, Security security, CloudInstance skeleton,
             InstanceAuthentication instanceAuthentication, String loginUserName, String publicKey,
             int rootVolumeSize, Optional<CloudFileSystemView> identity) {
-        this.name = name;
-        this.type = type;
-        this.instances = ImmutableList.copyOf(instances);
-        this.security = security;
-        this.skeleton = Optional.ofNullable(skeleton);
-        this.instanceAuthentication = instanceAuthentication;
-        this.publicKey = publicKey;
-        this.loginUserName = loginUserName;
-        this.rootVolumeSize = rootVolumeSize;
-        this.identity = identity;
+        this(name, type, instances, security, skeleton, new HashMap<>(), instanceAuthentication, loginUserName, publicKey,
+            rootVolumeSize, identity, new ArrayList<>());
+    }
+
+    public Group(String name, InstanceGroupType type, Collection<CloudInstance> instances, Security security, CloudInstance skeleton,
+            InstanceAuthentication instanceAuthentication, String loginUserName, String publicKey,
+            int rootVolumeSize, Optional<CloudFileSystemView> identity, List<CloudInstance> deletedInstances) {
+        this(name, type, instances, security, skeleton, new HashMap<>(), instanceAuthentication, loginUserName, publicKey,
+            rootVolumeSize, identity, deletedInstances);
     }
 
     public Group(String name, InstanceGroupType type, Collection<CloudInstance> instances, Security security, CloudInstance skeleton,
             Map<String, Object> parameters, InstanceAuthentication instanceAuthentication, String loginUserName,
             String publicKey, int rootVolumeSize, Optional<CloudFileSystemView> identity) {
+        this(name, type, instances, security, skeleton, parameters, instanceAuthentication, loginUserName, publicKey,
+            rootVolumeSize, identity, new ArrayList<>());
+    }
+
+    public Group(String name, InstanceGroupType type, Collection<CloudInstance> instances, Security security, CloudInstance skeleton,
+            Map<String, Object> parameters, InstanceAuthentication instanceAuthentication, String loginUserName,
+            String publicKey, int rootVolumeSize, Optional<CloudFileSystemView> identity, List<CloudInstance> deletedInstances) {
         super(parameters);
         this.name = name;
         this.type = type;
@@ -61,6 +71,7 @@ public class Group extends DynamicModel {
         this.loginUserName = loginUserName;
         this.rootVolumeSize = rootVolumeSize;
         this.identity = identity;
+        this.deletedInstances = deletedInstances;
     }
 
     public CloudInstance getReferenceInstanceConfiguration() {
@@ -114,6 +125,10 @@ public class Group extends DynamicModel {
         return identity;
     }
 
+    public List<CloudInstance> getDeletedInstances() {
+        return deletedInstances;
+    }
+
     @Override
     public String toString() {
         return "Group{"
@@ -125,6 +140,7 @@ public class Group extends DynamicModel {
                 + ", loginUserName='" + loginUserName + '\''
                 + ", instanceAuthentication=" + instanceAuthentication
                 + ", skeleton=" + skeleton
+                + ", deletedInstances=" + deletedInstances
                 + '}';
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsCloudWatchService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsCloudWatchService.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.cloud.aws.connector.resource;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -74,35 +75,51 @@ public class AwsCloudWatchService {
         });
     }
 
-    public void deleteCloudWatchAlarmsForSystemFailures(CloudStack stack, String regionName, AwsCredentialView credentialView) {
+    public void deleteAllCloudWatchAlarmsForSystemFailures(CloudStack stack, String regionName, AwsCredentialView credentialView) {
         List<String> instanceIds = stack.getGroups().stream()
                 .flatMap(group -> group.getInstances().stream())
                 .map(CloudInstance::getInstanceId)
                 .collect(Collectors.toList());
+        LOGGER.info("Found ids for running instances: [{}]. Cloudwatch alarms for these instances will be deleted.", instanceIds);
+        List<String> deletedInstanceIds = stack.getGroups().stream()
+            .flatMap(group -> group.getDeletedInstances().stream())
+            .map(CloudInstance::getInstanceId)
+            .collect(Collectors.toList());
+        LOGGER.info("Found ids for deleted instances: [{}]. Deletion will be attempted on the cloudwatch alarms for these instances.", deletedInstanceIds);
+        instanceIds.addAll(deletedInstanceIds);
         deleteCloudWatchAlarmsForSystemFailures(stack, regionName, credentialView, instanceIds);
     }
 
     public void deleteCloudWatchAlarmsForSystemFailures(CloudStack stack, String regionName, AwsCredentialView credentialView, List<String> instanceIds) {
-        List<String> instanceIdsFromStack = stack.getGroups().stream()
+        if (instanceIds == null || instanceIds.isEmpty()) {
+            LOGGER.warn("No instance ids provided for cloudwatch alarm deletion. No alarms will be deleted.");
+        } else {
+            LOGGER.info("Deleting alarms for instance ids [{}]", instanceIds);
+            List<String> instanceIdsFromStack = stack.getGroups().stream()
                 .flatMap(group -> group.getInstances().stream())
                 .map(CloudInstance::getInstanceId)
                 .collect(Collectors.toList());
-        List<String> instanceIdsNotInStack = instanceIds.stream()
+            List<String> instanceIdsNotInStack = instanceIds.stream()
                 .filter(instanceId -> !instanceIdsFromStack.contains(instanceId))
                 .collect(Collectors.toList());
-        if (!instanceIdsNotInStack.isEmpty()) {
-            LOGGER.warn("Instance IDs [{}] are not part of cloud stack {}, these instances may have already been deleted on the cloud provider side.",
-                    instanceIdsFromStack, stack);
+            if (!instanceIdsNotInStack.isEmpty()) {
+                LOGGER.warn("Instance IDs [{}] are not part of cloud stack {}, these instances may have already been deleted on the cloud provider side.",
+                    instanceIdsNotInStack, stack);
+            }
+            deleteCloudWatchAlarmsForSystemFailures(regionName, credentialView, instanceIds);
         }
-        deleteCloudWatchAlarmsForSystemFailures(regionName, credentialView, instanceIds);
     }
 
     private void deleteCloudWatchAlarmsForSystemFailures(String regionName, AwsCredentialView credentialView, List<String> instanceIds) {
+        // The list of alarms received may be longer than 100 items, but alarms can only be deleted in batches of max
+        // size 100. To work around this, break the instanceIds list into chunks no greater than 100, and process each
+        // chunk. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_DeleteAlarms.html
         final AtomicInteger counter = new AtomicInteger(0);
-        instanceIds.stream()
+        Map<Integer, List<String>> grouping = instanceIds.stream()
                 .map(instanceId -> instanceId + alarmSuffix)
-                .collect(Collectors.groupingBy(s -> counter.getAndIncrement() / maxBatchsize))
-                .values()
+                .collect(Collectors.groupingBy(s -> counter.getAndIncrement() / maxBatchsize));
+        LOGGER.debug("Batched cloudwatch alarm delete requests: {}", grouping);
+        grouping.values()
                 .stream()
                 .flatMap(alarmNames -> getExistingCloudWatchAlarms(regionName, credentialView, alarmNames))
                 .filter(alarmNames -> !alarmNames.isEmpty())
@@ -113,6 +130,7 @@ public class AwsCloudWatchService {
         Stream<List<String>> filteredAlarmNamesStream;
         AmazonCloudWatchClient amazonCloudWatchClient = awsClient.createCloudWatchClient(credentialView, regionName);
 
+        LOGGER.info("Searching for cloudwatch alarms [{}]", alarmNames);
         try {
             DescribeAlarmsRequest request = new DescribeAlarmsRequest().withAlarmNames(alarmNames).withMaxRecords(maxBatchsize);
             List<String> filteredAlarmNames = amazonCloudWatchClient.describeAlarms(request).getMetricAlarms().stream()
@@ -129,11 +147,12 @@ public class AwsCloudWatchService {
     }
 
     private void deleteCloudWatchAlarms(String regionName, AwsCredentialView credentialView, List<String> alarmNames) {
+        LOGGER.info("Attempting to delete cloudwatch alarms [{}]", alarmNames);
         try {
             DeleteAlarmsRequest deleteAlarmsRequest = new DeleteAlarmsRequest().withAlarmNames(alarmNames);
             AmazonCloudWatchClient amazonCloudWatchClient = awsClient.createCloudWatchClient(credentialView, regionName);
             amazonCloudWatchClient.deleteAlarms(deleteAlarmsRequest);
-            LOGGER.debug("Deleted cloudwatch alarms [{}]", alarmNames);
+            LOGGER.info("Deleted cloudwatch alarms [{}]", alarmNames);
         } catch (AmazonCloudWatchException acwe) {
             LOGGER.error("Unable to delete cloudwatch alarms [{}]: {}", alarmNames, acwe.getLocalizedMessage());
             throw new CloudConnectorException("Unable to delete cloud watch alarms: " + acwe.getLocalizedMessage(), acwe);

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsDownscaleService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsDownscaleService.java
@@ -73,6 +73,7 @@ public class AwsDownscaleService {
             AwsCredentialView credentialView = new AwsCredentialView(auth.getCloudCredential());
             AuthenticatedContextView authenticatedContextView = new AuthenticatedContextView(auth);
             String regionName = authenticatedContextView.getRegion();
+            LOGGER.debug("Calling deleteCloudWatchAlarmsForSystemFailures from AwsDownscaleService");
             awsCloudWatchService.deleteCloudWatchAlarmsForSystemFailures(stack, regionName, credentialView, instanceIds);
 
             List<CloudResource> resourcesToDownscale = resources.stream()

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsTerminateService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsTerminateService.java
@@ -76,7 +76,8 @@ public class AwsTerminateService {
         AmazonEc2Client amazonEC2Client = authenticatedContextView.getAmazonEC2Client();
         AmazonCloudFormationClient amazonCloudFormationClient = awsClient.createCloudFormationClient(credentialView, regionName);
 
-        awsCloudWatchService.deleteCloudWatchAlarmsForSystemFailures(stack, regionName, credentialView);
+        LOGGER.debug("Calling deleteCloudWatchAlarmsForSystemFailures from AwsTerminateService");
+        awsCloudWatchService.deleteAllCloudWatchAlarmsForSystemFailures(stack, regionName, credentialView);
         waitAndDeleteCloudformationStack(ac, stack, resources, amazonCloudFormationClient);
         awsComputeResourceService.deleteComputeResources(ac, stack, resources);
         deleteKeyPair(ac, stack, amazonEC2Client, credentialView, regionName);

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceGroup.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceGroup.java
@@ -130,6 +130,12 @@ public class InstanceGroup implements ProvisionEntity, Comparable<InstanceGroup>
                 .collect(Collectors.toSet());
     }
 
+    public Set<InstanceMetaData> getDeletedInstanceMetaDataSet() {
+        return instanceMetaData.stream()
+            .filter(metaData -> metaData.isTerminated() || metaData.isDeletedOnProvider())
+            .collect(Collectors.toSet());
+    }
+
     public Set<InstanceMetaData> getReachableInstanceMetaDataSet() {
         return instanceMetaData.stream()
                 .filter(InstanceMetaData::isReachable)


### PR DESCRIPTION
Adds a list of deleted instances to the CloudStack object. During a stack termination, we'll send both the
running instances ids and terminated instances ids to the deleteCloudWatchAlarmsForSystemFailures. This
will allow us to delete any lingering cloudwatch alarms for instances that have been termianted on the
provider side.

Tested with unit tests and running CB locally, deleting the cloud instances, and verifying the deleted alarm
request succeeded for the deleted instances.

See detailed description in the commit message.