### PR TITLE
Update GCP templates for performance

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilder.java
@@ -55,7 +55,7 @@ public class GcpDiskResourceBuilder extends AbstractGcpComputeBuilder {
         disk.setDescription(description());
         disk.setSizeGb((long) group.getRootVolumeSize());
         disk.setName(buildableResources.get(0).getName());
-        disk.setKind(GcpDiskType.HDD.getUrl(projectId, location.getAvailabilityZone()));
+        disk.setKind(GcpDiskType.SSD.getUrl(projectId, location.getAvailabilityZone()));
 
         InstanceTemplate template = group.getReferenceInstanceTemplate();
         gcpDiskEncryptionService.addEncryptionKeyToDisk(template, disk);

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-spark3.json
@@ -16,7 +16,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"
@@ -32,7 +32,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"
@@ -48,7 +48,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering.json
@@ -16,10 +16,10 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -32,7 +32,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"
@@ -48,7 +48,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"
@@ -64,7 +64,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-spark3.json
@@ -16,7 +16,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"
@@ -32,7 +32,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"
@@ -48,7 +48,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering.json
@@ -16,10 +16,10 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
-          "instanceType": "e2-standard-8"
+          "instanceType": "e2-standard-16"
         },
         "nodeCount": 1,
         "type": "GATEWAY",
@@ -32,7 +32,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"
@@ -48,7 +48,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"
@@ -64,7 +64,7 @@
             {
               "count": 1,
               "size": 100,
-              "type": "pd-standard"
+              "type": "pd-ssd"
             }
           ],
           "instanceType": "e2-standard-8"


### PR DESCRIPTION
1. DISTX-557 -> To overcome memory overcommit problem in default DE template AWS and Azure was already moved to 64 GB memory, this is the GCP followup
2. DISTX-575 -> DE AWS and Azure was already handled to move to SSDs by default. The GCP DE HA template was also updated. This is just the GCP followup for other templates.
3. CB-9521 -> Moved the root volume of GCP to SSD, this should help in custom parcel handling, among other perf improvement and gets it on par with AWS and Azure.

See detailed description in the commit message.