### PR TITLE
CB-12382: Make image catalog APIs internally callable by SDX

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/ImageCatalogV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/ImageCatalogV4Endpoint.java
@@ -25,6 +25,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageCat
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageCatalogV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
+import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.doc.ControllerDescription;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.ImageCatalogOpDescription;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
@@ -131,7 +132,8 @@ public interface ImageCatalogV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ImageCatalogOpDescription.GET_IMAGE_BY_ID, produces = MediaType.APPLICATION_JSON,
             notes = IMAGE_CATALOG_NOTES, nickname = "getImageById")
-    ImagesV4Response getImageByImageId(@PathParam("workspaceId") Long workspaceId, @QueryParam("imageId") String imageId) throws Exception;
+    ImagesV4Response getImageByImageId(@PathParam("workspaceId") Long workspaceId, @QueryParam("imageId") String imageId,
+            @AccountId @QueryParam("accountId") String accountId) throws Exception;
 
     @GET
     @Path("{name}/image")
@@ -139,7 +141,7 @@ public interface ImageCatalogV4Endpoint {
     @ApiOperation(value = ImageCatalogOpDescription.GET_IMAGE_BY_NAME_AND_ID, produces = MediaType.APPLICATION_JSON,
             notes = IMAGE_CATALOG_NOTES, nickname = "getImageByNameAndId")
     ImagesV4Response getImageByCatalogNameAndImageId(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
-            @QueryParam("imageId") String imageId) throws Exception;
+            @QueryParam("imageId") String imageId, @AccountId @QueryParam("accountId") String accountId) throws Exception;
 
     @GET
     @Path("{name}/singleimage")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
@@ -11,9 +11,6 @@ import javax.inject.Inject;
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.requests.ImageEntryV4Request;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageBasicInfoV4Response;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
@@ -31,18 +28,23 @@ import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.ImageCatalogV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.requests.ImageCatalogV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.requests.ImageEntryV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.requests.UpdateImageCatalogV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageBasicInfoV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageCatalogV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageCatalogV4Responses;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.authorization.ImageCatalogFiltering;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
 import com.sequenceiq.cloudbreak.common.type.ResourceEvent;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
+import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 import com.sequenceiq.cloudbreak.workspace.controller.WorkspaceEntityType;
 
 @Controller
@@ -59,6 +61,9 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @Inject
     private ImageCatalogFiltering imageCatalogFiltering;
 
