### PR TITLE
DISTX-576 Implement cloud-provider load-balancer support for Azure DE…

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -702,7 +702,7 @@ cb:
     readTimeoutMs: 5000
 
   loadBalancer:
-    supportedPlatforms: AWS,YARN
+    supportedPlatforms: AWS,YARN,AZURE
 
   upgrade:
     validation:

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/dataengineering-ha.json
@@ -11,9 +11,10 @@
     "externalDatabase": {
       "availabilityType": "HA"
     },
+    "enableLoadBalancer": true,
     "instanceGroups": [
       {
-        "nodeCount": 1,
+        "nodeCount": 2,
         "name": "manager",
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/azure/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/azure/dataengineering-ha.json
@@ -11,9 +11,10 @@
     "externalDatabase": {
       "availabilityType": "HA"
     },
+    "enableLoadBalancer": true,
     "instanceGroups": [
       {
-        "nodeCount": 1,
+        "nodeCount": 2,
         "name": "manager",
         "type": "GATEWAY",
         "recoveryMode": "MANUAL",


### PR DESCRIPTION
… HA clusters for Knox HA

1. Azure already supports load-balancers.
2. 7.2.10 will have Azure load-balancers in the preview mode. ETA mid-June.
3. To make Knox HA, increased the number of gateway nodes to two for 7.2.10+

Tested in the private stack.