### PR TITLE
CB-12292 EventBusConfigTest.uncaughtErrorButFlowFound unit test is flaky

### DIFF
--- a/flow/src/test/java/com/sequenceiq/flow/reactor/config/EventBusConfigTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/reactor/config/EventBusConfigTest.java
@@ -51,9 +51,9 @@ class EventBusConfigTest {
         headers.set("FLOW_ID", "123");
         eventBus.notify("notexist", new Event<>(headers, null));
         verify(flowLogDBService, timeout(2000).times(1)).getLastFlowLog("123");
-        verify(applicationFlowInformation, times(1)).handleFlowFail(flowLog);
-        verify(flowLogDBService, times(1)).updateLastFlowLogStatus(flowLog, true);
-        verify(flowLogDBService, times(1)).finalize(flowLog.getFlowId());
+        verify(applicationFlowInformation, timeout(1000).times(1)).handleFlowFail(flowLog);
+        verify(flowLogDBService, timeout(1000).times(1)).updateLastFlowLogStatus(flowLog, true);
+        verify(flowLogDBService, timeout(1000).times(1)).finalize(flowLog.getFlowId());
     }
 
     @Test
@@ -82,9 +82,9 @@ class EventBusConfigTest {
         });
         eventBus.notify("exampleselector", new Event<>(headers, null));
         verify(flowLogDBService, timeout(2000).times(1)).getLastFlowLog("123");
-        verify(applicationFlowInformation, times(1)).handleFlowFail(flowLog);
-        verify(flowLogDBService, times(1)).updateLastFlowLogStatus(flowLog, true);
-        verify(flowLogDBService, times(1)).finalize(flowLog.getFlowId());
+        verify(applicationFlowInformation, timeout(1000).times(1)).handleFlowFail(flowLog);
+        verify(flowLogDBService, timeout(1000).times(1)).updateLastFlowLogStatus(flowLog, true);
+        verify(flowLogDBService, timeout(1000).times(1)).finalize(flowLog.getFlowId());
     }
 
     @Test


### PR DESCRIPTION
The event bus is async this is why I added timeout(2000) to getLastFlowLog
method verification. The problem is sometimes the test verification thread
is faster than the async eventbus error handling thread so it can happen the
flowLogDBService method calls are not invoked when it was verified. I
hope this 1000 ms timeout can avoid the flakiness.