+    @Inject
+    private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
+
     @Override
     @FilterListBasedOnPermissions(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG, filter = ImageCatalogFiltering.class)
     public ImageCatalogV4Responses list(Long workspaceId, boolean customCatalogsOnly) {
@@ -69,9 +74,9 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public ImageCatalogV4Response getByName(Long workspaceId, @ResourceName String name, Boolean withImages) {
-        ImageCatalog catalog = imageCatalogService.get(NameOrCrn.ofName(name), workspaceId);
+        ImageCatalog catalog = imageCatalogService.get(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
         ImageCatalogV4Response imageCatalogResponse = converterUtil.convert(catalog, ImageCatalogV4Response.class);
-        Images images = imageCatalogService.propagateImagesIfRequested(workspaceId, name, withImages);
+        Images images = imageCatalogService.propagateImagesIfRequested(restRequestThreadLocalService.getRequestedWorkspaceId(), name, withImages);
         if (images != null) {
             imageCatalogResponse.setImages(converterUtil.convert(images, ImagesV4Response.class));
         }
@@ -81,9 +86,9 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public ImageCatalogV4Response getByCrn(Long workspaceId, @ResourceCrn String crn, Boolean withImages) {
-        ImageCatalog catalog = imageCatalogService.get(NameOrCrn.ofCrn(crn), workspaceId);
+        ImageCatalog catalog = imageCatalogService.get(NameOrCrn.ofCrn(crn), restRequestThreadLocalService.getRequestedWorkspaceId());
         ImageCatalogV4Response imageCatalogResponse = converterUtil.convert(catalog, ImageCatalogV4Response.class);
-        Images images = imageCatalogService.propagateImagesIfRequested(workspaceId, catalog.getName(), withImages);
+        Images images = imageCatalogService.propagateImagesIfRequested(restRequestThreadLocalService.getRequestedWorkspaceId(), catalog.getName(), withImages);
         if (images != null) {
             imageCatalogResponse.setImages(converterUtil.convert(images, ImagesV4Response.class));
         }
@@ -96,7 +101,8 @@ public class ImageCatalogV4Controller extends NotificationController implements 
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         String creator = ThreadBasedUserCrnProvider.getUserCrn();
         ImageCatalog catalogToSave = converterUtil.convert(request, ImageCatalog.class);
-        ImageCatalog imageCatalog = imageCatalogService.createForLoggedInUser(catalogToSave, workspaceId, accountId, creator);
+        ImageCatalog imageCatalog = imageCatalogService.createForLoggedInUser(catalogToSave, restRequestThreadLocalService.getRequestedWorkspaceId(),
+                accountId, creator);
         notify(ResourceEvent.IMAGE_CATALOG_CREATED);
         return converterUtil.convert(imageCatalog, ImageCatalogV4Response.class);
     }
@@ -104,7 +110,7 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DELETE_IMAGE_CATALOG)
     public ImageCatalogV4Response deleteByName(Long workspaceId, @ResourceName String name) {
-        ImageCatalog deleted = imageCatalogService.delete(NameOrCrn.ofName(name), workspaceId);
+        ImageCatalog deleted = imageCatalogService.delete(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
         notify(ResourceEvent.IMAGE_CATALOG_DELETED);
         return converterUtil.convert(deleted, ImageCatalogV4Response.class);
     }
@@ -112,7 +118,7 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DELETE_IMAGE_CATALOG)
     public ImageCatalogV4Response deleteByCrn(Long workspaceId, @ResourceCrn String crn) {
-        ImageCatalog deleted = imageCatalogService.delete(NameOrCrn.ofCrn(crn), workspaceId);
+        ImageCatalog deleted = imageCatalogService.delete(NameOrCrn.ofCrn(crn), restRequestThreadLocalService.getRequestedWorkspaceId());
         notify(ResourceEvent.IMAGE_CATALOG_DELETED);
         return converterUtil.convert(deleted, ImageCatalogV4Response.class);
     }
@@ -120,7 +126,7 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @Override
     @CheckPermissionByResourceNameList(action = AuthorizationResourceAction.DELETE_IMAGE_CATALOG)
     public ImageCatalogV4Responses deleteMultiple(Long workspaceId, @ResourceNameList Set<String> names) {
-        Set<ImageCatalog> deleted = imageCatalogService.deleteMultiple(workspaceId, names);
+        Set<ImageCatalog> deleted = imageCatalogService.deleteMultiple(restRequestThreadLocalService.getRequestedWorkspaceId(), names);
         notify(ResourceEvent.IMAGE_CATALOG_DELETED);
         return new ImageCatalogV4Responses(converterUtil.convertAllAsSet(deleted, ImageCatalogV4Response.class));
     }
@@ -128,14 +134,15 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @Override
     @CheckPermissionByRequestProperty(path = "crn", type = CRN, action = EDIT_IMAGE_CATALOG)
     public ImageCatalogV4Response update(Long workspaceId, @RequestObject UpdateImageCatalogV4Request request) {
-        ImageCatalog imageCatalog = imageCatalogService.update(workspaceId, converterUtil.convert(request, ImageCatalog.class));
+        ImageCatalog imageCatalog = imageCatalogService.update(restRequestThreadLocalService.getRequestedWorkspaceId(),
+                converterUtil.convert(request, ImageCatalog.class));
         return converterUtil.convert(imageCatalog, ImageCatalogV4Response.class);
     }
 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public ImageCatalogV4Request getRequest(Long workspaceId, @ResourceName String name) {
-        ImageCatalog imageCatalog = imageCatalogService.get(workspaceId, name);
+        ImageCatalog imageCatalog = imageCatalogService.get(restRequestThreadLocalService.getRequestedWorkspaceId(), name);
         return converterUtil.convert(imageCatalog, ImageCatalogV4Request.class);
     }
 
@@ -143,7 +150,8 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @DisableCheckPermissions
     public ImagesV4Response getImages(Long workspaceId, String stackName, String platform,
             String runtimeVersion, String imageType) throws Exception {
-        Images images = imageCatalogService.getImagesFromDefault(workspaceId, stackName, platform, Collections.emptySet());
+        Images images = imageCatalogService.getImagesFromDefault(restRequestThreadLocalService.getRequestedWorkspaceId(), stackName,
+                platform, Collections.emptySet());
         return converterUtil.convert(images, ImagesV4Response.class);
     }
 
@@ -151,22 +159,23 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public ImagesV4Response getImagesByName(Long workspaceId, @ResourceName String name, String stackName, String platform,
         String runtimeVersion, String imageType) throws Exception {
-        Images images = imageCatalogService.getImagesByCatalogName(workspaceId, name, stackName, platform);
+        Images images = imageCatalogService.getImagesByCatalogName(restRequestThreadLocalService.getRequestedWorkspaceId(), name, stackName, platform);
         return converterUtil.convert(images, ImagesV4Response.class);
     }
 
     @Override
     @DisableCheckPermissions
-    public ImagesV4Response getImageByImageId(Long workspaceId, String imageId) throws Exception {
-        StatedImage statedImage = imageCatalogService.getImageByCatalogName(workspaceId, imageId, "");
+    public ImagesV4Response getImageByImageId(Long workspaceId, String imageId, @AccountId String accountId) throws Exception {
+        StatedImage statedImage = imageCatalogService.getImageByCatalogName(restRequestThreadLocalService.getRequestedWorkspaceId(), imageId, "");
         Images images = new Images(List.of(), List.of(statedImage.getImage()), Set.of());
         return converterUtil.convert(images, ImagesV4Response.class);
     }
 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
-    public ImagesV4Response getImageByCatalogNameAndImageId(Long workspaceId, @ResourceName String name, String imageId) throws Exception {
-        StatedImage statedImage = imageCatalogService.getImageByCatalogName(workspaceId, imageId, name);
+    public ImagesV4Response getImageByCatalogNameAndImageId(Long workspaceId, @ResourceName String name,
+            String imageId, @AccountId String accountId) throws Exception {
+        StatedImage statedImage = imageCatalogService.getImageByCatalogName(restRequestThreadLocalService.getRequestedWorkspaceId(), imageId, name);
         Images images = new Images(List.of(), List.of(statedImage.getImage()), Set.of());
         return converterUtil.convert(images, ImagesV4Response.class);
     }
@@ -174,7 +183,7 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public ImageV4Response getSingleImageByCatalogNameAndImageId(Long workspaceId, @ResourceName String name, String imageId) throws Exception {
-        StatedImage statedImage = imageCatalogService.getImageByCatalogName(workspaceId, imageId, name);
+        StatedImage statedImage = imageCatalogService.getImageByCatalogName(restRequestThreadLocalService.getRequestedWorkspaceId(), imageId, name);
         // FIXME: This conversion WILL fail unless properly implemented!
         return converterUtil.convert(statedImage.getImage(), ImageV4Response.class);
     }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -223,6 +223,8 @@ public class SdxService implements ResourceIdProvider, ResourcePropertyProvider 
     }
 
     public ImageV4Response getImageResponseFromImageRequest(ImageSettingsV4Request imageSettingsV4Request, CloudPlatform cloudPlatform) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+
         if (imageSettingsV4Request == null) {
             return null;
         }
@@ -235,10 +237,10 @@ public class SdxService implements ResourceIdProvider, ResourcePropertyProvider 
             ImagesV4Response imagesV4Response = null;
             try {
                 if (Strings.isBlank(imageSettingsV4Request.getCatalog())) {
-                    imagesV4Response = imageCatalogV4Endpoint.getImageByImageId(WORKSPACE_ID_DEFAULT, imageSettingsV4Request.getId());
+                    imagesV4Response = imageCatalogV4Endpoint.getImageByImageId(WORKSPACE_ID_DEFAULT, imageSettingsV4Request.getId(), accountId);
                 } else {
-                    imagesV4Response = imageCatalogV4Endpoint.getImageByCatalogNameAndImageId(
-                            WORKSPACE_ID_DEFAULT, imageSettingsV4Request.getCatalog(), imageSettingsV4Request.getId());
+                    imagesV4Response = imageCatalogV4Endpoint.getImageByCatalogNameAndImageId(WORKSPACE_ID_DEFAULT,
+                            imageSettingsV4Request.getCatalog(), imageSettingsV4Request.getId(), accountId);
                 }
             } catch (Exception e) {
                 LOGGER.error("Sdx service fails to get image using image id", e);

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/SdxServiceTest.java
@@ -231,7 +231,8 @@ class SdxServiceTest {
         existing.setEnvName("envir");
         when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(Collections.singletonList(existing));
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                        underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)));
         assertEquals("SDX cluster exists for environment name: envir", badRequestException.getMessage());
     }
 
@@ -241,7 +242,8 @@ class SdxServiceTest {
         when(sdxClusterRepository.findByAccountIdAndEnvNameAndDeletedIsNull(anyString(), anyString())).thenReturn(new ArrayList<>());
         mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                        underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)));
         assertEquals("Cloud storage parameter is required.", badRequestException.getMessage());
     }
 
