### PR TITLE
CDPCP-3974. Update gradle dependencies (v2 - spring messaging)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ allprojects {
         force "org.codehaus.jackson:jackson-core-asl:1.9.13"
         force "org.codehaus.jackson:jackson-xc:1.9.13"
         force "org.testng:testng:$testNgVersion"
+        force "org.springframework:spring-messaging:$springFrameworkVersion"
       }
     }
   }


### PR DESCRIPTION
details:
- CB-11603. Upgrade package spring-messaging to version 4.3.16.RELEASE or above. (CVE-2018-1275)
- CB-11604. Upgrade package spring-messaging to version 4.3.16.RELEASE or above. (CVE-2018-1270)
(new spring-messaging version: 5.3.2 - as the spring framework version)

See detailed description in the commit message.