### PR TITLE
CB-12111: Update FreeIPA instance to "stopped" immediately after stac…

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/stop/StackStopService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/stop/StackStopService.java
@@ -8,9 +8,11 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.event.instance.StopInstancesResult;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
 import com.sequenceiq.freeipa.flow.stack.StackStartStopService;
+import com.sequenceiq.freeipa.service.stack.instance.InstanceUpdater;
 import com.sequenceiq.freeipa.service.stack.StackUpdater;
 
 @Component
@@ -23,6 +25,9 @@ public class StackStopService {
 
     @Inject
     private StackStartStopService stackStartStopService;
+
+    @Inject
+    private InstanceUpdater instanceUpdater;
 
     public void startStackStop(StackStopContext context) {
         stackUpdater.updateStackStatus(context.getStack(), DetailedStackStatus.STOP_IN_PROGRESS, "Stack infrastructure is now stopping.");
@@ -39,6 +44,7 @@ public class StackStopService {
         stackStartStopService.validateResourceResults(context.getCloudContext(),
                 stopInstancesResult.getErrorDetails(), stopInstancesResult.getResults(), false);
         stackUpdater.updateStackStatus(stack.getId(), DetailedStackStatus.STOPPED, "Stack infrastructure stopped successfully.");
+        instanceUpdater.updateStatuses(stack, InstanceStatus.STOPPED);
     }
 
     public boolean isStopPossible(Stack stack) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/InstanceUpdater.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/instance/InstanceUpdater.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.freeipa.service.stack.instance;
+
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+
+import javax.inject.Inject;
+
+@Component
+public class InstanceUpdater {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceUpdater.class);
+
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    public Set<InstanceMetaData> updateStatuses(Stack stack, InstanceStatus instanceStatus) {
+        Set<InstanceMetaData> checkableInstances = stack.getNotDeletedInstanceMetaDataSet();
+        checkableInstances.forEach(instanceMetaData -> {
+            setStatusIfNotTheSame(instanceMetaData, instanceStatus);
+            instanceMetaDataService.save(instanceMetaData);
+        });
+        return checkableInstances;
+    }
+
+    private void setStatusIfNotTheSame(InstanceMetaData instanceMetaData, InstanceStatus newStatus) {
+        InstanceStatus oldStatus = instanceMetaData.getInstanceStatus();
+        if (oldStatus != newStatus) {
+            instanceMetaData.setInstanceStatus(newStatus);
+            LOGGER.info("The instance status updated from {} to {}", oldStatus, newStatus);
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/ProviderChecker.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/ProviderChecker.java
@@ -41,11 +41,11 @@ public class ProviderChecker {
     private boolean updateStatus;
 
     public List<ProviderSyncResult> updateAndGetStatuses(Stack stack, Set<InstanceMetaData> checkableInstances,
-        Map<InstanceMetaData, DetailedStackStatus> instanceHealthStatusMap) {
+        Map<InstanceMetaData, DetailedStackStatus> instanceHealthStatusMap, boolean updateStatusFromFlow) {
         return checkedMeasure(() -> {
             List<ProviderSyncResult> results = new ArrayList<>();
             List<CloudVmInstanceStatus> statuses = stackInstanceProviderChecker.checkStatus(stack, checkableInstances);
-            if (flowLogService.isOtherFlowRunning(stack.getId())) {
+            if (!updateStatusFromFlow && flowLogService.isOtherFlowRunning(stack.getId())) {
                 throw new InterruptSyncingException(":::Auto sync::: interrupt syncing in updateAndGetStatuses, flow is running on freeipa stack " +
                         stack.getName());
             } else {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/sync/StackStatusCheckerJob.java
@@ -118,7 +118,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
                             updateStackStatus(stack, syncResult, null, alreadyDeletedCount, updateStatusFromFlow);
                         } else {
                             List<ProviderSyncResult> results = providerChecker.updateAndGetStatuses(stack, checkableInstances,
-                                    syncResult.getInstanceStatusMap());
+                                    syncResult.getInstanceStatusMap(), updateStatusFromFlow);
                             if (!results.isEmpty()) {
                                 updateStackStatus(stack, syncResult, results, alreadyDeletedCount, updateStatusFromFlow);
                             } else {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/instance/InstanceUpdaterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/instance/InstanceUpdaterTest.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.freeipa.service.stack.instance;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InstanceUpdaterTest {
+
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Mock
+    private Stack stack;
+
+    @InjectMocks
+    private InstanceUpdater underTest;
+
+    @Test
+    public void testUpdateStatuses() {
+
+        InstanceMetaData instanceMetaData1 = mock(InstanceMetaData.class);
+        InstanceMetaData instanceMetaData2 = mock(InstanceMetaData.class);
+        when(instanceMetaData1.getInstanceStatus()).thenReturn(InstanceStatus.CREATED);
+        when(instanceMetaData2.getInstanceStatus()).thenReturn(InstanceStatus.CREATED);
+
+        Set<InstanceMetaData> metadata = Set.of(instanceMetaData1, instanceMetaData2);
+        when(stack.getNotDeletedInstanceMetaDataSet()).thenReturn(metadata);
+
+        underTest.updateStatuses(stack, InstanceStatus.STOPPED);
+
+        verify(instanceMetaData1, times(1)).setInstanceStatus(InstanceStatus.STOPPED);
+        verify(instanceMetaData2, times(1)).setInstanceStatus(InstanceStatus.STOPPED);
+        verify(instanceMetaDataService, times(2)).save(any());
+    }
+
+}


### PR DESCRIPTION
…k was stopped

This is a bug that FreeIPA instance is "running" after stack was stopped. 
There is a 3 minutes delay in UI until next health check. 
We fixed by updating FreeIPA instance to "stopped" immediately after stack was stopped.

See detailed description in the commit message.