### PR TITLE
 CB-12538 Move runtime update before image change in datalake service 

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/DatalakeUpgradeActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/datalake/upgrade/DatalakeUpgradeActions.java
@@ -121,6 +121,7 @@ public class DatalakeUpgradeActions {
             @Override
             protected void doExecute(SdxContext context, DatalakeImageChangeEvent payload, Map<Object, Object> variables) {
                 LOGGER.info("Start Datalake upgrade image change for {} ", payload.getResourceId());
+                sdxUpgradeService.updateRuntimeVersionFromCloudbreak(payload.getResourceId());
                 String catalogName = sdxUpgradeService.getCurrentImageCatalogName(payload.getResourceId());
                 UpgradeOptionV4Response upgrade = new UpgradeOptionV4Response().upgrade(
                         new ImageInfoV4Response().imageId(payload.getImageId()).imageCatalogName(catalogName)
@@ -170,7 +171,6 @@ public class DatalakeUpgradeActions {
 
             @Override
             protected void doExecute(SdxContext context, DatalakeVmReplaceEvent payload, Map<Object, Object> variables) {
-                sdxUpgradeService.updateRuntimeVersionFromCloudbreak(payload.getResourceId());
                 if ((boolean) variables.get(REPLACE_VMS_AFTER_UPGRADE)) {
                     LOGGER.info("Start Datalake upgrade vm replacement for {} ", payload.getResourceId());
                     sdxUpgradeService.upgradeOs(payload.getResourceId());


### PR DESCRIPTION
Right now runtime is refreshed in datalake service after upgrade.
The experience is upgrade fails usually during image change, so datalake service contains the old runtime.
With this change it will be updated before the image change.

See detailed description in the commit message.