### PR TITLE
CB-11658. Create config that holds common configurations for all serv…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/config/CommonConfig.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/config/CommonConfig.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.cloudbreak.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+import com.sequenceiq.cloudbreak.spring.YamlPropertySourceFactory;
+
+/**
+ * This configuration reads the common-config.yml partial Spring config from the classpath
+ * Then it tries to override with the content of the same named file under cb.etc.config.dir
+ *
+ * The @PropertySource annotation order is important!
+ */
+@Configuration
+@PropertySource(value = "classpath:common-config.yml", factory = YamlPropertySourceFactory.class)
+@PropertySource(value = "file:${cb.etc.config.dir:}/common-config.yml", ignoreResourceNotFound = true, factory = YamlPropertySourceFactory.class)
+public class CommonConfig {
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/config/DataBusS3EndpointPattern.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/config/DataBusS3EndpointPattern.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.config;
+
+public class DataBusS3EndpointPattern {
+
+    private String pattern;
+
+    private String endpoint;
+
+    public String getPattern() {
+        return pattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.pattern = pattern;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/config/DataBusS3EndpointPatternsConfig.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/config/DataBusS3EndpointPatternsConfig.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.config;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("altus.databus.s3.endpoint")
+public class DataBusS3EndpointPatternsConfig {
+
+    private List<DataBusS3EndpointPattern> patterns;
+
+    public List<DataBusS3EndpointPattern> getPatterns() {
+        return patterns;
+    }
+
+    public void setPatterns(List<DataBusS3EndpointPattern> patterns) {
+        this.patterns = patterns;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/DataBusEndpointProvider.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/DataBusEndpointProvider.java
@@ -1,38 +1,43 @@
 package com.sequenceiq.cloudbreak.telemetry;
 
-import java.util.Map;
-
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.config.DataBusS3EndpointPattern;
+import com.sequenceiq.cloudbreak.config.DataBusS3EndpointPatternsConfig;
 
 @Component
 public class DataBusEndpointProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DataBusEndpointProvider.class);
 
-    private static final String CNAME_ENDPOINT = "https://dbusapi.us-west-1.altus.cloudera.com";
+    private final DataBusS3EndpointPatternsConfig dataBusS3EndpointPatternsConfig;
 
-    private static final Map<String, String> DBUS_API_S3_ENDPOINT_PATTERN_PAIRS =
-            Map.of("dbusapi.us-west-1", "https://cloudera-dbus-prod.s3.amazonaws.com",
-                    "dbusapi.sigma-dev", "https://cloudera-dbus-dev.s3.amazonaws.com",
-                    "dbusapi.sigma-stage", "https://cloudera-dbus-stage.s3.amazonaws.com");
+    private final String databusCnameEndpoint;
+
+    public DataBusEndpointProvider(DataBusS3EndpointPatternsConfig dataBusS3EndpointPatternsConfig,
+            @Value("${altus.databus.cname}") String databusCnameEndpoint) {
+        this.dataBusS3EndpointPatternsConfig = dataBusS3EndpointPatternsConfig;
+        this.databusCnameEndpoint = databusCnameEndpoint;
+    }
 
     public String getDataBusEndpoint(String endpoint, boolean useCname) {
         String databusUrl = endpoint;
         if (useCname) {
-            LOGGER.debug("Forcing to use '{}' for databus endpoint.", CNAME_ENDPOINT);
-            databusUrl = CNAME_ENDPOINT;
+            LOGGER.debug("Forcing to use '{}' for databus endpoint.", databusCnameEndpoint);
+            databusUrl = databusCnameEndpoint;
         }
         return databusUrl;
     }
 
     public String getDatabusS3Endpoint(String endpoint) {
         String dbusS3Endpoint = null;
-        for (Map.Entry<String, String> entry : DBUS_API_S3_ENDPOINT_PATTERN_PAIRS.entrySet()) {
-            if (StringUtils.isNotBlank(endpoint) && endpoint.contains(entry.getKey())) {
-                return entry.getValue();
+        for (DataBusS3EndpointPattern s3EndpointPatternObj : dataBusS3EndpointPatternsConfig.getPatterns()) {
+            if (StringUtils.isNotBlank(endpoint) && endpoint.contains(s3EndpointPatternObj.getPattern())) {
+                return s3EndpointPatternObj.getEndpoint();
             }
         }
         return dbusS3Endpoint;

--- a/common/src/main/resources/common-config.yml
+++ b/common/src/main/resources/common-config.yml
@@ -1,0 +1,10 @@
+altus:
+  databus:
+    cname: https://dbusapi.us-west-1.altus.cloudera.com
+    s3.endpoint.patterns:
+      - pattern: dbusapi.us-west-1
+        endpoint: https://cloudera-dbus-prod.s3.amazonaws.com
+      - pattern: dbusapi.sigma-dev
+        endpoint: https://cloudera-dbus-dev.s3.amazonaws.com
+      - pattern: dbusapi.sigma-stage
+        endpoint: https://cloudera-dbus-stage.s3.amazonaws.com

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/DataBusEndpointProviderTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/DataBusEndpointProviderTest.java
@@ -3,16 +3,24 @@ package com.sequenceiq.cloudbreak.telemetry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.sequenceiq.cloudbreak.config.DataBusS3EndpointPattern;
+import com.sequenceiq.cloudbreak.config.DataBusS3EndpointPatternsConfig;
+
 public class DataBusEndpointProviderTest {
+
+    private static final String DATABUS_ENDPOINT_CNAME = "https://dbusapi.us-west-1.altus.cloudera.com";
 
     private DataBusEndpointProvider underTest;
 
     @BeforeEach
     public void setUp() {
-        underTest = new DataBusEndpointProvider();
+        underTest = new DataBusEndpointProvider(createDatabusS3EndpointPatterns(), DATABUS_ENDPOINT_CNAME);
     }
 
     @Test
@@ -76,5 +84,24 @@ public class DataBusEndpointProviderTest {
         String result = underTest.getDatabusS3Endpoint(null);
         // THEN
         assertNull(result);
+    }
+
+    private DataBusS3EndpointPatternsConfig createDatabusS3EndpointPatterns() {
+        DataBusS3EndpointPatternsConfig dataBusS3EndpointPatternsConfig = new DataBusS3EndpointPatternsConfig();
+        List<DataBusS3EndpointPattern> endpointPatterns = new ArrayList<>();
+        DataBusS3EndpointPattern s3DevEndpointPattern = new DataBusS3EndpointPattern();
+        s3DevEndpointPattern.setPattern("dbusapi.sigma-dev");
+        s3DevEndpointPattern.setEndpoint("https://cloudera-dbus-dev.s3.amazonaws.com");
+        DataBusS3EndpointPattern s3StageEndpointPattern = new DataBusS3EndpointPattern();
+        s3StageEndpointPattern.setPattern("dbusapi.sigma-stage");
+        s3StageEndpointPattern.setEndpoint("https://cloudera-dbus-stage.s3.amazonaws.com");
+        DataBusS3EndpointPattern s3ProdEndpointPattern = new DataBusS3EndpointPattern();
+        s3ProdEndpointPattern.setPattern("dbusapi.us-west-1");
+        s3ProdEndpointPattern.setEndpoint("https://cloudera-dbus-prod.s3.amazonaws.com");
+        endpointPatterns.add(s3DevEndpointPattern);
+        endpointPatterns.add(s3StageEndpointPattern);
+        endpointPatterns.add(s3ProdEndpointPattern);
+        dataBusS3EndpointPatternsConfig.setPatterns(endpointPatterns);
+        return dataBusS3EndpointPatternsConfig;
     }
 }


### PR DESCRIPTION
…ices.

details:
- create new CommonConfig that holds common static configurations. (instead of any hard coded constant that is the same for every services)
- use common config with spec. objects for databus s3 endpoints.
- use the same way of implementation that experiences config used.
- update UTs

See detailed description in the commit message.