### PR TITLE
CB-7972 Increase datalake start timeout to 120 min

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/EnvWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/EnvWaitHandler.java
@@ -1,11 +1,10 @@
 package com.sequenceiq.datalake.flow.create.handler;
 
-import static com.sequenceiq.datalake.service.sdx.EnvironmentService.DURATION_IN_MINUTES_FOR_ENV_POLLING;
-
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.dyngr.exception.PollerException;
@@ -27,6 +26,9 @@ import reactor.bus.Event;
 public class EnvWaitHandler extends ExceptionCatcherEventHandler<EnvWaitRequest> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EnvWaitHandler.class);
+
+    @Value("${sdx.environment.duration_min:60}")
+    private int durationInMinutes;
 
     @Inject
     private EnvironmentService environmentService;
@@ -61,7 +63,7 @@ public class EnvWaitHandler extends ExceptionCatcherEventHandler<EnvWaitRequest>
         } catch (PollerStoppedException pollerStoppedException) {
             LOGGER.error("Env poller stopped for sdx: {}", datalakeId, pollerStoppedException);
             response = new SdxCreateFailedEvent(datalakeId, userId,
-                    new PollerStoppedException("Env wait timed out after " + DURATION_IN_MINUTES_FOR_ENV_POLLING + " minutes"));
+                    new PollerStoppedException("Env wait timed out after " + durationInMinutes + " minutes"));
         } catch (PollerException exception) {
             LOGGER.error("Env polling failed for sdx: {}", datalakeId, exception);
             response = new SdxCreateFailedEvent(datalakeId, userId, exception);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/RdsWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/RdsWaitHandler.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.datalake.flow.create.handler;
 
 import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFound;
-import static com.sequenceiq.datalake.service.sdx.database.DatabaseService.DURATION_IN_MINUTES_FOR_DB_POLLING;
 
 import java.util.Map;
 import java.util.Optional;
@@ -11,6 +10,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.dyngr.exception.PollerException;
@@ -38,6 +38,9 @@ import reactor.bus.Event;
 public class RdsWaitHandler extends ExceptionCatcherEventHandler<RdsWaitRequest> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RdsWaitHandler.class);
+
+    @Value("${sdx.db.operation.duration_min:60}")
+    private int durationInMinutes;
 
     @Inject
     private EnvironmentService environmentService;
@@ -89,7 +92,7 @@ public class RdsWaitHandler extends ExceptionCatcherEventHandler<RdsWaitRequest>
         } catch (PollerStoppedException pollerStoppedException) {
             LOGGER.error("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
             return new SdxCreateFailedEvent(sdxId, userId,
-                    new PollerStoppedException("Database creation timed out after " + DURATION_IN_MINUTES_FOR_DB_POLLING + " minutes"));
+                    new PollerStoppedException("Database creation timed out after " + durationInMinutes + " minutes"));
         } catch (PollerException exception) {
             LOGGER.error("Database polling failed for sdx: {}", sdxId, exception);
             return new SdxCreateFailedEvent(sdxId, userId, exception);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/StorageValidationHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/StorageValidationHandler.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.datalake.flow.create.handler;
 
 import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFound;
-import static com.sequenceiq.datalake.service.sdx.database.DatabaseService.DURATION_IN_MINUTES_FOR_DB_POLLING;
 
 import java.util.Optional;
 
@@ -9,6 +8,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.dyngr.exception.PollerException;
@@ -31,6 +31,9 @@ import reactor.bus.Event;
 public class StorageValidationHandler extends ExceptionCatcherEventHandler<StorageValidationRequest> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StorageValidationHandler.class);
+
+    @Value("${sdx.db.operation.duration_min:60}")
+    private int durationInMinutes;
 
     @Inject
     private EnvironmentService environmentService;
@@ -71,7 +74,7 @@ public class StorageValidationHandler extends ExceptionCatcherEventHandler<Stora
         } catch (PollerStoppedException pollerStoppedException) {
             LOGGER.error("Env poller stopped for sdx: {}", sdxId, pollerStoppedException);
             return new SdxCreateFailedEvent(sdxId, userId,
-                    new PollerStoppedException("Env wait timed out after " + DURATION_IN_MINUTES_FOR_DB_POLLING + " minutes in sdx storage validation phase"));
+                    new PollerStoppedException("Env wait timed out after " + durationInMinutes + " minutes in sdx storage validation phase"));
         } catch (PollerException exception) {
             LOGGER.error("Env polling failed for sdx: {}", sdxId, exception);
             return new SdxCreateFailedEvent(sdxId, userId, exception);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeChangeImageWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeChangeImageWaitHandler.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.dyngr.exception.PollerException;
@@ -28,9 +29,11 @@ public class DatalakeChangeImageWaitHandler extends ExceptionCatcherEventHandler
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DatalakeChangeImageWaitHandler.class);
 
