### PR TITLE
CB-11874: Make DiskEncryptionSetId available in environment service API response

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -103,6 +103,7 @@ public class EnvironmentModelDescription {
             + "or use multiple resource groups.";
 
     public static final String ENCRYPTION_KEY_URL = "URL of the CustomerManagedkey to encrypt Azure resources";
+    public static final String DISK_ENCRYPTION_SET_ID = "Resource Id of the disk encryption set used to encrypt Azure disks.";
     public static final String RESOURCE_ENCRYPTION_PARAMETERS = "Parameter 'encryptionKeyUrl' - to encrypt Azure resources.";
     public static final String PARENT_ENVIRONMENT_CRN = "Parent environment global identifier";
     public static final String PARENT_ENVIRONMENT_NAME = "Parent environment name";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureResourceEncryptionParameters.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureResourceEncryptionParameters.java
@@ -17,12 +17,23 @@ public class AzureResourceEncryptionParameters {
                     "keyVersion can only contain alphanumeric characters.")
     private String encryptionKeyUrl;
 
+    @ApiModelProperty(EnvironmentModelDescription.DISK_ENCRYPTION_SET_ID)
+    private String diskEncryptionSetId;
+
     public String getEncryptionKeyUrl() {
         return encryptionKeyUrl;
     }
 
     public void setEncryptionKeyUrl(String encryptionKeyUrl) {
         this.encryptionKeyUrl = encryptionKeyUrl;
+    }
+
+    public String getDiskEncryptionSetId() {
+        return diskEncryptionSetId;
+    }
+
+    public void setDiskEncryptionSetId(String diskEncryptionSetId) {
+        this.diskEncryptionSetId = diskEncryptionSetId;
     }
 
     public static Builder builder() {
@@ -33,6 +44,7 @@ public class AzureResourceEncryptionParameters {
     public String toString() {
         return "AzureResourceEncryptionParameters{" +
                 "encryptionKeyUrl=" + encryptionKeyUrl +
+                "diskEncryptionSetId=" + diskEncryptionSetId +
                 '}';
     }
 
@@ -40,14 +52,22 @@ public class AzureResourceEncryptionParameters {
 
         private String encryptionKeyUrl;
 
+        private String diskEncryptionSetId;
+
         public Builder withEncryptionKeyUrl(String encryptionKeyUrl) {
             this.encryptionKeyUrl = encryptionKeyUrl;
+            return this;
+        }
+
+        public Builder withDiskEncryptionSetId(String diskEncryptionSetId) {
+            this.diskEncryptionSetId = diskEncryptionSetId;
             return this;
         }
 
         public AzureResourceEncryptionParameters build() {
             AzureResourceEncryptionParameters resourceEncryptionParameters = new AzureResourceEncryptionParameters();
             resourceEncryptionParameters.setEncryptionKeyUrl(encryptionKeyUrl);
+            resourceEncryptionParameters.setDiskEncryptionSetId(diskEncryptionSetId);
             return resourceEncryptionParameters;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -222,6 +222,7 @@ public class EnvironmentResponseConverter {
             AzureResourceEncryptionParametersDto azureResourceEncryptionParametersDto) {
         return AzureResourceEncryptionParameters.builder()
                 .withEncryptionKeyUrl(azureResourceEncryptionParametersDto.getEncryptionKeyUrl())
+                .withDiskEncryptionSetId(azureResourceEncryptionParametersDto.getDiskEncryptionSetId())
                 .build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/AzureParameters.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/AzureParameters.java
@@ -31,10 +31,24 @@ public class AzureParameters extends BaseParameters implements AccountIdAwareRes
     @Convert(converter = ResourceGroupUsagePatternConverter.class)
     private ResourceGroupUsagePattern resourceGroupUsagePattern;
 
-    @Column(name = "encryption_keyUrl")
+    /**
+     * This field is not used anymore
+     * @deprecated This field is no longer in use.
+     * Use {@link #encryptionKeyUrl} instead.
+     */
+    @Column(name = "encryption_keyurl")
+    @Convert(converter = SecretToString.class)
+    @Deprecated(since = "CB 2.41.0", forRemoval = true)
+    @SecretValue
+    private Secret encryptionKeyUrlDummy = Secret.EMPTY;
+
+    @Column(name = "encryption_key_url")
     @Convert(converter = SecretToString.class)
     @SecretValue
     private Secret encryptionKeyUrl = Secret.EMPTY;
+
+    @Column(name = "disk_encryption_set_id")
+    private String diskEncryptionSetId;
 
     public String getResourceGroupName() {
         return resourceGroupName;
@@ -70,5 +84,13 @@ public class AzureParameters extends BaseParameters implements AccountIdAwareRes
 
     public void setEncryptionKeyUrl(String encryptionKeyUrl) {
         this.encryptionKeyUrl = new Secret(encryptionKeyUrl);
+    }
+
+    public String getDiskEncryptionSetId() {
+        return diskEncryptionSetId;
+    }
+
+    public void setDiskEncryptionSetId(String diskEncryptionSetId) {
+        this.diskEncryptionSetId = diskEncryptionSetId;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverter.java
@@ -64,6 +64,7 @@ public class AzureEnvironmentParametersConverter extends BaseEnvironmentParamete
                 .withEncryptionParameters(
                         AzureResourceEncryptionParametersDto.builder()
                                 .withEncryptionKeyUrl(azureParameters.getEncryptionKeyUrl())
+                                .withDiskEncryptionSetId(azureParameters.getDiskEncryptionSetId())
                                 .build())
                 .build());
     }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AzureParameterValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AzureParameterValidator.java
@@ -141,6 +141,14 @@ public class AzureParameterValidator implements ParameterValidator {
                         build();
             }
         }
+        String diskEncryptionSetId = azureResourceEncryptionParametersDto.getDiskEncryptionSetId();
+        if (Objects.nonNull(diskEncryptionSetId)) {
+            LOGGER.info("Invalid request, diskEncryptionSetId cannot be specified");
+            return validationResultBuilder.error(
+                    "Specifying diskEncryptionSetId in request is Invalid." +
+                            "Please specify encryptionKeyUrl to use Server Side Encryption for Azure Managed disks with CMK.").
+                    build();
+        }
         return validationResultBuilder.build();
     }
     //CHECKSTYLE:ON

--- a/environment/src/main/resources/schema/app/20210407150154_CB-11874_Make_DiskEncryptionSetId_available_in_environment_service_API_response.sql
+++ b/environment/src/main/resources/schema/app/20210407150154_CB-11874_Make_DiskEncryptionSetId_available_in_environment_service_API_response.sql
@@ -1,0 +1,12 @@
+-- // CB-11874: Make DiskEncryptionSetId available in environment service API response
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_parameters ADD COLUMN IF NOT EXISTS encryption_key_url text;
+ALTER TABLE environment_parameters ADD COLUMN IF NOT EXISTS disk_encryption_set_id text;
+
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE environment_parameters DROP COLUMN IF EXISTS disk_encryption_set_id;
+ALTER TABLE environment_parameters DROP COLUMN IF EXISTS encryption_key_url;
+

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
@@ -239,6 +239,7 @@ public class EnvironmentResponseConverterTest {
         assertEquals(azureParametersDto.getAzureResourceGroupDto().getName(), azureEnvironmentParameters.getResourceGroup().getName());
         assertEquals(azureParametersDto.getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl(),
                 azureEnvironmentParameters.getResourceEncryptionParameters().getEncryptionKeyUrl());
+        assertEquals("dummy-des-id", azureEnvironmentParameters.getResourceEncryptionParameters().getDiskEncryptionSetId());
     }
 
     private EnvironmentDto createEnvironmentDto(CloudPlatform cloudPlatform) {
@@ -303,6 +304,7 @@ public class EnvironmentResponseConverterTest {
                         .withEncryptionParameters(
                                 AzureResourceEncryptionParametersDto.builder()
                                         .withEncryptionKeyUrl("dummy-key-url")
+                                        .withDiskEncryptionSetId("dummy-des-id")
                                         .build())
                         .build())
                 .build();

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverterTest.java
@@ -83,6 +83,7 @@ public class AzureEnvironmentParametersConverterTest {
             parameters.setId(ID);
             parameters.setName(ENV_NAME);
             parameters.setEncryptionKeyUrl(KEY_URL);
+            parameters.setDiskEncryptionSetId("DummyDesId");
 
             ParametersDto result = underTest.convertToDto(parameters);
 
@@ -90,5 +91,6 @@ public class AzureEnvironmentParametersConverterTest {
             assertEquals(ID, result.getId());
             assertEquals(ENV_NAME, result.getName());
             assertEquals(KEY_URL, result.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl());
+            assertEquals("DummyDesId", result.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getDiskEncryptionSetId());
         }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AzureParameterValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AzureParameterValidatorTest.java
@@ -352,6 +352,20 @@ public class AzureParameterValidatorTest {
     }
 
     @Test
+    public void testWhenResourceEncryptionParameterDiskEncryptionSetIdThenError() {
+        EnvironmentDto environmentDto = new EnvironmentDtoBuilder()
+                .withAzureParameters(AzureParametersDto.builder()
+                        .withResourceGroup(AzureResourceGroupDto.builder().build())
+                        .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
+                                .withDiskEncryptionSetId("DummyDesId").build())
+                        .build())
+                .build();
+        ValidationResult validationResult = underTest.validate(environmentDto, environmentDto.getParameters(), ValidationResult.builder());
+
+        assertTrue(validationResult.hasError());
+    }
+
+    @Test
     public void testCloudPlatform() {
         assertEquals(CloudPlatform.AZURE, underTest.getcloudPlatform());
     }

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AzureResourceEncryptionParametersDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AzureResourceEncryptionParametersDto.java
@@ -3,12 +3,19 @@ package com.sequenceiq.environment.parameter.dto;
 public class AzureResourceEncryptionParametersDto {
     private final String encryptionKeyUrl;
 
+    private final String diskEncryptionSetId;
+
     private AzureResourceEncryptionParametersDto(AzureResourceEncryptionParametersDto.Builder builder) {
         encryptionKeyUrl = builder.encryptionKeyUrl;
+        diskEncryptionSetId = builder.diskEncryptionSetId;
     }
 
     public String getEncryptionKeyUrl() {
         return encryptionKeyUrl;
+    }
+
+    public String getDiskEncryptionSetId() {
+        return diskEncryptionSetId;
     }
 
     public static AzureResourceEncryptionParametersDto.Builder builder() {
@@ -19,14 +26,22 @@ public class AzureResourceEncryptionParametersDto {
     public String toString() {
         return "AzureResourceEncryptionParametersDto{" +
                 "encryptionKeyUrl=" + encryptionKeyUrl +
+                "diskEncryptionSetId=" + diskEncryptionSetId +
                 '}';
     }
 
     public static final class Builder {
         private String encryptionKeyUrl;
 
+        private String diskEncryptionSetId;
+
         public AzureResourceEncryptionParametersDto.Builder withEncryptionKeyUrl(String encryptionKeyUrl) {
             this.encryptionKeyUrl = encryptionKeyUrl;
+            return this;
+        }
+
+        public AzureResourceEncryptionParametersDto.Builder withDiskEncryptionSetId(String diskEncryptionSetId) {
+            this.diskEncryptionSetId = diskEncryptionSetId;
             return this;
         }
 

--- a/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/AzureResourceEncryptionParametersDtoTest.java
+++ b/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/AzureResourceEncryptionParametersDtoTest.java
@@ -15,7 +15,16 @@ public class AzureResourceEncryptionParametersDtoTest {
         assertEquals(dummyAzureResourceEncryptionParametersDto.getEncryptionKeyUrl(), "dummy-key-url");
     }
 
+    @Test
+    void testAzureResourceEncryptionParametersDtowithDiskEncryptionSetId() {
+        AzureResourceEncryptionParametersDto dummyAzureResourceEncryptionParametersDto = createAzureResourceEncryptionParametersDto();
+        assertEquals(dummyAzureResourceEncryptionParametersDto.getDiskEncryptionSetId(), "dummy-des-id");
+    }
+
     private AzureResourceEncryptionParametersDto createAzureResourceEncryptionParametersDto() {
-        return AzureResourceEncryptionParametersDto.builder().withEncryptionKeyUrl("dummy-key-url").build();
+        return AzureResourceEncryptionParametersDto.builder()
+                .withDiskEncryptionSetId("dummy-des-id")
+                .withEncryptionKeyUrl("dummy-key-url")
+                .build();
     }
 }


### PR DESCRIPTION
CB-11874: Make DiskEncryptionSetId available in environment service API response.

     1. AzureResourceEncryptionParameters extended with the new field diskEncryptionSetId.
     2. New column `disk_encryption_set_id` and `encryption_key_url` are added to environment_parameters table.
     3. To prohibit passing in the DES Resource ID in the request, validation is added.
     4. Column `encryption_keyUrl` is deprecated.
     
  Testing - Combined these changes with [CB-11872](https://github.com/hortonworks/cloudbreak/pull/10372).

  1. Entries in DB are populated for `disk_encryption_set_id` and `encryption_key_url`. As expected `encryption_keyUrl` is not populated.
  
  
<img width="1293" alt="Screenshot 2021-04-08 at 10 15 06 PM" src="https://user-images.githubusercontent.com/32215750/114065460-51e07100-98b8-11eb-9d67-4c87a76c5ed1.png">


 2. DES creation is successful, required tags are attached.
 
 
<img width="1775" alt="Screenshot 2021-04-08 at 10 13 49 PM" src="https://user-images.githubusercontent.com/32215750/114065568-70466c80-98b8-11eb-86df-2759f88f71b8.png">
