### PR TITLE
CB-11674 Knox needs a DB for Token Management backend

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/database/base/DatabaseType.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/database/base/DatabaseType.java
@@ -17,4 +17,5 @@ public enum DatabaseType {
     PROFILER_AGENT,
     PROFILER_METRIC,
     NIFIREGISTRY,
+    KNOX_GATEWAY,
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/externaldatabase/SupportedDatabaseProvider.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/validation/externaldatabase/SupportedDatabaseProvider.java
@@ -32,6 +32,7 @@ public final class SupportedDatabaseProvider {
         SUPPORTED_EXTERNAL_DATABASES.add(getSupportedServiceEntry("Streams Messaging Manager", POSTGRES, MYSQL, ORACLE11, ORACLE12));
         SUPPORTED_EXTERNAL_DATABASES.add(getSupportedServiceEntry("Hue", POSTGRES, MYSQL, ORACLE11, ORACLE12));
         SUPPORTED_EXTERNAL_DATABASES.add(getSupportedServiceEntry("Cloudera Manager", POSTGRES));
+        SUPPORTED_EXTERNAL_DATABASES.add(getSupportedServiceEntry("Knox Gateway", POSTGRES));
         SUPPORTED_EXTERNAL_DATABASES.add(getSupportedServiceEntry("Cloudera Manager Management Service Activity Monitor", POSTGRES));
         SUPPORTED_EXTERNAL_DATABASES.add(getSupportedServiceEntry("Cloudera Manager Management Service Reports Manager", POSTGRES));
     }

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/cloud/VersionComparatorTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/cloud/VersionComparatorTest.java
@@ -32,6 +32,7 @@ public class VersionComparatorTest {
     public void testGreaterNonEqualLength() {
         Assert.assertEquals(1L, underTest.compare(new VersionString("2.4.0.0"), new VersionString("2.4.0.0-770")));
         Assert.assertEquals(1L, underTest.compare(new VersionString("2.5.0.0"), new VersionString("2.5.0.0-770")));
+        Assert.assertEquals(1L, underTest.compare(new VersionString("7.2.9.1"), new VersionString("7.2.9-1000")));
     }
 
     @Test
@@ -40,6 +41,10 @@ public class VersionComparatorTest {
         Assert.assertEquals(-1L, underTest.compare(new VersionString("2.4.0.0-770"), new VersionString("2.4.0.0-1000")));
         Assert.assertEquals(-1L, underTest.compare(new VersionString("2.4.0.0-1000"), new VersionString("2.5.0.0-1000")));
         Assert.assertEquals(-1L, underTest.compare(new VersionString("2.5.0.0-1000"), new VersionString("2.15.0.0-1000")));
+        Assert.assertEquals(-1L, underTest.compare(new VersionString("7.2.9"), new VersionString("7.2.9.1")));
+        Assert.assertEquals(-1L, underTest.compare(new VersionString("7.2.9-1000"), new VersionString("7.2.9.1")));
+        Assert.assertEquals(-1L, underTest.compare(new VersionString("7.2.9-1"), new VersionString("7.2.9.1-200")));
+        Assert.assertEquals(-1L, underTest.compare(new VersionString("7.2.9"), new VersionString("7.2.9.1-1000")));
     }
 
     @Test

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/KnoxGatewayServiceRdsConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/KnoxGatewayServiceRdsConfigProvider.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.service.rdsconfig;
+
+import javax.inject.Inject;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+
+@Component
+public class KnoxGatewayServiceRdsConfigProvider extends AbstractRdsConfigProvider {
+
+    private static final String PILLAR_KEY = "knox_gateway";
+
+    @Value("${cb.knox_gateway.database.port:5432}")
+    private String port;
+
+    @Value("${cb.knox_gateway.database.user:knox_gateway}")
+    private String userName;
+
+    @Value("${cb.knox_gateway.database.db:knox_gateway}")
+    private String db;
+
+    @Inject
+    private CmTemplateProcessorFactory cmTemplateProcessorFactory;
+
+    @Override
+    protected String getDbUser() {
+        return userName;
+    }
+
+    @Override
+    protected String getDb() {
+        return db;
+    }
+
+    @Override
+    protected String getDbPort() {
+        return port;
+    }
+
+    @Override
+    protected String getPillarKey() {
+        return PILLAR_KEY;
+    }
+
+    @Override
+    protected DatabaseType getRdsType() {
+        return DatabaseType.KNOX_GATEWAY;
+    }
+
+    @Override
+    protected boolean isRdsConfigNeeded(Blueprint blueprint) {
+        CmTemplateProcessor blueprintProcessor = cmTemplateProcessorFactory.get(blueprint.getBlueprintText());
+        return blueprintProcessor.getServiceByType("KNOX").isPresent();
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/runtimes/SupportedRuntimesTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/runtimes/SupportedRuntimesTest.java
@@ -29,6 +29,7 @@ public class SupportedRuntimesTest {
         Assert.assertTrue(underTest.isSupported("7.1.0"));
         Assert.assertTrue(underTest.isSupported("7.1.0.0"));
         Assert.assertTrue(underTest.isSupported("7.0.99.0"));
+        Assert.assertTrue(underTest.isSupported("7"));
         Assert.assertTrue(underTest.isSupported("7.0.99"));
     }
 
@@ -44,7 +45,6 @@ public class SupportedRuntimesTest {
         Whitebox.setInternalState(underTest, "latestSupportedRuntime", "7.1.0");
         // Invalid versions shall not be supported, but at least they shall not throw exception
         Assert.assertFalse(underTest.isSupported("blah"));
-        Assert.assertFalse(underTest.isSupported("7"));
         Assert.assertFalse(underTest.isSupported("8"));
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ComponentVersionComparatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ComponentVersionComparatorTest.java
@@ -44,7 +44,6 @@ public class ComponentVersionComparatorTest {
 
     @Test
     public void testInvalid() {
-        assertFalse(underTest.permitCmAndStackUpgradeByComponentVersion("2", "2.2.0"));
         assertFalse(underTest.permitCmAndStackUpgradeByComponentVersion("2.a", "2.2.0"));
         assertFalse(underTest.permitCmAndStackUpgradeByComponentVersion("2.2", "u"));
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -40,7 +40,11 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_4_1 = () -> "7.4.1";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_4_2 = () -> "7.4.2";
+
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_10 = () -> "7.2.10";
+
+    public static final Versioned CLOUDERA_STACK_VERSION_7_2_9_1 = () -> "7.2.9.1";
 
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
@@ -82,6 +86,21 @@ public class CMRepositoryVersionUtil {
     public static boolean isRangerTearDownSupported(ClouderaManagerRepo clouderaManagerRepoDetails) {
         LOGGER.info("ClouderaManagerRepo is compared for ranger tear down support");
         return isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_4_1);
+    }
+
+    public static boolean isKnoxDatabaseSupported(ClouderaManagerRepo clouderaManagerRepoDetails, String cdhVersion) {
+        LOGGER.info("ClouderaManagerRepo is compared for knox database support");
+        boolean supported = false;
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_10)) {
+            if (isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_4_2)) {
+                supported = true;
+            }
+        } else if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_9_1)) {
+            if (isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_4_1)) {
+                supported = true;
+            }
+        }
+        return supported;
     }
 
     public static boolean isRazConfigurationSupportedInDatalake(ClouderaManagerRepo clouderaManagerRepoDetails, CloudPlatform cloudPlatform) {

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxServiceConfigProvider.java
@@ -1,22 +1,39 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_1_0;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isKnoxDatabaseSupported;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static java.util.Collections.emptyList;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
-import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.RdsView;
 
 @Component
-public class KnoxServiceConfigProvider implements CmTemplateComponentConfigProvider {
+public class KnoxServiceConfigProvider extends AbstractRdsRoleConfigProvider {
 
     private static final String KNOX_AUTORESTART_ON_STOP = "autorestart_on_stop";
+
+    private static final String DATABASE_TYPE = "knox_gateway_database_type";
+
+    private static final String DATABASE_NAME = "knox_gateway_database_name";
+
+    private static final String DATABASE_HOST = "knox_gateway_database_host";
+
+    private static final String DATABASE_PORT = "knox_gateway_database_port";
+
+    private static final String DATABASE_USER = "knox_gateway_database_user";
+
+    private static final String DATABASE_PASSWORD = "knox_gateway_database_password";
 
     @Override
     public String getServiceType() {
@@ -30,12 +47,35 @@ public class KnoxServiceConfigProvider implements CmTemplateComponentConfigProvi
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
-        return List.of(config(KNOX_AUTORESTART_ON_STOP, Boolean.TRUE.toString()));
+        List<ApiClusterTemplateConfig> configList = new ArrayList<>();
+        String cdhVersion = source.getBlueprintView().getProcessor().getStackVersion() == null ?
+                "" : source.getBlueprintView().getProcessor().getStackVersion();
+        if (isKnoxDatabaseSupported(source.getProductDetailsView().getCm(), cdhVersion)) {
+            RdsView knoxGatewayRdsView = getRdsView(source);
+            configList.add(config(DATABASE_TYPE, knoxGatewayRdsView.getSubprotocol()));
+            configList.add(config(DATABASE_NAME, knoxGatewayRdsView.getDatabaseName()));
+            configList.add(config(DATABASE_HOST, knoxGatewayRdsView.getHost()));
+            configList.add(config(DATABASE_PORT, knoxGatewayRdsView.getPort()));
+            configList.add(config(DATABASE_USER, knoxGatewayRdsView.getConnectionUserName()));
+            configList.add(config(DATABASE_PASSWORD, knoxGatewayRdsView.getConnectionPassword()));
+        }
+        configList.add(config(KNOX_AUTORESTART_ON_STOP, Boolean.TRUE.toString()));
+        return configList;
+    }
+
+    @Override
+    protected DatabaseType dbType() {
+        return DatabaseType.KNOX_GATEWAY;
     }
 
     @Override
     public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
         String cmVersion = cmTemplateProcessor.getCmVersion().orElse("");
         return isVersionNewerOrEqualThanLimited(cmVersion, CLOUDERAMANAGER_VERSION_7_1_0);
+    }
+
+    @Override
+    protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
+        return emptyList();
     }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxServiceConfigProviderTest.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox.KnoxRoles.KNOX;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockitoAnnotations;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.domain.RDSConfig;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.processor.BlueprintTextProcessor;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
+
+public class KnoxServiceConfigProviderTest {
+
+    private KnoxServiceConfigProvider underTest = new KnoxServiceConfigProvider();
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testGetServiceTypeShouldReturnKnox() {
+        Assert.assertTrue(underTest.getServiceType().equals(KNOX));
+    }
+
+    @Test
+    public void testGetRoleConfigsShouldReturnEmptyList() {
+        Assert.assertTrue(underTest.getRoleConfigs(anyString(), any(TemplatePreparationObject.class)).isEmpty());
+    }
+
+    @Test
+    public void testDbTypeShouldReturnKnoxGateway() {
+        Assert.assertTrue(underTest.dbType().equals(DatabaseType.KNOX_GATEWAY));
+    }
+
+    @Test
+    public void testGetRoleTypesShouldReturnKnoxGatewayIdbroker() {
+        Assert.assertTrue(underTest.getRoleTypes().equals(List.of(KnoxRoles.KNOX_GATEWAY, KnoxRoles.IDBROKER)));
+    }
+
+    @ParameterizedTest(name = "{index}: check knox properties cm version {0} and cdh version {1} will produce {2} property")
+    @MethodSource("cmCdhCombinations")
+    public void testGetServiceConfigsWhenCMAtLeast741AndCDHVersion7291ShouldIncludeDBProperties(
+            String cdhVersion,
+            String cmVersion,
+            int numberOfProperties) {
+        CmTemplateProcessor templateProcessor = mock(CmTemplateProcessor.class);
+        BlueprintTextProcessor blueprintTextProcessor = mock(BlueprintTextProcessor.class);
+        BlueprintView blueprintView = new BlueprintView("text", cdhVersion, "CDH", blueprintTextProcessor);
+        RDSConfig rdsConfig = new RDSConfig();
+        rdsConfig.setConnectionPassword("pw");
+        rdsConfig.setConnectionUserName("usr");
+        rdsConfig.setType(DatabaseType.KNOX_GATEWAY.name());
+        rdsConfig.setConnectionURL("jdbc:postgresql://somehost.com:5432/dbName");
+        TemplatePreparationObject source = TemplatePreparationObject.Builder.builder()
+                .withBlueprintView(blueprintView)
+                .withRdsSslCertificateFilePath("file://path")
+                .withRdsConfigs(Set.of(rdsConfig))
+                .withProductDetails(new ClouderaManagerRepo().withVersion(cmVersion), List.of())
+                .build();
+
+        when(blueprintTextProcessor.getStackVersion()).thenReturn(cdhVersion);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, source);
+
+        Assert.assertTrue(serviceConfigs.size() == numberOfProperties);
+    }
+
+    static Object[][] cmCdhCombinations() {
+        return new Object[][]{
+                { "7.2.10",     "7.4.2", 7 },
+                { "7.2.11",     "7.4.1", 1 },
+                { "7.2.11",     "7.4.2", 7 },
+                { "7.2.9.1",    "7.4.1", 7 },
+                { "7.2.8",      "7.4.2", 1 },
+                { "7.2.8",      "7.4.1", 1 },
+                { "7.2.9",      "7.4.2", 1 },
+        };
+    }
+}


### PR DESCRIPTION
Tested with Sandor from Knox team we generated the token and communicated with webhdfs
Properties are setted:
knox_gateway_database_type (as of now, only PostgreSQL is supported)
knox_gateway_database_name
knox_gateway_database_host
knox_gateway_database_port
knox_gateway_database_user
knox_gateway_database_password
gateway_service_tokenstate_impl should be set to org.apache.knox.gateway.services.token.impl.JDBCTokenStateService (it's a radio button on CM UI)

See detailed description in the commit message.