### PR TITLE
CB-12197 Introduce authorization tests regarding environment groups

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -818,18 +818,18 @@ public class GrpcUmsClient {
     }
 
     public void assignResourceRole(
-            String userCrn, String resourceCrn, String resourceRoleCrn, Optional<String> requestId) {
+            String assigneeCrn, String resourceCrn, String resourceRoleCrn, Optional<String> requestId) {
         UmsClient client = makeClient(channelWrapper.getChannel(), ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN);
-        LOGGER.info("Assigning {} role for resource {} to user {}", resourceRoleCrn, resourceCrn, userCrn);
-        client.assignResourceRole(RequestIdUtil.getOrGenerate(requestId), userCrn, resourceCrn, resourceRoleCrn);
-        LOGGER.info("Assigned {} role for resource {} to user {}", resourceRoleCrn, resourceCrn, userCrn);
+        LOGGER.info("Assigning {} role for resource {} to assignee {}", resourceRoleCrn, resourceCrn, assigneeCrn);
+        client.assignResourceRole(RequestIdUtil.getOrGenerate(requestId), assigneeCrn, resourceCrn, resourceRoleCrn);
+        LOGGER.info("Assigned {} role for resource {} to assignee {}", resourceRoleCrn, resourceCrn, assigneeCrn);
     }
 
