### PR TITLE
CB-8090 CB fails to update manually terminated AWS instances as unhea…

### DIFF
--- a/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/CmApiRetryAspect.java
+++ b/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/CmApiRetryAspect.java
@@ -21,7 +21,11 @@ public class CmApiRetryAspect {
     public void allCmApiCalls() {
     }
 
-    @Around("allCmApiCalls()")
+    @Pointcut("!execution(public * com.cloudera.api.swagger.ClouderaManagerResourceApi.getVersion())")
+    public void noGetVersion() {
+    }
+
+    @Around("allCmApiCalls() && noGetVersion()")
     // CHECKSTYLE:OFF
     public Object retryableApiCall(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
         // CHECKSTYLE:ON

--- a/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/CmApiRetryTemplateConfig.java
+++ b/client-cm/src/main/java/com/sequenceiq/cloudbreak/cm/client/retry/CmApiRetryTemplateConfig.java
@@ -17,6 +17,7 @@ public class CmApiRetryTemplateConfig {
         fixedBackOffPolicy.setBackOffPeriod(BACK_OFF_PERIOD);
         retryTemplate.setBackOffPolicy(fixedBackOffPolicy);
         retryTemplate.setRetryPolicy(new ApiExceptionRetryPolicy());
+        retryTemplate.setThrowLastExceptionOnExhausted(true);
         return retryTemplate;
     }
 

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
@@ -24,4 +24,6 @@ public interface ClusterStatusService {
     Map<HostName, String> getHostStatusesRaw();
 
     boolean isClusterManagerRunning();
+
+    boolean isClusterManagerRunningQuickCheck();
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
@@ -8,6 +8,7 @@ import static com.sequenceiq.cloudbreak.cm.ClouderaManagerClusterStatusService.H
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -24,6 +25,7 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.retry.support.RetryTemplate;
 
 import com.cloudera.api.swagger.ClouderaManagerResourceApi;
 import com.cloudera.api.swagger.HostsResourceApi;
@@ -82,6 +84,9 @@ public class ClouderaManagerClusterStatusServiceTest {
 
     @Mock
     private HostsResourceApi hostsApi;
+
+    @Mock
+    private RetryTemplate retryTemplate;
 
     @InjectMocks
     private ClouderaManagerClusterStatusService subject;
@@ -355,7 +360,11 @@ public class ClouderaManagerClusterStatusServiceTest {
     }
 
     private void cmIsNotReachable() throws ApiException {
-        when(cmApi.getVersion()).thenThrow(new ApiException("CM is not reachable"));
+        try {
+            when(retryTemplate.execute(any(), any(), any())).thenThrow(new ApiException("CM is not reachable"));
+        } catch (Throwable t) {
+            throw new ApiException(t);
+        }
     }
 
     private void cmIsReachable() throws ApiException {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -33,8 +33,6 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.HostName;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
-import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
-import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerState;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerState.ClusterManagerStatus;
@@ -257,7 +255,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
     private boolean isClusterManagerRunning(Stack stack, ClusterApi connector) {
         return !stack.isStopped()
                 && !stack.isStackInDeletionOrFailedPhase()
-                && !queryClusterStatus(connector).getClusterStatus().equals(ClusterStatus.CLUSTERMANAGER_NOT_RUNNING);
+                && isCMRunning(connector);
     }
 
     private void syncInstances(Stack stack, Collection<InstanceMetaData> instanceMetaData, boolean cmServerRunning) {
@@ -273,8 +271,8 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         ifFlowNotRunning(() -> syncService.autoSync(stack, runningInstances, instanceStatuses, defaultState, syncConfig));
     }
 
-    private ClusterStatusResult queryClusterStatus(ClusterApi connector) {
-        return connector.clusterStatusService().getStatus(false);
+    private boolean isCMRunning(ClusterApi connector) {
+        return connector.clusterStatusService().isClusterManagerRunningQuickCheck();
     }
 
     private Set<String> getNewHealthyHostNames(Map<HostName, ClusterManagerState> hostStatuses, Set<InstanceMetaData> runningInstances) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
@@ -3,7 +3,6 @@ package com.sequenceiq.cloudbreak.job;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -36,7 +35,6 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.HostName;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterStatusService;
-import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatusResult;
 import com.sequenceiq.cloudbreak.cluster.status.ExtendedHostStatuses;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerState;
@@ -180,7 +178,6 @@ public class StackStatusCheckerJobTest {
     @Test
     public void testInstanceSyncCMRunning() throws JobExecutionException {
         setupForCM();
-        when(clusterStatusResult.getClusterStatus()).thenReturn(ClusterStatus.CLUSTERMANAGER_RUNNING);
         when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
         when(clusterApi.clusterStatusService()).thenReturn(clusterStatusService);
         underTest.executeTracedJob(jobExecutionContext);
@@ -209,7 +206,8 @@ public class StackStatusCheckerJobTest {
 
     private void setupForCM() {
         setStackStatus(DetailedStackStatus.AVAILABLE);
-        when(clusterStatusService.getStatus(anyBoolean())).thenReturn(clusterStatusResult);
+        when(clusterApi.clusterStatusService()).thenReturn(clusterStatusService);
+        when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(true);
         ClusterManagerState clusterManagerState = new ClusterManagerState(ClusterManagerStatus.HEALTHY, null);
         ExtendedHostStatuses extendedHostStatuses = new ExtendedHostStatuses(Map.of(HostName.hostName("host1"), clusterManagerState), true);
         when(clusterStatusService.getExtendedHostStatuses()).thenReturn(extendedHostStatuses);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
@@ -334,6 +334,7 @@ class StackStatusIntegrationTest {
 
     private void setUpClusterStatus(ClusterStatus clusterStatus) {
         when(clusterStatusService.getStatus(anyBoolean())).thenReturn(new ClusterStatusResult(clusterStatus, ""));
+        when(clusterStatusService.isClusterManagerRunningQuickCheck()).thenReturn(true);
     }
 
     private void setUpClusterManagerStatus(String fqdn, ClusterManagerStatus clusterManagerStatus) {


### PR DESCRIPTION
…lthy

If CM is down the the StatusChecker hangs for 15 minutes (2min connection timeout and 5x retry with backoff periods).

Changes:
- new method for quick CM status check (15 sec (configurable) connection timeout and no retry)
- only the StackStatusCheckerJob changed, the old behavior remained at all other places