### PR TITLE
CB-10402:  Load balancer support on Azure to enable semi-private networks

### DIFF
--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -297,17 +297,15 @@
                                    </#if>
                                    <#if loadBalancerMapping[instance.groupName]?? && (loadBalancerMapping[instance.groupName]?size > 0)>
                                    ,"loadBalancerBackendAddressPools": [
-                                       {
                                            <#--
                                                This is adding the NIC to all load balancer backend address pools.
                                                When we add more load balancers, we'll have to associate the NIC with
                                                only a single LB pool
                                            -->
-                                           <#list loadBalancerMapping[instance.groupName] as loadBalancer>
-                                           "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '${loadBalancer.name}', 'address-pool')]"
-                                           <#if (loadBalancer_index + 1) != loadBalancerMapping[instance.groupName]?size>,</#if>
-                                           </#list>
-                                       }
+                                       <#list loadBalancerMapping[instance.groupName] as loadBalancer>
+                                       { "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', '${loadBalancer.name}', 'address-pool')]" }
+                                       <#sep>, </#sep>
+                                       </#list>
                                    ]
                                    </#if>
                                }


### PR DESCRIPTION
Closes [CB-10402](https://jira.cloudera.com/browse/CB-10402).

* Fix arm-template issue.
* Refactor AzureLoadBalancerModelBuilder.

## ARM template issue
I messed up nesting levels of the arm template and had a template that looked like:
```
[
  { "id": "value", "id": "different_value"}
]
```

instead of:
```
[
  {"id": "value"},
  {"id": "different_value"}
]
```
Causing NICs to be set up belonging to only a single backend address pool, rather than both the public and private pools.

## Refactor
The AzureLoadBalancerModelBuilder is just reordering method definitions to match the invocation and including a javadoc comment.

## Testing
Tested by creating an Azure Medium Duty DL using the `--no-use-public-ip` and forcing Cloudbreak to set up an Azure environment with the `PublicEndpointAccessGateway.ENABLED` option.

This should simulate the configuration of Azure semi-private networks.