-    public void unassignResourceRole(String userCrn, String resourceCrn, String resourceRoleCrn, Optional<String> requestId) {
+    public void unassignResourceRole(String assigneeCrn, String resourceCrn, String resourceRoleCrn, Optional<String> requestId) {
         UmsClient client = makeClient(channelWrapper.getChannel(), ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN);
-        LOGGER.info("Unassigning {} role for resource {} from user {}", resourceRoleCrn, resourceCrn, userCrn);
-        client.unassignResourceRole(RequestIdUtil.getOrGenerate(requestId), userCrn, resourceCrn, resourceRoleCrn);
-        LOGGER.info("Unassigned {} role for resource {} from user {}", resourceRoleCrn, resourceCrn, userCrn);
+        LOGGER.info("Unassigning {} role for resource {} from assignee {}", resourceRoleCrn, resourceCrn, assigneeCrn);
+        client.unassignResourceRole(RequestIdUtil.getOrGenerate(requestId), assigneeCrn, resourceCrn, resourceRoleCrn);
+        LOGGER.info("Unassigned {} role for resource {} from assignee {}", resourceRoleCrn, resourceCrn, assigneeCrn);
     }
 
     public void notifyResourceDeleted(String resourceCrn, Optional<String> requestId) {

--- a/integration-test/Makefile
+++ b/integration-test/Makefile
@@ -52,6 +52,9 @@ create-cloudbreak-context:
 fetch-secrets:
 	./scripts/fetch-secrets.sh
 
+fetch-l0-secrets:
+	SECRET_VERSION=9793d2c1afa84cbb9fdfeaee2f4327db USER_JSON_SECRET=l0-ums-users-dev USER_JSON_LOCATION=./src/main/resources/ums-users/l0-api-credentials.json ./scripts/fetch-secrets.sh
+
 fetch-secrets-docker:
 	docker run --rm -v "${PWD}/:/tmp/" \
 	-e AZURE_CLIENT_ID=${AZURE_CLIENT_ID} \

--- a/integration-test/scripts/fetch-secrets.sh
+++ b/integration-test/scripts/fetch-secrets.sh
@@ -2,23 +2,38 @@
 
 set -ex
 
-secret_version="69f803e3ff3c42d79be1f87bb04341e9"
+: ${SECRET_VERSION:="69f803e3ff3c42d79be1f87bb04341e9"}
+: ${USER_JSON_LOCATION:="./src/main/resources/ums-users/api-credentials.json"}
+: ${USER_JSON_SECRET:="real-ums-users-dev"}
 
-USER_JSON_LOCATION="./src/main/resources/ums-users/api-credentials.json"
+init-ums-users-temp() {
+    if [[ -d ./src/main/resources/ums-users ]]; then
+        rm -rf ./src/main/resources/ums-users
+    fi
+    mkdir -p ./src/main/resources/ums-users
+}
 
-if [[ -z $AZURE_CLIENT_ID ]]; then
-  echo "Variable AZURE_CLIENT_ID not set, using az login."
-  az login
-else
-  az login -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --service-principal --tenant $AZURE_TENANT_ID
-fi
+init-azure-auth() {
+    if [[ -z $AZURE_CLIENT_ID ]]; then
+        echo "Azure Username and Password has not been set! So Azure Interactive Login has been initiated!"
+        az login
+    else
+        az login -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --service-principal --tenant $AZURE_TENANT_ID
+    fi
+}
 
-mkdir -p ./src/main/resources/ums-users
+fetch-real-ums-users() {
+    echo "Fetching Manowar Dev Real UMS Users from Azure 'jenkins-secret' key vault..."
+    az keyvault secret show --name $USER_JSON_SECRET --vault-name "jenkins-secret" --version $SECRET_VERSION --query 'value' -o tsv | jq '.' > $USER_JSON_LOCATION
 
-echo "Executing secret fetching from Azure 'jenkins-secret' store"
-az keyvault secret show --name "real-ums-users-dev" --vault-name "jenkins-secret" --version $secret_version --query 'value' -o tsv | jq '.' > $USER_JSON_LOCATION
+    echo "Validate Real UMS User Store: File should be a valid JSON at: $USER_JSON_LOCATION"
+    cat $USER_JSON_LOCATION | jq type
+}
 
-echo "Checking if valid json file was fetched: $USER_JSON_LOCATION"
-cat $USER_JSON_LOCATION | jq type
+main() {
+  init-ums-users-temp
+  init-azure-auth
+  fetch-real-ums-users
+}
 
-
+main "$@"

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
@@ -9,6 +9,7 @@ import com.sequenceiq.cloudbreak.auth.altus.config.UmsClientConfig;
 import com.sequenceiq.flow.api.FlowPublicEndpoint;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.dto.ums.UmsGroupTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.util.wait.service.WaitObject;
@@ -61,6 +62,7 @@ public class UmsClient extends MicroserviceClient<GrpcUmsClient, Void> {
 
     @Override
     public Set<String> supportedTestDtos() {
-        return Set.of(UmsTestDto.class.getSimpleName());
+        return Set.of(UmsTestDto.class.getSimpleName(),
+                UmsGroupTestDto.class.getSimpleName());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignResourceRoleGroupAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignResourceRoleGroupAction.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.it.cloudbreak.action.ums;
+
+import static java.lang.String.format;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.UmsClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class AssignResourceRoleGroupAction implements Action<UmsTestDto, UmsClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AssignResourceRoleGroupAction.class);
+
+    private final String groupCrn;
+
+    public AssignResourceRoleGroupAction(String groupCrn) {
+        this.groupCrn = groupCrn;
+    }
+
+    @Override
+    public UmsTestDto action(TestContext testContext, UmsTestDto testDto, UmsClient client) throws Exception {
+        String resourceRole = testDto.getRequest().getRoleCrn();
+        String resourceCrn = testDto.getRequest().getResourceCrn();
+        Log.when(LOGGER, format(" Assigning resource role '%s' at resource '%s' for group '%s' ", resourceRole, resourceCrn, groupCrn));
+        Log.whenJson(LOGGER, format(" Assign resource role request:%n "), testDto.getRequest());
+        client.getDefaultClient().assignResourceRole(groupCrn, resourceCrn, resourceRole, Optional.of(""));
+        // wait for UmsRightsCache to expire
+        Thread.sleep(7000);
+        LOGGER.info(format(" Resource role '%s' has been assigned at resource '%s' for group '%s' ", resourceRole, resourceCrn, groupCrn));
+        Log.when(LOGGER, format(" Resource role '%s' has been assigned at resource '%s' for group '%s' ", resourceRole, resourceCrn, groupCrn));
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignResourceRoleUserAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignResourceRoleUserAction.java
@@ -14,13 +14,13 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
 
-public class AssignResourceRoleAction implements Action<UmsTestDto, UmsClient> {
+public class AssignResourceRoleUserAction implements Action<UmsTestDto, UmsClient> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AssignResourceRoleAction.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AssignResourceRoleUserAction.class);
 
     private final String userKey;
 
-    public AssignResourceRoleAction(String userKey) {
+    public AssignResourceRoleUserAction(String userKey) {
         this.userKey = userKey;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/DeleteUserGroupAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/DeleteUserGroupAction.java
@@ -31,8 +31,8 @@ public class DeleteUserGroupAction implements Action<UmsGroupTestDto, UmsClient>
         Log.when(LOGGER, format(" Deleting user group '%s' at account '%s'. ", groupName, accountId));
         Log.whenJson(LOGGER, format(" Delete user group request:%n "), testDto.getRequest());
         client.getDefaultClient().deleteGroup(userCrn, accountId, groupName, Optional.of(""));
-        LOGGER.info(format(" User group '%s' has been deleted at account '%s'. ", testDto.getResponse().getGroupName(), accountId));
-        Log.when(LOGGER, format(" User group '%s' has been deleted at account '%s'. ", testDto.getResponse().getGroupName(), accountId));
+        LOGGER.info(format(" User group '%s' has been deleted at account '%s'. ", groupName, accountId));
+        Log.when(LOGGER, format(" User group '%s' has been deleted at account '%s'. ", groupName, accountId));
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/ListGroupMembersAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/ListGroupMembersAction.java
@@ -33,8 +33,8 @@ public class ListGroupMembersAction implements Action<UmsGroupTestDto, UmsClient
         Log.when(LOGGER, format(" Listing user group '%s' members at account '%s'. ", groupName, accountId));
         Log.whenJson(LOGGER, format(" List user group members request:%n "), testDto.getRequest());
         List<String> members = client.getDefaultClient().listMembersFromGroup(userCrn, accountId, groupName, Optional.of(""));
-        LOGGER.info(format(" User group '%s' contains members: [%s] ", testDto.getResponse().getGroupName(), members));
-        Log.when(LOGGER, format(" User group '%s' contains members: [%s] ", testDto.getResponse().getGroupName(), members));
+        LOGGER.info(format(" User group '%s' contains members: [%s] ", groupName, members));
+        Log.when(LOGGER, format(" User group '%s' contains members: [%s] ", groupName, members));
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/RemoveUserFromGroupAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/RemoveUserFromGroupAction.java
@@ -13,15 +13,15 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsGroupTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
 
-public class AddUserToGroupAction implements Action<UmsGroupTestDto, UmsClient> {
+public class RemoveUserFromGroupAction implements Action<UmsGroupTestDto, UmsClient> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AddUserToGroupAction.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoveUserFromGroupAction.class);
 
     private final String groupName;
 
     private final String memberCrn;
 
-    public AddUserToGroupAction(String groupName, String memberCrn) {
+    public RemoveUserFromGroupAction(String groupName, String memberCrn) {
         this.groupName = groupName;
         this.memberCrn = memberCrn;
     }
@@ -32,11 +32,11 @@ public class AddUserToGroupAction implements Action<UmsGroupTestDto, UmsClient> 
         String accountId = testDto.getRequest().getAccountId();
         testDto.withName(groupName);
         testDto.withMember(memberCrn);
-        Log.when(LOGGER, format(" Assigning user '%s' to group '%s' at account '%s'. ", memberCrn, groupName, accountId));
-        Log.whenJson(LOGGER, format(" Assign user to group request:%n "), testDto.getRequest());
-        client.getDefaultClient().addMemberToGroup(userCrn, accountId, groupName, memberCrn, Optional.of(""));
-        LOGGER.info(format(" User '%s' has been assigned to group '%s' at account '%s'. ", memberCrn, groupName, accountId));
-        Log.when(LOGGER, format(" User '%s' has been assigned to group '%s' at account '%s'. ", memberCrn, groupName, accountId));
+        Log.when(LOGGER, format(" Removing user '%s' from group '%s' at account '%s'. ", memberCrn, groupName, accountId));
+        Log.whenJson(LOGGER, format(" Remove user from group request:%n "), testDto.getRequest());
+        client.getDefaultClient().removeMemberFromGroup(userCrn, accountId, groupName, memberCrn, Optional.of(""));
+        LOGGER.info(format(" User '%s' has been removed from group '%s' at account '%s'. ", memberCrn, groupName, accountId));
+        Log.when(LOGGER, format(" User '%s' has been removed from group '%s' at account '%s'. ", memberCrn, groupName, accountId));
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/actor/CloudbreakUserCache.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/actor/CloudbreakUserCache.java
@@ -41,11 +41,19 @@ public class CloudbreakUserCache {
 
     @PostConstruct
     private void initRealUmsUserCache() {
-        String userConfigPath = "ums-users/api-credentials.json";
+        String userConfigPath;
+        String authUserConfigPath = "ums-users/api-credentials.json";
+        String l0UserConfigPath = "ums-users/l0-api-credentials.json";
         Map<String, Map<String, List<CloudbreakUser>>> fetchedUserStore;
         List<CloudbreakUser> cloudbreakUsers;
         Set<String> accountIds = new HashSet<>();
         String accountId;
+
+        if (new ClassPathResource(l0UserConfigPath).exists()) {
+            userConfigPath = l0UserConfigPath;
+        } else {
+            userConfigPath = authUserConfigPath;
+        }
 
         if (new ClassPathResource(userConfigPath).exists()) {
             LOGGER.info("Real UMS users are initializing by deployment: {} and account: {}. User store is present at: {} path", realUmsUserDeployment,

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/UmsTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/UmsTestClient.java
@@ -5,11 +5,13 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.it.cloudbreak.UmsClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.action.ums.AddUserToGroupAction;
-import com.sequenceiq.it.cloudbreak.action.ums.AssignResourceRoleAction;
+import com.sequenceiq.it.cloudbreak.action.ums.AssignResourceRoleGroupAction;
+import com.sequenceiq.it.cloudbreak.action.ums.AssignResourceRoleUserAction;
 import com.sequenceiq.it.cloudbreak.action.ums.CreateUserGroupAction;
 import com.sequenceiq.it.cloudbreak.action.ums.DeleteUserGroupAction;
 import com.sequenceiq.it.cloudbreak.action.ums.GetUserDetailsAction;
 import com.sequenceiq.it.cloudbreak.action.ums.ListGroupMembersAction;
+import com.sequenceiq.it.cloudbreak.action.ums.RemoveUserFromGroupAction;
 import com.sequenceiq.it.cloudbreak.action.ums.SetWorkloadPasswordAction;
 import com.sequenceiq.it.cloudbreak.action.ums.UnassignResourceRoleAction;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsGroupTestDto;
@@ -19,11 +21,15 @@ import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
 public class UmsTestClient {
 
     public Action<UmsTestDto, UmsClient> assignResourceRole(String userKey) {
-        return new AssignResourceRoleAction(userKey);
+        return new AssignResourceRoleUserAction(userKey);
     }
 
     public Action<UmsTestDto, UmsClient> unAssignResourceRole(String userKey) {
         return new UnassignResourceRoleAction(userKey);
+    }
+
+    public Action<UmsTestDto, UmsClient> assignResourceRoleWithGroup(String groupCrn) {
+        return new AssignResourceRoleGroupAction(groupCrn);
     }
 
     public Action<UmsTestDto, UmsClient> setWorkloadPassword(String newPassword) {
@@ -42,8 +48,12 @@ public class UmsTestClient {
         return new DeleteUserGroupAction(groupName);
     }
 
-    public Action<UmsGroupTestDto, UmsClient> addUserToGroup(String userName, String memberCrn) {
-        return new AddUserToGroupAction(userName, memberCrn);
+    public Action<UmsGroupTestDto, UmsClient> addUserToGroup(String groupName, String memberCrn) {
+        return new AddUserToGroupAction(groupName, memberCrn);
+    }
+
+    public Action<UmsGroupTestDto, UmsClient> removeUserFromGroup(String groupName, String memberCrn) {
+        return new RemoveUserFromGroupAction(groupName, memberCrn);
     }
 
     public Action<UmsGroupTestDto, UmsClient> listGroupMembers(String groupName) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/RunningParameter.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/RunningParameter.java
@@ -5,17 +5,12 @@ import java.util.Arrays;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
-import com.sequenceiq.it.cloudbreak.testcase.authorization.AuthUserKeys;
 
 @Component
 public class RunningParameter {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(RunningParameter.class);
 
     private CloudbreakUser who;
 
@@ -41,7 +36,7 @@ public class RunningParameter {
     public CloudbreakUser getWho() {
         if (doAsAdmin) {
             if (testContext.realUmsUserCacheReadyToUse()) {
-                return testContext.getRealUmsUserByKey(AuthUserKeys.ACCOUNT_ADMIN);
+                return testContext.getRealUmsAdmin();
             }
         }
         return who;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -635,6 +635,27 @@ public abstract class TestContext implements ApplicationContextAware {
         return requestedRealUmsUser;
     }
 
+    /**
+     * Request the real UMS admin from the fetched ums-users json
+     *
+     * @return                   Returns with the UMS admin user (CloudbreakUser)
+     */
+    public CloudbreakUser getRealUmsAdmin() {
+        String accountId = Objects.requireNonNull(Crn.fromString(actingUser.getCrn())).getAccountId();
+        CloudbreakUser adminUser = cloudbreakActor.getAdminByAccountId(accountId);
+        if (actingUser.getDisplayName().equalsIgnoreCase(adminUser.getDisplayName())) {
+            LOGGER.info(" Requested real UMS user is the same as acting user:: \nDisplay Name: {} \nAccess Key: {} \nSecret Key: {} \nCRN: {} \nAdmin: {}" +
+                            " \nDescription: {} ", actingUser.getDisplayName(), actingUser.getAccessKey(), actingUser.getSecretKey(), actingUser.getCrn(),
+                    actingUser.getAdmin(), actingUser.getDescription());
+        } else {
+            LOGGER.info(" Found real UMS admin user:: \nDisplay Name: {} \nWorkload username: {} \nAccess Key: {} \nSecret Key: {} \nCRN: {} \nAdmin: {}" +
+                            " \nDescription: {} ", adminUser.getDisplayName(), adminUser.getWorkloadUserName(),
+                    adminUser.getAccessKey(), adminUser.getSecretKey(), adminUser.getCrn(), adminUser.getAdmin(),
+                    adminUser.getDescription());
+        }
+        return adminUser;
+    }
+
     public <O extends CloudbreakTestDto> O init(Class<O> clss) {
         return init(clss, CloudPlatform.valueOf(commonCloudProperties.getCloudProvider()));
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ums/UmsGroupTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ums/UmsGroupTestDto.java
@@ -61,12 +61,21 @@ public class UmsGroupTestDto extends AbstractTestDto<CreateUserGroupRequest, Use
 
     @Override
     public String getCrn() {
+        if (getResponse() == null) {
+            throw new IllegalStateException("UMS Group response hasn't been set, therefore 'getCrn' cannot be fulfilled.");
+        }
         return getResponse().getCrn();
     }
 
     @Override
     public UmsGroupTestDto when(Action<UmsGroupTestDto, UmsClient> action) {
         return getTestContext().when((UmsGroupTestDto) this, UmsClient.class, action, emptyRunningParameter());
+    }
+
+    @Override
+    public <E extends Exception> UmsGroupTestDto whenException(Action<UmsGroupTestDto, UmsClient> action, Class<E> expectedException,
+            RunningParameter runningParameter) {
+        return getTestContext().whenException((UmsGroupTestDto) this, UmsClient.class, action, expectedException, runningParameter);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ums/UmsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ums/UmsTestDto.java
@@ -32,6 +32,8 @@ public class UmsTestDto extends AbstractTestDto<AssignResourceRequest, UserManag
 
     private static final String SHARED_RESOURCE_USER = "crn:altus:iam:us-west-1:altus:resourceRole:SharedResourceUser";
 
+    private static final String IAM_GROUP_ADMIN = "crn:altus:iam:us-west-1:altus:resourceRole:IamGroupAdmin";
+
     public UmsTestDto(TestContext testContext) {
         super(new AssignResourceRequest(), testContext);
     }
@@ -76,6 +78,11 @@ public class UmsTestDto extends AbstractTestDto<AssignResourceRequest, UserManag
         return this;
     }
 
+    public UmsTestDto withGroupAdmin() {
+        getRequest().setRoleCrn(IAM_GROUP_ADMIN);
+        return this;
+    }
+
     public UmsTestDto assignTarget(String key) {
         try {
             Assignable dto = getTestContext().get(key);
@@ -84,6 +91,11 @@ public class UmsTestDto extends AbstractTestDto<AssignResourceRequest, UserManag
             throw new IllegalArgumentException(String.format("TestContext member with key %s does not implement %s interface",
                     key, Assignable.class.getCanonicalName()), e);
         }
+        return this;
+    }
+
+    public UmsTestDto assignTargetByCrn(String targetCrn) {
+        getRequest().setResourceCrn(targetCrn);
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/BasicEnvironmentVirtualGroupTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/BasicEnvironmentVirtualGroupTest.java
@@ -1,10 +1,13 @@
 package com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion;
 
 import static com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider.INTERNAL_ACTOR_CRN;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.expectedMessage;
+import static java.lang.String.format;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -19,9 +22,10 @@ import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.auth.altus.UmsRight;
 import com.sequenceiq.cloudbreak.logger.MDCUtils;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
 import com.sequenceiq.it.cloudbreak.UmsClient;
-import com.sequenceiq.it.cloudbreak.actor.CloudbreakActor;
+import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.client.UmsTestClient;
@@ -30,9 +34,10 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaUserSyncTestDto;
+import com.sequenceiq.it.cloudbreak.dto.ums.UmsGroupTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
-import com.sequenceiq.it.cloudbreak.testcase.authorization.AuthUserKeys;
+import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 
 import io.grpc.Status;
@@ -41,6 +46,16 @@ import io.grpc.StatusRuntimeException;
 public class BasicEnvironmentVirtualGroupTest extends AbstractE2ETest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BasicEnvironmentVirtualGroupTest.class);
+
+    private static final String ADMIN_GROUP_NAME = "testgroupa";
+
+    private static final String ADMIN_GROUP_CRN = "crn:altus:iam:us-west-1:f8e2f110-fc7e-4e46-ae55-381aacc6718c:group:" +
+            "testgroupa/ebc27aff-7d91-4f76-bf98-e81dbbd615e9";
+
+    private static final String USER_GROUP_NAME = "testgroupb";
+
+    private static final String USER_GROUP_CRN = "crn:altus:iam:us-west-1:f8e2f110-fc7e-4e46-ae55-381aacc6718c:group:" +
+            "testgroupb/b983b572-9774-4f8f-8377-861b511442de";
 
     @Inject
     private FreeIpaTestClient freeIpaTestClient;
@@ -51,14 +66,12 @@ public class BasicEnvironmentVirtualGroupTest extends AbstractE2ETest {
     @Inject
     private EnvironmentTestClient environmentTestClient;
 
-    @Inject
-    private CloudbreakActor cloudbreakActor;
-
     @Override
     protected void setupTest(TestContext testContext) {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
-        useRealUmsUser(testContext, AuthUserKeys.USER_ACCOUNT_ADMIN);
+        useRealUmsUser(testContext, L0UserKeys.USER_ACCOUNT_ADMIN);
         initializeDefaultBlueprints(testContext);
+        useRealUmsUser(testContext, L0UserKeys.ENV_CREATOR_A);
         createDefaultCredential(testContext);
         createEnvironmentWithNetworkAndFreeIpa(testContext);
     }
@@ -70,8 +83,10 @@ public class BasicEnvironmentVirtualGroupTest extends AbstractE2ETest {
             then = "FreeIPA should be successfully synced with new users and theirs resource roles.")
     public void testAddUsersToEnvironment(TestContext testContext) {
         AtomicReference<Map<UmsRight, String>> environmentVirtualGroups = new AtomicReference<>();
-        String workloadUsernameEnvAdminA = testContext.getRealUmsUserByKey(AuthUserKeys.ENV_ADMIN_A).getWorkloadUserName();
-        String workloadUsernameEnvCreatorA =  testContext.getRealUmsUserByKey(AuthUserKeys.ENV_CREATOR_A).getWorkloadUserName();
+        String workloadUsernameEnvAdminA = testContext.getRealUmsUserByKey(L0UserKeys.ENV_ADMIN_A).getWorkloadUserName();
+        String workloadUsernameEnvCreatorB =  testContext.getRealUmsUserByKey(L0UserKeys.ENV_CREATOR_B).getWorkloadUserName();
+
+        useRealUmsUser(testContext, L0UserKeys.ENV_CREATOR_A);
 
         testContext
                 .given(FreeIpaTestDto.class)
@@ -82,48 +97,147 @@ public class BasicEnvironmentVirtualGroupTest extends AbstractE2ETest {
                 .given(UmsTestDto.class)
                 .assignTarget(EnvironmentTestDto.class.getSimpleName())
                 .withEnvironmentAdmin()
-                .when(umsTestClient.assignResourceRole(AuthUserKeys.ENV_ADMIN_A))
+                .when(umsTestClient.assignResourceRole(L0UserKeys.ENV_ADMIN_A))
                 .withEnvironmentUser()
-                .when(umsTestClient.assignResourceRole(AuthUserKeys.ENV_CREATOR_A))
-                .then((context, dto, client) -> {
-                    environmentVirtualGroups.set(getEnvironmentVirtualGroups(context, client));
+                .when(umsTestClient.assignResourceRole(L0UserKeys.ENV_CREATOR_B))
+                .then((tc, dto, client) -> {
+                    environmentVirtualGroups.set(getEnvironmentVirtualGroups(tc, client));
                     return dto;
                 })
                 .given(FreeIpaUserSyncTestDto.class)
                 .when(freeIpaTestClient.syncAll())
                 .await(OperationState.COMPLETED)
                 .given(FreeIpaTestDto.class)
-                .when(freeIpaTestClient.findUsers(Set.of(workloadUsernameEnvAdminA, workloadUsernameEnvCreatorA), true))
-                .then((context, dto, client) -> validateNewEnvironmentUserGroupMembership(dto, environmentVirtualGroups.get(),
-                        Set.of(workloadUsernameEnvCreatorA), true))
+                .when(freeIpaTestClient.findUsers(Set.of(workloadUsernameEnvAdminA, workloadUsernameEnvCreatorB), true))
+                .then((tc, dto, client) -> validateUserVirtualGroupMembership(tc, dto, environmentVirtualGroups.get(),
+                        Set.of(workloadUsernameEnvCreatorB), true))
                 .validate();
+
         testContext
                 .given(UmsTestDto.class)
                 .assignTarget(EnvironmentTestDto.class.getSimpleName())
                 .withEnvironmentAdmin()
-                .when(umsTestClient.assignResourceRole(AuthUserKeys.ENV_CREATOR_A))
+                .when(umsTestClient.assignResourceRole(L0UserKeys.ENV_CREATOR_B))
                 .given(FreeIpaUserSyncTestDto.class)
                 .when(freeIpaTestClient.syncAll())
                 .await(OperationState.COMPLETED)
                 .given(FreeIpaTestDto.class)
-                .then((context, dto, client) -> validateNewEnvironmentAdminGroupMembership(dto, environmentVirtualGroups.get(),
-                        Set.of(workloadUsernameEnvAdminA, workloadUsernameEnvCreatorA), true))
+                .then((tc, dto, client) -> validateAdminVirtualGroupMembership(tc, dto, environmentVirtualGroups.get(),
+                        Set.of(workloadUsernameEnvAdminA, workloadUsernameEnvCreatorB), true))
                 .validate();
+
         testContext
                 .given(UmsTestDto.class)
                 .assignTarget(EnvironmentTestDto.class.getSimpleName())
                 .withEnvironmentAdmin()
-                .when(umsTestClient.unAssignResourceRole(AuthUserKeys.ENV_ADMIN_A))
+                .when(umsTestClient.unAssignResourceRole(L0UserKeys.ENV_ADMIN_A))
                 .withEnvironmentUser()
-                .when(umsTestClient.unAssignResourceRole(AuthUserKeys.ENV_CREATOR_A))
+                .when(umsTestClient.unAssignResourceRole(L0UserKeys.ENV_CREATOR_B))
                 .given(FreeIpaUserSyncTestDto.class)
                 .when(freeIpaTestClient.syncAll())
                 .await(OperationState.COMPLETED)
                 .given(FreeIpaTestDto.class)
-                .when(freeIpaTestClient.findUsers(Set.of(workloadUsernameEnvAdminA, workloadUsernameEnvCreatorA), false))
-                .then((context, dto, client) -> validateNewEnvironmentAdminGroupMembership(dto, environmentVirtualGroups.get(),
-                        Set.of(workloadUsernameEnvCreatorA), false))
+                .when(freeIpaTestClient.findUsers(Set.of(workloadUsernameEnvAdminA, workloadUsernameEnvCreatorB), false))
+                .then((tc, dto, client) -> validateAdminVirtualGroupMembership(tc, dto, environmentVirtualGroups.get(),
+                        Set.of(workloadUsernameEnvCreatorB), false))
                 .validate();
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @Description(
+            given = "there is a running Manowar Environment with synced FreeIPA",
+            when = "add then remove admin and user groups to Environment",
+            then = "FreeIPA should be successfully synced with new groups and theirs resource roles.")
+    public void testAddGroupsToEnvironment(TestContext testContext) {
+        AtomicReference<Map<UmsRight, String>> environmentVirtualGroups = new AtomicReference<>();
+        CloudbreakUser userEnvAdminA = testContext.getRealUmsUserByKey(L0UserKeys.ENV_ADMIN_A);
+        CloudbreakUser userEnvCreatorB =  testContext.getRealUmsUserByKey(L0UserKeys.ENV_CREATOR_B);
+
+        useRealUmsUser(testContext, L0UserKeys.ENV_CREATOR_A);
+
+        testContext
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.describe())
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.getLastSyncOperationStatus())
+                .await(OperationState.COMPLETED)
+                .given(UmsTestDto.class)
+                .assignTargetByCrn(ADMIN_GROUP_CRN)
+                .withGroupAdmin()
+                .when(umsTestClient.assignResourceRole(L0UserKeys.ENV_CREATOR_A))
+                .assignTargetByCrn(USER_GROUP_CRN)
+                .withGroupAdmin()
+                .when(umsTestClient.assignResourceRole(L0UserKeys.ENV_CREATOR_A))
+                .given(UmsGroupTestDto.class)
+                .when(umsTestClient.addUserToGroup(ADMIN_GROUP_NAME, userEnvAdminA.getCrn()))
+                .when(umsTestClient.addUserToGroup(USER_GROUP_NAME, userEnvCreatorB.getCrn()))
+                .then((tc, dto, client) -> validateUserGroupMembership(tc, dto, client, userEnvAdminA, ADMIN_GROUP_NAME, true))
+                .then((tc, dto, client) -> validateUserGroupMembership(tc, dto, client, userEnvCreatorB, USER_GROUP_NAME, true))
+                .validate();
+
+        testContext
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.describe())
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.getLastSyncOperationStatus())
+                .await(OperationState.COMPLETED)
+                .given(UmsTestDto.class)
+                .assignTarget(EnvironmentTestDto.class.getSimpleName())
+                .withEnvironmentAdmin()
+                .when(umsTestClient.assignResourceRoleWithGroup(ADMIN_GROUP_CRN))
+                .withEnvironmentUser()
+                .when(umsTestClient.assignResourceRoleWithGroup(USER_GROUP_CRN))
+                .then((tc, dto, client) -> {
+                    environmentVirtualGroups.set(getEnvironmentVirtualGroups(tc, client));
+                    return dto;
+                })
+                .given(FreeIpaUserSyncTestDto.class)
+                .when(freeIpaTestClient.syncAll())
+                .await(OperationState.COMPLETED)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.findGroups(Set.of(ADMIN_GROUP_NAME, USER_GROUP_NAME)))
+                .then((tc, dto, client) -> validateAdminVirtualGroupMembership(tc, dto, environmentVirtualGroups.get(),
+                        Set.of(userEnvAdminA.getWorkloadUserName()), true))
+                .then((tc, dto, client) -> validateUserVirtualGroupMembership(tc, dto, environmentVirtualGroups.get(),
+                        Set.of(userEnvCreatorB.getWorkloadUserName()), true))
+                .validate();
+
+        testContext
+                .given(EnvironmentTestDto.class)
+                .when(environmentTestClient.delete())
+                .await(EnvironmentStatus.ARCHIVED)
+                .validate();
+
+        testContext
+                .given(UmsGroupTestDto.class)
+                .when(umsTestClient.removeUserFromGroup(ADMIN_GROUP_NAME, userEnvAdminA.getCrn()))
+                .when(umsTestClient.removeUserFromGroup(USER_GROUP_NAME, userEnvCreatorB.getCrn()))
+                .then((tc, dto, client) -> validateUserGroupMembership(tc, dto, client, userEnvAdminA, ADMIN_GROUP_NAME, false))
+                .then((tc, dto, client) -> validateUserGroupMembership(tc, dto, client, userEnvCreatorB, USER_GROUP_NAME, false))
+                .validate();
+
+        testContext
+                .given(UmsTestDto.class)
+                .assignTargetByCrn(ADMIN_GROUP_CRN)
+                .withGroupAdmin()
+                .when(umsTestClient.unAssignResourceRole(L0UserKeys.ENV_CREATOR_A))
+                .assignTargetByCrn(USER_GROUP_CRN)
+                .withGroupAdmin()
+                .when(umsTestClient.unAssignResourceRole(L0UserKeys.ENV_CREATOR_A))
+                .given(UmsGroupTestDto.class)
+                .whenException(umsTestClient.addUserToGroup(ADMIN_GROUP_NAME, userEnvAdminA.getCrn()), StatusRuntimeException.class,
+                        expectedMessage(iamAddMemberToGroupErrorMessage() + iamAddMemberToGroupPattern()))
+                .whenException(umsTestClient.addUserToGroup(USER_GROUP_NAME, userEnvCreatorB.getCrn()), StatusRuntimeException.class,
+                        expectedMessage(iamAddMemberToGroupErrorMessage() + iamAddMemberToGroupPattern()))
+                .validate();
+    }
+
+    private String iamAddMemberToGroupErrorMessage() {
+        return "PERMISSION_DENIED: This operation requires the right 'iam/addMemberToGroup' for resource ";
+    }
+
+    private String iamAddMemberToGroupPattern() {
+        return "'crn:altus:iam:us-west-1:.*:group:.*'";
     }
 
     private Map<UmsRight, String> getEnvironmentVirtualGroups(TestContext testContext, UmsClient client) {
@@ -147,34 +261,66 @@ public class BasicEnvironmentVirtualGroupTest extends AbstractE2ETest {
         }
 
         if (MapUtils.isNotEmpty(virtualGroups)) {
+            Log.then(LOGGER, format(" Virtual groups are present [%s] for environment '%s' ", virtualGroups, environmentCrn));
             LOGGER.info(String.format(" Virtual groups are present [%s] for environment '%s' ", virtualGroups, environmentCrn));
         } else {
             throw new TestFailException(String.format(" Cannot find virtual groups for environment '%s' ", environmentCrn));
         }
+
         return virtualGroups;
     }
 
-    private FreeIpaTestDto validateNewEnvironmentAdminGroupMembership(FreeIpaTestDto testDto, Map<UmsRight, String> environmentVirtualGroups,
+    private FreeIpaTestDto validateAdminVirtualGroupMembership(TestContext testContext, FreeIpaTestDto testDto, Map<UmsRight, String> environmentVirtualGroups,
             Set<String> adminUsers, boolean expectedPresence) {
+
         List<String> adminGroups = environmentVirtualGroups
                 .entrySet().stream()
-                .filter(group -> group.getKey().getRight().contains("ADMIN"))
+                .filter(group -> group.getKey().name().contains("ADMIN"))
                 .map(Map.Entry::getValue)
                 .collect(Collectors.toList());
         LOGGER.info(String.format(" Admin groups are present [%s] at environment '%s' ", adminGroups, testDto.getResponse().getEnvironmentCrn()));
         adminGroups.forEach(adminGroup -> freeIpaTestClient.findUsersInGroup(adminUsers, adminGroup, expectedPresence));
+
         return testDto;
     }
 
-    private FreeIpaTestDto validateNewEnvironmentUserGroupMembership(FreeIpaTestDto testDto, Map<UmsRight, String> environmentVirtualGroups,
+    private FreeIpaTestDto validateUserVirtualGroupMembership(TestContext testContext, FreeIpaTestDto testDto, Map<UmsRight, String> environmentVirtualGroups,
             Set<String> environmentUsers, boolean expectedPresence) {
+
         List<String> userGroups = environmentVirtualGroups
                 .entrySet().stream()
-                .filter(group -> !group.getKey().getRight().contains("ADMIN"))
+                .filter(group -> group.getKey().name().contains("ACCESS"))
                 .map(Map.Entry::getValue)
                 .collect(Collectors.toList());
         LOGGER.info(String.format(" User groups are present [%s] at environment '%s' ", userGroups, testDto.getResponse().getEnvironmentCrn()));
-        userGroups.forEach(adminGroup -> freeIpaTestClient.findUsersInGroup(environmentUsers, adminGroup, expectedPresence));
+        userGroups.forEach(userGroup -> freeIpaTestClient.findUsersInGroup(environmentUsers, userGroup, expectedPresence));
+
         return testDto;
+    }
+
+    private UmsGroupTestDto validateUserGroupMembership(TestContext testContext, UmsGroupTestDto umsGroupTestDto, UmsClient client, CloudbreakUser groupMember,
+            String groupName, boolean expectedPresence) {
+        String accountId = testContext.getActingUserCrn().getAccountId();
+
+        List<String> groupMembers = client.getDefaultClient().listMembersFromGroup(testContext.getActingUserCrn().toString(), accountId, groupName,
+                Optional.of(""));
+        boolean memberPresent = groupMembers.stream().anyMatch(memberCrn -> groupMember.getCrn().equals(memberCrn));
+        if (expectedPresence) {
+            if (memberPresent) {
+                LOGGER.info("User '{}' have been assigned successfully to group {}.", groupMember.getDisplayName(), groupName);
+                Log.then(LOGGER, format(" User '%s' have been assigned successfully to group '%s'. ", groupMember.getDisplayName(), groupName));
+            } else {
+                throw new TestFailException(String.format(" User '%s' is missing from group '%s' members! ", groupMember.getDisplayName(), groupName));
+            }
+        } else {
+            if (!memberPresent) {
+                LOGGER.info("User '{}' have been removed successfully from group {}.", groupMember.getDisplayName(), groupName);
+                Log.then(LOGGER, format(" User '%s' have been removed successfully from group '%s'. ", groupMember.getDisplayName(), groupName));
+            } else {
+                throw new TestFailException(String.format(" User '%s' is still member of group '%s'! ", groupMember.getDisplayName(), groupName));
+            }
+        }
+
+        return umsGroupTestDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/L0UserKeys.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/L0UserKeys.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion;
+
+public class L0UserKeys {
+
+    public static final String USER_ACCOUNT_ADMIN = "cloudbreak-qe@cloudera.com";
+
+    public static final String ENV_CREATOR_A = "cb-qe-machine-envcreator-a";
+
+    public static final String ENV_CREATOR_B = "cb-qe-machine-envcreator-b";
+
+    public static final String ENV_ADMIN_A = "cb-qe-machine-envadmin-a";
+
+    public static final String ENV_ADMIN_B = "cb-qe-machine-envadmin-b";
+
+    private L0UserKeys() {
+
+    }
+}


### PR DESCRIPTION
The related test (`testAddGroupsToEnvironment`) tends to cover:

1. Group
    1. test_add_group_to_env
    2. test_multiple_groups
    3. test_delete_group_from_env

test cases from `CB promotion L0/basic tests` ([cdpmc-qe/tests/regression/users/test_reset_password_flow.py](https://github.infra.cloudera.com/CDH/cdpmc-qe/blob/master/tests/regression/users/test_reset_password_flow.py)).