### PR TITLE
CB-11906: Fixed creation of datalake with unique image ID when catalog name not present.

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/ImageCatalogV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/ImageCatalogV4Endpoint.java
@@ -118,6 +118,13 @@ public interface ImageCatalogV4Endpoint {
             @QueryParam("stackName") String stackName, @QueryParam("platform") String platform) throws Exception;
 
     @GET
+    @Path("image")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ImageCatalogOpDescription.GET_IMAGE_BY_ID, produces = MediaType.APPLICATION_JSON,
+            notes = IMAGE_CATALOG_NOTES, nickname = "getImageById")
+    ImagesV4Response getImageByImageId(@PathParam("workspaceId") Long workspaceId, @QueryParam("imageId") String imageId) throws Exception;
+
+    @GET
     @Path("{name}/image")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ImageCatalogOpDescription.GET_IMAGE_BY_NAME_AND_ID, produces = MediaType.APPLICATION_JSON,

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -158,6 +158,7 @@ public class OperationDescriptions {
         public static final String GET_BY_IMAGE_CATALOG_NAME = "retrieve imagecatalog request by imagecatalog name";
         public static final String GET_IMAGES_BY_NAME = "determines available images for the given stack or platform"
                 + "from the given imagecatalog name";
+        public static final String GET_IMAGE_BY_ID = "determines the image for the image UUID using a default imagecatalog name";
         public static final String GET_IMAGE_BY_NAME_AND_ID = "determines the image for the image UUID"
                 + "from the given imagecatalog name";
         public static final String GET_IMAGES = "determines available images for the given stack or platform"

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
@@ -151,6 +151,14 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     }
 
     @Override
+    @DisableCheckPermissions
+    public ImagesV4Response getImageByImageId(Long workspaceId, String imageId) throws Exception {
+        StatedImage statedImage = imageCatalogService.getImageByCatalogName(workspaceId, imageId, "");
+        Images images = new Images(List.of(), List.of(statedImage.getImage()), Set.of());
+        return converterUtil.convert(images, ImagesV4Response.class);
+    }
+
+    @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public ImagesV4Response getImageByCatalogNameAndImageId(Long workspaceId, @ResourceName String name, String imageId) throws Exception {
         StatedImage statedImage = imageCatalogService.getImageByCatalogName(workspaceId, imageId, name);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/V4ExistingResourceRestUrlParser.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/V4ExistingResourceRestUrlParser.java
@@ -23,7 +23,7 @@ public class V4ExistingResourceRestUrlParser extends LegacyRestUrlParser {
             "v4/\\d+/(audits/.*"
             + "|blueprints/recommendation"
             + "|blueprints_util/.*"
-            + "|image_catalogs/images"
+            + "|image_catalogs/image(s\\b|\\b)"
             + "|connectors/[a-z_]+"
             + "|file_systems/[a-z_]+)");
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -234,8 +234,12 @@ public class SdxService implements ResourceIdProvider, ResourceCrnAndNameProvide
                     imageSettingsV4Request.getCatalog(), imageSettingsV4Request.getId());
             ImagesV4Response imagesV4Response = null;
             try {
-                imagesV4Response = imageCatalogV4Endpoint.getImageByCatalogNameAndImageId(
-                        WORKSPACE_ID_DEFAULT, imageSettingsV4Request.getCatalog(), imageSettingsV4Request.getId());
+                if (Strings.isBlank(imageSettingsV4Request.getCatalog())) {
+                    imagesV4Response = imageCatalogV4Endpoint.getImageByImageId(WORKSPACE_ID_DEFAULT, imageSettingsV4Request.getId());
+                } else {
+                    imagesV4Response = imageCatalogV4Endpoint.getImageByCatalogNameAndImageId(
+                            WORKSPACE_ID_DEFAULT, imageSettingsV4Request.getCatalog(), imageSettingsV4Request.getId());
+                }
             } catch (Exception e) {
                 LOGGER.error("Sdx service fails to get image using image id", e);
             }


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-11906

Changes I made:
- Added a new endpoint path for the image catalog for getting an image without a catalog name
- Needed to do this since with the previous path, not having a name would result in a malformed path that would be rejected by the validator

Tested this with the CDP CLI change I made and seems to be working correctly for the two use cases.

Let me know if there is anything we want to change for this.