### PR TITLE
CB-12443 Decommission InstanceIds Should be part of RequestBody

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
@@ -56,9 +56,7 @@ public class CloudbreakCommunicator {
     public void decommissionInstancesForCluster(Cluster cluster, List<String> decommissionNodeIds) {
         requestLogging.logResponseTime(() -> {
             cloudbreakInternalCrnClient.withInternalCrn().autoscaleEndpoint()
-                    .decommissionInstancesForClusterCrn(cluster.getStackCrn(),
-                            cluster.getClusterPertain().getWorkspaceId(),
-                            decommissionNodeIds, false);
+                    .decommissionInternalInstancesForClusterCrn(cluster.getStackCrn(), decommissionNodeIds, false);
             return Optional.empty();
         }, String.format("DecommissionInstancesForCluster query for cluster crn %s, NodeIds %s",
                 cluster.getStackCrn(), decommissionNodeIds));

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/AutoscaleV4Endpoint.java
@@ -16,6 +16,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
+import org.springframework.web.bind.annotation.RequestBody;
+
 import com.cloudera.cdp.shaded.javax.ws.rs.core.MediaType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.UpdateStackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.AuthorizeForAutoscaleV4Response;
@@ -115,6 +117,15 @@ public interface AutoscaleV4Endpoint {
     void decommissionInstancesForClusterCrn(@PathParam("crn") String clusterCrn,
             @QueryParam("workspaceId") @Valid Long workspaceId,
             @QueryParam("instanceId") @NotEmpty List<String> instanceIds,
+            @QueryParam("forced") @DefaultValue("false") Boolean forced);
+
+    @DELETE
+    @Path("/stack/crn/{crn}/instances/internal")
+    @Produces(APPLICATION_JSON)
+    @ApiOperation(value = StackOpDescription.DELETE_MULTIPLE_INSTANCES_BY_ID_IN_WORKSPACE, produces = APPLICATION_JSON,
+            notes = Notes.STACK_NOTES, nickname = "decommissionInternalInstancesForClusterCrn")
+    void decommissionInternalInstancesForClusterCrn(@PathParam("crn") String clusterCrn,
+            @RequestBody @NotEmpty List<String> instanceIds,
             @QueryParam("forced") @DefaultValue("false") Boolean forced);
 
     @GET

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/AutoscaleV4Controller.java
@@ -120,6 +120,14 @@ public class AutoscaleV4Controller implements AutoscaleV4Endpoint {
     }
 
     @Override
+    @InternalOnly
+    public void decommissionInternalInstancesForClusterCrn(@TenantAwareParam @ResourceCrn String clusterCrn,
+            List<String> instanceIds, Boolean forced) {
+        stackCommonService.deleteMultipleInstancesInWorkspace(NameOrCrn.ofCrn(clusterCrn), restRequestThreadLocalService.getRequestedWorkspaceId(),
+                new HashSet(instanceIds), forced);
+    }
+
+    @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)
     public AutoscaleStackV4Responses getAllForAutoscale() {
         Set<AutoscaleStackV4Response> allForAutoscale = stackCommonService.getAllForAutoscale();


### PR DESCRIPTION
Instance Ids for decommission should be part of RequestBody so that it does not cause BufferOverflowException.

See detailed description in the commit message.