### PR TITLE
CB-11898 we schedule at the end of provision and unschedule at the be…

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -53,7 +53,11 @@ public class StackService implements ResourceCrnAndNameProvider {
                 Status.UNREACHABLE,
                 Status.UNHEALTHY,
                 Status.UNKNOWN,
-                Status.STOPPED));
+                Status.STOPPED,
+                Status.START_IN_PROGRESS,
+                Status.STOP_IN_PROGRESS,
+                Status.STOP_REQUESTED,
+                Status.START_REQUESTED));
     }
 
     public Stack getByIdWithListsInTransaction(Long id) {


### PR DESCRIPTION
…ginning of termination. If the stack in START_IN_PROGRESS, STOP_IN_PROGRESS,STOP_REQUESTED or START_REQUESTED states we doesn't schedule again the stack if the pod will be restarted and we doesn't schedule again unless we restart the pod when the stack in the proper status.

See detailed description in the commit message.