### PR TITLE
CB-11996 Support Runtime upgrade without OS upgrade (image swap) for all DH clusters

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
@@ -21,7 +21,7 @@ import com.sequenceiq.cloudbreak.service.parcel.ParcelService;
 import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterParams;
 
 @Component
-class ImageFilterParamsFactory {
+public class ImageFilterParamsFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ImageFilterParamsFactory.class);
 
@@ -31,11 +31,11 @@ class ImageFilterParamsFactory {
     @Inject
     private ClouderaManagerProductsProvider clouderaManagerProductsProvider;
 
-    ImageFilterParams create(Image image, boolean lockComponents, Stack stack) {
+    public ImageFilterParams create(Image image, boolean lockComponents, Stack stack) {
         return new ImageFilterParams(image, lockComponents, getStackRelatedParcels(stack), stack.getType(), getBlueprint(stack));
     }
 
-    private Map<String, String> getStackRelatedParcels(Stack stack) {
+    public Map<String, String> getStackRelatedParcels(Stack stack) {
         Set<ClusterComponent> componentsByBlueprint = parcelService.getParcelComponentsByBlueprint(stack);
         if (stack.isDatalake()) {
             ClouderaManagerProduct stackProduct = getCdhProduct(componentsByBlueprint);


### PR DESCRIPTION
CB-11996 Support Runtime upgrade without OS upgrade (image swap) for all DH clusters

* In case of distrox runtime upgrade the replaceVms parameter in the request will be overridden to false.
  This means that the vm replacement will be always skipped in case of distrox runtime upgrade.
* In case of distrox os upgrade the replaceVms parameter won't be changed,
  so the vm replacement can be controllable via this parameter.
