### PR TITLE
CB-11992:  Add zookeeper service to Datamart templates for 7.2.9 and …

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-mart.bp
@@ -21,6 +21,23 @@
         ]
       },
       {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [
+          {
+            "name": "service_config_suppression_server_count_validator",
+            "value": "true"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
         "refName": "hue",
         "serviceType": "HUE",
         "roleConfigGroups": [
@@ -94,6 +111,7 @@
         "roleConfigGroupsRefNames": [
           "core_settings-GATEWAY-BASE",
           "core_settings-STORAGEOPERATIONS-BASE",
+          "zookeeper-SERVER-BASE",
           "hue-HUE_LOAD_BALANCER-BASE",
           "hue-HUE_SERVER-BASE",
           "impala-CATALOGSERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-mart.bp
@@ -21,6 +21,23 @@
         ]
       },
       {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [
+          {
+            "name": "service_config_suppression_server_count_validator",
+            "value": "true"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
         "refName": "hue",
         "serviceType": "HUE",
         "roleConfigGroups": [
@@ -94,6 +111,7 @@
         "roleConfigGroupsRefNames": [
           "core_settings-GATEWAY-BASE",
           "core_settings-STORAGEOPERATIONS-BASE",
+          "zookeeper-SERVER-BASE",
           "hue-HUE_LOAD_BALANCER-BASE",
           "hue-HUE_SERVER-BASE",
           "impala-CATALOGSERVER-BASE",


### PR DESCRIPTION
CB-11992:  Add zookeeper service to Datamart templates for 7.2.9 and later

    Add instance of zookeeper service as required by Knox

See https://jira.cloudera.com/browse/OPSAPS-60160 for additional background