### PR TITLE
CB-11923 Loadbalancer takes ~2.5 mins to failover requests when one of the Knox host is down

### DIFF
--- a/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
@@ -314,6 +314,9 @@
           "Protocol" : "TCP",
           "TargetType" : "instance",
           "HealthCheckPort" : "${listener.targetGroup.healthCheckPort}",
+          "HealthCheckIntervalSeconds" : 10,
+          "HealthyThresholdCount" : 2,
+          "UnhealthyThresholdCount" : 2,
           <#if existingVPC>
           "VpcId" : { "Ref" : "VPCId" }
           <#else>


### PR DESCRIPTION
Reduces the AWS target group HealthyThresholdCount to the minimum value of 2 from the default of 3,
and the HealthCheckIntervalSeconds to 10s from the default of 30s. This will reduce the failover
time for the load balancer to detect an unhealthy node to ~20s.