-    private static final int SLEEP_TIME_IN_SEC = 20;
+    @Value("${sdx.stack.change.image.sleeptime_sec:20}")
+    private int sleepTimeInSec;
 
-    private static final int DURATION_IN_MINUTES = 60;
+    @Value("${sdx.stack.change.image.duration_min:60}")
+    private int durationInMinutes;
 
     @Inject
     private SdxUpgradeService upgradeService;
@@ -53,7 +56,7 @@ public class DatalakeChangeImageWaitHandler extends ExceptionCatcherEventHandler
         Selectable response;
         try {
             LOGGER.info("Start polling change image process for id: {}", sdxId);
-            PollingConfig pollingConfig = new PollingConfig(SLEEP_TIME_IN_SEC, TimeUnit.SECONDS, DURATION_IN_MINUTES, TimeUnit.MINUTES);
+            PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, durationInMinutes, TimeUnit.MINUTES);
             upgradeService.waitCloudbreakFlow(sdxId, pollingConfig, "Change image");
             String imageId = upgradeService.getImageId(sdxId);
             String expectedImageId = request.getUpgradeOption().getUpgrade().getImageId();
@@ -71,7 +74,7 @@ public class DatalakeChangeImageWaitHandler extends ExceptionCatcherEventHandler
         } catch (PollerStoppedException pollerStoppedException) {
             LOGGER.error("Change image poller stopped for cluster: {}", sdxId);
             response = new DatalakeUpgradeFailedEvent(sdxId, userId,
-                    new PollerStoppedException("Change image poller timed out after " + DURATION_IN_MINUTES + " minutes"));
+                    new PollerStoppedException("Change image poller timed out after " + durationInMinutes + " minutes"));
         } catch (PollerException exception) {
             LOGGER.error("Change image polling failed for cluster: {}", sdxId);
             response = new DatalakeUpgradeFailedEvent(sdxId, userId, exception);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeVmReplaceWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeVmReplaceWaitHandler.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.dyngr.exception.PollerException;
@@ -27,9 +28,11 @@ public class DatalakeVmReplaceWaitHandler extends ExceptionCatcherEventHandler<D
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DatalakeVmReplaceWaitHandler.class);
 
-    private static final int SLEEP_TIME_IN_SEC = 20;
+    @Value("${sdx.vm.replace.sleeptime_sec:20}")
+    private int sleepTimeInSec;
 
-    private static final int DURATION_IN_MINUTES = 60;
+    @Value("${sdx.vm.replace.duration_min:60}")
+    private int durationInMinutes;
 
     @Inject
     private SdxUpgradeService upgradeService;
@@ -52,7 +55,7 @@ public class DatalakeVmReplaceWaitHandler extends ExceptionCatcherEventHandler<D
         Selectable response;
         try {
             LOGGER.info("Start polling cluster VM replacement process for id: {}", sdxId);
-            PollingConfig pollingConfig = new PollingConfig(SLEEP_TIME_IN_SEC, TimeUnit.SECONDS, DURATION_IN_MINUTES, TimeUnit.MINUTES);
+            PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, durationInMinutes, TimeUnit.MINUTES);
             upgradeService.waitCloudbreakFlow(sdxId, pollingConfig, "VM replace");
             response = new DatalakeUpgradeSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
