### PR TITLE
CB-12533 Disable the upgrade for the Medium duty HA template

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilter.java
@@ -17,7 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.ImagePackageVersion;
@@ -123,8 +122,7 @@ public class ClusterUpgradeImageFilter {
     }
 
     private boolean isValidBlueprint(ImageFilterParams imageFilterParams) {
-        return imageFilterParams.getStackType().equals(StackType.DATALAKE)
-                || blueprintUpgradeOptionValidator.isValidBlueprint(imageFilterParams.getBlueprint());
+        return blueprintUpgradeOptionValidator.isValidBlueprint(imageFilterParams.getBlueprint());
     }
 
     private boolean isOsVersionsMatch(Image currentImage, Image newImage) {
@@ -132,6 +130,6 @@ public class ClusterUpgradeImageFilter {
     }
 
     private ImageFilterResult createEmptyResult() {
-        return new ImageFilterResult(new Images(null, Collections.emptyList(), null, null), "The upgrade is not allowed for this blueprint.");
+        return new ImageFilterResult(new Images(null, Collections.emptyList(), null, null), "The upgrade is not allowed for this template.");
     }
 }

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx-medium-ha.bp
@@ -2,6 +2,7 @@
   "tags": {
     "shared_services_ready": true
   },
+  "blueprintUpgradeOption" : "DISABLED",
   "description": "7.2.10 - Medium SDX template with Atlas, HMS, Ranger and other services they are dependent on.  Services like HDFS, HBASE, RANGER, HMS have HA",
   "blueprint": {
     "cdhVersion": "7.2.10",

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx-medium-ha.bp
@@ -2,6 +2,7 @@
   "tags": {
     "shared_services_ready": true
   },
+  "blueprintUpgradeOption" : "DISABLED",
   "description": "7.2.11 - Medium SDX template with Atlas, HMS, Ranger and other services they are dependent on.  Services like HDFS, HBASE, RANGER, HMS have HA",
   "blueprint": {
     "cdhVersion": "7.2.11",

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx-medium-ha.bp
@@ -2,6 +2,7 @@
   "tags": {
     "shared_services_ready": true
   },
+  "blueprintUpgradeOption" : "DISABLED",
   "description": "7.2.6 - Medium SDX template with Atlas, HMS, Ranger and other services they are dependent on.  Services like HDFS, HBASE, RANGER, HMS have HA",
   "blueprint": {
     "cdhVersion": "7.2.6",

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
@@ -2,6 +2,7 @@
   "tags": {
     "shared_services_ready": true
   },
+  "blueprintUpgradeOption" : "DISABLED",
   "description": "7.2.7 - Medium SDX template with Atlas, HMS, Ranger and other services they are dependent on.  Services like HDFS, HBASE, RANGER, HMS have HA",
   "blueprint": {
     "cdhVersion": "7.2.7",

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx-medium-ha.bp
@@ -2,6 +2,7 @@
   "tags": {
     "shared_services_ready": true
   },
+  "blueprintUpgradeOption" : "DISABLED",
   "description": "7.2.8 - Medium SDX template with Atlas, HMS, Ranger and other services they are dependent on.  Services like HDFS, HBASE, RANGER, HMS have HA",
   "blueprint": {
     "cdhVersion": "7.2.8",

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx-medium-ha.bp
@@ -2,6 +2,7 @@
   "tags": {
     "shared_services_ready": true
   },
+  "blueprintUpgradeOption" : "DISABLED",
   "description": "7.2.9 - Medium SDX template with Atlas, HMS, Ranger and other services they are dependent on.  Services like HDFS, HBASE, RANGER, HMS have HA",
   "blueprint": {
     "cdhVersion": "7.2.9",

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilterTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -109,6 +108,7 @@ public class ClusterUpgradeImageFilterTest {
         when(entitlementDrivenPackageLocationFilter.filterImage(any(Image.class), any(ImageFilterParams.class))).thenReturn(predicate);
         when(imageCreationBasedFilter.filterPreviousImages(any(Image.class), any())).thenReturn(predicate);
         when(cmAndStackVersionFilter.filterCmAndStackVersion(any(ImageFilterParams.class), any())).thenReturn(predicate);
+        when(blueprintUpgradeOptionValidator.isValidBlueprint(any())).thenReturn(true);
     }
 
     @Test
@@ -122,7 +122,6 @@ public class ClusterUpgradeImageFilterTest {
 
         assertTrue(actual.getReason(), actual.getAvailableImages().getCdhImages().contains(this.properImage));
         assertEquals(1, actual.getAvailableImages().getCdhImages().size());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -147,10 +146,9 @@ public class ClusterUpgradeImageFilterTest {
 
         ImageFilterResult actual = underTest.filter(cloudbreakImageCatalogV3, CLOUD_PLATFORM, imageFilterParams);
 
-        assertEquals("The upgrade is not allowed for this blueprint.", actual.getReason());
+        assertEquals("The upgrade is not allowed for this template.", actual.getReason());
         assertTrue(actual.getAvailableImages().getCdhImages().isEmpty());
         verify(blueprintUpgradeOptionValidator).isValidBlueprint(blueprint);
-        verifyNoInteractions(imageCatalogServiceProxy);
     }
 
     @Test
@@ -167,7 +165,6 @@ public class ClusterUpgradeImageFilterTest {
         ImageFilterResult actual = underTest.filter(cloudbreakImageCatalogV3, CLOUD_PLATFORM, imageFilterParams);
 
         assertTrue(actual.getAvailableImages().getCdhImages().isEmpty());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -184,7 +181,6 @@ public class ClusterUpgradeImageFilterTest {
         ImageFilterResult actual = underTest.filter(cloudbreakImageCatalogV3, CLOUD_PLATFORM, imageFilterParams);
 
         assertTrue(actual.getAvailableImages().getCdhImages().isEmpty());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -200,7 +196,6 @@ public class ClusterUpgradeImageFilterTest {
 
         assertTrue(actual.getReason(), actual.getAvailableImages().getCdhImages().contains(properImage));
         assertEquals(1, actual.getAvailableImages().getCdhImages().size());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -216,7 +211,6 @@ public class ClusterUpgradeImageFilterTest {
 
         assertTrue(actual.getAvailableImages().getCdhImages().isEmpty());
         assertEquals("There are no eligible images to upgrade for aws cloud platform.", actual.getReason());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -232,7 +226,6 @@ public class ClusterUpgradeImageFilterTest {
 
         assertTrue(actual.getAvailableImages().getCdhImages().isEmpty());
         assertEquals("There are no eligible images to upgrade with the same OS version.", actual.getReason());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -247,7 +240,6 @@ public class ClusterUpgradeImageFilterTest {
 
         assertTrue(actual.getAvailableImages().getCdhImages().isEmpty());
         assertEquals("There are no eligible images with supported Cloudera Manager or CDP version.", actual.getReason());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -262,7 +254,6 @@ public class ClusterUpgradeImageFilterTest {
 
         assertTrue(actual.getAvailableImages().getCdhImages().isEmpty());
         assertEquals("There are no eligible images to upgrade available with Cloudera Manager packages.", actual.getReason());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -278,7 +269,6 @@ public class ClusterUpgradeImageFilterTest {
 
         assertTrue(actual.getReason(), actual.getAvailableImages().getCdhImages().contains(imageWithSameStackAndCmVersion));
         assertEquals(1, actual.getAvailableImages().getCdhImages().size());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -294,7 +284,6 @@ public class ClusterUpgradeImageFilterTest {
 
         assertTrue(actual.getAvailableImages().getCdhImages().contains(properImage));
         assertEquals(1, actual.getAvailableImages().getCdhImages().size());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -309,7 +298,6 @@ public class ClusterUpgradeImageFilterTest {
 
         assertTrue(actual.getAvailableImages().getCdhImages().isEmpty());
         assertEquals("There are no newer compatible images available.", actual.getReason());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -326,7 +314,6 @@ public class ClusterUpgradeImageFilterTest {
         ImageFilterResult actual = underTest.filter(cloudbreakImageCatalogV3, CLOUD_PLATFORM, imageFilterParams);
 
         assertEquals(actual.getReason(), 2, actual.getAvailableImages().getCdhImages().size());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     @Test
@@ -343,7 +330,6 @@ public class ClusterUpgradeImageFilterTest {
         ImageFilterResult actual = underTest.filter(cloudbreakImageCatalogV3, CLOUD_PLATFORM, imageFilterParams);
 
         assertEquals(actual.getReason(), 2, actual.getAvailableImages().getCdhImages().size());
-        verifyNoInteractions(blueprintUpgradeOptionValidator);
     }
 
     private Image createCurrentImage() {


### PR DESCRIPTION
The upgrade is broken for Medium Duty with CCM. Broken means that
the repair phase of the upgrade process will fail. In the repair phase
we're re-creating all the instances with the new cloud image. Until
this bug is not fixed it is not safe to do an upgrade on this cluster
type. In the blueprint there is a field where this can be controlled
however, it's only updated when certain operations are performed like
opening the Shared resources > Cluster templates page or the
Cluster Definitions page on the Data Lake page. There are other operations
that can refresh this field in the database like launching Data Hubs or
the cache expires.
