### PR TITLE
CB-11936: Fix FreeIPA HA repair when an IP address is reused

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
@@ -9,12 +9,13 @@ net.ipv6.conf.lo.disable_ipv6:
     - value: 0
 
 {% for host in salt['pillar.get']('freeipa:hosts') %}
-/etc/hosts/{{ host['fqdn'] }}:
-  host.present:
-    - ip:
-      - {{ host['ip'] }}
-    - names:
+{{ host['ip'] }}:
+  host.only:
+    - hostnames:
       - {{ host['fqdn'] }}
+{% if '.' in host['fqdn'] %}
+      - {{ host['fqdn'].split('.')[0] }}
+{% endif %}
 {% endfor %}
 
 /opt/salt/scripts/freeipa_install.sh:

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveHostsHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/downscale/handler/RemoveHostsHandlerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.Template;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.CleanupEvent;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.event.removehosts.RemoveHostsFromOrchestrationRequest;
 import com.sequenceiq.freeipa.service.BootstrapService;
@@ -99,4 +103,38 @@ class RemoveHostsHandlerTest {
         verify(eventBus, times(1)).notify(eq("REMOVEHOSTSFROMORCHESTRATIONSUCCESS"), ArgumentMatchers.<Event>any());
     }
 
+    @Test
+    void testSendsSuccessMessageWhenRemovingHostAndIPAddressIsReusedAfterRepair() throws Exception {
+        CleanupEvent cleanupEvent =
+                new CleanupEvent(STACK_ID, USERS, Set.of("example1.com"), ROLES, IPS, STATES_TO_SKIP, ACCOUNT_ID, OPERATION_ID, CLUSTER_NAME, ENVIRONMENT_CRN);
+        RemoveHostsFromOrchestrationRequest request = new RemoveHostsFromOrchestrationRequest(cleanupEvent);
+        Stack stack = new Stack();
+        when(stackService.getByIdWithListsInTransaction(any())).thenReturn(stack);
+        InstanceGroup ig = new InstanceGroup();
+        ig.setGroupName("group");
+        Template t = new Template();
+        t.setInstanceType("GATEWAY");
+        ig.setTemplate(t);
+        InstanceMetaData im1 = new InstanceMetaData();
+        im1.setDiscoveryFQDN("example1.com");
+        im1.setPrivateIp("192.168.0.1");
+        im1.setInstanceId("i-1");
+        im1.setInstanceGroup(ig);
+        InstanceMetaData im2 = new InstanceMetaData();
+        im2.setDiscoveryFQDN("example2.com");
+        im2.setPrivateIp("192.168.0.2");
+        im2.setInstanceId("i-2");
+        im2.setInstanceGroup(ig);
+        InstanceMetaData im3 = new InstanceMetaData();
+        im3.setDiscoveryFQDN("example3.com");
+        im3.setPrivateIp("192.168.0.1");
+        im3.setInstanceId("i-3");
+        im3.setInstanceGroup(ig);
+        ig.setInstanceMetaData(Set.of(im1, im2, im3));
+        stack.setInstanceGroups(Set.of(ig));
+        underTest.accept(new Event<>(request));
+        verify(eventBus, times(1)).notify(eq("REMOVEHOSTSFROMORCHESTRATIONSUCCESS"), ArgumentMatchers.<Event>any());
+        verify(bootstrapService).bootstrap(any(), any());
+        verify(hostOrchestrator).tearDown(any(), eq(Map.of("example1.com", "192.168.0.1")), any(), any());
+    }
 }


### PR DESCRIPTION
During FreeIPA HA repair, if the same IP address is resused, it can
break the FreeIPA installation and downscaling. The FreeIPA installion
was fixed by ensuring that the /etc/hosts file does not contain
multiple entries for the same IP address for other FreeIPA nodes.

During downscale, the selection of which nodes to delete no relies on
the IP address and hostname. In cases where the FQDN hasn't been
assinged, then only the hostname is used.

This was tested by unit tests and by repairing a cluster that repair
was failing on Azure.

See detailed description in the commit message.