### PR TITLE
CB-11843 Create new endpoint and flows for creating ldap/kerberos config

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -172,6 +172,7 @@ dependencyManagement {
     dependency group: 'org.mybatis',                        name: 'mybatis-migrations',          version: '3.2.0'
     dependency group: 'org.mockito',                        name: 'mockito-core',                version: mockitoVersion
     dependency group: 'org.apache.commons',                 name: 'commons-collections4',        version: commonsCollections4Version
+    dependency group: 'org.apache.commons',                 name: 'commons-lang3',               version: apacheCommonsLangVersion
     dependency group: 'com.cloudera.cdp',                   name: 'cdp-sdk-java',                version: cdpSdkVersion
   }
 }
@@ -198,6 +199,7 @@ dependencies {
   compile group: 'io.projectreactor',                  name: 'reactor-bus'
 
   compile group: 'org.apache.commons',                 name: 'commons-collections4'
+  compile group: 'org.apache.commons',                 name: 'commons-lang3'
   compile group: 'org.freemarker',                     name: 'freemarker'
   compile group: 'org.postgresql',                     name: 'postgresql'
   compile group: 'org.codehaus.jettison',              name: 'jettison'

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/handler/PillarConfigUpdateHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/config/update/handler/PillarConfigUpdateHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarCo
 import com.sequenceiq.cloudbreak.core.flow2.cluster.config.update.event.PillarConfigUpdateSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -35,7 +36,7 @@ public class PillarConfigUpdateHandler extends ExceptionCatcherEventHandler<Pill
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<PillarConfigUpdateRequest> event) {
         PillarConfigUpdateRequest request = event.getData();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/start/handler/StartExternalDatabaseHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/start/handler/StartExternalDatabaseHandler.java
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.StartExterna
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -62,7 +63,7 @@ public class StartExternalDatabaseHandler extends ExceptionCatcherEventHandler<S
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<StartExternalDatabaseRequest> event) {
         LOGGER.debug("In StartExternalDatabaseHandler.doAccept");
         StartExternalDatabaseRequest request = event.getData();
         Stack stack = request.getStack();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/stop/handler/StopExternalDatabaseHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/externaldatabase/stop/handler/StopExternalDatabaseHandler.java
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.externaldatabase.StopExternal
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -62,7 +63,7 @@ public class StopExternalDatabaseHandler extends ExceptionCatcherEventHandler<St
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<StopExternalDatabaseRequest> event) {
         LOGGER.debug("In StopExternalDatabaseHandler.doAccept");
         StopExternalDatabaseRequest request = event.getData();
         Stack stack = request.getStack();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateCloudLoadBalancersHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateCloudLoadBalancersHandler.java
@@ -35,6 +35,7 @@ import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -69,7 +70,7 @@ public class CreateCloudLoadBalancersHandler extends ExceptionCatcherEventHandle
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<CreateCloudLoadBalancersRequest> event) {
         CreateCloudLoadBalancersRequest request = event.getData();
         CloudContext cloudContext = request.getCloudContext();
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateLoadBalancerEntityHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateLoadBalancerEntityHandler.java
@@ -39,6 +39,7 @@ import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 @Component
 public class CreateLoadBalancerEntityHandler extends ExceptionCatcherEventHandler<CreateLoadBalancerEntityRequest> {
@@ -77,7 +78,7 @@ public class CreateLoadBalancerEntityHandler extends ExceptionCatcherEventHandle
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<CreateLoadBalancerEntityRequest> event) {
         CreateLoadBalancerEntityRequest request = event.getData();
         Stack stack = stackService.getById(request.getResourceId());
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/LoadBalancerMetadataHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/LoadBalancerMetadataHandler.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.stack.flow.MetadataSetupService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 @Component
 public class LoadBalancerMetadataHandler extends ExceptionCatcherEventHandler<LoadBalancerMetadataRequest> {
@@ -47,7 +48,7 @@ public class LoadBalancerMetadataHandler extends ExceptionCatcherEventHandler<Lo
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<LoadBalancerMetadataRequest> event) {
         LoadBalancerMetadataRequest request = event.getData();
         CloudContext cloudContext = request.getCloudContext();
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/RegisterFreeIpaDnsHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/RegisterFreeIpaDnsHandler.java
@@ -16,6 +16,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.stack.loadbalancer.RegisterFr
 import com.sequenceiq.cloudbreak.service.publicendpoint.ClusterPublicEndpointManagementService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 @Component
 public class RegisterFreeIpaDnsHandler extends ExceptionCatcherEventHandler<RegisterFreeIpaDnsRequest> {
@@ -36,7 +37,7 @@ public class RegisterFreeIpaDnsHandler extends ExceptionCatcherEventHandler<Regi
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<RegisterFreeIpaDnsRequest> event) {
         RegisterFreeIpaDnsRequest request = event.getData();
         Stack stack = request.getStack();
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/RegisterPublicDnsHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/RegisterPublicDnsHandler.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 @Component
 public class RegisterPublicDnsHandler extends ExceptionCatcherEventHandler<RegisterPublicDnsRequest> {
@@ -53,7 +54,7 @@ public class RegisterPublicDnsHandler extends ExceptionCatcherEventHandler<Regis
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<RegisterPublicDnsRequest> event) {
         RegisterPublicDnsRequest request = event.getData();
         Stack stack = request.getStack();
         if (gatewayPublicEndpointManagementService.isCertRenewalTriggerable(stack)) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/RestartCmForLbHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/RestartCmForLbHandler.java
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 @Component
 public class RestartCmForLbHandler extends ExceptionCatcherEventHandler<RestartCmForLbRequest> {
@@ -58,7 +59,7 @@ public class RestartCmForLbHandler extends ExceptionCatcherEventHandler<RestartC
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<RestartCmForLbRequest> event) {
         RestartCmForLbRequest request = event.getData();
         Stack stack = request.getStack();
         requireNonNull(stack);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/UpdateServiceConfigHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/UpdateServiceConfigHandler.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -59,7 +60,7 @@ public class UpdateServiceConfigHandler extends ExceptionCatcherEventHandler<Upd
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<UpdateServiceConfigRequest> event) {
         UpdateServiceConfigRequest request = event.getData();
         Stack stack = request.getStack();
         requireNonNull(stack);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterDownscaleFailedConclusionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterDownscaleFailedConclusionHandler.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterDownscaleFailedConclusionRequest;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -45,7 +46,7 @@ public class ClusterDownscaleFailedConclusionHandler extends ExceptionCatcherEve
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ClusterDownscaleFailedConclusionRequest> event) {
         ClusterDownscaleFailedConclusionRequest request = event.getData();
         LOGGER.info("Handle ClusterDownscaleFailedConclusionRequest, stackId: {}", request.getResourceId());
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartPillarConfigUpdateHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartPillarConfigUpdateHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartPillarCon
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartPillarConfigUpdateResult;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -34,7 +35,7 @@ public class ClusterStartPillarConfigUpdateHandler extends ExceptionCatcherEvent
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ClusterStartPillarConfigUpdateRequest> event) {
         ClusterStartPillarConfigUpdateRequest request = event.getData();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterUpscaleFailedConclusionHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterUpscaleFailedConclusionHandler.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterUpscaleFailedConclusionRequest;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -45,7 +46,7 @@ public class ClusterUpscaleFailedConclusionHandler extends ExceptionCatcherEvent
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ClusterUpscaleFailedConclusionRequest> event) {
         ClusterUpscaleFailedConclusionRequest request = event.getData();
         LOGGER.info("Handle ClusterUpscaleFailedConclusionRequest, stackId: {}", request.getResourceId());
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RestartClusterManagerServerHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RestartClusterManagerServerHandler.java
@@ -26,6 +26,7 @@ import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -59,7 +60,7 @@ public class RestartClusterManagerServerHandler  extends ExceptionCatcherEventHa
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<RestartClusterManagerServerRequest> event) {
         LOGGER.debug("Accepting Cluster Manager restart request...");
         RestartClusterManagerServerRequest request = event.getData();
         Long stackId = request.getResourceId();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RestartClusterServicesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/RestartClusterServicesHandler.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -39,7 +40,7 @@ public class RestartClusterServicesHandler extends ExceptionCatcherEventHandler<
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<RestartClusterServicesRequest> event) {
         LOGGER.debug("Accepting Cluster services restart request...");
         RestartClusterServicesRequest request = event.getData();
         Long stackId = request.getResourceId();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/certrotate/ClusterHostCertificatesRotationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/certrotate/ClusterHostCertificatesRotationHandler.java
@@ -21,6 +21,7 @@ import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.ssh.SshKeyService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -54,7 +55,7 @@ public class ClusterHostCertificatesRotationHandler extends ExceptionCatcherEven
         return new ClusterCertificatesRotationFailed(resourceId, e);
     }
 
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ClusterHostCertificatesRotationRequest> event) {
         LOGGER.debug("Accepting Cluster Manager host certificates rotation request...");
         ClusterHostCertificatesRotationRequest request = event.getData();
         Selectable result;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -65,7 +66,7 @@ public class DatabaseBackupHandler extends ExceptionCatcherEventHandler<Database
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<DatabaseBackupRequest> event) {
         DatabaseBackupRequest request = event.getData();
         Selectable result;
         Long stackId = request.getResourceId();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/restore/DatabaseRestoreHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/restore/DatabaseRestoreHandler.java
@@ -29,6 +29,7 @@ import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -65,7 +66,7 @@ public class DatabaseRestoreHandler extends ExceptionCatcherEventHandler<Databas
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<DatabaseRestoreRequest> event) {
         DatabaseRestoreRequest request = event.getData();
         Selectable result;
         Long stackId = request.getResourceId();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ClusterManagerConfigureKerberosHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ClusterManagerConfigureKerberosHandler.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ClusterManage
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -37,7 +38,7 @@ public class ClusterManagerConfigureKerberosHandler extends ExceptionCatcherEven
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ClusterManagerConfigureKerberosRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ClusterManagerPrepareProxyConfigHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ClusterManagerPrepareProxyConfigHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ClusterManage
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ClusterManagerPrepareProxyConfigSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -36,7 +37,7 @@ public class ClusterManagerPrepareProxyConfigHandler extends ExceptionCatcherEve
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ClusterManagerPrepareProxyConfigRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ClusterManagerRefreshParcelClusterHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ClusterManagerRefreshParcelClusterHandler.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ClusterManage
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ClusterManagerRefreshParcelSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -37,7 +38,7 @@ public class ClusterManagerRefreshParcelClusterHandler extends ExceptionCatcherE
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ClusterManagerRefreshParcelRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ClusterManagerSetupMonitoringHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ClusterManagerSetupMonitoringHandler.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ClusterManage
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -37,7 +38,7 @@ public class ClusterManagerSetupMonitoringHandler extends ExceptionCatcherEventH
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ClusterManagerSetupMonitoringRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ConfigureClusterManagerManagementServicesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ConfigureClusterManagerManagementServicesHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ConfigureClus
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ConfigureClusterManagerManagementServicesSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -36,7 +37,7 @@ public class ConfigureClusterManagerManagementServicesHandler extends ExceptionC
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ConfigureClusterManagerManagementServicesRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ConfigureClusterManagerSupportTagsHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ConfigureClusterManagerSupportTagsHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ConfigureClus
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ConfigureClusterManagerSupportTagsSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -36,7 +37,7 @@ public class ConfigureClusterManagerSupportTagsHandler extends ExceptionCatcherE
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ConfigureClusterManagerSupportTagsRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ExecutePostClusterManagerStartRecipesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ExecutePostClusterManagerStartRecipesHandler.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ExecutePostCl
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -37,7 +38,7 @@ public class ExecutePostClusterManagerStartRecipesHandler extends ExceptionCatch
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ExecutePostClusterManagerStartRecipesRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ExecutePostInstallRecipesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ExecutePostInstallRecipesHandler.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ExecutePostIn
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -37,7 +38,7 @@ public class ExecutePostInstallRecipesHandler extends ExceptionCatcherEventHandl
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ExecutePostInstallRecipesRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/FinalizeClusterInstallHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/FinalizeClusterInstallHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.FinalizeClust
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.FinalizeClusterInstallSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -36,7 +37,7 @@ public class FinalizeClusterInstallHandler extends ExceptionCatcherEventHandler<
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<FinalizeClusterInstallRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/PrepareDatalakeResourceHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/PrepareDatalakeResourceHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.PrepareDatala
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.PrepareDatalakeResourceSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -36,7 +37,7 @@ public class PrepareDatalakeResourceHandler extends ExceptionCatcherEventHandler
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<PrepareDatalakeResourceRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/PrepareExtendedTemplateHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/PrepareExtendedTemplateHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.PrepareExtend
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.PrepareExtendedTemplateSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -36,7 +37,7 @@ public class PrepareExtendedTemplateHandler extends ExceptionCatcherEventHandler
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<PrepareExtendedTemplateRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/StartClusterManagerManagementServicesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/StartClusterManagerManagementServicesHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.StartClusterM
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.StartClusterManagerManagementServicesSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -36,7 +37,7 @@ public class StartClusterManagerManagementServicesHandler extends ExceptionCatch
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<StartClusterManagerManagementServicesRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/SuppressClusterWarningsHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/SuppressClusterWarningsHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.SuppressClust
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.SuppressClusterWarningsSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -36,7 +37,7 @@ public class SuppressClusterWarningsHandler extends ExceptionCatcherEventHandler
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<SuppressClusterWarningsRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/UpdateClusterConfigHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/UpdateClusterConfigHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.UpdateCluster
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.UpdateClusterConfigSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -36,7 +37,7 @@ public class UpdateClusterConfigHandler extends ExceptionCatcherEventHandler<Upd
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<UpdateClusterConfigRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ValidateClusterLicenceHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/ValidateClusterLicenceHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ValidateClust
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.ValidateClusterLicenceSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -36,7 +37,7 @@ public class ValidateClusterLicenceHandler extends ExceptionCatcherEventHandler<
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ValidateClusterLicenceRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/WaitClusterManagerHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/WaitClusterManagerHandler.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.WaitForCluste
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -38,7 +39,7 @@ public class WaitClusterManagerHandler extends ExceptionCatcherEventHandler<Wait
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<WaitForClusterManagerRequest> event) {
         Long stackId = event.getData().getResourceId();
         Selectable response;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterManagerUpgradeHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterManagerUpgradeHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterManage
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterManagerUpgradeSuccess;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgradeFailedEvent;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -35,7 +36,7 @@ public class ClusterManagerUpgradeHandler extends ExceptionCatcherEventHandler<C
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ClusterManagerUpgradeRequest> event) {
         LOGGER.debug("Accepting Cluster Manager upgrade event..");
         ClusterManagerUpgradeRequest request = event.getData();
         Selectable result;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterUpgradeHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterUpgradeHandler.java
@@ -21,6 +21,7 @@ import com.sequenceiq.cloudbreak.service.parcel.ParcelService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -49,7 +50,7 @@ public class ClusterUpgradeHandler extends ExceptionCatcherEventHandler<ClusterU
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ClusterUpgradeRequest> event) {
         LOGGER.debug("Accepting Cluster upgrade event..");
         ClusterUpgradeRequest request = event.getData();
         Long stackId = request.getResourceId();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterUpgradeInitHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterUpgradeInitHandler.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgrad
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgradeInitSuccess;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -35,7 +36,7 @@ public class ClusterUpgradeInitHandler extends ExceptionCatcherEventHandler<Clus
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ClusterUpgradeInitRequest> event) {
         LOGGER.debug("Accepting Cluster Manager parcel deactivation event..");
         ClusterUpgradeInitRequest request = event.getData();
         Selectable result;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeIpaOperationCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeIpaOperationCheckerTask.java
@@ -41,7 +41,7 @@ public class FreeIpaOperationCheckerTask<T extends FreeIpaOperationPollerObject>
                             .collect(Collectors.joining(","))
                     : "empty";
         } catch (Exception e) {
-            LOGGER.error("Cannot evaulate Failure details [{}]", failureDetails, e);
+            LOGGER.error("Cannot evaluate Failure details [{}]", failureDetails, e);
             failureDetails = "empty";
         }
         return failureDetails;
@@ -50,13 +50,13 @@ public class FreeIpaOperationCheckerTask<T extends FreeIpaOperationPollerObject>
     @Override
     public void handleTimeout(T operationPollerObject) {
         OperationStatus operationStatus = operationPollerObject.getOperationV1Endpoint().getOperationStatus(operationPollerObject.getOperationId());
-        throw new FreeIpaOperationFailedException(String.format("FreeIPA  [%s] operation [%s] timed out. Current state is [%s]",
+        throw new FreeIpaOperationFailedException(String.format("FreeIPA [%s] operation [%s] timed out. Current state is [%s]",
                 operationStatus.getOperationType(), operationPollerObject.getOperationId(), operationStatus.getStatus()));
     }
 
     @Override
     public String successMessage(T operationPollerObject) {
-        return String.format("FreeIPA  [%s] operation [%s] finished successfully",
+        return String.format("FreeIPA [%s] operation [%s] finished successfully",
                 operationPollerObject.getOperationType(), operationPollerObject.getOperationId());
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/handler/SdxCertRotationWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/cert/rotation/handler/SdxCertRotationWaitHandler.java
@@ -22,6 +22,7 @@ import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.cert.CertRotationService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -50,7 +51,7 @@ public class SdxCertRotationWaitHandler extends ExceptionCatcherEventHandler<Sdx
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<SdxCertRotationWaitEvent> event) {
         SdxEvent sdxEvent = event.getData();
         Long sdxId = sdxEvent.getResourceId();
         String userId = sdxEvent.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/EnvWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/EnvWaitHandler.java
@@ -20,6 +20,7 @@ import com.sequenceiq.datalake.service.sdx.EnvironmentService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -45,7 +46,7 @@ public class EnvWaitHandler extends ExceptionCatcherEventHandler<EnvWaitRequest>
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<EnvWaitRequest> event) {
         EnvWaitRequest envWaitRequest = event.getData();
         Long datalakeId = envWaitRequest.getResourceId();
         String userId = envWaitRequest.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/RdsWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/RdsWaitHandler.java
@@ -31,6 +31,7 @@ import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -62,7 +63,7 @@ public class RdsWaitHandler extends ExceptionCatcherEventHandler<RdsWaitRequest>
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<RdsWaitRequest> event) {
         RdsWaitRequest rdsWaitRequest = event.getData();
         Long sdxId = rdsWaitRequest.getResourceId();
         String userId = rdsWaitRequest.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/StackCreationHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/StackCreationHandler.java
@@ -24,6 +24,7 @@ import com.sequenceiq.datalake.service.sdx.ProvisionerService;
 import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -58,7 +59,7 @@ public class StackCreationHandler extends ExceptionCatcherEventHandler<StackCrea
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent handlerEvent) {
+    protected Selectable doAccept(HandlerEvent<StackCreationWaitRequest> handlerEvent) {
         StackCreationWaitRequest stackCreationWaitRequest = handlerEvent.getData();
         Long sdxId = stackCreationWaitRequest.getResourceId();
         String userId = stackCreationWaitRequest.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/StorageValidationHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/handler/StorageValidationHandler.java
@@ -24,6 +24,7 @@ import com.sequenceiq.datalake.service.sdx.EnvironmentService;
 import com.sequenceiq.datalake.service.sdx.StackRequestManifester;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -52,7 +53,7 @@ public class StorageValidationHandler extends ExceptionCatcherEventHandler<Stora
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<StorageValidationRequest> event) {
         StorageValidationRequest storageValidationRequest = event.getData();
         Long sdxId = storageValidationRequest.getResourceId();
         String userId = storageValidationRequest.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeChangeImageWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeChangeImageWaitHandler.java
@@ -20,6 +20,7 @@ import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.SdxUpgradeService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -46,7 +47,7 @@ public class DatalakeChangeImageWaitHandler extends ExceptionCatcherEventHandler
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<DatalakeChangeImageWaitRequest> event) {
         DatalakeChangeImageWaitRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeUpgradeWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeUpgradeWaitHandler.java
@@ -18,6 +18,7 @@ import com.sequenceiq.datalake.flow.datalake.upgrade.event.DatalakeUpgradeWaitRe
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.SdxUpgradeService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -44,7 +45,7 @@ public class DatalakeUpgradeWaitHandler extends ExceptionCatcherEventHandler<Dat
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<DatalakeUpgradeWaitRequest> event) {
         DatalakeUpgradeWaitRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeVmReplaceWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/handler/DatalakeVmReplaceWaitHandler.java
@@ -19,6 +19,7 @@ import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.SdxUpgradeService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -45,7 +46,7 @@ public class DatalakeVmReplaceWaitHandler extends ExceptionCatcherEventHandler<D
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<DatalakeVmReplaceWaitRequest> event) {
         DatalakeVmReplaceWaitRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/RdsDeletionHandler.java
@@ -25,6 +25,7 @@ import com.sequenceiq.datalake.repository.SdxClusterRepository;
 import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -55,7 +56,7 @@ public class RdsDeletionHandler extends ExceptionCatcherEventHandler<RdsDeletion
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<RdsDeletionWaitRequest> event) {
         RdsDeletionWaitRequest rdsWaitRequest = event.getData();
         Long sdxId = rdsWaitRequest.getResourceId();
         String userId = rdsWaitRequest.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/StackDeletionHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/delete/handler/StackDeletionHandler.java
@@ -19,6 +19,7 @@ import com.sequenceiq.datalake.flow.delete.event.StackDeletionWaitRequest;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.ProvisionerService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -47,7 +48,7 @@ public class StackDeletionHandler extends ExceptionCatcherEventHandler<StackDele
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<StackDeletionWaitRequest> event) {
         StackDeletionWaitRequest stackDeletionWaitRequest = event.getData();
         Long sdxId = stackDeletionWaitRequest.getResourceId();
         String userId = stackDeletionWaitRequest.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/diagnostics/handler/SdxCmDiagnosticsCollectionHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/diagnostics/handler/SdxCmDiagnosticsCollectionHandler.java
@@ -20,6 +20,7 @@ import com.sequenceiq.datalake.flow.diagnostics.event.SdxCmDiagnosticsWaitReques
 import com.sequenceiq.datalake.flow.diagnostics.event.SdxDiagnosticsSuccessEvent;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -43,7 +44,7 @@ public class SdxCmDiagnosticsCollectionHandler extends ExceptionCatcherEventHand
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<SdxCmDiagnosticsWaitRequest> event) {
         SdxCmDiagnosticsWaitRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/diagnostics/handler/SdxDiagnosticsCollectionHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/diagnostics/handler/SdxDiagnosticsCollectionHandler.java
@@ -20,6 +20,7 @@ import com.sequenceiq.datalake.flow.diagnostics.event.SdxDiagnosticsSuccessEvent
 import com.sequenceiq.datalake.flow.diagnostics.event.SdxDiagnosticsWaitRequest;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -43,7 +44,7 @@ public class SdxDiagnosticsCollectionHandler extends ExceptionCatcherEventHandle
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<SdxDiagnosticsWaitRequest> event) {
         SdxDiagnosticsWaitRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeDatabaseBackupWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeDatabaseBackupWaitHandler.java
@@ -13,6 +13,7 @@ import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.dr.SdxBackupRestoreService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import java.util.concurrent.TimeUnit;
 
@@ -53,7 +54,7 @@ public class DatalakeDatabaseBackupWaitHandler extends ExceptionCatcherEventHand
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<DatalakeDatabaseBackupWaitRequest> event) {
         DatalakeDatabaseBackupWaitRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeFullBackupWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/handler/DatalakeFullBackupWaitHandler.java
@@ -12,6 +12,7 @@ import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.dr.SdxBackupRestoreService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import java.util.concurrent.TimeUnit;
 
@@ -49,7 +50,7 @@ public class DatalakeFullBackupWaitHandler extends ExceptionCatcherEventHandler<
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<DatalakeFullBackupWaitRequest> event) {
         DatalakeFullBackupWaitRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeDatabaseRestoreWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeDatabaseRestoreWaitHandler.java
@@ -11,6 +11,7 @@ import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.dr.SdxBackupRestoreService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import java.util.concurrent.TimeUnit;
 
@@ -48,7 +49,7 @@ public class DatalakeDatabaseRestoreWaitHandler extends ExceptionCatcherEventHan
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<DatalakeDatabaseRestoreWaitRequest> event) {
         DatalakeDatabaseRestoreWaitRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeFullRestoreWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/handler/DatalakeFullRestoreWaitHandler.java
@@ -12,6 +12,7 @@ import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.dr.SdxBackupRestoreService;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import java.util.concurrent.TimeUnit;
 
@@ -49,7 +50,7 @@ public class DatalakeFullRestoreWaitHandler extends ExceptionCatcherEventHandler
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<DatalakeFullRestoreWaitRequest> event) {
         DatalakeFullRestoreWaitRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/handler/SdxRepairStartHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/handler/SdxRepairStartHandler.java
@@ -12,6 +12,7 @@ import com.sequenceiq.datalake.flow.repair.event.SdxRepairInProgressEvent;
 import com.sequenceiq.datalake.flow.repair.event.SdxRepairStartRequest;
 import com.sequenceiq.datalake.service.sdx.SdxRepairService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -34,7 +35,7 @@ public class SdxRepairStartHandler extends ExceptionCatcherEventHandler<SdxRepai
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<SdxRepairStartRequest> event) {
         SdxRepairStartRequest request = event.getData();
         Long sdxId = request.getResourceId();
         String userId = request.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/handler/SdxRepairWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/repair/handler/SdxRepairWaitHandler.java
@@ -19,6 +19,7 @@ import com.sequenceiq.datalake.flow.repair.event.SdxRepairWaitRequest;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.SdxRepairService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -47,7 +48,7 @@ public class SdxRepairWaitHandler extends ExceptionCatcherEventHandler<SdxRepair
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<SdxRepairWaitRequest> event) {
         SdxRepairWaitRequest sdxRepairWaitRequest = event.getData();
         Long sdxId = sdxRepairWaitRequest.getResourceId();
         String userId = sdxRepairWaitRequest.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/RdsStartHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/RdsStartHandler.java
@@ -21,6 +21,7 @@ import com.sequenceiq.datalake.service.pause.DatabasePauseSupportService;
 import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -52,7 +53,7 @@ public class RdsStartHandler extends ExceptionCatcherEventHandler<RdsWaitingToSt
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<RdsWaitingToStartRequest> event) {
         RdsWaitingToStartRequest rdsWaitRequest = event.getData();
         Long sdxId = rdsWaitRequest.getResourceId();
         String userId = rdsWaitRequest.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/SdxStartWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/start/handler/SdxStartWaitHandler.java
@@ -18,6 +18,7 @@ import com.sequenceiq.datalake.flow.start.event.SdxStartWaitRequest;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.start.SdxStartService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -44,7 +45,7 @@ public class SdxStartWaitHandler extends ExceptionCatcherEventHandler<SdxStartWa
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<SdxStartWaitRequest> event) {
         SdxStartWaitRequest waitRequest = event.getData();
         Long sdxId = waitRequest.getResourceId();
         String userId = waitRequest.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/RdsStopHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/RdsStopHandler.java
@@ -21,6 +21,7 @@ import com.sequenceiq.datalake.service.pause.DatabasePauseSupportService;
 import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -52,7 +53,7 @@ public class RdsStopHandler extends ExceptionCatcherEventHandler<RdsWaitingToSto
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<RdsWaitingToStopRequest> event) {
         RdsWaitingToStopRequest rdsWaitRequest = event.getData();
         Long sdxId = rdsWaitRequest.getResourceId();
         String userId = rdsWaitRequest.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/SdxStopAllDatahubHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/SdxStopAllDatahubHandler.java
@@ -17,6 +17,7 @@ import com.sequenceiq.datalake.flow.stop.event.SdxStopAllDatahubRequest;
 import com.sequenceiq.datalake.flow.stop.event.SdxStopFailedEvent;
 import com.sequenceiq.datalake.service.sdx.stop.SdxStopService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -41,7 +42,7 @@ public class SdxStopAllDatahubHandler extends ExceptionCatcherEventHandler<SdxSt
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<SdxStopAllDatahubRequest> event) {
         SdxStopAllDatahubRequest stopAllDatahubRequest = event.getData();
         Long sdxId = stopAllDatahubRequest.getResourceId();
         String userId = stopAllDatahubRequest.getUserId();

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/SdxStopWaitHandler.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/stop/handler/SdxStopWaitHandler.java
@@ -18,6 +18,7 @@ import com.sequenceiq.datalake.flow.stop.event.SdxStopWaitRequest;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.stop.SdxStopService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -39,7 +40,7 @@ public class SdxStopWaitHandler extends ExceptionCatcherEventHandler<SdxStopWait
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<SdxStopWaitRequest> event) {
         SdxStopWaitRequest waitRequest = event.getData();
         Long sdxId = waitRequest.getResourceId();
         String userId = waitRequest.getUserId();

--- a/flow/src/main/java/com/sequenceiq/flow/core/helloworld/reactor/HelloWorldFirstStepLongLastingTaskHandler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/helloworld/reactor/HelloWorldFirstStepLongLastingTaskHandler.java
@@ -9,6 +9,7 @@ import com.sequenceiq.flow.core.helloworld.flowevents.HelloWorldFirstStepLongLas
 import com.sequenceiq.flow.core.helloworld.flowevents.HelloWorldFirstStepLongLastingTaskSuccessResponse;
 import com.sequenceiq.flow.core.helloworld.flowevents.HelloWorldFirstStepLongLastingTaskTriggerEvent;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 
@@ -27,7 +28,7 @@ public class HelloWorldFirstStepLongLastingTaskHandler extends ExceptionCatcherE
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<HelloWorldFirstStepLongLastingTaskTriggerEvent> event) {
         HelloWorldFirstStepLongLastingTaskTriggerEvent helloWorldReactorEvent = event.getData();
         Long resourceId = helloWorldReactorEvent.getResourceId();
         try {

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/api/handler/ExceptionCatcherEventHandler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/api/handler/ExceptionCatcherEventHandler.java
@@ -22,13 +22,13 @@ public abstract class ExceptionCatcherEventHandler<T extends Payload> implements
 
     protected abstract Selectable defaultFailureEvent(Long resourceId, Exception e, Event<T> event);
 
-    protected abstract Selectable doAccept(HandlerEvent event);
+    protected abstract Selectable doAccept(HandlerEvent<T> event);
 
     @Override
     public void accept(Event<T> event) {
         String handlerName = getClass().getSimpleName();
         try {
-            HandlerEvent handlerEvent = new HandlerEvent(event);
+            HandlerEvent<T> handlerEvent = new HandlerEvent<T>(event);
             sendEvent(doAccept(handlerEvent), handlerEvent);
             if (handlerEvent.getCounter() < 1) {
                 String message = "No event has been sent from " + handlerName;
@@ -42,40 +42,9 @@ public abstract class ExceptionCatcherEventHandler<T extends Payload> implements
         }
     }
 
-    private void sendEvent(Selectable event, HandlerEvent originalEvent) {
+    private void sendEvent(Selectable event, HandlerEvent<T> originalEvent) {
         eventBus.notify(event.selector(), new Event<>(originalEvent.getEvent().getHeaders(), event));
         originalEvent.increaseCounter();
-    }
-
-    protected class HandlerEvent {
-
-        private Event<T> event;
-
-        private int eventCounter;
-
-        public HandlerEvent(Event<T> event) {
-            this.event = event;
-        }
-
-        public Event<T> getEvent() {
-            return event;
-        }
-
-        public void setEvent(Event<T> event) {
-            this.event = event;
-        }
-
-        public T getData() {
-            return event.getData();
-        }
-
-        private void increaseCounter() {
-            eventCounter++;
-        }
-
-        private int getCounter() {
-            return eventCounter;
-        }
     }
 
 }

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/api/handler/HandlerEvent.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/api/handler/HandlerEvent.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.flow.reactor.api.handler;
+
+import reactor.bus.Event;
+
+public class HandlerEvent<T> {
+
+    private Event<T> event;
+
+    private int eventCounter;
+
+    public HandlerEvent(Event<T> event) {
+        this.event = event;
+    }
+
+    public Event<T> getEvent() {
+        return event;
+    }
+
+    public void setEvent(Event<T> event) {
+        this.event = event;
+    }
+
+    public T getData() {
+        return event.getData();
+    }
+
+    public void increaseCounter() {
+        eventCounter++;
+    }
+
+    public int getCounter() {
+        return eventCounter;
+    }
+}

--- a/flow/src/test/java/com/sequenceiq/cloudbreak/reactor/api/handler/ExceptionCatcherEventHandlerTestHelper.java
+++ b/flow/src/test/java/com/sequenceiq/cloudbreak/reactor/api/handler/ExceptionCatcherEventHandlerTestHelper.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.event.Payload;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 
 import reactor.bus.Event;
 

--- a/flow/src/test/java/com/sequenceiq/flow/reactor/api/handler/ExceptionCatcherEventHandlerTestSupport.java
+++ b/flow/src/test/java/com/sequenceiq/flow/reactor/api/handler/ExceptionCatcherEventHandlerTestSupport.java
@@ -25,12 +25,12 @@ public class ExceptionCatcherEventHandlerTestSupport<T extends Payload> {
     }
 
     /**
-     * Delegates to {@link ExceptionCatcherEventHandler#doAccept(ExceptionCatcherEventHandler.HandlerEvent)}.
+     * Delegates to {@link ExceptionCatcherEventHandler#doAccept(HandlerEvent)}.
      * @param event reactor event
      * @return response event payload
      */
     public Selectable doAccept(Event<T> event) {
-        return eventHandler.doAccept(eventHandler.new HandlerEvent(event));
+        return eventHandler.doAccept(new HandlerEvent(event));
     }
 
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -21,6 +22,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.cleanup.CleanupRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaNotes;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaOperationDescriptions;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.attachchildenv.AttachChildEnvironmentRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.binduser.BindUserCreateRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.detachchildenv.DetachChildEnvironmentRequest;
@@ -161,4 +163,11 @@ public interface FreeIpaV1Endpoint {
     @ApiOperation(value = FreeIpaOperationDescriptions.DEREGISTER_WITH_CLUSTER_PROXY, produces = MediaType.APPLICATION_JSON,
             notes = FreeIpaNotes.FREEIPA_NOTES, nickname = "clusterProxyDeregisterV1")
     void deregisterWithClusterProxy(@QueryParam("environment") @NotEmpty String environmentCrn);
+
+    @POST
+    @Path("binduser/create")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = FreeIpaOperationDescriptions.BIND_USER_CREATE, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
+            nickname = "createBindUserV1")
+    OperationStatus createBindUser(@Valid @NotNull BindUserCreateRequest request, @QueryParam("initiatorUserCrn") @NotEmpty String initiatorUserCrn);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -19,6 +19,7 @@ public final class FreeIpaOperationDescriptions {
     public static final String HEALTH = "Provides a detailed health of the FreeIPA stack";
     public static final String REBOOT = "Reboot one or more instances";
     public static final String REPAIR = "Repair one or more instances";
+    public static final String BIND_USER_CREATE = "Creates kerberos and ldap bind users for cluster";
 
     private FreeIpaOperationDescriptions() {
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/binduser/BindUserCreateRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/binduser/BindUserCreateRequest.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.binduser;
+
+import javax.validation.constraints.NotEmpty;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
+import com.sequenceiq.cloudbreak.validation.ValidCrn;
+import com.sequenceiq.service.api.doc.ModelDescriptions;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel("BindUserCreateV1Request")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BindUserCreateRequest {
+    @NotEmpty
+    @ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+    @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_CRN, required = true)
+    private String environmentCrn;
+
+    @NotEmpty
+    @ApiModelProperty(value = "Bind user suffix, eg cluster name", required = true)
+    private String bindUserNameSuffix;
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public void setEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+    }
+
+    public String getBindUserNameSuffix() {
+        return bindUserNameSuffix;
+    }
+
+    public void setBindUserNameSuffix(String bindUserNameSuffix) {
+        this.bindUserNameSuffix = bindUserNameSuffix;
+    }
+
+    @Override
+    public String toString() {
+        return "BindUserCreateRequest{" +
+                "environmentCrn='" + environmentCrn + '\'' +
+                ", bindUserNameSuffix='" + bindUserNameSuffix + '\'' +
+                '}';
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/model/OperationType.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/model/OperationType.java
@@ -9,7 +9,8 @@ public enum OperationType {
     REBOOT,
     REPAIR,
     DOWNSCALE,
-    UPSCALE;
+    UPSCALE,
+    BIND_USER_CREATE;
 
     public static OperationType fromSyncOperationType(SyncOperationType syncOperationType) {
         switch (syncOperationType) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.flow.core.ApplicationFlowInformation;
 import com.sequenceiq.flow.core.config.FlowConfiguration;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupEvent;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionFlowConfig;
@@ -24,11 +26,13 @@ public class FreeIpaFlowInformation implements ApplicationFlowInformation {
             FreeIpaProvisionFlowConfig.class,
             StackStartFlowConfig.class,
             StackStopFlowConfig.class,
-            FreeIpaCleanupFlowConfig.class);
+            FreeIpaCleanupFlowConfig.class,
+            CreateBindUserFlowConfig.class);
 
     private static final List<String> PARALLEL_FLOWS = List.of(
             FreeIpaCleanupEvent.CLEANUP_EVENT.event(),
-            StackTerminationEvent.TERMINATION_EVENT.event());
+            StackTerminationEvent.TERMINATION_EVENT.event(),
+            CreateBindUserFlowEvent.CREATE_BIND_USER_EVENT.event());
 
     @Override
     public List<Class<? extends FlowConfiguration<?>>> getRestartableFlows() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -9,6 +9,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,6 +23,7 @@ import com.sequenceiq.authorization.annotation.RequestObject;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
+import com.sequenceiq.cloudbreak.auth.security.internal.InitiatorUserCrn;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.structuredevent.rest.annotation.AccountEntityType;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
@@ -29,6 +31,7 @@ import com.sequenceiq.cloudbreak.validation.ValidationResult.State;
 import com.sequenceiq.freeipa.api.v1.freeipa.cleanup.CleanupRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.attachchildenv.AttachChildEnvironmentRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.binduser.BindUserCreateRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.detachchildenv.DetachChildEnvironmentRequest;
@@ -43,6 +46,7 @@ import com.sequenceiq.freeipa.client.FreeIpaClientExceptionWrapper;
 import com.sequenceiq.freeipa.controller.validation.AttachChildEnvironmentRequestValidator;
 import com.sequenceiq.freeipa.controller.validation.CreateFreeIpaRequestValidator;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.binduser.BindUserCreateService;
 import com.sequenceiq.freeipa.service.freeipa.cert.root.FreeIpaRootCertificateService;
 import com.sequenceiq.freeipa.service.freeipa.cleanup.CleanupService;
 import com.sequenceiq.freeipa.service.stack.ChildEnvironmentService;
@@ -110,6 +114,9 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
 
     @Inject
     private FreeIpaFiltering freeIpaFiltering;
+
+    @Inject
+    private BindUserCreateService bindUserCreateService;
 
     @Override
     @CheckPermissionByRequestProperty(path = "environmentCrn", type = CRN, action = EDIT_ENVIRONMENT)
@@ -247,5 +254,12 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
     public void deregisterWithClusterProxy(@ResourceCrn @NotEmpty String environmentCrn) {
         String accountId = crnService.getCurrentAccountId();
         clusterProxyService.deregisterFreeIpa(accountId, environmentCrn);
+    }
+
+    @Override
+    @InternalOnly
+    public OperationStatus createBindUser(@Valid @NotNull BindUserCreateRequest request, @InitiatorUserCrn @NotEmpty String initiatorUserCrn) {
+        String accountId = crnService.getCurrentAccountId();
+        return bindUserCreateService.createBindUser(accountId, request);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/BindUserCreateOperationAcceptor.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/BindUserCreateOperationAcceptor.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.repository.OperationRepository;
+import com.sequenceiq.freeipa.service.freeipa.user.AcceptResult;
+import com.sequenceiq.freeipa.service.operation.OperationAcceptor;
+
+@Component
+public class BindUserCreateOperationAcceptor extends OperationAcceptor {
+    protected BindUserCreateOperationAcceptor(OperationRepository operationRepository) {
+        super(operationRepository);
+    }
+
+    @Override
+    public AcceptResult accept(Operation operation) {
+        Optional<AcceptResult> validationResult = validateOperation(operation);
+        if (validationResult.isPresent()) {
+            return validationResult.get();
+        } else {
+            boolean runningForSameCluster = isRunningOperationForSameCluster(operation);
+            if (runningForSameCluster) {
+                return AcceptResult.reject("There is already a running bind user creation for cluster");
+            } else {
+                return AcceptResult.accept();
+            }
+        }
+    }
+
+    private boolean isRunningOperationForSameCluster(Operation operation) {
+        List<Operation> runningOperations = getOperationRepository().findRunningByAccountIdAndType(operation.getAccountId(), selector());
+        return runningOperations.stream()
+                .filter(op -> !op.getId().equals(operation.getId()))
+                .filter(op -> op.getEnvironmentList().contains(operation.getEnvironmentList().get(0)))
+                .flatMap(op -> op.getUserList().stream())
+                .anyMatch(clusterName -> clusterName.equalsIgnoreCase(operation.getUserList().get(0)));
+    }
+
+    private Optional<AcceptResult> validateOperation(Operation operation) {
+        if (operation.getEnvironmentList() == null || operation.getEnvironmentList().size() != 1) {
+            return Optional.of(AcceptResult.reject("Bind user create must run only for one environment!"));
+        } else if (operation.getUserList() == null || operation.getUserList().size() != 1) {
+            return Optional.of(AcceptResult.reject("Bind user create must run only for one suffix!"));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    protected OperationType selector() {
+        return OperationType.BIND_USER_CREATE;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/CreateBindUserFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/CreateBindUserFlowConfig.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create;
+
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserState.CREATE_BIND_USER_FAILED_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserState.CREATE_BIND_USER_FINISHED_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserState.CREATE_KERBEROS_BIND_USER_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserState.CREATE_LDAP_BIND_USER_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserState.FINAL_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserState.INIT_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent.CREATE_BIND_USER_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent.CREATE_BIND_USER_FAILED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent.CREATE_BIND_USER_FAILURE_HANDLED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent.CREATE_BIND_USER_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent.CREATE_KERBEROS_BIND_USER_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent.CREATE_LDAP_BIND_USER_FINISHED_EVENT;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
+
+@Component
+public class CreateBindUserFlowConfig extends AbstractFlowConfiguration<CreateBindUserState, CreateBindUserFlowEvent> {
+
+    private static final CreateBindUserFlowEvent[] INIT_EVENTS = {CREATE_BIND_USER_EVENT};
+
+    private static final FlowEdgeConfig<CreateBindUserState, CreateBindUserFlowEvent> EDGE_CONFIG =
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, CREATE_BIND_USER_FAILED_STATE, CREATE_BIND_USER_FAILURE_HANDLED_EVENT);
+
+    private static final List<Transition<CreateBindUserState, CreateBindUserFlowEvent>> TRANSITIONS =
+            new Transition.Builder<CreateBindUserState, CreateBindUserFlowEvent>().defaultFailureEvent(CREATE_BIND_USER_FAILED_EVENT)
+                    .from(INIT_STATE).to(CREATE_KERBEROS_BIND_USER_STATE).event(CREATE_BIND_USER_EVENT).defaultFailureEvent()
+                    .from(CREATE_KERBEROS_BIND_USER_STATE).to(CREATE_LDAP_BIND_USER_STATE).event(CREATE_KERBEROS_BIND_USER_FINISHED_EVENT).defaultFailureEvent()
+                    .from(CREATE_LDAP_BIND_USER_STATE).to(CREATE_BIND_USER_FINISHED_STATE).event(CREATE_LDAP_BIND_USER_FINISHED_EVENT).defaultFailureEvent()
+                    .from(CREATE_BIND_USER_FINISHED_STATE).to(FINAL_STATE).event(CREATE_BIND_USER_FINISHED_EVENT).defaultFailureEvent()
+                    .build();
+
+    public CreateBindUserFlowConfig() {
+        super(CreateBindUserState.class, CreateBindUserFlowEvent.class);
+    }
+
+    @Override
+    public CreateBindUserFlowEvent[] getInitEvents() {
+        return INIT_EVENTS;
+    }
+
+    @Override
+    public CreateBindUserFlowEvent[] getEvents() {
+        return CreateBindUserFlowEvent.values();
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Bind user creation";
+    }
+
+    @Override
+    protected FlowEdgeConfig<CreateBindUserState, CreateBindUserFlowEvent> getEdgeConfig() {
+        return EDGE_CONFIG;
+    }
+
+    @Override
+    protected List<Transition<CreateBindUserState, CreateBindUserFlowEvent>> getTransitions() {
+        return TRANSITIONS;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/CreateBindUserState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/CreateBindUserState.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create;
+
+import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.InitializeMDCContextRestartAction;
+
+public enum CreateBindUserState implements FlowState {
+    INIT_STATE,
+    CREATE_KERBEROS_BIND_USER_STATE,
+    CREATE_LDAP_BIND_USER_STATE,
+    CREATE_BIND_USER_FAILED_STATE,
+    CREATE_BIND_USER_FINISHED_STATE,
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return InitializeMDCContextRestartAction.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/action/AbstractBindUserCreateAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/action/AbstractBindUserCreateAction.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create.action;
+
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent.CREATE_BIND_USER_FAILED_EVENT;
+
+import java.util.Optional;
+
+import org.springframework.statemachine.StateContext;
+
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.CommonContext;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFailureEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserState;
+
+public abstract class AbstractBindUserCreateAction<P extends CreateBindUserEvent>
+        extends AbstractAction<CreateBindUserState, CreateBindUserFlowEvent, CommonContext, P> {
+
+    protected AbstractBindUserCreateAction(Class<P> payloadClass) {
+        super(payloadClass);
+    }
+
+    @Override
+    protected CommonContext createFlowContext(FlowParameters flowParameters, StateContext<CreateBindUserState, CreateBindUserFlowEvent> stateContext,
+            P payload) {
+        MDCBuilder.addOperationId(payload.getOperationId());
+        return new CommonContext(flowParameters);
+    }
+
+    @Override
+    protected Object getFailurePayload(P payload, Optional<CommonContext> flowContext, Exception ex) {
+        return new CreateBindUserFailureEvent(CREATE_BIND_USER_FAILED_EVENT.event(), payload, "Unexpected failure", ex);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/action/CreateBindUserActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/action/CreateBindUserActions.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create.action;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+
+import com.sequenceiq.flow.core.CommonContext;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFailureEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateKerberosBindUserEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateLdapBindUserEvent;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+
+@Configuration
+public class CreateBindUserActions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreateBindUserActions.class);
+
+    @Bean("CREATE_KERBEROS_BIND_USER_STATE")
+    public Action<?, ?> createKerberosBindUserAction() {
+        return new AbstractBindUserCreateAction<>(CreateBindUserEvent.class) {
+            @Override
+            protected void doExecute(CommonContext context, CreateBindUserEvent payload, Map<Object, Object> variables) {
+                LOGGER.info("Sending request to create Kerberos bind user for {}", payload.getSuffix());
+                sendEvent(context, new CreateKerberosBindUserEvent(payload));
+            }
+        };
+    }
+
+    @Bean("CREATE_LDAP_BIND_USER_STATE")
+    public Action<?, ?> createLdapBindUserAction() {
+        return new AbstractBindUserCreateAction<>(CreateBindUserEvent.class) {
+            @Override
+            protected void doExecute(CommonContext context, CreateBindUserEvent payload, Map<Object, Object> variables) {
+                LOGGER.info("Sending request to create LDAP bind user for {}", payload.getSuffix());
+                sendEvent(context, new CreateLdapBindUserEvent(payload));
+            }
+        };
+    }
+
+    @Bean("CREATE_BIND_USER_FINISHED_STATE")
+    public Action<?, ?> createBindUserFinishedAction() {
+        return new AbstractBindUserCreateAction<>(CreateBindUserEvent.class) {
+
+            @Inject
+            private OperationService operationService;
+
+            @Override
+            protected void doExecute(CommonContext context, CreateBindUserEvent payload, Map<Object, Object> variables) throws Exception {
+                LOGGER.info("Bind user creation successfully finished with payload: {}", payload);
+                SuccessDetails successDetails = new SuccessDetails(payload.getEnvironmentCrn());
+                successDetails.getAdditionalDetails().put("suffix", List.of(payload.getSuffix()));
+                operationService.completeOperation(payload.getAccountId(), payload.getOperationId(), Set.of(successDetails), Set.of());
+                LOGGER.debug("Finalizing user creation finished");
+                sendEvent(context, CreateBindUserFlowEvent.CREATE_BIND_USER_FINISHED_EVENT.event(), payload);
+            }
+        };
+    }
+
+    @Bean("CREATE_BIND_USER_FAILED_STATE")
+    public Action<?, ?> createBindUserFailureAction() {
+        return new AbstractBindUserCreateAction<>(CreateBindUserFailureEvent.class) {
+            @Inject
+            private OperationService operationService;
+
+            @Override
+            protected void doExecute(CommonContext context, CreateBindUserFailureEvent payload, Map<Object, Object> variables) throws Exception {
+                LOGGER.error("Bind user creation failed with payload: {}", payload, payload.getException());
+                operationService.failOperation(payload.getAccountId(), payload.getOperationId(), payload.getFailureMessage());
+                LOGGER.debug("Failure handling finished");
+                sendEvent(context, CreateBindUserFlowEvent.CREATE_BIND_USER_FAILURE_HANDLED_EVENT.event(), payload);
+            }
+        };
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateBindUserEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateBindUserEvent.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create.event;
+
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+
+public class CreateBindUserEvent extends StackEvent {
+
+    private String accountId;
+
+    private String operationId;
+
+    private String suffix;
+
+    private String environmentCrn;
+
+    public CreateBindUserEvent(Long stackId) {
+        super(stackId);
+    }
+
+    public CreateBindUserEvent(String selector, Long stackId) {
+        super(selector, stackId);
+    }
+
+    public CreateBindUserEvent(String selector, Long stackId, String accountId, String operationId, String suffix, String environmentCrn) {
+        super(selector, stackId);
+        this.accountId = accountId;
+        this.operationId = operationId;
+        this.suffix = suffix;
+        this.environmentCrn = environmentCrn;
+    }
+
+    public CreateBindUserEvent(String selector, CreateBindUserEvent event) {
+        super(selector, event.getResourceId());
+        accountId = event.getAccountId();
+        operationId = event.getOperationId();
+        suffix = event.getSuffix();
+        environmentCrn = event.getEnvironmentCrn();
+    }
+
+    public String getAccountId() {
+        return accountId;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + ' ' +
+                "CreateBindUserEvent{" +
+                "accountId='" + accountId + '\'' +
+                ", operationId='" + operationId + '\'' +
+                ", suffix='" + suffix + '\'' +
+                ", environmentCrn='" + environmentCrn + '\'' +
+                '}';
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateBindUserFailureEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateBindUserFailureEvent.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create.event;
+
+public class CreateBindUserFailureEvent extends CreateBindUserEvent {
+
+    private final String failureMessage;
+
+    private final Exception exception;
+
+    public CreateBindUserFailureEvent(String selector, Long stackId, String accountId, String operationId, String suffix, String environmentCrn,
+            String failureMessage, Exception exception) {
+        super(selector, stackId, accountId, operationId, suffix, environmentCrn);
+        this.failureMessage = failureMessage;
+        this.exception = exception;
+    }
+
+    public CreateBindUserFailureEvent(String selector, CreateBindUserEvent event, String failureMessage, Exception exception) {
+        super(selector, event.getResourceId(), event.getAccountId(), event.getOperationId(), event.getSuffix(), event.getEnvironmentCrn());
+        this.failureMessage = failureMessage;
+        this.exception = exception;
+    }
+
+    public String getFailureMessage() {
+        return failureMessage;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + ' ' +
+                "CreateBindUserFailureEvent{" +
+                "failureMessage='" + failureMessage + '\'' +
+                ", exception=" + exception +
+                '}';
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateBindUserFlowEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateBindUserFlowEvent.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create.event;
+
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+
+public enum CreateBindUserFlowEvent implements FlowEvent {
+    CREATE_BIND_USER_EVENT,
+    CREATE_KERBEROS_BIND_USER_FINISHED_EVENT,
+    CREATE_LDAP_BIND_USER_FINISHED_EVENT,
+
+    CREATE_BIND_USER_FINISHED_EVENT,
+    CREATE_BIND_USER_FAILED_EVENT(EventSelectorUtil.selector(CreateBindUserFailureEvent.class)),
+    CREATE_BIND_USER_FAILURE_HANDLED_EVENT;
+
+    private final String event;
+
+    CreateBindUserFlowEvent(String event) {
+        this.event = event;
+    }
+
+    CreateBindUserFlowEvent() {
+        this.event = name();
+    }
+
+    @Override
+    public String event() {
+        return event;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateKerberosBindUserEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateKerberosBindUserEvent.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create.event;
+
+import com.sequenceiq.flow.event.EventSelectorUtil;
+
+public class CreateKerberosBindUserEvent extends CreateBindUserEvent {
+    public CreateKerberosBindUserEvent(CreateBindUserEvent event) {
+        super(EventSelectorUtil.selector(CreateKerberosBindUserEvent.class), event);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateLdapBindUserEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/event/CreateLdapBindUserEvent.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create.event;
+
+import com.sequenceiq.flow.event.EventSelectorUtil;
+
+public class CreateLdapBindUserEvent extends CreateBindUserEvent {
+    public CreateLdapBindUserEvent(CreateBindUserEvent event) {
+        super(EventSelectorUtil.selector(CreateLdapBindUserEvent.class), event);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/handler/KerberosBindUserCreationHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/handler/KerberosBindUserCreationHandler.java
@@ -1,0 +1,81 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create.handler;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFailureEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateKerberosBindUserEvent;
+import com.sequenceiq.freeipa.kerberos.KerberosConfig;
+import com.sequenceiq.freeipa.kerberos.KerberosConfigService;
+import com.sequenceiq.freeipa.kerberos.v1.KerberosConfigV1Service;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+import reactor.bus.Event;
+
+@Component
+public class KerberosBindUserCreationHandler extends ExceptionCatcherEventHandler<CreateKerberosBindUserEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KerberosBindUserCreationHandler.class);
+
+    private static final String SELECTOR = EventSelectorUtil.selector(CreateKerberosBindUserEvent.class);
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private KerberosConfigV1Service kerberosConfigV1Service;
+
+    @Inject
+    private KerberosConfigService kerberosConfigService;
+
+    @Override
+    public String selector() {
+        return SELECTOR;
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<CreateKerberosBindUserEvent> event) {
+        CreateBindUserEvent eventData = event.getData();
+        String failureMsg = String.format("Kerberos bind user creation failed for %s with %s", eventData.getSuffix(), e.getMessage());
+        return new CreateBindUserFailureEvent(CreateBindUserFlowEvent.CREATE_BIND_USER_FAILED_EVENT.event(), eventData, failureMsg, e);
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent<CreateKerberosBindUserEvent> event) {
+        CreateBindUserEvent data = event.getData();
+        Optional<KerberosConfig> kerberosConfig = kerberosConfigService.find(data.getEnvironmentCrn(), data.getAccountId(), data.getSuffix());
+        if (kerberosConfig.isPresent()) {
+            LOGGER.info("Kerberos configuration already exist: {}", kerberosConfig.get());
+            return new CreateBindUserEvent(CreateBindUserFlowEvent.CREATE_KERBEROS_BIND_USER_FINISHED_EVENT.event(), data);
+        } else {
+            return createKerberosBindUser(event.getEvent(), data);
+        }
+    }
+
+    private Selectable createKerberosBindUser(Event<CreateKerberosBindUserEvent> event, CreateBindUserEvent data) {
+        Stack stack = stackService.getByEnvironmentCrnAndAccountId(data.getEnvironmentCrn(), data.getAccountId());
+        MDCBuilder.buildMdcContext(stack);
+        LOGGER.info("Create Kerberos bind user for [{}]", data.getSuffix());
+        try {
+            kerberosConfigV1Service.createNewKerberosConfig(data.getEnvironmentCrn(), data.getSuffix(), stack, true);
+            return new CreateBindUserEvent(CreateBindUserFlowEvent.CREATE_KERBEROS_BIND_USER_FINISHED_EVENT.event(), data);
+        } catch (FreeIpaClientException e) {
+            LOGGER.error("Couldn't create Kerberos bind user: {}", data, e);
+            return defaultFailureEvent(data.getResourceId(), e, event);
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/handler/LdapBindUserCreationHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/handler/LdapBindUserCreationHandler.java
@@ -1,0 +1,81 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create.handler;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFailureEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateLdapBindUserEvent;
+import com.sequenceiq.freeipa.ldap.LdapConfig;
+import com.sequenceiq.freeipa.ldap.LdapConfigService;
+import com.sequenceiq.freeipa.ldap.v1.LdapConfigV1Service;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+import reactor.bus.Event;
+
+@Component
+public class LdapBindUserCreationHandler extends ExceptionCatcherEventHandler<CreateLdapBindUserEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LdapBindUserCreationHandler.class);
+
+    private static final String SELECTOR = EventSelectorUtil.selector(CreateLdapBindUserEvent.class);
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private LdapConfigV1Service ldapConfigV1Service;
+
+    @Inject
+    private LdapConfigService ldapConfigService;
+
+    @Override
+    public String selector() {
+        return SELECTOR;
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<CreateLdapBindUserEvent> event) {
+        CreateBindUserEvent eventData = event.getData();
+        String failureMsg = String.format("LDAP bind user creation failed for %s with %s", eventData.getSuffix(), e.getMessage());
+        return new CreateBindUserFailureEvent(CreateBindUserFlowEvent.CREATE_BIND_USER_FAILED_EVENT.event(), eventData, failureMsg, e);
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent<CreateLdapBindUserEvent> event) {
+        CreateBindUserEvent data = event.getData();
+        Optional<LdapConfig> ldapConfig = ldapConfigService.find(data.getEnvironmentCrn(), data.getAccountId(), data.getSuffix());
+        if (ldapConfig.isPresent()) {
+            LOGGER.info("LDAP configuration already exists: {}", ldapConfig.get());
+            return new CreateBindUserEvent(CreateBindUserFlowEvent.CREATE_LDAP_BIND_USER_FINISHED_EVENT.event(), data);
+        } else {
+            return createLdapBindUSer(event.getEvent(), data);
+        }
+    }
+
+    private Selectable createLdapBindUSer(Event<CreateLdapBindUserEvent> event, CreateBindUserEvent data) {
+        Stack stack = stackService.getByEnvironmentCrnAndAccountId(data.getEnvironmentCrn(), data.getAccountId());
+        MDCBuilder.buildMdcContext(stack);
+        LOGGER.info("Create LDAP bind user for [{}]", data.getSuffix());
+        try {
+            ldapConfigV1Service.createNewLdapConfig(data.getEnvironmentCrn(), data.getSuffix(), stack, true);
+            return new CreateBindUserEvent(CreateBindUserFlowEvent.CREATE_LDAP_BIND_USER_FINISHED_EVENT.event(), data);
+        } catch (FreeIpaClientException e) {
+            LOGGER.error("Couldn't create LDAP bind user: {}", data, e);
+            return defaultFailureEvent(data.getResourceId(), e, event);
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/AbstractFreeIpaCleanupAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/cleanup/AbstractFreeIpaCleanupAction.java
@@ -2,30 +2,28 @@ package com.sequenceiq.freeipa.flow.freeipa.cleanup;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.statemachine.StateContext;
 
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.freeipa.entity.FreeIpa;
+import com.sequenceiq.freeipa.flow.freeipa.cleanup.event.failure.CleanupFailureEvent;
 import com.sequenceiq.freeipa.flow.stack.AbstractStackAction;
-import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
-import com.sequenceiq.freeipa.service.freeipa.cleanup.CleanupService;
 
 public abstract class AbstractFreeIpaCleanupAction<P extends CleanupEvent>
         extends AbstractStackAction<FreeIpaCleanupState, FreeIpaCleanupEvent, FreeIpaContext, P> {
 
-    @Inject
-    private FreeIpaClientFactory freeIpaClientFactory;
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractFreeIpaCleanupAction.class);
 
     @Inject
     private FreeIpaService freeIpaService;
-
-    @Inject
-    private CleanupService cleanupService;
 
     protected AbstractFreeIpaCleanupAction(Class<P> payloadClass) {
         super(payloadClass);
@@ -41,11 +39,8 @@ public abstract class AbstractFreeIpaCleanupAction<P extends CleanupEvent>
 
     @Override
     protected Object getFailurePayload(P payload, Optional<FreeIpaContext> flowContext, Exception ex) {
-        return null;
-    }
-
-    protected CleanupService getCleanupService() {
-        return cleanupService;
+        LOGGER.warn("Failure happened during cleanup, and 'getFailurePayload' is not overridden in state.", ex);
+        return new CleanupFailureEvent(payload, "Unknown phase", Map.of(), Set.of());
     }
 
     protected boolean shouldSkipState(CleanupEvent event, Map<Object, Object> variables) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/CollectAdditionalHostnamesHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/CollectAdditionalHostnamesHandler.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.IpaServer;
@@ -45,7 +46,7 @@ public class CollectAdditionalHostnamesHandler extends ExceptionCatcherEventHand
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<CollectAdditionalHostnamesRequest> event) {
         CollectAdditionalHostnamesRequest request = event.getData();
         Selectable result;
         try {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/UpdateDnsSoaRecordsHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/UpdateDnsSoaRecordsHandler.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.DnsZone;
@@ -47,7 +48,7 @@ public class UpdateDnsSoaRecordsHandler extends ExceptionCatcherEventHandler<Upd
                 resourceId, "Downscale Update DNS SOA Records", Set.of(), Map.of(), e);    }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<UpdateDnsSoaRecordsRequest> event) {
         UpdateDnsSoaRecordsRequest request = event.getData();
         Selectable result;
         try {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/handler/OrchestratorConfigHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/handler/OrchestratorConfigHandler.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.orchestrator.OrchestratorConfigFailed;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.orchestrator.OrchestratorConfigRequest;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.orchestrator.OrchestratorConfigSuccess;
@@ -38,7 +39,7 @@ public class OrchestratorConfigHandler extends ExceptionCatcherEventHandler<Orch
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<OrchestratorConfigRequest> event) {
         OrchestratorConfigRequest request = event.getData();
         Selectable response;
         try {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/handler/ValidateCloudStorageHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/provision/handler/ValidateCloudStorageHandler.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.cloudstorage.ValidateCloudStorageFailed;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.cloudstorage.ValidateCloudStorageRequest;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.cloudstorage.ValidateCloudStorageSuccess;
@@ -38,7 +39,7 @@ public class ValidateCloudStorageHandler extends ExceptionCatcherEventHandler<Va
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<ValidateCloudStorageRequest> event) {
         ValidateCloudStorageRequest request = event.getData();
         Selectable response;
         try {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/binduser/BindUserCreateService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/binduser/BindUserCreateService.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.freeipa.service.binduser;
+
+import static com.sequenceiq.freeipa.api.v1.operation.model.OperationState.RUNNING;
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent.CREATE_BIND_USER_EVENT;
+
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.binduser.BindUserCreateRequest;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.converter.operation.OperationToOperationStatusConverter;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserEvent;
+import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Service
+public class BindUserCreateService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BindUserCreateService.class);
+
+    @Inject
+    private OperationService operationService;
+
+    @Inject
+    private FreeIpaFlowManager flowManager;
+
+    @Inject
+    private OperationToOperationStatusConverter operationConverter;
+
+    @Inject
+    private StackService stackService;
+
+    public OperationStatus createBindUser(String accountId, BindUserCreateRequest request) {
+        Long stackId = stackService.getIdByEnvironmentCrnAndAccountId(request.getEnvironmentCrn(), accountId);
+        LOGGER.info("Start 'BIND_USER_CREATE' operation from request: {}", request);
+        Operation operation = operationService.startOperation(accountId, OperationType.BIND_USER_CREATE, List.of(request.getEnvironmentCrn()),
+                List.of(request.getBindUserNameSuffix()));
+        if (RUNNING == operation.getStatus()) {
+            return operationConverter.convert(startCreateBindUserFLow(accountId, request, stackId, operation));
+        } else {
+            LOGGER.info("Operation isn't in RUNNING state: {}", operation);
+            return operationConverter.convert(operation);
+        }
+    }
+
+    private Operation startCreateBindUserFLow(String accountId, BindUserCreateRequest request, Long stackId, Operation operation) {
+        CreateBindUserEvent event = new CreateBindUserEvent(CREATE_BIND_USER_EVENT.event(), stackId, accountId, operation.getOperationId(),
+                request.getBindUserNameSuffix(), request.getEnvironmentCrn());
+        try {
+            LOGGER.info("Start CreateBindUserFlow");
+            flowManager.notify(CREATE_BIND_USER_EVENT.event(), event);
+            LOGGER.info("Started CreateBindUserFlow");
+            return operation;
+        } catch (Exception e) {
+            LOGGER.error("Couldn't start create bind user flow", e);
+            return operationService.failOperation(accountId, operation.getOperationId(), "Couldn't start create bind user flow: " + e.getMessage());
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaFlowManager.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaFlowManager.java
@@ -40,10 +40,11 @@ public class FreeIpaFlowManager {
     @Inject
     private ErrorHandlerAwareReactorEventFactory eventFactory;
 
-    public void notify(String selector, Acceptable acceptable) {
+    public FlowIdentifier notify(String selector, Acceptable acceptable) {
         Map<String, Object> headerWithUserCrn = getHeaderWithUserCrn(null);
         Event<Acceptable> event = eventFactory.createEventWithErrHandler(headerWithUserCrn, acceptable);
         notify(selector, event);
+        return checkFlowOperationForResource(event);
     }
 
     public void notify(Selectable selectable) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationAcceptor.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationAcceptor.java
@@ -66,4 +66,8 @@ public abstract class OperationAcceptor {
     protected boolean doListsConflict(List<String> list1, List<String> list2) {
         return list1.isEmpty() || list2.isEmpty() || !Sets.intersection(Set.copyOf(list1), Set.copyOf(list2)).isEmpty();
     }
+
+    protected OperationRepository getOperationRepository() {
+        return operationRepository;
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -21,6 +21,7 @@ import com.sequenceiq.authorization.resource.AuthorizationResourceType;
 import com.sequenceiq.authorization.service.ResourceCrnAndNameProvider;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.dto.StackIdWithStatus;
@@ -102,6 +103,17 @@ public class StackService implements ResourceCrnAndNameProvider {
 
     public List<Long> findAllIdByEnvironmentCrnAndAccountId(String environmentCrn, String accountId) {
         return stackRepository.findAllIdByEnvironmentCrnAndAccountId(environmentCrn, accountId);
+    }
+
+    public Long getIdByEnvironmentCrnAndAccountId(String environmentCrn, String accountId) {
+        List<Long> ids = stackRepository.findAllIdByEnvironmentCrnAndAccountId(environmentCrn, accountId);
+        if (ids.isEmpty()) {
+            throw new NotFoundException(String.format("FreeIPA stack by environment [%s] not found", environmentCrn));
+        } else if (ids.size() > 1) {
+            throw new BadRequestException(String.format("Multiple FreeIPA stack by environment [%s] found", environmentCrn));
+        } else {
+            return ids.get(0);
+        }
     }
 
     public Stack getByEnvironmentCrnAndAccountIdWithLists(String environmentCrn, String accountId) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/BindUserCreateOperationAcceptorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/BindUserCreateOperationAcceptorTest.java
@@ -1,0 +1,139 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.repository.OperationRepository;
+import com.sequenceiq.freeipa.service.freeipa.user.AcceptResult;
+
+class BindUserCreateOperationAcceptorTest {
+
+    private static final String ENV_CRN = "ENV_CRN";
+
+    private static final String SUFFIX = "cluster";
+
+    private static final String ACCOUNT = "accountId";
+
+    private OperationRepository repository;
+
+    private BindUserCreateOperationAcceptor underTest;
+
+    @BeforeEach
+    public void init() {
+        repository = mock(OperationRepository.class);
+        underTest = new BindUserCreateOperationAcceptor(repository);
+    }
+
+    @Test
+    public void testRejectedAlreadyRunning() {
+        Operation runningOperation = createCurrentOperation();
+        runningOperation.setId(0L);
+        runningOperation.setOperationId("other");
+        Operation currentOperation = createCurrentOperation();
+        when(repository.findRunningByAccountIdAndType(ACCOUNT, underTest.selector())).thenReturn(List.of(runningOperation, currentOperation));
+
+        AcceptResult result = underTest.accept(currentOperation);
+
+        assertFalse(result.isAccepted());
+        assertEquals("There is already a running bind user creation for cluster", result.getRejectionMessage().get());
+    }
+
+    @Test
+    public void testMissingEnv() {
+        Operation currentOperation = createCurrentOperation();
+        currentOperation.setEnvironmentList(null);
+        when(repository.findRunningByAccountIdAndType(ACCOUNT, underTest.selector())).thenReturn(List.of(currentOperation));
+
+        AcceptResult result = underTest.accept(currentOperation);
+
+        assertFalse(result.isAccepted());
+        assertEquals("Bind user create must run only for one environment!", result.getRejectionMessage().get());
+    }
+
+    @Test
+    public void testMultipleEnv() {
+        Operation currentOperation = createCurrentOperation();
+        currentOperation.setEnvironmentList(List.of(ENV_CRN, "env2"));
+        when(repository.findRunningByAccountIdAndType(ACCOUNT, underTest.selector())).thenReturn(List.of(currentOperation));
+
+        AcceptResult result = underTest.accept(currentOperation);
+
+        assertFalse(result.isAccepted());
+        assertEquals("Bind user create must run only for one environment!", result.getRejectionMessage().get());
+    }
+
+    @Test
+    public void testMissingSuffix() {
+        Operation currentOperation = createCurrentOperation();
+        currentOperation.setUserList(null);
+        when(repository.findRunningByAccountIdAndType(ACCOUNT, underTest.selector())).thenReturn(List.of(currentOperation));
+
+        AcceptResult result = underTest.accept(currentOperation);
+
+        assertFalse(result.isAccepted());
+        assertEquals("Bind user create must run only for one suffix!", result.getRejectionMessage().get());
+    }
+
+    @Test
+    public void testMultipleSuffix() {
+        Operation currentOperation = createCurrentOperation();
+        currentOperation.setUserList(List.of(SUFFIX, "cluster2"));
+        when(repository.findRunningByAccountIdAndType(ACCOUNT, underTest.selector())).thenReturn(List.of(currentOperation));
+
+        AcceptResult result = underTest.accept(currentOperation);
+
+        assertFalse(result.isAccepted());
+        assertEquals("Bind user create must run only for one suffix!", result.getRejectionMessage().get());
+    }
+
+    @Test
+    public void testDifferentEnvSameSuffixIsAccepted() {
+        Operation runningOperation = createCurrentOperation();
+        runningOperation.setId(0L);
+        runningOperation.setOperationId("other");
+        runningOperation.setEnvironmentList(List.of("otherEnv"));
+        Operation currentOperation = createCurrentOperation();
+        when(repository.findRunningByAccountIdAndType(ACCOUNT, underTest.selector())).thenReturn(List.of(runningOperation, currentOperation));
+
+        AcceptResult result = underTest.accept(currentOperation);
+
+        assertTrue(result.isAccepted());
+        assertTrue(result.getRejectionMessage().isEmpty());
+    }
+
+    @Test
+    public void testSameEnvDifferentSuffixIsAccepted() {
+        Operation runningOperation = createCurrentOperation();
+        runningOperation.setId(0L);
+        runningOperation.setOperationId("other");
+        runningOperation.setUserList(List.of("cluster2"));
+        Operation currentOperation = createCurrentOperation();
+        when(repository.findRunningByAccountIdAndType(ACCOUNT, underTest.selector())).thenReturn(List.of(runningOperation, currentOperation));
+
+        AcceptResult result = underTest.accept(currentOperation);
+
+        assertTrue(result.isAccepted());
+        assertTrue(result.getRejectionMessage().isEmpty());
+    }
+
+    private Operation createCurrentOperation() {
+        Operation operation = new Operation();
+        operation.setId(1L);
+        operation.setOperationId("id1");
+        operation.setAccountId(ACCOUNT);
+        operation.setOperationType(OperationType.BIND_USER_CREATE);
+        operation.setEnvironmentList(List.of(ENV_CRN));
+        operation.setUserList(List.of(SUFFIX));
+        return operation;
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/handler/KerberosBindUserCreationHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/handler/KerberosBindUserCreationHandlerTest.java
@@ -1,0 +1,136 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFailureEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateKerberosBindUserEvent;
+import com.sequenceiq.freeipa.kerberos.KerberosConfig;
+import com.sequenceiq.freeipa.kerberos.KerberosConfigService;
+import com.sequenceiq.freeipa.kerberos.v1.KerberosConfigV1Service;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+import reactor.bus.Event;
+
+@ExtendWith(MockitoExtension.class)
+class KerberosBindUserCreationHandlerTest {
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private KerberosConfigV1Service kerberosConfigV1Service;
+
+    @Mock
+    private KerberosConfigService kerberosConfigService;
+
+    @InjectMocks
+    private KerberosBindUserCreationHandler underTest;
+
+    @Test
+    public void testSelector() {
+        assertEquals(EventSelectorUtil.selector(CreateKerberosBindUserEvent.class), underTest.selector());
+    }
+
+    @Test
+    public void testDefaultFailureEventCreation() {
+        CreateBindUserEvent createBindUserEvent = new CreateBindUserEvent("selector", 1L, "acc", "opid", "suffix", "envcrn");
+        CreateKerberosBindUserEvent createKerberosBindUserEvent = new CreateKerberosBindUserEvent(createBindUserEvent);
+        Exception exception = new Exception("test");
+
+        Selectable result = underTest.defaultFailureEvent(1L, exception, new Event<>(createKerberosBindUserEvent));
+
+        assertTrue(result instanceof CreateBindUserFailureEvent);
+        CreateBindUserFailureEvent failureEvent = (CreateBindUserFailureEvent) result;
+        assertEquals(CreateBindUserFlowEvent.CREATE_BIND_USER_FAILED_EVENT.event(), failureEvent.selector());
+        assertEquals("Kerberos bind user creation failed for suffix with test", failureEvent.getFailureMessage());
+        assertEquals(exception, failureEvent.getException());
+    }
+
+    @Test
+    public void testEventSentIfConfigAlreadyExists() {
+        CreateBindUserEvent createBindUserEvent = new CreateBindUserEvent("selector", 1L, "acc", "opid", "suffix", "envcrn");
+        CreateKerberosBindUserEvent createKerberosBindUserEvent = new CreateKerberosBindUserEvent(createBindUserEvent);
+        HandlerEvent<CreateKerberosBindUserEvent> handlerEvent = new HandlerEvent<>(new Event<>(createKerberosBindUserEvent));
+        when(kerberosConfigService.find(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId(), createBindUserEvent.getSuffix()))
+                .thenReturn(Optional.of(new KerberosConfig()));
+
+        Selectable selectable = underTest.doAccept(handlerEvent);
+
+        assertTrue(selectable instanceof CreateBindUserEvent);
+        CreateBindUserEvent event = (CreateBindUserEvent) selectable;
+        assertEquals(CreateBindUserFlowEvent.CREATE_KERBEROS_BIND_USER_FINISHED_EVENT.event(), event.selector());
+        assertEquals(createBindUserEvent.getOperationId(), event.getOperationId());
+        assertEquals(createBindUserEvent.getSuffix(), event.getSuffix());
+        assertEquals(createBindUserEvent.getAccountId(), event.getAccountId());
+        assertEquals(createBindUserEvent.getResourceId(), event.getResourceId());
+        verifyNoInteractions(stackService);
+        verifyNoInteractions(kerberosConfigV1Service);
+    }
+
+    @Test
+    public void testCreated() throws FreeIpaClientException {
+        CreateBindUserEvent createBindUserEvent = new CreateBindUserEvent("selector", 1L, "acc", "opid", "suffix", "envcrn");
+        CreateKerberosBindUserEvent createKerberosBindUserEvent = new CreateKerberosBindUserEvent(createBindUserEvent);
+        HandlerEvent<CreateKerberosBindUserEvent> handlerEvent = new HandlerEvent<>(new Event<>(createKerberosBindUserEvent));
+        when(kerberosConfigService.find(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId(), createBindUserEvent.getSuffix()))
+                .thenReturn(Optional.empty());
+        Stack stack = new Stack();
+        when(stackService.getByEnvironmentCrnAndAccountId(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId())).thenReturn(stack);
+
+        Selectable selectable = underTest.doAccept(handlerEvent);
+
+        assertTrue(selectable instanceof CreateBindUserEvent);
+        CreateBindUserEvent event = (CreateBindUserEvent) selectable;
+        assertEquals(CreateBindUserFlowEvent.CREATE_KERBEROS_BIND_USER_FINISHED_EVENT.event(), event.selector());
+        assertEquals(createBindUserEvent.getOperationId(), event.getOperationId());
+        assertEquals(createBindUserEvent.getSuffix(), event.getSuffix());
+        assertEquals(createBindUserEvent.getAccountId(), event.getAccountId());
+        assertEquals(createBindUserEvent.getResourceId(), event.getResourceId());
+        verify(stackService).getByEnvironmentCrnAndAccountId(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId());
+        verify(kerberosConfigV1Service).createNewKerberosConfig(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getSuffix(), stack, true);
+    }
+
+    @Test
+    public void testCreateFailed() throws FreeIpaClientException {
+        CreateBindUserEvent createBindUserEvent = new CreateBindUserEvent("selector", 1L, "acc", "opid", "suffix", "envcrn");
+        CreateKerberosBindUserEvent createKerberosBindUserEvent = new CreateKerberosBindUserEvent(createBindUserEvent);
+        HandlerEvent<CreateKerberosBindUserEvent> handlerEvent = new HandlerEvent<>(new Event<>(createKerberosBindUserEvent));
+        when(kerberosConfigService.find(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId(), createBindUserEvent.getSuffix()))
+                .thenReturn(Optional.empty());
+        Stack stack = new Stack();
+        when(stackService.getByEnvironmentCrnAndAccountId(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId())).thenReturn(stack);
+        when(kerberosConfigV1Service.createNewKerberosConfig(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getSuffix(), stack, true))
+                .thenThrow(new FreeIpaClientException("test"));
+
+        Selectable selectable = underTest.doAccept(handlerEvent);
+
+        assertTrue(selectable instanceof CreateBindUserEvent);
+        CreateBindUserEvent event = (CreateBindUserEvent) selectable;
+        assertEquals(CreateBindUserFlowEvent.CREATE_BIND_USER_FAILED_EVENT.event(), event.selector());
+        assertEquals(createBindUserEvent.getOperationId(), event.getOperationId());
+        assertEquals(createBindUserEvent.getSuffix(), event.getSuffix());
+        assertEquals(createBindUserEvent.getAccountId(), event.getAccountId());
+        assertEquals(createBindUserEvent.getResourceId(), event.getResourceId());
+        verify(stackService).getByEnvironmentCrnAndAccountId(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId());
+        verify(kerberosConfigV1Service).createNewKerberosConfig(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getSuffix(), stack, true);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/handler/LdapBindUserCreationHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/binduser/create/handler/LdapBindUserCreationHandlerTest.java
@@ -1,0 +1,135 @@
+package com.sequenceiq.freeipa.flow.freeipa.binduser.create.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFailureEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateLdapBindUserEvent;
+import com.sequenceiq.freeipa.ldap.LdapConfig;
+import com.sequenceiq.freeipa.ldap.LdapConfigService;
+import com.sequenceiq.freeipa.ldap.v1.LdapConfigV1Service;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+import reactor.bus.Event;
+
+@ExtendWith(MockitoExtension.class)
+class LdapBindUserCreationHandlerTest {
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private LdapConfigV1Service ldapConfigV1Service;
+
+    @Mock
+    private LdapConfigService ldapConfigService;
+
+    @InjectMocks
+    private LdapBindUserCreationHandler underTest;
+
+    @Test
+    public void testSelector() {
+        assertEquals(EventSelectorUtil.selector(CreateLdapBindUserEvent.class), underTest.selector());
+    }
+
+    @Test
+    public void testDefaultFailureEventCreation() {
+        CreateBindUserEvent createBindUserEvent = new CreateBindUserEvent("selector", 1L, "acc", "opid", "suffix", "envcrn");
+        CreateLdapBindUserEvent createLdapBindUserEvent = new CreateLdapBindUserEvent(createBindUserEvent);
+        Exception exception = new Exception("test");
+
+        Selectable result = underTest.defaultFailureEvent(1L, exception, new Event<>(createLdapBindUserEvent));
+
+        assertTrue(result instanceof CreateBindUserFailureEvent);
+        CreateBindUserFailureEvent failureEvent = (CreateBindUserFailureEvent) result;
+        assertEquals(CreateBindUserFlowEvent.CREATE_BIND_USER_FAILED_EVENT.event(), failureEvent.selector());
+        assertEquals("LDAP bind user creation failed for suffix with test", failureEvent.getFailureMessage());
+        assertEquals(exception, failureEvent.getException());
+    }
+
+    @Test
+    public void testEventSentIfConfigAlreadyExists() {
+        CreateBindUserEvent createBindUserEvent = new CreateBindUserEvent("selector", 1L, "acc", "opid", "suffix", "envcrn");
+        CreateLdapBindUserEvent createLdapBindUserEvent = new CreateLdapBindUserEvent(createBindUserEvent);
+        HandlerEvent<CreateLdapBindUserEvent> handlerEvent = new HandlerEvent<>(new Event<>(createLdapBindUserEvent));
+        when(ldapConfigService.find(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId(), createBindUserEvent.getSuffix()))
+                .thenReturn(Optional.of(new LdapConfig()));
+
+        Selectable selectable = underTest.doAccept(handlerEvent);
+
+        assertTrue(selectable instanceof CreateBindUserEvent);
+        CreateBindUserEvent event = (CreateBindUserEvent) selectable;
+        assertEquals(CreateBindUserFlowEvent.CREATE_LDAP_BIND_USER_FINISHED_EVENT.event(), event.selector());
+        assertEquals(createBindUserEvent.getOperationId(), event.getOperationId());
+        assertEquals(createBindUserEvent.getSuffix(), event.getSuffix());
+        assertEquals(createBindUserEvent.getAccountId(), event.getAccountId());
+        assertEquals(createBindUserEvent.getResourceId(), event.getResourceId());
+        verifyNoInteractions(stackService);
+        verifyNoInteractions(ldapConfigV1Service);
+    }
+
+    @Test
+    public void testCreated() throws FreeIpaClientException {
+        CreateBindUserEvent createBindUserEvent = new CreateBindUserEvent("selector", 1L, "acc", "opid", "suffix", "envcrn");
+        CreateLdapBindUserEvent createLdapBindUserEvent = new CreateLdapBindUserEvent(createBindUserEvent);
+        HandlerEvent<CreateLdapBindUserEvent> handlerEvent = new HandlerEvent<>(new Event<>(createLdapBindUserEvent));
+        when(ldapConfigService.find(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId(), createBindUserEvent.getSuffix()))
+                .thenReturn(Optional.empty());
+        Stack stack = new Stack();
+        when(stackService.getByEnvironmentCrnAndAccountId(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId())).thenReturn(stack);
+
+        Selectable selectable = underTest.doAccept(handlerEvent);
+
+        assertTrue(selectable instanceof CreateBindUserEvent);
+        CreateBindUserEvent event = (CreateBindUserEvent) selectable;
+        assertEquals(CreateBindUserFlowEvent.CREATE_LDAP_BIND_USER_FINISHED_EVENT.event(), event.selector());
+        assertEquals(createBindUserEvent.getOperationId(), event.getOperationId());
+        assertEquals(createBindUserEvent.getSuffix(), event.getSuffix());
+        assertEquals(createBindUserEvent.getAccountId(), event.getAccountId());
+        assertEquals(createBindUserEvent.getResourceId(), event.getResourceId());
+        verify(stackService).getByEnvironmentCrnAndAccountId(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId());
+        verify(ldapConfigV1Service).createNewLdapConfig(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getSuffix(), stack, true);
+    }
+
+    @Test
+    public void testCreateFailed() throws FreeIpaClientException {
+        CreateBindUserEvent createBindUserEvent = new CreateBindUserEvent("selector", 1L, "acc", "opid", "suffix", "envcrn");
+        CreateLdapBindUserEvent createLdapBindUserEvent = new CreateLdapBindUserEvent(createBindUserEvent);
+        HandlerEvent<CreateLdapBindUserEvent> handlerEvent = new HandlerEvent<>(new Event<>(createLdapBindUserEvent));
+        when(ldapConfigService.find(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId(), createBindUserEvent.getSuffix()))
+                .thenReturn(Optional.empty());
+        Stack stack = new Stack();
+        when(stackService.getByEnvironmentCrnAndAccountId(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId())).thenReturn(stack);
+        when(ldapConfigV1Service.createNewLdapConfig(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getSuffix(), stack, true))
+                .thenThrow(new FreeIpaClientException("test"));
+
+        Selectable selectable = underTest.doAccept(handlerEvent);
+
+        assertTrue(selectable instanceof CreateBindUserEvent);
+        CreateBindUserEvent event = (CreateBindUserEvent) selectable;
+        assertEquals(CreateBindUserFlowEvent.CREATE_BIND_USER_FAILED_EVENT.event(), event.selector());
+        assertEquals(createBindUserEvent.getOperationId(), event.getOperationId());
+        assertEquals(createBindUserEvent.getSuffix(), event.getSuffix());
+        assertEquals(createBindUserEvent.getAccountId(), event.getAccountId());
+        assertEquals(createBindUserEvent.getResourceId(), event.getResourceId());
+        verify(stackService).getByEnvironmentCrnAndAccountId(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getAccountId());
+        verify(ldapConfigV1Service).createNewLdapConfig(createBindUserEvent.getEnvironmentCrn(), createBindUserEvent.getSuffix(), stack, true);
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/binduser/BindUserCreateServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/binduser/BindUserCreateServiceTest.java
@@ -1,0 +1,133 @@
+package com.sequenceiq.freeipa.service.binduser;
+
+import static com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent.CREATE_BIND_USER_EVENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.Acceptable;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.binduser.BindUserCreateRequest;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.converter.operation.OperationToOperationStatusConverter;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserEvent;
+import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class BindUserCreateServiceTest {
+
+    private static final Long STACK_ID = 1L;
+
+    private static final String ENV_CRN = "envCrn";
+
+    private static final String ACCOUNT = "accountId";
+
+    @Mock
+    private OperationService operationService;
+
+    @Mock
+    private FreeIpaFlowManager flowManager;
+
+    @Mock
+    private OperationToOperationStatusConverter operationConverter;
+
+    @Mock
+    private StackService stackService;
+
+    @InjectMocks
+    private BindUserCreateService underTest;
+
+    @BeforeEach
+    public void init() {
+        when(stackService.getIdByEnvironmentCrnAndAccountId(ENV_CRN, ACCOUNT)).thenReturn(STACK_ID);
+    }
+
+    @Test
+    public void testCreateStartedFLowNotified() {
+        BindUserCreateRequest request = createRequest();
+        Operation operation = new Operation();
+        operation.setOperationId("op");
+        operation.setStatus(OperationState.RUNNING);
+        when(operationService.startOperation(eq(ACCOUNT), eq(OperationType.BIND_USER_CREATE), anyCollection(), anyCollection())).thenReturn(operation);
+        OperationStatus operationStatus = new OperationStatus();
+        when(operationConverter.convert(operation)).thenReturn(operationStatus);
+
+        OperationStatus response = underTest.createBindUser(ACCOUNT, request);
+
+        assertEquals(operationStatus, response);
+        ArgumentCaptor<Acceptable> captor = ArgumentCaptor.forClass(Acceptable.class);
+        verify(flowManager).notify(eq(CREATE_BIND_USER_EVENT.event()), captor.capture());
+        Acceptable event = captor.getValue();
+        assertTrue(event instanceof CreateBindUserEvent);
+        CreateBindUserEvent bindUserEvent = (CreateBindUserEvent) event;
+        assertEquals(CREATE_BIND_USER_EVENT.event(), bindUserEvent.selector());
+        assertEquals(STACK_ID, bindUserEvent.getResourceId());
+        assertEquals(ACCOUNT, bindUserEvent.getAccountId());
+        assertEquals(operation.getOperationId(), bindUserEvent.getOperationId());
+        assertEquals(request.getEnvironmentCrn(), bindUserEvent.getEnvironmentCrn());
+        assertEquals(request.getBindUserNameSuffix(), bindUserEvent.getSuffix());
+    }
+
+    @Test
+    public void testOperationRejected() {
+        BindUserCreateRequest request = createRequest();
+        Operation operation = new Operation();
+        operation.setOperationId("op");
+        operation.setStatus(OperationState.REJECTED);
+        when(operationService.startOperation(eq(ACCOUNT), eq(OperationType.BIND_USER_CREATE), anyCollection(), anyCollection())).thenReturn(operation);
+        OperationStatus operationStatus = new OperationStatus();
+        when(operationConverter.convert(operation)).thenReturn(operationStatus);
+
+        OperationStatus response = underTest.createBindUser(ACCOUNT, request);
+
+        assertEquals(operationStatus, response);
+        verifyNoInteractions(flowManager);
+    }
+
+    @Test
+    public void testFlowRejected() {
+        BindUserCreateRequest request = createRequest();
+        Operation operation = new Operation();
+        operation.setOperationId("op");
+        operation.setStatus(OperationState.RUNNING);
+        Operation failedOperation = new Operation();
+        failedOperation.setOperationId("op");
+        failedOperation.setStatus(OperationState.FAILED);
+        when(operationService.startOperation(eq(ACCOUNT), eq(OperationType.BIND_USER_CREATE), anyCollection(), anyCollection())).thenReturn(operation);
+        when(operationService.failOperation(ACCOUNT, operation.getOperationId(), "Couldn't start create bind user flow: Flow failure"))
+                .thenReturn(failedOperation);
+        OperationStatus failedOperationStatus = new OperationStatus();
+        failedOperationStatus.setStatus(OperationState.FAILED);
+        when(operationConverter.convert(failedOperation)).thenReturn(failedOperationStatus);
+        when(flowManager.notify(anyString(), any(Acceptable.class))).thenThrow(new RuntimeException("Flow failure"));
+
+        OperationStatus response = underTest.createBindUser(ACCOUNT, request);
+
+        assertEquals(failedOperationStatus, response);
+    }
+
+    private BindUserCreateRequest createRequest() {
+        BindUserCreateRequest request = new BindUserCreateRequest();
+        request.setEnvironmentCrn(ENV_CRN);
+        request.setBindUserNameSuffix("suffix");
+        return request;
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/AllocateDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/AllocateDatabaseServerHandler.java
@@ -28,6 +28,7 @@ import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.service.OperationException;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate.AllocateDatabaseServerFailed;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate.AllocateDatabaseServerRequest;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.allocate.AllocateDatabaseServerSuccess;

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/UpdateDatabaseServerRegistrationHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/handler/UpdateDatabaseServerRegistrationHandler.java
@@ -17,6 +17,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.common.api.type.ResourceType;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.redbeams.provision.event.register.UpdateDatabaseServerRegistrationFailed;

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/DeregisterDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/DeregisterDatabaseServerHandler.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.flow.redbeams.termination.event.deregister.DeregisterDatabaseServerFailed;
 import com.sequenceiq.redbeams.flow.redbeams.termination.event.deregister.DeregisterDatabaseServerRequest;
@@ -42,7 +43,7 @@ public class DeregisterDatabaseServerHandler extends ExceptionCatcherEventHandle
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<DeregisterDatabaseServerRequest> event) {
         DeregisterDatabaseServerRequest request = event.getData();
         Selectable response = new DeregisterDatabaseServerSuccess(request.getResourceId());
 

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/TerminateDatabaseServerHandler.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/termination/handler/TerminateDatabaseServerHandler.java
@@ -26,6 +26,7 @@ import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
 import com.sequenceiq.redbeams.flow.redbeams.termination.event.terminate.TerminateDatabaseServerFailed;
 import com.sequenceiq.redbeams.flow.redbeams.termination.event.terminate.TerminateDatabaseServerRequest;
 import com.sequenceiq.redbeams.flow.redbeams.termination.event.terminate.TerminateDatabaseServerSuccess;
@@ -69,7 +70,7 @@ public class TerminateDatabaseServerHandler extends ExceptionCatcherEventHandler
     }
 
     @Override
-    protected Selectable doAccept(HandlerEvent event) {
+    protected Selectable doAccept(HandlerEvent<TerminateDatabaseServerRequest> event) {
         LOGGER.debug("Received event: {}", event);
         TerminateDatabaseServerRequest request = event.getData();
         CloudContext cloudContext = request.getCloudContext();


### PR DESCRIPTION
A new flow and endpoint introduced to create bind users used by clusters.
In this implentation if the bind user already exists on the FreeIPA we will replace it's password, while in the old implementation
this case resulted in an exception.
Requests are rejected using operation to ensure only one flow is running per cluster.
If the configs already exists the flow/operation is still started, but would finish faster as no connection to FreeIPA is necessary.
The status of the flow can be tracked by polling the operation status. Operation would be rejected if there is already a running operation
in the same environment for the same cluster. If the flow can't be started the operation will have failed state.
If the flow fails the operation will have failed state also.

See detailed description in the commit message.