### PR TITLE
CB-11981: Fixed YCloud datalake creation NPE due to not checking if stack network is null.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -628,7 +628,9 @@ public class ClusterHostServiceRunner {
         }
         serviceLocations.put(exposedServiceCollector.getClouderaManagerService().getServiceName(), asList(gatewayConfig.getHostname()));
         gateway.put("location", serviceLocations);
-        gateway.put("cidrBlocks", stack.getNetwork().getNetworkCidrs());
+        if (stack.getNetwork() != null) {
+            gateway.put("cidrBlocks", stack.getNetwork().getNetworkCidrs());
+        }
         servicePillar.put("gateway", new SaltPillarProperties("/gateway/init.sls", singletonMap("gateway", gateway)));
     }
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-11981

Simply added check to ensure network is not null before trying to access the internal CIDRs.