### PR TITLE
ENGESC-5190 Make Hue follow the HDFS failovers using WebHDFS

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
@@ -107,6 +107,11 @@
               {
                 "name": "hdfs_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
+              },
+              {
+                "refName": "hdfs-HTTPFS-BASE",
+                "roleType": "HTTPFS",
+                "base": true
               }
             ]
           }
@@ -483,6 +488,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
@@ -107,6 +107,11 @@
               {
                 "name": "hdfs_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
+              },
+              {
+                "refName": "hdfs-HTTPFS-BASE",
+                "roleType": "HTTPFS",
+                "base": true
               }
             ]
           }
@@ -483,6 +488,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
@@ -107,6 +107,11 @@
               {
                 "name": "hdfs_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
+              },
+              {
+                "refName": "hdfs-HTTPFS-BASE",
+                "roleType": "HTTPFS",
+                "base": true
               }
             ]
           }
@@ -483,6 +488,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
@@ -107,6 +107,11 @@
               {
                 "name": "hdfs_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
+              },
+              {
+                "refName": "hdfs-HTTPFS-BASE",
+                "roleType": "HTTPFS",
+                "base": true
               }
             ]
           }
@@ -483,6 +488,7 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",


### PR DESCRIPTION
1. This was done upto 7.2.7 via #9628
2. 7.2.8 template must have been in code-review at that time.
3. So the template change did not reflect in the future versions.
4. Without this customers cannot use Hue Oozie editor in DE HA cluster.