### PR TITLE
CB-11252 Repair puts DL in an inconsistent state if the DB is stopped

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/SdxRepairActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/SdxRepairActions.java
@@ -2,7 +2,6 @@ package com.sequenceiq.datalake.flow.repair;
 
 import static com.sequenceiq.datalake.flow.repair.SdxRepairEvent.SDX_REPAIR_FAILED_HANDLED_EVENT;
 import static com.sequenceiq.datalake.flow.repair.SdxRepairEvent.SDX_REPAIR_FINALIZED_EVENT;
-import static com.sequenceiq.datalake.flow.repair.SdxRepairEvent.SDX_REPAIR_IN_PROGRESS_EVENT;
 
 import java.util.Map;
 import java.util.Optional;
@@ -25,6 +24,7 @@ import com.sequenceiq.datalake.flow.SdxEvent;
 import com.sequenceiq.datalake.flow.repair.event.SdxRepairCouldNotStartEvent;
 import com.sequenceiq.datalake.flow.repair.event.SdxRepairFailedEvent;
 import com.sequenceiq.datalake.flow.repair.event.SdxRepairStartEvent;
+import com.sequenceiq.datalake.flow.repair.event.SdxRepairStartRequest;
 import com.sequenceiq.datalake.flow.repair.event.SdxRepairSuccessEvent;
 import com.sequenceiq.datalake.flow.repair.event.SdxRepairWaitRequest;
 import com.sequenceiq.datalake.metric.MetricType;
@@ -51,7 +51,7 @@ public class SdxRepairActions {
     private SdxMetricService metricService;
 
     @Bean(name = "SDX_REPAIR_START_STATE")
-    public Action<?, ?> sdxDeletion() {
+    public Action<?, ?> sdxRepairStarted() {
         return new AbstractSdxAction<>(SdxRepairStartEvent.class) {
 
             @Override
@@ -62,8 +62,8 @@ public class SdxRepairActions {
             @Override
             protected void doExecute(SdxContext context, SdxRepairStartEvent payload, Map<Object, Object> variables) throws Exception {
                 LOGGER.info("Start repair flow for Datalake: {}", payload.getResourceId());
-                repairService.startSdxRepair(payload.getResourceId(), payload.getRepairSettings());
-                sendEvent(context, SDX_REPAIR_IN_PROGRESS_EVENT.event(), payload);
+                SdxRepairStartRequest request = new SdxRepairStartRequest(payload.getResourceId(), payload.getUserId(), payload.getRepairSettings());
+                sendEvent(context, request.selector(), request);
             }
 
             @Override

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/SdxRepairEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/SdxRepairEvent.java
@@ -5,7 +5,7 @@ import com.sequenceiq.flow.core.FlowEvent;
 public enum SdxRepairEvent implements FlowEvent {
 
     SDX_REPAIR_EVENT("SDX_REPAIR_EVENT"),
-    SDX_REPAIR_IN_PROGRESS_EVENT("SDX_REPAIR_IN_PROGRESS_EVENT"),
+    SDX_REPAIR_IN_PROGRESS_EVENT("SdxRepairInProgressEvent"),
     SDX_REPAIR_SUCCESS_EVENT("SdxRepairSuccessEvent"),
     SDX_REPAIR_FAILED_EVENT("SdxRepairFailedEvent"),
     SDX_REPAIR_COULD_NOT_START_EVENT("SdxRepairCouldNotStartEvent"),

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/event/SdxRepairInProgressEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/event/SdxRepairInProgressEvent.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.datalake.flow.repair.event;
+
+import com.sequenceiq.datalake.flow.SdxEvent;
+
+public class SdxRepairInProgressEvent extends SdxEvent {
+
+    public SdxRepairInProgressEvent(Long sdxId, String userId) {
+        super(sdxId, userId);
+    }
+
+    @Override
+    public String selector() {
+        return "SdxRepairInProgressEvent";
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/event/SdxRepairStartRequest.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/event/SdxRepairStartRequest.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.datalake.flow.repair.event;
+
+import com.sequenceiq.datalake.flow.SdxEvent;
+import com.sequenceiq.datalake.settings.SdxRepairSettings;
+
+public class SdxRepairStartRequest extends SdxEvent {
+
+    private final SdxRepairSettings repairSettings;
+
+    public SdxRepairStartRequest(Long sdxId, String userId, SdxRepairSettings repairSettings) {
+        super(sdxId, userId);
+        this.repairSettings = repairSettings;
+    }
+
+    public SdxRepairSettings getRepairSettings() {
+        return repairSettings;
+    }
+
+    @Override
+    public String selector() {
+        return "SdxRepairStartRequest";
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/handler/SdxRepairStartHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/handler/SdxRepairStartHandler.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.datalake.flow.repair.handler;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.datalake.flow.repair.event.SdxRepairCouldNotStartEvent;
+import com.sequenceiq.datalake.flow.repair.event.SdxRepairInProgressEvent;
+import com.sequenceiq.datalake.flow.repair.event.SdxRepairStartRequest;
+import com.sequenceiq.datalake.service.sdx.SdxRepairService;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+
+import reactor.bus.Event;
+
+@Component
+public class SdxRepairStartHandler extends ExceptionCatcherEventHandler<SdxRepairStartRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxRepairStartHandler.class);
+
+    @Inject
+    private SdxRepairService repairService;
+
+    @Override
+    public String selector() {
+        return "SdxRepairStartRequest";
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<SdxRepairStartRequest> event) {
+        return new SdxRepairCouldNotStartEvent(resourceId, null, e);
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent event) {
+        SdxRepairStartRequest request = event.getData();
+        Long sdxId = request.getResourceId();
+        String userId = request.getUserId();
+        try {
+            repairService.startSdxRepair(sdxId, request.getRepairSettings());
+        } catch (Exception e) {
+            LOGGER.error("Sdx repair start failed, sdxId: {}, error: {}", sdxId, e.getMessage());
+            return new SdxRepairCouldNotStartEvent(sdxId, userId, e);
+        }
+        return new SdxRepairInProgressEvent(sdxId, userId);
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/handler/SdxRepairWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/handler/SdxRepairWaitHandler.java
@@ -53,7 +53,7 @@ public class SdxRepairWaitHandler extends ExceptionCatcherEventHandler<SdxRepair
         String userId = sdxRepairWaitRequest.getUserId();
         Selectable response;
         try {
-            LOGGER.debug("Start polling stack deletion process for id: {}", sdxId);
+            LOGGER.debug("Start polling stack repair process for id: {}", sdxId);
             PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, durationInMinutes, TimeUnit.MINUTES);
             repairService.waitCloudbreakClusterRepair(sdxId, pollingConfig);
             response = new SdxRepairSuccessEvent(sdxId, userId);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/SdxStartWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/SdxStartWaitHandler.java
@@ -50,7 +50,7 @@ public class SdxStartWaitHandler extends ExceptionCatcherEventHandler<SdxStartWa
         String userId = waitRequest.getUserId();
         Selectable response;
         try {
-            LOGGER.debug("Start polling stack deletion process for id: {}", sdxId);
+            LOGGER.debug("Start polling stack start process for id: {}", sdxId);
             PollingConfig pollingConfig = new PollingConfig(SLEEP_TIME_IN_SEC, TimeUnit.SECONDS, DURATION_IN_MINUTES, TimeUnit.MINUTES);
             sdxStartService.waitCloudbreakCluster(sdxId, pollingConfig);
             response = new SdxStartSuccessEvent(sdxId, userId);


### PR DESCRIPTION
Before starting a repair the external database state should be validated.
Minor copy-paste naming fixes.

See detailed description in the commit message.