### PR TITLE
CB-12407: Increase FreeIPA certificate serial number max value

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -267,7 +267,7 @@ public class FreeIpaClient {
         return (Set<Cert>) invoke("cert_find", List.of(), Map.of(), type).getResult();
     }
 
-    public void revokeCert(int serialNumber) throws FreeIpaClientException {
+    public void revokeCert(long serialNumber) throws FreeIpaClientException {
         List<Object> flags = List.of(String.valueOf(serialNumber));
         Map<String, Object> params = Map.of("revocation_reason", CESSATION_OF_OPERATION);
         invoke("cert_revoke", flags, params, Object.class);

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Cert.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/Cert.java
@@ -10,7 +10,7 @@ public class Cert {
     private String cacn;
 
     @JsonProperty("serial_number")
-    private int serialNumber;
+    private long serialNumber;
 
     @JsonProperty("valid_not_before")
     private String validNotBefore;
@@ -40,11 +40,11 @@ public class Cert {
         this.cacn = cacn;
     }
 
-    public int getSerialNumber() {
+    public long getSerialNumber() {
         return serialNumber;
     }
 
-    public void setSerialNumber(int serialNumber) {
+    public void setSerialNumber(long serialNumber) {
         this.serialNumber = serialNumber;
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/cleanup/CleanupServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/cleanup/CleanupServiceTest.java
@@ -455,7 +455,7 @@ public class CleanupServiceTest {
         verify(ldapConfigService, times(1)).delete("envCrn", "accountId", "test-wl-1");
     }
 
-    private Cert createCert(String subject, int serialNumber, boolean revoked) {
+    private Cert createCert(String subject, long serialNumber, boolean revoked) {
         Cert cert = new Cert();
         cert.setSubject(subject);
         cert.setRevoked(revoked);
@@ -463,8 +463,8 @@ public class CleanupServiceTest {
         return cert;
     }
 
-    private void verifyRevokeNotInvoked(FreeIpaClient freeIpaClient, int... serialNumber) throws FreeIpaClientException {
-        for (int num : serialNumber) {
+    private void verifyRevokeNotInvoked(FreeIpaClient freeIpaClient, long... serialNumber) throws FreeIpaClientException {
+        for (long num : serialNumber) {
             verify(freeIpaClient, times(0)).revokeCert(num);
         }
     }


### PR DESCRIPTION
The FreeIPA certificate serial number's is an ASN.1 integer. ANS.1
intergers are unbounded. The java code was increased from an int to a
long. While this doesn't fix the problem in all cases, in practise it
should be sufficient. When FreeIPA is installed, it will pick a range
and use consecutive serial number for that instance of FreeIPA.

This was tested using a local deployment of cloudbreak that had an out
of range number in the serial number.

See detailed description in the commit message.