### PR TITLE
CB-12411: Fix String.format("{}") to use "%s" instead

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/client/YarnMetricsClient.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/client/YarnMetricsClient.java
@@ -58,7 +58,7 @@ public class YarnMetricsClient {
             String hostGroup, Optional<Integer> mandatoryDownScaleCount) throws Exception {
         TlsConfiguration tlsConfig = tlsSecurityService.getTls(cluster.getId());
         String clusterProxyUrl = clusterProxyConfigurationService.getClusterProxyUrl()
-                .orElseThrow(() -> new RuntimeException(String.format("ClusterProxy Not Configured for Cluster {}, " +
+                .orElseThrow(() -> new RuntimeException(String.format("ClusterProxy Not Configured for Cluster %s, " +
                         " cannot query YARN Metrics.", cluster.getStackCrn())));
 
         Client restClient = RestClientUtil.createClient(tlsConfig.getServerCert(),

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/ChangePrimaryGatewayService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/repair/changeprimarygw/ChangePrimaryGatewayService.java
@@ -111,6 +111,6 @@ public class ChangePrimaryGatewayService {
         return instanceMetaDataSet.stream()
                 .filter(im -> instanceId.equals(im.getInstanceId()))
                 .findFirst()
-                .orElseThrow(() -> new NotFoundException(String.format("The instance id {} could not be found", instanceId)));
+                .orElseThrow(() -> new NotFoundException(String.format("The instance id %s could not be found", instanceId)));
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/RebootActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/instance/reboot/action/RebootActions.java
@@ -211,7 +211,7 @@ public class RebootActions {
             protected void doExecute(RebootContext context, InstanceFailureEvent payload, Map<Object, Object> variables) {
                 addMdcOperationId(variables);
                 rebootService.handleInstanceRebootError(context);
-                String message = String.format("Rebooting failed for {}.", context.getInstanceIds());
+                String message = String.format("Rebooting failed for %s.", context.getInstanceIds());
                 LOGGER.error(message);
                 Stack stack = context.getStack();
                 SuccessDetails successDetails = new SuccessDetails(stack.getEnvironmentCrn());

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/SubnetListerService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/network/SubnetListerService.java
@@ -56,7 +56,7 @@ public class SubnetListerService {
         if (credential.getAzure().isPresent()) {
             return credential.getAzure().get().getSubscriptionId();
         } else {
-            throw new RedbeamsException(String.format("Retrieved credential {} for Azure environment {} which lacks subscription ID",
+            throw new RedbeamsException(String.format("Retrieved credential %s for Azure environment %s which lacks subscription ID",
                     credential.getName(), environmentCrn));
         }
     }


### PR DESCRIPTION
Fix String.format("{}") to use "%s" instead.

See detailed description in the commit message.