### PR TITLE
CB-11802 Rollback of failed upscale resources due to AWS quota limit fails when there is activity still in progress on the auto scaling group

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/mapper/SdkClientExceptionMapper.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/mapper/SdkClientExceptionMapper.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
+import com.amazonaws.services.autoscaling.model.ScalingActivityInProgressException;
 import com.sequenceiq.cloudbreak.cloud.aws.util.AwsEncodedAuthorizationFailureMessageDecoder;
 import com.sequenceiq.cloudbreak.cloud.aws.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
@@ -26,6 +27,11 @@ public class SdkClientExceptionMapper {
             return new CloudConnectorException(message, e);
         }
         if (message.contains("Rate exceeded") || message.contains("Request limit exceeded")) {
+            message = addMethodNameIfNotContains(message, methodName);
+            return new ActionFailedException(message);
+        }
+
+        if (e instanceof ScalingActivityInProgressException) {
             message = addMethodNameIfNotContains(message, methodName);
             return new ActionFailedException(message);
         }


### PR DESCRIPTION
See detailed description in the commit message.