### PR TITLE
CB-12302 Move and migrate EdgeNode templates to CB code

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -403,7 +403,10 @@ cb:
           7.2.2 - Flow Management Heavy Duty with Apache NiFi, Apache NiFi Registry=cdp-flow-management;
           7.2.2 - Data Discovery and Exploration=cdp-dde;
           7.2.2 - Streaming Analytics Light Duty with Apache Flink=cdp-flink-light;
-          7.2.2 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy
+          7.2.2 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy;
+          7.2.2 COD Edge Node=cdp-cod-edge-node
+        7.2.3: >
+          7.2.3 COD Edge Node=cdp-cod-edge-node
         7.2.6: >
           7.2.6 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx;
           7.2.6 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha;
@@ -419,7 +422,8 @@ cb:
           7.2.6 - Flow Management Heavy Duty with Apache NiFi, Apache NiFi Registry=cdp-flow-management;
           7.2.6 - Data Discovery and Exploration=cdp-dde;
           7.2.6 - Streaming Analytics Light Duty with Apache Flink=cdp-flink-light;
-          7.2.6 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy
+          7.2.6 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy;
+          7.2.6 COD Edge Node=cdp-cod-edge-node
         7.2.7: >
           7.2.7 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx;
           7.2.7 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha;
@@ -435,7 +439,8 @@ cb:
           7.2.7 - Flow Management Heavy Duty with Apache NiFi, Apache NiFi Registry=cdp-flow-management;
           7.2.7 - Data Discovery and Exploration=cdp-dde;
           7.2.7 - Streaming Analytics Light Duty with Apache Flink=cdp-flink-light;
-          7.2.7 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy
+          7.2.7 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy;
+          7.2.7 COD Edge Node=cdp-cod-edge-node
         7.2.8: >
           7.2.8 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx;
           7.2.8 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha;
@@ -451,7 +456,8 @@ cb:
           7.2.8 - Flow Management Heavy Duty with Apache NiFi, Apache NiFi Registry=cdp-flow-management;
           7.2.8 - Data Discovery and Exploration=cdp-dde;
           7.2.8 - Streaming Analytics Light Duty with Apache Flink=cdp-flink-light;
-          7.2.8 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy
+          7.2.8 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy;
+          7.2.8 COD Edge Node=cdp-cod-edge-node
         7.2.9: >
           7.2.9 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx;
           7.2.9 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha;
@@ -467,7 +473,8 @@ cb:
           7.2.9 - Flow Management Heavy Duty with Apache NiFi, Apache NiFi Registry=cdp-flow-management;
           7.2.9 - Data Discovery and Exploration=cdp-dde;
           7.2.9 - Streaming Analytics Light Duty with Apache Flink=cdp-flink-light;
-          7.2.9 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy
+          7.2.9 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy;
+          7.2.9 COD Edge Node=cdp-cod-edge-node
         7.2.10: >
           7.2.10 - SDX Light Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx;
           7.2.10 - SDX Medium Duty: Apache Hive Metastore, Apache Ranger, Apache Atlas=cdp-sdx-medium-ha;
@@ -483,7 +490,8 @@ cb:
           7.2.10 - Flow Management Heavy Duty with Apache NiFi, Apache NiFi Registry=cdp-flow-management;
           7.2.10 - Data Discovery and Exploration=cdp-dde;
           7.2.10 - Streaming Analytics Light Duty with Apache Flink=cdp-flink-light;
