### PR TITLE
CB-12559 add default client configuration for cloudwatchclient

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsClient.java
@@ -138,6 +138,7 @@ public class AwsClient {
 
     public AmazonCloudWatchClient createCloudWatchClient(AwsCredentialView awsCredential, String regionName) {
         AmazonCloudWatch client = proxy(com.amazonaws.services.cloudwatch.AmazonCloudWatchClient.builder()
+                .withClientConfiguration(getDefaultClientConfiguration())
                 .withCredentials(getCredentialProvider(awsCredential))
                 .withRequestHandlers(new AwsTracingRequestHandler(tracer))
                 .withRegion(regionName)


### PR DESCRIPTION
Stack update failed. Reason: Failed to create some resource on AWS for upscaled nodes, please check your quotas on AWS. Original autoscaling group state has been recovered. Exception: Cannot execute method: putMetricAlarm. Rate exceeded (Service: AmazonCloudWatch; Status Code: 400; Error Code: Throttling; Request ID: 43c0e282-da14-4c0e-aeac-7f72cf61d278; Proxy: null) 