### PR TITLE
CB-12046 s3 calls should not leave the s3 region

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsLogRolePermissionValidator.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/validator/AwsLogRolePermissionValidator.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -23,6 +21,7 @@ import com.amazonaws.services.identitymanagement.model.Role;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonIdentityManagementClient;
 import com.sequenceiq.cloudbreak.cloud.aws.util.AwsIamService;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
+import com.sequenceiq.cloudbreak.cloud.storage.LocationHelper;
 import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
 
 @Component
@@ -30,10 +29,11 @@ public class AwsLogRolePermissionValidator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsLogRolePermissionValidator.class);
 
-    private static final Pattern EXTRACT_BUCKET_PATTERN = Pattern.compile("^s3.?://([^/]*)");
-
     @Inject
     private AwsIamService awsIamService;
+
+    @Inject
+    private LocationHelper locationHelper;
 
     public void validate(AmazonIdentityManagementClient iam, InstanceProfile instanceProfile,
             CloudS3View cloudFileSystem, String logLocationBase, ValidationResultBuilder validationResultBuilder) {
@@ -43,7 +43,7 @@ public class AwsLogRolePermissionValidator {
         }
         Map<String, String> replacements = Map.ofEntries(
                 Map.entry("${LOGS_LOCATION_BASE}", removeProtocol(logLocationBase)),
-                Map.entry("${LOGS_BUCKET}", parseBucket(logLocationBase))
+                Map.entry("${LOGS_BUCKET}", locationHelper.parseS3BucketName(logLocationBase))
         );
         Policy policy = awsIamService.getPolicy("aws-cdp-log-policy.json", replacements);
         List<Role> roles = instanceProfile.getRoles();
@@ -75,15 +75,6 @@ public class AwsLogRolePermissionValidator {
 
     private String removeProtocol(String logLocationBase) {
         return logLocationBase.replaceFirst("^s3.?://", "");
-    }
-
-    private String parseBucket(String logLocationBase) {
-        String result = "";
-        Matcher m = EXTRACT_BUCKET_PATTERN.matcher(logLocationBase);
-        if (m.find()) {
-            result = m.group(1);
-        }
-        return result;
     }
 
     /**

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsLaunchTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsLaunchTest.java
@@ -78,6 +78,7 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
+import com.sequenceiq.cloudbreak.cloud.storage.LocationHelper;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
@@ -129,6 +130,9 @@ public class AwsLaunchTest {
 
     @Inject
     private ComponentTestUtil componentTestUtil;
+
+    @MockBean
+    private LocationHelper locationHelper;
 
     @MockBean
     private AmazonCloudFormationClient amazonCloudFormationClient;
@@ -278,6 +282,7 @@ public class AwsLaunchTest {
         when(customAmazonWaiterProvider.getAutoscalingActivitiesWaiter(any(), any())).thenReturn(describeScalingActivitiesRequestWaiter);
         when(awsClient.createCloudWatchClient(any(), anyString())).thenReturn(cloudWatchClient);
         when(entitlementService.awsCloudStorageValidationEnabled(any())).thenReturn(Boolean.TRUE);
+        when(locationHelper.parseS3BucketName(anyString())).thenCallRealMethod();
     }
 
     private void setupRetryService() {

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
@@ -91,6 +91,7 @@ import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.notification.ResourceNotifier;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
+import com.sequenceiq.cloudbreak.cloud.storage.LocationHelper;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.common.api.type.CommonStatus;
@@ -160,6 +161,9 @@ public class AwsRepairTest {
 
     @MockBean
     private DeleteFileSystemResult deleteFileSystemResult;
+
+    @MockBean
+    private LocationHelper locationHelper;
 
     @Inject
     private AwsResourceConnector underTest;
@@ -277,6 +281,7 @@ public class AwsRepairTest {
         when(amazonEfsClient.deleteFileSystem(any())).thenReturn(deleteFileSystemResult);
 
         when(entitlementService.awsCloudStorageValidationEnabled(any())).thenReturn(Boolean.TRUE);
+        when(locationHelper.parseS3BucketName(anyString())).thenCallRealMethod();
     }
 
     private void setupRetryService() {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/cloud/storage/LocationHelper.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/cloud/storage/LocationHelper.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.cloud.storage;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocationHelper {
+
+    private static final Pattern EXTRACT_BUCKET_PATTERN = Pattern.compile("^s3.?://([^/]+)");
+
+    public String parseS3BucketName(String cloudStorageLocation) {
+        String result = "";
+        Matcher m = EXTRACT_BUCKET_PATTERN.matcher(cloudStorageLocation);
+        if (m.find()) {
+            result = m.group(1);
+        }
+        return result;
+    }
+}

--- a/common/src/test/java/com/sequenceiq/cloudbreak/cloud/storage/LocationHelperTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/cloud/storage/LocationHelperTest.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.cloud.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class LocationHelperTest {
+
+    private LocationHelper underTest = new LocationHelper();
+
+    @ParameterizedTest
+    @CsvSource({
+            "s3a://bucket-name, bucket-name",
+            "s3a://bucket-name/path1/path2, bucket-name",
+            "s3://bucket-name/path1/path2, bucket-name",
+            "s3b://bucket-name/path1/path2, bucket-name",
+            "s3c://buck_et-na2.3me/path1/path2, buck_et-na2.3me",
+    })
+    void testExtractS3Bucket(String s3Location, String expectedBucketName) {
+        assertEquals(expectedBucketName, underTest.parseS3BucketName(s3Location));
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -61,7 +61,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
         "com.sequenceiq.cloudbreak.tracing",
         "com.sequenceiq.cloudbreak.tag",
         "com.sequenceiq.cloudbreak.filter",
-        "com.sequenceiq.cloudbreak.common"
+        "com.sequenceiq.cloudbreak.common",
+        "com.sequenceiq.cloudbreak.cloud.storage"
 },
         exclude = WebMvcMetricsAutoConfiguration.class)
 public class RedbeamsApplication {

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/CoreConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/CoreConfigProvider.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Lists;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
-import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3guard.S3GuardConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3.S3ConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.common.api.type.InstanceGroupType;
@@ -38,7 +38,7 @@ public class CoreConfigProvider extends AbstractRoleConfigProvider {
     private static final String CORE_SITE_SAFETY_VALVE = "core_site_safety_valve";
 
     @Inject
-    private S3GuardConfigProvider s3GuardConfigProvider;
+    private S3ConfigProvider s3ConfigProvider;
 
     @Override
     protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
@@ -52,7 +52,7 @@ public class CoreConfigProvider extends AbstractRoleConfigProvider {
                 .ifPresent(location -> apiClusterTemplateConfigs.add(config(CORE_DEFAULTFS, location.getValue())));
 
         StringBuilder hdfsCoreSiteSafetyValveValue = new StringBuilder();
-        s3GuardConfigProvider.getServiceConfigs(source, hdfsCoreSiteSafetyValveValue);
+        s3ConfigProvider.getServiceConfigs(source, hdfsCoreSiteSafetyValveValue);
         if (!hdfsCoreSiteSafetyValveValue.toString().isEmpty()) {
             apiClusterTemplateConfigs.add(config(CORE_SITE_SAFETY_VALVE, hdfsCoreSiteSafetyValveValue.toString()));
         }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsConfigProvider.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
-import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3guard.S3GuardConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3.S3ConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 
 @Component
@@ -20,13 +20,13 @@ public class HdfsConfigProvider implements CmTemplateComponentConfigProvider {
     private static final String CORE_SITE_SAFETY_VALVE = "core_site_safety_valve";
 
     @Inject
-    private S3GuardConfigProvider s3GuardConfigProvider;
+    private S3ConfigProvider s3ConfigProvider;
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
         StringBuilder hdfsCoreSiteSafetyValveValue = new StringBuilder();
 
-        s3GuardConfigProvider.getServiceConfigs(templatePreparationObject, hdfsCoreSiteSafetyValveValue);
+        s3ConfigProvider.getServiceConfigs(templatePreparationObject, hdfsCoreSiteSafetyValveValue);
 
         return hdfsCoreSiteSafetyValveValue.toString().isEmpty() ? List.of()
                 : List.of(config(CORE_SITE_SAFETY_VALVE, hdfsCoreSiteSafetyValveValue.toString()));

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/s3/S3ConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/s3/S3ConfigProvider.java
@@ -1,19 +1,24 @@
-package com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3guard;
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreCloudStorageServiceConfigProvider.HMS_METASTORE_DIR;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.cloud.storage.LocationHelper;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.filesystem.s3.S3FileSystemConfigurationsView;
 import com.sequenceiq.common.model.FileSystemType;
 
 @Component
-public class S3GuardConfigProvider {
+public class S3ConfigProvider {
 
     private static final String S3GUARD_METADATASTORE_IMPL_PARAM = "fs.s3a.metadatastore.impl";
 
@@ -35,15 +40,39 @@ public class S3GuardConfigProvider {
 
     private static final String S3GUARD_TABLE_TAG_VALUE = "s3guard";
 
+    private static final String S3_BUCKET_ENDPOINT_PARAM_TEMPLATE = "fs.s3a.bucket.%s.endpoint";
+
+    private static final String S3_ENDPOINT_TEMPLATE = "s3.%s.amazonaws.com";
+
+    @Inject
+    private LocationHelper locationHelper;
+
     public void getServiceConfigs(TemplatePreparationObject templatePreparationObject, StringBuilder hdfsCoreSiteSafetyValveValue) {
         if (isS3FileSystemConfigured(templatePreparationObject)) {
             configureS3GuardCoreSiteParameters(templatePreparationObject, hdfsCoreSiteSafetyValveValue);
+            configureS3BucketLocationCoreSiteParameters(templatePreparationObject, hdfsCoreSiteSafetyValveValue);
         }
     }
 
     private boolean isS3FileSystemConfigured(TemplatePreparationObject source) {
         return source.getFileSystemConfigurationView().isPresent()
                 && source.getFileSystemConfigurationView().get().getType().equals(FileSystemType.S3.name());
+    }
+
+    private void configureS3BucketLocationCoreSiteParameters(TemplatePreparationObject source, StringBuilder hdfsCoreSiteSafetyValveValue) {
+        S3FileSystemConfigurationsView s3FileSystemConfigurationsView =
+                (S3FileSystemConfigurationsView) source.getFileSystemConfigurationView().get();
+
+        source.getPlacementView().ifPresent(placementView -> {
+            Set<String> buckets = s3FileSystemConfigurationsView.getLocations().stream()
+                    .map(loc -> locationHelper.parseS3BucketName(loc.getValue()))
+                    .collect(Collectors.toSet());
+            buckets.forEach(bucketName -> {
+                String s3BucketEndpointParam = String.format(S3_BUCKET_ENDPOINT_PARAM_TEMPLATE, bucketName);
+                String s3BucketEndpoint = String.format(S3_ENDPOINT_TEMPLATE, placementView.getRegion());
+                hdfsCoreSiteSafetyValveValue.append(ConfigUtils.getSafetyValveProperty(s3BucketEndpointParam, s3BucketEndpoint));
+            });
+        });
     }
 
     private void configureS3GuardCoreSiteParameters(TemplatePreparationObject source, StringBuilder hdfsCoreSiteSafetyValveValue) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CentralCmTemplateUpdaterTest.java
@@ -39,7 +39,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.core.CoreConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hbase.HbaseCloudStorageServiceConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreConfigProvider;
-import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3guard.S3GuardConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3.S3ConfigProvider;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.StorageLocation;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
@@ -90,7 +90,7 @@ public class CentralCmTemplateUpdaterTest {
     private BlueprintView blueprintView;
 
     @Mock
-    private S3GuardConfigProvider s3GuardConfigProvider;
+    private S3ConfigProvider s3ConfigProvider;
 
     @Mock
     private GeneralClusterConfigs generalClusterConfigs;
@@ -113,7 +113,7 @@ public class CentralCmTemplateUpdaterTest {
         when(templatePreparationObject.getBlueprintView()).thenReturn(blueprintView);
         when(templatePreparationObject.getHostgroupViews()).thenReturn(toHostgroupViews(getHostgroupMappings()));
         when(templatePreparationObject.getGeneralClusterConfigs()).thenReturn(generalClusterConfigs);
-        doNothing().when(s3GuardConfigProvider).getServiceConfigs(any(TemplatePreparationObject.class), any(StringBuilder.class));
+        doNothing().when(s3ConfigProvider).getServiceConfigs(any(TemplatePreparationObject.class), any(StringBuilder.class));
         RDSConfig rdsConfig = TestUtil.rdsConfig(DatabaseType.HIVE);
         when(templatePreparationObject.getRdsConfigs()).thenReturn(Set.of(rdsConfig));
         when(templatePreparationObject.getRdsConfig(DatabaseType.HIVE)).thenReturn(rdsConfig);
@@ -215,7 +215,7 @@ public class CentralCmTemplateUpdaterTest {
     @Test
     public void getKafkaPropertiesWhenNoHdfsInClusterShouldPresentCoreSettings() {
         CoreConfigProvider coreConfigProvider = new CoreConfigProvider();
-        ReflectionTestUtils.setField(coreConfigProvider, "s3GuardConfigProvider", s3GuardConfigProvider);
+        ReflectionTestUtils.setField(coreConfigProvider, "s3ConfigProvider", s3ConfigProvider);
         List<CmTemplateComponentConfigProvider> cmTemplateComponentConfigProviders = List.of(coreConfigProvider);
         ReflectionTestUtils.setField(cmTemplateComponentConfigProviderProcessor, "providers", cmTemplateComponentConfigProviders);
         S3FileSystem s3FileSystem = new S3FileSystem();

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hdfs/HdfsConfigProviderTest.java
@@ -21,7 +21,7 @@ import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
-import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3guard.S3GuardConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3.S3ConfigProvider;
 import com.sequenceiq.cloudbreak.domain.StorageLocation;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
@@ -45,11 +45,11 @@ public class HdfsConfigProviderTest {
     private HdfsConfigProvider underTest;
 
     @Mock
-    private S3GuardConfigProvider s3GuardConfigProvider;
+    private S3ConfigProvider s3ConfigProvider;
 
     @Test
     public void testGetHdfsServiceConfigsWithoutS3Guard() {
-        doNothing().when(s3GuardConfigProvider).getServiceConfigs(any(TemplatePreparationObject.class), any(StringBuilder.class));
+        doNothing().when(s3ConfigProvider).getServiceConfigs(any(TemplatePreparationObject.class), any(StringBuilder.class));
 
         TemplatePreparationObject preparationObject = getTemplatePreparationObject(false, false, false);
         String inputJson = getBlueprintText("input/clouderamanager.bp");
@@ -62,7 +62,7 @@ public class HdfsConfigProviderTest {
 
     @Test
     public void testGetHdfsServiceConfigsWithS3FileSystemNoDynamoTable() {
-        doNothing().when(s3GuardConfigProvider).getServiceConfigs(any(TemplatePreparationObject.class), any(StringBuilder.class));
+        doNothing().when(s3ConfigProvider).getServiceConfigs(any(TemplatePreparationObject.class), any(StringBuilder.class));
 
         TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, false, false);
         String inputJson = getBlueprintText("input/clouderamanager.bp");

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/s3/S3ConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/s3/S3ConfigProviderTest.java
@@ -1,6 +1,8 @@
-package com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3guard;
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -8,12 +10,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.cloud.storage.LocationHelper;
 import com.sequenceiq.cloudbreak.domain.StorageLocation;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.gateway.Gateway;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
@@ -28,17 +32,17 @@ import com.sequenceiq.common.api.filesystem.AdlsFileSystem;
 import com.sequenceiq.common.api.filesystem.S3FileSystem;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
-@RunWith(MockitoJUnitRunner.class)
-public class S3GuardConfigProviderTest {
-    private S3GuardConfigProvider underTest;
+@ExtendWith(MockitoExtension.class)
+public class S3ConfigProviderTest {
 
-    @Before
-    public void setUp() {
-        underTest = new S3GuardConfigProvider();
-    }
+    @Mock
+    private LocationHelper locationHelper;
+
+    @InjectMocks
+    private S3ConfigProvider underTest;
 
     @Test
-    public void testGetHdfsServiceConfigsWithS3GuardWithoutAuthoriative() {
+    void testGetHdfsServiceConfigsWithS3GuardWithoutAuthoriative() {
         TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, false);
         StringBuilder sb = new StringBuilder();
 
@@ -54,7 +58,8 @@ public class S3GuardConfigProviderTest {
     }
 
     @Test
-    public void testGetHdfsServiceConfigsWithS3GuardWithAuthoriativeWarehousePath() {
+    void testGetHdfsServiceConfigsWithS3GuardWithAuthoriativeWarehousePath() {
+        when(locationHelper.parseS3BucketName(anyString())).thenCallRealMethod();
         TemplatePreparationObject preparationObject = getTemplatePreparationObject(true, true, true);
         StringBuilder sb = new StringBuilder();
 
@@ -68,7 +73,9 @@ public class S3GuardConfigProviderTest {
                 "<property><name>fs.s3a.s3guard.ddb.table</name><value>dynamoTable</value></property>" +
                 "<property><name>fs.s3a.s3guard.ddb.region</name><value>region</value></property>" +
                 "<property><name>fs.s3a.authoritative.path</name>" +
-                "<value>s3a://bucket/warehouse/managed</value></property>", sb.toString());
+                "<value>s3a://bucket-first/warehouse/managed</value></property>" +
+                "<property><name>fs.s3a.bucket.bucket-first.endpoint</name><value>s3.region.amazonaws.com</value></property>" +
+                "<property><name>fs.s3a.bucket.bucket-second.endpoint</name><value>s3.region.amazonaws.com</value></property>", sb.toString());
     }
 
     private TemplatePreparationObject getTemplatePreparationObject(boolean useS3FileSystem, boolean fillDynamoTableName, boolean includeLocations) {
@@ -78,8 +85,9 @@ public class S3GuardConfigProviderTest {
         List<StorageLocationView> locations = new ArrayList<>();
 
         if (includeLocations) {
-            locations.add(new StorageLocationView(getStorageLocation("hive.metastore.warehouse.dir", "s3a://bucket/warehouse/managed")));
-            locations.add(new StorageLocationView(getStorageLocation("hive.metastore.warehouse.external.dir", "s3a://bucket/warehouse/external")));
+            locations.add(new StorageLocationView(getStorageLocation("hive.metastore.warehouse.dir", "s3a://bucket-first/warehouse/managed")));
+            locations.add(new StorageLocationView(getStorageLocation("hive.metastore.warehouse.external.dir", "s3a://bucket-first/warehouse/external")));
+            locations.add(new StorageLocationView(getStorageLocation("ranger_plugin_hdfs_audit_url", "s3a://bucket-second/ranger/audit")));
         }
 
         BaseFileSystemConfigurationsView fileSystemConfigurationsView;


### PR DESCRIPTION
A customer has a restriction that calls to s3 have to remain within their region (done with a policy from AWS Landing Zone). During datalake install, CM first run the task HDFS dir create failed.
Analysis revealed a connection timeout to s3. The connection, however, was made to s3 region east-us, the default s3 region in the absence of region info, to resolve the region of the bucket. Because of the barrage, however, the call was blocked.

The solution is based on a setting offered by the hadoop-aws component: adding the fs.s3.bucket.BUCKET-NAME.endpoint parameter with the regional endpoint will let hdfs know that it should use the given endpoint for the bucket (storage location base) given.

See detailed description in the commit message.