### PR TITLE
CB-11868 Create default edge node cluster definitions.

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/aws/edgenode.json
@@ -1,0 +1,35 @@
+{
+  "name": "7.2.10 COD Edge Node for AWS",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.10 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/azure/edgenode.json
@@ -1,0 +1,38 @@
+{
+  "name": "7.2.10 COD Edge Node for Azure",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.10 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3",
+          "cloudPlatform": "AZURE"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/yarn/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/yarn/edgenode.json
@@ -1,0 +1,27 @@
+{
+  "name": "7.2.10 COD Edge Node for YCloud",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.10 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          },
+          "cloudPlatform": "YARN"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/aws/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/aws/edgenode.json
@@ -1,0 +1,35 @@
+{
+  "name": "7.2.11 COD Edge Node for AWS",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.11 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/azure/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/azure/edgenode.json
@@ -1,0 +1,38 @@
+{
+  "name": "7.2.11 COD Edge Node for Azure",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.11 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3",
+          "cloudPlatform": "AZURE"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/yarn/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/yarn/edgenode.json
@@ -1,0 +1,27 @@
+{
+  "name": "7.2.11 COD Edge Node for YCloud",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.11 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          },
+          "cloudPlatform": "YARN"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/aws/edgenode.json
@@ -1,0 +1,35 @@
+{
+  "name": "7.2.2 COD Edge Node for AWS",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.2 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/azure/edgenode.json
@@ -1,0 +1,38 @@
+{
+  "name": "7.2.2 COD Edge Node for Azure",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.2 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3",
+          "cloudPlatform": "AZURE"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.2/yarn/edgenode.json
@@ -1,0 +1,27 @@
+{
+  "name": "7.2.2 COD Edge Node for YCloud",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.2 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          },
+          "cloudPlatform": "YARN"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/aws/edgenode.json
@@ -1,0 +1,35 @@
+{
+  "name": "7.2.6 COD Edge Node for AWS",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.6 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/azure/edgenode.json
@@ -1,0 +1,38 @@
+{
+  "name": "7.2.6 COD Edge Node for Azure",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.6 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3",
+          "cloudPlatform": "AZURE"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/yarn/edgenode.json
@@ -1,0 +1,27 @@
+{
+  "name": "7.2.6 COD Edge Node for YCloud",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.6 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          },
+          "cloudPlatform": "YARN"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/aws/edgenode.json
@@ -1,0 +1,35 @@
+{
+  "name": "7.2.7 COD Edge Node for AWS",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.7 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/azure/edgenode.json
@@ -1,0 +1,38 @@
+{
+  "name": "7.2.7 COD Edge Node for Azure",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.7 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3",
+          "cloudPlatform": "AZURE"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/yarn/edgenode.json
@@ -1,0 +1,27 @@
+{
+  "name": "7.2.7 COD Edge Node for YCloud",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.7 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          },
+          "cloudPlatform": "YARN"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/aws/edgenode.json
@@ -1,0 +1,35 @@
+{
+  "name": "7.2.8 COD Edge Node for AWS",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.8 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/azure/edgenode.json
@@ -1,0 +1,38 @@
+{
+  "name": "7.2.8 COD Edge Node for Azure",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.8 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3",
+          "cloudPlatform": "AZURE"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/yarn/edgenode.json
@@ -1,0 +1,27 @@
+{
+  "name": "7.2.8 COD Edge Node for YCloud",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.8 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          },
+          "cloudPlatform": "YARN"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/aws/edgenode.json
@@ -1,0 +1,35 @@
+{
+  "name": "7.2.9 COD Edge Node for AWS",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AWS",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.9 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "standard"
+            }
+          ],
+          "aws": {
+            "encryption": {
+              "type": "NONE"
+            }
+          },
+          "instanceType": "m5.2xlarge"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/azure/edgenode.json
@@ -1,0 +1,38 @@
+{
+  "name": "7.2.9 COD Edge Node for Azure",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "AZURE",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.9 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "attachedVolumes": [
+            {
+              "count": 1,
+              "size": 100,
+              "type": "StandardSSD_LRS"
+            }
+          ],
+          "azure": {
+            "availabilitySet": {
+              "name": "",
+              "faultDomainCount": 2,
+              "updateDomainCount": 20
+            }
+          },
+          "instanceType": "Standard_D8_v3",
+          "cloudPlatform": "AZURE"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/yarn/edgenode.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/yarn/edgenode.json
@@ -1,0 +1,27 @@
+{
+  "name": "7.2.9 COD Edge Node for YCloud",
+  "description": "",
+  "type": "OPERATIONALDATABASE",
+  "featureState": "RELEASED",
+  "cloudPlatform": "YARN",
+  "distroXTemplate": {
+    "cluster": {
+      "blueprintName": "7.2.9 COD Edge Node"
+    },
+    "instanceGroups": [
+      {
+        "name": "leader",
+        "nodeCount": 1,
+        "recoveryMode": "MANUAL",
+        "template": {
+          "yarn": {
+            "cpus": 4,
+            "memory": 8192
+          },
+          "cloudPlatform": "YARN"
+        },
+        "type": "GATEWAY"
+      }
+    ]
+  }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -362,7 +362,7 @@ public class ClusterTemplateTest extends AbstractMockTest {
             assertNotNull(entity);
             assertNotNull(entity.getResponses());
             long defaultCount = entity.getResponses().stream().filter(template -> ResourceStatus.DEFAULT.equals(template.getStatus())).count();
-            long expectedCount = 440;
+            long expectedCount = 461;
             assertEquals("Should have " + expectedCount + " of default cluster templates.", expectedCount, defaultCount);
         } catch (Exception e) {
             throw new TestFailException(String.format("Failed to validate default count of cluster templates: %s", e.getMessage()), e);


### PR DESCRIPTION
We migrated edge node blueprints as defaults. Now the user won't see them under the Create DataHub -> Custom Tab since we only list user managed blueprints there. This change fixes this by creating default cluster templates that the user will see under the Cluster Definitions tab which is what we promised on the first place.