### PR TITLE
CB-12159 Solr UI load fails - 502 Service Con Error/ HA failover disabled

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -278,7 +278,7 @@
              {% if 'SOLR' in exposed and 'SOLR_SERVER' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>SOLR</name>
-                 <value>enableStickySession=true;noFallback=true;enableLoadBalancing=true</value>
+                 <value>enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
              </param>
              {%- endif %}
              {% if 'JOBHISTORYUI' in exposed and 'JOBHISTORY' in salt['pillar.get']('gateway:location') -%}


### PR DESCRIPTION
Sticky sessions and noFallback were enabled for the Solr UI Knox endpoints, under the assumption that
the Solr UI requires a valid session. This prevented failover if one of the Solr instances was down.
The Solr team has since verified that the UI is stateless and there's no need for sticky sessions, and
no reason to disable fallback. Updating the topology to turn off sticky sessions and turn on falback.

Tested by manually update the topology.xml document on the data lake and verifying the Solr UI failed
over successfully.