@@ -253,7 +255,7 @@ class SdxServiceTest {
         StackV4Request stackV4Request = new StackV4Request();
         ClusterV4Request clusterV4Request = new ClusterV4Request();
         stackV4Request.setCluster(clusterV4Request);
-        underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, stackV4Request);
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, stackV4Request));
     }
 
     @Test
@@ -272,7 +274,8 @@ class SdxServiceTest {
         });
         when(clock.getCurrentTimeMillis()).thenReturn(1L);
         mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AZURE);
-        Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null);
+        Pair<SdxCluster, FlowIdentifier> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
         SdxCluster createdSdxCluster = result.getLeft();
         Assertions.assertEquals(id, createdSdxCluster.getId());
         final ArgumentCaptor<SdxCluster> captor = ArgumentCaptor.forClass(SdxCluster.class);
@@ -323,7 +326,8 @@ class SdxServiceTest {
             return sdxWithId;
         });
         mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
-        Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null);
+        Pair<SdxCluster, FlowIdentifier> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
         SdxCluster createdSdxCluster = result.getLeft();
         assertEquals("s3a://some/dir", createdSdxCluster.getCloudStorageBaseLocation());
     }
@@ -343,7 +347,8 @@ class SdxServiceTest {
             return sdxWithId;
         });
         mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
