### PR TITLE
CB-11514 DFX to use redbeams to create databaseServers

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/Crn.java
@@ -171,7 +171,8 @@ public class Crn {
         DE("de", NON_ADMIN_SERVICE),
         ACCOUNTTAG("accounttag", NON_ADMIN_SERVICE),
         ACCOUNTTELEMETRY("accounttelemetry", NON_ADMIN_SERVICE),
-        ML("ml", NON_ADMIN_SERVICE);
+        ML("ml", NON_ADMIN_SERVICE),
+        DF("df", NON_ADMIN_SERVICE);
 
         private static final ImmutableMap<String, Service> FROM_STRING;
 
@@ -331,7 +332,8 @@ public class Crn {
         ACCOUNT_TAG("accountTag"),
         ACCOUNT_TELEMETRY("accountTelemetry"),
         DATAHUB_AUTOSCALE_CONFIG("datahubAutoscaleConfig"),
-        PROXY_CONIFG("proxyConfig");
+        PROXY_CONIFG("proxyConfig"),
+        SERVICE("service");
 
         private static final ImmutableMap<String, ResourceType> FROM_STRING;
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/CrnResourceDescriptor.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/auth/altus/CrnResourceDescriptor.java
@@ -34,7 +34,10 @@ public enum CrnResourceDescriptor {
     // datalake service
     DATALAKE(Crn.ResourceType.DATALAKE, Crn.Service.DATALAKE),
     // periscope (autoscale) service
-    ALERT(Crn.ResourceType.DATAHUB_AUTOSCALE_CONFIG, Crn.Service.AUTOSCALE);
+    ALERT(Crn.ResourceType.DATAHUB_AUTOSCALE_CONFIG, Crn.Service.AUTOSCALE),
+    // DFX service
+    DFX_INTERIM(Crn.ResourceType.ENVIRONMENT, Crn.Service.DF),
+    DFX(Crn.ResourceType.SERVICE, Crn.Service.DF);
 
     private Crn.ResourceType resourceType;
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/validation/AbstractCrnValidator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/validation/AbstractCrnValidator.java
@@ -15,9 +15,12 @@ public abstract class AbstractCrnValidator<T> implements ConstraintValidator<Val
 
     private CrnResourceDescriptor[] resourceDescriptors;
 
+    private ValidCrn.Effect effect;
+
     @Override
     public void initialize(ValidCrn constraintAnnotation) {
         resourceDescriptors = constraintAnnotation.resource();
+        effect = constraintAnnotation.effect();
     }
 
     @Override
@@ -31,11 +34,11 @@ public abstract class AbstractCrnValidator<T> implements ConstraintValidator<Val
             addValidationErrorMessage(errorMessage, constraintValidatorContext);
             return false;
         }
-        if (resourceDescriptors.length != 0 && crnInputHasInvalidServiceOrResourceType(req)) {
+        if (resourceDescriptors.length != 0 && crnInputHasInvalidServiceOrResourceType(req, effect)) {
             Set<Pair> serviceAndResourceTypePairs = Arrays.stream(resourceDescriptors)
                     .map(CrnResourceDescriptor::createServiceAndResourceTypePair)
                     .collect(Collectors.toSet());
-            String errorMessage = getErrorMessageIfServiceOrResourceTypeInvalid(req, serviceAndResourceTypePairs);
+            String errorMessage = getErrorMessageIfServiceOrResourceTypeInvalid(req, serviceAndResourceTypePairs, effect);
             addValidationErrorMessage(errorMessage, constraintValidatorContext);
             return false;
         }
@@ -46,9 +49,13 @@ public abstract class AbstractCrnValidator<T> implements ConstraintValidator<Val
         return resourceDescriptors;
     }
 
-    protected abstract String getErrorMessageIfServiceOrResourceTypeInvalid(T req, Set<Pair> serviceAndResourceTypePairs);
+    public ValidCrn.Effect getEffect() {
+        return effect;
+    }
 
-    protected abstract boolean crnInputHasInvalidServiceOrResourceType(T req);
+    protected abstract String getErrorMessageIfServiceOrResourceTypeInvalid(T req, Set<Pair> serviceAndResourceTypePairs, ValidCrn.Effect effect);
+
+    protected abstract boolean crnInputHasInvalidServiceOrResourceType(T req, ValidCrn.Effect effect);
 
     protected abstract String getInvalidCrnErrorMessage(T req);
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/validation/ValidCrn.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/validation/ValidCrn.java
@@ -17,7 +17,7 @@ import javax.validation.Payload;
 import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
 
 @Documented
-@Constraint(validatedBy = { CrnValidator.class, CrnCollectionValidator.class })
+@Constraint(validatedBy = { CrnValidator.class, CrnCollectionValidator.class})
 @Target({ METHOD, FIELD, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidCrn {
@@ -26,7 +26,24 @@ public @interface ValidCrn {
 
     CrnResourceDescriptor[] resource();
 
+    Effect effect() default Effect.ACCEPT;
+
     Class<?>[] groups() default {};
 
     Class<? extends Payload>[] payload() default {};
+
+    enum Effect {
+        ACCEPT("Accepted"),
+        DENY("Denied");
+
+        private String name;
+
+        Effect(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/validation/CrnValidatorTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/validation/CrnValidatorTest.java
@@ -7,18 +7,23 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 
 import java.lang.annotation.Annotation;
+import java.util.Set;
 
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.Payload;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.google.common.base.Joiner;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
 
@@ -57,14 +62,27 @@ public class CrnValidatorTest {
 
     @Test
     public void testValidationIfDescriptorsIsEmpty() {
-        underTest.initialize(sampleAnnotation(new CrnResourceDescriptor[]{}));
+        underTest.initialize(sampleAnnotation(new CrnResourceDescriptor[]{}, ValidCrn.Effect.ACCEPT));
         assertTrue(underTest.isValid(MIXED_CRN, context));
     }
 
+    @ParameterizedTest
+    @EnumSource(ValidCrn.Effect.class)
+    public void testGetErrorMessageIfServiceOrResourceTypeInvalid(ValidCrn.Effect effect) {
+
+        Set<Pair> serviceAndResourceTypePairs = Set.of(Pair.of("myService", "myResource"));
+        String message = underTest.getErrorMessageIfServiceOrResourceTypeInvalid("myCrn", serviceAndResourceTypePairs, effect);
+
+        String expectedMessage = String.format("Crn provided: myCrn has invalid resource type or service type. %s service type / resource type pairs: %s",
+                effect.getName(), Joiner.on(",").join(serviceAndResourceTypePairs));
+        assertEquals(expectedMessage, message);
+    }
+
     @Test
-    public void testValidationIfDescriptorProvidedButCrnDoesntMatch() {
+    public void testValidationIfDescriptorProvidedButCrnDoesntMatchWhenEffectAccept() {
         setupContext();
-        underTest.initialize(sampleAnnotation(new CrnResourceDescriptor[]{ CrnResourceDescriptor.ENVIRONMENT, CrnResourceDescriptor.DATALAKE }));
+        underTest.initialize(
+                sampleAnnotation(new CrnResourceDescriptor[]{ CrnResourceDescriptor.ENVIRONMENT, CrnResourceDescriptor.DATALAKE }, ValidCrn.Effect.ACCEPT));
         assertFalse(underTest.isValid(MIXED_CRN, context));
         assertEquals("Crn provided: crn:cdp:iam:us-west-1:acc:datalake:res has invalid resource type or service type. " +
                 "Accepted service type / resource type pairs: (datalake,datalake),(environments,environment)", errorMessageCaptor.getValue());
@@ -74,9 +92,27 @@ public class CrnValidatorTest {
     }
 
     @Test
-    public void testValidationIfDescriptorProvidedAndCrnMatches() {
-        underTest.initialize(sampleAnnotation(new CrnResourceDescriptor[]{ CrnResourceDescriptor.ENVIRONMENT, CrnResourceDescriptor.DATALAKE }));
+    public void testValidationIfDescriptorProvidedButCrnMatchesWhenEffectDeny() {
+        setupContext();
+        underTest.initialize(
+                sampleAnnotation(new CrnResourceDescriptor[]{ CrnResourceDescriptor.ENVIRONMENT, CrnResourceDescriptor.DATALAKE }, ValidCrn.Effect.DENY));
+        assertFalse(underTest.isValid(ENVIRONMENT_CRN, context));
+        assertEquals("Crn provided: crn:cdp:environments:us-west-1:acc:environment:res has invalid resource type or service type. Denied service type" +
+                " / resource type pairs: (datalake,datalake),(environments,environment)", errorMessageCaptor.getValue());
+    }
+
+    @Test
+    public void testValidationIfDescriptorProvidedAndCrnMatchesWhenEffectAccept() {
+        underTest.initialize(
+                sampleAnnotation(new CrnResourceDescriptor[]{ CrnResourceDescriptor.ENVIRONMENT, CrnResourceDescriptor.DATALAKE }, ValidCrn.Effect.ACCEPT));
         assertTrue(underTest.isValid(ENVIRONMENT_CRN, context));
+    }
+
+    @Test
+    public void testValidationIfDescriptorProvidedAndCrnMatchesWhenEffectDeny() {
+        underTest.initialize(
+                sampleAnnotation(new CrnResourceDescriptor[]{ CrnResourceDescriptor.ENVIRONMENT, CrnResourceDescriptor.DATALAKE }, ValidCrn.Effect.DENY));
+        assertTrue(underTest.isValid(MIXED_CRN, context));
     }
 
     private void setupContext() {
@@ -85,7 +121,7 @@ public class CrnValidatorTest {
         doReturn(context).when(builder).addConstraintViolation();
     }
 
-    private ValidCrn sampleAnnotation(CrnResourceDescriptor[] descriptors) {
+    private ValidCrn sampleAnnotation(CrnResourceDescriptor[] descriptors, ValidCrn.Effect effect) {
         return new ValidCrn() {
 
             @Override
@@ -101,6 +137,11 @@ public class CrnValidatorTest {
             @Override
             public CrnResourceDescriptor[] resource() {
                 return descriptors;
+            }
+
+            @Override
+            public Effect effect() {
+                return effect;
             }
 
             @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseServerTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/RedbeamsDatabaseServerTest.java
@@ -87,7 +87,7 @@ public class RedbeamsDatabaseServerTest extends AbstractMockTest {
                 .withClusterCrn(Crn.builder(CrnResourceDescriptor.ENVIRONMENT).setAccountId("acc").setResource("res").build().toString())
                 .whenException(redbeamsDatabaseServerTest.createV4(), BadRequestException.class,
                         expectedMessage(".*Crn provided: crn:cdp:environments:us-west-1:acc:environment:res has invalid resource type or" +
-                                " service type. Accepted service type / resource type pairs: [(]datalake,datalake[)],[(]datahub,cluster[)].*"))
+                                " service type. Denied service type / resource type pairs: [(]environments,environment[)].*"))
                 .validate();
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4Request.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/requests/AllocateDatabaseServerV4Request.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests;
 
+import static com.sequenceiq.cloudbreak.validation.ValidCrn.Effect.DENY;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,7 +45,7 @@ public class AllocateDatabaseServerV4Request extends ProviderParametersBase {
     private String environmentCrn;
 
     @NotNull
-    @ValidCrn(resource = { CrnResourceDescriptor.DATALAKE, CrnResourceDescriptor.DATAHUB })
+    @ValidCrn(resource = { CrnResourceDescriptor.ENVIRONMENT }, effect = DENY)
     @ApiModelProperty(value = DatabaseServer.CLUSTER_CRN, required = true)
     private String clusterCrn;
 


### PR DESCRIPTION
When redbeams databaseserver create endpoint is called, a clusterCrn has to be provided. Currently it is allowed to be datalake or datahub only. As a result of that services, that do not posses such CRNs are not allowed to call redbeams.

The present commit allows a databaseServer to be created with any CRN except of an environmentCrn.

See detailed description in the commit message.