### PR TITLE
CDPD-25222 Disable hive.compactor.initiator.on in DL HMS

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx-medium-ha.bp
@@ -412,7 +412,13 @@
           {
             "base": true,
             "refName": "hive-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE"
+            "roleType": "HIVEMETASTORE",
+            "configs": [
+              { 
+                "name": "hive_compactor_initiator_on",
+                "value": "false"
+              }
+            ]
           }
         ],
         "serviceType": "HIVE"

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx.bp
@@ -357,7 +357,13 @@
           {
             "base": true,
             "refName": "hive-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE"
+            "roleType": "HIVEMETASTORE",
+            "configs": [
+              { 
+                "name": "hive_compactor_initiator_on",
+                "value": "false"
+              }
+            ]
           }
         ],
         "serviceType": "HIVE"

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx-medium-ha.bp
@@ -412,7 +412,13 @@
           {
             "base": true,
             "refName": "hive-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE"
+            "roleType": "HIVEMETASTORE",
+            "configs": [
+              { 
+                "name": "hive_compactor_initiator_on",
+                "value": "false"
+              }
+            ]
           }
         ],
         "serviceType": "HIVE"

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx.bp
@@ -357,7 +357,13 @@
           {
             "base": true,
             "refName": "hive-HIVEMETASTORE-BASE",
-            "roleType": "HIVEMETASTORE"
+            "roleType": "HIVEMETASTORE",
+            "configs": [
+              { 
+                "name": "hive_compactor_initiator_on",
+                "value": "false"
+              }
+            ]
           }
         ],
         "serviceType": "HIVE"


### PR DESCRIPTION
[CDPD-25222](https://jira.cloudera.com/browse/CDPD-25222)

Initiator running in DL HMS adds up object store listing cost.
Hence setting following config to turn it off.
  hive.compactor.initiator.on=false

Testing done:
Have created a DL using a modified sdx template that includes above mentioned config change. DL creation was successful on AWS and config change was applied.