-        Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null);
+        Pair<SdxCluster, FlowIdentifier> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
         SdxCluster createdSdxCluster = result.getLeft();
         // AWS 7.1.0 light duty contains exactly 2 instance groups
         assertThat(createdSdxCluster.getStackRequest()).containsSubsequence(
@@ -367,7 +372,8 @@ class SdxServiceTest {
             return sdxWithId;
         });
         mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
-        Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null);
+        Pair<SdxCluster, FlowIdentifier> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
         SdxCluster createdSdxCluster = result.getLeft();
         assertEquals("s3a://some/dir", createdSdxCluster.getCloudStorageBaseLocation());
     }
@@ -396,7 +402,8 @@ class SdxServiceTest {
         when(environmentClientService.getByName(anyString())).thenReturn(detailedEnvironmentResponse);
 
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null), "BadRequestException should thrown");
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)),
+                "BadRequestException should thrown");
         assertEquals(exceptionMessage, badRequestException.getMessage());
     }
 
@@ -431,7 +438,8 @@ class SdxServiceTest {
         when(environmentClientService.getByName(anyString())).thenReturn(detailedEnvironmentResponse);
 
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null), "BadRequestException should thrown");
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)),
+                "BadRequestException should thrown");
         assertEquals("The environment is in delete in progress phase. Please create a new environment first!", badRequestException.getMessage());
     }
 
