### PR TITLE
CB-10579 Clean up unused targetgroup and loadbalancer columns

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancer.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancer.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import java.util.stream.Collectors;
-import javax.persistence.CascadeType;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -14,7 +13,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 
 import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
@@ -42,13 +40,6 @@ public class LoadBalancer implements ProvisionEntity  {
     private LoadBalancerType type;
 
     private String endpoint;
-
-    /**
-     * @deprecated Use {@link #targetGroupSet} instead.
-     */
-    @Deprecated
-    @OneToMany(mappedBy = "loadBalancer", cascade = CascadeType.REMOVE, orphanRemoval = true)
-    private Set<TargetGroup> targetGroups = new HashSet<>();
 
     @ManyToMany(mappedBy = "loadBalancerSet", fetch = FetchType.LAZY)
     private Set<TargetGroup> targetGroupSet = new HashSet<>();
@@ -107,28 +98,8 @@ public class LoadBalancer implements ProvisionEntity  {
         this.endpoint = endpoint;
     }
 
-    /**
-     * @deprecated Use {@link #getTargetGroupSet()} instead.
-     */
-    @Deprecated
-    public Set<TargetGroup> getTargetGroups() {
-        return targetGroups;
-    }
-
-    /**
-     * @deprecated Use {@link #setTargetGroupSet()} instead.
-     */
-    @Deprecated
-    public void setTargetGroups(Set<TargetGroup> targetGroups) {
-        this.targetGroups = targetGroups;
-    }
-
     public Set<TargetGroup> getTargetGroupSet() {
-        if (targetGroupSet != null) {
-            return targetGroupSet;
-        } else {
-            return targetGroups;
-        }
+        return targetGroupSet;
     }
 
     public Set<InstanceGroup> getAllInstanceGroups() {
@@ -139,7 +110,6 @@ public class LoadBalancer implements ProvisionEntity  {
 
     public void setTargetGroupSet(Set<TargetGroup> targetGroups) {
         this.targetGroupSet = targetGroups;
-        this.targetGroups = targetGroups;
     }
 
     public void addTargetGroup(TargetGroup targetGroup) {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/TargetGroup.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/TargetGroup.java
@@ -11,7 +11,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
-import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 
 import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
@@ -28,13 +27,6 @@ public class TargetGroup implements ProvisionEntity {
 
     @Convert(converter = TargetGroupTypeConverter.class)
     private TargetGroupType type;
-
-    /**
-     * @deprecated Use {@link #loadBalancerSet} instead.
-     */
-    @Deprecated
-    @ManyToOne(fetch = FetchType.LAZY)
-    private LoadBalancer loadBalancer;
 
     @ManyToMany(fetch = FetchType.EAGER)
     private Set<LoadBalancer> loadBalancerSet = new HashSet<>();
@@ -54,38 +46,16 @@ public class TargetGroup implements ProvisionEntity {
         this.type = type;
     }
 
-    /**
-     * @deprecated Use {@link #getLoadBalancerSet()} instead.
-     */
-    @Deprecated
-    public LoadBalancer getLoadBalancer() {
-        return loadBalancer;
-    }
-
     public Set<LoadBalancer> getLoadBalancerSet() {
-        if (loadBalancerSet != null) {
-            return loadBalancerSet;
-        } else {
-            return Set.of(loadBalancer);
-        }
-    }
-
-    /**
-     * @deprecated Use {@link #setLoadBalancerSet()} instead.
-     */
-    @Deprecated
-    public void setLoadBalancer(LoadBalancer loadBalancer) {
-        this.loadBalancer = loadBalancer;
+        return loadBalancerSet;
     }
 
     public void setLoadBalancerSet(Set<LoadBalancer> loadBalancerSet) {
         this.loadBalancerSet = loadBalancerSet;
-        this.loadBalancer = loadBalancerSet.iterator().next();
     }
 
     public void addLoadBalancer(LoadBalancer loadBalancer) {
         loadBalancerSet.add(loadBalancer);
-        this.loadBalancer = loadBalancer;
     }
 
     public Set<InstanceGroup> getInstanceGroups() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/TargetGroupRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/TargetGroupRepository.java
@@ -1,12 +1,15 @@
 package com.sequenceiq.cloudbreak.repository;
 
-import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
-import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 import java.util.Set;
+
 import javax.transaction.Transactional;
+
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 
 @EntityType(entityClass = TargetGroup.class)
 @Transactional(Transactional.TxType.REQUIRED)
@@ -14,8 +17,6 @@ public interface TargetGroupRepository extends CrudRepository<TargetGroup, Long>
 
     @Query("SELECT t FROM TargetGroup t INNER JOIN t.instanceGroups ig WHERE ig.id= :instanceGroupId")
     Set<TargetGroup> findByInstanceGroupId(@Param("instanceGroupId") Long instanceGroupId);
-
-    Set<TargetGroup> findByLoadBalancerId(@Param("loadBalancerId") Long loadBalancerId);
 
     @Query("SELECT t FROM TargetGroup t INNER JOIN t.loadBalancerSet lb WHERE lb.id= :loadBalancerId")
     Set<TargetGroup> findTargetGroupsByLoadBalancerId(@Param("loadBalancerId") Long loadBalancerId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/TargetGroupPersistenceService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/TargetGroupPersistenceService.java
@@ -24,11 +24,7 @@ public class TargetGroupPersistenceService {
     }
 
     public Set<TargetGroup> findByLoadBalancerId(Long loadBalancerId) {
-        Set<TargetGroup> targetGroups = repository.findTargetGroupsByLoadBalancerId(loadBalancerId);
-        if (targetGroups == null || targetGroups.isEmpty()) {
-            targetGroups = repository.findByLoadBalancerId(loadBalancerId);
-        }
-        return targetGroups;
+        return repository.findTargetGroupsByLoadBalancerId(loadBalancerId);
     }
 
     public Set<TargetGroup> findByInstanceGroupId(Long instanceGroupId) {


### PR DESCRIPTION
Removes the deprecated LoadBalancer and TargetGroup related fields and methods that were replaced
in CB-10578.