### PR TITLE
CB-12224: Add FreeIPA availability status

### DIFF
--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/DistroXService.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/DistroXService.java
@@ -59,7 +59,7 @@ public class DistroXService {
             throw new BadRequestException(format("'%s' Environment does not exist.", request.getEnvironmentName()));
         }
         DescribeFreeIpaResponse freeipa = freeipaClientService.getByEnvironmentCrn(environment.getCrn());
-        if (!freeipa.getStatus().isAvailable()) {
+        if (freeipa == null || freeipa.getAvailabilityStatus() == null || !freeipa.getAvailabilityStatus().isAvailable()) {
             throw new BadRequestException(format("If you want to provision a Data Hub then the FreeIPA instance must be running in the '%s' Environment.",
                     environment.getName()));
         }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/start/SdxStartService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/start/SdxStartService.java
@@ -167,7 +167,7 @@ public class SdxStartService {
 
     private void checkFreeipaRunning(String envCrn) {
         DescribeFreeIpaResponse freeipa = freeipaService.describe(envCrn);
-        if (freeipa != null && !freeipa.getStatus().isAvailable()) {
+        if (freeipa != null && freeipa.getAvailabilityStatus() != null && !freeipa.getAvailabilityStatus().isAvailable()) {
             throw new BadRequestException("Freeipa should be in Available state but currently is " + freeipa.getStatus().name());
         }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/stop/SdxStopService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/stop/SdxStopService.java
@@ -179,7 +179,7 @@ public class SdxStopService {
 
     private void checkFreeipaRunning(String envCrn) {
         DescribeFreeIpaResponse freeipa = freeipaService.describe(envCrn);
-        if (freeipa != null && !freeipa.getStatus().isAvailable()) {
+        if (freeipa != null && freeipa.getAvailabilityStatus() != null && !freeipa.getAvailabilityStatus().isAvailable()) {
             throw new BadRequestException("Freeipa should be in Available state but currently is " + freeipa.getStatus().name());
         }
     }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/start/SdxStartServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/start/SdxStartServiceTest.java
@@ -46,6 +46,7 @@ import com.sequenceiq.datalake.service.sdx.CloudbreakFlowService;
 import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.datalake.service.sdx.status.AvailabilityChecker;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 
@@ -89,7 +90,7 @@ public class SdxStartServiceTest {
         sdxCluster.setEnvCrn("envCrn");
 
         DescribeFreeIpaResponse freeIpaResponse = new DescribeFreeIpaResponse();
-        freeIpaResponse.setStatus(Status.AVAILABLE);
+        freeIpaResponse.setAvailabilityStatus(AvailabilityStatus.AVAILABLE);
 
         when(freeipaService.describe("envCrn")).thenReturn(freeIpaResponse);
 
@@ -114,6 +115,7 @@ public class SdxStartServiceTest {
 
         DescribeFreeIpaResponse freeipa = new DescribeFreeIpaResponse();
         freeipa.setStatus(Status.STOPPED);
+        freeipa.setAvailabilityStatus(AvailabilityStatus.UNAVAILABLE);
 
         when(freeipaService.describe("envCrn")).thenReturn(freeipa);
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationRetrievalTask.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationRetrievalTask.java
@@ -53,7 +53,7 @@ public class FreeIpaCreationRetrievalTask extends SimpleStatusCheckerTask<FreeIp
                 throw new FreeIpaOperationFailedException(String.format("FreeIpa creation failed. Status: '%s' statusReason: '%s'",
                         freeIpa.getStatus(), freeIpa.getStatusReason()));
             }
-            if (freeIpa.getStatus().isAvailable()) {
+            if (freeIpa.getAvailabilityStatus() != null && freeIpa.getAvailabilityStatus().isAvailable()) {
                 return true;
             }
         } catch (Exception e) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/start/handler/StartFreeIpaHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/start/handler/StartFreeIpaHandler.java
@@ -44,9 +44,9 @@ public class StartFreeIpaHandler extends EventSenderAwareHandler<EnvironmentStar
         EnvironmentDto environmentDto = environmentStartDtoEvent.getData().getEnvironmentDto();
         try {
             freeIpaService.describe(environmentDto.getResourceCrn()).ifPresentOrElse(freeIpa -> {
-                if (freeIpa.getStatus() == null) {
+                if (freeIpa.getStatus() == null || freeIpa.getAvailabilityStatus() == null) {
                     throw new FreeIpaOperationFailedException("FreeIPA status is unpredictable, env start will be interrupted.");
-                } else if (freeIpa.getStatus().isAvailable() || freeIpa.getStatus().isStartInProgressPhase()) {
+                } else if (freeIpa.getAvailabilityStatus().isAvailable() || freeIpa.getStatus().isStartInProgressPhase()) {
                     LOGGER.info("Start has already been triggered continuing without new start trigger. FreeIPA status: {}", freeIpa.getStatus());
                 } else if (!freeIpa.getStatus().isStartable()) {
                     throw new FreeIpaOperationFailedException("FreeIPA is not in a valid state to start! Current state is: " + freeIpa.getStatus().name());

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/start/handler/SynchronizeUsersHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/start/handler/SynchronizeUsersHandler.java
@@ -50,7 +50,7 @@ public class SynchronizeUsersHandler extends EventSenderAwareHandler<Environment
         try {
             if (synchronizeOnStartEnabled) {
                 freeIpaService.describe(environmentDto.getResourceCrn()).ifPresent(freeIpa -> {
-                    if (freeIpa.getStatus() != null && !freeIpa.getStatus().isAvailable()) {
+                    if (freeIpa.getStatus() != null && freeIpa.getAvailabilityStatus() != null && !freeIpa.getAvailabilityStatus().isAvailable()) {
                         throw new FreeIpaOperationFailedException("FreeIPA is not in AVAILABLE state to synchronize users! Current state is: " +
                                 freeIpa.getStatus().name());
                     }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationRetrievalTaskTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaCreationRetrievalTaskTest.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.environment.environment.service.freeipa.FreeIpaService;
 import com.sequenceiq.environment.exception.FreeIpaOperationFailedException;
 import com.sequenceiq.environment.store.EnvironmentInMemoryStateStore;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 
 import net.jcip.annotations.NotThreadSafe;
@@ -70,6 +71,7 @@ class FreeIpaCreationRetrievalTaskTest {
     void testCheckStatusWithDeleteInProgressState() {
         FreeIpaPollerObject freeIpaPollerObject = new FreeIpaPollerObject(ENV_ID, ENV_CRN);
         DescribeFreeIpaResponse freeIpa = new DescribeFreeIpaResponse();
+        freeIpa.setAvailabilityStatus(AvailabilityStatus.UNAVAILABLE);
         freeIpa.setStatus(DELETE_IN_PROGRESS);
         freeIpa.setName(FREE_IPA_NAME);
         freeIpa.setCrn(FREE_IPA_CRN);
@@ -82,6 +84,7 @@ class FreeIpaCreationRetrievalTaskTest {
     void testCheckStatusWithFailedState() {
         FreeIpaPollerObject freeIpaPollerObject = new FreeIpaPollerObject(ENV_ID, ENV_CRN);
         DescribeFreeIpaResponse freeIpa = new DescribeFreeIpaResponse();
+        freeIpa.setAvailabilityStatus(AvailabilityStatus.UNAVAILABLE);
         freeIpa.setStatus(DELETE_IN_PROGRESS);
         freeIpa.setName(FREE_IPA_NAME);
         freeIpa.setCrn(FREE_IPA_CRN);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/start/handler/SynchronizeUsersHandlerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/start/handler/SynchronizeUsersHandlerTest.java
@@ -32,6 +32,7 @@ import com.sequenceiq.environment.environment.flow.start.event.EnvStartStateSele
 import com.sequenceiq.environment.environment.service.freeipa.FreeIpaPollerService;
 import com.sequenceiq.environment.environment.service.freeipa.FreeIpaService;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 
@@ -85,6 +86,7 @@ class SynchronizeUsersHandlerTest {
         ReflectionTestUtils.setField(underTest, "synchronizeOnStartEnabled", true);
 
         when(freeIpaService.describe(ENV_CRN)).thenReturn(Optional.of(describeFreeIpaResponse));
+        when(describeFreeIpaResponse.getAvailabilityStatus()).thenReturn(AvailabilityStatus.AVAILABLE);
         when(describeFreeIpaResponse.getStatus()).thenReturn(Status.AVAILABLE);
 
         underTest.accept(environmentDtoEvent);
@@ -118,6 +120,7 @@ class SynchronizeUsersHandlerTest {
         ReflectionTestUtils.setField(underTest, "synchronizeOnStartEnabled", true);
 
         when(freeIpaService.describe(ENV_CRN)).thenReturn(Optional.of(describeFreeIpaResponse));
+        when(describeFreeIpaResponse.getAvailabilityStatus()).thenReturn(AvailabilityStatus.UNAVAILABLE);
         when(describeFreeIpaResponse.getStatus()).thenReturn(Status.STOPPED);
 
         underTest.accept(environmentDtoEvent);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaPollerServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaPollerServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.dyngr.core.AttemptResults;
 import com.sequenceiq.environment.environment.poller.FreeIpaPollerProvider;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.FailureDetails;
@@ -54,6 +55,7 @@ public class FreeIpaPollerServiceTest {
     @Test
     void testStopAttachedFreeipaInstancesWhenFreeipaAvailable() {
         DescribeFreeIpaResponse freeipaResponse = new DescribeFreeIpaResponse();
+        freeipaResponse.setAvailabilityStatus(AvailabilityStatus.AVAILABLE);
         freeipaResponse.setStatus(Status.AVAILABLE);
         when(freeIpaService.describe(ENV_CRN)).thenReturn(Optional.of(freeipaResponse));
         when(freeipaPollerProvider.stopPoller(ENV_ID, ENV_CRN)).thenReturn(AttemptResults::justFinish);
@@ -66,6 +68,7 @@ public class FreeIpaPollerServiceTest {
     @Test
     void testStopAttachedFreeipaInstancesWhenFreeipaStopped() {
         DescribeFreeIpaResponse freeipaResponse = new DescribeFreeIpaResponse();
+        freeipaResponse.setAvailabilityStatus(AvailabilityStatus.UNAVAILABLE);
         freeipaResponse.setStatus(Status.STOPPED);
         when(freeIpaService.describe(ENV_CRN)).thenReturn(Optional.of(freeipaResponse));
         when(freeipaPollerProvider.stopPoller(ENV_ID, ENV_CRN)).thenReturn(AttemptResults::justFinish);
@@ -78,6 +81,7 @@ public class FreeIpaPollerServiceTest {
     @Test
     void testStartAttachedFreeipaInstancesWhenFreeipaAvailable() {
         DescribeFreeIpaResponse freeipaResponse = new DescribeFreeIpaResponse();
+        freeipaResponse.setAvailabilityStatus(AvailabilityStatus.AVAILABLE);
         freeipaResponse.setStatus(Status.AVAILABLE);
         when(freeIpaService.describe(ENV_CRN)).thenReturn(Optional.of(freeipaResponse));
         when(freeipaPollerProvider.startPoller(ENV_ID, ENV_CRN)).thenReturn(AttemptResults::justFinish);
@@ -90,6 +94,7 @@ public class FreeIpaPollerServiceTest {
     @Test
     void testStartAttachedFreeipaInstancesWhenFreeipaStopped() {
         DescribeFreeIpaResponse freeipaResponse = new DescribeFreeIpaResponse();
+        freeipaResponse.setAvailabilityStatus(AvailabilityStatus.UNAVAILABLE);
         freeipaResponse.setStatus(Status.STOPPED);
         when(freeIpaService.describe(ENV_CRN)).thenReturn(Optional.of(freeipaResponse));
         when(freeipaPollerProvider.startPoller(ENV_ID, ENV_CRN)).thenReturn(AttemptResults::justFinish);
@@ -102,6 +107,7 @@ public class FreeIpaPollerServiceTest {
     @Test
     void testSyncUsersWhenFreeIpaAvailable() {
         DescribeFreeIpaResponse freeipaResponse = new DescribeFreeIpaResponse();
+        freeipaResponse.setAvailabilityStatus(AvailabilityStatus.AVAILABLE);
         freeipaResponse.setStatus(Status.AVAILABLE);
         when(freeIpaService.describe(ENV_CRN)).thenReturn(Optional.of(freeipaResponse));
         when(freeIpaService.synchronizeAllUsersInEnvironment(ENV_CRN)).thenReturn(createStatus(SynchronizationStatus.REQUESTED, ""));
@@ -115,6 +121,7 @@ public class FreeIpaPollerServiceTest {
     @Test
     void testSyncUsersWhenFreeIpaStopped() {
         DescribeFreeIpaResponse freeipaResponse = new DescribeFreeIpaResponse();
+        freeipaResponse.setAvailabilityStatus(AvailabilityStatus.UNAVAILABLE);
         freeipaResponse.setStatus(Status.STOPPED);
         when(freeIpaService.describe(ENV_CRN)).thenReturn(Optional.of(freeipaResponse));
 

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/AvailabilityStatus.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/AvailabilityStatus.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common;
+
+public enum AvailabilityStatus {
+    UNKNOWN,
+    AVAILABLE,
+    UNAVAILABLE;
+
+    AvailabilityStatus() {
+    }
+
+    public Boolean isAvailable() {
+        return AVAILABLE.equals(this);
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/DetailedStackStatus.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/DetailedStackStatus.java
@@ -1,80 +1,99 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 public enum DetailedStackStatus {
-    UNKNOWN(Status.UNKNOWN),
+    UNKNOWN(Status.UNKNOWN, AvailabilityStatus.UNKNOWN),
     // Provision statuses
-    PROVISION_REQUESTED(Status.REQUESTED),
-    PROVISION_SETUP(Status.CREATE_IN_PROGRESS),
-    IMAGE_SETUP(Status.CREATE_IN_PROGRESS),
-    CREATING_INFRASTRUCTURE(Status.CREATE_IN_PROGRESS),
-    METADATA_COLLECTION(Status.CREATE_IN_PROGRESS),
-    TLS_SETUP(Status.CREATE_IN_PROGRESS),
-    REGISTERING_WITH_CLUSTER_PROXY(Status.CREATE_IN_PROGRESS),
-    STACK_PROVISIONED(Status.STACK_AVAILABLE),
-    PROVISIONED(Status.AVAILABLE),
-    PROVISION_FAILED(Status.CREATE_FAILED),
+    PROVISION_REQUESTED(Status.REQUESTED, AvailabilityStatus.UNAVAILABLE),
+    PROVISION_SETUP(Status.CREATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    IMAGE_SETUP(Status.CREATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    CREATING_INFRASTRUCTURE(Status.CREATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    METADATA_COLLECTION(Status.CREATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    TLS_SETUP(Status.CREATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    REGISTERING_WITH_CLUSTER_PROXY(Status.CREATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    STACK_PROVISIONED(Status.STACK_AVAILABLE, AvailabilityStatus.UNAVAILABLE),
+    PROVISIONED(Status.AVAILABLE, AvailabilityStatus.AVAILABLE),
+    PROVISION_FAILED(Status.CREATE_FAILED, AvailabilityStatus.UNAVAILABLE),
     // Orchestration statuses
-    BOOTSTRAPPING_MACHINES(Status.UPDATE_IN_PROGRESS),
-    COLLECTING_HOST_METADATA(Status.UPDATE_IN_PROGRESS),
-    MOUNTING_DISKS(Status.UPDATE_IN_PROGRESS),
-    CONFIGURING_ORCHESTRATOR(Status.UPDATE_IN_PROGRESS),
-    VALIDATING_CLOUD_STORAGE(Status.UPDATE_IN_PROGRESS),
-    STARTING_FREEIPA_SERVICES(Status.UPDATE_IN_PROGRESS),
-    REGISTER_WITH_CLUSTER_PROXY(Status.UPDATE_IN_PROGRESS),
-    UPDATE_CLUSTER_PROXY_REGISTRATION(Status.UPDATE_IN_PROGRESS),
-    POSTINSTALL_FREEIPA_CONFIGURATION(Status.UPDATE_IN_PROGRESS),
+    BOOTSTRAPPING_MACHINES(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    COLLECTING_HOST_METADATA(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    MOUNTING_DISKS(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    CONFIGURING_ORCHESTRATOR(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    VALIDATING_CLOUD_STORAGE(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    STARTING_FREEIPA_SERVICES(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    REGISTER_WITH_CLUSTER_PROXY(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    UPDATE_CLUSTER_PROXY_REGISTRATION(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    POSTINSTALL_FREEIPA_CONFIGURATION(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
     // Start statuses
-    START_REQUESTED(Status.START_REQUESTED),
-    START_IN_PROGRESS(Status.START_IN_PROGRESS),
-    STARTED(Status.AVAILABLE),
-    START_FAILED(Status.START_FAILED),
+    START_REQUESTED(Status.START_REQUESTED, AvailabilityStatus.UNAVAILABLE),
+    START_IN_PROGRESS(Status.START_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    STARTED(Status.AVAILABLE, AvailabilityStatus.AVAILABLE),
+    START_FAILED(Status.START_FAILED, AvailabilityStatus.UNAVAILABLE),
     // Stop statuses
-    STOP_REQUESTED(Status.STOP_REQUESTED),
-    STOP_IN_PROGRESS(Status.STOP_IN_PROGRESS),
-    STOPPED(Status.STOPPED),
-    STOP_FAILED(Status.STOP_FAILED),
+    STOP_REQUESTED(Status.STOP_REQUESTED, AvailabilityStatus.UNAVAILABLE),
+    STOP_IN_PROGRESS(Status.STOP_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    STOPPED(Status.STOPPED, AvailabilityStatus.UNAVAILABLE),
+    STOP_FAILED(Status.STOP_FAILED, AvailabilityStatus.UNAVAILABLE),
     // Upscale statuses
-    UPSCALE_REQUESTED(Status.UPDATE_REQUESTED),
-    UPSCALE_IN_PROGRESS(Status.UPDATE_IN_PROGRESS),
-    UPSCALE_COMPLETED(Status.AVAILABLE),
-    UPSCALE_FAILED(Status.UPSCALE_FAILED),
+    UPSCALE_REQUESTED(Status.UPDATE_REQUESTED, AvailabilityStatus.AVAILABLE),
+    UPSCALE_IN_PROGRESS(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.AVAILABLE),
+    UPSCALE_COMPLETED(Status.AVAILABLE, AvailabilityStatus.AVAILABLE),
+    UPSCALE_FAILED(Status.UPSCALE_FAILED, AvailabilityStatus.UNAVAILABLE),
     // Downscale statuses
-    DOWNSCALE_REQUESTED(Status.UPDATE_REQUESTED),
-    DOWNSCALE_IN_PROGRESS(Status.UPDATE_IN_PROGRESS),
-    DOWNSCALE_COMPLETED(Status.AVAILABLE),
-    DOWNSCALE_FAILED(Status.DOWNSCALE_FAILED),
+    DOWNSCALE_REQUESTED(Status.UPDATE_REQUESTED, AvailabilityStatus.AVAILABLE),
+    DOWNSCALE_IN_PROGRESS(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.AVAILABLE),
+    DOWNSCALE_COMPLETED(Status.AVAILABLE, AvailabilityStatus.AVAILABLE),
+    DOWNSCALE_FAILED(Status.DOWNSCALE_FAILED, AvailabilityStatus.UNAVAILABLE),
     // Repair statuses
-    REPAIR_REQUESTED(Status.UPDATE_REQUESTED),
-    REPAIR_IN_PROGRESS(Status.UPDATE_IN_PROGRESS),
-    REPAIR_COMPLETED(Status.AVAILABLE),
-    REPAIR_FAILED(Status.REPAIR_FAILED),
+    REPAIR_REQUESTED(Status.UPDATE_REQUESTED, AvailabilityStatus.AVAILABLE),
+    REPAIR_IN_PROGRESS(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.AVAILABLE),
+    REPAIR_COMPLETED(Status.AVAILABLE, AvailabilityStatus.AVAILABLE),
+    REPAIR_FAILED(Status.REPAIR_FAILED, AvailabilityStatus.UNAVAILABLE),
     // Termination statuses
-    DEREGISTERING_WITH_CLUSTERPROXY(Status.DELETE_IN_PROGRESS),
-    DEREGISTERING_CCM_KEY(Status.DELETE_IN_PROGRESS),
-    DELETE_IN_PROGRESS(Status.DELETE_IN_PROGRESS),
-    DELETE_COMPLETED(Status.DELETE_COMPLETED),
-    DELETE_FAILED(Status.DELETE_FAILED),
+    DEREGISTERING_WITH_CLUSTERPROXY(Status.DELETE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    DEREGISTERING_CCM_KEY(Status.DELETE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    DELETE_IN_PROGRESS(Status.DELETE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
+    DELETE_COMPLETED(Status.DELETE_COMPLETED, AvailabilityStatus.UNAVAILABLE),
+    DELETE_FAILED(Status.DELETE_FAILED, AvailabilityStatus.UNAVAILABLE),
     // Rollback statuses
-    ROLLING_BACK(Status.UPDATE_IN_PROGRESS),
+    ROLLING_BACK(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
     // The stack is available
-    AVAILABLE(Status.AVAILABLE),
+    AVAILABLE(Status.AVAILABLE, AvailabilityStatus.AVAILABLE),
     // Instance removing status
-    REMOVE_INSTANCE(Status.UPDATE_IN_PROGRESS),
+    REMOVE_INSTANCE(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.UNAVAILABLE),
     // Cluster operation is in progress
-    CLUSTER_OPERATION(Status.UPDATE_IN_PROGRESS),
+    CLUSTER_OPERATION(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.AVAILABLE),
     // Wait for sync
-    WAIT_FOR_SYNC(Status.WAIT_FOR_SYNC),
-    UNREACHABLE(Status.UNREACHABLE),
-    DELETED_ON_PROVIDER_SIDE(Status.DELETED_ON_PROVIDER_SIDE),
-    UNHEALTHY(Status.UNHEALTHY);
+    WAIT_FOR_SYNC(Status.WAIT_FOR_SYNC, AvailabilityStatus.UNAVAILABLE),
+    UNREACHABLE(Status.UNREACHABLE, AvailabilityStatus.UNAVAILABLE),
+    DELETED_ON_PROVIDER_SIDE(Status.DELETED_ON_PROVIDER_SIDE, AvailabilityStatus.UNAVAILABLE),
+    UNHEALTHY(Status.UNHEALTHY, AvailabilityStatus.AVAILABLE);
+
+    public static final Collection<DetailedStackStatus> AVAILABLE_STATUSES;
+
+    static {
+        AVAILABLE_STATUSES = Stream.of(DetailedStackStatus.values())
+                .filter(s -> s.getAvailabilityStatus().isAvailable())
+                .collect(Collectors.toList());
+    }
 
     private final Status status;
 
-    DetailedStackStatus(Status status) {
+    private final AvailabilityStatus availabilityStatus;
+
+    DetailedStackStatus(Status status, AvailabilityStatus availabilityStatus) {
         this.status = status;
+        this.availabilityStatus = availabilityStatus;
     }
 
     public Status getStatus() {
         return status;
+    }
+
+    public AvailabilityStatus getAvailabilityStatus() {
+        return availabilityStatus;
     }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/Status.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/Status.java
@@ -35,8 +35,6 @@ public enum Status {
     DELETED_ON_PROVIDER_SIDE,
     UNKNOWN;
 
-    public static final Collection<Status> AVAILABLE_STATUSES = List.of(AVAILABLE, MAINTENANCE_MODE_ENABLED);
-
     public static final Collection<Status> REMOVABLE_STATUSES = List.of(AVAILABLE, UPDATE_FAILED, CREATE_FAILED, DELETE_FAILED,
             DELETE_COMPLETED, STOPPED, START_FAILED, STOP_FAILED, REPAIR_FAILED, UPSCALE_FAILED, DOWNSCALE_FAILED);
 
@@ -62,10 +60,6 @@ public enum Status {
 
     public boolean isFailed() {
         return FAILED_STATUSES.contains(this);
-    }
-
-    public boolean isAvailable() {
-        return AVAILABLE_STATUSES.contains(this);
     }
 
     public boolean isSuccessfullyDeleted() {

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/describe/DescribeFreeIpaResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/describe/DescribeFreeIpaResponse.java
@@ -11,6 +11,7 @@ import com.sequenceiq.common.api.cloudstorage.CloudStorageResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupResponse;
@@ -61,6 +62,8 @@ public class DescribeFreeIpaResponse {
     @NotNull
     @ApiModelProperty(value = FreeIpaModelDescriptions.FREEIPA_SERVER_SETTINGS, required = true)
     private FreeIpaServerResponse freeIpa;
+
+    private AvailabilityStatus availabilityStatus;
 
     private Status status;
 
@@ -169,6 +172,14 @@ public class DescribeFreeIpaResponse {
 
     public void setCloudStorage(CloudStorageResponse cloudStorage) {
         this.cloudStorage = cloudStorage;
+    }
+
+    public AvailabilityStatus getAvailabilityStatus() {
+        return availabilityStatus;
+    }
+
+    public void setAvailabilityStatus(AvailabilityStatus availabilityStatus) {
+        this.availabilityStatus = availabilityStatus;
     }
 
     public Status getStatus() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
@@ -16,6 +16,7 @@ import com.sequenceiq.common.api.cloudstorage.StorageIdentityBase;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.common.model.CloudIdentityType;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetaDataResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.region.PlacementResponse;
@@ -30,6 +31,7 @@ import com.sequenceiq.freeipa.converter.usersync.UserSyncStatusToUserSyncStatusR
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.StackStatus;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.config.FreeIpaDomainUtils;
 import com.sequenceiq.freeipa.util.BalancedDnsAvailabilityChecker;
@@ -73,6 +75,7 @@ public class StackToDescribeFreeIpaResponseConverter {
         describeFreeIpaResponse.setNetwork(networkResponseConverter.convert(stack));
         describeFreeIpaResponse.setPlacement(convert(stack));
         describeFreeIpaResponse.setInstanceGroups(instanceGroupConverter.convert(stack.getInstanceGroups()));
+        describeFreeIpaResponse.setAvailabilityStatus(convertAvailabilityStatus(stack.getStackStatus()));
         describeFreeIpaResponse.setStatus(stack.getStackStatus().getStatus());
         describeFreeIpaResponse.setStatusString(stack.getStackStatus().getStatusString());
         describeFreeIpaResponse.setStatusReason(stack.getStackStatus().getStatusReason());
@@ -122,5 +125,12 @@ public class StackToDescribeFreeIpaResponseConverter {
         placementResponse.setAvailabilityZone(source.getAvailabilityZone());
         placementResponse.setRegion(source.getRegion());
         return placementResponse;
+    }
+
+    private AvailabilityStatus convertAvailabilityStatus(StackStatus status) {
+        if (status == null || status.getDetailedStackStatus() == null) {
+            return AvailabilityStatus.UNKNOWN;
+        }
+        return status.getDetailedStackStatus().getAvailabilityStatus();
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.repository.query.Param;
 import com.sequenceiq.authorization.service.model.projection.ResourceCrnAndNameView;
 import com.sequenceiq.cloudbreak.structuredevent.repository.AccountAwareResourceRepository;
 import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.dto.StackIdWithStatus;
 import com.sequenceiq.freeipa.entity.ImageEntity;
@@ -75,6 +76,9 @@ public interface StackRepository extends AccountAwareResourceRepository<Stack, L
 
     @Query("SELECT s FROM Stack s WHERE s.stackStatus.status IN :stackStatuses AND s.terminated = -1 ")
     List<Stack> findAllWithStatuses(@Param("stackStatuses") Collection<Status> stackStatuses);
+
+    @Query("SELECT s FROM Stack s WHERE s.stackStatus.detailedStackStatus IN :detailedStackStatuses AND s.terminated = -1 ")
+    List<Stack> findAllWithDetailedStackStatuses(@Param("detailedStackStatuses") Collection<DetailedStackStatus> detailedStackStatuses);
 
     @Query("SELECT s FROM Stack s WHERE s.accountId = :accountId AND s.stackStatus.status IN :stackStatuses AND s.terminated = -1 ")
     List<Stack> findByAccountIdWithStatuses(@Param("accountId") String accountId, @Param("stackStatuses") Collection<Status> stackStatuses);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPoller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPoller.java
@@ -22,16 +22,16 @@ import org.springframework.stereotype.Service;
 import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.WorkloadCredentialsUpdateType;
 import com.sequenceiq.freeipa.entity.Operation;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.freeipa.user.EventGenerationIdsChecker;
-import com.sequenceiq.freeipa.service.freeipa.user.ums.UmsEventGenerationIdsProvider;
 import com.sequenceiq.freeipa.service.freeipa.user.UserSyncService;
 import com.sequenceiq.freeipa.service.freeipa.user.UserSyncStatusService;
 import com.sequenceiq.freeipa.service.freeipa.user.model.UmsEventGenerationIds;
+import com.sequenceiq.freeipa.service.freeipa.user.ums.UmsEventGenerationIdsProvider;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
 @Service
@@ -89,7 +89,7 @@ public class UserSyncPoller {
 
             ThreadBasedUserCrnProvider.doAs(INTERNAL_ACTOR_CRN, () -> {
                 LOGGER.debug("Attempting to sync users to FreeIPA stacks");
-                List<Stack> stackList = stackService.findAllWithStatuses(Status.AVAILABLE_STATUSES);
+                List<Stack> stackList = stackService.findAllWithDetailedStackStatuses(DetailedStackStatus.AVAILABLE_STATUSES);
                 LOGGER.debug("Found {} active stacks", stackList.size());
 
                 stackList.stream()

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -23,6 +23,7 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.dto.StackIdWithStatus;
 import com.sequenceiq.freeipa.entity.ImageEntity;
@@ -141,6 +142,10 @@ public class StackService implements ResourcePropertyProvider {
 
     public List<Stack> findAllWithStatuses(Collection<Status> statuses) {
         return stackRepository.findAllWithStatuses(statuses);
+    }
+
+    public List<Stack> findAllWithDetailedStackStatuses(Collection<DetailedStackStatus> detailedStackStatuses) {
+        return stackRepository.findAllWithDetailedStackStatuses(detailedStackStatuses);
     }
 
     public List<Stack> findAllByAccountIdWithStatuses(String accountId, Collection<Status> statuses) {

--- a/freeipa/src/main/resources/schema/app/20210422110735_CB-12224_add_new_index_stack_detailed_status.sql
+++ b/freeipa/src/main/resources/schema/app/20210422110735_CB-12224_add_new_index_stack_detailed_status.sql
@@ -1,0 +1,9 @@
+-- // CB-12224 new index for detailed stack status
+-- Migration SQL that makes the change goes here.
+
+CREATE INDEX IF NOT EXISTS stackstatus_detailedstackstatus_idx ON stackstatus USING btree (detailedstackstatus);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS stackstatus_detailedstackstatus_idx;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupResponse;
@@ -60,6 +61,8 @@ class StackToDescribeFreeIpaResponseConverterTest {
     private static final UserSyncStatusResponse USERSYNC_STATUS_RESPONSE = new UserSyncStatusResponse();
 
     private static final Status STATUS = Status.AVAILABLE;
+
+    private static final DetailedStackStatus DETAILED_STACK_STATUS = DetailedStackStatus.AVAILABLE;
 
     private static final String STATUS_REASON = "Because reasons";
 
@@ -168,6 +171,7 @@ class StackToDescribeFreeIpaResponseConverterTest {
         stackStatus.setStatus(STATUS);
         stackStatus.setStatusString(STATUS_STRING);
         stackStatus.setStatusReason(STATUS_REASON);
+        stackStatus.setDetailedStackStatus(DETAILED_STACK_STATUS);
         return stackStatus;
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPollerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/poller/UserSyncPollerTest.java
@@ -19,15 +19,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.WorkloadCredentialsUpdateType;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.freeipa.user.EventGenerationIdsChecker;
-import com.sequenceiq.freeipa.service.freeipa.user.ums.UmsEventGenerationIdsProvider;
-import com.sequenceiq.freeipa.service.freeipa.user.UserSyncTestUtils;
 import com.sequenceiq.freeipa.service.freeipa.user.UserSyncService;
 import com.sequenceiq.freeipa.service.freeipa.user.UserSyncStatusService;
+import com.sequenceiq.freeipa.service.freeipa.user.UserSyncTestUtils;
+import com.sequenceiq.freeipa.service.freeipa.user.ums.UmsEventGenerationIdsProvider;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
 @ExtendWith(MockitoExtension.class)
@@ -126,7 +126,7 @@ class UserSyncPollerTest {
     }
 
     private Stack setupMockStackService(Stack stack) {
-        when(stackService.findAllWithStatuses(Status.AVAILABLE_STATUSES)).thenReturn(List.of(stack));
+        when(stackService.findAllWithDetailedStackStatuses(DetailedStackStatus.AVAILABLE_STATUSES)).thenReturn(List.of(stack));
         return stack;
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/StackServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/StackServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -15,9 +16,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.repository.StackRepository;
 
@@ -163,5 +166,13 @@ class StackServiceTest {
         underTest.getImagesOfAliveStacks(thresholdInDays);
 
         verify(stackRepository).findImagesOfAliveStacks(Timestamp.valueOf(thresholdTime).getTime());
+    }
+
+    @Test
+    void findAllWithDetailedStackStatuses() {
+        when(stackRepository.findAllWithDetailedStackStatuses(Mockito.eq(List.of(DetailedStackStatus.AVAILABLE)))).thenReturn(List.of(stack));
+        List<Stack> results = underTest.findAllWithDetailedStackStatuses(List.of(DetailedStackStatus.AVAILABLE));
+
+        assertEquals(List.of(stack), results);
     }
 }


### PR DESCRIPTION
Provide workloads a summary of whether FreeIPA is available and able
to respond to API requests. Several checks were modified to use this
new status, since it is more accurate than the old way of checking if
FreeIPA is available.

Unit tests were updated.
The FreeIPA management service API was manually checked with a local
deployment of cloudbreak.

See detailed description in the commit message.