### PR TITLE
CB-11754 change compute.storageAdmin role to storage.admin in the GCP credential create command

### DIFF
--- a/cloud-gcp/src/main/resources/definitions/gcp-prerequisites-creation-command.json
+++ b/cloud-gcp/src/main/resources/definitions/gcp-prerequisites-creation-command.json
@@ -21,7 +21,7 @@ echo "Binding Image User role to the service account"
 gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:$SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com --role roles/compute.imageUser --quiet --no-user-output-enabled --condition=None
 
 echo "Binding Storage Admin role to the service account"
-gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:$SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com --role roles/compute.storageAdmin --quiet --no-user-output-enabled --condition=None
+gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:$SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com --role roles/storage.admin --quiet --no-user-output-enabled --condition=None
 
 echo "Binding RuntimeConfig Admin role to the service account"
 gcloud projects add-iam-policy-binding $PROJECT_ID --member serviceAccount:$SERVICE_ACCOUNT_NAME@$PROJECT_ID.iam.gserviceaccount.com --role roles/runtimeconfig.admin --quiet --no-user-output-enabled --condition=None


### PR DESCRIPTION
The compute.storageAdmin role is completely superseded by compute.instanceAdmin.v1 so it could be removed, but storage.admin role is neccesary for CDP related storage operations.

I think it should go into 2.42 line of CB, so master is fine for now...