### PR TITLE
CB-12511 added DeprecatedValidator to blueprint url based submission

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/blueprint/requests/BlueprintV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/blueprint/requests/BlueprintV4Request.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.blueprint.BlueprintV4Base;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.BlueprintModelDescription;
-import com.sequenceiq.cloudbreak.validation.ValidHttpContentSize;
+import com.sequenceiq.cloudbreak.validation.ValidDeprecated;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -28,7 +28,7 @@ public class BlueprintV4Request extends BlueprintV4Base {
     @Pattern(regexp = "^[^;\\/%]*$")
     private String name;
 
-    @ValidHttpContentSize
+    @ValidDeprecated(message = "Submitting Cluster Template by URL is not allowed anymore. Please use text based submission.")
     @ApiModelProperty(BlueprintModelDescription.URL)
     private String url;
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/DeprecatedValidator.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/DeprecatedValidator.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import io.micrometer.core.instrument.util.StringUtils;
+
+public class DeprecatedValidator implements ConstraintValidator<ValidDeprecated, String> {
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (StringUtils.isEmpty(value)) {
+            return true;
+        } else {
+            ValidatorUtil.addConstraintViolation(context,
+                    "You have submitted a field that is not accepted anymore. This is usually due to deprecation or security reasons.");
+            return false;
+        }
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidDeprecated.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/ValidDeprecated.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = DeprecatedValidator.class)
+public @interface ValidDeprecated {
+
+    String message() default "This field has been deprecated and is not in use anymore.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/validation/DeprecatedValidatorTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/validation/DeprecatedValidatorTest.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.cloudbreak.validation;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import javax.validation.ConstraintValidatorContext;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class DeprecatedValidatorTest {
+
+    private DeprecatedValidator underTest;
+
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    private ConstraintValidatorContext context;
+
+    @Before
+    public void setUp() {
+        openMocks(this);
+        when(context.buildConstraintViolationWithTemplate(any(String.class)).addConstraintViolation()).thenReturn(context);
+
+        underTest = new DeprecatedValidator();
+    }
+
+    @Test
+    public void shouldBeValidIfFieldIsEmpty() {
+        assertTrue(underTest.isValid("", context));
+        verify(context, never()).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+    @Test
+    public void shouldBeValidIfFieldIsNull() {
+        assertTrue(underTest.isValid(null, context));
+        verify(context, never()).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+    @Test
+    public void shouldBeInValidIfFieldHasWhiteSpace() {
+        assertFalse(underTest.isValid(" ", context));
+        verify(context, atLeastOnce()).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+    @Test
+    public void shouldValidationFailIfAnyValueIsSubmitted() {
+        assertFalse(underTest.isValid("https://192.168.10.1/", context));
+        verify(context, atLeastOnce()).buildConstraintViolationWithTemplate(any(String.class));
+    }
+
+    @Test
+    public void shouldValidationFailIfAnyStringIsSubmitted() {
+        assertFalse(underTest.isValid("abcd", context));
+        verify(context, atLeastOnce()).buildConstraintViolationWithTemplate(any(String.class));
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/blueprint/BlueprintTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/blueprint/BlueprintTestDto.java
@@ -70,11 +70,6 @@ public class BlueprintTestDto extends AbstractCloudbreakTestDto<BlueprintV4Reque
         return this;
     }
 
-    public BlueprintTestDto withUrl(String url) {
-        getRequest().setUrl(url);
-        return this;
-    }
-
     public BlueprintTestDto withBlueprint(String blueprint) {
         getRequest().setBlueprint(blueprint);
         return this;


### PR DESCRIPTION
New error message when submitting URL for BPs
`Submitting Cluster Template by URL is not allowed anymore. Please use text based submission.
You have submitted a field that is not accepted anymore. This is usually due to deprecation or security reasons.`

Please do not MERGE until @aszegedi is finished with the Blueprint changes for the GUI tests.