### PR TITLE
CB-11987 - Appending the profile and topologies query parameters into the Token Integration URL

### DIFF
--- a/core-api/src/main/resources/definitions/exposed-services.json
+++ b/core-api/src/main/resources/definitions/exposed-services.json
@@ -645,7 +645,7 @@
       "displayName": "Token Integration",
       "serviceName": "KNOX",
       "knoxService": "KNOX_TOKEN_INTEGRATOR",
-      "knoxUrl": "/homepage/home",
+      "knoxUrl": "/homepage/home?profile=token&topologies=cdp-proxy-token",
       "ssoSupported": true,
       "apiOnly": false,
       "apiIncluded": false,


### PR DESCRIPTION
The Knox team introduced a very useful usability improvement on the Knox side to display certain elements only in the `General Proxy Information` section on the `Knox Home` page  (using pre-defined profile names) as well as we added the ability to filter topologies we display. To be able to do it on the client-side (i.e. without any server-side config), this can be achieved by adding the appropriate query parameter in the homepage's URL: `https://host:port/gateway_path/homepage/home?profile=token&topologies=cdp-proxy-token`

In this change, I added the missing query parameters into the previously created `Token Integration` link.