### PR TITLE
CB-11711 Open NGINX for VPC CIDR with CCMv2 for FreeIPA

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/gcp/FreeIpaGcpNetworkProvider.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/gcp/FreeIpaGcpNetworkProvider.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.environment.environment.flow.creation.handler.freeipa.gcp;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Sets;
@@ -9,6 +12,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.flow.creation.handler.freeipa.FreeIpaNetworkProvider;
 import com.sequenceiq.environment.network.dto.GcpParams;
+import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.GcpNetworkParameters;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 
@@ -18,14 +22,16 @@ public class FreeIpaGcpNetworkProvider implements FreeIpaNetworkProvider {
     @Override
     public NetworkRequest provider(EnvironmentDto environment) {
         NetworkRequest networkRequest = new NetworkRequest();
-        GcpParams gcpParams = environment.getNetwork().getGcp();
+        NetworkDto network = environment.getNetwork();
+        GcpParams gcpParams = network.getGcp();
         GcpNetworkParameters gcpNetworkParameters = new GcpNetworkParameters();
         gcpNetworkParameters.setNetworkId(gcpParams.getNetworkId());
         gcpNetworkParameters.setNoFirewallRules(gcpParams.getNoFirewallRules());
         gcpNetworkParameters.setNoPublicIp(gcpParams.getNoPublicIp());
         gcpNetworkParameters.setSharedProjectId(gcpParams.getSharedProjectId());
-        gcpNetworkParameters.setSubnetId(environment.getNetwork().getSubnetIds().iterator().next());
+        gcpNetworkParameters.setSubnetId(network.getSubnetIds().iterator().next());
         networkRequest.setGcp(gcpNetworkParameters);
+        networkRequest.setNetworkCidrs(collectNetworkCidrs(network));
         return networkRequest;
     }
 
@@ -43,5 +49,9 @@ public class FreeIpaGcpNetworkProvider implements FreeIpaNetworkProvider {
     @Override
     public CloudPlatform cloudPlatform() {
         return CloudPlatform.GCP;
+    }
+
+    private List<String> collectNetworkCidrs(NetworkDto network) {
+        return CollectionUtils.isNotEmpty(network.getNetworkCidrs()) ? new ArrayList<>(network.getNetworkCidrs()) : List.of();
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigService.java
@@ -72,6 +72,7 @@ public class FreeIpaConfigService {
                 .withHosts(hosts)
                 .withBackupConfig(determineAndSetBackup(stack))
                 .withCcmv2Enabled(stack.getTunnel().useCcmV2())
+                .withCidrBlocks(stack.getNetwork().getNetworkCidrs())
                 .build();
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigView.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigView.java
@@ -1,22 +1,19 @@
 package com.sequenceiq.freeipa.service.freeipa.config;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.ObjectUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
 
 public class FreeIpaConfigView {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaConfigView.class);
 
     private static final String EMPTY_CONFIG_DEFAULT = "";
 
@@ -42,6 +39,8 @@ public class FreeIpaConfigView {
 
     private final boolean ccmv2Enabled;
 
+    private final List<String> cidrBlocks;
+
     @SuppressWarnings("ExecutableStatementCount")
     private FreeIpaConfigView(Builder builder) {
         this.realm = builder.realm;
@@ -55,6 +54,7 @@ public class FreeIpaConfigView {
         this.hosts = builder.hosts;
         this.backup = builder.backup;
         this.ccmv2Enabled = builder.ccmv2Enabled;
+        this.cidrBlocks = builder.cidrBlocks;
     }
 
     public String getRealm() {
@@ -97,6 +97,10 @@ public class FreeIpaConfigView {
         return backup;
     }
 
+    public List<String> getCidrBlocks() {
+        return cidrBlocks;
+    }
+
     @SuppressWarnings("ExecutableStatementCount")
     public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
@@ -115,6 +119,7 @@ public class FreeIpaConfigView {
         if (CollectionUtils.isNotEmpty(this.hosts)) {
             map.put("hosts", this.hosts);
         }
+        map.put("cidrBlocks", cidrBlocks);
         return map;
     }
 
@@ -141,6 +146,8 @@ public class FreeIpaConfigView {
         private FreeIpaBackupConfigView backup;
 
         private boolean ccmv2Enabled;
+
+        private List<String> cidrBlocks;
 
         public FreeIpaConfigView build() {
             return new FreeIpaConfigView(this);
@@ -198,6 +205,11 @@ public class FreeIpaConfigView {
 
         public Builder withCcmv2Enabled(boolean ccmv2Enabled) {
             this.ccmv2Enabled = ccmv2Enabled;
+            return this;
+        }
+
+        public Builder withCidrBlocks(List<String> cidrBlocks) {
+            this.cidrBlocks = cidrBlocks;
             return this;
         }
     }

--- a/freeipa/src/main/resources/freeipa-salt/salt/nginx/conf/ssl.conf
+++ b/freeipa/src/main/resources/freeipa-salt/salt/nginx/conf/ssl.conf
@@ -1,7 +1,15 @@
 #curl --verbose --key ./key.pem --cert ./cert.pem -k --user "user:password" -H "Accept: application/json" https://104.155.27.67:9443/saltboot/health
 server {
     {%- if salt['pillar.get']('freeipa:enable_ccmv2', False) %}
-        listen       127.0.0.1:9443;
+        {% if salt['pillar.get']('freeipa:cidrBlocks') %}
+            listen       9443;
+            {% for cidr in salt['pillar.get']('freeipa:cidrBlocks') %}
+            allow        {{ cidr }};
+            {% endfor %}
+            deny         all;
+        {% else %}
+            listen       127.0.0.1:9443;
+        {% endif %}
     {%- else %}
         listen       9443;
     {%- endif %}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/config/FreeIpaConfigServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -30,6 +31,7 @@ import com.sequenceiq.cloudbreak.telemetry.fluent.cloud.AdlsGen2ConfigGenerator;
 import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
 import com.sequenceiq.freeipa.api.model.Backup;
 import com.sequenceiq.freeipa.entity.FreeIpa;
+import com.sequenceiq.freeipa.entity.Network;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.GatewayConfigService;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
@@ -52,6 +54,8 @@ public class FreeIpaConfigServiceTest {
     private static final String REVERSE_ZONE = "117.10.in-addr.arpa.";
 
     private static final String PRIVATE_IP = "10.117.0.69";
+
+    private static final String CIDR = "10.0.0.0/24";
 
     private Multimap<String, String> subnetWithCidr;
 
@@ -104,6 +108,9 @@ public class FreeIpaConfigServiceTest {
         stack.setCloudPlatform(CloudPlatform.AWS.name());
         stack.setBackup(backup);
         stack.setEnvironmentCrn("envcrn");
+        Network network = new Network();
+        network.setNetworkCidrs(List.of(CIDR));
+        stack.setNetwork(network);
 
         when(freeIpaService.findByStack(any())).thenReturn(freeIpa);
         when(freeIpaClientFactory.getAdminUser()).thenReturn(ADMIN);
@@ -131,5 +138,6 @@ public class FreeIpaConfigServiceTest {
         assertEquals(backupLocation, freeIpaConfigView.getBackup().getLocation());
         assertEquals(CloudPlatform.AWS.name(), freeIpaConfigView.getBackup().getPlatform());
         assertEquals(expectedHosts, freeIpaConfigView.getHosts());
+        assertEquals(List.of(CIDR), freeIpaConfigView.getCidrBlocks());
     }
 }

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/ssl.conf
@@ -1,11 +1,15 @@
 #curl --verbose --key ./key.pem --cert ./cert.pem -k --user "user:password" -H "Accept: application/json" https://104.155.27.67:9443/saltboot/health
 server {
     {%- if salt['pillar.get']('gateway:enable_ccmv2', False) %}
-        listen       9443;
-        {% for cidr in salt['pillar.get']('gateway:cidrBlocks') %}
-        allow        {{ cidr }};
-        {% endfor %}
-        deny         all;
+        {% if salt['pillar.get']('gateway:cidrBlocks') %}
+            listen       9443;
+            {% for cidr in salt['pillar.get']('gateway:cidrBlocks') %}
+            allow        {{ cidr }};
+            {% endfor %}
+            deny         all;
+        {% else %}
+            listen       127.0.0.1:9443;
+        {% endif %}
     {%- else %}
         listen       9443;
     {%- endif %}


### PR DESCRIPTION
This way all ingress traffic is enabled from within the VPC towards
NGINX port 9443 if CCMv2 is enabled.
This is achieved by adding CIDR list to gateway pillar and using it
with NGINX SSL config.
There was a missing code part which did not fill the CIDR blocks in case
of GCP and AZURE providers, this is fixed too.
To avoid null problems in the DB the ssl.conf templates were modified
accordingly.