### PR TITLE
CB-12446. Support no_proxy in process responsible for uploading boots…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -4,7 +4,7 @@
 {% else %}
     {% set fluent_enabled = False %}
 {% endif %}
-{% set cdp_logging_agent_version = '0.2.6' %}
+{% set cdp_logging_agent_version = '0.2.10' %}
 {% set cdp_logging_agent_rpm = 'https://cloudera-service-delivery-cache.s3.amazonaws.com/telemetry/cdp-logging-agent/' + cdp_logging_agent_version + '/cdp_logging_agent-'+ cdp_logging_agent_version + '.x86_64.rpm' %}
 {% if salt['pillar.get']('fluent:cloudStorageLoggingEnabled') %}
     {% set cloud_storage_logging_enabled = True %}
@@ -146,6 +146,7 @@
   {% set proxy_auth = False %}
   {% set proxy_full_url = None %}
 {% endif %}
+{% set no_proxy_hosts = salt['pillar.get']('proxy:noProxyHosts') %}
 
 {% if dbus_metering_enabled %}
   {% if "metering_prewarmed_v2" in grains.get('roles', []) and salt['pillar.get']('fluent:dbusMeteringAppName') and salt['pillar.get']('fluent:dbusMeteringStreamName') %}
@@ -272,6 +273,7 @@
     "proxyUser": proxy_user,
     "proxyPassword": proxy_password,
     "proxyFullUrl": proxy_full_url,
+    "noProxyHosts": no_proxy_hosts,
     "binary": binary,
     "fluentVersion": fluent_version,
     "cdpLoggingAgentInstalled": cdp_logging_agent_installed,

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
@@ -23,14 +23,11 @@
     event_message_field              message
     headers                          {{ fluent.dbusMeteringAppHeaders }}
     stream_name                      {{ fluent.dbusMeteringStreamName }}
-    partition_key                    "#{Socket.gethostname}"
-    {%- if fluent.proxyUrl %}
-    proxy_url                        "{{ fluent.proxyUrl }}"
-    {%- if fluent.proxyAuth %}
+    partition_key                    "#{Socket.gethostname}"{%- if fluent.proxyUrl %}
+    proxy_url                        "{{ fluent.proxyUrl }}"{%- if fluent.proxyAuth %}
     proxy_username                   "{{ fluent.proxyUser }}"
-    proxy_password                   "{{ fluent.proxyPassword }}"
-    {% endif %}
-    {% endif %}
+    proxy_password                   "{{ fluent.proxyPassword }}"{% endif %}{% if fluent.noProxyHosts and fluent.fluentVersion > 3 %}
+    no_proxy                         "{{ fluent.noProxyHosts }}"{% endif %}{% endif %}
     <buffer tag,time>
       @type file
       path /var/log/{{ fluent.binary }}/metering_databus

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_monitoring.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_monitoring.conf.j2
@@ -23,14 +23,11 @@
     event_message_field              message
     headers                          {{ fluent.dbusMonitoringAppHeaders }}
     stream_name                      {{ fluent.dbusMonitoringStreamName }}
-    partition_key                    "#{Socket.gethostname}"
-    {%- if fluent.proxyUrl %}
-    proxy_url                        "{{ fluent.proxyUrl }}"
-    {%- if fluent.proxyAuth %}
+    partition_key                    "#{Socket.gethostname}"{%- if fluent.proxyUrl %}
+    proxy_url                        "{{ fluent.proxyUrl }}"{%- if fluent.proxyAuth %}
     proxy_username                   "{{ fluent.proxyUser }}"
-    proxy_password                   "{{ fluent.proxyPassword }}"
-    {% endif %}
-    {% endif %}
+    proxy_password                   "{{ fluent.proxyPassword }}"{% endif %}{% if fluent.noProxyHosts and fluent.fluentVersion > 3 %}
+    no_proxy                         "{{ fluent.noProxyHosts }}"{% endif %}{% endif %}
     <buffer tag,time>
       @type file
       path /var/log/{{ fluent.binary }}/monitoring_databus

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
@@ -15,14 +15,11 @@
     extra_headers_field              bundleContext
     event_message_field              message
     stream_name                      {{ fluent.dbusClusterLogsCollectionStreamName }}
-    partition_key                    "#{Socket.gethostname}"
-    {%- if fluent.proxyUrl %}
-    proxy_url                        "{{ fluent.proxyUrl }}"
-    {%- if fluent.proxyAuth %}
+    partition_key                    "#{Socket.gethostname}"{%- if fluent.proxyUrl %}
+    proxy_url                        "{{ fluent.proxyUrl }}"{%- if fluent.proxyAuth %}
     proxy_username                   "{{ fluent.proxyUser }}"
-    proxy_password                   "{{ fluent.proxyPassword }}"
-    {% endif %}
-    {% endif %}
+    proxy_password                   "{{ fluent.proxyPassword }}"{% endif %}{% if fluent.noProxyHosts and fluent.fluentVersion > 3 %}
+    no_proxy                         "{{ fluent.noProxyHosts }}"{% endif %}{% endif %}
     <buffer tag,time>
       @type file
       path /var/log/{{ fluent.binary }}/databus_service_logs


### PR DESCRIPTION
…trap logs.

details:
- use noProxyHosts pillar for the logging-agent
- no_proxy option is supported from the next cdp-logging-agent release, the prewarmed version of that is 3, so supports if the version is larger than 3
- small refactor: remove endlines around jinja conditions, so it won't be any empty lines in the configs (around proxy settings)

See detailed description in the commit message.