### PR TITLE
CB-12291 Trim too long string fields in CDPStatusDetails.

### DIFF
--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToStatusDetailsConverter.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToStatusDetailsConverter.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.structuredevent.service.telemetry.converter;
 
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
@@ -12,6 +13,8 @@ import com.sequenceiq.cloudbreak.structuredevent.event.StructuredSyncEvent;
 
 @Component
 public class StructuredEventToStatusDetailsConverter {
+
+    private static final int MAX_STRING_LENGTH = 5000;
 
     public UsageProto.CDPStatusDetails convert(StructuredFlowEvent structuredFlowEvent) {
 
@@ -42,12 +45,14 @@ public class StructuredEventToStatusDetailsConverter {
         if (stackDetails != null) {
             cdpStatusDetails.setStackStatus(defaultIfEmpty(stackDetails.getStatus(), ""));
             cdpStatusDetails.setStackDetailedStatus(defaultIfEmpty(stackDetails.getDetailedStatus(), ""));
-            cdpStatusDetails.setStackStatusReason(defaultIfEmpty(stackDetails.getStatusReason(), ""));
+            cdpStatusDetails.setStackStatusReason(defaultIfEmpty(StringUtils.substring(stackDetails.getStatusReason(),
+                    0, Math.min(StringUtils.length(stackDetails.getStatusReason()), MAX_STRING_LENGTH)), ""));
         }
 
         if (clusterDetails != null) {
             cdpStatusDetails.setClusterStatus(defaultIfEmpty(clusterDetails.getStatus(), ""));
-            cdpStatusDetails.setClusterStatusReason(defaultIfEmpty(clusterDetails.getStatusReason(), ""));
+            cdpStatusDetails.setClusterStatusReason(defaultIfEmpty(StringUtils.substring(clusterDetails.getStatusReason(),
+                    0, Math.min(StringUtils.length(clusterDetails.getStatusReason()), MAX_STRING_LENGTH)), ""));
         }
 
         return cdpStatusDetails;

--- a/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredFlowEventToStatusDetailsConverterTest.java
+++ b/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredFlowEventToStatusDetailsConverterTest.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.structuredevent.service.telemetry.converter;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -73,6 +75,49 @@ public class StructuredFlowEventToStatusDetailsConverterTest {
         Assert.assertEquals("statusreason", syncStatusDetails.getStackStatusReason());
         Assert.assertEquals("AVAILABLE", syncStatusDetails.getClusterStatus());
         Assert.assertEquals("statusreason", syncStatusDetails.getClusterStatusReason());
+    }
+
+    @Test
+    public void testStatusReasonStringTrimming() {
+        StructuredFlowEvent structuredFlowEvent = new StructuredFlowEvent();
+        StackDetails stackDetails = new StackDetails();
+        ClusterDetails clusterDetails = new ClusterDetails();
+        structuredFlowEvent.setStack(stackDetails);
+        structuredFlowEvent.setCluster(clusterDetails);
+
+        UsageProto.CDPStatusDetails flowStatusDetails = underTest.convert(structuredFlowEvent);
+
+        Assertions.assertEquals("", flowStatusDetails.getStackStatusReason());
+        Assertions.assertEquals("", flowStatusDetails.getClusterStatusReason());
+
+        stackDetails.setStatusReason("");
+        clusterDetails.setStatusReason("");
+        flowStatusDetails = underTest.convert(structuredFlowEvent);
+
+        Assertions.assertEquals("", flowStatusDetails.getStackStatusReason());
+        Assertions.assertEquals("", flowStatusDetails.getClusterStatusReason());
+
+        stackDetails.setStatusReason(StringUtils.repeat("*", 10));
+        clusterDetails.setStatusReason(StringUtils.repeat("*", 10));
+        flowStatusDetails = underTest.convert(structuredFlowEvent);
+
+        Assertions.assertEquals(StringUtils.repeat("*", 10), flowStatusDetails.getStackStatusReason());
+        Assertions.assertEquals(StringUtils.repeat("*", 10), flowStatusDetails.getClusterStatusReason());
+
+        stackDetails.setStatusReason(StringUtils.repeat("*", 5000));
+        clusterDetails.setStatusReason(StringUtils.repeat("*", 5000));
+        flowStatusDetails = underTest.convert(structuredFlowEvent);
+
+        Assertions.assertEquals(StringUtils.repeat("*", 5000), flowStatusDetails.getStackStatusReason());
+        Assertions.assertEquals(StringUtils.repeat("*", 5000), flowStatusDetails.getClusterStatusReason());
+
+        stackDetails.setStatusReason(StringUtils.repeat("*", 10000));
+        clusterDetails.setStatusReason(StringUtils.repeat("*", 10000));
+        flowStatusDetails = underTest.convert(structuredFlowEvent);
+
+        Assertions.assertEquals(StringUtils.repeat("*", 5000), flowStatusDetails.getStackStatusReason());
+        Assertions.assertEquals(StringUtils.repeat("*", 5000), flowStatusDetails.getClusterStatusReason());
+
     }
 
     private StackDetails createStackDetails() {


### PR DESCRIPTION
Too long string fileds in CDPStatusDetails caused telemetry logs to exceed the maximum log size, splitting the log into several log entries and preventing the EDH pipeline to successfully collect these events.