### PR TITLE
CB-12634 Extend AWS policy with S3 encryption permissions

### DIFF
--- a/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
+++ b/cloud-aws/src/main/resources/definitions/aws-cb-policy.json
@@ -138,7 +138,9 @@
         "s3:PutObject",
         "s3:DeleteBucket",
         "s3:PutBucketPublicAccessBlock",
-        "s3:PutBucketTagging"
+        "s3:PutBucketTagging",
+        "s3:GetEncryptionConfiguration",
+        "s3:PutEncryptionConfiguration"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
DWX-6155 adds a feature for encrypting the S3 buckets. This requires
that the IAM policy has the appropriate encryption permissions.

See detailed description in the commit message.