### PR TITLE
CB-12331: Force the removal of old FreeIPA server installations

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -181,7 +181,11 @@ public class FreeIpaClient {
     }
 
     public Host deleteServer(String fqdn) throws FreeIpaClientException {
-        Map<String, Object> params = Map.of();
+        Map<String, Object> params = Map.of(
+                "force", true,
+                "ignore_last_of_role", true,
+                "ignore_topology_disconnect", true
+        );
         return (Host) invoke("server_del", List.of(fqdn), params, Host.class).getResult();
     }
 

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
@@ -56,6 +56,11 @@ ipa topologysuffix-find | grep "Suffix name" | cut -f2 -d":" | cut -f2 -d" " | w
   done
 done
 
+if ipa hostgroup-show ipaservers | grep "$FQDN"; then
+  echo "Cleaning up ipaservers host group for $FQDN"
+  ipa hostgroup-remove-member ipaservers "--hosts=$FQDN"
+fi
+
 FORWARDERS=$(grep -Ev '^#|^;' /etc/resolv.conf.orig | grep nameserver | awk '{print "--forwarder " $2}')
 PRIMARY_IPA=$(grep -Ev '^#|^;' /etc/resolv.conf | grep nameserver | awk '{print $2}')
 


### PR DESCRIPTION
If FreeIPA replica install fails, the `ipa-server-install --uninstall`
will not always clean up everthing. Add commands to force the cleanup
so that it will attempt to clean up anything that is dangling.

Also cleanup the old installation of FreeIPA from the ipaservers host
group.

This was manually tested using a local deployment of cloudbreak.

See detailed description in the commit message.