### PR TITLE
CDPAM-1597 | Ship CCMv2 inverting proxy agent logs at the time of env creation

### DIFF
--- a/core/src/main/resources/defaults/vm-logs.json
+++ b/core/src/main/resources/defaults/vm-logs.json
@@ -297,5 +297,9 @@
   {
     "path": "/var/log/cm_generate_agent_tokens.log",
     "label": "generate_agent_token"
+  },
+  {
+    "path": "/var/log/ccmv2-inverting-proxy-agent.log",
+    "label": "ccmv2_inverting_proxy_agent"
   }
 ]

--- a/freeipa/src/main/resources/defaults/vm-logs.json
+++ b/freeipa/src/main/resources/defaults/vm-logs.json
@@ -81,5 +81,9 @@
   {
     "path": "/var/log/ipareplica-install.log",
     "label": "ipa_replica_install"
+  },
+  {
+    "path": "/var/log/ccmv2-inverting-proxy-agent.log",
+    "label": "ccmv2_inverting_proxy_agent"
   }
 ]


### PR DESCRIPTION
[CDPAM-1597](https://jira.cloudera.com/browse/CDPAM-1597):
Based on @oleewere [comment](https://jira.cloudera.com/browse/CDPAM-1597?focusedCommentId=4473163&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4473163), have added the location of CCMv2 inverting proxy agent logs that need to shipped at the time of env creation similar to how it is done for other components' logs.

Thanks
