### PR TITLE
CB-11606 Update docker image parents to latest Cloudera image

### DIFF
--- a/docker-autoscale/Dockerfile
+++ b/docker-autoscale/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/openjdk:11.0.6-jdk-slim-buster
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar

--- a/docker-cloudbreak/Dockerfile
+++ b/docker-cloudbreak/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/openjdk:11.0.6-jdk-slim-buster
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar

--- a/docker-datalake/Dockerfile
+++ b/docker-datalake/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/openjdk:11.0.6-jdk-slim-buster
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar

--- a/docker-environment/Dockerfile
+++ b/docker-environment/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/openjdk:11.0.6-jdk-slim-buster
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar

--- a/docker-freeipa/Dockerfile
+++ b/docker-freeipa/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/openjdk:11.0.6-jdk-slim-buster
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar

--- a/docker-redbeams/Dockerfile
+++ b/docker-redbeams/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/openjdk:11.0.6-jdk-slim-buster
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar


### PR DESCRIPTION
A new Cloudera JDK 11.0.6 image was built to have the latest versions of
openssl and p11-kit to comply to findigs of security checks.
