### PR TITLE
CB-12710: Fix closing FormDataMultiPart to not close it early

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltUploadWithPermission.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/poller/SaltUploadWithPermission.java
@@ -26,7 +26,7 @@ public class SaltUploadWithPermission extends SaltFileUpload {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("SaltUpload{");
+        StringBuilder sb = new StringBuilder("SaltUploadWithPermission{");
         sb.append("sc=").append(getSaltConnector());
         sb.append(", originalTargets=").append(getOriginalTargets());
         sb.append(", path='").append(path).append('\'');


### PR DESCRIPTION
FormDataMultiPart was being closed multiple times while it was still
being used. This was fixed so that it is only closed when it is done
being used.

Also some missing toString() methods were added.

This was tested manually with a local deployment of cloudbreak.

See detailed description in the commit message.