### PR TITLE
CB-12262 Fix missing stack related data from datalake and datahub mes…

### DIFF
--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/LegacyFlowStructuredEventHandler.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/LegacyFlowStructuredEventHandler.java
@@ -89,12 +89,11 @@ public class LegacyFlowStructuredEventHandler<S, E> extends StateMachineListener
             String fromId = from != null ? from.getId().toString() : "unknown";
             String toId = to != null ? to.getId().toString() : "unknown";
             String eventId = trigger != null ? trigger.getEvent().toString() : "unknown";
-            Boolean detailed = toId.equals(initState.toString()) || toId.equals(finalState.toString());
             FlowDetails flowDetails = new FlowDetails(flowChainType, flowType, flowChainId, flowId, fromId, toId, eventId,
                     lastStateChange == null ? 0L : currentTime - lastStateChange);
             StructuredEvent structuredEvent;
             if (exception == null) {
-                structuredEvent = legacyStructuredFlowEventFactory.createStucturedFlowEvent(stackId, flowDetails, detailed);
+                structuredEvent = legacyStructuredFlowEventFactory.createStucturedFlowEvent(stackId, flowDetails, true);
             } else {
                 structuredEvent = legacyStructuredFlowEventFactory.createStucturedFlowEvent(stackId, flowDetails, true, exception);
                 exception = null;


### PR DESCRIPTION
…sages.

By enabling detailed creation of structuredflowevents during the whole flow instead of only at the init and final states we will have the missing stack data in the structured events when generating EDH datahub and datalake logs.

See detailed description in the commit message.