### PR TITLE
CB-12352 - [KNOX] Handle the case when NN is HA in Knox topology

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -414,9 +414,13 @@
     {% if 'NAMENODE' in exposed -%}
     <service>
         <role>NAMENODE</role>
+        {% if salt['pillar.get']('gateway:location')['NAMENODE']  is defined and salt['pillar.get']('gateway:location')['NAMENODE']|length > 1 %}
+        <url>hdfs://ns1</url>
+        {% else %}
         {% for hostloc in salt['pillar.get']('gateway:location')['NAMENODE'] -%}
         <url>hdfs://{{ hostloc }}:{{ ports['NAMENODE'] }}</url>
         {%- endfor %}
+        {% endif %}
     </service>
     {%- endif %}
     {%- endif %}


### PR DESCRIPTION
In public cloud when HA clusters are created NN service created in Knox topology is expected to have value `hdfs://nn1` instead of `hdfs://<host>:<port>` 

Currently the log that generated topologies using salt does not take this into account. This PR fixes that. 

**Testing**
This patch was tested locally with HA cluster and non-HA cluster
Topology value for HA cluster:
```
   <service>
        <role>NAMENODE</role>
        <url>hdfs://ns1</url>
    </service>
```
Topology value for non-HA cluster:
```
            <service>
	        <role>NAMENODE</role>
	        <url>hdfs://srm-azure-local-ha-dl-master0.srm-azur.xcu2-8y8x.wl.cloudera.site:8020</url>
	    </service>
```
