### PR TITLE
CB-12350 Scale up hangs if node stopped during aws autoscaling group …

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetadataCollector.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetadataCollector.java
@@ -164,7 +164,7 @@ public class AwsMetadataCollector implements MetadataCollector {
         return instanceGroupMap;
     }
 
-    private List<Instance> collectInstancesForGroup(AuthenticatedContext ac, AmazonAutoScalingClient amazonASClient,
+    public List<Instance> collectInstancesForGroup(AuthenticatedContext ac, AmazonAutoScalingClient amazonASClient,
             AmazonEc2Client amazonEC2Client, AmazonCloudFormationClient amazonCFClient, String group) {
 
         LOGGER.debug("Collect aws instances for group: {}", group);

--- a/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
+++ b/cloud-aws/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
@@ -70,6 +70,7 @@ import com.amazonaws.services.elasticfilesystem.model.MountTargetDescription;
 import com.amazonaws.waiters.Waiter;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.aws.AwsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.AwsMetadataCollector;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonAutoScalingClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationClient;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudWatchClient;
@@ -227,6 +228,9 @@ public class AwsRepairTest {
 
     @MockBean
     private EntitlementService entitlementService;
+
+    @MockBean
+    private AwsMetadataCollector awsMetadataCollector;
 
     @Test
     public void repairStack() throws Exception {


### PR DESCRIPTION
…configuration

Fixex the issue that if a vm is stopped during aws autoscaling group operation, then the operation will hang for hours.
After asg reconfiguration CB will wait only for the new nodes. If there is any instance in "not running" state after the operation then the upscale will be reverted.