### PR TITLE
CB-12614 Validate at cluster creation time, that instance types support instance storage, when cluster was posted with ephemeral volumes as temporary storage

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceTemplate.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.EncryptionType;
 
 public class InstanceTemplate extends DynamicModel {
@@ -60,6 +61,8 @@ public class InstanceTemplate extends DynamicModel {
 
     private final String imageId;
 
+    private final TemporaryStorage temporaryStorage;
+
     @JsonCreator
     public InstanceTemplate(@JsonProperty("flavor") String flavor,
             @JsonProperty("groupName") String groupName,
@@ -68,7 +71,8 @@ public class InstanceTemplate extends DynamicModel {
             @JsonProperty("status") InstanceStatus status,
             @JsonProperty("parameters") Map<String, Object> parameters,
             @JsonProperty("templateId") Long templateId,
-            @JsonProperty("imageId") String imageId) {
+            @JsonProperty("imageId") String imageId,
+            @JsonProperty("temporaryStorage") TemporaryStorage temporaryStorage) {
         super(parameters);
         this.flavor = flavor;
         this.templateId = templateId;
@@ -77,6 +81,7 @@ public class InstanceTemplate extends DynamicModel {
         this.volumes = ImmutableList.copyOf(volumes);
         this.status = status;
         this.imageId = imageId;
+        this.temporaryStorage = temporaryStorage;
     }
 
     public String getFlavor() {
@@ -105,6 +110,10 @@ public class InstanceTemplate extends DynamicModel {
 
     public String getImageId() {
         return imageId;
+    }
+
+    public TemporaryStorage getTemporaryStorage() {
+        return temporaryStorage;
     }
 
     @Override

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 
 public class AwsInstanceTemplate extends InstanceTemplate {
 
@@ -80,8 +81,8 @@ public class AwsInstanceTemplate extends InstanceTemplate {
     public static final String PLACEMENT_GROUP_STRATEGY = "placementGroupStrategy";
 
     public AwsInstanceTemplate(String flavor, String groupName, Long privateId, Collection<Volume> volumes, InstanceStatus status,
-            Map<String, Object> parameters, Long templateId, String imageId) {
-        super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId);
+            Map<String, Object> parameters, Long templateId, String imageId, TemporaryStorage temporaryStorage) {
+        super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId, temporaryStorage);
     }
 
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AzureInstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AzureInstanceTemplate.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 
 public class AzureInstanceTemplate extends InstanceTemplate {
 
@@ -49,7 +50,7 @@ public class AzureInstanceTemplate extends InstanceTemplate {
 
     public AzureInstanceTemplate(String flavor, String groupName, Long privateId, Collection<Volume> volumes, InstanceStatus status,
             Map<String, Object> parameters, Long templateId, String imageId) {
-        super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId);
+        super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId, TemporaryStorage.ATTACHED_VOLUMES);
     }
 
 }

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackValidator.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackValidator.java
@@ -1,20 +1,38 @@
 package com.sequenceiq.cloudbreak.cloud.aws;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
+import com.amazonaws.services.ec2.model.DescribeInstanceTypesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstanceTypesResult;
+import com.amazonaws.services.ec2.model.InstanceTypeInfo;
 import com.sequenceiq.cloudbreak.cloud.Validator;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 
 @Component
 public class AwsStackValidator implements Validator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsStackValidator.class);
 
     @Inject
     private LegacyAwsClient awsClient;
@@ -24,15 +42,62 @@ public class AwsStackValidator implements Validator {
 
     @Override
     public void validate(AuthenticatedContext ac, CloudStack cloudStack) {
+        validateStackNameAvailability(ac);
+        validateInstanceStorageOnInstanceTypes(ac, cloudStack);
+    }
+
+    private void validateStackNameAvailability(AuthenticatedContext ac) {
         AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
         String regionName = ac.getCloudContext().getLocation().getRegion().value();
         AmazonCloudFormationClient cfClient = awsClient.createCloudFormationClient(credentialView, regionName);
         String cFStackName = cfStackUtil.getCfStackName(ac);
         try {
+            LOGGER.debug("Checking stack name availability. [{}]", cFStackName);
             cfClient.describeStacks(new DescribeStacksRequest().withStackName(cFStackName));
             throw new CloudConnectorException(String.format("Stack is already exists with the given name: %s", cFStackName));
-        } catch (AmazonServiceException ignored) {
+        } catch (AmazonServiceException e) {
+            if (e.getMessage().toLowerCase().contains("not found")) {
+                LOGGER.info("Stack name is available, CF stack not found by name {}", cFStackName);
+            } else {
+                LOGGER.warn("Exception while checking stack name availability.", e);
+            }
+        }
+    }
 
+    private void validateInstanceStorageOnInstanceTypes(AuthenticatedContext ac, CloudStack cloudStack) {
+        LOGGER.debug("Check instance storage availability on instance types");
+        List<String> instanceTypes = cloudStack.getGroups().stream()
+                .map(Group::getInstances)
+                .flatMap(Collection::stream)
+                .filter(toEphemeralStorageTemplates())
+                .map(CloudInstance::getTemplate)
+                .map(InstanceTemplate::getFlavor)
+                .collect(Collectors.toList());
+        LOGGER.debug("Instance types to check: {}", instanceTypes);
+        List<String> notSupportedTypes = getInstanceStorageNotSupportedTypes(ac, instanceTypes);
+        if (!CollectionUtils.isEmpty(notSupportedTypes)) {
+            LOGGER.warn("The following instance types does not support instance storage: {}", notSupportedTypes);
+            throw new CloudConnectorException(String.format("The following instance types does not support instance storage: %s", notSupportedTypes));
+        }
+    }
+
+    private Predicate<CloudInstance> toEphemeralStorageTemplates() {
+        return instance -> instance.getTemplate().getTemporaryStorage() == TemporaryStorage.EPHEMERAL_VOLUMES;
+    }
+
+    private List<String> getInstanceStorageNotSupportedTypes(AuthenticatedContext authenticatedContext, List<String> instanceTypes) {
+        AwsCredentialView credentialView = new AwsCredentialView(authenticatedContext.getCloudCredential());
+        AmazonEc2Client amazonEC2Client = awsClient.createEc2Client(credentialView);
+        DescribeInstanceTypesRequest request = new DescribeInstanceTypesRequest().withInstanceTypes(instanceTypes);
+        try {
+            DescribeInstanceTypesResult result = amazonEC2Client.describeInstanceTypes(request);
+            return result.getInstanceTypes().stream()
+                    .filter(types -> !types.getInstanceStorageSupported())
+                    .map(InstanceTypeInfo::getInstanceType)
+                    .collect(Collectors.toList());
+        } catch (Exception ex) {
+            LOGGER.warn("Failed to describe instance types: {}", instanceTypes, ex);
+            throw ex;
         }
     }
 }

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsContextServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsContextServiceTest.java
@@ -25,6 +25,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.Security;
 import com.sequenceiq.cloudbreak.cloud.template.context.ResourceBuilderContext;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -93,7 +94,8 @@ class AwsContextServiceTest {
     }
 
     private InstanceTemplate getInstanceTemplate(long privateId, String group) {
-        return new InstanceTemplate("large", group, privateId, new ArrayList<>(), InstanceStatus.CREATED, null, 1L, "image");
+        return new InstanceTemplate("large", group, privateId, new ArrayList<>(), InstanceStatus.CREATED, null, 1L,
+                "image", TemporaryStorage.ATTACHED_VOLUMES);
     }
 
 }

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetaDataCollectorTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetaDataCollectorTest.java
@@ -46,6 +46,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -125,7 +126,8 @@ public class AwsMetaDataCollectorTest {
         List<Volume> volumes = new ArrayList<>();
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         vms.add(new CloudInstance("i-1",
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
+                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
                 instanceAuthentication));
 
 
@@ -167,13 +169,16 @@ public class AwsMetaDataCollectorTest {
         List<Volume> volumes = new ArrayList<>();
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         vms.add(new CloudInstance(null,
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
+                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
                 instanceAuthentication));
         vms.add(new CloudInstance(null,
-                new InstanceTemplate("fla", "cbgateway", 6L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
+                new InstanceTemplate("fla", "cbgateway", 6L, volumes, InstanceStatus.CREATED, null, 0L,
+                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
                 instanceAuthentication));
         vms.add(new CloudInstance(null,
-                new InstanceTemplate("fla", "cbgateway", 7L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
+                new InstanceTemplate("fla", "cbgateway", 7L, volumes, InstanceStatus.CREATED, null, 0L,
+                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
                 instanceAuthentication));
 
         when(awsClient.createCloudFormationClient(any(AwsCredentialView.class), eq("region"))).thenReturn(amazonCFClient);
@@ -224,10 +229,12 @@ public class AwsMetaDataCollectorTest {
         List<Volume> volumes = new ArrayList<>();
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         vms.add(new CloudInstance(null,
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
+                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
                 instanceAuthentication));
         vms.add(new CloudInstance("i-1",
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
+                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
                 instanceAuthentication));
 
 
@@ -283,13 +290,15 @@ public class AwsMetaDataCollectorTest {
         List<Volume> volumes = new ArrayList<>();
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         CloudInstance cloudInstance1 = new CloudInstance(null,
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
+                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
                 instanceAuthentication);
         everyVms.add(cloudInstance1);
         newVms.add(cloudInstance1);
 
         everyVms.add(new CloudInstance("i-1",
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
+                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
                 instanceAuthentication));
 
 

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
@@ -36,6 +36,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import com.amazonaws.services.ec2.model.DescribeInstanceTypesResult;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsAuthenticator;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsDefaultZoneProvider;
@@ -44,6 +45,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.AwsPlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsSessionCredentialClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsTagValidator;
 import com.sequenceiq.cloudbreak.cloud.aws.common.CommonAwsClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsEncodedAuthorizationFailureMessageDecoder;
 import com.sequenceiq.cloudbreak.cloud.aws.conf.AwsConfig;
@@ -97,6 +99,9 @@ public class AwsValidatorsTest {
     @MockBean
     private AwsEncodedAuthorizationFailureMessageDecoder awsEncodedAuthorizationFailureMessageDecoder;
 
+    @Mock
+    private AmazonEc2Client amazonEc2Client;
+
     private AuthenticatedContext authenticatedContext;
 
     @BeforeEach
@@ -127,7 +132,9 @@ public class AwsValidatorsTest {
     public void testStackValidatorStackUnexistent() {
         doReturn(amazonCloudFormationClient).when(awsClient).createCloudFormationClient(any(), anyString());
         when(amazonCloudFormationClient.describeStacks(any())).thenThrow(new AmazonServiceException("test exist"));
-        Assertions.assertDoesNotThrow(() -> awsStackValidatorUnderTest.validate(authenticatedContext, null));
+        doReturn(amazonEc2Client).when(awsClient).createEc2Client(any());
+        when(amazonEc2Client.describeInstanceTypes(any())).thenReturn(new DescribeInstanceTypesResult());
+        Assertions.assertDoesNotThrow(() -> awsStackValidatorUnderTest.validate(authenticatedContext, getTestCloudStackWithTags(Map.of())));
     }
 
     @Test

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
@@ -67,6 +67,7 @@ import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.efs.CloudEfsConfiguration;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
 import com.sequenceiq.common.api.placement.AwsPlacementGroupStrategy;
@@ -1605,7 +1606,7 @@ public class CloudFormationTemplateBuilderTest {
         List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
                 new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         return new InstanceTemplate("m1.medium", "master", 0L, volumes, InstanceStatus.CREATE_REQUESTED, new HashMap<>(), 0L,
-                "cb-centos66-amb200-2015-05-25");
+                "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
     }
 
     private Map<String, String> getDefaultCloudStackParameters() {

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
@@ -94,6 +94,7 @@ import com.sequenceiq.cloudbreak.cloud.notification.ResourceNotifier;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.storage.LocationHelper;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -417,7 +418,8 @@ public class AwsRepairTest {
         when(amazonAutoScalingClient.describeAutoScalingGroups(any())).thenReturn(describeAutoScalingGroupsResult);
 
         List<Volume> volumes = List.of();
-        InstanceTemplate instanceTemplate = new InstanceTemplate("", WORKER_GROUP, 0L, volumes, InstanceStatus.STARTED, Map.of(), 0L, IMAGE_ID);
+        InstanceTemplate instanceTemplate = new InstanceTemplate("", WORKER_GROUP, 0L, volumes, InstanceStatus.STARTED, Map.of(), 0L,
+                IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
         InstanceAuthentication authentication = new InstanceAuthentication("publicKey", "publicKeyId", "cloudbreak");
         CloudInstance firstCloudInstance = new CloudInstance(INSTANCE_ID_1, instanceTemplate, authentication);
         CloudInstance secondCloudInstance = new CloudInstance(INSTANCE_ID_2, instanceTemplate, authentication);

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/ComponentTestUtil.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/ComponentTestUtil.java
@@ -40,6 +40,7 @@ import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
 import com.sequenceiq.cloudbreak.cloud.model.Subnet;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.efs.CloudEfsConfiguration;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.model.FileSystemType;
 
@@ -164,7 +165,7 @@ public class ComponentTestUtil {
                 new Volume("/hadoop/fs2", "HDD", SIZE_DISK_2, CloudVolumeUsageType.GENERAL)
         );
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", groupName, privateId, volumes, instanceStatus,
-                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25");
+                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
         Map<String, Object> params = new HashMap<>();
         return new CloudInstance(instanceId, instanceTemplate, instanceAuthentication, params);
     }

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilderTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilderTest.java
@@ -49,6 +49,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.common.api.type.InstanceGroupType;
@@ -279,7 +280,7 @@ class AwsVolumeResourceBuilderTest {
 
     private Group createGroup(List<Volume> volumes, Map<String, Object> templateParameters) {
         InstanceTemplate template = new InstanceTemplate(FLAVOR, GROUP_NAME, PRIVATE_ID, volumes, InstanceStatus.CREATE_REQUESTED, templateParameters,
-                TEMPLATE_ID, IMAGE_ID);
+                TEMPLATE_ID, IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
         CloudInstance instance = new CloudInstance(INSTANCE_ID, template, null);
         return new Group(GROUP_NAME, InstanceGroupType.GATEWAY, singletonList(instance), null, null, null, null, null, null, ROOT_VOLUME_SIZE, null);
     }

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/view/AwsInstanceViewTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/view/AwsInstanceViewTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.placement.AwsPlacementGroupStrategy;
 import com.sequenceiq.common.api.type.EncryptionType;
 
@@ -29,7 +30,7 @@ public class AwsInstanceViewTest {
         map.put(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name());
 
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                map, 0L, IMAGE_ID);
+                map, 0L, IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
 
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
 
@@ -47,7 +48,7 @@ public class AwsInstanceViewTest {
         map.put(AwsInstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, ENCRYPTION_KEY_ARN);
 
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                map, 0L, IMAGE_ID);
+                map, 0L, IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
 
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
 
@@ -62,7 +63,7 @@ public class AwsInstanceViewTest {
         Map<String, Object> map = new HashMap<>();
         map.put(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, 30);
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                map, 0L, IMAGE_ID);
+                map, 0L, IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertThat(actual.getOnDemandPercentage()).isEqualTo(70);
     }
@@ -70,7 +71,7 @@ public class AwsInstanceViewTest {
     @Test
     public void testOnDemandMissingPercentage() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(), 0L, IMAGE_ID);
+                Map.of(), 0L, IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertThat(actual.getOnDemandPercentage()).isEqualTo(100);
     }
@@ -81,7 +82,7 @@ public class AwsInstanceViewTest {
         Double spotMaxPrice = 0.9;
         map.put(AwsInstanceTemplate.EC2_SPOT_MAX_PRICE, spotMaxPrice);
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                map, 0L, "imageId");
+                map, 0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals(spotMaxPrice, actual.getSpotMaxPrice());
     }
@@ -89,7 +90,7 @@ public class AwsInstanceViewTest {
     @Test
     public void testMissingSpotMaxPrice() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(), 0L, "imageId");
+                Map.of(), 0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertNull(actual.getSpotMaxPrice());
     }
@@ -97,7 +98,8 @@ public class AwsInstanceViewTest {
     @Test
     public void testPlacementGroupWhenPartition() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.PARTITION.name()), 0L, "imageId");
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.PARTITION.name()),
+                0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals("Placement Group Strategy should be partition.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.PARTITION);
     }
@@ -105,7 +107,8 @@ public class AwsInstanceViewTest {
     @Test
     public void testPlacementGroupWhenSpread() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.SPREAD.name()), 0L, "imageId");
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.SPREAD.name()),
+                0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals("Placement Group Strategy should be spread.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.SPREAD);
     }
@@ -113,7 +116,8 @@ public class AwsInstanceViewTest {
     @Test
     public void testPlacementGroupWhenCluster() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.CLUSTER.name()), 0L, "imageId");
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.CLUSTER.name()),
+                0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals("Placement Group Strategy should be cluster.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.CLUSTER);
     }
@@ -121,7 +125,7 @@ public class AwsInstanceViewTest {
     @Test
     public void testPlacementGroupWhenMissing() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(), 0L, "imageId");
+                Map.of(), 0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals("Placement Group Strategy should be none.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.NONE);
     }
@@ -129,7 +133,8 @@ public class AwsInstanceViewTest {
     @Test
     public void testPlacementGroupWhenNone() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.NONE.name()), 0L, "imageId");
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.NONE.name()),
+                0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals("Placement Group Strategy should be none.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.NONE);
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
@@ -36,6 +36,7 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -171,7 +172,7 @@ public class AzureMetadataCollectorTest {
 
     private CloudInstance createCloudInstance(String instanceId, Long privateId) {
         InstanceTemplate instanceTemplate = new InstanceTemplate(null, INSTANCE_GROUP_NAME, privateId, Collections.emptyList(), null, Collections.emptyMap(),
-                null, null);
+                null, null, TemporaryStorage.ATTACHED_VOLUMES);
         return new CloudInstance(instanceId, instanceTemplate, null);
     }
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProviderTest.java
@@ -37,6 +37,7 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @RunWith(Parameterized.class)
@@ -148,7 +149,8 @@ public class AzureStackViewProviderTest {
     }
 
     private InstanceTemplate createInstanceTemplate() {
-        return new InstanceTemplate(null, INSTANCE_ID, 1L, Collections.emptyList(), null, Map.of("managedDisk", true), null, IMAGE_ID);
+        return new InstanceTemplate(null, INSTANCE_ID, 1L, Collections.emptyList(), null, Map.of("managedDisk", true), null,
+                IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
     }
 
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -75,6 +75,7 @@ import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudAdlsGen2View;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AzureInstanceTemplate;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
 import com.sequenceiq.cloudbreak.util.Version;
 import com.sequenceiq.common.api.type.InstanceGroupType;
@@ -215,7 +216,7 @@ public class AzureTemplateBuilderTest {
         List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
                 new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", name, 0L, volumes, InstanceStatus.CREATE_REQUESTED,
-                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25");
+                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
         Map<String, Object> params = new HashMap<>();
         params.put(CloudInstance.SUBNET_ID, "existingSubnet");
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureVirtualMachineTypeProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureVirtualMachineTypeProviderTest.java
@@ -18,6 +18,7 @@ import com.sequenceiq.cloudbreak.cloud.azure.view.AzureInstanceView;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureStackView;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 
 public class AzureVirtualMachineTypeProviderTest {
 
@@ -88,7 +89,7 @@ public class AzureVirtualMachineTypeProviderTest {
 
     private AzureInstanceView createAzureInstanceView(String groupName, String flavour) {
         InstanceTemplate instanceTemplate = new InstanceTemplate(flavour, groupName, null,
-                Collections.emptyList(), null, Collections.emptyMap(), null, null);
+                Collections.emptyList(), null, Collections.emptyMap(), null, null, TemporaryStorage.ATTACHED_VOLUMES);
         CloudInstance cloudInstance = new CloudInstance(null, instanceTemplate, null);
         return AzureInstanceView.builder(cloudInstance).build();
     }

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpMetadataCollectorTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpMetadataCollectorTest.java
@@ -32,6 +32,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudVmMetaDataStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
 
@@ -181,7 +182,7 @@ public class GcpMetadataCollectorTest {
     }
 
     private InstanceTemplate createInstanceTemplate(Long privateId) {
-        return new InstanceTemplate(null, null, privateId, Collections.emptyList(), null, null, null, null);
+        return new InstanceTemplate(null, null, privateId, Collections.emptyList(), null, null, null, null, TemporaryStorage.ATTACHED_VOLUMES);
     }
 
     private Map<String, Optional<NetworkInterface>> createNetworkInterfaces() {

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnectorTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnectorTest.java
@@ -49,6 +49,7 @@ import com.sequenceiq.cloudbreak.cloud.template.context.ResourceBuilderContext;
 import com.sequenceiq.cloudbreak.cloud.template.group.GroupResourceService;
 import com.sequenceiq.cloudbreak.cloud.template.init.ContextBuilders;
 import com.sequenceiq.cloudbreak.cloud.template.network.NetworkResourceService;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -225,7 +226,8 @@ public class GcpResourceConnectorTest {
     }
 
     private InstanceTemplate instanceTemplate() {
-        return new InstanceTemplate("large", "master", 1L, new ArrayList<>(), InstanceStatus.CREATE_REQUESTED, null, 1L, "image");
+        return new InstanceTemplate("large", "master", 1L, new ArrayList<>(), InstanceStatus.CREATE_REQUESTED, null, 1L,
+                "image", TemporaryStorage.ATTACHED_VOLUMES);
     }
 
     private InstanceAuthentication instanceAuthentication() {

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilderTest.java
@@ -59,6 +59,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Security;
 import com.sequenceiq.cloudbreak.cloud.model.SecurityRule;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -159,7 +160,7 @@ public class GcpAttachedDiskResourceBuilderTest {
 
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         InstanceTemplate instanceTemplate = new InstanceTemplate(flavor, name, privateId, volumes, InstanceStatus.CREATE_REQUESTED, params,
-                0L, "cb-centos66-amb200-2015-05-25");
+                0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
         CloudInstance cloudInstance =  new CloudInstance(instanceId, instanceTemplate, instanceAuthentication);
         group = new Group(name, InstanceGroupType.CORE, Collections.singletonList(cloudInstance), security, null,
                 instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), 50, Optional.empty());

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilderTest.java
@@ -58,6 +58,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.Security;
 import com.sequenceiq.cloudbreak.cloud.model.SecurityRule;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -152,7 +153,7 @@ class GcpDiskResourceBuilderTest {
 
         instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         instanceTemplate = new InstanceTemplate(flavor, name, privateId, volumes, InstanceStatus.CREATE_REQUESTED, params,
-                0L, "cb-centos66-amb200-2015-05-25");
+                0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
         group = createGroup(50);
 
         buildableResource = List.of(CloudResource.builder()

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
@@ -83,6 +83,7 @@ import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudFileSystemView;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudGcsView;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.common.api.type.InstanceGroupType;
@@ -356,7 +357,7 @@ public class GcpInstanceResourceBuilderTest {
 
     public CloudInstance newCloudInstance(Map<String, Object> params, InstanceAuthentication instanceAuthentication) {
         InstanceTemplate instanceTemplate = new InstanceTemplate(flavor, name, privateId, volumes, InstanceStatus.CREATE_REQUESTED, params,
-                0L, "cb-centos66-amb200-2015-05-25");
+                0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
         return new CloudInstance(instanceId, instanceTemplate, instanceAuthentication, params);
     }
 

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/CustomGcpDiskEncryptionServiceTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/CustomGcpDiskEncryptionServiceTest.java
@@ -21,6 +21,7 @@ import com.google.api.services.compute.model.CustomerEncryptionKey;
 import com.google.api.services.compute.model.Disk;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.EncryptionType;
 
 @ExtendWith(MockitoExtension.class)
@@ -82,7 +83,7 @@ public class CustomGcpDiskEncryptionServiceTest {
         parameters.put(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "testurl");
 
         InstanceTemplate instanceTemplate = new InstanceTemplate("large", "master", 1L,
-                new ArrayList<>(), InstanceStatus.CREATE_REQUESTED, parameters, 1L, "image");
+                new ArrayList<>(), InstanceStatus.CREATE_REQUESTED, parameters, 1L, "image", TemporaryStorage.ATTACHED_VOLUMES);
 
         return instanceTemplate;
     }

--- a/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackFlavorVerifierTest.java
+++ b/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackFlavorVerifierTest.java
@@ -25,6 +25,7 @@ import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -92,7 +93,8 @@ public class OpenStackFlavorVerifierTest {
     }
 
     private Group createGroup(String flavor) {
-        InstanceTemplate template = new InstanceTemplate(flavor, null, null, new ArrayList<>(), null, null, null, null);
+        InstanceTemplate template =
+                new InstanceTemplate(flavor, null, null, new ArrayList<>(), null, null, null, null, TemporaryStorage.ATTACHED_VOLUMES);
         CloudInstance skeleton = new CloudInstance("id1", template, null);
 
         Group group = new Group("name", InstanceGroupType.GATEWAY, new ArrayList<>(), null, skeleton,

--- a/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/HeatTemplateBuilderTest.java
+++ b/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/HeatTemplateBuilderTest.java
@@ -53,6 +53,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.openstack.common.OpenStackUtils;
 import com.sequenceiq.cloudbreak.cloud.openstack.heat.HeatTemplateBuilder.ModelContext;
 import com.sequenceiq.cloudbreak.cloud.openstack.view.NeutronNetworkView;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
@@ -119,7 +120,7 @@ public class HeatTemplateBuilderTest {
         List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
                 new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", name, 0L, volumes, InstanceStatus.CREATE_REQUESTED,
-                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25");
+                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         CloudInstance instance = new CloudInstance("SOME_ID", instanceTemplate, instanceAuthentication);
         List<SecurityRule> rules = singletonList(new SecurityRule("0.0.0.0/0",

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ParameterGenerator.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ParameterGenerator.java
@@ -38,6 +38,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Security;
 import com.sequenceiq.cloudbreak.cloud.model.SecurityRule;
 import com.sequenceiq.cloudbreak.cloud.model.Subnet;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.AdjustmentType;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -82,7 +83,7 @@ public class ParameterGenerator {
         List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
                 new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", name, 0L, volumes, InstanceStatus.CREATE_REQUESTED,
-                new HashMap<>(), 0L, "default-id");
+                new HashMap<>(), 0L, "default-id", TemporaryStorage.ATTACHED_VOLUMES);
 
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         CloudInstance instance = new CloudInstance("SOME_ID", instanceTemplate, instanceAuthentication);

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/testcontext/TestApplicationContext.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/testcontext/TestApplicationContext.java
@@ -54,6 +54,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.service.Persister;
 import com.sequenceiq.cloudbreak.cloud.service.ResourceRetriever;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.grpc.ManagedChannelWrapper;
 import com.sequenceiq.common.api.type.ResourceType;
 import com.sequenceiq.flow.core.ApplicationFlowInformation;
@@ -74,11 +75,11 @@ public class TestApplicationContext {
 
     private final CloudInstance cloudInstance = new CloudInstance("instanceId",
             new InstanceTemplate("flavor", "groupName", 1L, Collections.emptyList(),
-                    InstanceStatus.CREATE_REQUESTED, new HashMap<>(), 0L, "imageId"), instanceAuthentication);
+                    InstanceStatus.CREATE_REQUESTED, new HashMap<>(), 0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES), instanceAuthentication);
 
     private final CloudInstance cloudInstanceBad = new CloudInstance("instanceIdBad",
             new InstanceTemplate("flavor", "groupName", 1L, Collections.emptyList(),
-                    InstanceStatus.CREATE_REQUESTED, new HashMap<>(), 1L, "imageId"), instanceAuthentication);
+                    InstanceStatus.CREATE_REQUESTED, new HashMap<>(), 1L, "imageId", TemporaryStorage.ATTACHED_VOLUMES), instanceAuthentication);
 
     @Mock
     private CloudPlatformConnectors cloudPlatformConnectors;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -52,6 +52,7 @@ import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.converter.InstanceMetadataToImageIdConverter;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.FileSystem;
@@ -199,7 +200,8 @@ public class StackToCloudStackConverter {
                 volumes.add(volume);
             }
         });
-        return new InstanceTemplate(template.getInstanceType(), name, privateId, volumes, status, fields, template.getId(), instanceImageId);
+        TemporaryStorage temporaryStorage = template.getTemporaryStorage();
+        return new InstanceTemplate(template.getInstanceType(), name, privateId, volumes, status, fields, template.getId(), instanceImageId, temporaryStorage);
     }
 
     private CloudVolumeUsageType getVolumeUsageType(VolumeUsageType volumeUsageType) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
@@ -36,6 +36,7 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.service.Clock;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
@@ -171,7 +172,8 @@ public class MetadataSetupServiceTest {
     }
 
     private Iterable<CloudVmMetaDataStatus> getCloudVmMetaDataStatuses(InstanceStatus instanceStatus) {
-        InstanceTemplate instanceTemplate = new InstanceTemplate(null, GROUP_NAME, PRIVATE_ID, List.of(), null, Map.of(), null, null);
+        InstanceTemplate instanceTemplate = new InstanceTemplate(null, GROUP_NAME, PRIVATE_ID, List.of(), null, Map.of(), null, null,
+                TemporaryStorage.ATTACHED_VOLUMES);
         Map<String, Object> params = new HashMap<>();
         params.put(CloudInstance.SUBNET_ID, SUBNET_ID);
         params.put(CloudInstance.INSTANCE_NAME, INSTANCE_NAME);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
@@ -51,6 +51,7 @@ import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudFileSystemView;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudGcsView;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
 import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -168,7 +169,8 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
             Volume volume = new Volume("/mnt/vol" + (i + 1), template.getVolumeType(), template.getVolumeSize(), CloudVolumeUsageType.GENERAL);
             volumes.add(volume);
         }
-        return new InstanceTemplate(template.getInstanceType(), name, privateId, volumes, status, fields, template.getId(), instanceImageId);
+        return new InstanceTemplate(template.getInstanceType(), name, privateId, volumes, status, fields, template.getId(), instanceImageId,
+                TemporaryStorage.ATTACHED_VOLUMES);
     }
 
     private Map<String, String> getUserDefinedTags(Stack stack) {

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/DefaultModelService.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/DefaultModelService.java
@@ -88,6 +88,6 @@ public class DefaultModelService {
     private InstanceTemplate getTemplateCreated(CloudInstance cloudInstance) {
         InstanceTemplate template = cloudInstance.getTemplate();
         return new InstanceTemplate(template.getFlavor(), template.getGroupName(), template.getPrivateId(), template.getVolumes(), InstanceStatus.CREATED,
-                template.getParameters(), template.getTemplateId(), template.getImageId());
+                template.getParameters(), template.getTemplateId(), template.getImageId(), template.getTemporaryStorage());
     }
 }


### PR DESCRIPTION
Validate at cluster creation time, that instance types support instance storage, when cluster was posted with ephemeral volumes as temporary storage

https://github.com/hortonworks/cloudbreak/pull/10698 is a prerequisite for this PR.