### PR TITLE
CB-10610: Remove CDP_SDX_HBASE_CLOUD_STORAGE entitlement at GA for AWS

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProvider.java
@@ -17,6 +17,7 @@ import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.SharedServiceConfigsView;
 
@@ -56,11 +57,12 @@ public class HbaseCloudStorageServiceConfigProvider implements CmTemplateCompone
         String cdhVersion = getCdhVersion(source);
         boolean is727OrNewer = isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_2_7);
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
-        boolean sdxHbaseCloudStorageEnabled =
-                entitlementService.sdxHbaseCloudStorageEnabled(accountId);
+        boolean sdxHbaseCloudStorageEnabled = entitlementService.sdxHbaseCloudStorageEnabled(accountId);
+        boolean razEnabled =  source.getGeneralClusterConfigs().isEnableRangerRaz();
+        boolean awsWithRazDisabled = CloudPlatform.AWS.equals(source.getCloudPlatform()) && !razEnabled;
         return source.getFileSystemConfigurationView().isPresent()
                 && cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes())
-                && (!datalakeCluster || (is727OrNewer && sdxHbaseCloudStorageEnabled));
+                && (!datalakeCluster || (is727OrNewer && (awsWithRazDisabled || sdxHbaseCloudStorageEnabled)));
     }
 
     private String getCdhVersion(TemplatePreparationObject source) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseCloudStorageServiceConfigProviderTest.java
@@ -1,8 +1,6 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.hbase;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -11,22 +9,25 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.StorageLocation;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
 import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
 import com.sequenceiq.cloudbreak.template.filesystem.s3.S3FileSystemConfigurationsView;
+import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
 import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.cloudbreak.template.views.SharedServiceConfigsView;
@@ -34,7 +35,7 @@ import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.common.api.filesystem.S3FileSystem;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class HbaseCloudStorageServiceConfigProviderTest {
 
     @InjectMocks
@@ -43,128 +44,55 @@ public class HbaseCloudStorageServiceConfigProviderTest {
     @Mock
     private EntitlementService entitlementService;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         if (StringUtils.isEmpty(ThreadBasedUserCrnProvider.getUserCrn())) {
             ThreadBasedUserCrnProvider.setUserCrn("crn:cdp:iam:us-west-1:1234:user:1");
         }
-        when(entitlementService.sdxHbaseCloudStorageEnabled(anyString())).thenReturn(true);
     }
 
-    @Test
-    public void testGetHbaseStorageServiceConfigsWhenAttachedCluster() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, false);
+    static Object[][] templateConfigParameters() {
+        return new Object[][]{
+            { true, false, "7.2.1", CloudPlatform.AWS, false, true, true, 1, "hdfs_rootdir", "s3a://bucket/cluster1/hbase" },
+            { true, false, "7.2.1", CloudPlatform.AWS, false, false, true, 1, "hdfs_rootdir", "s3a://bucket/cluster1/hbase" },
+            { true, true, "7.2.1", CloudPlatform.AWS, false, true, false, 1, "hdfs_rootdir", "s3a://bucket/cluster1/hbase" },
+            { false, false, "7.2.1", CloudPlatform.AWS, false, true, true, 0, "", "" },
+            { false, true, "7.2.1", CloudPlatform.AWS, false, true, false, 0, "", "" },
+            { true, true, "7.2.6", CloudPlatform.AWS, false, true, false, 1, "hdfs_rootdir", "s3a://bucket/cluster1/hbase" },
+            { true, true, "7.2.7", CloudPlatform.AWS, false, true, true, 1, "hdfs_rootdir", "s3a://bucket/cluster1/hbase" },
+            { true, true, "7.2.8", CloudPlatform.AWS, false, true, true, 1, "hdfs_rootdir", "s3a://bucket/cluster1/hbase" },
+            { true, true, "7.2.7", CloudPlatform.AWS, false, false, true, 1, "hdfs_rootdir", "s3a://bucket/cluster1/hbase" },
+            { true, true, "7.2.7", CloudPlatform.AWS, true, false, false, 1, "hdfs_rootdir", "s3a://bucket/cluster1/hbase" },
+            { true, true, "7.2.7", CloudPlatform.AZURE, false, false, false, 1, "hdfs_rootdir", "s3a://bucket/cluster1/hbase" },
+            { true, true, "7.2.7", CloudPlatform.AZURE, false, true, true, 1, "hdfs_rootdir", "s3a://bucket/cluster1/hbase" },
+        };
+    }
+
+    @ParameterizedTest
+    @MethodSource("templateConfigParameters")
+    public void testGetHbaseStorageServiceConfigs(boolean includeLocation, boolean datalakeCluster, String cdhVersion,
+        CloudPlatform cloudPlatform, boolean enableRaz, boolean enableHbaseCloudStorage, boolean configurationNeeded, int configurationSize,
+        String configName, String configValue) {
+        when(entitlementService.sdxHbaseCloudStorageEnabled(anyString())).thenReturn(enableHbaseCloudStorage);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(includeLocation, datalakeCluster, cdhVersion, cloudPlatform, enableRaz);
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
 
         List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
 
-        assertEquals(1, serviceConfigs.size());
-        assertEquals("hdfs_rootdir", serviceConfigs.get(0).getName());
-        assertEquals("s3a://bucket/cluster1/hbase", serviceConfigs.get(0).getValue());
+        assertEquals(configurationSize, serviceConfigs.size());
+
+        if (configurationSize > 0) {
+            assertEquals(configName, serviceConfigs.get(0).getName());
+            assertEquals(configValue, serviceConfigs.get(0).getValue());
+        }
+
+        boolean ifConfigurationNeeded = underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject);
+        assertEquals(configurationNeeded, ifConfigurationNeeded);
     }
 
