### PR TITLE
CB-12188 Remove old salt minions before boostrap

### DIFF
--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -116,4 +116,6 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     void runOrchestratorState(OrchestratorStateParams stateParameters) throws CloudbreakOrchestratorFailedException;
 
     Map<String, String> getFreeDiskSpaceByNodes(Set<Node> nodes, List<GatewayConfig> gatewayConfigs);
+
+    void removeDeadSaltMinions(GatewayConfig gatewayConfig) throws CloudbreakOrchestratorFailedException;
 }


### PR DESCRIPTION
This removes old/dead salt minions that no longer exist on salt masters before bootstrapping new salt master nodes.

See detailed description in the commit message.