@@ -459,7 +467,8 @@ class SdxServiceTest {
         when(environmentClientService.getByName(anyString())).thenReturn(detailedEnvironmentResponse);
 
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null), "BadRequestException should thrown");
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)),
+                "BadRequestException should thrown");
         assertEquals("The environment is in failed phase. Please fix the environment or create a new one first!", badRequestException.getMessage());
     }
 
@@ -589,7 +598,8 @@ class SdxServiceTest {
         when(clock.getCurrentTimeMillis()).thenReturn(1L);
         mockEnvironmentCall(sdxClusterRequest, cloudPlatform);
         sdxClusterRequest.setEnableRangerRaz(false);
-        Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null);
+        Pair<SdxCluster, FlowIdentifier> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
         SdxCluster createdSdxCluster = result.getLeft();
         Assertions.assertEquals(id, createdSdxCluster.getId());
         final ArgumentCaptor<SdxCluster> captor = ArgumentCaptor.forClass(SdxCluster.class);
@@ -626,7 +636,8 @@ class SdxServiceTest {
         mockEnvironmentCall(sdxClusterRequest, cloudPlatform);
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString())).thenReturn(true);
-        Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null);
+        Pair<SdxCluster, FlowIdentifier> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
         SdxCluster createdSdxCluster = result.getLeft();
         Assertions.assertEquals(id, createdSdxCluster.getId());
         final ArgumentCaptor<SdxCluster> captor = ArgumentCaptor.forClass(SdxCluster.class);
@@ -645,7 +656,7 @@ class SdxServiceTest {
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString())).thenReturn(false);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)));
         assertEquals("Provisioning Ranger Raz is not enabled for this account.", badRequestException.getMessage());
     }
 
@@ -657,7 +668,7 @@ class SdxServiceTest {
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)));
         assertEquals("Provisioning Ranger Raz is only valid for Amazon Web Services and Microsoft Azure.", badRequestException.getMessage());
     }
 
@@ -669,7 +680,7 @@ class SdxServiceTest {
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString())).thenReturn(false);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)));
         assertEquals("1. Provisioning Ranger Raz is not enabled for this account.\n" +
                 "2. Provisioning Ranger Raz is only valid for Amazon Web Services and Microsoft Azure.", badRequestException.getMessage());
     }
@@ -693,7 +704,7 @@ class SdxServiceTest {
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)));
         assertEquals(expectedErrorMsg, badRequestException.getMessage());
     }
 
@@ -716,7 +727,7 @@ class SdxServiceTest {
         sdxClusterRequest.setEnableRangerRaz(true);
         when(entitlementService.razEnabled(anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)));
         assertEquals(expectedErrorMsg, badRequestException.getMessage());
     }
 
@@ -739,7 +750,8 @@ class SdxServiceTest {
         when(clock.getCurrentTimeMillis()).thenReturn(1L);
         mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
         when(entitlementService.mediumDutySdxEnabled(anyString())).thenReturn(true);
-        Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null);
+        Pair<SdxCluster, FlowIdentifier> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
         SdxCluster createdSdxCluster = result.getLeft();
         Assertions.assertEquals(id, createdSdxCluster.getId());
         final ArgumentCaptor<SdxCluster> captor = ArgumentCaptor.forClass(SdxCluster.class);
@@ -756,7 +768,7 @@ class SdxServiceTest {
         mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AZURE);
         when(entitlementService.mediumDutySdxEnabled(anyString())).thenReturn(false);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)));
         assertEquals(String.format("Provisioning a medium duty data lake cluster is not enabled for %s. ", CloudPlatform.AZURE.name()) +
                 "Contact Cloudera support to enable CDP_MEDIUM_DUTY_SDX entitlement for the account.", badRequestException.getMessage());
     }
