### PR TITLE
CB-12497: Add availability status to the FreeIPA list API

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/list/ListFreeIpaResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/list/ListFreeIpaResponse.java
@@ -5,6 +5,7 @@ import javax.validation.constraints.NotNull;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.service.api.doc.ModelDescriptions;
 
@@ -32,6 +33,8 @@ public class ListFreeIpaResponse {
     private Status status;
 
     private String statusString;
+
+    private AvailabilityStatus availabilityStatus;
 
     public String getEnvironmentCrn() {
         return environmentCrn;
@@ -79,5 +82,13 @@ public class ListFreeIpaResponse {
 
     public void setStatusString(String statusString) {
         this.statusString = statusString;
+    }
+
+    public AvailabilityStatus getAvailabilityStatus() {
+        return availabilityStatus;
+    }
+
+    public void setAvailabilityStatus(AvailabilityStatus availabilityStatus) {
+        this.availabilityStatus = availabilityStatus;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/FreeIpaToListFreeIpaResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/FreeIpaToListFreeIpaResponseConverter.java
@@ -3,6 +3,8 @@ package com.sequenceiq.freeipa.converter.stack;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
@@ -11,6 +13,9 @@ import com.sequenceiq.freeipa.entity.Stack;
 
 @Component
 public class FreeIpaToListFreeIpaResponseConverter {
+
+    @Inject
+    private StackToAvailabilityStatusConverter stackToAvailabilityStatusConverter;
 
     public List<ListFreeIpaResponse> convertList(List<FreeIpa> freeIpaList) {
         return freeIpaList.stream()
@@ -28,6 +33,7 @@ public class FreeIpaToListFreeIpaResponseConverter {
             response.setEnvironmentCrn(stack.getEnvironmentCrn());
             response.setStatus(stack.getStackStatus().getStatus());
             response.setStatusString(stack.getStackStatus().getStatusString());
+            response.setAvailabilityStatus(stackToAvailabilityStatusConverter.convert(stack));
         }
         return response;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToAvailabilityStatusConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToAvailabilityStatusConverter.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.freeipa.converter.stack;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.StackStatus;
+
+@Component
+public class StackToAvailabilityStatusConverter {
+
+    public AvailabilityStatus convert(Stack stack) {
+        StackStatus status = stack.getStackStatus();
+        if (status == null || status.getDetailedStackStatus() == null) {
+            return AvailabilityStatus.UNKNOWN;
+        }
+        return status.getDetailedStackStatus().getAvailabilityStatus();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
@@ -16,7 +16,6 @@ import com.sequenceiq.common.api.cloudstorage.StorageIdentityBase;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
 import com.sequenceiq.common.model.CloudIdentityType;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerResponse;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceMetaDataResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.region.PlacementResponse;
@@ -31,7 +30,6 @@ import com.sequenceiq.freeipa.converter.usersync.UserSyncStatusToUserSyncStatusR
 import com.sequenceiq.freeipa.entity.FreeIpa;
 import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
-import com.sequenceiq.freeipa.entity.StackStatus;
 import com.sequenceiq.freeipa.entity.UserSyncStatus;
 import com.sequenceiq.freeipa.service.config.FreeIpaDomainUtils;
 import com.sequenceiq.freeipa.util.BalancedDnsAvailabilityChecker;
@@ -63,6 +61,9 @@ public class StackToDescribeFreeIpaResponseConverter {
     @Inject
     private BalancedDnsAvailabilityChecker balancedDnsAvailabilityChecker;
 
+    @Inject
+    private StackToAvailabilityStatusConverter stackToAvailabilityStatusConverter;
+
     public DescribeFreeIpaResponse convert(Stack stack, ImageEntity image, FreeIpa freeIpa, UserSyncStatus userSyncStatus) {
         DescribeFreeIpaResponse describeFreeIpaResponse = new DescribeFreeIpaResponse();
         describeFreeIpaResponse.setName(stack.getName());
@@ -75,7 +76,7 @@ public class StackToDescribeFreeIpaResponseConverter {
         describeFreeIpaResponse.setNetwork(networkResponseConverter.convert(stack));
         describeFreeIpaResponse.setPlacement(convert(stack));
         describeFreeIpaResponse.setInstanceGroups(instanceGroupConverter.convert(stack.getInstanceGroups()));
-        describeFreeIpaResponse.setAvailabilityStatus(convertAvailabilityStatus(stack.getStackStatus()));
+        describeFreeIpaResponse.setAvailabilityStatus(stackToAvailabilityStatusConverter.convert(stack));
         describeFreeIpaResponse.setStatus(stack.getStackStatus().getStatus());
         describeFreeIpaResponse.setStatusString(stack.getStackStatus().getStatusString());
         describeFreeIpaResponse.setStatusReason(stack.getStackStatus().getStatusReason());
@@ -125,12 +126,5 @@ public class StackToDescribeFreeIpaResponseConverter {
         placementResponse.setAvailabilityZone(source.getAvailabilityZone());
         placementResponse.setRegion(source.getRegion());
         return placementResponse;
-    }
-
-    private AvailabilityStatus convertAvailabilityStatus(StackStatus status) {
-        if (status == null || status.getDetailedStackStatus() == null) {
-            return AvailabilityStatus.UNKNOWN;
-        }
-        return status.getDetailedStackStatus().getAvailabilityStatus();
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/FreeIpaToListFreeIpaResponseConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/FreeIpaToListFreeIpaResponseConverterTest.java
@@ -1,14 +1,18 @@
 package com.sequenceiq.freeipa.converter.stack;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
 import com.sequenceiq.freeipa.entity.FreeIpa;
@@ -33,9 +37,14 @@ class FreeIpaToListFreeIpaResponseConverterTest {
     @InjectMocks
     private FreeIpaToListFreeIpaResponseConverter underTest;
 
+    @Mock
+    private StackToAvailabilityStatusConverter stackToAvailabilityStatusConverter;
+
     @Test
     void testConvertList() {
         List<FreeIpa> freeIpaList = createFreeIpaList();
+
+        when(stackToAvailabilityStatusConverter.convert(any())).thenReturn(AvailabilityStatus.AVAILABLE);
 
         List<ListFreeIpaResponse> actual = underTest.convertList(freeIpaList);
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToAvailabiltyStatusConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToAvailabiltyStatusConverterTest.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.freeipa.converter.stack;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.StackStatus;
+
+@ExtendWith(MockitoExtension.class)
+class StackToAvailabiltyStatusConverterTest {
+
+    @InjectMocks
+    private StackToAvailabilityStatusConverter underTest;
+
+    @Test
+    void testConvertUnknown() {
+        Stack stack = mock(Stack.class);
+        assertEquals(AvailabilityStatus.UNKNOWN, underTest.convert(stack));
+    }
+
+    @Test
+    void testConvertAvailable() {
+        Stack stack = new Stack();
+        StackStatus status = new StackStatus();
+        status.setDetailedStackStatus(DetailedStackStatus.AVAILABLE);
+        stack.setStackStatus(status);
+        assertEquals(AvailabilityStatus.AVAILABLE, underTest.convert(stack));
+    }
+
+    @Test
+    void testConvertUnavailable() {
+        Stack stack = new Stack();
+        StackStatus status = new StackStatus();
+        status.setDetailedStackStatus(DetailedStackStatus.UNREACHABLE);
+        stack.setStackStatus(status);
+        assertEquals(AvailabilityStatus.UNAVAILABLE, underTest.convert(stack));
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverterTest.java
@@ -14,6 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerResponse;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsResponse;
@@ -105,6 +106,9 @@ class StackToDescribeFreeIpaResponseConverterTest {
     @Mock
     private BalancedDnsAvailabilityChecker balancedDnsAvailabilityChecker;
 
+    @Mock
+    private StackToAvailabilityStatusConverter stackToAvailabilityStatusConverter;
+
     @BeforeAll
     static void initInstanceGroupResponse() {
         InstanceMetaDataResponse instanceMetaDataResponse = new InstanceMetaDataResponse();
@@ -126,6 +130,7 @@ class StackToDescribeFreeIpaResponseConverterTest {
         when(instanceGroupConverter.convert(stack.getInstanceGroups())).thenReturn(INSTANCE_GROUP_RESPONSES);
         when(userSyncStatusConverter.convert(userSyncStatus)).thenReturn(USERSYNC_STATUS_RESPONSE);
         when(balancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)).thenReturn(true);
+        when(stackToAvailabilityStatusConverter.convert(stack)).thenReturn(AvailabilityStatus.AVAILABLE);
 
         DescribeFreeIpaResponse result = underTest.convert(stack, image, freeIpa, userSyncStatus);
 


### PR DESCRIPTION
Add availability status to the FreeIPA list API.

A unit test was added. This was manually tested with a local
deploymnet of cloudbreak.

See detailed description in the commit message.