### PR TITLE
CB-12244 Key Vault access permission grant to DES SP may fail

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/service/Retry.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/service/Retry.java
@@ -19,5 +19,21 @@ public interface Retry {
         public ActionFailedException(String message) {
             super(message);
         }
+
+        public ActionFailedException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public ActionFailedException(Throwable cause) {
+            super(cause);
+        }
+
+        public ActionFailedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+            super(message, cause, enableSuppression, writableStackTrace);
+        }
+
+        public static ActionFailedException ofCause(Throwable cause) {
+            return new ActionFailedException(cause != null ? cause.getMessage() : null, cause);
+        }
     }
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/service/RetryTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/service/RetryTest.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.cloudbreak.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RetryTest {
+
+    private static final String MESSAGE = "message";
+
+    @Test
+    void actionFailedExceptionConstructorTestWhenDefault() {
+        Retry.ActionFailedException underTest = new Retry.ActionFailedException();
+
+        assertThat(underTest.getMessage()).isNull();
+        assertThat(underTest.getCause()).isNull();
+    }
+
+    @Test
+    void actionFailedExceptionConstructorTestWhenMessage() {
+        Retry.ActionFailedException underTest = new Retry.ActionFailedException(MESSAGE);
+
+        assertThat(underTest.getMessage()).isEqualTo(MESSAGE);
+        assertThat(underTest.getCause()).isNull();
+    }
+
+    @Test
+    void actionFailedExceptionConstructorTestWhenMessageAndCause() {
+        Throwable cause = new RuntimeException();
+
+        Retry.ActionFailedException underTest = new Retry.ActionFailedException(MESSAGE, cause);
+
+        assertThat(underTest.getMessage()).isEqualTo(MESSAGE);
+        assertThat(underTest.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void actionFailedExceptionConstructorTestWhenCause() {
+        Throwable cause = new RuntimeException(MESSAGE);
+
+        Retry.ActionFailedException underTest = new Retry.ActionFailedException(cause);
+
+        assertThat(underTest.getMessage()).isEqualTo("java.lang.RuntimeException: message");
+        assertThat(underTest.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void actionFailedExceptionConstructorTestWhenMessageAndCauseAndEnableSuppressionAndWritableStackTrace() {
+        Throwable cause = new RuntimeException();
+        Throwable suppressed = new RuntimeException();
+
+        Retry.ActionFailedException underTest = new Retry.ActionFailedException(MESSAGE, cause, false, false);
+        underTest.addSuppressed(suppressed);
+
+        assertThat(underTest.getMessage()).isEqualTo(MESSAGE);
+        assertThat(underTest.getCause()).isSameAs(cause);
+        assertThat(underTest.getSuppressed()).isEmpty();
+        assertThat(underTest.getStackTrace()).isEmpty();
+    }
+
+    @Test
+    void actionFailedExceptionOfCauseTestWhenNull() {
+        Retry.ActionFailedException underTest = Retry.ActionFailedException.ofCause(null);
+
+        assertThat(underTest.getMessage()).isNull();
+        assertThat(underTest.getCause()).isNull();
+    }
+
+    @Test
+    void actionFailedExceptionOfCauseTestWhenNotNull() {
+        Throwable cause = new RuntimeException(MESSAGE);
+
+        Retry.ActionFailedException underTest = Retry.ActionFailedException.ofCause(cause);
+
+        assertThat(underTest.getMessage()).isEqualTo(MESSAGE);
+        assertThat(underTest.getCause()).isSameAs(cause);
+    }
+
+}


### PR DESCRIPTION
* Error handling enhancements:
  * `AzureEncryptionResources`:
    * Key Vault permission granting is executed as a fault-tolerant logic with retries. At most 15 retries will be performed using delays of 2, 4, 8, 10, 10... sec. (Hence the raw max duration for these operations is expected to be 124 sec.) All exceptions are caught and wrapped in a `Retry.ActionFailedException` for sake of retries.
* Code quality enhancements:
  * Add new constructor variants and a factory method to `Retry.ActionFailedException`.
* Testing:
  * Manual verification in local CB with various combinations of permissions in the Azure credential app role.
  * Added new unit tests and updated existing ones.