### PR TITLE
CFM-1861 Nifi service data and settings are gone after datahub upgrad…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-flow-management-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-flow-management-small.bp
@@ -49,6 +49,30 @@
             "base": true,
             "configs": [
               {
+                "name": "ssl_enabled",
+                "value": "true"
+              },
+              {
+                "name": "ssl_server_keystore_location",
+                "value": "{{CM_AUTO_TLS}}"
+              },
+              {
+                "name": "ssl_server_keystore_password",
+                "value": "{{CM_AUTO_TLS}}"
+              },
+              {
+                "name": "ssl_server_keystore_keypassword",
+                "value": "{{CM_AUTO_TLS}}"
+              },
+              {
+                "name": "ssl_client_truststore_location",
+                "value": "{{CM_AUTO_TLS}}"
+              },
+              {
+                "name": "ssl_client_truststore_password",
+                "value": "{{CM_AUTO_TLS}}"
+              },
+              {
                 "name": "xml.authorizers.userGroupProvider.file-user-group-provider.enabled",
                 "value": "true"
               },
@@ -290,6 +314,14 @@
         "roleConfigGroupsRefNames": [
           "nifi-NIFI_NODE-BASE",
           "zookeeper-SERVER-BASE",
+          "core_settings-STORAGEOPERATIONS-BASE"
+        ]
+      },
+      {
+        "refName": "nifi_scaling",
+        "cardinality": 0,
+        "roleConfigGroupsRefNames": [
+          "nifi-NIFI_NODE-BASE",
           "core_settings-STORAGEOPERATIONS-BASE"
         ]
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/flow-management-small.json
@@ -28,6 +28,25 @@
         }
       },
       {
+        "nodeCount": 0,
+        "name": "nifi_scaling",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "instanceType": "m5.2xlarge",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 500,
+              "count": 4,
+              "type": "standard"
+            }
+          ]
+        }
+      },
+      {
         "nodeCount": 3,
         "name": "nifi",
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/flow-management-small.json
@@ -28,6 +28,25 @@
         }
       },
       {
+        "nodeCount": 0,
+        "name": "nifi_scaling",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "instanceType": "Standard_D8_v3",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 500,
+              "count": 4,
+              "type": "Standard_LRS"
+            }
+          ]
+        }
+      },
+      {
         "nodeCount": 3,
         "name": "nifi",
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/flow-management-small.json
@@ -29,6 +29,25 @@
         }
       },
       {
+        "nodeCount": 0,
+        "name": "nifi_scaling",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "instanceType": "e2-standard-8",
+          "rootVolume": {
+            "size": 150
+          },
+          "attachedVolumes": [
+            {
+              "size": 500,
+              "count": 4,
+              "type": "pd-standard"
+            }
+          ]
+        }
+      },
+      {
         "nodeCount": 3,
         "name": "nifi",
         "type": "CORE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/yarn/flow-management-small.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/yarn/flow-management-small.json
@@ -24,6 +24,21 @@
         }
       },
       {
+        "nodeCount": 0,
+        "name": "nifi_scaling",
+        "type": "CORE",
+        "recoveryMode": "MANUAL",
+        "template": {
+          "rootVolume": {
+            "size": 50
+          },
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          }
+        }
+      },
+      {
         "nodeCount": 3,
         "name": "nifi",
         "type": "CORE",


### PR DESCRIPTION
…ed from 7.2.6 to 7.2.9. Added workaround for scaling up NiFi node (TLS/SSL properties and NiFi node with cardinality=0), because it's still not fixed in CM/CDH.

See detailed description in the commit message.