### PR TITLE
CDPD-9522 Set hive.vectorized.adaptor.usage.mode to all

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
@@ -170,6 +170,10 @@
               {
                 "name": "hiveserver2_idle_session_timeout",
                 "value": 14400000
+              },
+              {
+                "name": "hiveserver2_vectorized_adaptor_usage_mode",
+                "value": "all"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
@@ -320,6 +320,10 @@
               {
                 "name": "hiveserver2_idle_session_timeout",
                 "value": 14400000
+              },
+              {
+                "name": "hiveserver2_vectorized_adaptor_usage_mode",
+                "value": "all"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
@@ -310,6 +310,10 @@
               {
                 "name": "hiveserver2_idle_session_timeout",
                 "value": 14400000
+              },
+              {
+                "name": "hiveserver2_vectorized_adaptor_usage_mode",
+                "value": "all"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
@@ -170,6 +170,10 @@
               {
                 "name": "hiveserver2_idle_session_timeout",
                 "value": 14400000
+              },
+              {
+                "name": "hiveserver2_vectorized_adaptor_usage_mode",
+                "value": "all"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-spark3.bp
@@ -320,6 +320,10 @@
               {
                 "name": "hiveserver2_idle_session_timeout",
                 "value": 14400000
+              },
+              {
+                "name": "hiveserver2_vectorized_adaptor_usage_mode",
+                "value": "all"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering.bp
@@ -310,6 +310,10 @@
               {
                 "name": "hiveserver2_idle_session_timeout",
                 "value": 14400000
+              },
+              {
+                "name": "hiveserver2_vectorized_adaptor_usage_mode",
+                "value": "all"
               }
             ]
           }


### PR DESCRIPTION
[CDPD-9522](https://jira.cloudera.com/browse/CDPD-9522)
Default value of hive.vectorized.adaptor.usage.mode is "chosen", this
causes vectorization misses for hive queries. Hence setting following:
  hive.vectorized.adaptor.usage.mode=all
for 7.2.10 & 7.2.11 DE, DE-HA, DE-Spark3 templates.

Testing done:
Have created a datahub cluster using a modified DE template that includes above mentioned config change. Datahub cluster creation was successful on AWS and config change was applied.