### PR TITLE
CB-11720 Tie volume sets to discovery FQDNs

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VolumeSetAttributes.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VolumeSetAttributes.java
@@ -28,6 +28,8 @@ public class VolumeSetAttributes {
 
     private String volumeType;
 
+    private String discoveryFQDN;
+
     @JsonCreator
     public VolumeSetAttributes(@JsonProperty("availabilityZone") String availabilityZone, @JsonProperty("deleteOnTermination") Boolean deleteOnTermination,
             @JsonProperty("fstab") String fstab, @JsonProperty("volumes") List<Volume> volumes, @JsonProperty("volumeSize") Integer volumeSize,
@@ -94,6 +96,14 @@ public class VolumeSetAttributes {
 
     public void setVolumeType(String volumeType) {
         this.volumeType = volumeType;
+    }
+
+    public void setDiscoveryFQDN(String discoveryFQDN) {
+        this.discoveryFQDN = discoveryFQDN;
+    }
+
+    public String getDiscoveryFQDN() {
+        return discoveryFQDN;
     }
 
     @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsContextService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsContextService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
@@ -16,6 +18,8 @@ import com.sequenceiq.common.api.type.ResourceType;
 
 @Service
 public class AwsContextService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsContextService.class);
 
     public void addInstancesToContext(List<CloudResource> instances, ResourceBuilderContext context, List<Group> groups) {
         groups.forEach(group -> {
@@ -46,10 +50,15 @@ public class AwsContextService {
             List<CloudResource> groupVolumeSets = getResourcesOfTypeInGroup(resources, group, ResourceType.AWS_VOLUMESET);
             for (int i = 0; i < ids.size(); i++) {
                 if (i < groupInstances.size()) {
+                    Long privateId = ids.get(i);
+                    CloudResource instanceResource = groupInstances.get(i);
                     if (i > groupVolumeSets.size() - 1) {
-                        context.addComputeResources(ids.get(i), List.of(groupInstances.get(i)));
+                        context.addComputeResources(privateId, List.of(instanceResource));
                     } else {
-                        context.addComputeResources(ids.get(i), List.of(groupInstances.get(i), groupVolumeSets.get(i)));
+                        CloudResource volumesetResource = groupVolumeSets.get(i);
+                        LOGGER.debug("Adding instance and volume set to context under private id: {}. "
+                                + "Instance: {}, Volume Set: {}", privateId, instanceResource, volumesetResource);
+                        context.addComputeResources(privateId, List.of(instanceResource, volumesetResource));
                     }
                 }
             }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
@@ -289,10 +289,12 @@ public class AwsUpscaleService {
     }
 
     private List<CloudResource> getReattachableVolumeSets(List<Group> scaledGroups, List<CloudResource> resources) {
-        return resources.stream()
+        List<CloudResource> volumeSets = resources.stream()
                 .filter(cloudResource -> ResourceType.AWS_VOLUMESET.equals(cloudResource.getType()))
                 .filter(cloudResource -> CommonStatus.DETACHED.equals(cloudResource.getStatus()))
                 .collect(Collectors.toList());
+        LOGGER.debug("Collected detached volumesets for reattachment: {}", volumeSets);
+        return volumeSets;
     }
 
     private List<Group> getGroupsWithNewInstances(List<Group> scaledGroups) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -31,8 +30,10 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.service.HostDiscoveryService;
@@ -44,6 +45,7 @@ import com.sequenceiq.cloudbreak.core.bootstrap.service.host.HostClusterAvailabi
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.context.HostBootstrapApiContext;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.context.HostOrchestratorClusterContext;
 import com.sequenceiq.cloudbreak.domain.Orchestrator;
+import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
@@ -126,6 +128,9 @@ public class ClusterBootstrapper {
 
     @Inject
     private InstanceMetaDataToCloudInstanceConverter cloudInstanceConverter;
+
+    @Inject
+    private ResourceAttributeUtil resourceAttributeUtil;
 
     public void bootstrapMachines(Long stackId) throws CloudbreakException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
@@ -314,7 +319,7 @@ public class ClusterBootstrapper {
     }
 
     public void bootstrapNewNodes(Long stackId, Set<String> upscaleCandidateAddresses, Collection<String> recoveryHostNames) throws CloudbreakException {
-        Stack stack = stackService.getByIdWithListsInTransaction(stackId);
+        Stack stack = stackService.getByIdWithResourcesInTransaction(stackId);
         Set<Node> nodes = new HashSet<>();
         Set<Node> allNodes = new HashSet<>();
         boolean recoveredNodes = Integer.valueOf(recoveryHostNames.size()).equals(upscaleCandidateAddresses.size());
@@ -328,14 +333,15 @@ public class ClusterBootstrapper {
         Set<String> clusterNodeNames = stack.getNotTerminatedInstanceMetaDataList().stream()
                 .map(InstanceMetaData::getShortHostname).collect(Collectors.toSet());
 
-        Iterator<String> iterator = recoveryHostNames.iterator();
+        Map<String, Optional<String>> instanceIdToFQDN = createInstanceIdToFQDNMappingFromDiskResources(stack);
         for (InstanceMetaData im : metaDataSet) {
             Node node = createNodeAndInitFqdnInInstanceMetadata(stack, im, clusterDomain, hostGroupNodeIndexes, clusterNodeNames);
             if (upscaleCandidateAddresses.contains(im.getPrivateIp())) {
                 // use the hostname of the node we're recovering instead of generating a new one
                 // but only when we would have generated a hostname, otherwise use the cloud provider's default mechanism
-                if (recoveredNodes && isNoneBlank(node.getHostname())) {
-                    node.setHostname(iterator.next().split("\\.")[0]);
+                Optional<String> fqdnOptional = instanceIdToFQDN.getOrDefault(im.getInstanceId(), Optional.empty());
+                if (recoveredNodes && isNoneBlank(node.getHostname()) && fqdnOptional.isPresent()) {
+                    node.setHostname(fqdnOptional.get().split("\\.")[0]);
                     LOGGER.debug("Set the hostname to {} for address: {}", node.getHostname(), im.getPrivateIp());
                 }
                 nodes.add(node);
@@ -351,6 +357,16 @@ public class ClusterBootstrapper {
         } catch (CloudbreakOrchestratorException e) {
             throw new CloudbreakException(e);
         }
+    }
+
+    private Map<String, Optional<String>> createInstanceIdToFQDNMappingFromDiskResources(Stack stack) {
+        List<Resource> diskResources = stack.getDiskResources();
+        Map<String, Optional<String>> imIdToFQDN = diskResources.stream()
+                .collect(Collectors.toMap(Resource::getInstanceId, volumeSet -> {
+                    Optional<VolumeSetAttributes> volumeSetAttributes = resourceAttributeUtil.getTypedAttributes(volumeSet, VolumeSetAttributes.class);
+                    return volumeSetAttributes.map(VolumeSetAttributes::getDiscoveryFQDN);
+                }));
+        return imIdToFQDN;
     }
 
     private String getClusterDomain(Set<InstanceMetaData> metaDataSet, String customDomain) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/generator/OfflineStateGenerator.java
@@ -350,6 +350,11 @@ public class OfflineStateGenerator {
         }
 
         @Override
+        public Optional<Stack> findOneWithResources(Long id) {
+            return Optional.empty();
+        }
+
+        @Override
         public Optional<Stack> findOneWithGateway(Long id) {
             return Optional.empty();
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -81,6 +81,10 @@ public interface StackRepository extends WorkspaceResourceRepository<Stack, Long
             "LEFT JOIN FETCH ig.securityGroup WHERE s.id= :id AND (s.type is not 'TEMPLATE' OR s.type is null)")
     Optional<Stack> findOneWithLists(@Param("id") Long id);
 
+    @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.resources LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData "
+            + "LEFT JOIN FETCH ig.template LEFT JOIN FETCH ig.securityGroup WHERE s.id= :id AND (s.type is not 'TEMPLATE' OR s.type is null)")
+    Optional<Stack> findOneWithResources(@Param("id") Long id);
+
     @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData im LEFT JOIN FETCH ig.template " +
             "WHERE s.id= :id AND ig.instanceGroupType = 'GATEWAY' AND im.instanceMetadataType = 'GATEWAY_PRIMARY' " +
             "AND (s.type is not 'TEMPLATE' OR s.type is null)")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -345,6 +345,19 @@ public class StackService implements ResourceIdProvider, ResourcePropertyProvide
         return stack;
     }
 
+    public Stack getByIdWithResourcesInTransaction(Long id) {
+        Stack stack;
+        try {
+            stack = transactionService.required(() -> stackRepository.findOneWithResources(id).orElse(null));
+        } catch (TransactionExecutionException e) {
+            throw new TransactionRuntimeExecutionException(e);
+        }
+        if (stack == null) {
+            throw new NotFoundException(format(STACK_NOT_FOUND_BY_ID_EXCEPTION_MESSAGE, id));
+        }
+        return stack;
+    }
+
     public Stack getByIdWithGatewayInTransaction(Long id) {
         Stack stack;
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MountDisks.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MountDisks.java
@@ -112,7 +112,7 @@ public class MountDisks {
                     String uuids = value.getOrDefault("uuids", "");
                     String fstab = value.getOrDefault("fstab", "");
                     if (!StringUtils.isEmpty(uuids) && !StringUtils.isEmpty(fstab)) {
-                        persistUuidAndFstab(stack, instanceIdOptional.get(), uuids, fstab);
+                        persistUuidAndFstab(stack, instanceIdOptional.get(), hostname, uuids, fstab);
                     }
                 }
             });
@@ -122,12 +122,13 @@ public class MountDisks {
         }
     }
 
-    private void persistUuidAndFstab(Stack stack, String instanceId, String uuids, String fstab) {
+    private void persistUuidAndFstab(Stack stack, String instanceId, String discoveryFQDN, String uuids, String fstab) {
         resourceService.saveAll(stack.getDiskResources().stream()
                 .filter(volumeSet -> instanceId.equals(volumeSet.getInstanceId()))
                 .peek(volumeSet -> resourceAttributeUtil.getTypedAttributes(volumeSet, VolumeSetAttributes.class).ifPresent(volumeSetAttributes -> {
                     volumeSetAttributes.setUuids(uuids);
                     volumeSetAttributes.setFstab(fstab);
+                    volumeSetAttributes.setDiscoveryFQDN(discoveryFQDN);
                     resourceAttributeUtil.setTypedAttributes(volumeSet, volumeSetAttributes);
                 }))
                 .collect(Collectors.toList()));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperTest.java
@@ -12,16 +12,21 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.service.HostDiscoveryService;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.HostBootstrapApiCheckerTask;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.HostClusterAvailabilityCheckerTask;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.context.HostBootstrapApiContext;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.context.HostOrchestratorClusterContext;
+import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -37,6 +42,7 @@ import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.orchestrator.OrchestratorService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.common.api.type.ResourceType;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterBootstrapperTest {
@@ -92,13 +98,17 @@ public class ClusterBootstrapperTest {
     @Mock
     private InstanceMetaDataService instanceMetaDataService;
 
+    @Spy
+    private ResourceAttributeUtil resourceAttributeUtil;
+
     @Test
     public void shouldUseReachableInstances() throws CloudbreakException, CloudbreakImageNotFoundException {
-        when(stackService.getByIdWithListsInTransaction(1L)).thenReturn(stack);
+        when(stackService.getByIdWithResourcesInTransaction(1L)).thenReturn(stack);
         InstanceMetaData instanceMetaData = new InstanceMetaData();
         instanceMetaData.setPrivateIp("1.1.1.1");
         instanceMetaData.setPublicIp("2.2.2.2");
         instanceMetaData.setDiscoveryFQDN("FQDN");
+        instanceMetaData.setInstanceId("instanceId");
         InstanceGroup instanceGroup = new InstanceGroup();
         instanceGroup.setGroupName("master");
         Template template = new Template();
@@ -108,6 +118,12 @@ public class ClusterBootstrapperTest {
         when(stack.getId()).thenReturn(1L);
         when(stack.getReachableInstanceMetaDataSet()).thenReturn(Set.of(instanceMetaData));
         when(stack.getCustomDomain()).thenReturn("CUSTOM_DOMAIN");
+        Resource volumeset = new Resource(ResourceType.AWS_VOLUMESET, "aws-volumeset", stack);
+        volumeset.setInstanceId("instanceId");
+        VolumeSetAttributes attribute = new VolumeSetAttributes("eu", true, "", List.of(), 100, "SSD");
+        attribute.setDiscoveryFQDN("host.example.com");
+        volumeset.setAttributes(new Json(attribute));
+        when(stack.getDiskResources()).thenReturn(List.of(volumeset));
         Cluster cluster = new Cluster();
         cluster.setGateway(new Gateway());
         when(stack.getCluster()).thenReturn(cluster);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/CollectDownscaleCandidatesHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/CollectDownscaleCandidatesHandlerTest.java
@@ -60,7 +60,7 @@ public class CollectDownscaleCandidatesHandlerTest {
     public void testFlowWithPrivateIds() {
         //given
         Stack stack = generateStackData();
-        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        when(stackService.getByIdWithResourcesInTransaction(STACK_ID)).thenReturn(stack);
         Event<CollectDownscaleCandidatesRequest> event = generateTestDataEvent(Collections.singleton(PRIVATE_ID));
         //when
         testedClass.accept(event);
@@ -78,7 +78,7 @@ public class CollectDownscaleCandidatesHandlerTest {
         //given
         Stack stack = generateStackData();
         Event<CollectDownscaleCandidatesRequest> event = generateTestDataEvent(Collections.singleton(PRIVATE_ID));
-        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        when(stackService.getByIdWithResourcesInTransaction(STACK_ID)).thenReturn(stack);
         //when
         testedClass.accept(event);
         //then
@@ -95,7 +95,7 @@ public class CollectDownscaleCandidatesHandlerTest {
         //given
         Stack stack = generateStackData();
         Event<CollectDownscaleCandidatesRequest> event = generateTestDataEvent(Collections.singleton(PRIVATE_ID), new ClusterDownscaleDetails(true, false));
-        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        when(stackService.getByIdWithResourcesInTransaction(STACK_ID)).thenReturn(stack);
         //when
         testedClass.accept(event);
         //then


### PR DESCRIPTION
Some services are sensitive to have the volumes reattached to a machine
with the same FQDN.

* Discovery FQDN now also stored in volumesets
* Discovery FQDN saved the same time as mount info
* For already running clusters, discovery FQDN ges saved at the start of repair
* During bootstraping new nodes, discovery FQDN gets read from volume sets to
set the proper hostname based on instance id

See detailed description in the commit message.