### PR TITLE
CB-12360 Azure Private Link name has a length limit of 85 characters

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDatabaseTemplateBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureDatabaseTemplateBuilder.java
@@ -48,6 +48,9 @@ public class AzureDatabaseTemplateBuilder {
     @Inject
     private AzureDatabaseTemplateProvider azureDatabaseTemplateProvider;
 
+    @Inject
+    private AzureUtils azureUtils;
+
     public String build(CloudContext cloudContext, DatabaseStack databaseStack) {
         try {
             String location = cloudContext.getLocation().getRegion().getRegionName();
@@ -81,7 +84,7 @@ public class AzureDatabaseTemplateBuilder {
             model.put("batchSize", azureNetworkView.getSubnets().split(",").length >= defaultBatchSize ? defaultBatchSize : 1);
             model.put("location", azureDatabaseServerView.getLocation());
             model.put("privateEndpointName", String.format("pe-%s-to-%s",
-                    getSubnetName(azureNetworkView.getSubnetList().get(0)), azureDatabaseServerView.getDbServerName()));
+                    azureUtils.encodeString(getSubnetName(azureNetworkView.getSubnetList().get(0))), azureDatabaseServerView.getDbServerName()));
             String generatedTemplate = freeMarkerTemplateUtils.processTemplateIntoString(azureDatabaseTemplateProvider.getTemplate(databaseStack), model);
             LOGGER.debug("Generated ARM database template: {}", AnonymizerUtil.anonymize(generatedTemplate));
             return generatedTemplate;

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorage.java
@@ -7,8 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.zip.Adler32;
-import java.util.zip.Checksum;
 
 import javax.inject.Inject;
 
@@ -176,29 +174,15 @@ public class AzureStorage {
     private String getPersistentStorageName(String prefix, AzureCredentialView acv, String region, String resourceGroup) {
         String subscriptionIdPart = StringUtils.isBlank(resourceGroup)
                 ? acv.getSubscriptionId().replaceAll("-", "").toLowerCase()
-                : encodeString(acv.getSubscriptionId().replaceAll("-", "").toLowerCase());
+                : armUtils.encodeString(acv.getSubscriptionId().replaceAll("-", "").toLowerCase());
         String regionInitials = WordUtils.initials(Region.findByLabelOrName(region).label(), ' ').toLowerCase();
-        String resourceGroupPart = encodeString(resourceGroup);
+        String resourceGroupPart = armUtils.encodeString(resourceGroup);
         String result = String.format("%s%s%s%s", prefix, regionInitials, subscriptionIdPart, resourceGroupPart);
         if (result.length() > MAX_LENGTH_OF_RESOURCE_NAME) {
             result = result.substring(0, MAX_LENGTH_OF_RESOURCE_NAME);
         }
         LOGGER.debug("Storage account name: {}", result);
         return result;
-    }
-
-    // Encode input to 8 digit hex output
-    private String encodeString(String string) {
-        if (StringUtils.isNotBlank(string)) {
-            byte[] bytes = string.getBytes();
-            Checksum checksum = new Adler32();
-            checksum.reset();
-            checksum.update(bytes, 0, bytes.length);
-            long checksumValue = checksum.getValue();
-            return Long.toHexString(checksumValue).toLowerCase();
-        } else {
-            return "";
-        }
     }
 
     public String getDiskContainerName(CloudContext cloudContext) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureUtils.java
@@ -10,6 +10,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.zip.Adler32;
+import java.util.zip.Checksum;
 
 import javax.inject.Inject;
 
@@ -722,6 +724,20 @@ public class AzureUtils {
                     actionDescription, e.body().code(), e.body().message(), details));
         } else {
             return new CloudConnectorException(String.format("%s failed: '%s', please go to Azure Portal for detailed message", actionDescription, e));
+        }
+    }
+
+    // Encode input to 8 digit hex output
+    public String encodeString(String string) {
+        if (StringUtils.isNotBlank(string)) {
+            byte[] bytes = string.getBytes();
+            Checksum checksum = new Adler32();
+            checksum.reset();
+            checksum.update(bytes, 0, bytes.length);
+            long checksumValue = checksum.getValue();
+            return Long.toHexString(checksumValue).toLowerCase();
+        } else {
+            return "";
         }
     }
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStorageTest.java
@@ -115,6 +115,8 @@ public class AzureStorageTest {
 
         when(azureResourceGroupMetadataProvider.useSingleResourceGroup(cloudStack)).thenReturn(true);
         when(azureResourceGroupMetadataProvider.getResourceGroupName(cloudContext, cloudStack)).thenReturn(RESOURCE_GROUP);
+        when(armUtils.encodeString(RESOURCE_GROUP)).thenReturn("2b8305c3");
+        when(armUtils.encodeString("subscriptionone")).thenReturn("33890668");
 
         String imageStorageName = underTest.getImageStorageName(azureCredentialView, cloudContext, cloudStack);
         assertEquals("cbimgwu2338906682b8305c3", imageStorageName);
@@ -128,6 +130,8 @@ public class AzureStorageTest {
         CloudContext cloudContext = createCloudContext();
 
         when(azureResourceGroupMetadataProvider.useSingleResourceGroup(cloudStack)).thenReturn(false);
+        when(armUtils.encodeString("subscriptionone")).thenReturn("33890668");
+        when(armUtils.encodeString(null)).thenReturn("");
 
         String imageStorageName = underTest.getImageStorageName(azureCredentialView, cloudContext, cloudStack);
         assertEquals("cbimgwu2subscriptionone", imageStorageName);


### PR DESCRIPTION
Whenever we create a Private Link on Azure we use the name of the subnet
and the name of the DB server to construct the Private Link name. However,
this name has a length limit of 85 characters. If the name of the subnet
is too long then the cluster creation will fail with the following message:

```
{
  "error": {
    "code": "PrivateEndpointNameTooLong",
    "message": "Call to Microsoft.DBforPostgreSQL/servers failed. Error message: Private Endpoint Name may only be a maximum of 85 characters",
    "details": []
  }
}
```

To shorten the Private Link name we're going to use the Adler32 algorithm
to get a fix 8 characters long hash of the subnet. The same algorithm is
already used when we create the Storage Accounts.
