### PR TITLE
CB-12396 Logging, error handling and code style refactor for DES logics

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudCredential.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudCredential.java
@@ -57,4 +57,15 @@ public class CloudCredential extends DynamicModel {
         this.verifyPermissions = verifyPermissions;
     }
 
+    // Must not reveal any secrets, hence not including DynamicModel.toString()!
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("CloudCredential{");
+        sb.append("id='").append(id).append('\'');
+        sb.append(", name='").append(name).append('\'');
+        sb.append(", verifyPermissions=").append(verifyPermissions);
+        sb.append('}');
+        return sb.toString();
+    }
+
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/ExtendedCloudCredential.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/ExtendedCloudCredential.java
@@ -40,4 +40,18 @@ public class ExtendedCloudCredential extends CloudCredential {
     public String getAccountId() {
         return accountId;
     }
+
+    // Must not reveal any secrets, hence not including DynamicModel.toString()!
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("ExtendedCloudCredential{");
+        sb.append("description='").append(description).append('\'');
+        sb.append(", cloudPlatform='").append(cloudPlatform).append('\'');
+        sb.append(", userCrn='").append(userCrn).append('\'');
+        sb.append(", accountId='").append(accountId).append('\'');
+        sb.append(", cloudCredential=").append(super.toString());
+        sb.append('}');
+        return sb.toString();
+    }
+
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/encryption/CreatedDiskEncryptionSet.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/encryption/CreatedDiskEncryptionSet.java
@@ -3,28 +3,24 @@ package com.sequenceiq.cloudbreak.cloud.model.encryption;
 import java.util.Map;
 
 public class CreatedDiskEncryptionSet {
-    private String diskEncryptionSetId;
+    private final String diskEncryptionSetId;
 
-    private String diskEncryptionSetPrincipalId;
+    private final String diskEncryptionSetPrincipalObjectId;
 
-    private String diskEncryptionSetLocation;
+    private final String diskEncryptionSetLocation;
 
-    private String diskEncryptionSetName;
+    private final String diskEncryptionSetName;
 
-    private Map<String, String> tags;
+    private final Map<String, String> tags;
 
-    private String diskEncryptionSetResourceGroup;
-
-    public CreatedDiskEncryptionSet(String diskEncryptionSetId) {
-        this.diskEncryptionSetId = diskEncryptionSetId;
-    }
+    private final String diskEncryptionSetResourceGroupName;
 
     private CreatedDiskEncryptionSet(CreatedDiskEncryptionSet.Builder builder) {
         this.diskEncryptionSetId = builder.diskEncryptionSetId;
-        this.diskEncryptionSetPrincipalId = builder.diskEncryptionSetPrincipalId;
+        this.diskEncryptionSetPrincipalObjectId = builder.diskEncryptionSetPrincipalObjectId;
         this.diskEncryptionSetLocation = builder.diskEncryptionSetLocation;
         this.diskEncryptionSetName = builder.diskEncryptionSetName;
-        this.diskEncryptionSetResourceGroup = builder.diskEncryptionSetResourceGroup;
+        this.diskEncryptionSetResourceGroupName = builder.diskEncryptionSetResourceGroupName;
         this.tags = builder.tags;
     }
 
@@ -32,8 +28,8 @@ public class CreatedDiskEncryptionSet {
         return diskEncryptionSetId;
     }
 
-    public String getDiskEncryptionSetPrincipalId() {
-        return diskEncryptionSetPrincipalId;
+    public String getDiskEncryptionSetPrincipalObjectId() {
+        return diskEncryptionSetPrincipalObjectId;
     }
 
     public String getDiskEncryptionSetLocation() {
@@ -44,25 +40,38 @@ public class CreatedDiskEncryptionSet {
         return diskEncryptionSetName;
     }
 
-    public String getDiskEncryptionSetResourceGroup() {
-        return diskEncryptionSetResourceGroup;
+    public String getDiskEncryptionSetResourceGroupName() {
+        return diskEncryptionSetResourceGroupName;
     }
 
     public Map<String, String> getTags() {
         return tags;
     }
 
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("CreatedDiskEncryptionSet{");
+        sb.append("diskEncryptionSetId='").append(diskEncryptionSetId).append('\'');
+        sb.append(", diskEncryptionSetPrincipalObjectId='").append(diskEncryptionSetPrincipalObjectId).append('\'');
+        sb.append(", diskEncryptionSetLocation='").append(diskEncryptionSetLocation).append('\'');
+        sb.append(", diskEncryptionSetName='").append(diskEncryptionSetName).append('\'');
+        sb.append(", tags=").append(tags);
+        sb.append(", diskEncryptionSetResourceGroupName='").append(diskEncryptionSetResourceGroupName).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
     public static final class Builder {
 
         private String diskEncryptionSetId;
 
-        private String diskEncryptionSetPrincipalId;
+        private String diskEncryptionSetPrincipalObjectId;
 
         private String diskEncryptionSetLocation;
 
         private String diskEncryptionSetName;
 
-        private String diskEncryptionSetResourceGroup;
+        private String diskEncryptionSetResourceGroupName;
 
         private Map<String, String> tags;
 
@@ -74,8 +83,8 @@ public class CreatedDiskEncryptionSet {
             return this;
         }
 
-        public CreatedDiskEncryptionSet.Builder withDiskEncryptionSetPrincipalId(String diskEncryptionSetPrincipalId) {
-            this.diskEncryptionSetPrincipalId = diskEncryptionSetPrincipalId;
+        public CreatedDiskEncryptionSet.Builder withDiskEncryptionSetPrincipalObjectId(String diskEncryptionSetPrincipalObjectId) {
+            this.diskEncryptionSetPrincipalObjectId = diskEncryptionSetPrincipalObjectId;
             return this;
         }
 
@@ -94,8 +103,8 @@ public class CreatedDiskEncryptionSet {
             return this;
         }
 
-        public CreatedDiskEncryptionSet.Builder withDiskEncryptionSetResourceGroup(String diskEncryptionSetResourceGroup) {
-            this.diskEncryptionSetResourceGroup = diskEncryptionSetResourceGroup;
+        public CreatedDiskEncryptionSet.Builder withDiskEncryptionSetResourceGroupName(String diskEncryptionSetResourceGroupName) {
+            this.diskEncryptionSetResourceGroupName = diskEncryptionSetResourceGroupName;
             return this;
         }
 

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/encryption/DiskEncryptionSetCreationRequest.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/encryption/DiskEncryptionSetCreationRequest.java
@@ -7,28 +7,19 @@ import com.sequenceiq.cloudbreak.cloud.CloudPlatformAware;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
-import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.Variant;
 
 public class DiskEncryptionSetCreationRequest implements CloudPlatformAware {
 
     private final String id;
 
-    private final String cloudPlatform;
-
     private final CloudContext cloudContext;
 
     private final CloudCredential cloudCredential;
 
-    private final Region region;
-
     private final String resourceGroupName;
 
     private final boolean singleResourceGroup;
-
-    private final Long environmentId;
-
-    private final String environmentName;
 
     private final Map<String, String> tags;
 
@@ -36,13 +27,9 @@ public class DiskEncryptionSetCreationRequest implements CloudPlatformAware {
 
     private DiskEncryptionSetCreationRequest(Builder builder) {
         this.id = builder.id;
-        this.cloudPlatform = builder.cloudPlatform;
         this.cloudCredential = builder.cloudCredential;
-        this.region = builder.region;
         this.resourceGroupName = builder.resourceGroupName;
         this.singleResourceGroup = builder.singleResourceGroup;
-        this.environmentId = builder.environmentId;
-        this.environmentName = builder.environmentName;
         this.tags = builder.tags;
         this.encryptionKeyUrl = builder.encryptionKeyUrl;
         this.cloudContext = builder.cloudContext;
@@ -56,32 +43,16 @@ public class DiskEncryptionSetCreationRequest implements CloudPlatformAware {
         return cloudContext;
     }
 
-    public String getCloudPlatform() {
-        return cloudPlatform;
-    }
-
     public CloudCredential getCloudCredential() {
         return cloudCredential;
     }
 
-    public Region getRegion() {
-        return region;
-    }
-
-    public String getResourceGroup() {
+    public String getResourceGroupName() {
         return resourceGroupName;
     }
 
     public boolean isSingleResourceGroup() {
         return singleResourceGroup;
-    }
-
-    public Long getEnvironmentId() {
-        return environmentId;
-    }
-
-    public String getEnvironmentName() {
-        return environmentName;
     }
 
     public Map<String, String> getTags() {
@@ -94,33 +65,39 @@ public class DiskEncryptionSetCreationRequest implements CloudPlatformAware {
 
     @Override
     public Platform platform() {
-        return Platform.platform(cloudPlatform);
+        return cloudContext.getPlatform();
     }
 
     @Override
     public Variant variant() {
-        return Variant.variant(cloudPlatform);
+        return cloudContext.getVariant();
+    }
+
+    // Must not reveal any secrets, hence not including encryptionKeyUrl!
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("DiskEncryptionSetCreationRequest{");
+        sb.append("id='").append(id).append('\'');
+        sb.append(", cloudContext=").append(cloudContext);
+        sb.append(", cloudCredential=").append(cloudCredential);
+        sb.append(", resourceGroupName='").append(resourceGroupName).append('\'');
+        sb.append(", singleResourceGroup=").append(singleResourceGroup);
+        sb.append(", tags=").append(tags);
+        sb.append('}');
+        return sb.toString();
     }
 
     public static final class Builder {
 
         private String id;
 
-        private String cloudPlatform;
-
         private CloudContext cloudContext;
 
         private CloudCredential cloudCredential;
 
-        private Region region;
-
         private String resourceGroupName;
 
         private boolean singleResourceGroup;
-
-        private Long environmentId;
-
-        private String environmentName;
 
         private Map<String, String> tags = new HashMap<>();
 
@@ -134,33 +111,13 @@ public class DiskEncryptionSetCreationRequest implements CloudPlatformAware {
             return this;
         }
 
-        public Builder withCloudPlatform(String cloudPlatform) {
-            this.cloudPlatform = cloudPlatform;
-            return this;
-        }
-
         public Builder withCloudContext(CloudContext cloudContext) {
             this.cloudContext = cloudContext;
             return this;
         }
 
-        public Builder withEnvironmentId(Long environmentId) {
-            this.environmentId = environmentId;
-            return this;
-        }
-
-        public Builder withEnvironmentName(String environmentName) {
-            this.environmentName = environmentName;
-            return this;
-        }
-
         public Builder withCloudCredential(CloudCredential cloudCredential) {
             this.cloudCredential = cloudCredential;
-            return this;
-        }
-
-        public Builder withRegion(Region region) {
-            this.region = region;
             return this;
         }
 
@@ -187,5 +144,7 @@ public class DiskEncryptionSetCreationRequest implements CloudPlatformAware {
         public DiskEncryptionSetCreationRequest build() {
             return new DiskEncryptionSetCreationRequest(this);
         }
+
     }
+
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/encryption/DiskEncryptionSetDeletionRequest.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/encryption/DiskEncryptionSetDeletionRequest.java
@@ -2,11 +2,14 @@ package com.sequenceiq.cloudbreak.cloud.model.encryption;
 
 import java.util.List;
 
+import com.sequenceiq.cloudbreak.cloud.CloudPlatformAware;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
 
-public class DiskEncryptionSetDeletionRequest {
+public class DiskEncryptionSetDeletionRequest implements CloudPlatformAware {
 
     private final CloudCredential cloudCredential;
 
@@ -30,6 +33,26 @@ public class DiskEncryptionSetDeletionRequest {
 
     public List<CloudResource> getCloudResources() {
         return cloudResources;
+    }
+
+    @Override
+    public Platform platform() {
+        return cloudContext.getPlatform();
+    }
+
+    @Override
+    public Variant variant() {
+        return cloudContext.getVariant();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("DiskEncryptionSetDeletionRequest{");
+        sb.append("cloudCredential=").append(cloudCredential);
+        sb.append(", cloudContext=").append(cloudContext);
+        sb.append(", cloudResources=").append(cloudResources);
+        sb.append('}');
+        return sb.toString();
     }
 
     public static final class Builder {
@@ -61,5 +84,7 @@ public class DiskEncryptionSetDeletionRequest {
         public DiskEncryptionSetDeletionRequest build() {
             return new DiskEncryptionSetDeletionRequest(this);
         }
+
     }
+
 }

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/CloudCredentialTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/CloudCredentialTest.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class CloudCredentialTest {
+
+    private static final String CONFIDENTIAL = "confidential";
+
+    private static final String SECRET = "mySecret";
+
+    @Test
+    void toStringTestShouldNotIncludeSecrets() {
+        CloudCredential underTest = new CloudCredential("id", "name", Map.of(CONFIDENTIAL, SECRET), true);
+        String result = underTest.toString();
+
+        assertThat(underTest.getStringParameter(CONFIDENTIAL)).isEqualTo(SECRET);
+        assertThat(result).doesNotContain("DynamicModel");
+        assertThat(result).doesNotContain(CONFIDENTIAL);
+        assertThat(result).doesNotContain(SECRET);
+    }
+
+}

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/ExtendedCloudCredentialTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/ExtendedCloudCredentialTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExtendedCloudCredentialTest {
+
+    private static final String CONFIDENTIAL = "confidential";
+
+    private static final String SECRET = "mySecret";
+
+    @Mock
+    private CloudCredential cloudCredential;
+
+    @Test
+    void toStringTestShouldNotIncludeSecrets() {
+        Map<String, Object> parameters = Map.of(CONFIDENTIAL, SECRET);
+        when(cloudCredential.getParameters()).thenReturn(parameters);
+        when(cloudCredential.getId()).thenReturn("id");
+        when(cloudCredential.getName()).thenReturn("name");
+        when(cloudCredential.isVerifyPermissions()).thenReturn(true);
+
+        ExtendedCloudCredential underTest = new ExtendedCloudCredential(cloudCredential, "AWS", "myCred", "myUser", "accountId");
+        String result = underTest.toString();
+
+        assertThat(underTest.getStringParameter(CONFIDENTIAL)).isEqualTo(SECRET);
+        assertThat(result).doesNotContain("DynamicModel");
+        assertThat(result).doesNotContain(CONFIDENTIAL);
+        assertThat(result).doesNotContain(SECRET);
+    }
+
+}

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/encryption/DiskEncryptionSetCreationRequestTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/encryption/DiskEncryptionSetCreationRequestTest.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.cloud.model.encryption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+
+@ExtendWith(MockitoExtension.class)
+class DiskEncryptionSetCreationRequestTest {
+
+    private static final String ENCRYPTION_KEY_URL = "mySecretKey";
+
+    @Mock
+    private CloudContext cloudContext;
+
+    @Mock
+    private CloudCredential cloudCredential;
+
+    @Test
+    void toStringTestShouldNotIncludeEncryptionKeyUrl() {
+        DiskEncryptionSetCreationRequest underTest = new DiskEncryptionSetCreationRequest.Builder()
+                .withEncryptionKeyUrl(ENCRYPTION_KEY_URL)
+                .withCloudContext(cloudContext)
+                .withTags(Map.of())
+                .withCloudCredential(cloudCredential)
+                .withId("foo")
+                .withResourceGroupName("myRg")
+                .withSingleResourceGroup(true)
+                .build();
+
+        assertThat(underTest.getEncryptionKeyUrl()).isEqualTo(ENCRYPTION_KEY_URL);
+        assertThat(underTest.toString()).doesNotContain(ENCRYPTION_KEY_URL);
+    }
+
+}

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
@@ -101,8 +101,7 @@ public class AwsClient {
             AmazonEc2Client amazonEC2Client = region != null
                     ? createEc2Client(authenticatedContextView.getAwsCredentialView(), region)
                     : createEc2Client(authenticatedContextView.getAwsCredentialView());
-            authenticatedContext.putParameter(AmazonEc2Client.class,
-                    amazonEC2Client);
+            authenticatedContext.putParameter(AmazonEc2Client.class, amazonEC2Client);
         } catch (AmazonServiceException e) {
             throw new CredentialVerificationException(e.getErrorMessage(), e);
         }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResources.java
@@ -17,8 +17,10 @@ import com.microsoft.azure.management.compute.implementation.DiskEncryptionSetIn
 import com.sequenceiq.cloudbreak.cloud.EncryptionResources;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClientService;
-import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
-import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncryptionSetCreationCheckerContext;
+import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncryptionSetCreationPoller;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Variant;
@@ -26,9 +28,9 @@ import com.sequenceiq.cloudbreak.cloud.model.encryption.CreatedDiskEncryptionSet
 import com.sequenceiq.cloudbreak.cloud.model.encryption.DiskEncryptionSetCreationRequest;
 import com.sequenceiq.cloudbreak.cloud.model.encryption.DiskEncryptionSetDeletionRequest;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
+import com.sequenceiq.cloudbreak.cloud.transform.CloudResourceHelper;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.common.api.type.CommonStatus;
-import com.sequenceiq.common.api.type.ResourceType;
 
 @Service
 public class AzureEncryptionResources implements EncryptionResources {
@@ -47,11 +49,17 @@ public class AzureEncryptionResources implements EncryptionResources {
     private AzureUtils azureUtils;
 
     @Inject
+    private DiskEncryptionSetCreationPoller diskEncryptionSetCreationPoller;
+
+    @Inject
     @Qualifier("DefaultRetryService")
     private Retry retryService;
 
     @Inject
     private PersistenceNotifier persistenceNotifier;
+
+    @Inject
+    private CloudResourceHelper cloudResourceHelper;
 
     @Override
     public Platform platform() {
@@ -65,134 +73,164 @@ public class AzureEncryptionResources implements EncryptionResources {
 
     @Override
     public CreatedDiskEncryptionSet createDiskEncryptionSet(DiskEncryptionSetCreationRequest diskEncryptionSetCreationRequest) {
-        String vaultName;
-        String vaultResourceGroupName;
-        String desResourceGroupName;
-        AzureClient azureClient = azureClientService.getClient(diskEncryptionSetCreationRequest.getCloudCredential());
+        try {
+            String vaultName;
+            String vaultResourceGroupName;
+            String desResourceGroupName;
+            AuthenticatedContext authenticatedContext = azureClientService.createAuthenticatedContext(diskEncryptionSetCreationRequest.getCloudContext(),
+                    diskEncryptionSetCreationRequest.getCloudCredential());
+            AzureClient azureClient = authenticatedContext.getParameter(AzureClient.class);
 
-        Matcher matcher = ENCRYPTION_KEY_URL_PATTERN.matcher(diskEncryptionSetCreationRequest.getEncryptionKeyUrl());
-        if (matcher.matches()) {
-            vaultName = matcher.group(1);
-        } else {
-            throw new IllegalArgumentException("vaultName cannot be fetched from encryptionKeyUrl. encryptionKeyUrl should be of format - " +
-                    "'https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>'");
-        }
-        if (diskEncryptionSetCreationRequest.isSingleResourceGroup()) {
-            desResourceGroupName = diskEncryptionSetCreationRequest.getResourceGroup();
-            vaultResourceGroupName = desResourceGroupName;
-        } else {
-            throw new IllegalArgumentException("Customer Managed Key Encryption for managed Azure disks is supported only if the CDP resources " +
-                    "are in the same resource group as the vault.");
-        }
-        String sourceVaultId = String.format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s",
-                azureClient.getCurrentSubscription().subscriptionId(), vaultResourceGroupName, vaultName);
+            Matcher matcher = ENCRYPTION_KEY_URL_PATTERN.matcher(diskEncryptionSetCreationRequest.getEncryptionKeyUrl());
+            if (matcher.matches()) {
+                vaultName = matcher.group(1);
+            } else {
+                throw new IllegalArgumentException("vaultName cannot be fetched from encryptionKeyUrl. encryptionKeyUrl should be of format - " +
+                        "'https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>'");
+            }
+            if (diskEncryptionSetCreationRequest.isSingleResourceGroup()) {
+                desResourceGroupName = diskEncryptionSetCreationRequest.getResourceGroupName();
+                vaultResourceGroupName = desResourceGroupName;
+            } else {
+                throw new IllegalArgumentException("Customer Managed Key Encryption for managed Azure disks is supported only if the CDP resources " +
+                        "are in the same resource group as the vault.");
+            }
+            String sourceVaultId = String.format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s",
+                    azureClient.getCurrentSubscription().subscriptionId(), vaultResourceGroupName, vaultName);
 
-        CreatedDiskEncryptionSet diskEncryptionSet = getOrCreateDiskEncryptionSetOnCloud(
-                azureClient,
-                desResourceGroupName,
-                sourceVaultId,
-                diskEncryptionSetCreationRequest);
-        grantKeyVaultAccessPolicyToDiskEncryptionSetServicePrincipal(azureClient, vaultResourceGroupName, vaultName,
-                diskEncryptionSet.getDiskEncryptionSetPrincipalId());
-        return diskEncryptionSet;
+            CreatedDiskEncryptionSet diskEncryptionSet = getOrCreateDiskEncryptionSetOnCloud(
+                    authenticatedContext,
+                    azureClient,
+                    desResourceGroupName,
+                    sourceVaultId,
+                    diskEncryptionSetCreationRequest);
+            // The existence of the DES SP cannot be easily checked. That would need powerful special AD API permissions for the credential app itself that
+            // most customers would never grant. Though there is a system assigned managed identity as well sitting behind the SP, querying the properties of
+            // this identity (in order to check its existence) would also need an additional powerful Action for the role assigned to the credential app.
+            grantKeyVaultAccessPolicyToDiskEncryptionSetServicePrincipal(azureClient, vaultResourceGroupName, vaultName, desResourceGroupName,
+                    diskEncryptionSet.getDiskEncryptionSetName(), diskEncryptionSet.getDiskEncryptionSetPrincipalObjectId());
+            return diskEncryptionSet;
+        } catch (Exception e) {
+            LOGGER.error("Disk Encryption Set creation failed, request=" + diskEncryptionSetCreationRequest, e);
+            throw azureUtils.convertToCloudConnectorException(e, "Disk Encryption Set creation");
+        }
     }
 
     @Override
     public void deleteDiskEncryptionSet(DiskEncryptionSetDeletionRequest diskEncryptionSetDeletionRequest) {
-        Optional<CloudResource> desCloudResourceOptional = diskEncryptionSetDeletionRequest.getCloudResources().stream()
-                .filter(r -> r.getType() == ResourceType.AZURE_DISK_ENCRYPTION_SET)
-                .findFirst();
-        if (desCloudResourceOptional.isPresent()) {
-            CloudResource desCloudResource = desCloudResourceOptional.get();
-            String diskEncryptionSetId = desCloudResource.getReference();
-            CloudCredential cloudCredential = diskEncryptionSetDeletionRequest.getCloudCredential();
-            AzureClient azureClient = azureClientService.getClient(cloudCredential);
-            String diskEncryptionSetName;
-            String desResourceGroupName;
+        try {
+            Optional<CloudResource> desCloudResourceOptional =
+                    cloudResourceHelper.getResourceTypeFromList(AZURE_DISK_ENCRYPTION_SET, diskEncryptionSetDeletionRequest.getCloudResources());
+            if (desCloudResourceOptional.isPresent()) {
+                CloudResource desCloudResource = desCloudResourceOptional.get();
+                String diskEncryptionSetId = desCloudResource.getReference();
+                AzureClient azureClient = azureClientService.getClient(diskEncryptionSetDeletionRequest.getCloudCredential());
+                String diskEncryptionSetName;
+                String desResourceGroupName;
 
-            Matcher matcher = DISK_ENCRYPTION_SET_NAME.matcher(diskEncryptionSetId);
-            if (matcher.matches()) {
-                diskEncryptionSetName = matcher.group(1);
+                Matcher matcher = DISK_ENCRYPTION_SET_NAME.matcher(diskEncryptionSetId);
+                if (matcher.matches()) {
+                    diskEncryptionSetName = matcher.group(1);
+                } else {
+                    throw new IllegalArgumentException(String.format("Failed to deduce Disk Encryption Set name from given resource id \"%s\"",
+                            diskEncryptionSetId));
+                }
+                matcher = DISK_ENCRYPTION_SET_RESOURCE_GROUP.matcher(diskEncryptionSetId);
+                if (matcher.matches()) {
+                    desResourceGroupName = matcher.group(1);
+                } else {
+                    throw new IllegalArgumentException(String.format("Failed to deduce Disk Encryption Set's resource group name from given resource id \"%s\"",
+                            diskEncryptionSetId));
+                }
+                LOGGER.info("Deleting Disk Encryption Set \"{}\"", diskEncryptionSetId);
+                deleteDiskEncryptionSetOnCloud(azureClient, desResourceGroupName, diskEncryptionSetName);
+                persistenceNotifier.notifyDeletion(desCloudResource, diskEncryptionSetDeletionRequest.getCloudContext());
             } else {
-                throw new IllegalArgumentException(String.format("Failed to deduce Disk Encryption Set name from given resource id %s",
-                        diskEncryptionSetId));
+                LOGGER.info("No Disk Encryption Set found to delete, request=" + diskEncryptionSetDeletionRequest);
             }
-            matcher = DISK_ENCRYPTION_SET_RESOURCE_GROUP.matcher(diskEncryptionSetId);
-            if (matcher.matches()) {
-                desResourceGroupName = matcher.group(1);
-            } else {
-                throw new IllegalArgumentException(String.format("Failed to deduce Disk Encryption Set's resource group name from given resource id %s",
-                        diskEncryptionSetId));
-            }
-            LOGGER.info("Deleting Disk Encryption Set {}", diskEncryptionSetId);
-            deleteDiskEncryptionSetOnCloud(azureClient, desResourceGroupName, diskEncryptionSetName);
-            persistenceNotifier.notifyDeletion(desCloudResource, diskEncryptionSetDeletionRequest.getCloudContext());
-        } else {
-            LOGGER.info("No Disk Encryption Set found to delete");
+        } catch (Exception e) {
+            LOGGER.error("Disk Encryption Set deletion failed, request=" + diskEncryptionSetDeletionRequest, e);
+            throw azureUtils.convertToCloudConnectorException(e, "Disk Encryption Set deletion");
         }
     }
 
-    private CreatedDiskEncryptionSet getOrCreateDiskEncryptionSetOnCloud(AzureClient azureClient, String desResourceGroupName,
-            String sourceVaultId, DiskEncryptionSetCreationRequest diskEncryptionSetCreationRequest) {
+    private CreatedDiskEncryptionSet getOrCreateDiskEncryptionSetOnCloud(AuthenticatedContext authenticatedContext, AzureClient azureClient,
+            String desResourceGroupName, String sourceVaultId, DiskEncryptionSetCreationRequest diskEncryptionSetCreationRequest) {
+        CloudContext cloudContext = diskEncryptionSetCreationRequest.getCloudContext();
         String diskEncryptionSetName = azureUtils.generateDesNameByNameAndId(
-                String.format("%s-DES-", diskEncryptionSetCreationRequest.getEnvironmentName()),
-                diskEncryptionSetCreationRequest.getId());
-        LOGGER.info("Checking if Disk Encryption Set {} exists on cloud Azure", diskEncryptionSetName);
-        DiskEncryptionSetInner createdSet = azureClient.getDiskEncryptionSet(desResourceGroupName, diskEncryptionSetName);
+                String.format("%s-DES-", cloudContext.getName()), diskEncryptionSetCreationRequest.getId());
+        LOGGER.info("Checking if Disk Encryption Set \"{}\" exists", diskEncryptionSetName);
+        DiskEncryptionSetInner createdSet = azureClient.getDiskEncryptionSetByName(desResourceGroupName, diskEncryptionSetName);
         if (createdSet == null) {
-            LOGGER.info("Creating Disk Encryption Set {}", diskEncryptionSetName);
+            LOGGER.info("Creating Disk Encryption Set \"{}\"", diskEncryptionSetName);
             createdSet = azureClient.createDiskEncryptionSet(diskEncryptionSetName, diskEncryptionSetCreationRequest.getEncryptionKeyUrl(),
-                    diskEncryptionSetCreationRequest.getRegion().getRegionName(), desResourceGroupName, sourceVaultId,
+                    cloudContext.getLocation().getRegion().getRegionName(), desResourceGroupName, sourceVaultId,
                     diskEncryptionSetCreationRequest.getTags());
         } else {
-            LOGGER.info("Disk Encryption Set {} exists on cloud Azure, Proceeding with the same", diskEncryptionSetName);
+            LOGGER.info("Disk Encryption Set \"{}\" already exists, proceeding with the same", diskEncryptionSetName);
         }
-        if (createdSet != null) {
-            CloudResource desCloudResource = CloudResource.builder()
-                    .name(diskEncryptionSetName)
-                    .type(AZURE_DISK_ENCRYPTION_SET)
-                    .reference(createdSet.id())
-                    .status(CommonStatus.CREATED)
-                    .build();
-            persistenceNotifier.notifyAllocation(desCloudResource, diskEncryptionSetCreationRequest.getCloudContext());
+        createdSet = pollDiskEncryptionSetCreation(authenticatedContext, desResourceGroupName, diskEncryptionSetName, createdSet);
+        // Neither of createdSet, createdSet.id() or createdSet.identity().principalId() can be null at this point; polling will fail otherwise
 
-            return new CreatedDiskEncryptionSet.Builder()
-                    .withDiskEncryptionSetId(createdSet.id())
-                    .withDiskEncryptionSetPrincipalId(createdSet.identity().principalId())
-                    .withDiskEncryptionSetLocation(createdSet.location())
-                    .withDiskEncryptionSetName(createdSet.name())
-                    .withTags(createdSet.getTags())
-                    .withDiskEncryptionSetResourceGroup(desResourceGroupName)
-                    .build();
-        } else {
-            throw new CloudConnectorException("Creating Disk Encryption Set resulted in failure from Azure cloud.");
-        }
+        CloudResource desCloudResource = CloudResource.builder()
+                .name(diskEncryptionSetName)
+                .type(AZURE_DISK_ENCRYPTION_SET)
+                .reference(createdSet.id())
+                .status(CommonStatus.CREATED)
+                .build();
+        persistenceNotifier.notifyAllocation(desCloudResource, cloudContext);
+
+        return new CreatedDiskEncryptionSet.Builder()
+                .withDiskEncryptionSetId(createdSet.id())
+                .withDiskEncryptionSetPrincipalObjectId(createdSet.identity().principalId())
+                .withDiskEncryptionSetLocation(createdSet.location())
+                .withDiskEncryptionSetName(createdSet.name())
+                .withTags(createdSet.getTags())
+                .withDiskEncryptionSetResourceGroupName(desResourceGroupName)
+                .build();
+    }
+
+    private DiskEncryptionSetInner pollDiskEncryptionSetCreation(AuthenticatedContext authenticatedContext, String desResourceGroupName, String desName,
+            DiskEncryptionSetInner desInitial) {
+        LOGGER.info("Initializing poller for the creation of Disk Encryption Set \"{}\" in Resource Group \"{}\".", desName, desResourceGroupName);
+        DiskEncryptionSetCreationCheckerContext checkerContext = new DiskEncryptionSetCreationCheckerContext(desResourceGroupName, desName);
+        return diskEncryptionSetCreationPoller.startPolling(authenticatedContext, checkerContext, desInitial);
     }
 
     private void grantKeyVaultAccessPolicyToDiskEncryptionSetServicePrincipal(AzureClient azureClient, String vaultResourceGroupName, String vaultName,
-            String diskEncryptionSetPrincipalId) {
-        String description = String.format("access to Key Vault \"%s\"", vaultName);
+            String desResourceGroupName, String desName, String desPrincipalObjectId) {
+        String description = String.format("access to Key Vault \"%s\" in Resource Group \"%s\" for Service Principal having object ID \"%s\" " +
+                        "associated with Disk Encryption Set \"%s\" in Resource Group \"%s\"", vaultName, vaultResourceGroupName, desPrincipalObjectId,
+                desName, desResourceGroupName);
         retryService.testWith2SecDelayMax15Times(() -> {
             try {
                 LOGGER.info("Granting {}.", description);
-                azureClient.grantKeyVaultAccessPolicyToServicePrincipal(vaultResourceGroupName, vaultName, diskEncryptionSetPrincipalId);
+                azureClient.grantKeyVaultAccessPolicyToServicePrincipal(vaultResourceGroupName, vaultName, desPrincipalObjectId);
                 LOGGER.info("Granted {}.", description);
                 return true;
             } catch (Exception e) {
-                LOGGER.warn(String.format("Granting %s failed, %s happened:", description, e.getClass().getName()), e);
-                throw Retry.ActionFailedException.ofCause(e);
+                throw azureUtils.convertToActionFailedExceptionCausedByCloudConnectorException(e, "Granting " + description);
             }
         });
     }
 
-    private void deleteDiskEncryptionSetOnCloud(AzureClient azureClient, String desResourceGroupName, String diskEncryptionSetName) {
-        LOGGER.info("Checking if Disk Encryption Set {} exists on cloud Azure", diskEncryptionSetName);
-        DiskEncryptionSetInner existingDiskEncryptionSet = azureClient.getDiskEncryptionSet(desResourceGroupName, diskEncryptionSetName);
-        if (existingDiskEncryptionSet != null) {
-            azureClient.deleteDiskEncryptionSet(desResourceGroupName, diskEncryptionSetName);
-            LOGGER.info("Deleted Disk Encryption Set on Azure cloud");
-        } else {
-            LOGGER.info("No Disk Encryption Set found to delete");
-        }
+    private void deleteDiskEncryptionSetOnCloud(AzureClient azureClient, String desResourceGroupName, String desName) {
+        String description = String.format("Disk Encryption Set \"%s\" in Resource Group \"%s\"", desName, desResourceGroupName);
+        retryService.testWith2SecDelayMax15Times(() -> {
+            try {
+                LOGGER.info("Checking if {} exists.", description);
+                DiskEncryptionSetInner existingDiskEncryptionSet = azureClient.getDiskEncryptionSetByName(desResourceGroupName, desName);
+                if (existingDiskEncryptionSet != null) {
+                    LOGGER.info("Deleting {}.", description);
+                    azureClient.deleteDiskEncryptionSet(desResourceGroupName, desName);
+                    LOGGER.info("Deleted {}.", description);
+                } else {
+                    LOGGER.info("No {} found to delete.", description);
+                }
+                return true;
+            } catch (Exception e) {
+                throw azureUtils.convertToActionFailedExceptionCausedByCloudConnectorException(e, "Deletion of " + description);
+            }
+        });
     }
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientCredentials.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientCredentials.java
@@ -136,4 +136,5 @@ public class AzureClientCredentials {
             return Optional.empty();
         }
     }
+
 }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/AzurePollTaskFactory.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/AzurePollTaskFactory.java
@@ -5,7 +5,10 @@ import javax.inject.Inject;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
+import com.microsoft.azure.management.compute.implementation.DiskEncryptionSetInner;
 import com.sequenceiq.cloudbreak.cloud.azure.context.AzureInteractiveLoginStatusCheckerContext;
+import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncryptionSetCreationCheckerContext;
+import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncryptionSetCreationCheckerTask;
 import com.sequenceiq.cloudbreak.cloud.azure.task.dnszone.AzureDnsZoneCreationCheckerContext;
 import com.sequenceiq.cloudbreak.cloud.azure.task.dnszone.AzureDnsZoneCreationCheckerTask;
 import com.sequenceiq.cloudbreak.cloud.azure.task.image.AzureManagedImageCreationCheckerContext;
@@ -47,6 +50,11 @@ public class AzurePollTaskFactory {
     public PollTask<Boolean> dnsZoneCreationCheckerTask(AuthenticatedContext authenticatedContext,
             AzureDnsZoneCreationCheckerContext azureDnsZoneCreationCheckerContext) {
         return createPollTask(AzureDnsZoneCreationCheckerTask.NAME, authenticatedContext, azureDnsZoneCreationCheckerContext);
+    }
+
+    public PollTask<DiskEncryptionSetInner> diskEncryptionSetCreationCheckerTask(AuthenticatedContext authenticatedContext,
+            DiskEncryptionSetCreationCheckerContext checkerContext) {
+        return createPollTask(DiskEncryptionSetCreationCheckerTask.NAME, authenticatedContext, checkerContext);
     }
 
     @SuppressWarnings("unchecked")

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/diskencryptionset/DiskEncryptionSetCreationCheckerContext.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/diskencryptionset/DiskEncryptionSetCreationCheckerContext.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset;
+
+public class DiskEncryptionSetCreationCheckerContext {
+
+    private final String resourceGroupName;
+
+    private final String diskEncryptionSetName;
+
+    public DiskEncryptionSetCreationCheckerContext(String resourceGroupName, String diskEncryptionSetName) {
+        this.resourceGroupName = resourceGroupName;
+        this.diskEncryptionSetName = diskEncryptionSetName;
+    }
+
+    public String getResourceGroupName() {
+        return resourceGroupName;
+    }
+
+    public String getDiskEncryptionSetName() {
+        return diskEncryptionSetName;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("DiskEncryptionSetCreationCheckerContext{");
+        sb.append("resourceGroupName='").append(resourceGroupName).append('\'');
+        sb.append(", diskEncryptionSetName='").append(diskEncryptionSetName).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/diskencryptionset/DiskEncryptionSetCreationCheckerTask.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/diskencryptionset/DiskEncryptionSetCreationCheckerTask.java
@@ -1,0 +1,57 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.microsoft.azure.ProxyResource;
+import com.microsoft.azure.management.compute.EncryptionSetIdentity;
+import com.microsoft.azure.management.compute.implementation.DiskEncryptionSetInner;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.task.PollPredicateStateTask;
+
+@Component(DiskEncryptionSetCreationCheckerTask.NAME)
+@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+public class DiskEncryptionSetCreationCheckerTask extends PollPredicateStateTask<DiskEncryptionSetInner> {
+
+    public static final String NAME = "DiskEncryptionSetCreationCheckerTask";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DiskEncryptionSetCreationCheckerTask.class);
+
+    private final AzureClient azureClient;
+
+    private final DiskEncryptionSetCreationCheckerContext checkerContext;
+
+    public DiskEncryptionSetCreationCheckerTask(AuthenticatedContext authenticatedContext, DiskEncryptionSetCreationCheckerContext checkerContext) {
+        super(requireNonNull(authenticatedContext), false, DiskEncryptionSetCreationCheckerTask::isDiskEncryptionSetValid);
+        azureClient = requireNonNull(authenticatedContext.getParameter(AzureClient.class));
+        this.checkerContext = requireNonNull(checkerContext);
+    }
+
+    private static boolean isDiskEncryptionSetValid(DiskEncryptionSetInner des) {
+        Optional<DiskEncryptionSetInner> desOptional = Optional.ofNullable(des);
+        String id = desOptional.map(ProxyResource::id)
+                .orElse(null);
+        String principalObjectId = desOptional.map(DiskEncryptionSetInner::identity)
+                .map(EncryptionSetIdentity::principalId)
+                .orElse(null);
+        return id != null && principalObjectId != null;
+    }
+
+    @Override
+    protected DiskEncryptionSetInner doCall() {
+        String resourceGroupName = checkerContext.getResourceGroupName();
+        String diskEncryptionSetName = checkerContext.getDiskEncryptionSetName();
+        LOGGER.info("Waiting for the creation of Disk Encryption Set \"{}\" in Resource Group \"{}\" to complete", diskEncryptionSetName, resourceGroupName);
+
+        return azureClient.getDiskEncryptionSetByName(resourceGroupName, diskEncryptionSetName);
+    }
+
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/diskencryptionset/DiskEncryptionSetCreationPoller.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/task/diskencryptionset/DiskEncryptionSetCreationPoller.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.microsoft.azure.management.compute.implementation.DiskEncryptionSetInner;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
+import com.sequenceiq.cloudbreak.cloud.azure.task.AzurePollTaskFactory;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
+import com.sequenceiq.cloudbreak.cloud.task.PollTask;
+
+@Component
+public class DiskEncryptionSetCreationPoller {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DiskEncryptionSetCreationPoller.class);
+
+    @Value("${cb.azure.poller.des.checkinterval:1000}")
+    private int creationCheckInterval;
+
+    @Value("${cb.azure.poller.des.maxattempt:30}")
+    private int creationCheckMaxAttempt;
+
+    @Value("${cb.azure.poller.des.maxfailurenumber:5}")
+    private int maxTolerableFailureNumber;
+
+    @Inject
+    private AzurePollTaskFactory azurePollTaskFactory;
+
+    @Inject
+    private SyncPollingScheduler<DiskEncryptionSetInner> syncPollingScheduler;
+
+    @Inject
+    private AzureUtils azureUtils;
+
+    public DiskEncryptionSetInner startPolling(AuthenticatedContext authenticatedContext, DiskEncryptionSetCreationCheckerContext checkerContext,
+            DiskEncryptionSetInner desInitial) {
+        try {
+            PollTask<DiskEncryptionSetInner> checkerTask =
+                    azurePollTaskFactory.diskEncryptionSetCreationCheckerTask(requireNonNull(authenticatedContext), requireNonNull(checkerContext));
+            String resourceGroupName = checkerContext.getResourceGroupName();
+            String diskEncryptionSetName = checkerContext.getDiskEncryptionSetName();
+            DiskEncryptionSetInner result = desInitial;
+
+            if (checkerTask.completed(result)) {
+                LOGGER.info("Creation of Disk Encryption Set \"{}\" in Resource Group \"{}\" has already completed.", diskEncryptionSetName, resourceGroupName);
+            } else {
+                LOGGER.info("Start polling the creation of Disk Encryption Set \"{}\" in Resource Group \"{}\".", diskEncryptionSetName, resourceGroupName);
+                result = syncPollingScheduler.schedule(checkerTask, creationCheckInterval, creationCheckMaxAttempt, maxTolerableFailureNumber);
+                LOGGER.info("Polling finished, creation of Disk Encryption Set \"{}\" in Resource Group \"{}\" is complete.", diskEncryptionSetName,
+                        resourceGroupName);
+            }
+
+            return result;
+        } catch (Exception e) {
+            LOGGER.error("Disk Encryption Set creation failed, context=" + checkerContext, e);
+            throw azureUtils.convertToCloudConnectorException(e, "Disk Encryption Set creation");
+        }
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResourcesTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResourcesTest.java
@@ -1,10 +1,14 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static com.sequenceiq.cloudbreak.cloud.model.Location.location;
+import static com.sequenceiq.cloudbreak.cloud.model.Region.region;
+import static com.sequenceiq.common.api.type.CommonStatus.CREATED;
+import static com.sequenceiq.common.api.type.ResourceType.AZURE_DISK_ENCRYPTION_SET;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -14,10 +18,14 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Supplier;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -32,26 +40,30 @@ import com.microsoft.azure.management.compute.implementation.DiskEncryptionSetIn
 import com.microsoft.azure.management.resources.Subscription;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClientService;
+import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncryptionSetCreationCheckerContext;
+import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncryptionSetCreationPoller;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
-import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.model.encryption.CreatedDiskEncryptionSet;
 import com.sequenceiq.cloudbreak.cloud.model.encryption.DiskEncryptionSetCreationRequest;
 import com.sequenceiq.cloudbreak.cloud.model.encryption.DiskEncryptionSetDeletionRequest;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.notification.model.ResourcePersisted;
+import com.sequenceiq.cloudbreak.cloud.transform.CloudResourceHelper;
 import com.sequenceiq.cloudbreak.service.Retry;
-import com.sequenceiq.common.api.type.CommonStatus;
-import com.sequenceiq.common.api.type.ResourceType;
 
 @ExtendWith(MockitoExtension.class)
 public class AzureEncryptionResourcesTest {
 
     private static final String DES_PRINCIPAL_ID = "desPrincipalId";
+
+    private static final String DES_RESOURCE_ID =
+            "/subscriptions/dummySubscriptionId/resourceGroups/dummyResourceGroup/providers/Microsoft.Compute/diskEncryptionSets/dummyEnvName-DES-uniqueId";
 
     @InjectMocks
     private AzureEncryptionResources underTest;
@@ -66,10 +78,29 @@ public class AzureEncryptionResourcesTest {
     private AzureUtils azureUtils;
 
     @Mock
+    private DiskEncryptionSetCreationPoller diskEncryptionSetCreationPoller;
+
+    @Mock
     private Retry retryService;
 
     @Mock
     private PersistenceNotifier persistenceNotifier;
+
+    @Mock
+    private CloudResourceHelper cloudResourceHelper;
+
+    @Mock
+    private CloudCredential cloudCredential;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    private CloudContext cloudContext;
+
+    @BeforeEach
+    void setUp() {
+        cloudContext = createCloudContext();
+    }
 
     @Test
     public void testPlatformShouldReturnAzurePlatform() {
@@ -85,40 +116,74 @@ public class AzureEncryptionResourcesTest {
         assertEquals(AzureConstants.VARIANT, actual);
     }
 
+    private CloudContext createCloudContext() {
+        return CloudContext.Builder.builder()
+                .withId(1L)
+                .withName("envName")
+                .withCrn("crn:cdp:environments:us-west-1:dummyUser:environment:randomGeneratedResource")
+                .withPlatform("AZURE")
+                .withVariant("AZURE")
+                .withLocation(location(region("dummyRegion")))
+                .withUserName("dummyUser")
+                .withAccountId("dummyAccountId")
+                .build();
+    }
+
+    private void initExceptionConversion() {
+        when(azureUtils.convertToCloudConnectorException(any(Exception.class), any(String.class)))
+                .thenAnswer(invocation -> new CloudConnectorException(invocation.getArgument(0, Exception.class)));
+    }
+
+    private void initActionFailedExceptionConversion() {
+        when(azureUtils.convertToActionFailedExceptionCausedByCloudConnectorException(any(Exception.class), any(String.class)))
+                .thenAnswer(invocation -> new Retry.ActionFailedException(new CloudConnectorException(invocation.getArgument(0, Exception.class))));
+    }
+
     @Test
     public void testExceptionIsThrownWhenNotIsSingleResourceGroup() {
         DiskEncryptionSetCreationRequest requestedSet = new DiskEncryptionSetCreationRequest.Builder()
-                .withCloudCredential(new CloudCredential())
-                .withRegion(Region.region("dummyRegion"))
-                .withEnvironmentName("dummyEnvName")
-                .withEnvironmentId(1L)
+                .withCloudCredential(cloudCredential)
+                .withCloudContext(cloudContext)
                 .withSingleResourceGroup(false)
                 .withResourceGroupName("dummyResourceGroup")
                 .withTags(new HashMap<>())
                 .withEncryptionKeyUrl("https://dummyVaultName.vault.azure.net/keys/dummyKeyName/dummyKeyVersion")
                 .build();
-        when(azureClientService.getClient(any(CloudCredential.class))).thenReturn(azureClient);
+        when(azureClientService.createAuthenticatedContext(cloudContext, cloudCredential)).thenReturn(authenticatedContext);
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+        initExceptionConversion();
 
-        assertEquals(assertThrows(IllegalArgumentException.class, () -> underTest.createDiskEncryptionSet(requestedSet)).getMessage(),
+        verifyException(IllegalArgumentException.class, () -> underTest.createDiskEncryptionSet(requestedSet),
                 "Customer Managed Key Encryption for managed Azure disks is supported only if the CDP resources " +
                         "are in the same resource group as the vault.");
+    }
+
+    private <T extends Throwable> void verifyException(Class<T> expectedType, Executable executable, String messageExpected) {
+        CloudConnectorException cloudConnectorException = assertThrows(CloudConnectorException.class, executable);
+
+        assertThat(verifyAndGetCause(expectedType, cloudConnectorException)).hasMessage(messageExpected);
+    }
+
+    private <T extends Throwable> T verifyAndGetCause(Class<T> expectedType, Throwable e) {
+        assertThat(e).hasCauseInstanceOf(expectedType);
+        return expectedType.cast(e.getCause());
     }
 
     @Test
     public void testExceptionIsThrownWhenVaultNameIsNotFound() {
         DiskEncryptionSetCreationRequest requestedSet = new DiskEncryptionSetCreationRequest.Builder()
-                .withCloudCredential(new CloudCredential())
-                .withRegion(Region.region("dummyRegion"))
-                .withEnvironmentName("dummyEnvName")
-                .withEnvironmentId(1L)
+                .withCloudCredential(cloudCredential)
+                .withCloudContext(cloudContext)
                 .withSingleResourceGroup(true)
                 .withResourceGroupName("dummyResourceGroup")
                 .withTags(new HashMap<>())
                 .withEncryptionKeyUrl("wrongKeyUrl")
                 .build();
-        when(azureClientService.getClient(any(CloudCredential.class))).thenReturn(azureClient);
+        when(azureClientService.createAuthenticatedContext(cloudContext, cloudCredential)).thenReturn(authenticatedContext);
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+        initExceptionConversion();
 
-        assertEquals(assertThrows(IllegalArgumentException.class, () -> underTest.createDiskEncryptionSet(requestedSet)).getMessage(),
+        verifyException(IllegalArgumentException.class, () -> underTest.createDiskEncryptionSet(requestedSet),
                 "vaultName cannot be fetched from encryptionKeyUrl. encryptionKeyUrl should be of format - " +
                         "'https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>'");
     }
@@ -126,10 +191,9 @@ public class AzureEncryptionResourcesTest {
     @Test
     public void testCreateDiskEncryptionSetShouldMakeCloudCallAndThrowException() {
         DiskEncryptionSetCreationRequest requestedSet = new DiskEncryptionSetCreationRequest.Builder()
-                .withCloudCredential(new CloudCredential())
-                .withRegion(Region.region("dummyRegion"))
-                .withEnvironmentName("dummyEnvName")
-                .withEnvironmentId(1L)
+                .withId("uniqueId")
+                .withCloudCredential(cloudCredential)
+                .withCloudContext(cloudContext)
                 .withSingleResourceGroup(true)
                 .withResourceGroupName("dummyResourceGroup")
                 .withTags(new HashMap<>())
@@ -137,25 +201,24 @@ public class AzureEncryptionResourcesTest {
                 .build();
         Subscription subscription = mock(Subscription.class);
         when(subscription.subscriptionId()).thenReturn("dummySubscriptionId");
-        when(azureClientService.getClient(any(CloudCredential.class))).thenReturn(azureClient);
+        when(azureUtils.generateDesNameByNameAndId("envName-DES-", "uniqueId")).thenReturn("dummyEnvName-DES-uniqueId");
+        when(azureClientService.createAuthenticatedContext(cloudContext, cloudCredential)).thenReturn(authenticatedContext);
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+        initExceptionConversion();
         when(azureClient.getCurrentSubscription()).thenReturn(subscription);
 
-        //Call to createDiskEncryptionSet is made and exception is thrown because of dummy parameters.
-        assertEquals(assertThrows(CloudConnectorException.class, () -> underTest.createDiskEncryptionSet(requestedSet)).getMessage(),
-                "Creating Disk Encryption Set resulted in failure from Azure cloud.");
+        when(azureClient.getDiskEncryptionSetByName("dummyResourceGroup", "dummyEnvName-DES-uniqueId"))
+                .thenThrow(new UnsupportedOperationException("Serious problem"));
+
+        verifyException(UnsupportedOperationException.class, () -> underTest.createDiskEncryptionSet(requestedSet), "Serious problem");
     }
 
     @Test
-    public void testCreateDiskEncryptionSetShouldReturnExistingDiskEncryptionSet() {
+    public void testCreateDiskEncryptionSetShouldReturnExistingDiskEncryptionSetWithoutPolling() {
         DiskEncryptionSetCreationRequest requestedSet = new DiskEncryptionSetCreationRequest.Builder()
                 .withId("uniqueId")
-                .withCloudContext(CloudContext.Builder.builder()
-                        .withId(1L)
-                        .withName("envName").build())
-                .withCloudCredential(new CloudCredential())
-                .withRegion(Region.region("dummyRegion"))
-                .withEnvironmentName("dummyEnvName")
-                .withEnvironmentId(1L)
+                .withCloudContext(cloudContext)
+                .withCloudCredential(cloudCredential)
                 .withSingleResourceGroup(true)
                 .withResourceGroupName("dummyResourceGroup")
                 .withTags(new HashMap<>())
@@ -172,22 +235,40 @@ public class AzureEncryptionResourcesTest {
                 .withIdentity(identity)
                 .withLocation("dummyRegion")
                 .withTags(new HashMap<>());
+        ReflectionTestUtils.setField(des, "id", DES_RESOURCE_ID);
         Subscription subscription = mock(Subscription.class);
-        when(persistenceNotifier.notifyAllocation(any(CloudResource.class), any(CloudContext.class))).thenReturn(new ResourcePersisted());
+        when(persistenceNotifier.notifyAllocation(any(CloudResource.class), eq(cloudContext))).thenReturn(new ResourcePersisted());
         when(subscription.subscriptionId()).thenReturn("dummySubscriptionId");
         when(azureUtils.generateDesNameByNameAndId(any(String.class), any(String.class))).thenReturn("dummyEnvName-DES-uniqueId");
-        when(azureClientService.getClient(any(CloudCredential.class))).thenReturn(azureClient);
+        when(azureClientService.createAuthenticatedContext(cloudContext, cloudCredential)).thenReturn(authenticatedContext);
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
         when(azureClient.getCurrentSubscription()).thenReturn(subscription);
-        when(azureClient.getDiskEncryptionSet(any(String.class), any(String.class))).thenReturn(des);
+        when(azureClient.getDiskEncryptionSetByName(any(String.class), any(String.class))).thenReturn(des);
         initRetry();
+        // Return the same DES instance to simulate that the poller checker task instantly completed
+        when(diskEncryptionSetCreationPoller.startPolling(eq(authenticatedContext), any(DiskEncryptionSetCreationCheckerContext.class), eq(des)))
+                .thenReturn(des);
 
         CreatedDiskEncryptionSet createdDes = underTest.createDiskEncryptionSet(requestedSet);
 
         assertEquals(createdDes.getDiskEncryptionSetLocation(), "dummyRegion");
-        assertEquals(createdDes.getDiskEncryptionSetResourceGroup(), "dummyResourceGroup");
+        assertEquals(createdDes.getDiskEncryptionSetResourceGroupName(), "dummyResourceGroup");
+        assertThat(createdDes.getDiskEncryptionSetId()).isEqualTo(DES_RESOURCE_ID);
         verify(azureClient, never()).createDiskEncryptionSet(any(String.class), any(String.class), any(String.class),
                 any(String.class), any(String.class), any(Map.class));
         verify(azureClient).grantKeyVaultAccessPolicyToServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
+
+        verifyPersistedCloudResource();
+    }
+
+    private void verifyPersistedCloudResource() {
+        ArgumentCaptor<CloudResource> cloudResourceCaptor = ArgumentCaptor.forClass(CloudResource.class);
+        verify(persistenceNotifier).notifyAllocation(cloudResourceCaptor.capture(), eq(cloudContext));
+        CloudResource cloudResourceCaptured = cloudResourceCaptor.getValue();
+        assertThat(cloudResourceCaptured.getName()).isEqualTo("dummyEnvName-DES-uniqueId");
+        assertThat(cloudResourceCaptured.getType()).isEqualTo(AZURE_DISK_ENCRYPTION_SET);
+        assertThat(cloudResourceCaptured.getReference()).isEqualTo(DES_RESOURCE_ID);
+        assertThat(cloudResourceCaptured.getStatus()).isEqualTo(CREATED);
     }
 
     private void initRetry() {
@@ -195,16 +276,70 @@ public class AzureEncryptionResourcesTest {
     }
 
     @Test
+    public void testCreateDiskEncryptionSetShouldReturnExistingDiskEncryptionSetWithPolling() {
+        DiskEncryptionSetCreationRequest requestedSet = new DiskEncryptionSetCreationRequest.Builder()
+                .withId("uniqueId")
+                .withCloudContext(cloudContext)
+                .withCloudCredential(cloudCredential)
+                .withSingleResourceGroup(true)
+                .withResourceGroupName("dummyResourceGroup")
+                .withTags(new HashMap<>())
+                .withEncryptionKeyUrl("https://dummyVaultName.vault.azure.net/keys/dummyKeyName/dummyKeyVersion")
+                .build();
+        DiskEncryptionSetInner desInitial = (DiskEncryptionSetInner) new DiskEncryptionSetInner()
+                .withEncryptionType(DiskEncryptionSetType.ENCRYPTION_AT_REST_WITH_CUSTOMER_KEY)
+                .withActiveKey(new KeyVaultAndKeyReference()
+                        .withKeyUrl("https://dummyVaultName.vault.azure.net/keys/dummyKeyName/dummyKeyVersion")
+                        .withSourceVault(new SourceVault()
+                                .withId("/subscriptions/dummySubs/resourceGroups/dummyResourceGroup/providers/Microsoft.KeyVault/vaults/dummyVaultName")))
+                .withIdentity(new EncryptionSetIdentity().withType(DiskEncryptionSetIdentityType.SYSTEM_ASSIGNED))
+                .withLocation("dummyRegion")
+                .withTags(new HashMap<>());
+        ReflectionTestUtils.setField(desInitial, "id", DES_RESOURCE_ID);
+        EncryptionSetIdentity identity = new EncryptionSetIdentity().withType(DiskEncryptionSetIdentityType.SYSTEM_ASSIGNED);
+        ReflectionTestUtils.setField(identity, "principalId", DES_PRINCIPAL_ID);
+        DiskEncryptionSetInner desAfterPolling = (DiskEncryptionSetInner) new DiskEncryptionSetInner()
+                .withEncryptionType(DiskEncryptionSetType.ENCRYPTION_AT_REST_WITH_CUSTOMER_KEY)
+                .withActiveKey(new KeyVaultAndKeyReference()
+                        .withKeyUrl("https://dummyVaultName.vault.azure.net/keys/dummyKeyName/dummyKeyVersion")
+                        .withSourceVault(new SourceVault()
+                                .withId("/subscriptions/dummySubs/resourceGroups/dummyResourceGroup/providers/Microsoft.KeyVault/vaults/dummyVaultName")))
+                .withIdentity(identity)
+                .withLocation("dummyRegion")
+                .withTags(new HashMap<>());
+        ReflectionTestUtils.setField(desAfterPolling, "id", DES_RESOURCE_ID);
+        Subscription subscription = mock(Subscription.class);
+        when(persistenceNotifier.notifyAllocation(any(CloudResource.class), eq(cloudContext))).thenReturn(new ResourcePersisted());
+        when(subscription.subscriptionId()).thenReturn("dummySubscriptionId");
+        when(azureUtils.generateDesNameByNameAndId(any(String.class), any(String.class))).thenReturn("dummyEnvName-DES-uniqueId");
+        when(azureClientService.createAuthenticatedContext(cloudContext, cloudCredential)).thenReturn(authenticatedContext);
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+        when(azureClient.getCurrentSubscription()).thenReturn(subscription);
+        when(azureClient.getDiskEncryptionSetByName(any(String.class), any(String.class))).thenReturn(desInitial);
+        initRetry();
+        // Return a different DES instance to simulate that the poller checker task initially indicated incomplete, hence the final DES was obtained by the
+        // scheduled execution of the poller
+        when(diskEncryptionSetCreationPoller.startPolling(eq(authenticatedContext), any(DiskEncryptionSetCreationCheckerContext.class), eq(desInitial)))
+                .thenReturn(desAfterPolling);
+
+        CreatedDiskEncryptionSet createdDes = underTest.createDiskEncryptionSet(requestedSet);
+
+        assertEquals(createdDes.getDiskEncryptionSetLocation(), "dummyRegion");
+        assertEquals(createdDes.getDiskEncryptionSetResourceGroupName(), "dummyResourceGroup");
+        assertThat(createdDes.getDiskEncryptionSetId()).isEqualTo(DES_RESOURCE_ID);
+        verify(azureClient, never()).createDiskEncryptionSet(any(String.class), any(String.class), any(String.class),
+                any(String.class), any(String.class), any(Map.class));
+        verify(azureClient).grantKeyVaultAccessPolicyToServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
+
+        verifyPersistedCloudResource();
+    }
+
+    @Test
     public void testCreateDiskEncryptionSetShouldReturnNewlyCreatedDiskEncryptionSetIfNotAlreadyExists() {
         DiskEncryptionSetCreationRequest requestedSet = new DiskEncryptionSetCreationRequest.Builder()
                 .withId("uniqueId")
-                .withCloudContext(CloudContext.Builder.builder()
-                        .withId(1L)
-                        .withName("envName").build())
-                .withCloudCredential(new CloudCredential())
-                .withRegion(Region.region("dummyRegion"))
-                .withEnvironmentName("dummyEnvName")
-                .withEnvironmentId(1L)
+                .withCloudContext(cloudContext)
+                .withCloudCredential(cloudCredential)
                 .withSingleResourceGroup(true)
                 .withResourceGroupName("dummyResourceGroup")
                 .withTags(new HashMap<>())
@@ -221,35 +356,37 @@ public class AzureEncryptionResourcesTest {
                 .withIdentity(identity)
                 .withLocation("dummyRegion")
                 .withTags(new HashMap<>());
+        ReflectionTestUtils.setField(des, "id", DES_RESOURCE_ID);
         Subscription subscription = mock(Subscription.class);
-        when(persistenceNotifier.notifyAllocation(any(CloudResource.class), any(CloudContext.class))).thenReturn(new ResourcePersisted());
+        when(persistenceNotifier.notifyAllocation(any(CloudResource.class), eq(cloudContext))).thenReturn(new ResourcePersisted());
         when(subscription.subscriptionId()).thenReturn("dummySubscriptionId");
         when(azureUtils.generateDesNameByNameAndId(any(String.class), any(String.class))).thenReturn("dummyEnvName-DES-uniqueId");
-        when(azureClientService.getClient(any(CloudCredential.class))).thenReturn(azureClient);
+        when(azureClientService.createAuthenticatedContext(cloudContext, cloudCredential)).thenReturn(authenticatedContext);
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
         when(azureClient.getCurrentSubscription()).thenReturn(subscription);
-        when(azureClient.getDiskEncryptionSet(any(String.class), any(String.class))).thenReturn(null);
+        when(azureClient.getDiskEncryptionSetByName(any(String.class), any(String.class))).thenReturn(null);
         when(azureClient.createDiskEncryptionSet(any(String.class), any(String.class), any(String.class),
                 any(String.class), any(String.class), any(Map.class))).thenReturn(des);
         initRetry();
+        // Return the same DES instance to simulate that the poller checker task instantly completed
+        when(diskEncryptionSetCreationPoller.startPolling(eq(authenticatedContext), any(DiskEncryptionSetCreationCheckerContext.class), eq(des)))
+                .thenReturn(des);
 
         CreatedDiskEncryptionSet createdDes = underTest.createDiskEncryptionSet(requestedSet);
 
         assertEquals(createdDes.getDiskEncryptionSetLocation(), "dummyRegion");
-        assertEquals(createdDes.getDiskEncryptionSetResourceGroup(), "dummyResourceGroup");
+        assertEquals(createdDes.getDiskEncryptionSetResourceGroupName(), "dummyResourceGroup");
         verify(azureClient).grantKeyVaultAccessPolicyToServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
+
+        verifyPersistedCloudResource();
     }
 
     @Test
     public void testCreateDiskEncryptionSetShouldReturnNewlyCreatedDiskEncryptionSetIfNotAlreadyExistsAndGrantKeyVaultAccessPolicyError() {
         DiskEncryptionSetCreationRequest requestedSet = new DiskEncryptionSetCreationRequest.Builder()
                 .withId("uniqueId")
-                .withCloudContext(CloudContext.Builder.builder()
-                        .withId(1L)
-                        .withName("envName").build())
-                .withCloudCredential(new CloudCredential())
-                .withRegion(Region.region("dummyRegion"))
-                .withEnvironmentName("dummyEnvName")
-                .withEnvironmentId(1L)
+                .withCloudContext(cloudContext)
+                .withCloudCredential(cloudCredential)
                 .withSingleResourceGroup(true)
                 .withResourceGroupName("dummyResourceGroup")
                 .withTags(new HashMap<>())
@@ -266,83 +403,117 @@ public class AzureEncryptionResourcesTest {
                 .withIdentity(identity)
                 .withLocation("dummyRegion")
                 .withTags(new HashMap<>());
+        ReflectionTestUtils.setField(des, "id", DES_RESOURCE_ID);
         Subscription subscription = mock(Subscription.class);
-        when(persistenceNotifier.notifyAllocation(any(CloudResource.class), any(CloudContext.class))).thenReturn(new ResourcePersisted());
+        when(persistenceNotifier.notifyAllocation(any(CloudResource.class), eq(cloudContext))).thenReturn(new ResourcePersisted());
         when(subscription.subscriptionId()).thenReturn("dummySubscriptionId");
         when(azureUtils.generateDesNameByNameAndId(any(String.class), any(String.class))).thenReturn("dummyEnvName-DES-uniqueId");
-        when(azureClientService.getClient(any(CloudCredential.class))).thenReturn(azureClient);
+        when(azureClientService.createAuthenticatedContext(cloudContext, cloudCredential)).thenReturn(authenticatedContext);
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
         when(azureClient.getCurrentSubscription()).thenReturn(subscription);
-        when(azureClient.getDiskEncryptionSet(any(String.class), any(String.class))).thenReturn(null);
+        when(azureClient.getDiskEncryptionSetByName(any(String.class), any(String.class))).thenReturn(null);
         when(azureClient.createDiskEncryptionSet(any(String.class), any(String.class), any(String.class),
                 any(String.class), any(String.class), any(Map.class))).thenReturn(des);
         initRetry();
-        Exception e = new RuntimeException("problem");
-        doThrow(e).when(azureClient).grantKeyVaultAccessPolicyToServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
+        // Return the same DES instance to simulate that the poller checker task instantly completed
+        when(diskEncryptionSetCreationPoller.startPolling(eq(authenticatedContext), any(DiskEncryptionSetCreationCheckerContext.class), eq(des)))
+                .thenReturn(des);
+        doThrow(new UnsupportedOperationException("Serious problem")).when(azureClient)
+                .grantKeyVaultAccessPolicyToServicePrincipal("dummyResourceGroup", "dummyVaultName", DES_PRINCIPAL_ID);
+        initExceptionConversion();
+        initActionFailedExceptionConversion();
 
-        Retry.ActionFailedException actionFailedException = assertThrows(Retry.ActionFailedException.class,
-                () -> underTest.createDiskEncryptionSet(requestedSet));
+        verifyActionFailedException(UnsupportedOperationException.class, () -> underTest.createDiskEncryptionSet(requestedSet), "Serious problem");
 
-        assertEquals("problem", actionFailedException.getMessage());
-        assertSame(e, actionFailedException.getCause());
+        verifyPersistedCloudResource();
+    }
+
+    private void verifyActionFailedException(Class<? extends Throwable> expectedType, Executable executable, String messageExpected) {
+        CloudConnectorException cloudConnectorExceptionOuter = assertThrows(CloudConnectorException.class, executable);
+
+        Retry.ActionFailedException actionFailedException = verifyAndGetCause(Retry.ActionFailedException.class, cloudConnectorExceptionOuter);
+        CloudConnectorException cloudConnectorExceptionInner = verifyAndGetCause(CloudConnectorException.class, actionFailedException);
+        assertThat(verifyAndGetCause(expectedType, cloudConnectorExceptionInner)).hasMessage(messageExpected);
+    }
+
+    @Test
+    void testDeleteDiskEncryptionSetShouldReturnSilentlyWhenThereIsNoCloudResource() {
+        List<CloudResource> resources = List.of();
+        DiskEncryptionSetDeletionRequest deletionRequest = new DiskEncryptionSetDeletionRequest.Builder()
+                .withCloudCredential(cloudCredential)
+                .withCloudContext(cloudContext)
+                .withCloudResources(resources)
+                .build();
+        initCloudResourceHelper(resources);
+
+        underTest.deleteDiskEncryptionSet(deletionRequest);
+
+        verify(azureClientService, never()).getClient(any(CloudCredential.class));
+    }
+
+    @Test
+    void testDeleteDiskEncryptionSetExceptionThrownWhenInvalidCredential() {
+        List<CloudResource> resources = getResources("dummyDesId");
+        DiskEncryptionSetDeletionRequest deletionRequest = new DiskEncryptionSetDeletionRequest.Builder()
+                .withCloudCredential(cloudCredential)
+                .withCloudContext(cloudContext)
+                .withCloudResources(resources)
+                .build();
+        initCloudResourceHelper(resources);
+        when(azureClientService.getClient(cloudCredential)).thenThrow(new UnsupportedOperationException("Serious problem"));
+        initExceptionConversion();
+
+        verifyException(UnsupportedOperationException.class, () -> underTest.deleteDiskEncryptionSet(deletionRequest), "Serious problem");
     }
 
     @Test
     public void testDeleteDiskEncryptionSetShouldThrowExceptionWhenDiskEncryptionSetNameIsNotFound() {
+        List<CloudResource> resources = getResources("dummyDesId");
         DiskEncryptionSetDeletionRequest deletionRequest = new DiskEncryptionSetDeletionRequest.Builder()
-                .withCloudCredential(new CloudCredential())
-                .withCloudContext(CloudContext.Builder.builder()
-                        .withId(1L)
-                        .withName("envName")
-                        .withCrn("crn:cdp:environments:us-west-1:dummyUser:environment:randomGeneratedResource")
-                        .withPlatform("AZURE")
-                        .withVariant("AZURE")
-                        .withLocation(location(Region.region("dummyRegion")))
-                        .withUserName("dummyUser")
-                        .withAccountId("dummyAccountId")
-                        .build())
-                .withCloudResources(getResource("dummyDesId"))
+                .withCloudCredential(cloudCredential)
+                .withCloudContext(cloudContext)
+                .withCloudResources(resources)
                 .build();
+        initCloudResourceHelper(resources);
+        when(azureClientService.getClient(cloudCredential)).thenReturn(azureClient);
+        initExceptionConversion();
 
-        assertThrows(IllegalArgumentException.class, () -> underTest.deleteDiskEncryptionSet(deletionRequest));
+        verifyException(IllegalArgumentException.class, () -> underTest.deleteDiskEncryptionSet(deletionRequest),
+                "Failed to deduce Disk Encryption Set name from given resource id \"dummyDesId\"");
+    }
+
+    private void initCloudResourceHelper(List<CloudResource> resources) {
+        when(cloudResourceHelper.getResourceTypeFromList(AZURE_DISK_ENCRYPTION_SET, resources))
+                .thenReturn(resources.isEmpty() ? Optional.empty() : Optional.of(resources.iterator().next()));
     }
 
     @Test
     public void testDeleteDiskEncryptionSetShouldThrowExceptionWhenResourceGroupIsNotFound() {
+        List<CloudResource> resources = getResources("/subscriptions/dummySubscriptionId/resourceGroups/wrongValuesFramed/diskEncryptionSets/dummyDesName");
         DiskEncryptionSetDeletionRequest deletionRequest = new DiskEncryptionSetDeletionRequest.Builder()
-                .withCloudCredential(new CloudCredential())
-                .withCloudContext(CloudContext.Builder.builder()
-                        .withId(1L)
-                        .withName("envName")
-                        .withCrn("crn:cdp:environments:us-west-1:dummyUser:environment:randomGeneratedResource")
-                        .withPlatform("AZURE")
-                        .withVariant("AZURE")
-                        .withLocation(location(Region.region("dummyRegion")))
-                        .withUserName("dummyUser")
-                        .withAccountId("dummyAccountId")
-                        .build())
-                .withCloudResources(getResource("/subscriptions/dummySubscriptionId/resourceGroups/wrongValuesFramed/diskEncryptionSets/dummyDesName"))
+                .withCloudCredential(cloudCredential)
+                .withCloudContext(cloudContext)
+                .withCloudResources(resources)
                 .build();
+        initCloudResourceHelper(resources);
+        when(azureClientService.getClient(cloudCredential)).thenReturn(azureClient);
+        initExceptionConversion();
 
-        assertThrows(IllegalArgumentException.class, () -> underTest.deleteDiskEncryptionSet(deletionRequest));
+        verifyException(IllegalArgumentException.class, () -> underTest.deleteDiskEncryptionSet(deletionRequest),
+                "Failed to deduce Disk Encryption Set's resource group name from given resource id " +
+                        "\"/subscriptions/dummySubscriptionId/resourceGroups/wrongValuesFramed/diskEncryptionSets/dummyDesName\"");
     }
 
     @Test
     public void testDeleteDiskEncryptionSetShouldDeduceValidResourceGroupAndDiskEncryptionSetName() {
+        List<CloudResource> resources = getResources("/subscriptions/dummySubscriptionId/resourceGroups/dummyResourceGroup/providers/" +
+                "Microsoft.Compute/diskEncryptionSets/dummyDesId");
         DiskEncryptionSetDeletionRequest deletionRequest = new DiskEncryptionSetDeletionRequest.Builder()
-                .withCloudCredential(new CloudCredential())
-                .withCloudContext(CloudContext.Builder.builder()
-                        .withId(1L)
-                        .withName("envName")
-                        .withCrn("crn:cdp:environments:us-west-1:dummyUser:environment:randomGeneratedResource")
-                        .withPlatform("AZURE")
-                        .withVariant("AZURE")
-                        .withLocation(location(Region.region("dummyRegion")))
-                        .withUserName("dummyUser")
-                        .withAccountId("dummyAccountId")
-                        .build())
-                .withCloudResources(getResource("/subscriptions/dummySubscriptionId/resourceGroups/dummyResourceGroup/providers/" +
-                        "Microsoft.Compute/diskEncryptionSets/dummyDesId"))
+                .withCloudCredential(cloudCredential)
+                .withCloudContext(cloudContext)
+                .withCloudResources(resources)
                 .build();
+        initCloudResourceHelper(resources);
         DiskEncryptionSetInner des = (DiskEncryptionSetInner) new DiskEncryptionSetInner()
                 .withEncryptionType(DiskEncryptionSetType.ENCRYPTION_AT_REST_WITH_CUSTOMER_KEY)
                 .withActiveKey(new KeyVaultAndKeyReference()
@@ -351,47 +522,64 @@ public class AzureEncryptionResourcesTest {
                                 .withId("/subscriptions/dummySubs/resourceGroups/dummyResourceGroup/providers/Microsoft.KeyVault/vaults/dummyVaultName")))
                 .withIdentity(new EncryptionSetIdentity().withType(DiskEncryptionSetIdentityType.SYSTEM_ASSIGNED))
                 .withLocation("dummyRegion");
-        when(azureClient.getDiskEncryptionSet(any(), any())).thenReturn(des);
-        when(azureClientService.getClient(any())).thenReturn(azureClient);
+        when(azureClient.getDiskEncryptionSetByName(any(), any())).thenReturn(des);
+        when(azureClientService.getClient(cloudCredential)).thenReturn(azureClient);
+        initRetry();
 
         underTest.deleteDiskEncryptionSet(deletionRequest);
 
         verify(azureClient).deleteDiskEncryptionSet("dummyResourceGroup", "dummyDesId");
-        verify(persistenceNotifier).notifyDeletion(deletionRequest.getCloudResources().stream().findFirst().get(), deletionRequest.getCloudContext());
+        verify(persistenceNotifier).notifyDeletion(deletionRequest.getCloudResources().iterator().next(), deletionRequest.getCloudContext());
     }
 
     @Test
     public void testDeleteDiskEncryptionSetShouldNotMakeCloudCallWhenDiskEncryptionSetIsNotFound() {
+        List<CloudResource> resources = getResources("/subscriptions/dummySubscriptionId/resourceGroups/dummyResourceGroup/providers/" +
+                "Microsoft.Compute/diskEncryptionSets/dummyDesId");
         DiskEncryptionSetDeletionRequest deletionRequest = new DiskEncryptionSetDeletionRequest.Builder()
-                .withCloudCredential(new CloudCredential())
-                .withCloudContext(CloudContext.Builder.builder()
-                        .withId(1L)
-                        .withName("envName")
-                        .withCrn("crn:cdp:environments:us-west-1:dummyUser:environment:randomGeneratedResource")
-                        .withPlatform("AZURE")
-                        .withVariant("AZURE")
-                        .withLocation(location(Region.region("dummyRegion")))
-                        .withUserName("dummyUser")
-                        .withAccountId("dummyAccountId")
-                        .build())
-                .withCloudResources(getResource("/subscriptions/dummySubscriptionId/resourceGroups/dummyResourceGroup/providers/" +
-                        "Microsoft.Compute/diskEncryptionSets/dummyDesId"))
+                .withCloudCredential(cloudCredential)
+                .withCloudContext(cloudContext)
+                .withCloudResources(resources)
                 .build();
-        when(azureClient.getDiskEncryptionSet(any(), any())).thenReturn(null);
-        when(azureClientService.getClient(any())).thenReturn(azureClient);
+        initCloudResourceHelper(resources);
+        when(azureClient.getDiskEncryptionSetByName(any(), any())).thenReturn(null);
+        when(azureClientService.getClient(cloudCredential)).thenReturn(azureClient);
+        initRetry();
 
         underTest.deleteDiskEncryptionSet(deletionRequest);
 
         verify(azureClient, never()).deleteDiskEncryptionSet("dummyResourceGroup", "dummyDesId");
-        verify(persistenceNotifier).notifyDeletion(deletionRequest.getCloudResources().stream().findFirst().get(), deletionRequest.getCloudContext());
+        verify(persistenceNotifier).notifyDeletion(deletionRequest.getCloudResources().iterator().next(), deletionRequest.getCloudContext());
     }
 
-    private List<CloudResource> getResource(String desId) {
+    @Test
+    void testDeleteDiskEncryptionSetWhenExceptionDuringDiskEncryptionSetExistenceCheck() {
+        List<CloudResource> resources = getResources("/subscriptions/dummySubscriptionId/resourceGroups/dummyResourceGroup/providers/" +
+                "Microsoft.Compute/diskEncryptionSets/dummyDesId");
+        DiskEncryptionSetDeletionRequest deletionRequest = new DiskEncryptionSetDeletionRequest.Builder()
+                .withCloudCredential(cloudCredential)
+                .withCloudContext(cloudContext)
+                .withCloudResources(resources)
+                .build();
+        initCloudResourceHelper(resources);
+        when(azureClient.getDiskEncryptionSetByName(any(), any())).thenThrow(new UnsupportedOperationException("Serious problem"));
+        when(azureClientService.getClient(cloudCredential)).thenReturn(azureClient);
+        initRetry();
+        initExceptionConversion();
+        initActionFailedExceptionConversion();
+
+        verifyActionFailedException(UnsupportedOperationException.class, () -> underTest.deleteDiskEncryptionSet(deletionRequest), "Serious problem");
+
+        verify(azureClient, never()).deleteDiskEncryptionSet("dummyResourceGroup", "dummyDesId");
+        verify(persistenceNotifier, never()).notifyDeletion(deletionRequest.getCloudResources().iterator().next(), deletionRequest.getCloudContext());
+    }
+
+    private List<CloudResource> getResources(String desId) {
         CloudResource desCloudResource = new CloudResource.Builder()
                 .name("Des")
-                .type(ResourceType.AZURE_DISK_ENCRYPTION_SET)
+                .type(AZURE_DISK_ENCRYPTION_SET)
                 .reference(desId)
-                .status(CommonStatus.CREATED)
+                .status(CREATED)
                 .build();
         return List.of(desCloudResource);
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkConnectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureNetworkConnectorTest.java
@@ -255,7 +255,7 @@ public class AzureNetworkConnectorTest {
 
         when(azureClient.getResourceGroup(networkDeletionRequest.getResourceGroup())).thenReturn(mock(ResourceGroup.class));
         when(azureClientService.getClient(networkDeletionRequest.getCloudCredential())).thenReturn(azureClient);
-        when(azureUtils.convertToCloudConnectorException(any(), anyString())).thenReturn(new CloudConnectorException(""));
+        when(azureUtils.convertToCloudConnectorException(any(CloudException.class), anyString())).thenReturn(new CloudConnectorException(""));
         doThrow(createCloudException()).when(azureClient).deleteTemplateDeployment(RESOURCE_GROUP, STACK);
 
         underTest.deleteNetworkWithSubnets(networkDeletionRequest);

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClientServiceTest.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.cloudbreak.cloud.azure.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.microsoft.rest.LogLevel;
+import com.sequenceiq.cloudbreak.cloud.azure.tracing.AzureOkHttp3TracingInterceptor;
+import com.sequenceiq.cloudbreak.cloud.azure.util.AzureAuthExceptionHandler;
+import com.sequenceiq.cloudbreak.cloud.azure.view.AzureCredentialView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+
+@ExtendWith(MockitoExtension.class)
+class AzureClientServiceTest {
+
+    @Mock
+    private CBRefreshTokenClientProvider cbRefreshTokenClientProvider;
+
+    @Mock
+    private AuthenticationContextProvider authenticationContextProvider;
+
+    @Mock
+    private AzureOkHttp3TracingInterceptor tracingInterceptor;
+
+    @Mock
+    private AzureAuthExceptionHandler azureAuthExceptionHandler;
+
+    @InjectMocks
+    private AzureClientService underTest;
+
+    @Mock
+    private CloudContext cloudContext;
+
+    @Mock
+    private CloudCredential cloudCredential;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(underTest, "logLevel", LogLevel.BASIC);
+    }
+
+    @Test
+    void createAuthenticatedContextTest() {
+        AuthenticatedContext authenticatedContext = underTest.createAuthenticatedContext(cloudContext, cloudCredential);
+
+        assertThat(authenticatedContext).isNotNull();
+        assertThat(authenticatedContext.getCloudContext()).isSameAs(cloudContext);
+        assertThat(authenticatedContext.getCloudCredential()).isSameAs(cloudCredential);
+        verifyAzureClient(authenticatedContext.getParameter(AzureClient.class));
+    }
+
+    @Test
+    void getClientTest() {
+        AzureClient azureClient = underTest.getClient(cloudCredential);
+
+        verifyAzureClient(azureClient);
+    }
+
+    private void verifyAzureClient(AzureClient azureClient) {
+        assertThat(azureClient).isNotNull();
+
+        AzureClientCredentials azureClientCredentials = (AzureClientCredentials) ReflectionTestUtils.getField(azureClient, "azureClientCredentials");
+        assertThat(azureClientCredentials).isNotNull();
+
+        AzureCredentialView azureCredentialView = (AzureCredentialView) ReflectionTestUtils.getField(azureClientCredentials, "credentialView");
+        assertThat(azureCredentialView).isNotNull();
+
+        assertThat((CloudCredential) ReflectionTestUtils.getField(azureCredentialView, "cloudCredential")).isSameAs(cloudCredential);
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/AzurePollTaskFactoryIntegrationTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/AzurePollTaskFactoryIntegrationTest.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.microsoft.azure.management.compute.implementation.DiskEncryptionSetInner;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncryptionSetCreationCheckerContext;
+import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncryptionSetCreationCheckerTask;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.task.PollTask;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = AzurePollTaskFactoryIntegrationTest.TestAppContext.class)
+class AzurePollTaskFactoryIntegrationTest {
+
+    private static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+
+    private static final String DISK_ENCRYPTION_SET_NAME = "diskEncryptionSetName";
+
+    @Inject
+    private AzurePollTaskFactory underTest;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private AzureClient azureClient;
+
+    @Test
+    void diskEncryptionSetCreationCheckerTaskTest() {
+        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+        DiskEncryptionSetCreationCheckerContext checkerContext = new DiskEncryptionSetCreationCheckerContext(RESOURCE_GROUP_NAME, DISK_ENCRYPTION_SET_NAME);
+
+        PollTask<DiskEncryptionSetInner> result = underTest.diskEncryptionSetCreationCheckerTask(authenticatedContext, checkerContext);
+
+        assertThat(result).isInstanceOf(DiskEncryptionSetCreationCheckerTask.class);
+
+        DiskEncryptionSetCreationCheckerTask checkerTask = (DiskEncryptionSetCreationCheckerTask) result;
+        assertThat(checkerTask.getAuthenticatedContext()).isSameAs(authenticatedContext);
+    }
+
+    @Configuration
+    @EnableConfigurationProperties
+    @Import({
+            AzurePollTaskFactory.class,
+            DiskEncryptionSetCreationCheckerTask.class
+    })
+    static class TestAppContext {
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/AzurePollTaskFactoryTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/AzurePollTaskFactoryTest.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+
+import com.microsoft.azure.management.compute.implementation.DiskEncryptionSetInner;
+import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncryptionSetCreationCheckerContext;
+import com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset.DiskEncryptionSetCreationCheckerTask;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.task.PollTask;
+
+@ExtendWith(MockitoExtension.class)
+class AzurePollTaskFactoryTest {
+
+    private static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+
+    private static final String DISK_ENCRYPTION_SET_NAME = "diskEncryptionSetName";
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @InjectMocks
+    private AzurePollTaskFactory underTest;
+
+    @Test
+    void diskEncryptionSetCreationCheckerTaskTest() {
+        DiskEncryptionSetCreationCheckerContext checkerContext = new DiskEncryptionSetCreationCheckerContext(RESOURCE_GROUP_NAME, DISK_ENCRYPTION_SET_NAME);
+        PollTask<DiskEncryptionSetInner> checkerTask = mock(PollTask.class);
+        when(applicationContext.getBean(DiskEncryptionSetCreationCheckerTask.NAME, authenticatedContext, checkerContext)).thenReturn(checkerTask);
+
+        PollTask<DiskEncryptionSetInner> result = underTest.diskEncryptionSetCreationCheckerTask(authenticatedContext, checkerContext);
+
+        assertThat(result).isSameAs(checkerTask);
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/diskencryptionset/DiskEncryptionSetCreationCheckerTaskTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/diskencryptionset/DiskEncryptionSetCreationCheckerTaskTest.java
@@ -1,0 +1,126 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.microsoft.azure.management.compute.EncryptionSetIdentity;
+import com.microsoft.azure.management.compute.implementation.DiskEncryptionSetInner;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+
+@ExtendWith(MockitoExtension.class)
+class DiskEncryptionSetCreationCheckerTaskTest {
+
+    private static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+
+    private static final String DISK_ENCRYPTION_SET_NAME = "diskEncryptionSetName";
+
+    private static final String ID = "id";
+
+    private static final String PRINCIPAL_OBJECT_ID = "principalObjectId";
+
+    @Mock
+    private AzureClient azureClient;
+
+    private DiskEncryptionSetCreationCheckerTask underTest;
+
+    private AuthenticatedContext authenticatedContext;
+
+    @BeforeEach
+    void setUp() {
+        authenticatedContext = createAuthenticatedContext(azureClient);
+        underTest = new DiskEncryptionSetCreationCheckerTask(authenticatedContext, createCheckerContext());
+    }
+
+    private static DiskEncryptionSetCreationCheckerContext createCheckerContext() {
+        return new DiskEncryptionSetCreationCheckerContext(RESOURCE_GROUP_NAME, DISK_ENCRYPTION_SET_NAME);
+    }
+
+    private static AuthenticatedContext createAuthenticatedContext(AzureClient azureClient) {
+        AuthenticatedContext context = mock(AuthenticatedContext.class);
+        when(context.getParameter(AzureClient.class)).thenReturn(azureClient);
+        return context;
+    }
+
+    static Object[][] constructorTestWhenNpeDataProvider() {
+        return new Object[][]{
+                // testCaseName authenticatedContext, DiskEncryptionSetCreationCheckerContext checkerContext
+                {"null, null", null, null},
+                {"null, checkerContext", null, createCheckerContext()},
+                {"authenticatedContext(null), checkerContext", createAuthenticatedContext(null), createCheckerContext()},
+                {"authenticatedContext(azureClient), null", createAuthenticatedContext(mock(AzureClient.class)), null},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("constructorTestWhenNpeDataProvider")
+    void constructorTestWhenNpe(String testCaseName, AuthenticatedContext authenticatedContext, DiskEncryptionSetCreationCheckerContext checkerContext) {
+        assertThrows(NullPointerException.class, () -> new DiskEncryptionSetCreationCheckerTask(authenticatedContext, checkerContext));
+    }
+
+    @Test
+    void constructorTestWhenSuccess() {
+        assertThat(underTest.getAuthenticatedContext()).isSameAs(authenticatedContext);
+    }
+
+    private static DiskEncryptionSetInner createDes(String id, boolean withIdentity, String principalObjectId) {
+        DiskEncryptionSetInner des = mock(DiskEncryptionSetInner.class);
+        when(des.id()).thenReturn(id);
+        if (withIdentity) {
+            EncryptionSetIdentity identity = mock(EncryptionSetIdentity.class);
+            when(des.identity()).thenReturn(identity);
+            when(identity.principalId()).thenReturn(principalObjectId);
+        }
+        return des;
+    }
+
+    static Object[][] completedDataProvider() {
+        return new Object[][]{
+                // testCaseName des completedExpected
+                {"null", null, false},
+                {"DES(null, false, null)", createDes(null, false, null), false},
+                {"DES(ID, false, null)", createDes(ID, false, null), false},
+                {"DES(null, true, null)", createDes(null, true, null), false},
+                {"DES(ID, true, null)", createDes(ID, true, null), false},
+                {"DES(null, true, PRINCIPAL_OBJECT_ID)", createDes(null, true, PRINCIPAL_OBJECT_ID), false},
+                {"DES(ID, true, PRINCIPAL_OBJECT_ID)", createDes(ID, true, PRINCIPAL_OBJECT_ID), true},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("completedDataProvider")
+    void completedTest(String testCaseName, DiskEncryptionSetInner des, boolean completedExpected) {
+        assertThat(underTest.completed(des)).isEqualTo(completedExpected);
+    }
+
+    @Test
+    void doCallTestWhenException() {
+        RuntimeException e = new RuntimeException();
+        when(azureClient.getDiskEncryptionSetByName(RESOURCE_GROUP_NAME, DISK_ENCRYPTION_SET_NAME)).thenThrow(e);
+
+        RuntimeException runtimeException = assertThrows(RuntimeException.class, () -> underTest.doCall());
+
+        assertThat(runtimeException).isSameAs(e);
+    }
+
+    @Test
+    void doCallTestWhenSuccess() {
+        DiskEncryptionSetInner des = mock(DiskEncryptionSetInner.class);
+        when(azureClient.getDiskEncryptionSetByName(RESOURCE_GROUP_NAME, DISK_ENCRYPTION_SET_NAME)).thenReturn(des);
+
+        DiskEncryptionSetInner result = underTest.doCall();
+
+        assertThat(result).isSameAs(des);
+    }
+
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/diskencryptionset/DiskEncryptionSetCreationPollerTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/task/diskencryptionset/DiskEncryptionSetCreationPollerTest.java
@@ -1,0 +1,132 @@
+package com.sequenceiq.cloudbreak.cloud.azure.task.diskencryptionset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.microsoft.azure.management.compute.implementation.DiskEncryptionSetInner;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
+import com.sequenceiq.cloudbreak.cloud.azure.task.AzurePollTaskFactory;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
+import com.sequenceiq.cloudbreak.cloud.task.PollTask;
+
+@ExtendWith(MockitoExtension.class)
+class DiskEncryptionSetCreationPollerTest {
+
+    private static final int CREATION_CHECK_INTERVAL = 12;
+
+    private static final int CREATION_CHECK_MAX_ATTEMPT = 34;
+
+    private static final int MAX_TOLERABLE_FAILURE_NUMBER = 56;
+
+    private static final String RESOURCE_GROUP_NAME = "resourceGroupName";
+
+    private static final String DISK_ENCRYPTION_SET_NAME = "diskEncryptionSetName";
+
+    @Mock
+    private AzurePollTaskFactory azurePollTaskFactory;
+
+    @Mock
+    private PollTask<DiskEncryptionSetInner> checkerTask;
+
+    @Mock
+    private SyncPollingScheduler<DiskEncryptionSetInner> syncPollingScheduler;
+
+    @Mock
+    private AzureUtils azureUtils;
+
+    @InjectMocks
+    private DiskEncryptionSetCreationPoller underTest;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private DiskEncryptionSetInner des;
+
+    private DiskEncryptionSetCreationCheckerContext checkerContext;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(underTest, "creationCheckInterval", CREATION_CHECK_INTERVAL);
+        ReflectionTestUtils.setField(underTest, "creationCheckMaxAttempt", CREATION_CHECK_MAX_ATTEMPT);
+        ReflectionTestUtils.setField(underTest, "maxTolerableFailureNumber", MAX_TOLERABLE_FAILURE_NUMBER);
+
+        checkerContext = new DiskEncryptionSetCreationCheckerContext(RESOURCE_GROUP_NAME, DISK_ENCRYPTION_SET_NAME);
+    }
+
+    @Test
+    void startPollingTestWhenGeneralException() {
+        RuntimeException e = new RuntimeException();
+        CloudConnectorException eWrapped = new CloudConnectorException(e);
+        when(azureUtils.convertToCloudConnectorException(e, "Disk Encryption Set creation")).thenReturn(eWrapped);
+
+        when(azurePollTaskFactory.diskEncryptionSetCreationCheckerTask(authenticatedContext, checkerContext)).thenThrow(e);
+
+        CloudConnectorException cloudConnectorException = assertThrows(CloudConnectorException.class,
+                () -> underTest.startPolling(authenticatedContext, checkerContext, null));
+
+        assertThat(cloudConnectorException).hasCauseReference(e);
+    }
+
+    @Test
+    void startPollingTestWhenNullCheckerContext() {
+        startPollingTestWhenNpeInternal(authenticatedContext, null);
+    }
+
+    private void startPollingTestWhenNpeInternal(AuthenticatedContext authenticatedContext1, DiskEncryptionSetCreationCheckerContext checkerContext) {
+        when(azureUtils.convertToCloudConnectorException(any(Exception.class), eq("Disk Encryption Set creation")))
+                .thenAnswer(invocation -> new CloudConnectorException(invocation.getArgument(0, Exception.class)));
+
+        CloudConnectorException cloudConnectorException = assertThrows(CloudConnectorException.class,
+                () -> underTest.startPolling(authenticatedContext1, checkerContext, null));
+
+        assertThat(cloudConnectorException).hasCauseInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void startPollingTestWhenNullAuthenticatedContext() {
+        startPollingTestWhenNpeInternal(null, checkerContext);
+    }
+
+    @Test
+    void startPollingTestWhenAlreadyCompleted() throws Exception {
+        when(azurePollTaskFactory.diskEncryptionSetCreationCheckerTask(authenticatedContext, checkerContext)).thenReturn(checkerTask);
+        when(checkerTask.completed(des)).thenReturn(true);
+
+        DiskEncryptionSetInner result = underTest.startPolling(authenticatedContext, checkerContext, des);
+
+        assertThat(result).isSameAs(des);
+        verify(syncPollingScheduler, never()).schedule(checkerTask, CREATION_CHECK_INTERVAL, CREATION_CHECK_MAX_ATTEMPT, MAX_TOLERABLE_FAILURE_NUMBER);
+    }
+
+    @Test
+    void startPollingTestWhenScheduling() throws Exception {
+        when(azurePollTaskFactory.diskEncryptionSetCreationCheckerTask(authenticatedContext, checkerContext)).thenReturn(checkerTask);
+        when(checkerTask.completed(des)).thenReturn(false);
+
+        DiskEncryptionSetInner desScheduled = mock(DiskEncryptionSetInner.class);
+        when(syncPollingScheduler.schedule(checkerTask, CREATION_CHECK_INTERVAL, CREATION_CHECK_MAX_ATTEMPT, MAX_TOLERABLE_FAILURE_NUMBER))
+                .thenReturn(desScheduled);
+
+        DiskEncryptionSetInner result = underTest.startPolling(authenticatedContext, checkerContext, des);
+
+        assertThat(result).isSameAs(desScheduled);
+    }
+
+}

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/exception/CloudExceptionConverter.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/exception/CloudExceptionConverter.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.cloud.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.service.Retry;
+
+@Component
+public class CloudExceptionConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CloudExceptionConverter.class);
+
+    public CloudConnectorException convertToCloudConnectorException(Throwable e, String actionDescription) {
+        LOGGER.warn(String.format("%s failed, %s happened:", actionDescription, e != null ? e.getClass().getName() : null), e);
+        Throwable eEffective = unwrapActionFailedException(e);
+        CloudConnectorException result;
+        if (eEffective instanceof CloudConnectorException) {
+            result = (CloudConnectorException) eEffective;
+        } else {
+            result = new CloudConnectorException(String.format("%s failed: %s", actionDescription, eEffective != null ? eEffective.getMessage() : null),
+                    eEffective);
+        }
+        return result;
+    }
+
+    private Throwable unwrapActionFailedException(Throwable e) {
+        return e instanceof Retry.ActionFailedException && e.getCause() != null ? e.getCause() : e;
+    }
+
+}

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollPredicateStateTask.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollPredicateStateTask.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.cloud.task;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Predicate;
+
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+
+public abstract class PollPredicateStateTask<T> extends AbstractPollTask<T> {
+
+    private final Predicate<? super T> predicate;
+
+    protected PollPredicateStateTask(AuthenticatedContext authenticatedContext, boolean cancellable, Predicate<? super T> predicate) {
+        super(requireNonNull(authenticatedContext), cancellable);
+        this.predicate = requireNonNull(predicate);
+    }
+
+    @Override
+    public boolean completed(T t) {
+        return predicate.test(t);
+    }
+
+}

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/transform/CloudResourceHelper.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/transform/CloudResourceHelper.java
@@ -25,4 +25,5 @@ public class CloudResourceHelper {
                 .filter(resource -> resource.getType() == type)
                 .findFirst();
     }
+
 }

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/exception/CloudExceptionConverterTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/exception/CloudExceptionConverterTest.java
@@ -1,0 +1,79 @@
+package com.sequenceiq.cloudbreak.cloud.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.service.Retry;
+
+class CloudExceptionConverterTest {
+
+    private CloudExceptionConverter underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new CloudExceptionConverter();
+    }
+
+    @Test
+    void convertToCloudConnectorExceptionTestWhenNull() {
+        CloudConnectorException result = underTest.convertToCloudConnectorException(null, "Checking resources");
+
+        verifyCloudConnectorException(result, null, "Checking resources failed: null");
+    }
+
+    @Test
+    void convertToCloudConnectorExceptionTestWhenActionFailedExceptionWithNoCause() {
+        Throwable e = new Retry.ActionFailedException("Serious problem");
+
+        CloudConnectorException result = underTest.convertToCloudConnectorException(e, "Checking resources");
+
+        verifyCloudConnectorException(result, e, "Checking resources failed: Serious problem");
+    }
+
+    private void verifyCloudConnectorException(CloudConnectorException cloudConnectorException, Throwable causeExpected, String messageExpected) {
+        assertThat(cloudConnectorException).isNotNull();
+        assertThat(cloudConnectorException).hasMessage(messageExpected);
+        assertThat(cloudConnectorException).hasCauseReference(causeExpected);
+    }
+
+    @Test
+    void convertToCloudConnectorExceptionTestWhenActionFailedExceptionWithCauseGeneralThrowable() {
+        Throwable cause = new UnsupportedOperationException("Serious problem #2");
+        Throwable e = new Retry.ActionFailedException("Serious problem #1", cause);
+
+        CloudConnectorException result = underTest.convertToCloudConnectorException(e, "Checking resources");
+
+        verifyCloudConnectorException(result, cause, "Checking resources failed: Serious problem #2");
+    }
+
+    @Test
+    void convertToCloudConnectorExceptionTestWhenActionFailedExceptionWithCauseActionFailedException() {
+        Throwable cause = new Retry.ActionFailedException("Serious problem #2");
+        Throwable e = new Retry.ActionFailedException("Serious problem #1", cause);
+
+        CloudConnectorException result = underTest.convertToCloudConnectorException(e, "Checking resources");
+
+        verifyCloudConnectorException(result, cause, "Checking resources failed: Serious problem #2");
+    }
+
+    @Test
+    void convertToCloudConnectorExceptionTestWhenGeneralThrowable() {
+        Throwable e = new UnsupportedOperationException("Serious problem");
+
+        CloudConnectorException result = underTest.convertToCloudConnectorException(e, "Checking resources");
+
+        verifyCloudConnectorException(result, e, "Checking resources failed: Serious problem");
+    }
+
+    @Test
+    void convertToCloudConnectorExceptionTestWhenCloudConnectorException() {
+        Throwable e = new CloudConnectorException("Serious problem");
+
+        CloudConnectorException result = underTest.convertToCloudConnectorException(e, "Checking resources");
+
+        assertThat(result).isSameAs(e);
+    }
+
+}

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/task/PollPredicateStateTaskTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/task/PollPredicateStateTaskTest.java
@@ -1,0 +1,99 @@
+package com.sequenceiq.cloudbreak.cloud.task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+
+@ExtendWith(MockitoExtension.class)
+class PollPredicateStateTaskTest {
+
+    private static final int RESULT = 12;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    private PollPredicateStateTask<Integer> underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new DummyPollPredicateStateTask(authenticatedContext, false, Objects::nonNull);
+    }
+
+    static Object[][] constructorTestWhenNpeDataProvider() {
+        return new Object[][]{
+                // testCaseName authenticatedContext predicate
+                {"null, null", null, null},
+                {"null, predicate", null, (Predicate<? super Integer>) Objects::nonNull},
+                {"authenticatedContext, null", mock(AuthenticatedContext.class), null},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("constructorTestWhenNpeDataProvider")
+    void constructorTestWhenNpe(String testCaseName, AuthenticatedContext authenticatedContext, Predicate<? super Integer> predicate) {
+        assertThrows(NullPointerException.class, () -> new DummyPollPredicateStateTask(authenticatedContext, false, predicate));
+    }
+
+    @Test
+    void constructorTestWhenSuccess() {
+        assertThat(underTest.getAuthenticatedContext()).isSameAs(authenticatedContext);
+    }
+
+    static Object[][] completedTestWhenSuccessDataProvider() {
+        return new Object[][]{
+                // testCaseName i resultExpected
+                {"null, false", null, false},
+                {"34, true", 34, true},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("completedTestWhenSuccessDataProvider")
+    void completedTestWhenSuccess(String testCaseName, Integer i, boolean resultExpected) {
+        assertThat(underTest.completed(i)).isEqualTo(resultExpected);
+    }
+
+    @Test
+    void completedTestWhenException() {
+        PollPredicateStateTask<Integer> underTest = new DummyPollPredicateStateTask(authenticatedContext, false,
+                i -> {
+                    throw new UnsupportedOperationException("Serious problem");
+                });
+
+        UnsupportedOperationException result = assertThrows(UnsupportedOperationException.class, () -> underTest.completed(null));
+
+        assertThat(result).hasMessage("Serious problem");
+    }
+
+    @Test
+    void doCallTest() {
+        assertThat(underTest.doCall()).isEqualTo(RESULT);
+    }
+
+    private static class DummyPollPredicateStateTask extends PollPredicateStateTask<Integer> {
+
+        private DummyPollPredicateStateTask(AuthenticatedContext authenticatedContext, boolean cancellable, Predicate<? super Integer> predicate) {
+            super(authenticatedContext, cancellable, predicate);
+        }
+
+        @Override
+        protected Integer doCall() {
+            return RESULT;
+        }
+
+    }
+
+}

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/transform/CloudResourceHelperTest.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/transform/CloudResourceHelperTest.java
@@ -1,0 +1,64 @@
+package com.sequenceiq.cloudbreak.cloud.transform;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.ResourceType;
+
+class CloudResourceHelperTest {
+
+    private static final CloudResource CLOUD_RESOURCE_AWS_INSTANCE = createCloudResourceByType(ResourceType.AWS_INSTANCE);
+
+    private static final CloudResource CLOUD_RESOURCE_AWS_INSTANCE_2 = createCloudResourceByType(ResourceType.AWS_INSTANCE);
+
+    private static final CloudResource CLOUD_RESOURCE_AWS_VPC = createCloudResourceByType(ResourceType.AWS_VPC);
+
+    private CloudResourceHelper underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new CloudResourceHelper();
+    }
+
+    private static CloudResource createCloudResourceByType(ResourceType resourceType) {
+        return CloudResource.builder()
+                .type(resourceType)
+                .status(CommonStatus.CREATED)
+                .name("name")
+                .build();
+    }
+
+    static Object[][] getResourceTypeFromListDataProvider() {
+        return new Object[][]{
+                // testCaseName type resources resultExpected
+                {"AWS_INSTANCE, []", ResourceType.AWS_INSTANCE, List.of(), null},
+                {"AWS_INSTANCE, [CLOUD_RESOURCE_AWS_INSTANCE]", ResourceType.AWS_INSTANCE, List.of(CLOUD_RESOURCE_AWS_INSTANCE), CLOUD_RESOURCE_AWS_INSTANCE},
+                {"AWS_INSTANCE, [CLOUD_RESOURCE_AWS_INSTANCE, CLOUD_RESOURCE_AWS_VPC]", ResourceType.AWS_INSTANCE,
+                        List.of(CLOUD_RESOURCE_AWS_INSTANCE, CLOUD_RESOURCE_AWS_VPC), CLOUD_RESOURCE_AWS_INSTANCE},
+                {"AWS_INSTANCE, [CLOUD_RESOURCE_AWS_VPC]", ResourceType.AWS_INSTANCE, List.of(CLOUD_RESOURCE_AWS_VPC), null},
+                {"AWS_INSTANCE, [CLOUD_RESOURCE_AWS_INSTANCE, CLOUD_RESOURCE_AWS_VPC, CLOUD_RESOURCE_AWS_INSTANCE_2]", ResourceType.AWS_INSTANCE,
+                        List.of(CLOUD_RESOURCE_AWS_INSTANCE, CLOUD_RESOURCE_AWS_VPC, CLOUD_RESOURCE_AWS_INSTANCE_2), CLOUD_RESOURCE_AWS_INSTANCE},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getResourceTypeFromListDataProvider")
+    void getResourceTypeFromListTest(String testCaseName, ResourceType type, List<CloudResource> resources, CloudResource resultExpected) {
+        Optional<CloudResource> optionalCloudResource = underTest.getResourceTypeFromList(type, resources);
+
+        if (resultExpected == null) {
+            assertThat(optionalCloudResource).isEmpty();
+        } else {
+            assertThat(optionalCloudResource).hasValue(resultExpected);
+        }
+    }
+
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/service/Retry.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/service/Retry.java
@@ -36,4 +36,5 @@ public interface Retry {
             return new ActionFailedException(cause != null ? cause.getMessage() : null, cause);
         }
     }
+
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -26,6 +26,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
         "com.sequenceiq.cloudbreak.cloud.gcp",
         "com.sequenceiq.cloudbreak.cloud.configuration",
         "com.sequenceiq.cloudbreak.cloud.credential",
+        "com.sequenceiq.cloudbreak.cloud.exception",
         "com.sequenceiq.cloudbreak.cloud.handler",
         "com.sequenceiq.cloudbreak.cloud.handler.service",
         "com.sequenceiq.cloudbreak.cloud.init",


### PR DESCRIPTION
Covering DES creation & deletion.

* Error handling enhancements:
  * Wrap all DES and Key Vault related methods of `AzureClient` in `handleAuthException()`.
  * `AzureEncryptionResources`:
    * Catch all exceptions in the `public` methods and wrap them in a `CloudConnectorException`. `CloudException` (Azure) and `Retry.ActionFailedException` are treated in a special way; see the related methods of `AzureUtils` and the new class `CloudExceptionConverter`.
    * DES creation is executed in a sync poller to await the resource readiness. Poller failures will result in a `CloudConnectorException`. Note that the DES MSI SP existence is not checked; see below for more details.
    * The implementation of #10595 / [CB-12244](https://jira.cloudera.com/browse/CB-12244) has been updated so that all exceptions are caught and wrapped as a `CloudConnectorException`. (The latter will be still wrapped in a `Retry.ActionFailedException` for sake of retries, but the actual cause will be unwrapped later before exiting the caller `public` method.) The retry logic has been also applied to the deletion of DES resources; see the wrapped `AzureClient.deleteDiskEncryptionSet()` call in `deleteDiskEncryptionSetOnCloud()`.
* Code quality enhancements:
  * `AzureClient`:
    * Extract `ComputeManager` as a new field.
    * Rename `getDiskEncryptionSet()` to `getDiskEncryptionSetByName()`.
  * Add `toString()` implementations for `CloudCredential`, `DiskEncryptionSetCreationRequest`, `DiskEncryptionSetDeletionRequest`, and `ExtendedCloudCredential`.
  * Clean up superfluous fields in `DiskEncryptionSetCreationRequest` that are also available in the `CloudContext`.
  * Rename `principalId` fields and related accessor methods to `principalObjectId`; see `AzureClient` and `CreatedDiskEncryptionSet`.
  * Various refactorings, improved logging and exception handling in `AzureEncryptionResources`, `EnvironmentEncryptionService`, `ResourceEncryptionDeleteHandler`, and `ResourceEncryptionInitializationHandler`.
  * Add `PollPredicateStateTask`, a new specialized kind of `PollTask`.
* Testing:
  * Manual verification in local CB with various combinations of permissions in the Azure credential app role.
  * Added new unit tests and updated existing ones.

The existence of the DES SP cannot be easily checked. That would need powerful special AD API permissions for the credential app itself that most customers would never grant. In particular, `AzureClient` was supposed to be extended with the following method:

```
    public ServicePrincipal getServicePrincipalByObjectId(String principalObjectId) {
        return handleAuthException(() ->
                azure.accessManagement()
                        .servicePrincipals()
                        .getById(principalObjectId));
    }
```

Executing the above method typically resulted in an exception like this:

```
com.microsoft.azure.management.graphrbac.GraphErrorException: Status code 403, {"odata.error":{"code":"Authorization_RequestDenied","message":{"lang":"en","value":"Insufficient privileges to complete the operation."},"requestId":"b16d24e8-5b3a-4458-b66a-2b4f27bfb3c9","date":"2021-04-28T13:55:07"}}
```

In order for this to succeed, the credential app should have been modified to possess special AD API permissions (`Application.Read.All`, `Application.ReadWrite.All`, `Application.ReadWrite.OwnedBy`, `Directory.Read.All`), but getting those would have allowed the credential app to query the details of any other apps in the subcription. See https://docs.microsoft.com/en-us/graph/api/serviceprincipal-get?view=graph-rest-1.0&tabs=http and https://docs.microsoft.com/en-us/graph/permissions-reference#application-resource-permissions for the related REST API and permissions involved.

Though there is a system assigned managed identity (MSI) as well sitting behind the SP (with the MSI `displayName` matching the DES name), querying the properties of this identity (in order to check its existence) would also need an additional powerful `Action` (`Microsoft.ManagedIdentity/identities/read`) for the role assigned to the credential app, which is probably not desirable. See https://docs.microsoft.com/en-us/azure/role-based-access-control/resource-provider-operations#microsoftmanagedidentity for the permissions related to operations on MSIs.