### PR TITLE
CB-12101 Environment API: Add encryptionKeyResourceGroupName for Azure

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -102,7 +102,8 @@ public class EnvironmentModelDescription {
     public static final String RESOURCE_GROUP_USAGE = "Resource group usage: single resource group for all resources where possible "
             + "or use multiple resource groups.";
 
-    public static final String ENCRYPTION_KEY_URL = "URL of the CustomerManagedkey to encrypt Azure resources";
+    public static final String ENCRYPTION_KEY_URL = "URL of the Customer Managed Key to encrypt Azure resources";
+    public static final String ENCRYPTION_KEY_RESOURCE_GROUP_NAME = "Name of the Azure resource group of the Customer Managed Key to encrypt Azure resources";
     public static final String DISK_ENCRYPTION_SET_ID = "Resource Id of the disk encryption set used to encrypt Azure disks.";
     public static final String RESOURCE_ENCRYPTION_PARAMETERS = "Parameter 'encryptionKeyUrl' - to encrypt Azure resources.";
     public static final String PARENT_ENVIRONMENT_CRN = "Parent environment global identifier";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureResourceEncryptionParameters.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureResourceEncryptionParameters.java
@@ -2,6 +2,7 @@ package com.sequenceiq.environment.api.v1.environment.model.request.azure;
 
 import javax.validation.constraints.Pattern;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
 
 import io.swagger.annotations.ApiModel;
@@ -10,12 +11,22 @@ import io.swagger.annotations.ApiModelProperty;
 @ApiModel(value = "AzureResourceEncryptionV1Parameters")
 public class AzureResourceEncryptionParameters {
 
+    @VisibleForTesting
+    static final String ENCRYPTION_KEY_URL_INVALID_MSG = "It should be of format 'https://<vaultName><dnsSuffix>/keys/<keyName>/<keyVersion>'. " +
+            "<vaultName> may only contain alphanumeric characters and dashes. " +
+            "<dnsSuffix> shall be either of the following: " +
+            "\".vault.azure.net\", \".vault.azure.cn\", \".vault.usgovcloudapi.net\", \".vault.microsoftazure.de\". " +
+            "<keyName> may only contain alphanumeric characters and dashes. " +
+            "<keyVersion> may only contain alphanumeric characters.";
+
     @ApiModelProperty(EnvironmentModelDescription.ENCRYPTION_KEY_URL)
-    @Pattern(regexp = "^https:\\/\\/[a-zA-Z-][0-9a-zA-Z-]*\\.vault\\.azure\\.net\\/keys\\/[0-9a-zA-Z-]+\\/[0-9A-Za-z]+",
-            message = "It should be of format 'https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>'" +
-                    "keyName can only contain alphanumeric characters and dashes." +
-                    "keyVersion can only contain alphanumeric characters.")
+    @Pattern(regexp =
+            "^https://[a-zA-Z-][0-9a-zA-Z-]*\\.vault\\.(azure\\.net|azure\\.cn|usgovcloudapi\\.net|microsoftazure\\.de)/keys/[0-9a-zA-Z-]+/[0-9A-Za-z]+",
+            message = ENCRYPTION_KEY_URL_INVALID_MSG)
     private String encryptionKeyUrl;
+
+    @ApiModelProperty(EnvironmentModelDescription.ENCRYPTION_KEY_RESOURCE_GROUP_NAME)
+    private String encryptionKeyResourceGroupName;
 
     @ApiModelProperty(EnvironmentModelDescription.DISK_ENCRYPTION_SET_ID)
     private String diskEncryptionSetId;
@@ -26,6 +37,14 @@ public class AzureResourceEncryptionParameters {
 
     public void setEncryptionKeyUrl(String encryptionKeyUrl) {
         this.encryptionKeyUrl = encryptionKeyUrl;
+    }
+
+    public String getEncryptionKeyResourceGroupName() {
+        return encryptionKeyResourceGroupName;
+    }
+
+    public void setEncryptionKeyResourceGroupName(String encryptionKeyResourceGroupName) {
+        this.encryptionKeyResourceGroupName = encryptionKeyResourceGroupName;
     }
 
     public String getDiskEncryptionSetId() {
@@ -43,8 +62,9 @@ public class AzureResourceEncryptionParameters {
     @Override
     public String toString() {
         return "AzureResourceEncryptionParameters{" +
-                "encryptionKeyUrl=" + encryptionKeyUrl +
-                "diskEncryptionSetId=" + diskEncryptionSetId +
+                "encryptionKeyUrl='" + encryptionKeyUrl + '\'' +
+                ", encryptionKeyResourceGroupName='" + encryptionKeyResourceGroupName + '\'' +
+                ", diskEncryptionSetId='" + diskEncryptionSetId + '\'' +
                 '}';
     }
 
@@ -52,10 +72,17 @@ public class AzureResourceEncryptionParameters {
 
         private String encryptionKeyUrl;
 
+        private String encryptionKeyResourceGroupName;
+
         private String diskEncryptionSetId;
 
         public Builder withEncryptionKeyUrl(String encryptionKeyUrl) {
             this.encryptionKeyUrl = encryptionKeyUrl;
+            return this;
+        }
+
+        public Builder withEncryptionKeyResourceGroupName(String encryptionKeyResourceGroupName) {
+            this.encryptionKeyResourceGroupName = encryptionKeyResourceGroupName;
             return this;
         }
 
@@ -67,8 +94,11 @@ public class AzureResourceEncryptionParameters {
         public AzureResourceEncryptionParameters build() {
             AzureResourceEncryptionParameters resourceEncryptionParameters = new AzureResourceEncryptionParameters();
             resourceEncryptionParameters.setEncryptionKeyUrl(encryptionKeyUrl);
+            resourceEncryptionParameters.setEncryptionKeyResourceGroupName(encryptionKeyResourceGroupName);
             resourceEncryptionParameters.setDiskEncryptionSetId(diskEncryptionSetId);
             return resourceEncryptionParameters;
         }
+
     }
+
 }

--- a/environment-api/src/test/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureResourceEncryptionParametersTest.java
+++ b/environment-api/src/test/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/AzureResourceEncryptionParametersTest.java
@@ -1,0 +1,101 @@
+package com.sequenceiq.environment.api.v1.environment.model.request.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+
+import org.hibernate.validator.HibernateValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+class AzureResourceEncryptionParametersTest {
+
+    private static final String ENCRYPTION_KEY_URL = "encryptionKeyUrl";
+
+    private static final String ENCRYPTION_KEY_RESOURCE_GROUP_NAME = "encryptionKeyResourceGroupName";
+
+    private static final String DISK_ENCRYPTION_SET_ID = "diskEncryptionSetId";
+
+    private LocalValidatorFactoryBean localValidatorFactory;
+
+    @BeforeEach
+    void setUp() {
+        localValidatorFactory = new LocalValidatorFactoryBean();
+        localValidatorFactory.setProviderClass(HibernateValidator.class);
+        localValidatorFactory.afterPropertiesSet();
+    }
+
+    @Test
+    void defaultConstructorTest() {
+        AzureResourceEncryptionParameters underTest = new AzureResourceEncryptionParameters();
+        underTest.setEncryptionKeyUrl(ENCRYPTION_KEY_URL);
+        underTest.setEncryptionKeyResourceGroupName(ENCRYPTION_KEY_RESOURCE_GROUP_NAME);
+        underTest.setDiskEncryptionSetId(DISK_ENCRYPTION_SET_ID);
+
+        verifyFields(underTest);
+    }
+
+    private void verifyFields(AzureResourceEncryptionParameters underTest) {
+        assertThat(underTest.getEncryptionKeyUrl()).isEqualTo(ENCRYPTION_KEY_URL);
+        assertThat(underTest.getEncryptionKeyResourceGroupName()).isEqualTo(ENCRYPTION_KEY_RESOURCE_GROUP_NAME);
+        assertThat(underTest.getDiskEncryptionSetId()).isEqualTo(DISK_ENCRYPTION_SET_ID);
+    }
+
+    @Test
+    void builderTest() {
+        AzureResourceEncryptionParameters underTest = AzureResourceEncryptionParameters.builder()
+                .withEncryptionKeyUrl(ENCRYPTION_KEY_URL)
+                .withEncryptionKeyResourceGroupName(ENCRYPTION_KEY_RESOURCE_GROUP_NAME)
+                .withDiskEncryptionSetId(DISK_ENCRYPTION_SET_ID)
+                .build();
+
+        verifyFields(underTest);
+    }
+
+    static Object[][] encryptionKeyUrlValidationTestDataProvider() {
+        return new Object[][]{
+                // testCaseName encryptionKeyUrl expectedValid
+                {"encryptionKeyUrl=null", null, true},
+                {"encryptionKeyUrl=ENCRYPTION_KEY_URL", ENCRYPTION_KEY_URL, false},
+                {"encryptionKeyUrl=https://myVault.foo.bar/keys/myKey/myVersion", "https://myVault.foo.bar/keys/myKey/myVersion", false},
+                {"encryptionKeyUrl=https://myVault.vault.azure.baddomain/keys/myKey/myVersion", "https://myVault.vault.azure.baddomain/keys/myKey/myVersion",
+                        false},
+                {"encryptionKeyUrl=https://0myInvalidVault.vault.azure.net/keys/myKey/myVersion",
+                        "https://0myInvalidVault.vault.azure.net/keys/myKey/myVersion", false},
+                {"encryptionKeyUrl=https://myVault.vault.azure.net/keys/myKey/myVersion", "https://myVault.vault.azure.net/keys/myKey/myVersion", true},
+                {"encryptionKeyUrl=https://myVault.vault.azure.cn/keys/myKey/myVersion", "https://myVault.vault.azure.cn/keys/myKey/myVersion", true},
+                {"encryptionKeyUrl=https://myVault.vault.usgovcloudapi.net/keys/myKey/myVersion",
+                        "https://myVault.vault.usgovcloudapi.net/keys/myKey/myVersion", true},
+                {"encryptionKeyUrl=https://myVault.vault.microsoftazure.de/keys/myKey/myVersion",
+                        "https://myVault.vault.microsoftazure.de/keys/myKey/myVersion", true},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("encryptionKeyUrlValidationTestDataProvider")
+    void encryptionKeyUrlValidationTest(String testCaseName, String encryptionKeyUrl, boolean expectedValid) {
+        AzureResourceEncryptionParameters underTest = AzureResourceEncryptionParameters.builder()
+                .withEncryptionKeyUrl(encryptionKeyUrl)
+                .build();
+
+        Set<ConstraintViolation<AzureResourceEncryptionParameters>> constraintViolations = localValidatorFactory.validate(underTest);
+
+        if (expectedValid) {
+            assertThat(constraintViolations
+                    .stream()
+                    .noneMatch(cv -> AzureResourceEncryptionParameters.ENCRYPTION_KEY_URL_INVALID_MSG.equals(cv.getMessage()))
+            ).isTrue();
+        } else {
+            assertThat(constraintViolations
+                    .stream()
+                    .anyMatch(cv -> AzureResourceEncryptionParameters.ENCRYPTION_KEY_URL_INVALID_MSG.equals(cv.getMessage()))
+            ).isTrue();
+        }
+    }
+
+}


### PR DESCRIPTION
* Add new String field / API property `encryptionKeyResourceGroupName` to `AzureResourceEncryptionParameters`.
* Fix validation pattern & error message for `encryptionKeyUrl`.
* Add UT for validating `encryptionKeyUrl`.

Backend changes (converters, validation, entity) will come in a later PR as part of [CB-12118](https://jira.cloudera.com/browse/CB-12118).

See [this Azure doc page](https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#dns-suffixes-for-base-url) for the allowed DNS suffixes in Key Vault key URLs.