### PR TITLE
CB-11945 Update GCP medium_duty_ha.json for 7.2.10 to match the previ…

### DIFF
--- a/datalake/src/main/resources/duties/7.2.10/gcp/medium_duty_ha.json
+++ b/datalake/src/main/resources/duties/7.2.10/gcp/medium_duty_ha.json
@@ -37,7 +37,7 @@
           }
         ]
       },
-      "nodeCount": 1,
+      "nodeCount": 2,
       "type": "GATEWAY",
       "recoveryMode": "MANUAL",
       "recipeNames": []
@@ -54,7 +54,7 @@
           }
         ]
       },
-      "nodeCount": 2,
+      "nodeCount": 3,
       "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []


### PR DESCRIPTION
…ous versions

1. When this node count update happened in previous versions, it is likely that 7.2.10 was in code review too.
2. Since 7.2.9 works no extra testing is done for this change.
