### PR TITLE
CB-12115 Enable maintenance upgrade for every customer

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -280,7 +280,7 @@ public class StackV4Controller extends NotificationController implements StackV4
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public UpgradeV4Response checkForClusterUpgradeByName(Long workspaceId, String name, UpgradeV4Request request,
             @AccountId String accountId) {
-        return stackOperations.checkForClusterUpgrade(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), request);
+        return stackOperations.checkForClusterUpgrade(accountId, NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), request);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeAvailabilityService.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/service/upgrade/DistroXUpgradeAvailabilityService.java
@@ -67,7 +67,7 @@ public class DistroXUpgradeAvailabilityService {
     public UpgradeV4Response checkForUpgrade(NameOrCrn nameOrCrn, Long workspaceId, UpgradeV4Request request, String userCrn) {
         verifyRuntimeUpgradeEntitlement(userCrn, request);
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
-        UpgradeV4Response response = stackOperations.checkForClusterUpgrade(stack, workspaceId, request);
+        UpgradeV4Response response = stackOperations.checkForClusterUpgrade(Crn.safeFromString(userCrn).getAccountId(), stack, workspaceId, request);
         List<ImageInfoV4Response> filteredCandidates = filterCandidates(stack, request, response);
         response.setUpgradeCandidates(filteredCandidates);
         return response;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
@@ -33,6 +33,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageComp
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageInfoV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.views.ClusterViewV4Response;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
@@ -63,6 +64,8 @@ import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterUpgradeAvailabilityServiceTest {
+    private static final String ACCOUNT_ID = "cloudera";
+
     private static final String CATALOG_NAME = "catalog";
 
     private static final String CATALOG_URL = "/images";
@@ -119,6 +122,9 @@ public class ClusterUpgradeAvailabilityServiceTest {
 
     @Mock
     private ImageFilterParamsFactory imageFilterParamsFactory;
+
+    @Mock
+    private EntitlementService entitlementService;
 
     private boolean lockComponents;
 
@@ -391,8 +397,9 @@ public class ClusterUpgradeAvailabilityServiceTest {
         lastImageInfo.setCreated(2);
         lastImageInfo.setComponentVersions(creatExpectedPackageVersions());
         response.setUpgradeCandidates(List.of(imageInfo, lastImageInfo));
+        when(entitlementService.runtimeUpgradeEnabled(ACCOUNT_ID)).thenReturn(true);
 
-        underTest.filterUpgradeOptions(response, request, true);
+        underTest.filterUpgradeOptions(ACCOUNT_ID, response, request, true);
 
         assertEquals(1, response.getUpgradeCandidates().size());
         assertEquals(IMAGE_ID_LAST, response.getUpgradeCandidates().get(0).getImageId());
@@ -413,7 +420,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         lastImageInfo.setComponentVersions(creatExpectedPackageVersions());
         response.setUpgradeCandidates(List.of(imageInfo, lastImageInfo));
 
-        underTest.filterUpgradeOptions(response, request, true);
+        underTest.filterUpgradeOptions(ACCOUNT_ID, response, request, true);
 
         assertEquals(1, response.getUpgradeCandidates().size());
         assertEquals(IMAGE_ID, response.getUpgradeCandidates().get(0).getImageId());
@@ -434,7 +441,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         lastImageInfo.setComponentVersions(creatExpectedPackageVersions());
         response.setUpgradeCandidates(List.of(imageInfo, lastImageInfo));
 
-        Exception e = Assertions.assertThrows(BadRequestException.class, () -> underTest.filterUpgradeOptions(response, request, true));
+        Exception e = Assertions.assertThrows(BadRequestException.class, () -> underTest.filterUpgradeOptions(ACCOUNT_ID, response, request, true));
         Assert.assertEquals("The given image (another-image-id) is not eligible for the cluster upgrade. "
                 + "Please choose an id from the following image(s): image-id-first,image-id-last", e.getMessage());
     }
@@ -454,7 +461,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         lastImageInfo.setComponentVersions(creatExpectedPackageVersions());
         response.setUpgradeCandidates(List.of(imageInfo, lastImageInfo));
 
-        underTest.filterUpgradeOptions(response, request, true);
+        underTest.filterUpgradeOptions(ACCOUNT_ID, response, request, true);
 
         assertEquals(2, response.getUpgradeCandidates().size());
         assertEquals(2, response.getUpgradeCandidates().stream().map(ImageInfoV4Response::getImageId).collect(Collectors.toSet()).size());
@@ -475,7 +482,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         lastImageInfo.setComponentVersions(creatExpectedPackageVersions());
         response.setUpgradeCandidates(List.of(imageInfo, lastImageInfo));
 
-        Exception e = Assertions.assertThrows(BadRequestException.class, () -> underTest.filterUpgradeOptions(response, request, true));
+        Exception e = Assertions.assertThrows(BadRequestException.class, () -> underTest.filterUpgradeOptions(ACCOUNT_ID, response, request, true));
         Assert.assertEquals("There is no image eligible for the cluster upgrade with runtime: 7.2.0. "
                 + "Please choose a runtime from the following: 7.0.2", e.getMessage());
     }
@@ -494,7 +501,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         lastImageInfo.setCreated(2);
         lastImageInfo.setComponentVersions(creatExpectedPackageVersions());
         response.setUpgradeCandidates(List.of(imageInfo, lastImageInfo));
-        underTest.filterUpgradeOptions(response, request, true);
+        underTest.filterUpgradeOptions(ACCOUNT_ID, response, request, true);
 
         assertEquals(2, response.getUpgradeCandidates().size());
         assertTrue(response.getUpgradeCandidates().stream().map(ImageInfoV4Response::getImageId).anyMatch(id -> id.equals(IMAGE_ID_LAST)));
@@ -515,7 +522,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         lastImageInfo.setCreated(2);
         lastImageInfo.setComponentVersions(creatExpectedPackageVersions());
         response.setUpgradeCandidates(List.of(imageInfo, lastImageInfo));
-        underTest.filterUpgradeOptions(response, request, true);
+        underTest.filterUpgradeOptions(ACCOUNT_ID, response, request, true);
 
         assertEquals(2, response.getUpgradeCandidates().size());
         assertEquals(2, response.getUpgradeCandidates().stream().map(ImageInfoV4Response::getImageId).collect(Collectors.toSet()).size());

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeController.java
@@ -34,7 +34,6 @@ public class SdxUpgradeController implements SdxUpgradeEndpoint {
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.UPGRADE_DATALAKE)
     public SdxUpgradeResponse upgradeClusterByName(@ResourceName String clusterName, SdxUpgradeRequest request) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        lockComponentsIfRuntimeUpgradeIsDisabled(request, userCrn, clusterName);
         if (request.isDryRun() || request.isShowAvailableImagesSet()) {
             return sdxRuntimeUpgradeService.checkForUpgradeByName(userCrn, clusterName, request, ThreadBasedUserCrnProvider.getAccountId());
         } else {
@@ -46,18 +45,10 @@ public class SdxUpgradeController implements SdxUpgradeEndpoint {
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.UPGRADE_DATALAKE)
     public SdxUpgradeResponse upgradeClusterByCrn(@ResourceCrn String clusterCrn, SdxUpgradeRequest request) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        lockComponentsIfRuntimeUpgradeIsDisabled(request, userCrn, clusterCrn);
         if (request.isDryRun() || request.isShowAvailableImagesSet()) {
             return sdxRuntimeUpgradeService.checkForUpgradeByCrn(userCrn, clusterCrn, request, ThreadBasedUserCrnProvider.getAccountId());
         } else {
             return sdxRuntimeUpgradeService.triggerUpgradeByCrn(userCrn, clusterCrn, request, ThreadBasedUserCrnProvider.getAccountId());
-        }
-    }
-
-    private void lockComponentsIfRuntimeUpgradeIsDisabled(SdxUpgradeRequest request, String userCrn, String clusterNameOrCrn) {
-        if (!sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(userCrn) && (!isUpgradeTypeSpecified(request) || isShowOnly(request))) {
-            LOGGER.info("Set lock-components since no upgrade type is specified and runtime upgrade is disabled for cluster: {}", clusterNameOrCrn);
-            request.setLockComponents(Boolean.TRUE);
         }
     }
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxUpgradeControllerTest.java
@@ -3,7 +3,6 @@ package com.sequenceiq.datalake.controller.sdx;
 import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.doAs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -52,8 +51,6 @@ public class SdxUpgradeControllerTest {
 
     @Test
     public void testUpgradeClusterByNameWhenRequestIsEmptyAndRuntimeIsDisabled() {
-        when(sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(USER_CRN)).thenReturn(false);
-
         SdxUpgradeRequest request = new SdxUpgradeRequest();
         doAs(USER_CRN, () -> underTest.upgradeClusterByName(CLUSTER_NAME, request));
 
@@ -63,8 +60,6 @@ public class SdxUpgradeControllerTest {
 
     @Test
     public void testUpgradeClusterByNameWhenRequestIsEmptyAndRuntimeIsEnabled() {
-        when(sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(USER_CRN)).thenReturn(true);
-
         SdxUpgradeRequest request = new SdxUpgradeRequest();
         doAs(USER_CRN, () -> underTest.upgradeClusterByName(CLUSTER_NAME, request));
 
@@ -73,7 +68,6 @@ public class SdxUpgradeControllerTest {
 
     @Test
     public void testUpgradeClusterByNameWhenRequestIsDryRunAndRuntimeIsDisabled() {
-        when(sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(USER_CRN)).thenReturn(false);
         SdxUpgradeResponse sdxUpgradeResponse = new SdxUpgradeResponse();
         sdxUpgradeResponse.setReason("No image available to upgrade");
 
@@ -196,7 +190,6 @@ public class SdxUpgradeControllerTest {
     @Test
     @DisplayName("when show images is requested and runtime upgrade is disabled it should set the lock components flag")
     public void testUpgradeClusterByNameWhenRequestIsShowImagesAndRuntimeIsDisabledShouldSetLockComponent() {
-        when(sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(USER_CRN)).thenReturn(false);
         SdxUpgradeRequest request = new SdxUpgradeRequest();
         request.setShowAvailableImages(SdxUpgradeShowAvailableImages.SHOW);
 
@@ -208,15 +201,14 @@ public class SdxUpgradeControllerTest {
 
         verify(sdxRuntimeUpgradeService, times(1))
                 .checkForUpgradeByName(any(), any(), upgradeRequestArgumentCaptor.capture(), anyString());
-        SdxUpgradeRequest capturedRequest = upgradeRequestArgumentCaptor.getValue();
-        assertTrue(capturedRequest.getLockComponents());
+        //SdxUpgradeRequest capturedRequest = upgradeRequestArgumentCaptor.getValue();
+        //assertTrue(capturedRequest.getLockComponents());
         assertEquals("No image available to upgrade", response.getReason());
     }
 
     @Test
     @DisplayName("when show latest images is requested and runtime upgrade is disabled it should set the lock components flag")
     public void testUpgradeClusterByNameWhenRequestIsShowLatestImagesAndRuntimeIsDisabledShouldSetLockComponent() {
-        when(sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(USER_CRN)).thenReturn(false);
         SdxUpgradeRequest request = new SdxUpgradeRequest();
         request.setShowAvailableImages(SdxUpgradeShowAvailableImages.LATEST_ONLY);
 
@@ -228,15 +220,14 @@ public class SdxUpgradeControllerTest {
 
         verify(sdxRuntimeUpgradeService, times(1))
                 .checkForUpgradeByName(any(), any(), upgradeRequestArgumentCaptor.capture(), anyString());
-        SdxUpgradeRequest capturedRequest = upgradeRequestArgumentCaptor.getValue();
-        assertTrue(capturedRequest.getLockComponents());
+        //SdxUpgradeRequest capturedRequest = upgradeRequestArgumentCaptor.getValue();
+        //assertTrue(capturedRequest.getLockComponents());
         assertEquals("No image available to upgrade", response.getReason());
     }
 
     @Test
     @DisplayName("when show images is requested and runtime upgrade is enabled it should not set the lock components flag")
     public void testUpgradeClusterByNameWhenRequestIsShowImagesAndRuntimeIsDisabledShouldNotSetLockComponent() {
-        when(sdxRuntimeUpgradeService.isRuntimeUpgradeEnabled(USER_CRN)).thenReturn(true);
         SdxUpgradeRequest request = new SdxUpgradeRequest();
         request.setShowAvailableImages(SdxUpgradeShowAvailableImages.SHOW);
 


### PR DESCRIPTION
CB-12115 Enable maintenance upgrade for every customer …

* CB-12183 Datalake maintenance upgrade validation improvement
* CB-12184 Image filtering improvement for Datalake maintenance upgrade

The maintenance upgrade will always be enabled for all the customers independently from the CDP_RUNTIME_UPGRADE entitlement.
Image filtering improvements:
* If CDP_RUNTIME_UPGRADE is enabled, filtering works as before
* If CDP_RUNTIME_UPGRADE is disabled, only patch upgrade images will be in the result.

Validation improvements:
* if CDP_RUNTIME_UPGRADE is enabled, validation works as before, otherwise:
* if runtime param is given: if no entitlement and no patch upgrades are available: candidate list will be empty, explanation is in reason param
* if imageid is given: if no entitlement and the given image is not a patch upgrade: candidate list will be empty, explanation is in reason param
* it's not needed for the datahubs to be stopped in case of datalake patch upgrade