-    @Test
-    public void testGetHbaseStorageServiceConfigsWhenDataLake721() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.1");
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
-
-        assertEquals(1, serviceConfigs.size());
-        assertEquals("hdfs_rootdir", serviceConfigs.get(0).getName());
-        assertEquals("s3a://bucket/cluster1/hbase", serviceConfigs.get(0).getValue());
-    }
-
-    @Test
-    public void testGetHbaseStorageServiceConfigsWhenDataLake722() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.2");
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
-
-        assertEquals(1, serviceConfigs.size());
-        assertEquals("hdfs_rootdir", serviceConfigs.get(0).getName());
-        assertEquals("s3a://bucket/cluster1/hbase", serviceConfigs.get(0).getValue());
-    }
-
-    @Test
-    public void testGetHbaseServiceConfigsWhenNoStorageConfiguredWithAttachedCluster() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false, false);
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
-        assertEquals(0, serviceConfigs.size());
-    }
-
-    @Test
-    public void testGetHbaseServiceConfigsWhenNoStorageConfiguredWithDataLake() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(false, true);
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
-        assertEquals(0, serviceConfigs.size());
-    }
-
-    @Test
-    public void testConfigurationNotNeededWhenDataLake721() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.1");
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        boolean configurationNeeded = underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject);
-        assertFalse(configurationNeeded);
-    }
-
-    @Test
-    public void testConfigurationNotNeededWhenDataLake726() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.6");
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        boolean configurationNeeded = underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject);
-        assertFalse(configurationNeeded);
-    }
-
-    @Test
-    public void testConfigurationNeededWhenDatalake727() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.7");
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        boolean configurationNeeded = underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject);
-        assertTrue(configurationNeeded);
-    }
-
-    @Test
-    public void testConfigurationNeededWhenDatalake728() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, "7.2.8");
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        boolean configurationNeeded = underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject);
-        assertTrue(configurationNeeded);
-    }
-
-    @Test
-    public void testIsConfigurationNeededWhenAttachedCluster() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, false);
-        String inputJson = getBlueprintText("input/clouderamanager.bp");
-        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
-
-        boolean configurationNeeded = underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject);
-        assertTrue(configurationNeeded);
-    }
-
-    private TemplatePreparationObject getTemplatePreparationObject(boolean includeLocations, boolean datalakeCluster) {
-        return getTemplatePreparationObject(includeLocations, datalakeCluster, "7.2.1");
-    }
-
-    private TemplatePreparationObject getTemplatePreparationObject(boolean includeLocations, boolean datalakeCluster, String cdhVersion) {
+    private TemplatePreparationObject getTemplatePreparationObject(boolean includeLocations, boolean datalakeCluster, String cdhVersion,
+            CloudPlatform cloudPlatform, boolean enableRaz) {
         HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
 
@@ -184,11 +112,16 @@ public class HbaseCloudStorageServiceConfigProviderTest {
         String inputJson = getBlueprintText("input/clouderamanager.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
         cmTemplateProcessor.setCdhVersion(cdhVersion);
+        GeneralClusterConfigs generalClusterConfigs = new GeneralClusterConfigs();
+        generalClusterConfigs.setEnableRangerRaz(enableRaz);
 
         return Builder.builder().withFileSystemConfigurationView(fileSystemConfigurationsView)
                 .withBlueprintView(new BlueprintView(inputJson, "", "", cmTemplateProcessor))
                 .withSharedServiceConfigs(sharedServicesConfigsView)
-                .withHostgroupViews(Set.of(master, worker)).build();
+                .withHostgroupViews(Set.of(master, worker))
+                .withCloudPlatform(cloudPlatform)
+                .withGeneralClusterConfigs(generalClusterConfigs)
+                .build();
     }
 
     private String getBlueprintText(String path) {


### PR DESCRIPTION
-From 7.2.7 Store HBase data on cloud storage for AWS at data lake when the entitlement CDP_SDX_HBASE_CLOUD_STORAGE is disabled and RAZ is disabled
-Add more test cases for this change

See detailed description in the commit message.