### PR TITLE
CB-12550 - [Knox] Increase sockettimeout and connection timeout values for ATLAS dispatches

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -570,6 +570,14 @@
               <name>replayBufferSize</name>
               <value>128</value>
         </param>
+        <param>
+              <name>httpclient.connectionTimeout</name>
+              <value>5m</value>
+        </param>
+        <param>
+               <name>httpclient.socketTimeout</name>
+               <value>5m</value>
+        </param>
     </service>
     <service>
         <role>ATLAS-API</role>
@@ -579,6 +587,14 @@
         <param>
               <name>replayBufferSize</name>
               <value>128</value>
+        </param>
+        <param>
+              <name>httpclient.connectionTimeout</name>
+              <value>5m</value>
+        </param>
+        <param>
+               <name>httpclient.socketTimeout</name>
+               <value>5m</value>
         </param>
     </service>
     {%- endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -278,6 +278,14 @@
               <name>replayBufferSize</name>
               <value>128</value>
         </param>
+        <param>
+              <name>httpclient.connectionTimeout</name>
+              <value>5m</value>
+        </param>
+        <param>
+               <name>httpclient.socketTimeout</name>
+               <value>5m</value>
+        </param>
     </service>
     {%- endif %}
     {%- endif %}


### PR DESCRIPTION
Currently the default socket timeout and connection timeouts are default (120s) which appear to be low in some cases. 
It was requested [CB-12550](https://jira.cloudera.com/browse/CB-12550) to increase the timeout to bring it in line with that of other services like CM. 

This PR increases the socket timeout for Atlas and Atlas API service to 5m.