### PR TITLE
CB-12345 Fix BindUsercreation for child environments

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/flow/FreeIpaPostInstallService.java
@@ -18,7 +18,6 @@ import com.sequenceiq.freeipa.client.model.Permission;
 import com.sequenceiq.freeipa.client.model.User;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
-import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
 import com.sequenceiq.freeipa.service.freeipa.user.UserSyncService;
 import com.sequenceiq.freeipa.service.stack.StackService;
 
@@ -32,18 +31,6 @@ public class FreeIpaPostInstallService {
     private static final String USER_ADMIN_PRIVILEGE = "User Administrators";
 
     private static final int MAX_USERNAME_LENGTH = 255;
-
-    private static final String HOST_ENROLLMENT_PRIVILEGE = "Host Enrollment";
-
-    private static final String ADD_HOSTS_PERMISSION = "System: Add Hosts";
-
-    private static final String REMOVE_SERVICES_PERMISSION = "System: Remove Services";
-
-    private static final String REMOVE_HOSTS_PERMISSION = "System: Remove Hosts";
-
-    private static final String DNS_ADMINISTRATORS_PRIVILEGE = "DNS Administrators";
-
-    private static final String ENROLLMENT_ADMINISTRATOR_ROLE = "Enrollment Administrator";
 
     @Inject
     private FreeIpaClientFactory freeIpaClientFactory;
@@ -62,9 +49,6 @@ public class FreeIpaPostInstallService {
 
     @Inject
     private FreeIpaTopologyService freeIpaTopologyService;
-
-    @Inject
-    private FreeIpaService freeIpaService;
 
     public void postInstallFreeIpa(Long stackId, boolean fullPostInstall) throws Exception {
         LOGGER.debug("Performing post-install configuration for stack {}. {}.", stackId, fullPostInstall ? "Full post install" : "Partial post install");

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/StackService.java
@@ -76,6 +76,7 @@ public class StackService implements ResourcePropertyProvider {
 
     public Stack getByEnvironmentCrnAndAccountId(String environmentCrn, String accountId) {
         return findByEnvironmentCrnAndAccountId(environmentCrn, accountId)
+                .or(() -> childEnvironmentService.findParentByEnvironmentCrnAndAccountId(environmentCrn, accountId))
                 .orElseThrow(() -> new NotFoundException(String.format("FreeIPA stack by environment [%s] not found", environmentCrn)));
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/binduser/BindUserCreateServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/binduser/BindUserCreateServiceTest.java
@@ -26,6 +26,7 @@ import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
 import com.sequenceiq.freeipa.converter.operation.OperationToOperationStatusConverter;
 import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserEvent;
 import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
 import com.sequenceiq.freeipa.service.operation.OperationService;
@@ -57,7 +58,11 @@ class BindUserCreateServiceTest {
 
     @BeforeEach
     public void init() {
-        when(stackService.getIdByEnvironmentCrnAndAccountId(ENV_CRN, ACCOUNT)).thenReturn(STACK_ID);
+        Stack stack = new Stack();
+        stack.setId(STACK_ID);
+        stack.setEnvironmentCrn(ENV_CRN);
+        stack.setAccountId(ACCOUNT);
+        when(stackService.getByEnvironmentCrnAndAccountId(ENV_CRN, ACCOUNT)).thenReturn(stack);
     }
 
     @Test


### PR DESCRIPTION
Child environment lookup was missing when creating bind users.
This caused an not found exception on FMS side which prevented YCLOUD cluster creation.

See detailed description in the commit message.