### PR TITLE
CB-12372: Create e2e test for distroX upgrade.

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakApiKeyEndpoints.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakApiKeyEndpoints.java
@@ -20,6 +20,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.userprofile.UserProfileV4Endpoi
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.UtilV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.WorkspaceAwareUtilV4Endpoint;
 import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXDatabaseServerV1Endpoint;
+import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXUpgradeV1Endpoint;
 import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXV1Endpoint;
 import com.sequenceiq.flow.api.FlowEndpoint;
 import com.sequenceiq.flow.api.FlowPublicEndpoint;
@@ -88,6 +89,10 @@ public class CloudbreakApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint i
 
     public DistroXV1Endpoint distroXV1Endpoint() {
         return getEndpoint(DistroXV1Endpoint.class);
+    }
+
+    public DistroXUpgradeV1Endpoint distroXUpgradeV1Endpoint() {
+        return getEndpoint(DistroXUpgradeV1Endpoint.class);
     }
 
     public DatalakeV4Endpoint datalakeV4Endpoint() {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakClient.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakClient.java
@@ -17,6 +17,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.userprofile.UserProfileV4Endpoi
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.UtilV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.WorkspaceAwareUtilV4Endpoint;
 import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXDatabaseServerV1Endpoint;
+import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXUpgradeV1Endpoint;
 import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXV1Endpoint;
 import com.sequenceiq.flow.api.FlowEndpoint;
 import com.sequenceiq.flow.api.FlowPublicEndpoint;
@@ -50,6 +51,8 @@ public interface CloudbreakClient {
     StackV4Endpoint stackV4Endpoint();
 
     DistroXV1Endpoint distroXV1Endpoint();
+
+    DistroXUpgradeV1Endpoint distroXUpgradeV1Endpoint();
 
     DatalakeV4Endpoint datalakeV4Endpoint();
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakServiceCrnEndpoints.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakServiceCrnEndpoints.java
@@ -21,6 +21,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.util.UtilV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.util.WorkspaceAwareUtilV4Endpoint;
 import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXDatabaseServerV1Endpoint;
 import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXInternalV1Endpoint;
+import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXUpgradeV1Endpoint;
 import com.sequenceiq.distrox.api.v1.distrox.endpoint.DistroXV1Endpoint;
 import com.sequenceiq.flow.api.FlowEndpoint;
 import com.sequenceiq.flow.api.FlowPublicEndpoint;
@@ -89,6 +90,10 @@ public class CloudbreakServiceCrnEndpoints extends AbstractUserCrnServiceEndpoin
 
     public DistroXV1Endpoint distroXV1Endpoint() {
         return getEndpoint(DistroXV1Endpoint.class);
+    }
+
+    public DistroXUpgradeV1Endpoint distroXUpgradeV1Endpoint() {
+        return getEndpoint(DistroXUpgradeV1Endpoint.class);
     }
 
     public DistroXInternalV1Endpoint distroXInternalV1Endpoint() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXUpgradeAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXUpgradeAction.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.it.cloudbreak.action.v1.distrox;
+
+import static java.lang.String.format;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
+import com.sequenceiq.distrox.api.v1.distrox.model.upgrade.DistroXUpgradeV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.upgrade.DistroXUpgradeV1Response;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+
+public class DistroXUpgradeAction implements Action<DistroXTestDto, CloudbreakClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DistroXUpgradeAction.class);
+
+    @Override
+    public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
+        DistroXUpgradeV1Request upgradeRequest = testDto.getDistroXUpgradeRequest();
+        Log.when(LOGGER, format(" Starting DistroX upgrade: %s ", testDto.getName()));
+        Log.whenJson(LOGGER, " DistroX upgrade request: ", upgradeRequest);
+        DistroXUpgradeV1Response response = client.getDefaultClient()
+                .distroXUpgradeV1Endpoint()
+                .upgradeClusterByName(testDto.getName(), upgradeRequest);
+        testDto.setFlow("DistroX upgrade flow identifier", response.getFlowIdentifier());
+        StackV4Response stackV4Response = client.getDefaultClient()
+                .distroXV1Endpoint()
+                .getByName(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(stackV4Response);
+        Log.whenJson(LOGGER, " DistroX upgrade response: ", stackV4Response);
+        return testDto;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
@@ -20,6 +20,7 @@ import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXScaleAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXShowBlueprintAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXStartAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXStopAction;
+import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXUpgradeAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.RenewDistroXCertificateAction;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
@@ -86,5 +87,9 @@ public class DistroXTestClient {
 
     public Action<DistroXTestDto, CloudbreakClient> repair(HostGroupType... hostGroupTypes) {
         return new DistroXRepairAction(List.of(hostGroupTypes));
+    }
+
+    public Action<DistroXTestDto, CloudbreakClient> upgrade() {
+        return new DistroXUpgradeAction();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
@@ -29,6 +29,7 @@ import com.sequenceiq.distrox.api.v1.distrox.model.DistroXV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.InstanceGroupV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsInstanceTemplateV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AwsInstanceTemplateV1SpotParameters;
+import com.sequenceiq.distrox.api.v1.distrox.model.upgrade.DistroXUpgradeV1Request;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.MicroserviceClient;
 import com.sequenceiq.it.cloudbreak.Prototype;
@@ -40,6 +41,7 @@ import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.clustertemplate.ClusterTemplateTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.DistroXUpgradeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.search.Searchable;
@@ -259,6 +261,14 @@ public class DistroXTestDto extends DistroXTestDtoBase<DistroXTestDto> implement
     public DistroXTestDto addTags(Map<String, String> tags) {
         getRequest().initAndGetTags().getUserDefined().putAll(tags);
         return this;
+    }
+
+    public DistroXUpgradeV1Request getDistroXUpgradeRequest() {
+        DistroXUpgradeTestDto upgradeTestDto = given(DistroXUpgradeTestDto.class);
+        if (upgradeTestDto == null) {
+            throw new IllegalArgumentException("DistroX upgrade dto does not exist!");
+        }
+        return upgradeTestDto.getRequest();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/cluster/DistroXUpgradeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/cluster/DistroXUpgradeTestDto.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.it.cloudbreak.dto.distrox.cluster;
+
+import javax.inject.Inject;
+
+import com.sequenceiq.distrox.api.v1.distrox.model.upgrade.DistroXUpgradeReplaceVms;
+import com.sequenceiq.distrox.api.v1.distrox.model.upgrade.DistroXUpgradeV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.upgrade.DistroXUpgradeV1Response;
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
+
+@Prototype
+public class DistroXUpgradeTestDto extends AbstractSdxTestDto<DistroXUpgradeV1Request, DistroXUpgradeV1Response, DistroXUpgradeTestDto> {
+
+    @Inject
+    private CommonClusterManagerProperties commonClusterManagerProperties;
+
+    public DistroXUpgradeTestDto(DistroXUpgradeV1Request request, TestContext testContext) {
+        super(request, testContext);
+    }
+
+    public DistroXUpgradeTestDto(TestContext testContext) {
+        super(new DistroXUpgradeV1Request(), testContext);
+    }
+
+    public DistroXUpgradeTestDto() {
+        super(DistroXUpgradeTestDto.class.getSimpleName().toUpperCase());
+    }
+
+    @Override
+    public DistroXUpgradeTestDto valid() {
+        return withRuntime(commonClusterManagerProperties.getUpgrade().getTargetRuntimeVersion())
+                .withReplaceVms(DistroXUpgradeReplaceVms.DISABLED);
+    }
+
+    public DistroXUpgradeTestDto withRuntime(String runtime) {
+        getRequest().setRuntime(runtime);
+        return this;
+    }
+
+    public DistroXUpgradeTestDto withReplaceVms(DistroXUpgradeReplaceVms replaceVms) {
+        getRequest().setReplaceVms(replaceVms);
+        return this;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXUpgradeTests.java
@@ -1,0 +1,128 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.distrox;
+
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.COMPUTE;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.WORKER;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.DistroXUpgradeTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxUpgradeTestDto;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
+import com.sequenceiq.it.cloudbreak.util.DistroxUtil;
+import com.sequenceiq.it.cloudbreak.util.InstanceUtil;
+import com.sequenceiq.it.cloudbreak.util.VolumeUtils;
+import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxUpgradeReplaceVms;
+
+public class DistroXUpgradeTests extends AbstractE2ETest {
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private DistroXTestClient distroXTestClient;
+
+    @Inject
+    private DistroxUtil distroxUtil;
+
+    @Inject
+    private CommonClusterManagerProperties commonClusterManagerProperties;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        initializeDefaultBlueprints(testContext);
+        createEnvironmentWithNetworkAndFreeIpa(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(given = "there is a running Cloudbreak, and an environment with SDX and DistroX cluster in available state",
+            when = "upgrade called on the DistroX cluster", then = "DistroX upgrade should be successful, the cluster should be up and running")
+    public void testDistroXUpgrade(TestContext testContext) {
+        List<String> actualVolumeIds = new ArrayList<>();
+        List<String> expectedVolumeIds = new ArrayList<>();
+
+        String sdxName = resourcePropertyProvider().getName();
+        String distroXName = resourcePropertyProvider().getName();
+        String currentRuntimeVersion = commonClusterManagerProperties.getUpgrade().getCurrentRuntimeVersion();
+        String targetRuntimeVersion = commonClusterManagerProperties.getUpgrade().getTargetRuntimeVersion();
+        testContext
+                .given(sdxName, SdxTestDto.class)
+                .withCloudStorage()
+                .withRuntimeVersion(currentRuntimeVersion)
+                .when(sdxTestClient.create(), key(sdxName))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxName))
+                .awaitForInstance(getSdxInstancesHealthyState())
+                .validate();
+        testContext
+                .given(distroXName, DistroXTestDto.class)
+                .withTemplate(commonClusterManagerProperties.getInternalDistroXBlueprintName())
+                .when(distroXTestClient.create(), key(distroXName))
+                .await(STACK_AVAILABLE)
+                .awaitForInstance(InstanceUtil.getHealthyDistroXInstances())
+                .then((tc, testDto, client) -> {
+                    List<String> instances = distroxUtil.getInstanceIds(testDto, client, MASTER.getName());
+                    instances.addAll(distroxUtil.getInstanceIds(testDto, client, COMPUTE.getName()));
+                    instances.addAll(distroxUtil.getInstanceIds(testDto, client, WORKER.getName()));
+                    CloudFunctionality cloudFunctionality = tc.getCloudProvider().getCloudFunctionality();
+                    expectedVolumeIds.addAll(cloudFunctionality.listInstanceVolumeIds(instances));
+                    return testDto;
+                })
+                .validate();
+        testContext
+                .given(distroXName, DistroXTestDto.class)
+                .when(distroXTestClient.stop(), key(distroXName))
+                .await(STACK_STOPPED)
+                .validate();
+        testContext
+                .given(SdxUpgradeTestDto.class)
+                .withReplaceVms(SdxUpgradeReplaceVms.DISABLED)
+                .withRuntime(targetRuntimeVersion)
+                .given(sdxName, SdxTestDto.class)
+                .when(sdxTestClient.upgrade(), key(sdxName))
+                .await(SdxClusterStatusResponse.DATALAKE_UPGRADE_IN_PROGRESS, key(sdxName).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxName))
+                .awaitForInstance(getSdxInstancesHealthyState())
+                .validate();
+        testContext
+                .given(distroXName, DistroXTestDto.class)
+                .when(distroXTestClient.start(), key(distroXName))
+                .await(STACK_AVAILABLE)
+                .validate();
+        testContext
+                .given(DistroXUpgradeTestDto.class)
+                .withRuntime(targetRuntimeVersion)
+                .given(distroXName, DistroXTestDto.class)
+                .when(distroXTestClient.upgrade(), key(distroXName))
+                .await(STACK_AVAILABLE, key(distroXName))
+                .awaitForInstance(InstanceUtil.getHealthyDistroXInstances())
+                .then((tc, testDto, client) -> {
+                    List<String> instances = distroxUtil.getInstanceIds(testDto, client, MASTER.getName());
+                    instances.addAll(distroxUtil.getInstanceIds(testDto, client, COMPUTE.getName()));
+                    instances.addAll(distroxUtil.getInstanceIds(testDto, client, WORKER.getName()));
+                    CloudFunctionality cloudFunctionality = tc.getCloudProvider().getCloudFunctionality();
+                    actualVolumeIds.addAll(cloudFunctionality.listInstanceVolumeIds(instances));
+                    return testDto;
+                })
+                .then((tc, testDto, client) -> VolumeUtils.compareVolumeIdsAfterRepair(testDto, actualVolumeIds, expectedVolumeIds))
+                .validate();
+    }
+}

--- a/integration-test/src/main/resources/testsuites/e2e/distrox-upgrade-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/distrox-upgrade-tests.yaml
@@ -1,0 +1,5 @@
+name: "distrox-upgrade-tests"
+tests:
+  - name: "distrox_e2e_upgrade_tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXUpgradeTests


### PR DESCRIPTION
This test case is required to test the functionality of the DistroX cluster upgrade.
After a proper environment has created, we need to upgrade the SDX first, then we can proceed with the DistroX upgrade.
When we call the DistroX upgrade endpoint with the proper runtime version the CB should select a new image and upgrade the CM and CDH components for the new runtime version.