-          7.2.10 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy
+          7.2.10 - Streaming Analytics Heavy Duty with Apache Flink=cdp-flink-heavy;
+          7.2.10 COD Edge Node=cdp-cod-edge-node
   clustertemplate.defaults:
   template.defaults: minviable-gcp,minviable-azure-managed-disks,minviable-aws
   custom.user.data: |

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-cod-edge-node.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-cod-edge-node.bp
@@ -1,0 +1,53 @@
+{
+  "description": "COD Edge Node cluster template",
+  "blueprint": {
+    "cdhVersion": "7.2.10",
+    "displayName": "opdb",
+    "cmVersion": null,
+    "repositories": [],
+    "products": [],
+    "services": [
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [],
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "displayName": null,
+            "configs": [
+              {
+                "name": "zookeeper_server_java_heapsize",
+                "value": "1073741824",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              },
+              {
+                "name": "maxClientCnxns",
+                "value": "200",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              }
+            ],
+            "base": true
+          }
+        ],
+        "displayName": null,
+        "roles": []
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "leader",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "zookeeper-SERVER-BASE"
+        ]
+      }
+    ],
+    "instantiator": null
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-cod-edge-node.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-cod-edge-node.bp
@@ -1,0 +1,53 @@
+{
+  "description": "COD Edge Node cluster template",
+  "blueprint": {
+    "cdhVersion": "7.2.2",
+    "displayName": "opdb",
+    "cmVersion": null,
+    "repositories": [],
+    "products": [],
+    "services": [
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [],
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "displayName": null,
+            "configs": [
+              {
+                "name": "zookeeper_server_java_heapsize",
+                "value": "1073741824",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              },
+              {
+                "name": "maxClientCnxns",
+                "value": "200",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              }
+            ],
+            "base": true
+          }
+        ],
+        "displayName": null,
+        "roles": []
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "leader",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "zookeeper-SERVER-BASE"
+        ]
+      }
+    ],
+    "instantiator": null
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/7.2.3/cdp-cod-edge-node.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.3/cdp-cod-edge-node.bp
@@ -1,0 +1,53 @@
+{
+  "description": "COD Edge Node cluster template",
+  "blueprint": {
+    "cdhVersion": "7.2.3",
+    "displayName": "opdb",
+    "cmVersion": null,
+    "repositories": [],
+    "products": [],
+    "services": [
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [],
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "displayName": null,
+            "configs": [
+              {
+                "name": "zookeeper_server_java_heapsize",
+                "value": "1073741824",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              },
+              {
+                "name": "maxClientCnxns",
+                "value": "200",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              }
+            ],
+            "base": true
+          }
+        ],
+        "displayName": null,
+        "roles": []
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "leader",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "zookeeper-SERVER-BASE"
+        ]
+      }
+    ],
+    "instantiator": null
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-cod-edge-node.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-cod-edge-node.bp
@@ -1,0 +1,53 @@
+{
+  "description": "COD Edge Node cluster template",
+  "blueprint": {
+    "cdhVersion": "7.2.6",
+    "displayName": "opdb",
+    "cmVersion": null,
+    "repositories": [],
+    "products": [],
+    "services": [
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [],
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "displayName": null,
+            "configs": [
+              {
+                "name": "zookeeper_server_java_heapsize",
+                "value": "1073741824",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              },
+              {
+                "name": "maxClientCnxns",
+                "value": "200",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              }
+            ],
+            "base": true
+          }
+        ],
+        "displayName": null,
+        "roles": []
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "leader",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "zookeeper-SERVER-BASE"
+        ]
+      }
+    ],
+    "instantiator": null
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-cod-edge-node.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-cod-edge-node.bp
@@ -1,0 +1,53 @@
+{
+  "description": "COD Edge Node cluster template",
+  "blueprint": {
+    "cdhVersion": "7.2.7",
+    "displayName": "opdb",
+    "cmVersion": null,
+    "repositories": [],
+    "products": [],
+    "services": [
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [],
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "displayName": null,
+            "configs": [
+              {
+                "name": "zookeeper_server_java_heapsize",
+                "value": "1073741824",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              },
+              {
+                "name": "maxClientCnxns",
+                "value": "200",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              }
+            ],
+            "base": true
+          }
+        ],
+        "displayName": null,
+        "roles": []
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "leader",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "zookeeper-SERVER-BASE"
+        ]
+      }
+    ],
+    "instantiator": null
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-cod-edge-node.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-cod-edge-node.bp
@@ -1,0 +1,53 @@
+{
+  "description": "COD Edge Node cluster template",
+  "blueprint": {
+    "cdhVersion": "7.2.8",
+    "displayName": "opdb",
+    "cmVersion": null,
+    "repositories": [],
+    "products": [],
+    "services": [
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [],
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "displayName": null,
+            "configs": [
+              {
+                "name": "zookeeper_server_java_heapsize",
+                "value": "1073741824",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              },
+              {
+                "name": "maxClientCnxns",
+                "value": "200",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              }
+            ],
+            "base": true
+          }
+        ],
+        "displayName": null,
+        "roles": []
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "leader",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "zookeeper-SERVER-BASE"
+        ]
+      }
+    ],
+    "instantiator": null
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-cod-edge-node.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-cod-edge-node.bp
@@ -1,0 +1,53 @@
+{
+  "description": "COD Edge Node cluster template",
+  "blueprint": {
+    "cdhVersion": "7.2.9",
+    "displayName": "opdb",
+    "cmVersion": null,
+    "repositories": [],
+    "products": [],
+    "services": [
+      {
+        "refName": "zookeeper",
+        "serviceType": "ZOOKEEPER",
+        "serviceConfigs": [],
+        "roleConfigGroups": [
+          {
+            "refName": "zookeeper-SERVER-BASE",
+            "roleType": "SERVER",
+            "displayName": null,
+            "configs": [
+              {
+                "name": "zookeeper_server_java_heapsize",
+                "value": "1073741824",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              },
+              {
+                "name": "maxClientCnxns",
+                "value": "200",
+                "ref": null,
+                "variable": null,
+                "autoConfig": false
+              }
+            ],
+            "base": true
+          }
+        ],
+        "displayName": null,
+        "roles": []
+      }
+    ],
+    "hostTemplates": [
+      {
+        "refName": "leader",
+        "cardinality": 1,
+        "roleConfigGroupsRefNames": [
+          "zookeeper-SERVER-BASE"
+        ]
+      }
+    ],
+    "instantiator": null
+  }
+}

