### PR TITLE
CB-11953 If the freeipa start failed in the first time, sometimes the…

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStartService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStartService.java
@@ -1,19 +1,26 @@
 package com.sequenceiq.freeipa.service.stack;
 
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus.START_REQUESTED;
 import static com.sequenceiq.freeipa.flow.stack.start.StackStartEvent.STACK_START_EVENT;
 
 import java.util.List;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
 
 @Service
 public class FreeIpaStartService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaStartService.class);
 
     @Inject
     private StackService stackService;
@@ -21,12 +28,26 @@ public class FreeIpaStartService {
     @Inject
     private FreeIpaFlowManager flowManager;
 
+    @Inject
+    private StackUpdater stackUpdater;
+
     public void start(String environmentCrn, String accountId) {
-        List<Long> stacks = stackService.findAllIdByEnvironmentCrnAndAccountId(environmentCrn, accountId);
+        MDCBuilder.addEnvCrn(environmentCrn);
+        MDCBuilder.addAccountId(accountId);
+        List<Stack> stacks = stackService.findAllByEnvironmentCrnAndAccountId(environmentCrn, accountId);
         if (stacks.isEmpty()) {
+            LOGGER.debug("No FreeIpa found in environment");
             throw new NotFoundException("No FreeIpa found in environment");
         }
+        stacks.stream()
+                .filter(s -> s.getStackStatus().getStatus().isStartable())
+                .forEach(this::triggerStackStart);
+    }
 
-        stacks.forEach(stackId -> flowManager.notify(STACK_START_EVENT.event(), new StackEvent(STACK_START_EVENT.event(), stackId)));
+    private void triggerStackStart(Stack stack) {
+        MDCBuilder.buildMdcContext(stack);
+        LOGGER.debug("Trigger start event, new status: {}", START_REQUESTED);
+        stackUpdater.updateStackStatus(stack, START_REQUESTED, "Started of stack infrastructure has been requested.");
+        flowManager.notify(STACK_START_EVENT.event(), new StackEvent(STACK_START_EVENT.event(), stack.getId()));
     }
 }


### PR DESCRIPTION
… second attempt to start failed again. I started the freeipa and it failed to start once. When I fixed it and I tried to start again, but my env instantly went to freeipa_start_failed state.

See detailed description in the commit message.