### PR TITLE
CB-10566 Add threshold parameter to used images endpoints

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/UtilV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/util/UtilV4Endpoint.java
@@ -97,5 +97,5 @@ public interface UtilV4Endpoint {
     @Path("used_images")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = UtilityOpDescription.USED_IMAGES, produces = MediaType.APPLICATION_JSON, nickname = "usedImages")
-    UsedImagesListV4Response usedImages();
+    UsedImagesListV4Response usedImages(@QueryParam("thresholdInDays") Integer thresholdInDays);
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/projection/StackImageView.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/projection/StackImageView.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.domain.projection;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+
+public interface StackImageView {
+
+    Long getId();
+
+    Json getImage();
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/UtilV4Controller.java
@@ -137,7 +137,7 @@ public class UtilV4Controller extends NotificationController implements UtilV4En
 
     @Override
     @InternalOnly
-    public UsedImagesListV4Response usedImages() {
-        return usedImagesProvider.getUsedImages();
+    public UsedImagesListV4Response usedImages(Integer thresholdInDays) {
+        return usedImagesProvider.getUsedImages(thresholdInDays);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
@@ -34,7 +34,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
-import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.core.flow2.AbstractStackAction;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.EphemeralClusterFlowConfig;
@@ -64,6 +63,7 @@ import com.sequenceiq.cloudbreak.domain.projection.AutoscaleStack;
 import com.sequenceiq.cloudbreak.domain.projection.StackClusterStatusView;
 import com.sequenceiq.cloudbreak.domain.projection.StackCrnView;
 import com.sequenceiq.cloudbreak.domain.projection.StackIdView;
+import com.sequenceiq.cloudbreak.domain.projection.StackImageView;
 import com.sequenceiq.cloudbreak.domain.projection.StackListItem;
 import com.sequenceiq.cloudbreak.domain.projection.StackStatusView;
 import com.sequenceiq.cloudbreak.domain.projection.StackTtlView;
@@ -380,7 +380,7 @@ public class OfflineStateGenerator {
         }
 
         @Override
-        public List<Json> findImagesOfAliveStacks() {
+        public List<StackImageView> findImagesOfAliveStacks(long thresholdTimestamp) {
             return null;
         }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -18,12 +18,12 @@ import com.sequenceiq.authorization.service.list.AuthorizationResource;
 import com.sequenceiq.authorization.service.model.projection.ResourceCrnAndNameView;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
-import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.projection.AutoscaleStack;
 import com.sequenceiq.cloudbreak.domain.projection.StackClusterStatusView;
 import com.sequenceiq.cloudbreak.domain.projection.StackCrnView;
 import com.sequenceiq.cloudbreak.domain.projection.StackIdView;
+import com.sequenceiq.cloudbreak.domain.projection.StackImageView;
 import com.sequenceiq.cloudbreak.domain.projection.StackListItem;
 import com.sequenceiq.cloudbreak.domain.projection.StackStatusView;
 import com.sequenceiq.cloudbreak.domain.projection.StackTtlView;
@@ -108,9 +108,9 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
             + "WHERE s.terminated = null AND (s.type is not 'TEMPLATE' OR s.type is null)")
     Set<Stack> findAllAliveWithInstanceGroups();
 
-    @Query("SELECT im.image FROM Stack s LEFT JOIN s.instanceGroups ig LEFT JOIN ig.instanceMetaData im "
-            + "WHERE s.terminated = null AND (s.type is not 'TEMPLATE' OR s.type is null) AND im.image is not null")
-    List<Json> findImagesOfAliveStacks();
+    @Query("SELECT DISTINCT s.id as id, im.image as image FROM Stack s JOIN s.instanceGroups ig JOIN ig.instanceMetaData im "
+            + "WHERE (s.terminated = null OR s.terminated >= :thresholdTimestamp) AND (s.type is not 'TEMPLATE' OR s.type is null) AND im.image is not null")
+    List<StackImageView> findImagesOfAliveStacks(@Param("thresholdTimestamp") long thresholdTimestamp);
 
     @Query("SELECT s.id as id, s.name as name, s.stackStatus as status FROM Stack s "
             + "WHERE s.stackStatus.status IN :statuses AND (s.type is not 'TEMPLATE' OR s.type is null)")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/UsedImagesProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/UsedImagesProvider.java
@@ -13,10 +13,10 @@ public class UsedImagesProvider {
     @Inject
     private StackService stackService;
 
-    public UsedImagesListV4Response getUsedImages() {
+    public UsedImagesListV4Response getUsedImages(Integer thresholdInDays) {
         final UsedImagesListV4Response usedImages = new UsedImagesListV4Response();
 
-        stackService.getImagesOfAliveStacks()
+        stackService.getImagesOfAliveStacks(thresholdInDays)
                 .forEach(usedImages::addImage);
 
         return usedImages;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -8,7 +8,9 @@ import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.substringBefore;
 
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -20,6 +22,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -30,9 +33,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.sequenceiq.authorization.service.list.AuthorizationResource;
 import com.sequenceiq.authorization.service.ResourceNameProvider;
+import com.sequenceiq.authorization.service.list.AuthorizationResource;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
@@ -130,6 +134,9 @@ public class StackService implements ResourceIdProvider, ResourceNameProvider {
     private static final Logger LOGGER = LoggerFactory.getLogger(StackService.class);
 
     private static final String SSH_USER_CB = "cloudbreak";
+
+    @VisibleForTesting
+    Supplier<LocalDateTime> nowSupplier = LocalDateTime::now;
 
     @Inject
     private ShowTerminatedClusterConfigService showTerminatedClusterConfigService;
@@ -666,13 +673,17 @@ public class StackService implements ResourceIdProvider, ResourceNameProvider {
         return stackRepository.findAllAliveWithInstanceGroups();
     }
 
-    public List<Image> getImagesOfAliveStacks() {
-        return stackRepository.findImagesOfAliveStacks().stream()
-                .map(image -> {
+    public List<Image> getImagesOfAliveStacks(Integer thresholdInDays) {
+        final LocalDateTime thresholdDate = nowSupplier.get()
+                .minusDays(Optional.ofNullable(thresholdInDays).orElse(0));
+        final long thresholdTimestamp = Timestamp.valueOf(thresholdDate).getTime();
+        return stackRepository.findImagesOfAliveStacks(thresholdTimestamp).stream()
+                .map(stackImageView -> {
                     try {
-                        return image.get(Image.class);
+                        return stackImageView.getImage().get(Image.class);
                     } catch (IOException e) {
-                        final String message = "Could not deserialize image from string " + image.getValue();
+                        final String message =
+                                String.format("Could not deserialize image for stack %d from %s", stackImageView.getId(), stackImageView.getImage());
                         LOGGER.error(message, e);
                         throw new IllegalStateException(message, e);
                     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/repository/StackRepositoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/repository/StackRepositoryTest.java
@@ -1,0 +1,155 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.envers.repository.support.EnversRevisionRepositoryFactoryBean;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.domain.projection.StackImageView;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+@EnableAutoConfiguration
+@EntityScan(basePackages = {
+        "com.sequenceiq.cloudbreak.repository",
+        "com.sequenceiq.cloudbreak.domain",
+        "com.sequenceiq.cloudbreak.workspace.repository",
+        "com.sequenceiq.cloudbreak.workspace.model",
+        "com.sequenceiq.flow.domain",
+        "com.sequenceiq.cloudbreak.ha.domain"
+})
+@EnableJpaRepositories(repositoryFactoryBeanClass = EnversRevisionRepositoryFactoryBean.class)
+@DataJpaTest
+class StackRepositoryTest {
+
+    private static final String ALIVE_STACK_IMAGE = "aliveStackImage";
+
+    private static final String TERMINATED_STACK_IMAGE = "terminatedStackImage";
+
+    private static final long TERMINATED_STACK_TIME = Timestamp.valueOf(LocalDateTime.now().minusDays(1)).getTime();
+
+    private static final String LONG_TERMINATED_STACK_IMAGE = "longTerminatedStackImage";
+
+    private static final long LONG_TERMINATED_STACK_TIME = Timestamp.valueOf(LocalDateTime.now().minusYears(1)).getTime();
+
+    @Inject
+    private StackRepository stackRepository;
+
+    @Inject
+    private InstanceGroupRepository instanceGroupRepository;
+
+    @Inject
+    private InstanceMetaDataRepository instanceMetaDataRepository;
+
+    @BeforeEach
+    void setUp() {
+        Stack terminatedStack = createStack(TERMINATED_STACK_IMAGE);
+        terminatedStack.setTerminated(TERMINATED_STACK_TIME);
+        save(terminatedStack);
+
+        Stack longTerminatedStack = createStack(LONG_TERMINATED_STACK_IMAGE);
+        longTerminatedStack.setTerminated(LONG_TERMINATED_STACK_TIME);
+        save(longTerminatedStack);
+
+        Stack aliveStack = createStack(ALIVE_STACK_IMAGE);
+        save(aliveStack);
+
+        Stack inCreationStack = createStack(null);
+        save(inCreationStack);
+    }
+
+    @Test
+    void testFindImagesOfAliveStacksWithNoThreshold() {
+        final long now = Timestamp.valueOf(LocalDateTime.now()).getTime();
+        final List<StackImageView> imagesOfAliveStacks = stackRepository.findImagesOfAliveStacks(now);
+
+        assertThat(imagesOfAliveStacks)
+                .hasSize(1)
+                .anyMatch(imageIdEquals(ALIVE_STACK_IMAGE))
+                .noneMatch(imageIdEquals(TERMINATED_STACK_IMAGE))
+                .noneMatch(imageIdEquals(LONG_TERMINATED_STACK_IMAGE));
+    }
+
+    @Test
+    void testFindImagesOfAliveStacksWithShortThreshold() {
+        final List<StackImageView> imagesOfAliveStacks = stackRepository.findImagesOfAliveStacks(TERMINATED_STACK_TIME);
+
+        assertThat(imagesOfAliveStacks)
+                .hasSize(2)
+                .anyMatch(imageIdEquals(ALIVE_STACK_IMAGE))
+                .anyMatch(imageIdEquals(TERMINATED_STACK_IMAGE))
+                .noneMatch(imageIdEquals(LONG_TERMINATED_STACK_IMAGE));
+    }
+
+    @Test
+    void testFindImagesOfAliveStacksWithLongThreshold() {
+        final List<StackImageView> imagesOfAliveStacks = stackRepository.findImagesOfAliveStacks(LONG_TERMINATED_STACK_TIME);
+
+        assertThat(imagesOfAliveStacks)
+                .hasSize(3)
+                .anyMatch(imageIdEquals(ALIVE_STACK_IMAGE))
+                .anyMatch(imageIdEquals(TERMINATED_STACK_IMAGE))
+                .anyMatch(imageIdEquals(LONG_TERMINATED_STACK_IMAGE));
+    }
+
+    private static Predicate<StackImageView> imageIdEquals(String imageId) {
+        return stackImageView -> imageId.equals(stackImageView.getImage().getSilent(Image.class).getImageId());
+    }
+
+    private Stack createStack(String imageId) {
+        final Stack stack = new Stack();
+        if (imageId != null) {
+            final InstanceGroup ig1 = new InstanceGroup();
+            ig1.setStack(stack);
+            final InstanceMetaData ig1im1 = new InstanceMetaData();
+            ig1im1.setInstanceGroup(ig1);
+            ig1im1.setImage(createImage(imageId));
+            ig1.setInstanceMetaData(Set.of(ig1im1));
+
+            final InstanceGroup ig2 = new InstanceGroup();
+            ig2.setStack(stack);
+            final InstanceMetaData ig2im1 = new InstanceMetaData();
+            ig2im1.setInstanceGroup(ig2);
+            ig2im1.setImage(createImage(imageId));
+            ig2.setInstanceMetaData(Set.of(ig2im1));
+
+            stack.setInstanceGroups(Set.of(ig1, ig2));
+        }
+        return stack;
+    }
+
+    private Json createImage(String imageId) {
+        final Image image = new Image("imageName", Map.of(), "os", "osType", "imageCatalogUrl", "imageCatalogName", imageId, null);
+        return new Json(image);
+    }
+
+    private void save(Stack stack) {
+        stackRepository.save(stack);
+        instanceGroupRepository.saveAll(stack.getInstanceGroups());
+        stack.getInstanceGroups().stream()
+                .map(InstanceGroup::getAllInstanceMetaData)
+                .forEach(instanceMetaDataRepository::saveAll);
+    }
+
+    @Configuration
+    static class TestConfig {
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/UsedImagesProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/UsedImagesProviderTest.java
@@ -19,6 +19,8 @@ import com.sequenceiq.cloudbreak.service.stack.StackService;
 @ExtendWith(MockitoExtension.class)
 class UsedImagesProviderTest {
 
+    private static final int THRESHOLD_IN_DAYS = 180;
+
     @Mock
     private StackService stackService;
 
@@ -27,19 +29,19 @@ class UsedImagesProviderTest {
 
     @Test
     void testEmpty() {
-        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of());
+        when(stackService.getImagesOfAliveStacks(THRESHOLD_IN_DAYS)).thenReturn(List.of());
 
-        final UsedImagesListV4Response result = underTest.getUsedImages();
+        final UsedImagesListV4Response result = underTest.getUsedImages(THRESHOLD_IN_DAYS);
 
         assertThat(result.getUsedImages()).isEmpty();
     }
 
     @Test
     void testSingleImage() {
-        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of(
+        when(stackService.getImagesOfAliveStacks(THRESHOLD_IN_DAYS)).thenReturn(List.of(
                 createImage("aws-image")));
 
-        final UsedImagesListV4Response result = underTest.getUsedImages();
+        final UsedImagesListV4Response result = underTest.getUsedImages(THRESHOLD_IN_DAYS);
 
         assertThat(result.getUsedImages())
                 .hasSize(1)
@@ -49,12 +51,12 @@ class UsedImagesProviderTest {
 
     @Test
     void testMultipleImages() {
-        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of(
+        when(stackService.getImagesOfAliveStacks(THRESHOLD_IN_DAYS)).thenReturn(List.of(
                 createImage("aws-image"),
                 createImage("aws-image"),
                 createImage("azure-image")));
 
-        final UsedImagesListV4Response result = underTest.getUsedImages();
+        final UsedImagesListV4Response result = underTest.getUsedImages(THRESHOLD_IN_DAYS);
 
         assertThat(result.getUsedImages())
                 .hasSize(2)

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/UtilV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/util/UtilV1Endpoint.java
@@ -4,6 +4,7 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
@@ -23,6 +24,5 @@ public interface UtilV1Endpoint {
     @Path("used_images")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = UtilDescriptions.USED_IMAGES, produces = MediaType.APPLICATION_JSON, nickname = "usedImagesV1")
-    UsedImagesListV1Response usedImages();
+    UsedImagesListV1Response usedImages(@QueryParam("thresholdInDays") Integer thresholdInDays);
 }
-

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UtilV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/UtilV1Controller.java
@@ -17,7 +17,7 @@ public class UtilV1Controller implements UtilV1Endpoint {
 
     @Override
     @InternalOnly
-    public UsedImagesListV1Response usedImages() {
-        return usedImagesProvider.getUsedImages();
+    public UsedImagesListV1Response usedImages(Integer thresholdInDays) {
+        return usedImagesProvider.getUsedImages(thresholdInDays);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
@@ -98,6 +98,6 @@ public interface StackRepository extends AccountAwareResourceRepository<Stack, L
     List<ResourceCrnAndNameView> findNamesByResourceCrnAndAccountId(@Param("resourceCrns") Collection<String> resourceCrns,
             @Param("accountId") String accountId);
 
-    @Query("SELECT i FROM Stack s INNER JOIN s.image i WHERE s.terminated = -1")
-    List<ImageEntity> findImagesOfAliveStacks();
+    @Query("SELECT i FROM Stack s JOIN s.image i WHERE (s.terminated = -1 OR s.terminated >= :thresholdTimestamp)")
+    List<ImageEntity> findImagesOfAliveStacks(@Param("thresholdTimestamp") long thresholdTimestamp);
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/UsedImagesProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/UsedImagesProvider.java
@@ -14,10 +14,10 @@ public class UsedImagesProvider {
     @Inject
     private StackService stackService;
 
-    public UsedImagesListV1Response getUsedImages() {
+    public UsedImagesListV1Response getUsedImages(Integer thresholdInDays) {
         final UsedImagesListV1Response usedImages = new UsedImagesListV1Response();
 
-        stackService.getImagesOfAliveStacks().stream()
+        stackService.getImagesOfAliveStacks(thresholdInDays).stream()
                 .map(ImageEntity::getImageId)
                 .forEach(usedImages::addImage);
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/UsedImagesProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/UsedImagesProviderTest.java
@@ -18,6 +18,8 @@ import com.sequenceiq.freeipa.service.stack.StackService;
 @ExtendWith(MockitoExtension.class)
 class UsedImagesProviderTest {
 
+    private static final int THRESHOLD_IN_DAYS = 180;
+
     @Mock
     private StackService stackService;
 
@@ -26,19 +28,19 @@ class UsedImagesProviderTest {
 
     @Test
     void testEmpty() {
-        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of());
+        when(stackService.getImagesOfAliveStacks(THRESHOLD_IN_DAYS)).thenReturn(List.of());
 
-        final UsedImagesListV1Response result = underTest.getUsedImages();
+        final UsedImagesListV1Response result = underTest.getUsedImages(THRESHOLD_IN_DAYS);
 
         assertThat(result.getUsedImages()).isEmpty();
     }
 
     @Test
     void testSingleImage() {
-        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of(
+        when(stackService.getImagesOfAliveStacks(THRESHOLD_IN_DAYS)).thenReturn(List.of(
                 createImage("aws-image")));
 
-        final UsedImagesListV1Response result = underTest.getUsedImages();
+        final UsedImagesListV1Response result = underTest.getUsedImages(THRESHOLD_IN_DAYS);
 
         assertThat(result.getUsedImages())
                 .hasSize(1);
@@ -48,12 +50,12 @@ class UsedImagesProviderTest {
 
     @Test
     void testMultipleImages() {
-        when(stackService.getImagesOfAliveStacks()).thenReturn(List.of(
+        when(stackService.getImagesOfAliveStacks(THRESHOLD_IN_DAYS)).thenReturn(List.of(
                 createImage("aws-image"),
                 createImage("aws-image"),
                 createImage("azure-image")));
 
-        final UsedImagesListV1Response result = underTest.getUsedImages();
+        final UsedImagesListV1Response result = underTest.getUsedImages(THRESHOLD_IN_DAYS);
 
         assertThat(result.getUsedImages())
                 .hasSize(2)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeipaUsedImagesAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/freeipa/FreeipaUsedImagesAction.java
@@ -10,7 +10,7 @@ public class FreeipaUsedImagesAction implements Action<FreeipaUsedImagesTestDto,
 
     @Override
     public FreeipaUsedImagesTestDto action(TestContext testContext, FreeipaUsedImagesTestDto testDto, FreeIpaClient client) throws Exception {
-        final UsedImagesListV1Response usedImages = client.getInternalClient(testContext).utilV1Endpoint().usedImages();
+        final UsedImagesListV1Response usedImages = client.getInternalClient(testContext).utilV1Endpoint().usedImages(null);
         testDto.setResponse(usedImages);
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/UsedImagesAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v4/util/UsedImagesAction.java
@@ -10,7 +10,7 @@ public class UsedImagesAction implements Action<UsedImagesTestDto, CloudbreakCli
 
     @Override
     public UsedImagesTestDto action(TestContext testContext, UsedImagesTestDto testDto, CloudbreakClient client) throws Exception {
-        final UsedImagesListV4Response usedImages = client.getInternalClient(testContext).utilV4Endpoint().usedImages();
+        final UsedImagesListV4Response usedImages = client.getInternalClient(testContext).utilV4Endpoint().usedImages(null);
         testDto.setResponse(usedImages);
         return testDto;
     }


### PR DESCRIPTION
Deleting non-used production images will require having a waiting period of predefined days after the last stack with that image was terminated, so a thresholdInDays parameter was introduced to both CB and Freeipa endpoints.
Additionally fix the CB numberOfStacks, as the previous solution returned the number of instance groups instead of stacks.

See detailed description in the commit message.