--- a/core/src/main/resources/schema/app/20210429105927_CB-12302_make_edge_node_templates_default.sql
+++ b/core/src/main/resources/schema/app/20210429105927_CB-12302_make_edge_node_templates_default.sql
@@ -1,0 +1,20 @@
+-- // CB-12302 Make edge node templates default
+-- Migration SQL that makes the change goes here.
+
+UPDATE blueprint SET status='DEFAULT' WHERE name='7.2.2 COD Edge Node';
+UPDATE blueprint SET status='DEFAULT' WHERE name='7.2.3 COD Edge Node';
+UPDATE blueprint SET status='DEFAULT' WHERE name='7.2.6 COD Edge Node';
+UPDATE blueprint SET status='DEFAULT' WHERE name='7.2.7 COD Edge Node';
+UPDATE blueprint SET status='DEFAULT' WHERE name='7.2.8 COD Edge Node';
+UPDATE blueprint SET status='DEFAULT' WHERE name='7.2.9 COD Edge Node';
+UPDATE blueprint SET status='DEFAULT' WHERE name='7.2.10 COD Edge Node';
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+UPDATE blueprint SET status='USER_MANAGED' WHERE name='7.2.2 COD Edge Node';
+UPDATE blueprint SET status='USER_MANAGED' WHERE name='7.2.3 COD Edge Node';
+UPDATE blueprint SET status='USER_MANAGED' WHERE name='7.2.6 COD Edge Node';
+UPDATE blueprint SET status='USER_MANAGED' WHERE name='7.2.7 COD Edge Node';
+UPDATE blueprint SET status='USER_MANAGED' WHERE name='7.2.8 COD Edge Node';
+UPDATE blueprint SET status='USER_MANAGED' WHERE name='7.2.9 COD Edge Node';
+UPDATE blueprint SET status='USER_MANAGED' WHERE name='7.2.10 COD Edge Node';


### PR DESCRIPTION
I add edge node templates to all of our runtimes appear to be in our code.

I tested the migration, it made the existing templates default, visible to other users as well, not just for the creator.

On mow-dev I found these edge node templates:

7.2.8 COD Edge Node
7.2.7 COD Edge Node
7.2.6 COD Edge Node
7.2.3 COD Edge Node
7.2.2 COD Edge Node
7.2.1 COD Edge Node
7.2.0 COD Edge Node
7.1.1 COD Edge Node

But we have 7.0.2, 7.1.0, 7.2.9, 7.2.10 runtimes in our code (I assume COD would create them anyway) so I add:

7.0.2 COD Edge Node
7.1.0 COD Edge Node
7.2.9 COD Edge Node
7.2.10 COD Edge Node

as well.

@lnardai @horadla23 @sodre90 @petersomogyi please correct me if some these are not needed and sure as hell that it won't break anything if I don't add them.