### PR TITLE
CDPD-24463 Hive proto logs not cleared up

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
@@ -141,7 +141,7 @@
           {
             "name": "hive_service_config_safety_valve",
             "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
-                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property>"
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-spark3.bp
@@ -291,7 +291,7 @@
           {
             "name": "hive_service_config_safety_valve",
             "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>
-                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property>"
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering.bp
@@ -281,7 +281,7 @@
           {
             "name": "hive_service_config_safety_valve",
             "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
-                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property>"
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
@@ -141,7 +141,7 @@
           {
             "name": "hive_service_config_safety_valve",
             "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
-                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property>"
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-spark3.bp
@@ -291,7 +291,7 @@
           {
             "name": "hive_service_config_safety_valve",
             "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>
-                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property>"
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering.bp
@@ -281,7 +281,7 @@
           {
             "name": "hive_service_config_safety_valve",
             "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
-                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property>"
+                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>"
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
[CDPD-24463](https://jira.cloudera.com/browse/CDPD-24463)
This sets hive.hook.proto.events.clean.freq=1h
for 7.2.10 and 7.2.11 DE, DE-HA, DE-Spark3 templates, so that logs are purged
every hour and saves storage cost. This will incur few list calls to object stores every hour.

Testing done:
Have created a datahub cluster using a modified DE template that includes above mentioned config change. Datahub cluster creation was successful on AWS and config change was applied.