### PR TITLE
CB-12180 Ignore `no modifications to be performed` when creating DNS …

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
@@ -157,6 +157,22 @@ public class FreeIpaClientExceptionUtil {
         }
     }
 
+    public static <T> Optional<T> ignoreEmptyModExceptionWithValue(FreeIpaClientCallable<T> callable, String message, Object... messageParams)
+            throws FreeIpaClientException {
+        try {
+            return Optional.ofNullable(callable.run());
+        } catch (FreeIpaClientException e) {
+            if (isEmptyModlistException(e)) {
+                Optional.ofNullable(message).ifPresentOrElse(
+                        msg -> LOGGER.debug(msg, messageParams),
+                        () -> LOGGER.debug("No modification was needed in FreeIPA is ignored. Exception message: {}", e.getMessage()));
+                return Optional.empty();
+            } else {
+                throw e;
+            }
+        }
+    }
+
     private static boolean isRetryable(FreeIpaClientException e) {
         return isExceptionWithErrorCode(e, RETRYABLE_ERROR_CODES) || isExceptionWithHttpCode(retryableHttpCodes, e) || isExceptionWithIOExceptionCause(e);
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/dns/DnsRecordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/dns/DnsRecordService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.service.freeipa.dns;
 
+import static com.sequenceiq.freeipa.client.FreeIpaClientExceptionUtil.ignoreEmptyModExceptionWithValue;
 import static com.sequenceiq.freeipa.client.FreeIpaClientExceptionUtil.ignoreNotFoundException;
 import static com.sequenceiq.freeipa.client.FreeIpaClientExceptionUtil.ignoreNotFoundExceptionWithValue;
 
@@ -157,7 +158,8 @@ public class DnsRecordService {
     private void createDnsARecord(FreeIpaClient client, String zone, String hostname, String ip, boolean createReverse) throws FreeIpaClientException {
         LOGGER.info("Creating A record in zone [{}] with hostname [{}] with IP [{}]. Create reverse set to [{}]",
                 zone, hostname, ip, createReverse);
-        DnsRecord record = client.addDnsARecord(zone, hostname, ip, createReverse);
+        Optional<DnsRecord> record = ignoreEmptyModExceptionWithValue(() -> client.addDnsARecord(zone, hostname, ip, createReverse),
+                "Record [{}] pointing to [{}] is already exists, nothing to do.", hostname, ip);
         LOGGER.info("A record [{}] pointing to [{}] is created successfully. Created record: {}", hostname, ip, record);
     }
 
@@ -193,7 +195,8 @@ public class DnsRecordService {
 
     private void createDnsCnameRecord(FreeIpaClient client, String zone, String cname, String targetFqdn) throws FreeIpaClientException {
         LOGGER.info("Creating CNAME record in zone [{}] with name [{}] with target [{}].", zone, cname, targetFqdn);
-        DnsRecord record = client.addDnsCnameRecord(zone, cname, targetFqdn);
+        Optional<DnsRecord> record = ignoreEmptyModExceptionWithValue(() -> client.addDnsCnameRecord(zone, cname, targetFqdn),
+                "CNAME record created with name [{}] with target [{}] is already exists, nothing to do.", cname, targetFqdn);
         LOGGER.info("CNAME record created with name [{}] with target [{}]. Record: {}", cname, targetFqdn, record);
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/dns/DnsRecordServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/dns/DnsRecordServiceTest.java
@@ -135,6 +135,28 @@ public class DnsRecordServiceTest {
     }
 
     @Test
+    public void testARecordAddEmptyModListIgnored() throws FreeIpaClientException {
+        AddDnsARecordRequest request = new AddDnsARecordRequest();
+        request.setEnvironmentCrn(ENV_CRN);
+        request.setHostname("Asdf");
+        request.setIp("1.1.1.2");
+        request.setCreateReverse(true);
+
+        Stack stack = createStack();
+        when(stackService.getByEnvironmentCrnAndAccountId(ENV_CRN, ACCOUNT_ID)).thenReturn(stack);
+        FreeIpa freeIpa = createFreeIpa();
+        when(freeIpaService.findByStack(stack)).thenReturn(freeIpa);
+        when(freeIpaClientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
+        JsonRpcClientException noModEx = new JsonRpcClientException(FreeIpaErrorCodes.EMPTY_MODLIST.getValue(), "no modifications to be performed", null);
+        when(freeIpaClient.addDnsARecord(DOMAIN, request.getHostname(), request.getIp(), request.isCreateReverse()))
+                .thenThrow(new FreeIpaClientException("can't create", noModEx));
+
+        underTest.addDnsARecord(ACCOUNT_ID, request);
+
+        verify(freeIpaClient).addDnsARecord(DOMAIN, request.getHostname(), request.getIp(), request.isCreateReverse());
+    }
+
+    @Test
     public void testARecordAddNotFound() throws FreeIpaClientException {
         AddDnsARecordRequest request = new AddDnsARecordRequest();
         request.setEnvironmentCrn(ENV_CRN);
@@ -289,6 +311,27 @@ public class DnsRecordServiceTest {
         FreeIpa freeIpa = createFreeIpa();
         when(freeIpaService.findByStack(stack)).thenReturn(freeIpa);
         when(freeIpaClientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
+
+        underTest.addDnsCnameRecord(ACCOUNT_ID, request);
+
+        verify(freeIpaClient).addDnsCnameRecord(DOMAIN, request.getCname(), request.getTargetFqdn());
+    }
+
+    @Test
+    public void testCnameRecordAddEmptyModListIgnored() throws FreeIpaClientException {
+        AddDnsCnameRecordRequest request = new AddDnsCnameRecordRequest();
+        request.setEnvironmentCrn(ENV_CRN);
+        request.setCname("Asdf");
+        request.setTargetFqdn(TARGET_FQDN);
+
+        Stack stack = createStack();
+        when(stackService.getByEnvironmentCrnAndAccountId(ENV_CRN, ACCOUNT_ID)).thenReturn(stack);
+        FreeIpa freeIpa = createFreeIpa();
+        when(freeIpaService.findByStack(stack)).thenReturn(freeIpa);
+        when(freeIpaClientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
+        JsonRpcClientException noModEx = new JsonRpcClientException(FreeIpaErrorCodes.EMPTY_MODLIST.getValue(), "no modifications to be performed", null);
+        when(freeIpaClient.addDnsCnameRecord(DOMAIN, request.getCname(), request.getTargetFqdn()))
+                .thenThrow(new FreeIpaClientException("can't create", noModEx));
 
         underTest.addDnsCnameRecord(ACCOUNT_ID, request);
 


### PR DESCRIPTION
…records

In some rare cases when retry is performed both by FMS and the calling service it's possible the ADD request is sent
twice to FreeIPA. This would cause one of them to fail with `EMPTY_MODLIST(4202)` error. This can be ignored.

Tested manually with using debug on real FreeIPA and covered with unit tests.

See detailed description in the commit message.