### PR TITLE
CB-12078 CB Scaling API that works with internal crns

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/controller/AutoScaleClusterCommonService.java
@@ -152,7 +152,7 @@ public class AutoScaleClusterCommonService  implements ResourcePropertyProvider 
     protected Cluster getClusterByCrnOrName(NameOrCrn nameOrCrn) {
         return nameOrCrn.hasName() ?
                 clusterService.findOneByStackNameAndTenant(nameOrCrn.getName(), restRequestThreadLocalService.getCloudbreakTenant())
-                        .orElseGet(() -> syncCBClusterByName(nameOrCrn.getName())) :
+                        .orElseGet(() -> syncCBClusterByName(nameOrCrn.getName(), restRequestThreadLocalService.getCloudbreakTenant())) :
                 clusterService.findOneByStackCrnAndTenant(nameOrCrn.getCrn(), restRequestThreadLocalService.getCloudbreakTenant())
                         .orElseGet(() -> syncCBClusterByCrn(nameOrCrn.getCrn()));
     }
@@ -164,8 +164,8 @@ public class AutoScaleClusterCommonService  implements ResourcePropertyProvider 
                 .orElseThrow(NotFoundException.notFound("cluster", stackCrn));
     }
 
-    protected Cluster syncCBClusterByName(String stackName) {
-        return Optional.ofNullable(cloudbreakCommunicator.getAutoscaleClusterByName(stackName))
+    protected Cluster syncCBClusterByName(String stackName, String accountId) {
+        return Optional.ofNullable(cloudbreakCommunicator.getAutoscaleClusterByName(stackName, accountId))
                 .filter(stack -> WORKLOAD.equals(stack.getStackType()))
                 .map(stack -> clusterService.create(stack))
                 .orElseThrow(NotFoundException.notFound("cluster", stackName));

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
@@ -36,13 +36,13 @@ public class CloudbreakCommunicator {
     }
 
     public AutoscaleStackV4Response getAutoscaleClusterByCrn(String stackCrn) {
-        return cloudbreakInternalCrnClient.withUserCrn(restRequestThreadLocalService.getCloudbreakUser().getUserCrn())
+        return cloudbreakInternalCrnClient.withInternalCrn()
                 .autoscaleEndpoint().getAutoscaleClusterByCrn(stackCrn);
     }
 
-    public AutoscaleStackV4Response getAutoscaleClusterByName(String stackName) {
-        return cloudbreakInternalCrnClient.withUserCrn(restRequestThreadLocalService.getCloudbreakUser().getUserCrn())
-                .autoscaleEndpoint().getAutoscaleClusterByName(stackName);
+    public AutoscaleStackV4Response getAutoscaleClusterByName(String stackName, String accountId) {
+        return cloudbreakInternalCrnClient.withInternalCrn()
+                .autoscaleEndpoint().getInternalAutoscaleClusterByName(stackName, accountId);
     }
 
     public AutoscaleRecommendationV4Response getRecommendationForCluster(String stackCrn) {
@@ -55,7 +55,7 @@ public class CloudbreakCommunicator {
 
     public void decommissionInstancesForCluster(Cluster cluster, List<String> decommissionNodeIds) {
         requestLogging.logResponseTime(() -> {
-            cloudbreakInternalCrnClient.withUserCrn(cluster.getClusterPertain().getUserCrn()).autoscaleEndpoint()
+            cloudbreakInternalCrnClient.withInternalCrn().autoscaleEndpoint()
                     .decommissionInstancesForClusterCrn(cluster.getStackCrn(),
                             cluster.getClusterPertain().getWorkspaceId(),
                             decommissionNodeIds, false);

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingRequest.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingRequest.java
@@ -121,7 +121,7 @@ public class ScalingRequest implements Runnable {
             instanceGroupAdjustmentJson.setInstanceGroup(hostGroup);
             updateStackJson.setInstanceGroupAdjustment(instanceGroupAdjustmentJson);
 
-            cloudbreakCrnClient.withUserCrn(userCrn).autoscaleEndpoint().putStack(stackCrn, cluster.getClusterPertain().getUserId(), updateStackJson);
+            cloudbreakCrnClient.withInternalCrn().autoscaleEndpoint().putStack(stackCrn, cluster.getClusterPertain().getUserId(), updateStackJson);
             scalingStatus = ScalingStatus.SUCCESS;
             statusReason =  getMessageForCBStatus(ScalingStatus.SUCCESS.name());
             metricService.incrementMetricCounter(MetricType.CLUSTER_UPSCALE_SUCCESSFUL);
@@ -153,7 +153,7 @@ public class ScalingRequest implements Runnable {
             hostGroupAdjustmentJson.setHostGroup(hostGroup);
             hostGroupAdjustmentJson.setValidateNodeCount(false);
             updateClusterJson.setHostGroupAdjustment(hostGroupAdjustmentJson);
-            cloudbreakCrnClient.withUserCrn(userCrn).autoscaleEndpoint()
+            cloudbreakCrnClient.withInternalCrn().autoscaleEndpoint()
                     .putCluster(stackCrn, cluster.getClusterPertain().getUserId(), updateClusterJson);
             scalingStatus = ScalingStatus.SUCCESS;
             statusReason =  getMessageForCBStatus(ScalingStatus.SUCCESS.name());

--- a/autoscale/src/test/java/com/sequenceiq/periscope/controller/AutoscaleClusterCommonServiceTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/controller/AutoscaleClusterCommonServiceTest.java
@@ -66,7 +66,7 @@ public class AutoscaleClusterCommonServiceTest {
         when(clusterService.findOneByStackNameAndTenant(TEST_CLUSTER_NAME, tenant)).thenReturn(getACluster());
 
         underTest.getClusterByCrnOrName(NameOrCrn.ofName(TEST_CLUSTER_NAME));
-        verify(cloudbreakCommunicator, never()).getAutoscaleClusterByName(TEST_CLUSTER_NAME);
+        verify(cloudbreakCommunicator, never()).getAutoscaleClusterByName(TEST_CLUSTER_NAME, tenant);
         verify(clusterService, never()).create(any(AutoscaleStackV4Response.class));
     }
 
@@ -87,7 +87,7 @@ public class AutoscaleClusterCommonServiceTest {
     public void testGetClusterByNameWhenNotPresentInDBThenCBSyncByName() {
         AutoscaleStackV4Response autoscaleStackV4Response = mock(AutoscaleStackV4Response.class);
         when(clusterService.findOneByStackNameAndTenant(TEST_CLUSTER_NAME, tenant)).thenReturn(Optional.empty());
-        when(cloudbreakCommunicator.getAutoscaleClusterByName(TEST_CLUSTER_NAME)).thenReturn(autoscaleStackV4Response);
+        when(cloudbreakCommunicator.getAutoscaleClusterByName(TEST_CLUSTER_NAME, tenant)).thenReturn(autoscaleStackV4Response);
         when(autoscaleStackV4Response.getStackType()).thenReturn(StackType.WORKLOAD);
         when(clusterService.create(autoscaleStackV4Response)).thenReturn(getACluster().get());
 
@@ -99,7 +99,7 @@ public class AutoscaleClusterCommonServiceTest {
     @Test(expected = NotFoundException.class)
     public void testGetClusterByNameWhenNotFound() {
         when(clusterService.findOneByStackNameAndTenant(TEST_CLUSTER_NAME, tenant)).thenReturn(Optional.empty());
-        when(cloudbreakCommunicator.getAutoscaleClusterByName(TEST_CLUSTER_NAME)).thenThrow(NotFoundException.class);
+        when(cloudbreakCommunicator.getAutoscaleClusterByName(TEST_CLUSTER_NAME, tenant)).thenThrow(NotFoundException.class);
 
         underTest.getClusterByCrnOrName(NameOrCrn.ofName(TEST_CLUSTER_NAME));
     }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
@@ -27,6 +27,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.UpdateClusterV4R
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.doc.ControllerDescription;
 import com.sequenceiq.cloudbreak.doc.Notes;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription;
@@ -73,6 +74,13 @@ public interface AutoscaleV4Endpoint {
     @ApiOperation(value = StackOpDescription.GET_AUTOSCALE_BY_NAME, produces = APPLICATION_JSON,
             notes = Notes.STACK_NOTES, nickname = "getAutoscaleClusterByName")
     AutoscaleStackV4Response getAutoscaleClusterByName(@PathParam("name") String name);
+
+    @GET
+    @Path("/autoscale_cluster/name/{name}/internal")
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = StackOpDescription.GET_INTERNAL_AUTOSCALE_BY_NAME, produces = APPLICATION_JSON,
+            notes = Notes.STACK_NOTES, nickname = "getInternalAutoscaleClusterByName")
+    AutoscaleStackV4Response getInternalAutoscaleClusterByName(@PathParam("name") String name, @AccountId @QueryParam("accountId") String accountId);
 
     @GET
     @Path("/stack/crn/{crn}")

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakInternalCrnClient.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakInternalCrnClient.java
@@ -16,8 +16,4 @@ public class CloudbreakInternalCrnClient {
     public CloudbreakServiceCrnEndpoints withInternalCrn() {
         return client.withCrn(internalCrnBuilder.getInternalCrnForServiceAsString());
     }
-
-    public CloudbreakServiceCrnEndpoints withUserCrn(String userCrn) {
-        return client.withCrn(userCrn);
-    }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -20,10 +20,12 @@ public class OperationDescriptions {
         public static final String PUT_BY_NAME = "update stack by name";
         public static final String GET_STACK_CERT = "retrieves the TLS certificate used by the gateway";
         public static final String GET_ALL = "retrieve all stacks";
+        public static final String GET_ALL_INTERNAL = "retrieve all stacks internally";
         public static final String LIST_BY_WORKSPACE = "list stacks for the given workspace and environment name";
         public static final String GET_BY_NAME_IN_WORKSPACE = "get stack by name in workspace";
         public static final String GET_BY_CRN_IN_WORKSPACE = "get stack by crn in workspace";
         public static final String GET_AUTOSCALE_BY_NAME = "get autoscale stack by name in workspace";
+        public static final String GET_INTERNAL_AUTOSCALE_BY_NAME = "get internal autoscale stack by name in workspace";
         public static final String GET_AUTOSCALE_BY_CRN = "get autoscale stack by crn in workspace";
         public static final String CREATE_IN_WORKSPACE = "create stack in workspace";
         public static final String CREATE_IN_WORKSPACE_INTERNAL = "create stack in workspace, internal only";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackApiViewService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackApiViewService.java
@@ -13,7 +13,6 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
@@ -124,7 +123,6 @@ public class StackApiViewService {
         ));
     }
 
-    @PreAuthorize("hasRole('INTERNAL')")
     public StackApiView retrieveStackByCrnAndType(String crn, StackType stackType) {
         return stackApiViewRepository.findByResourceCrnAndStackType(crn, stackType).orElseThrow(notFound("Stack", crn));
     }


### PR DESCRIPTION
- all "internal call compatible" CB autoscale API now can be called by internal actor (TenantAwareParam annotation added to crn parameters)
- all "internal call non-compatible" API, which has old PreAuthorize annotation, got relevant authorization annotation (typically name based methods, those are not used usually by periscope anyway)
- all "internal call non-compatible" API, which has old PreAuthorize annotation, got an equivalent internal API, using accountId queryparam
- all CB autoscale APIs will be called by Periscope with internal actor
- PreAuthorize annotations removed from periscope related APIs