### PR TITLE
CB-12543: sourceImageDate missing from custom images

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/customimage/response/CustomImageCatalogV4GetImageResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/customimage/response/CustomImageCatalogV4GetImageResponse.java
@@ -24,6 +24,9 @@ public class CustomImageCatalogV4GetImageResponse implements JsonEntity {
     private String sourceImageId;
 
     @JsonProperty
+    private Long sourceImageDate;
+
+    @JsonProperty
     private String baseParcelUrl;
 
     @JsonProperty
@@ -51,6 +54,14 @@ public class CustomImageCatalogV4GetImageResponse implements JsonEntity {
 
     public void setSourceImageId(String sourceImageId) {
         this.sourceImageId = sourceImageId;
+    }
+
+    public Long getSourceImageDate() {
+        return sourceImageDate;
+    }
+
+    public void setSourceImageDate(Long sourceImageDate) {
+        this.sourceImageDate = sourceImageDate;
     }
 
     public String getBaseParcelUrl() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/CustomImageCatalogV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/CustomImageCatalogV4Controller.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.controller.v4;
 
+import com.sequenceiq.authorization.annotation.AccountIdNotNeeded;
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceName;
 import com.sequenceiq.authorization.annotation.FilterListBasedOnPermissions;
@@ -21,6 +22,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.customimage.response.CustomImag
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.authorization.ImageCatalogFiltering;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.domain.CustomImage;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.service.image.CustomImageCatalogService;
@@ -55,6 +57,7 @@ public class CustomImageCatalogV4Controller implements CustomImageCatalogV4Endpo
     }
 
     @Override
+    @AccountIdNotNeeded
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public CustomImageCatalogV4GetResponse get(@ResourceName String name) {
         ImageCatalog imageCatalog = customImageCatalogService.getImageCatalog(restRequestThreadLocalService.getRequestedWorkspaceId(), name);
@@ -63,6 +66,7 @@ public class CustomImageCatalogV4Controller implements CustomImageCatalogV4Endpo
     }
 
     @Override
+    @AccountIdNotNeeded
     @CheckPermissionByAccount(action = AuthorizationResourceAction.CREATE_IMAGE_CATALOG)
     public CustomImageCatalogV4CreateResponse create(CustomImageCatalogV4CreateRequest request) {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
@@ -83,11 +87,15 @@ public class CustomImageCatalogV4Controller implements CustomImageCatalogV4Endpo
     }
 
     @Override
+    @AccountIdNotNeeded
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public CustomImageCatalogV4GetImageResponse getCustomImage(@ResourceName String name, String imageId) {
         CustomImage customImage = customImageCatalogService.getCustomImage(restRequestThreadLocalService.getRequestedWorkspaceId(), name, imageId);
+        Image sourceImage = customImageCatalogService.getSourceImage(customImage, name);
+        CustomImageCatalogV4GetImageResponse response = converterUtil.convert(customImage, CustomImageCatalogV4GetImageResponse.class);
+        response.setSourceImageDate(sourceImage.getCreated());
 
-        return converterUtil.convert(customImage, CustomImageCatalogV4GetImageResponse.class);
+        return response;
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
@@ -717,7 +717,7 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
         return imageCatalog.getCustomImages().stream().filter(i -> i.getName().equalsIgnoreCase(imageId)).findFirst();
     }
 
-    private StatedImage getSourceImageByImageType(CustomImage customImage, String catalogName)
+    public StatedImage getSourceImageByImageType(CustomImage customImage, String catalogName)
             throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
         StatedImage sourceImage;
         switch (customImage.getImageType()) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/CustomImageCatalogV4ControllerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/CustomImageCatalogV4ControllerTest.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.customimage.response.CustomImag
 import com.sequenceiq.cloudbreak.api.endpoint.v4.customimage.response.CustomImageCatalogV4UpdateImageResponse;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.domain.CustomImage;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.service.image.CustomImageCatalogService;
@@ -129,11 +130,15 @@ public class CustomImageCatalogV4ControllerTest {
     @Test
     public void testGetCustomImage() {
         CustomImage customImage = new CustomImage();
+        Image sourceImage = createTestImage();
+
         CustomImageCatalogV4GetImageResponse expected = new CustomImageCatalogV4GetImageResponse();
+        expected.setSourceImageDate(12345L);
 
         when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(WORKSPACE_ID);
         when(customImageCatalogService.getCustomImage(WORKSPACE_ID, IMAGE_CATALOG_NAME, IMAGE_ID)).thenReturn(customImage);
         when(converterUtil.convert(customImage, CustomImageCatalogV4GetImageResponse.class)).thenReturn(expected);
+        when(customImageCatalogService.getSourceImage(customImage, IMAGE_CATALOG_NAME)).thenReturn(sourceImage);
 
         CustomImageCatalogV4GetImageResponse actual = victim.getCustomImage(IMAGE_CATALOG_NAME, IMAGE_ID);
 
@@ -192,5 +197,9 @@ public class CustomImageCatalogV4ControllerTest {
         CustomImageCatalogV4DeleteImageResponse actual = victim.deleteCustomImage(IMAGE_CATALOG_NAME, IMAGE_ID);
 
         assertEquals(expected, actual);
+    }
+
+    private static Image createTestImage() {
+        return new Image(null, 12345L, null, null, null, null, null, null, null, null, null, null, null, null, true, null, null);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogServiceTest.java
@@ -1,8 +1,11 @@
 package com.sequenceiq.cloudbreak.service.image;
 
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.CustomImage;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.domain.VmImage;
@@ -146,6 +149,20 @@ public class CustomImageCatalogServiceTest {
         when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
 
         assertThrows(NotFoundException.class, () -> victim.getCustomImage(WORKSPACE_ID, IMAGE_CATALOG_NAME, IMAGE_NAME));
+    }
+
+    @Test
+    public void testGetSourceImage() throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        CustomImage customImage = new CustomImage();
+        customImage.setCustomizedImageId(CUSTOMIZED_IMAGE_ID);
+        Image expected = createTestImage();
+        StatedImage statedImage = StatedImage.statedImage(expected, null, IMAGE_CATALOG_NAME);
+
+        when(imageCatalogService.getSourceImageByImageType(customImage, IMAGE_CATALOG_NAME)).thenReturn(statedImage);
+
+        Image actual = victim.getSourceImage(customImage, IMAGE_CATALOG_NAME);
+
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -311,5 +328,9 @@ public class CustomImageCatalogServiceTest {
         customImage.setVmImage(Collections.singleton(vmImage));
 
         return customImage;
+    }
+
+    private Image createTestImage() {
+        return new Image(null, null, null, null, CUSTOMIZED_IMAGE_ID, null, null, null, null, null, null, null, null, null, true, null, null);
     }
 }


### PR DESCRIPTION
In case of custom image's query operation the related source creation date is also provided.
One option was to persist the date in the database, but this value can change so it should always be updated, so only this value will be retrieved at the moment of the query and sent as part of the response.