### PR TITLE
CB-11747 External database create flow is not restartable

### DIFF
--- a/authorization-common/src/main/java/com/sequenceiq/authorization/service/ResourceCrnAthorizationFactory.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/service/ResourceCrnAthorizationFactory.java
@@ -19,7 +19,7 @@ import com.sequenceiq.authorization.service.model.HasRight;
 @Component
 public class ResourceCrnAthorizationFactory extends TypedAuthorizationFactory<CheckPermissionByResourceCrn> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RequestPropertyAuthorizationFactory.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResourceCrnAthorizationFactory.class);
 
     @Inject
     private CommonPermissionCheckingUtils commonPermissionCheckingUtils;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsClientServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsClientServiceTest.java
@@ -3,16 +3,23 @@ package com.sequenceiq.cloudbreak.service.rdsconfig;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+
+import java.util.stream.Stream;
 
 import javax.ws.rs.NotFoundException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,9 +31,35 @@ class RedbeamsClientServiceTest {
     @InjectMocks
     private RedbeamsClientService underTest;
 
+    static Stream<Arguments> emptyStringValues() {
+        return Stream.of(
+                Arguments.of("Null string", null),
+                Arguments.of("Empty string", ""),
+                Arguments.of("Blank string", "  ")
+        );
+    }
+
     @Test
     void deleteByCrnNotFoundIsRethrownAsIs() {
         when(redbeamsServerEndpoint.deleteByCrn(any(), anyBoolean())).thenThrow(new NotFoundException("not found"));
         assertThatThrownBy(() -> underTest.deleteByCrn("crn", true)).isExactlyInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    void getByClusterCrnNotFoundIsRethrownAsIs() {
+        when(redbeamsServerEndpoint.getByClusterCrn(anyString(), anyString())).thenThrow(new NotFoundException("not found"));
+        assertThatThrownBy(() -> underTest.getByClusterCrn("crn", "crn2")).isExactlyInstanceOf(NotFoundException.class);
+    }
+
+    @MethodSource("emptyStringValues")
+    @ParameterizedTest(name = "{0}")
+    void getByClusterCrnThrowsIfNullEnvCrn(String testName, String value) {
+        assertThatThrownBy(() -> underTest.getByClusterCrn(value, "crn2")).isExactlyInstanceOf(CloudbreakServiceException.class);
+    }
+
+    @MethodSource("emptyStringValues")
+    @ParameterizedTest(name = "{0}")
+    void getByClusterCrnThrowsIfNullClusterCrn(String testName, String value) {
+        assertThatThrownBy(() -> underTest.getByClusterCrn("crn", value)).isExactlyInstanceOf(CloudbreakServiceException.class);
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.redbeams.api.endpoint.v4.databaseserver;
 
+import static com.sequenceiq.cloudbreak.validation.ValidCrn.Effect.DENY;
+
 import java.util.Set;
 
 import javax.validation.Valid;
@@ -75,6 +77,18 @@ public interface DatabaseServerV4Endpoint {
             @ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @NotNull @ApiParam(value = DatabaseServerParamDescriptions.ENVIRONMENT_CRN, required = true)
             @QueryParam("environmentCrn") String environmentCrn,
             @ApiParam(DatabaseServerParamDescriptions.NAME) @PathParam("name") String name
+    );
+
+    @GET
+    @Path("clusterCrn/{clusterCrn}")
+    @ApiOperation(value = DatabaseServerOpDescription.GET_BY_CLUSTER_CRN,
+            notes = DatabaseServerNotes.GET_BY_CLUSTER_CRN,
+            nickname = "getDatabaseServerByClusterCrn")
+    DatabaseServerV4Response getByClusterCrn(
+            @ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @NotNull @ApiParam(value = DatabaseServerParamDescriptions.ENVIRONMENT_CRN, required = true)
+            @QueryParam("environmentCrn") String environmentCrn,
+            @ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT, effect = DENY)
+            @NotNull @ApiParam(value = DatabaseServerParamDescriptions.CLUSTER_CRN, required = true) @PathParam("clusterCrn") String clusterCrn
     );
 
     @POST

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/Notes.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/Notes.java
@@ -49,6 +49,8 @@ public final class Notes {
             "Gets information on a database server by its name.";
         public static final String GET_BY_CRN =
             "Gets information on a database server by its CRN.";
+        public static final String GET_BY_CLUSTER_CRN =
+                "Gets information on a database server by cluster CRN";
         public static final String CREATE =
             "Creates a new database server. The database server starts out with only default databases.";
         public static final String RELEASE =

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
@@ -24,6 +24,7 @@ public final class OperationDescriptions {
         public static final String LIST = "list database servers";
         public static final String GET_BY_NAME = "get a database server by name";
         public static final String GET_BY_CRN = "get a database server by CRN";
+        public static final String GET_BY_CLUSTER_CRN = "get a database server by cluster CRN";
         public static final String CREATE = "create and register a database server in a cloud provider";
         public static final String CREATE_INTERNAL = "create and register a database server in a cloud provider with internal actor";
         public static final String RELEASE = "release management of a service-managed database server";

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ParamDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/ParamDescriptions.java
@@ -25,6 +25,7 @@ public final class ParamDescriptions {
         public static final String CRNS = "CRNs of the database servers";
         public static final String NAME = "Name of the database server";
         public static final String ENVIRONMENT_CRN = "CRN of the environment of the database server(s)";
+        public static final String CLUSTER_CRN = "CRN of cluster of the database server";
 
         public static final String ALLOCATE_DATABASE_SERVER_REQUEST = ModelDescriptions.ALLOCATE_DATABASE_SERVER_REQUEST;
         public static final String CREATE_DATABASE_REQUEST = ModelDescriptions.CREATE_DATABASE_REQUEST;

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -100,6 +100,13 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
     }
 
     @Override
+    @DisableCheckPermissions
+    public DatabaseServerV4Response getByClusterCrn(@TenantAwareParam String environmentCrn, String clusterCrn) {
+        DatabaseServerConfig server = databaseServerConfigService.getByClusterCrn(environmentCrn, clusterCrn);
+        return converterUtil.convert(server, DatabaseServerV4Response.class);
+    }
+
+    @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.CREATE_DATABASE_SERVER)
     public DatabaseServerStatusV4Response create(AllocateDatabaseServerV4Request request) {
         MDCBuilder.addEnvironmentCrn(request.getEnvironmentCrn());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/repository/DatabaseServerConfigRepository.java
@@ -50,5 +50,5 @@ public interface DatabaseServerConfigRepository extends JpaRepository<DatabaseSe
     @Query("SELECT c.resourceCrn FROM DatabaseServerConfig c WHERE c.name IN (:names)")
     List<Crn> findResourceCrnsByNames(@Param("names") Collection<String> names);
 
-    Optional<DatabaseServerConfig> findByClusterCrn(String clusterCrn);
+    Optional<DatabaseServerConfig> findByEnvironmentIdAndClusterCrn(String environmentId, String clusterCrn);
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigService.java
@@ -220,8 +220,16 @@ public class DatabaseServerConfigService extends AbstractArchivistService<Databa
         return repository.findByResourceCrn(resourceCrn);
     }
 
-    public Optional<DatabaseServerConfig> getByClusterCrn(String clusterCrn) {
-        return repository.findByClusterCrn(clusterCrn);
+    public DatabaseServerConfig getByClusterCrn(String environmentCrn, String clusterCrn) {
+        DatabaseServerConfig databaseServerConfig = findByEnvironmentCrnAndClusterCrn(environmentCrn, clusterCrn)
+                .orElseThrow(() -> new NotFoundException(String.format("No %s found with cluster CRN '%s' in environment '%s'",
+                        DatabaseServerConfig.class.getSimpleName(), clusterCrn, environmentCrn)));
+        MDCBuilder.buildMdcContext(databaseServerConfig);
+        return databaseServerConfig;
+    }
+
+    public Optional<DatabaseServerConfig> findByEnvironmentCrnAndClusterCrn(String environmentCrn, String clusterCrn) {
+        return repository.findByEnvironmentIdAndClusterCrn(environmentCrn, clusterCrn);
     }
 
     public DatabaseServerConfig deleteByCrn(String crn) {

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationService.java
@@ -54,7 +54,8 @@ public class RedbeamsCreationService {
             throw new BadRequestException("A stack for this database server already exists in the environment");
         }
 
-        Optional<DatabaseServerConfig> optionalDBServerConfig = databaseServerConfigService.getByClusterCrn(clusterCrn);
+        Optional<DatabaseServerConfig> optionalDBServerConfig =
+                databaseServerConfigService.findByEnvironmentCrnAndClusterCrn(dbStack.getEnvironmentId(), clusterCrn);
 
         DBStack savedDbStack;
         boolean startFlow = false;

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/dbserverconfig/DatabaseServerConfigServiceTest.java
@@ -80,6 +80,11 @@ public class DatabaseServerConfigServiceTest {
 
     private static final String USER_CRN = "crn:altus:iam:us-west-1:" + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
 
+    private static final Crn CLUSTER_CRN = Crn.builder(CrnResourceDescriptor.DATAHUB)
+            .setAccountId(ACCOUNT_ID)
+            .setResource("resource")
+            .build();
+
     private static final Crn SERVER_CRN = Crn.builder(CrnResourceDescriptor.DATABASE_SERVER)
             .setAccountId(ACCOUNT_ID)
             .setResource("resource")
@@ -425,4 +430,40 @@ public class DatabaseServerConfigServiceTest {
         assertNotEquals(server.getConnectionUserName(), databaseUserName);
         assertEquals(PASSWORD, db.getConnectionPassword().getRaw());
     }
+
+    @Test
+    public void testGetByClusterCrnFound() {
+        when(repository.findByEnvironmentIdAndClusterCrn(anyString(), anyString())).thenReturn(Optional.of(server));
+
+        DatabaseServerConfig foundServer = underTest.getByClusterCrn(ENVIRONMENT_CRN, CLUSTER_CRN.toString());
+
+        assertEquals(server, foundServer);
+    }
+
+    @Test
+    public void testGetByClusterCrnNotFound() {
+        when(repository.findByEnvironmentIdAndClusterCrn(anyString(), anyString())).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> underTest.getByClusterCrn(ENVIRONMENT_CRN, CLUSTER_CRN.toString()));
+    }
+
+    @Test
+    public void testGetByClusterCrnOptionalFound() {
+        when(repository.findByEnvironmentIdAndClusterCrn(anyString(), anyString())).thenReturn(Optional.of(server));
+
+        Optional<DatabaseServerConfig> foundServer = underTest.findByEnvironmentCrnAndClusterCrn(ENVIRONMENT_CRN, CLUSTER_CRN.toString());
+
+        assertTrue(foundServer.isPresent());
+        assertEquals(server, foundServer.get());
+    }
+
+    @Test
+    public void testGetByClusterCrnNotOptionalFound() {
+        when(repository.findByEnvironmentIdAndClusterCrn(anyString(), anyString())).thenReturn(Optional.empty());
+
+        Optional<DatabaseServerConfig> foundServer = underTest.findByEnvironmentCrnAndClusterCrn(ENVIRONMENT_CRN, CLUSTER_CRN.toString());
+
+        assertFalse(foundServer.isPresent());
+    }
+
 }

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationServiceTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/stack/RedbeamsCreationServiceTest.java
@@ -116,7 +116,7 @@ class RedbeamsCreationServiceTest {
         Crn crn = Crn.fromString("crn:cdp:iam:us-west-1:1234:database:2312312");
         when(dbStackService.findByNameAndEnvironmentCrn(DB_STACK_NAME, ENVIRONMENT_CRN)).thenReturn(Optional.empty());
         when(dbStackService.save(dbStack)).thenReturn(dbStack);
-        when(databaseServerConfigService.getByClusterCrn(CLUSTER_CRN)).thenReturn(Optional.empty());
+        when(databaseServerConfigService.findByEnvironmentCrnAndClusterCrn(ENVIRONMENT_CRN, CLUSTER_CRN)).thenReturn(Optional.empty());
 
         DBStack launchedStack = underTest.launchDatabaseServer(dbStack, CLUSTER_CRN);
         assertThat(launchedStack).isEqualTo(dbStack);
@@ -153,7 +153,7 @@ class RedbeamsCreationServiceTest {
     @Test
     public void testShouldNotLaunchDatabaseServerWhenDatabaseServerConfigIsAvailable() {
         when(dbStackService.findByNameAndEnvironmentCrn(DB_STACK_NAME, ENVIRONMENT_CRN)).thenReturn(Optional.empty());
-        when(databaseServerConfigService.getByClusterCrn(CLUSTER_CRN)).thenReturn(Optional.of(databaseServerConfig));
+        when(databaseServerConfigService.findByEnvironmentCrnAndClusterCrn(ENVIRONMENT_CRN, CLUSTER_CRN)).thenReturn(Optional.of(databaseServerConfig));
         when(databaseServerConfig.getDbStack()).thenReturn(Optional.of(dbStack));
 
         DBStack launchedStack = underTest.launchDatabaseServer(dbStack, CLUSTER_CRN);


### PR DESCRIPTION
In case flow was stopped and then restarted just after the external
DB provision started, it might happen that upon launching a new
create request to RedBeams caused and exception. This is fixed now.

See detailed description in the commit message.