### PR TITLE
DISTX-604 For AWS DE HA from 7.2.9 make CM run in a two node GATEWAY …

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/dataengineering-ha.json
@@ -2,7 +2,7 @@
   "name": "7.2.10 - Data Engineering HA for AWS",
   "description": "",
   "type": "DATAENGINEERING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "AWS",
   "distroXTemplate": {
     "cluster": {
@@ -13,7 +13,7 @@
     },
     "enableLoadBalancer": true,
     "instanceGroups": [{
-      "nodeCount": 1,
+      "nodeCount": 2,
       "name": "manager",
       "type": "GATEWAY",
       "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/dataengineering-ha.json
@@ -2,7 +2,7 @@
   "name": "7.2.9 - Data Engineering HA for AWS",
   "description": "",
   "type": "DATAENGINEERING",
-  "featureState": "PREVIEW",
+  "featureState": "RELEASED",
   "cloudPlatform": "AWS",
   "distroXTemplate": {
     "cluster": {
@@ -13,7 +13,7 @@
     },
     "enableLoadBalancer": true,
     "instanceGroups": [{
-      "nodeCount": 1,
+      "nodeCount": 2,
       "name": "manager",
       "type": "GATEWAY",
       "recoveryMode": "MANUAL",


### PR DESCRIPTION
…group

1. If this change is not done, then UI will not be HA.
2. The alternative fix for this is to run/configure nginx in non GATEWAY groups which is highly risky given past experience with CB-10699
3. This change is not done for Azure and GCP because there is no load-balancer support for it yet.
4. Later will be making this change in 2.41 branch because there may not be another cloudbreak release before 7.2.9 launch. We need to change the template shape before a first cluster with that version is launched in production. Also we want to call out this feature as GA.