### PR TITLE
CB-12395: DES SP access is not removed from Key Vault when deleting DES

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -983,6 +983,18 @@ public class AzureClient {
         });
     }
 
+    public void removeKeyVaultAccessPolicyFromServicePrincipal(String resourceGroupName, String vaultName, String principalObjectId) {
+        handleAuthException(() -> {
+            azure.vaults()
+                    .getByResourceGroup(resourceGroupName, vaultName)
+                    .update()
+                    .updateAccessPolicy(principalObjectId)
+                    .disallowKeyPermissions(List.of(KeyPermissions.WRAP_KEY, KeyPermissions.UNWRAP_KEY, KeyPermissions.GET))
+                    .parent()
+                    .apply();
+        });
+    }
+
     public void deleteDiskEncryptionSet(String resourceGroup, String diskEncryptionSetName) {
         handleAuthException(() -> {
             // The Disk encryption set operations are not exposed in public API, so have to rely on underlying DiskEncryptionSetsInner

--- a/environment/src/test/java/com/sequenceiq/environment/environment/encryption/EnvironmentEncryptionServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/encryption/EnvironmentEncryptionServiceTest.java
@@ -298,9 +298,10 @@ class EnvironmentEncryptionServiceTest {
                 .filter(r -> r.getType() == ResourceType.AZURE_DISK_ENCRYPTION_SET)
                 .findFirst();
         assertThat(desCloudResourceOptional).isNotEmpty();
-        assertEquals(desCloudResourceOptional.get().getReference(), DISK_ENCRYPTION_SET_ID);
-        assertEquals(desCloudResourceOptional.get().getName(), "Des");
-        assertEquals(desCloudResourceOptional.get().getType(), ResourceType.AZURE_DISK_ENCRYPTION_SET);
+        CloudResource desCloudResource = desCloudResourceOptional.get();
+        assertEquals(desCloudResource.getReference(), DISK_ENCRYPTION_SET_ID);
+        assertEquals(desCloudResource.getName(), "Des");
+        assertEquals(desCloudResource.getType(), ResourceType.AZURE_DISK_ENCRYPTION_SET);
         assertEquals(cloudContext.getAccountId(), ACCOUNT_ID);
         assertEquals(cloudContext.getCrn(), ENVIRONMENT_CRN);
     }


### PR DESCRIPTION
Inorder to to remove the Service principal(SP) access for Disk encryption set(DES) from key vault, following parameters are required -
1. key vault name
2. key vault resource group.
3. DES SP id.

With CB-9920(Phase 1), keyVault resource group is same as des resource group.
For phase 2, where desResourceGroup can be different from keyVaultResourceGroup, it will be taken care off as part of CB-11927.