### PR TITLE
CB-12464 Fix parcel status polling during upgrade

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDistributeListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDistributeListenerTask.java
@@ -41,7 +41,8 @@ public class ClouderaManagerUpgradeParcelDistributeListenerTask extends Abstract
         String parcelStage = apiParcel.getStage();
 
         if (!ParcelStatus.DISTRIBUTED.name().equals(parcelStage)
-                && !ParcelStatus.ACTIVATED.name().equals(parcelStage)) {
+                && !ParcelStatus.ACTIVATED.name().equals(parcelStage)
+                && !ParcelStatus.ACTIVATING.name().equals(parcelStage)) {
             LOGGER.warn("Expected parcel status is {}, received status is: {}", ParcelStatus.DISTRIBUTED.name(), parcelStage);
             return false;
         } else {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDownloadListenerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDownloadListenerTask.java
@@ -42,7 +42,9 @@ public class ClouderaManagerUpgradeParcelDownloadListenerTask extends AbstractCl
 
         if (!ParcelStatus.DOWNLOADED.name().equals(parcelStage)
                 && !ParcelStatus.DISTRIBUTED.name().equals(parcelStage)
-                && !ParcelStatus.ACTIVATED.name().equals(parcelStage)) {
+                && !ParcelStatus.DISTRIBUTING.name().equals(parcelStage)
+                && !ParcelStatus.ACTIVATED.name().equals(parcelStage)
+                && !ParcelStatus.ACTIVATING.name().equals(parcelStage)) {
             LOGGER.warn("Expected parcel status is {}, received status is: {}", ParcelStatus.DOWNLOADED.name(), parcelStage);
             return false;
         } else {
@@ -51,7 +53,7 @@ public class ClouderaManagerUpgradeParcelDownloadListenerTask extends AbstractCl
     }
 
     @Override
-    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi)  {
+    public void handleTimeout(ClouderaManagerCommandPollerObject toolsResourceApi) {
 
         //when downloading, progress and totalProgress will show the current number of bytes downloaded
         // and the total number of bytes needed to be downloaded respectively.

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDistributeListenerTaskTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDistributeListenerTaskTest.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.cloudbreak.cm.polling.task;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import com.cloudera.api.swagger.ParcelResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiParcel;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
+import com.sequenceiq.cloudbreak.cm.model.ParcelResource;
+import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
+
+public class ClouderaManagerUpgradeParcelDistributeListenerTaskTest {
+
+    private ClouderaManagerUpgradeParcelDistributeListenerTask underTest;
+
+    private ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory;
+
+    private ParcelResource parcelResource;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @BeforeEach
+    public void init() {
+        clouderaManagerApiPojoFactory = mock(ClouderaManagerApiPojoFactory.class);
+        parcelResource = mock(ParcelResource.class);
+        underTest = new ClouderaManagerUpgradeParcelDistributeListenerTask(clouderaManagerApiPojoFactory, null, parcelResource);
+    }
+
+    @Test
+    public void testDoStatusCheckWhenParcelIsActivating() throws ApiException {
+        testDoStatusCheckWhenParcelIsInState(ParcelStatus.ACTIVATING, true);
+    }
+
+    @Test
+    public void testDoStatusCheckWhenParcelIsActivated() throws ApiException {
+        testDoStatusCheckWhenParcelIsInState(ParcelStatus.ACTIVATED, true);
+    }
+
+    @Test
+    public void testDoStatusCheckWhenParcelIsDistributed() throws ApiException {
+        testDoStatusCheckWhenParcelIsInState(ParcelStatus.DISTRIBUTED, true);
+    }
+
+    @Test
+    public void testDoStatusCheckWhenParcelIsDistributing() throws ApiException {
+        testDoStatusCheckWhenParcelIsInState(ParcelStatus.DISTRIBUTING, false);
+    }
+
+    private void testDoStatusCheckWhenParcelIsInState(ParcelStatus parcelStatus, boolean expected) throws ApiException {
+        ApiClient apiClient = mock(ApiClient.class);
+        ParcelResourceApi parcelResourceApi = mock(ParcelResourceApi.class);
+        when(clouderaManagerApiPojoFactory.getParcelResourceApi(apiClient)).thenReturn(parcelResourceApi);
+        when(parcelResource.getProduct()).thenReturn("CDH");
+        when(parcelResource.getClusterName()).thenReturn("clusterName");
+        when(parcelResource.getVersion()).thenReturn("7.2.8");
+        ApiParcel apiParcel = mock(ApiParcel.class);
+        when(parcelResourceApi.readParcel("clusterName", "CDH", "7.2.8")).thenReturn(apiParcel);
+        when(apiParcel.getStage()).thenReturn(parcelStatus.name());
+        ClouderaManagerCommandPollerObject pollerObject = new ClouderaManagerCommandPollerObject(null, apiClient, BigDecimal.ONE);
+        boolean result = underTest.doStatusCheck(pollerObject, null);
+
+        Assertions.assertEquals(expected, result);
+    }
+}

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDownloadListenerTaskTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/polling/task/ClouderaManagerUpgradeParcelDownloadListenerTaskTest.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.cloudbreak.cm.polling.task;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import com.cloudera.api.swagger.ParcelResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiParcel;
+import com.sequenceiq.cloudbreak.cm.client.ClouderaManagerApiPojoFactory;
+import com.sequenceiq.cloudbreak.cm.model.ParcelResource;
+import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
+import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerCommandPollerObject;
+
+public class ClouderaManagerUpgradeParcelDownloadListenerTaskTest {
+
+    private ClouderaManagerUpgradeParcelDownloadListenerTask underTest;
+
+    private ClouderaManagerApiPojoFactory clouderaManagerApiPojoFactory;
+
+    private ParcelResource parcelResource;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @BeforeEach
+    public void init() {
+        clouderaManagerApiPojoFactory = mock(ClouderaManagerApiPojoFactory.class);
+        parcelResource = mock(ParcelResource.class);
+        underTest = new ClouderaManagerUpgradeParcelDownloadListenerTask(clouderaManagerApiPojoFactory, null, parcelResource);
+    }
+
+    @Test
+    public void testDoStatusCheckWhenParcelIsActivating() throws ApiException {
+        testDoStatusCheckWithParcelStatusShouldReturnTrue(ParcelStatus.ACTIVATING, true);
+    }
+
+    @Test
+    public void testDoStatusCheckWhenParcelIsActivated() throws ApiException {
+        testDoStatusCheckWithParcelStatusShouldReturnTrue(ParcelStatus.ACTIVATED, true);
+    }
+
+    @Test
+    public void testDoStatusCheckWhenParcelIsDistributing() throws ApiException {
+        testDoStatusCheckWithParcelStatusShouldReturnTrue(ParcelStatus.DISTRIBUTING, true);
+    }
+
+    @Test
+    public void testDoStatusCheckWhenParcelIsDistributed() throws ApiException {
+        testDoStatusCheckWithParcelStatusShouldReturnTrue(ParcelStatus.DISTRIBUTED, true);
+    }
+
+    @Test
+    public void testDoStatusCheckWhenParcelIsDownloaded() throws ApiException {
+        testDoStatusCheckWithParcelStatusShouldReturnTrue(ParcelStatus.DOWNLOADED, true);
+    }
+
+    @Test
+    public void testDoStatusCheckWhenParcelIsDownloading() throws ApiException {
+        testDoStatusCheckWithParcelStatusShouldReturnTrue(ParcelStatus.DOWNLOADING, false);
+    }
+
+    private void testDoStatusCheckWithParcelStatusShouldReturnTrue(ParcelStatus parcelStatus, boolean expected) throws ApiException {
+        ApiClient apiClient = mock(ApiClient.class);
+        ParcelResourceApi parcelResourceApi = mock(ParcelResourceApi.class);
+        when(clouderaManagerApiPojoFactory.getParcelResourceApi(apiClient)).thenReturn(parcelResourceApi);
+        when(parcelResource.getProduct()).thenReturn("CDH");
+        when(parcelResource.getClusterName()).thenReturn("clusterName");
+        when(parcelResource.getVersion()).thenReturn("7.2.8");
+        ApiParcel apiParcel = mock(ApiParcel.class);
+        when(parcelResourceApi.readParcel("clusterName", "CDH", "7.2.8")).thenReturn(apiParcel);
+        when(apiParcel.getStage()).thenReturn(parcelStatus.name());
+        ClouderaManagerCommandPollerObject pollerObject = new ClouderaManagerCommandPollerObject(null, apiClient, BigDecimal.ONE);
+        boolean result = underTest.doStatusCheck(pollerObject, null);
+
+        Assertions.assertEquals(expected, result);
+    }
+
+}


### PR DESCRIPTION
When we perform an upgrade we need to download and distribute
parcels. This is a long process and we poll the state of these
operations. When the flow is restarted we pre-check the state
of the parcels where we have left off and some of the parcel
states were not considered causing an upgrade failure. For
example when a parcel's status is ACTIVATING that means it's
already downloaded so this state must be considered as well.
This is true for the distributing phase, when a parcel is in
ACTIVATING state that means we've already distribute it.