@@ -769,7 +781,7 @@ class SdxServiceTest {
         mockEnvironmentCall(sdxClusterRequest, CloudPlatform.GCP);
         when(entitlementService.mediumDutySdxEnabled(anyString())).thenReturn(false);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)));
         assertEquals(String.format("Provisioning a medium duty data lake cluster is not enabled for %s. ", CloudPlatform.GCP.name()) +
                 "Contact Cloudera support to enable CDP_MEDIUM_DUTY_SDX entitlement for the account.", badRequestException.getMessage());
     }
@@ -793,7 +805,8 @@ class SdxServiceTest {
             return sdxWithId;
         });
         when(clock.getCurrentTimeMillis()).thenReturn(1L);
-        Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null);
+        Pair<SdxCluster, FlowIdentifier> result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
         SdxCluster createdSdxCluster = result.getLeft();
         Assertions.assertEquals(id, createdSdxCluster.getId());
         final ArgumentCaptor<SdxCluster> captor = ArgumentCaptor.forClass(SdxCluster.class);
@@ -810,7 +823,7 @@ class SdxServiceTest {
         mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
         when(entitlementService.mediumDutySdxEnabled(anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)));
         assertEquals("Provisioning a Medium Duty SDX shape is only valid for CM version >= " + MEDIUM_DUTY_REQUIRED_VERSION + " and not "
                 + invalidRuntime, badRequestException.getMessage());
     }
@@ -823,7 +836,7 @@ class SdxServiceTest {
         mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
         when(entitlementService.mediumDutySdxEnabled(anyString())).thenReturn(true);
         BadRequestException badRequestException = assertThrows(BadRequestException.class,
-                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null));
+                () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest, null)));
         assertEquals("Provisioning a Medium Duty SDX shape is only valid for CM version >= " + MEDIUM_DUTY_REQUIRED_VERSION + " and not "
                 + invalidRuntime, badRequestException.getMessage());
     }
@@ -892,7 +905,7 @@ class SdxServiceTest {
         when(entitlementService.dataLakeCustomImageEnabled(anyString())).thenReturn(true);
         when(cloudbreakInternalCrnClient.withInternalCrn()).thenReturn(cloudbreakServiceCrnEndpoints);
         when(cloudbreakServiceCrnEndpoints.imageCatalogV4Endpoint()).thenReturn(imageCatalogV4Endpoint);
-        when(imageCatalogV4Endpoint.getImageByCatalogNameAndImageId(any(), any(), any())).thenReturn(imagesV4Response);
+        when(imageCatalogV4Endpoint.getImageByCatalogNameAndImageId(any(), any(), any(), any())).thenReturn(imagesV4Response);
         when(transactionService.required(isA(Supplier.class))).thenAnswer(invocation -> invocation.getArgument(0, Supplier.class).get());
         String lightDutyJson = FileReaderUtils.readFileFromClasspath("/duties/7.2.7/aws/light_duty.json");
         when(cdpConfigService.getConfigForKey(any())).thenReturn(JsonUtil.readValue(lightDutyJson, StackV4Request.class));
@@ -907,7 +920,8 @@ class SdxServiceTest {
             return sdxWithId;
         });
         mockEnvironmentCall(sdxClusterRequest, CloudPlatform.AWS);
-        Pair<SdxCluster, FlowIdentifier> result = underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest);
+        Pair<SdxCluster, FlowIdentifier> result = ThreadBasedUserCrnProvider.doAs(USER_CRN,
+                () -> underTest.createSdx(USER_CRN, CLUSTER_NAME, sdxClusterRequest));
 
         SdxCluster createdSdxCluster = result.getLeft();
         StackV4Request stackV4Request = JsonUtil.readValue(createdSdxCluster.getStackRequest(), StackV4Request.class);


### PR DESCRIPTION
Currently SDX calls two API endpoints in the wrong way, which this fix should correct. It has been already tested.