@@ -61,7 +64,7 @@ public class DatalakeVmReplaceWaitHandler extends ExceptionCatcherEventHandler<D
         } catch (PollerStoppedException pollerStoppedException) {
             LOGGER.error("VM replace poller stopped for cluster: {}", sdxId);
             response = new DatalakeUpgradeFailedEvent(sdxId, userId,
-                    new PollerStoppedException("VM replace timed out after " + DURATION_IN_MINUTES + " minutes"));
+                    new PollerStoppedException("VM replace timed out after " + durationInMinutes + " minutes"));
         } catch (PollerException exception) {
             LOGGER.error("VM replace polling failed for cluster: {}", sdxId);
             response = new DatalakeUpgradeFailedEvent(sdxId, userId, exception);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandler.java
@@ -1,12 +1,11 @@
 package com.sequenceiq.datalake.flow.delete.handler;
 
-import static com.sequenceiq.datalake.service.sdx.database.DatabaseService.DURATION_IN_MINUTES_FOR_DB_POLLING;
-
 import javax.inject.Inject;
 
 import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.dyngr.exception.PollerException;
@@ -31,6 +30,9 @@ import reactor.bus.Event;
 @Component
 public class RdsDeletionHandler extends ExceptionCatcherEventHandler<RdsDeletionWaitRequest> {
     private static final Logger LOGGER = LoggerFactory.getLogger(RdsDeletionHandler.class);
+
+    @Value("${sdx.db.operation.duration_min:60}")
+    private int durationInMinutes;
 
     @Inject
     private SdxClusterRepository sdxClusterRepository;
@@ -77,7 +79,7 @@ public class RdsDeletionHandler extends ExceptionCatcherEventHandler<RdsDeletion
         } catch (PollerStoppedException pollerStoppedException) {
             LOGGER.error("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
             response = new SdxDeletionFailedEvent(sdxId, userId,
-                    new PollerStoppedException("Database deletion timed out after " + DURATION_IN_MINUTES_FOR_DB_POLLING + " minutes"),
+                    new PollerStoppedException("Database deletion timed out after " + durationInMinutes + " minutes"),
                     rdsWaitRequest.isForced());
         } catch (PollerException exception) {
             LOGGER.error("Database polling failed for sdx: {}", sdxId, exception);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/RdsStartHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/RdsStartHandler.java
@@ -1,11 +1,10 @@
 package com.sequenceiq.datalake.flow.start.handler;
 
-import static com.sequenceiq.datalake.service.sdx.database.DatabaseService.DURATION_IN_MINUTES_FOR_DB_POLLING;
-
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.dyngr.exception.PollerException;
@@ -28,6 +27,9 @@ import reactor.bus.Event;
 public class RdsStartHandler extends ExceptionCatcherEventHandler<RdsWaitingToStartRequest> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RdsStartHandler.class);
+
+    @Value("${sdx.db.operation.duration_min:60}")
+    private int durationInMinutes;
 
     @Inject
     private SdxClusterRepository sdxClusterRepository;
@@ -77,7 +79,7 @@ public class RdsStartHandler extends ExceptionCatcherEventHandler<RdsWaitingToSt
         } catch (PollerStoppedException pollerStoppedException) {
             LOGGER.error("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
             response = new SdxStartFailedEvent(sdxId, userId,
-                    new PollerStoppedException("Database start timed out after " + DURATION_IN_MINUTES_FOR_DB_POLLING + " minutes"));
+                    new PollerStoppedException("Database start timed out after " + durationInMinutes + " minutes"));
         } catch (PollerException exception) {
             LOGGER.error("Database polling failed for sdx: {}", sdxId, exception);
             response = new SdxStartFailedEvent(sdxId, userId, exception);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/RdsStopHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/RdsStopHandler.java
@@ -1,11 +1,10 @@
 package com.sequenceiq.datalake.flow.stop.handler;
 
-import static com.sequenceiq.datalake.service.sdx.database.DatabaseService.DURATION_IN_MINUTES_FOR_DB_POLLING;
-
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.dyngr.exception.PollerException;
@@ -28,6 +27,9 @@ import reactor.bus.Event;
 public class RdsStopHandler extends ExceptionCatcherEventHandler<RdsWaitingToStopRequest> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RdsStopHandler.class);
+
+    @Value("${sdx.db.operation.duration_min:60}")
+    private int durationInMinutes;
 
     @Inject
     private SdxClusterRepository sdxClusterRepository;
@@ -77,7 +79,7 @@ public class RdsStopHandler extends ExceptionCatcherEventHandler<RdsWaitingToSto
         } catch (PollerStoppedException pollerStoppedException) {
             LOGGER.error("Database poller stopped for sdx: {}", sdxId, pollerStoppedException);
             response = new SdxStopFailedEvent(sdxId, userId,
-                    new PollerStoppedException("Database stop timed out after " + DURATION_IN_MINUTES_FOR_DB_POLLING + " minutes"));
+                    new PollerStoppedException("Database stop timed out after " + durationInMinutes + " minutes"));
         } catch (PollerException exception) {
             LOGGER.error("Database polling failed for sdx: {}", sdxId, exception);
             response = new SdxStopFailedEvent(sdxId, userId, exception);

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/SdxStopWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/SdxStopWaitHandler.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.dyngr.exception.PollerException;
@@ -24,11 +25,13 @@ import reactor.bus.Event;
 @Component
 public class SdxStopWaitHandler extends ExceptionCatcherEventHandler<SdxStopWaitRequest> {
 
-    public static final int SLEEP_TIME_IN_SEC = 20;
-
-    public static final int DURATION_IN_MINUTES = 40;
-
     private static final Logger LOGGER = LoggerFactory.getLogger(SdxStopWaitHandler.class);
+
+    @Value("${sdx.stack.stop.sleeptime_sec:20}")
+    private int sleepTimeInSec;
+
+    @Value("${sdx.stack.stop.duration_min:40}")
+    private int durationInMinutes;
 
     @Inject
     private SdxStopService sdxStopService;
@@ -46,7 +49,7 @@ public class SdxStopWaitHandler extends ExceptionCatcherEventHandler<SdxStopWait
         Selectable response;
         try {
             LOGGER.debug("Stop polling stack stopping process for id: {}", sdxId);
-            PollingConfig pollingConfig = new PollingConfig(SLEEP_TIME_IN_SEC, TimeUnit.SECONDS, DURATION_IN_MINUTES, TimeUnit.MINUTES);
+            PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS, durationInMinutes, TimeUnit.MINUTES);
             sdxStopService.waitCloudbreakCluster(sdxId, pollingConfig);
             response = new SdxStopSuccessEvent(sdxId, userId);
         } catch (UserBreakException userBreakException) {
@@ -55,7 +58,7 @@ public class SdxStopWaitHandler extends ExceptionCatcherEventHandler<SdxStopWait
         } catch (PollerStoppedException pollerStoppedException) {
             LOGGER.error("Stop poller stopped for stack: {}", sdxId);
             response = new SdxStopFailedEvent(sdxId, userId,
-                    new PollerStoppedException("Datalake stop timed out after " + DURATION_IN_MINUTES + " minutes"));
+                    new PollerStoppedException("Datalake stop timed out after " + durationInMinutes + " minutes"));
         } catch (PollerException exception) {
             LOGGER.error("Stop polling failed for stack: {}", sdxId);
             response = new SdxStopFailedEvent(sdxId, userId, exception);

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/EnvironmentService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/EnvironmentService.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.dyngr.Polling;
@@ -28,11 +29,13 @@ import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentS
 @Service
 public class EnvironmentService {
 
-    public static final int SLEEP_TIME_IN_SEC_FOR_ENV_POLLING = 10;
-
-    public static final int DURATION_IN_MINUTES_FOR_ENV_POLLING = 60;
-
     private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentService.class);
+
+    @Value("${sdx.environment.sleeptime_sec:10}")
+    private int sleepTimeInSec;
+
+    @Value("${sdx.environment.duration_min:60}")
+    private int durationInMinutes;
 
     @Inject
     private SdxClusterRepository sdxClusterRepository;
@@ -44,14 +47,14 @@ public class EnvironmentService {
     private EnvironmentClientService environmentClientService;
 
     public DetailedEnvironmentResponse waitAndGetEnvironment(Long sdxId) {
-        PollingConfig pollingConfig = new PollingConfig(SLEEP_TIME_IN_SEC_FOR_ENV_POLLING, TimeUnit.SECONDS,
-                DURATION_IN_MINUTES_FOR_ENV_POLLING, TimeUnit.MINUTES);
+        PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS,
+                durationInMinutes, TimeUnit.MINUTES);
         return waitAndGetEnvironment(sdxId, pollingConfig, EnvironmentStatus::isAvailable);
     }
 
     public DetailedEnvironmentResponse waitNetworkAndGetEnvironment(Long sdxId) {
-        PollingConfig pollingConfig = new PollingConfig(SLEEP_TIME_IN_SEC_FOR_ENV_POLLING, TimeUnit.SECONDS,
-                DURATION_IN_MINUTES_FOR_ENV_POLLING, TimeUnit.MINUTES);
+        PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS,
+                durationInMinutes, TimeUnit.MINUTES);
         return waitAndGetEnvironment(sdxId, pollingConfig, EnvironmentStatus::isNetworkCreationFinished);
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/DatabaseService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/DatabaseService.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.dyngr.Polling;
@@ -51,15 +52,17 @@ import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackReque
 @Service
 public class DatabaseService {
 
-    public static final int SLEEP_TIME_IN_SEC_FOR_DB_POLLING = 10;
-
-    public static final int DURATION_IN_MINUTES_FOR_DB_POLLING = 60;
-
     private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseService.class);
 
     private static final String SSL_ENFORCEMENT_MIN_RUNTIME_VERSION = "7.2.2";
 
     private final Comparator<Versioned> versionComparator = new VersionComparator();
+
+    @Value("${sdx.db.operation.sleeptime_sec:10}")
+    private int sleepTimeInSec;
+
+    @Value("${sdx.db.operation.duration_min:60}")
+    private int durationInMinutes;
 
     @Inject
     private SdxClusterRepository sdxClusterRepository;
@@ -207,8 +210,8 @@ public class DatabaseService {
 
     public DatabaseServerStatusV4Response waitAndGetDatabase(SdxCluster sdxCluster, String databaseCrn,
             SdxDatabaseOperation sdxDatabaseOperation, boolean cancellable) {
-        PollingConfig pollingConfig = new PollingConfig(SLEEP_TIME_IN_SEC_FOR_DB_POLLING, TimeUnit.SECONDS,
-                DURATION_IN_MINUTES_FOR_DB_POLLING, TimeUnit.MINUTES);
+        PollingConfig pollingConfig = new PollingConfig(sleepTimeInSec, TimeUnit.SECONDS,
+                durationInMinutes, TimeUnit.MINUTES);
         return waitAndGetDatabase(sdxCluster, databaseCrn, pollingConfig, sdxDatabaseOperation, cancellable);
     }
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/EnvironmentServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/EnvironmentServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,7 +56,10 @@ public class EnvironmentServiceTest {
                 .thenReturn(getDetailedEnvironmentResponseWithStatus(EnvironmentStatus.NETWORK_CREATION_IN_PROGRESS))
                 .thenReturn(getDetailedEnvironmentResponseWithStatus(EnvironmentStatus.PUBLICKEY_CREATE_IN_PROGRESS));
 
-        DetailedEnvironmentResponse environment = underTest.waitNetworkAndGetEnvironment(sdxId);
+        PollingConfig pollingConfig = new PollingConfig(100, TimeUnit.MILLISECONDS, 10, TimeUnit.SECONDS);
+
+        DetailedEnvironmentResponse environment = underTest.waitAndGetEnvironment(sdxId, pollingConfig, EnvironmentStatus::isNetworkCreationFinished);
+
         assertThat(environment.getEnvironmentStatus(), is(EnvironmentStatus.PUBLICKEY_CREATE_IN_PROGRESS));
         verifyZeroInteractions(sdxClusterRepository);
         verifyZeroInteractions(environmentClientService);
@@ -82,7 +86,10 @@ public class EnvironmentServiceTest {
                 .thenReturn(getDetailedEnvironmentResponseWithStatus(EnvironmentStatus.FREEIPA_CREATION_IN_PROGRESS))
                 .thenReturn(getDetailedEnvironmentResponseWithStatus(EnvironmentStatus.AVAILABLE));
 
-        DetailedEnvironmentResponse environment = underTest.waitAndGetEnvironment(sdxId);
+        PollingConfig pollingConfig = new PollingConfig(100, TimeUnit.MILLISECONDS, 10, TimeUnit.SECONDS);
+
+        DetailedEnvironmentResponse environment = underTest.waitAndGetEnvironment(sdxId, pollingConfig, EnvironmentStatus::isAvailable);
+
         assertThat(environment.getEnvironmentStatus(), is(EnvironmentStatus.AVAILABLE));
         verifyZeroInteractions(sdxClusterRepository);
         verifyZeroInteractions(environmentClientService);


### PR DESCRIPTION
There may be a situation where a 40 min timeout is not enough. For example if something is slow on the provider side, the polling could timeout on datalake side before the flow in the core could finish, thus the stack remains in UPDATE_IN_PROGRESS state. Increasing the timeout lets CB to finish the flow. Since we have flow tracking it should not cause any problems.

See detailed description in the commit message.