### PR TITLE
CB-12229: Clean up Azure Load Balancer code

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -711,12 +711,15 @@ public class AzureClient {
      * @return IP addresses
      */
     public List<String> getLoadBalancerIps(String resourceGroupName, String loadBalancerName, LoadBalancerType loadBalancerType) {
-        if (loadBalancerType == LoadBalancerType.PRIVATE) {
-            return getLoadBalancerPrivateIps(resourceGroupName, loadBalancerName);
-        } else if (loadBalancerType == LoadBalancerType.PUBLIC) {
-            return getLoadBalancerIps(resourceGroupName, loadBalancerName);
-        } else {
-            return List.of();
+        switch (loadBalancerType) {
+            case PRIVATE:
+                return getLoadBalancerPrivateIps(resourceGroupName, loadBalancerName);
+            case PUBLIC:
+                return getLoadBalancerIps(resourceGroupName, loadBalancerName);
+            default:
+                LOGGER.warn("Cannot get IPs for load balancer {}, it has an unknown type {}. Using an empty list instead.", loadBalancerName, loadBalancerType);
+                return List.of();
+
         }
     }
 


### PR DESCRIPTION
Closes [CB-12229](https://jira.cloudera.com/browse/CB-12229).

* Add unit test to `AzureMetaDataCollector`, when collecting private ips.
* Fix imports for `AzureMetaDataCollectorTest`.
* Use an `Optional<String>` for LB ips instead of a `null` String.
* Use a switch/case for `AzureClient` when retrieving load balancer IPs based on the load balancer type.