### PR TITLE
CB-12325: DES resource may sometimes be left behind during environment delete

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/encryption/EnvironmentEncryptionService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/encryption/EnvironmentEncryptionService.java
@@ -22,7 +22,6 @@ import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.model.encryption.CreatedDiskEncryptionSet;
 import com.sequenceiq.cloudbreak.cloud.model.encryption.DiskEncryptionSetCreationRequest;
 import com.sequenceiq.cloudbreak.cloud.model.encryption.DiskEncryptionSetDeletionRequest;
-import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
 import com.sequenceiq.environment.credential.v1.converter.CredentialToCloudCredentialConverter;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
@@ -121,9 +120,8 @@ public class EnvironmentEncryptionService {
     }
 
     private List<CloudResource> getResourcesForDeletion(EnvironmentDto environment) {
-        Optional<CloudResource> desCloudResourceOptional = resourceRetriever.findByResourceReferenceAndStatusAndType(
-                environment.getParameters().getAzureParametersDto().getAzureResourceEncryptionParametersDto().getDiskEncryptionSetId(),
-                CommonStatus.CREATED, ResourceType.AZURE_DISK_ENCRYPTION_SET);
+        Optional<CloudResource> desCloudResourceOptional = resourceRetriever.findByEnvironmentIdAndType(environment.getId(),
+                ResourceType.AZURE_DISK_ENCRYPTION_SET);
         return desCloudResourceOptional.map(List::of).orElse(List.of());
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/ResourceEncryptionDeleteHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/ResourceEncryptionDeleteHandler.java
@@ -60,12 +60,12 @@ public class ResourceEncryptionDeleteHandler extends EventSenderAwareHandler<Env
         try {
             environmentService.findEnvironmentById(environmentDto.getId()).ifPresent(environment -> {
                 if (AZURE.name().equalsIgnoreCase(environmentDto.getCloudPlatform())) {
-                    String diskEncryptionSetId = Optional.ofNullable(environmentDto.getParameters())
+                    String encryptionKeyUrl = Optional.ofNullable(environmentDto.getParameters())
                             .map(ParametersDto::getAzureParametersDto)
                             .map(AzureParametersDto::getAzureResourceEncryptionParametersDto)
-                            .map(AzureResourceEncryptionParametersDto::getDiskEncryptionSetId)
+                            .map(AzureResourceEncryptionParametersDto::getEncryptionKeyUrl)
                             .orElse(null);
-                    if (StringUtils.isNotEmpty(diskEncryptionSetId) &&
+                    if (StringUtils.isNotEmpty(encryptionKeyUrl) &&
                             (environment.getStatus() != EnvironmentStatus.ENVIRONMENT_ENCRYPTION_RESOURCES_DELETED)) {
                         deleteEncryptionResources(environmentDto, environment);
                     } else {

--- a/environment/src/main/java/com/sequenceiq/environment/resourcepersister/CloudResourceRetrieverService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/resourcepersister/CloudResourceRetrieverService.java
@@ -32,4 +32,12 @@ public class CloudResourceRetrieverService implements ResourceRetriever {
         return optionalResource
                 .map(resource -> cloudResourceConverter.convert(resource));
     }
+
+    public Optional<CloudResource> findByEnvironmentIdAndType(Long environmentId, ResourceType resourceType) {
+        Optional<Resource> optionalResource = resourceService.findByEnvironmentIdAndType(environmentId, resourceType);
+        LOGGER.debug("Resource retrieved by environmentId: {} and type: {}. Is present: {}", environmentId, resourceType, optionalResource.isPresent());
+        return optionalResource
+                .map(resource -> cloudResourceConverter.convert(resource));
+    }
+
 }

--- a/environment/src/main/java/com/sequenceiq/environment/resourcepersister/ResourceRepository.java
+++ b/environment/src/main/java/com/sequenceiq/environment/resourcepersister/ResourceRepository.java
@@ -30,4 +30,7 @@ public interface ResourceRepository extends CrudRepository<Resource, Long> {
     @Query("SELECT r FROM Resource r WHERE r.resourceReference = :resourceReference AND r.resourceType = :type")
     Optional<Resource> findByResourceReferenceAndType(@Param("resourceReference") String resourceReference,
             @Param("type") ResourceType type);
+
+    @Query("SELECT r FROM Resource r WHERE r.environment.id = :environmentId AND r.resourceType = :type")
+    Optional<Resource> findByEnvironmentIdAndType(@Param("environmentId") Long environmentId, @Param("type") com.sequenceiq.common.api.type.ResourceType type);
 }

--- a/environment/src/main/java/com/sequenceiq/environment/resourcepersister/ResourceService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/resourcepersister/ResourceService.java
@@ -44,4 +44,8 @@ public class ResourceService {
     public Optional<Resource> findByResourceReferenceAndType(String resourceReference, ResourceType resourceType) {
         return repository.findByResourceReferenceAndType(resourceReference, resourceType);
     }
+
+    public Optional<Resource> findByEnvironmentIdAndType(Long environmentId, ResourceType resourceType) {
+        return repository.findByEnvironmentIdAndType(environmentId, resourceType);
+    }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/encryption/EnvironmentEncryptionServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/encryption/EnvironmentEncryptionServiceTest.java
@@ -67,6 +67,8 @@ class EnvironmentEncryptionServiceTest {
 
     private static final String DISK_ENCRYPTION_SET_ID = "dummyDesId";
 
+    private static final String DISK_ENCRYPTION_SET_NAME = "dummyDesName";
+
     private static final long ENVIRONMENT_ID = 1L;
 
     private static final String KEY_URL = "dummyKeyUrl";
@@ -204,19 +206,22 @@ class EnvironmentEncryptionServiceTest {
                 .withParameters(ParametersDto.builder()
                         .withAzureParameters(AzureParametersDto.builder()
                                 .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
-                                        .withDiskEncryptionSetId(DISK_ENCRYPTION_SET_ID).build())
+                                        .withDiskEncryptionSetId(DISK_ENCRYPTION_SET_ID)
+                                        .withEncryptionKeyUrl(KEY_URL)
+                                        .build())
                                 .build())
                         .build())
                 .withCreator(USER_NAME)
                 .withAccountId(ACCOUNT_ID)
                 .build();
         CloudResource desCloudResource = CloudResource.builder()
-                .name("Des")
+                .name(DISK_ENCRYPTION_SET_NAME)
                 .type(ResourceType.AZURE_DISK_ENCRYPTION_SET)
                 .reference(DISK_ENCRYPTION_SET_ID)
                 .status(CommonStatus.CREATED)
                 .build();
-        when(resourceRetriever.findByResourceReferenceAndStatusAndType(any(), any(), any())).thenReturn(Optional.ofNullable(desCloudResource));
+        when(resourceRetriever.findByEnvironmentIdAndType(ENVIRONMENT_ID, ResourceType.AZURE_DISK_ENCRYPTION_SET))
+                .thenReturn(Optional.of(desCloudResource));
         when(credentialToCloudCredentialConverter.convert(credential)).thenReturn(cloudCredential);
 
         DiskEncryptionSetDeletionRequest deletionRequest = underTest.createEncryptionResourcesDeletionRequest(environmentDto);
@@ -269,7 +274,9 @@ class EnvironmentEncryptionServiceTest {
                 .withParameters(ParametersDto.builder()
                         .withAzureParameters(AzureParametersDto.builder()
                                 .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
-                                        .withDiskEncryptionSetId(DISK_ENCRYPTION_SET_ID).build())
+                                        .withDiskEncryptionSetId(DISK_ENCRYPTION_SET_ID)
+                                        .withEncryptionKeyUrl(KEY_URL)
+                                        .build())
                                 .build())
                         .build())
                 .withCreator(USER_NAME)
@@ -277,12 +284,13 @@ class EnvironmentEncryptionServiceTest {
                 .withCredential(credential)
                 .build();
         CloudResource desCloudResource = CloudResource.builder()
-                .name("Des")
+                .name(DISK_ENCRYPTION_SET_NAME)
                 .type(ResourceType.AZURE_DISK_ENCRYPTION_SET)
                 .reference(DISK_ENCRYPTION_SET_ID)
                 .status(CommonStatus.CREATED)
                 .build();
-        when(resourceRetriever.findByResourceReferenceAndStatusAndType(any(), any(), any())).thenReturn(Optional.ofNullable(desCloudResource));
+        when(resourceRetriever.findByEnvironmentIdAndType(ENVIRONMENT_ID, ResourceType.AZURE_DISK_ENCRYPTION_SET))
+                .thenReturn(Optional.of(desCloudResource));
 
         underTest.deleteEncryptionResources(environmentDto);
 
@@ -300,7 +308,7 @@ class EnvironmentEncryptionServiceTest {
         assertThat(desCloudResourceOptional).isNotEmpty();
         CloudResource desCloudResource = desCloudResourceOptional.get();
         assertEquals(desCloudResource.getReference(), DISK_ENCRYPTION_SET_ID);
-        assertEquals(desCloudResource.getName(), "Des");
+        assertEquals(desCloudResource.getName(), DISK_ENCRYPTION_SET_NAME);
         assertEquals(desCloudResource.getType(), ResourceType.AZURE_DISK_ENCRYPTION_SET);
         assertEquals(cloudContext.getAccountId(), ACCOUNT_ID);
         assertEquals(cloudContext.getCrn(), ENVIRONMENT_CRN);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/deletion/handler/ResourceEncryptionDeleteHandlerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/deletion/handler/ResourceEncryptionDeleteHandlerTest.java
@@ -94,6 +94,7 @@ class ResourceEncryptionDeleteHandlerTest {
                                 .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
                                         .withDiskEncryptionSetId("/subscriptions/dummySubscriptionId/resourceGroups/dummyResourceGroup/" +
                                                 "providers/Microsoft.Compute/diskEncryptionSets/dummyDesId")
+                                        .withEncryptionKeyUrl("https://dummyVault.vault.azure.net/keys/dummyKey/dummyKeyVersion")
                                         .build())
                                 .build())
                         .build())
@@ -159,7 +160,7 @@ class ResourceEncryptionDeleteHandlerTest {
     }
 
     @Test
-    void testDeletionContinuesIfDiskEncryptionSetIdIsNotPresent() {
+    void testDeletionContinuesIfEncryptionKeyUrlIsNotPresent() {
         Environment environment = new Environment();
         when(environmentService.findEnvironmentById(ENVIRONMENT_ID)).thenReturn(Optional.of(environment));
         environmentDtoEvent.getData().setEnvironmentDto(EnvironmentDto.builder()


### PR DESCRIPTION
CB-12325: DES resource may sometimes be left behind during environment delete

In few cases, the flow to create DES(Disk encryption set) during environment creation might result in failure after creating DES i.e; the resource is created at Azure cloud but the process itself failed to complete, leading to dangling DES in Azure cloud.
Cases where DES process can fail - Lack of adequate permissions to set DES correctly, environment service failure e.t.c

DES is created only when encryption key url is present in AzureResourceEncryptionParametersDto. Further, encryption key url can only be present in AzureResourceEncryptionParametersDto if entitlement to enable SSE with CMK is enabled for the account. So, Inorder to delete DES, checking for presence of encryption key url is sufficient.
During deletion DES resource is fetched from DB using environmentId and ResourceType.AZURE_DISK_ENCRYPTION_SET - only a single DES exists for any environment.
 If resource is found, deletion is processed further else not.

