### PR TITLE
CB-12481: Use hardfail for FreeIPA salt states that affect running ...

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backups.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backups.sls
@@ -7,6 +7,7 @@ freeipa_initial_full_backup:
   cmd.run:
     - name: /usr/local/bin/freeipa_backup -t FULL -f "{{salt['grains.get']('fqdn')}}/full" && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/freeipa_initial_backup-executed
     - unless: test -f /var/log/freeipa_initial_backup-executed
+    - failhard: True
     - require:
         - file: /usr/local/bin/freeipa_backup
         - file: /usr/local/bin/backup-log-filter.sh
@@ -18,6 +19,7 @@ freeipa_backoff_monthly_full:
   cmd.run:
     - name: /sbin/anacron -u cron.monthly
     - onlyif: test ! -s /var/spool/anacron/cron.monthly
+    - failhard: True
 
 /etc/cron.monthly/freeipa_backup_monthly:
   file.managed:

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/common-install.sls
@@ -6,6 +6,7 @@ update_cnames:
         - DOMAIN: {{salt['pillar.get']('freeipa:domain')}}
         - REALM: {{salt['pillar.get']('freeipa:realm')}}
         - ADMIN_USER: {{salt['pillar.get']('freeipa:admin_user')}}
+    - failhard: True
     - require:
         - file: /opt/salt/scripts/update_cnames.sh
 
@@ -15,6 +16,7 @@ one_week_next_update_grace_period:
       - service pki-tomcatd@pki-tomcat stop
       - sed -i 's/^ca[.]crl[.]MasterCRL[.]nextUpdateGracePeriod=.*/ca.crl.MasterCRL.nextUpdateGracePeriod=10080/' /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
       - service pki-tomcatd@pki-tomcat start
+    - failhard: True
     - unless: grep "^ca[.]crl[.]MasterCRL[.]nextUpdateGracePeriod=10080$" /var/lib/pki/pki-tomcat/ca/conf/CS.cfg
 
 add-httpd-x-cdp-trace-id:
@@ -39,6 +41,7 @@ restart_freeipa_after_plugin_change:
   service.running:
     - name: ipa
     - onlyif: test -f /etc/ipa/default.conf
+    - failhard: True
     - watch:
       - file: /usr/lib/python2.7/site-packages/ipaserver/plugins/getkeytab.py
       - file: /usr/lib/python2.7/site-packages/ipaserver/rpcserver.py
@@ -53,6 +56,7 @@ set_number_of_krb5kdc_workers:
 restart_krb5kdc:
   service.running:
     - name: krb5kdc
+    - failhard: True
     - watch:
       - file: /etc/sysconfig/krb5kdc
 
@@ -87,6 +91,7 @@ disable_http_trace:
 restart_httpd:
   service.running:
     - name: httpd
+    - failhard: True
     - watch:
       - file: /etc/httpd/conf.d/ipa-rewrite.conf
       - file: /etc/httpd/conf/httpd.conf
@@ -101,5 +106,6 @@ restart_sssd_if_reconfigured:
   service.running:
     - enable: True
     - name: sssd
+    - failhard: True
     - watch:
       - file: /etc/sssd/sssd.conf

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/healthagent.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/healthagent.sls
@@ -34,4 +34,5 @@ setup-healthagent-certs:
 start-freeipa-healthagent:
   service.running:
     - name: cdp-freeipa-healthagent
+    - failhard: True
     - enable: True

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
@@ -1,5 +1,6 @@
 freeipa-install:
   pkg.installed:
+    - failhard: True
     - pkgs:
         - ipa-server
         - ipa-server-dns

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/services.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/services.sls
@@ -72,5 +72,6 @@ dirSrvRestartSec:
 reload-systemd:
   cmd.run:
     - name: systemctl daemon-reload
+    - failhard: True
 
 {%- endif %}

--- a/freeipa/src/main/resources/freeipa-salt/salt/nginx/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/nginx/init.sls
@@ -36,5 +36,6 @@ restart_nginx_after_ssl_reconfig:
   service.running:
     - name: nginx
     - enable: True
+    - failhard: True
     - watch:
       - file: /etc/nginx/sites-enabled/ssl.conf


### PR DESCRIPTION
...services

Ensure that if a salt command which affects a service fails, the later
steps are not run. If a service fails to start, then many later salt
commands can fail. By using a hard fail, it is easier to diagnose the
root cause of the failure using the salt error message and salt logs.

This was tested using a local deployment of cloudbreak.

See detailed description in the commit message.

Please note: I did not hardfail every salt command, but I think I got the ones that affect the running services on FreeIPA.