### PR TITLE
CB-12627: Fix NPE after FreeIPA repair failed

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaInstanceHealthDetailsService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaInstanceHealthDetailsService.java
@@ -80,6 +80,10 @@ public class FreeIpaInstanceHealthDetailsService {
     }
 
     private RPCResponse<CheckResult> freeIpaHealthCheck(Stack stack, InstanceMetaData instance) throws FreeIpaClientException {
+        if (instance.getDiscoveryFQDN() == null) {
+            LOGGER.info("The health check cannot run on {} because the instance was not fully installed and it is missing the FQDN", instance);
+            throw new FreeIpaClientException("The legacy health check cannot run on because the instance was not fully installed and it is missing the FQDN");
+        }
         try (FreeIpaHealthCheckClient client = freeIpaHealthCheckClientFactory.getClient(stack, instance)) {
             return client.nodeHealth();
         } catch (FreeIpaClientException e) {
@@ -91,6 +95,10 @@ public class FreeIpaInstanceHealthDetailsService {
     }
 
     private RPCResponse<Boolean> legacyFreeIpaHealthCheck(Stack stack, InstanceMetaData instance) throws FreeIpaClientException {
+        if (instance.getDiscoveryFQDN() == null) {
+            LOGGER.info("The legacy health check cannot run on {} because the instance was not fully installed and it is missing the FQDN", instance);
+            throw new FreeIpaClientException("The legacy health check cannot run on because the instance was not fully installed and it is missing the FQDN");
+        }
         FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStackForLegacyHealthCheck(stack, instance.getDiscoveryFQDN());
         return freeIpaClient.serverConnCheck(freeIpaClient.getHostname(), instance.getDiscoveryFQDN());
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStackHealthDetailsService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStackHealthDetailsService.java
@@ -20,7 +20,6 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.NodeHealthDetails;
-import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 
@@ -48,7 +47,7 @@ public class FreeIpaStackHealthDetailsService {
                 try {
                     NodeHealthDetails nodeHealthDetails = freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(stack, instance);
                     response.addNodeHealthDetailsFreeIpaResponses(nodeHealthDetails);
-                } catch (FreeIpaClientException e) {
+                } catch (Exception e) {
                     addUnreachableResponse(instance, response, e.getLocalizedMessage());
                     LOGGER.error(String.format("Unable to check the health of FreeIPA instance: %s", instance.getInstanceId()), e);
                 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaInstanceHealthDetailsServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaInstanceHealthDetailsServiceTest.java
@@ -335,4 +335,26 @@ public class FreeIpaInstanceHealthDetailsServiceTest {
         Assert.assertThrows(FreeIpaClientException.class, () -> underTest.checkFreeIpaHealth(stack, instanceMetaData));
     }
 
+    @Test
+    public void testCheckFreeIpaHealthThrowsWhenFqdnIsMissing() throws Exception {
+        Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(true);
+
+        InstanceMetaData instanceMetaData = getInstance();
+        instanceMetaData.setDiscoveryFQDN(null);
+        Stack stack = getStack(Set.of(instanceMetaData));
+
+        Assert.assertThrows(FreeIpaClientException.class, () -> underTest.checkFreeIpaHealth(stack, instanceMetaData));
+    }
+
+    @Test
+    public void testCheckLegacyFreeIpaHealthThrowsWhenFqdnIsMissing() throws Exception {
+        Mockito.when(healthCheckAvailabilityChecker.isCdpFreeIpaHeathAgentAvailable(any())).thenReturn(false);
+
+        InstanceMetaData instanceMetaData = getInstance();
+        instanceMetaData.setDiscoveryFQDN(null);
+        Stack stack = getStack(Set.of(instanceMetaData));
+
+        Assert.assertThrows(FreeIpaClientException.class, () -> underTest.checkFreeIpaHealth(stack, instanceMetaData));
+    }
+
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaStackHealthDetailsServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaStackHealthDetailsServiceTest.java
@@ -201,6 +201,21 @@ public class FreeIpaStackHealthDetailsServiceTest {
     }
 
     @Test
+    public void testUnresponsiveSingleNodeThatThrowsRuntimeException() throws Exception {
+        Mockito.when(stackService.getByEnvironmentCrnAndAccountIdWithLists(anyString(), anyString())).thenReturn(getStack());
+        Mockito.when(freeIpaInstanceHealthDetailsService.getInstanceHealthDetails(any(), any())).thenThrow(new RuntimeException("Expected"));
+        HealthDetailsFreeIpaResponse response = underTest.getHealthDetails(ENVIRONMENT_ID, ACCOUNT_ID);
+        Assert.assertEquals(Status.UNREACHABLE, response.getStatus());
+        Assert.assertTrue(response.getNodeHealthDetails().size() == 1);
+        for (NodeHealthDetails nodeHealth:response.getNodeHealthDetails()) {
+            Assert.assertTrue(!nodeHealth.getIssues().isEmpty());
+            Assert.assertEquals(InstanceStatus.UNREACHABLE, nodeHealth.getStatus());
+            Assert.assertTrue(nodeHealth.getIssues().size() == 1);
+            Assert.assertTrue(nodeHealth.getIssues().get(0).equals("Expected"));
+        }
+    }
+
+    @Test
     public void testUnresponsiveSecondaryNode() throws Exception {
         InstanceMetaData im1 = getInstance1();
         InstanceMetaData im2 = getInstance2();


### PR DESCRIPTION
After a FreeIPA HA repair fails, the health checks can throw NPEs. In
some cases the exception affects running the command on other
instances of FreeIPA (e.g. RuntimeException is thrown but only a
FreeIpaClientExcpetion is caught in the loop). The main cause is the
reliance on the FQDN which may be null in the cases where the repair
fails.

This was fixed and tested with unit tests and also it was validated
manually using a local deployment of cloudbreak.

See detailed description in the commit message.