### PR TITLE
CB-12412 Update the cluster status to "available" even on datalake ba…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusService.java
@@ -44,7 +44,7 @@ public class BackupRestoreStatusService {
     }
 
     public void handleDatabaseBackupFailure(long stackId, String errorReason, DetailedStackStatus detailedStatus) {
-        clusterService.updateClusterStatusByStackId(stackId, Status.BACKUP_FAILED, errorReason);
+        clusterService.updateClusterStatusByStackId(stackId, Status.AVAILABLE, errorReason);
         stackUpdater.updateStackStatus(stackId, detailedStatus, extractSaltErrorIfAvailable(errorReason));
         flowMessageService.fireEventAndLog(stackId, Status.UPDATE_FAILED.name(), DATALAKE_DATABASE_BACKUP_FAILED, errorReason);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -230,7 +230,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         clusterOperationService.reportHealthChange(stack.getResourceCrn(), newFailedNodeNames, newHealtyHostNames);
         if (!failedInstances.isEmpty()) {
             clusterService.updateClusterStatusByStackId(stack.getId(), Status.AMBIGUOUS);
-        } else if (statesFromAvailabeAllowed().contains(stack.getCluster().getStatus())) {
+        } else if (statesFromAvailableAllowed().contains(stack.getCluster().getStatus())) {
             clusterService.updateClusterStatusByStackId(stack.getId(), Status.AVAILABLE);
         }
     }
@@ -242,7 +242,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         function.run();
     }
 
-    private EnumSet<Status> statesFromAvailabeAllowed() {
+    private EnumSet<Status> statesFromAvailableAllowed() {
         return EnumSet.of(
                 Status.AMBIGUOUS,
                 Status.STOPPED,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/dr/BackupRestoreStatusServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/dr/BackupRestoreStatusServiceTest.java
@@ -74,7 +74,7 @@ public class BackupRestoreStatusServiceTest {
     public void testBackupFailure() {
         ArgumentCaptor<ResourceEvent> captor = ArgumentCaptor.forClass(ResourceEvent.class);
         service.handleDatabaseBackupFailure(STACK_ID, ERROR_MESSAGE, DetailedStackStatus.DATABASE_BACKUP_FAILED);
-        verify(clusterService, times(1)).updateClusterStatusByStackId(STACK_ID, Status.BACKUP_FAILED, ERROR_MESSAGE);
+        verify(clusterService, times(1)).updateClusterStatusByStackId(STACK_ID, Status.AVAILABLE, ERROR_MESSAGE);
         verify(flowMessageService).fireEventAndLog(eq(STACK_ID), eq(Status.UPDATE_FAILED.name()), captor.capture(), eq(ERROR_MESSAGE));
         assertEquals(DATALAKE_DATABASE_BACKUP_FAILED, captor.getValue());
     }


### PR DESCRIPTION
…ckup failure

Currently, when data lake backup fails, cluster status is set to BACKUP_FAILED state. In this state, the cluster can not be stopped. There is no need to be in a failure state like BACKUP_FAILED when a backup fails. We should set the cluster state back to "Available" and log the result of the backup operation in the events.

See detailed description in the commit message.