### PR TITLE
CB-12638 Disable mock idbroker in local dev, just to ensure that mock…

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -36,7 +36,7 @@ management:
 
 info:
   app:
-    capabilities: gov_cloud, mock_idbroker_mapping
+    capabilities: gov_cloud
 
 spring:
   application:


### PR DESCRIPTION
… idbroker path can be tested locally. This change should not cause issue in qa and mow environments, since there we are overrideing the capabilities parameter

See detailed description in the commit message.