### PR TITLE
CFM-1861 Nifi service data and settings are gone after datahub upgrad…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-flow-management-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-flow-management-small.bp
@@ -269,6 +269,14 @@
               {
                 "name": "xml.authorizers.userGroupProvider.composite-configurable-user-group-provider.property.User Group Provider 2",
                 "value": "shell-user-group-provider"
+              },
+              {
+                "name": "xml.providers.flowPersistenceProvider.file-provider.enabled",
+                "value": "false"
+              },
+              {
+                "name": "xml.providers.flowPersistenceProvider.database-provider.enabled",
+                "value": "true"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-flow-management.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-flow-management.bp
@@ -269,6 +269,14 @@
               {
                 "name": "xml.authorizers.userGroupProvider.composite-configurable-user-group-provider.property.User Group Provider 2",
                 "value": "shell-user-group-provider"
+              },
+              {
+                "name": "xml.providers.flowPersistenceProvider.file-provider.enabled",
+                "value": "false"
+              },
+              {
+                "name": "xml.providers.flowPersistenceProvider.database-provider.enabled",
+                "value": "true"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-flow-management-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-flow-management-small.bp
@@ -269,6 +269,14 @@
               {
                 "name": "xml.authorizers.userGroupProvider.composite-configurable-user-group-provider.property.User Group Provider 2",
                 "value": "shell-user-group-provider"
+              },
+              {
+                "name": "xml.providers.flowPersistenceProvider.file-provider.enabled",
+                "value": "false"
+              },
+              {
+                "name": "xml.providers.flowPersistenceProvider.database-provider.enabled",
+                "value": "true"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-flow-management.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-flow-management.bp
@@ -269,6 +269,14 @@
               {
                 "name": "xml.authorizers.userGroupProvider.composite-configurable-user-group-provider.property.User Group Provider 2",
                 "value": "shell-user-group-provider"
+              },
+              {
+                "name": "xml.providers.flowPersistenceProvider.file-provider.enabled",
+                "value": "false"
+              },
+              {
+                "name": "xml.providers.flowPersistenceProvider.database-provider.enabled",
+                "value": "true"
               }
             ]
           }


### PR DESCRIPTION
…ed from 7.2.6 to 7.2.9. Disabled file provider and enabled database provider, because NiFI Registry in CFM-2.2.0.0, should work with DB, on datahub. For private could it should work with file provider, that is why added changes into CB template.

See detailed description in the commit message.