### PR TITLE
CB-12595 Fix image id retrieval in base image validation test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -56,6 +56,7 @@ import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 import com.sequenceiq.sdx.api.model.SdxInternalClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
@@ -111,6 +112,14 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
     }
 
     public SdxInternalTestDto withDatabase(SdxDatabaseRequest sdxDatabaseRequest) {
+        getRequest().setExternalDatabase(sdxDatabaseRequest);
+        return this;
+    }
+
+    public SdxInternalTestDto withoutDatabase() {
+        final SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
+        sdxDatabaseRequest.setCreate(false);
+        sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
         getRequest().setExternalDatabase(sdxDatabaseRequest);
         return this;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/imagevalidation/PrewarmImageValidatorE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/imagevalidation/PrewarmImageValidatorE2ETest.java
@@ -13,8 +13,6 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.image.DistroXImageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
-import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
-import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 
 public class PrewarmImageValidatorE2ETest extends AbstractImageValidatorE2ETest {
 
@@ -31,11 +29,8 @@ public class PrewarmImageValidatorE2ETest extends AbstractImageValidatorE2ETest 
             when = "a SDX internal create request is sent",
             then = "the SDX cluster and the corresponding DistroX cluster is created")
     public void testCreateInternalSdxAndDistrox(TestContext testContext) {
-        SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
-        sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NONE);
-        sdxDatabaseRequest.setCreate(false);
         testContext.given(SdxInternalTestDto.class)
-                .withDatabase(sdxDatabaseRequest)
+                .withoutDatabase()
                 .withCloudStorage(getCloudStorageRequest(testContext))
                 .withTemplate(commonClusterManagerProperties().getInternalSdxBlueprintName())
                 .withRuntimeVersion(commonClusterManagerProperties().getRuntimeVersion())


### PR DESCRIPTION
Also disable external database creation to reduce test time.

See detailed description in the commit message.