### PR TITLE
CB-10773 [HA LB] Datalake create flow timed out instead of terminating gracefully

### DIFF
--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/CollectLoadBalancerMetadataHandler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/CollectLoadBalancerMetadataHandler.java
@@ -1,17 +1,20 @@
 package com.sequenceiq.cloudbreak.cloud.handler;
 
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
 import com.sequenceiq.cloudbreak.cloud.event.loadbalancer.CollectLoadBalancerMetadataRequest;
 import com.sequenceiq.cloudbreak.cloud.event.loadbalancer.CollectLoadBalancerMetadataResult;
 import com.sequenceiq.cloudbreak.cloud.handler.service.LoadBalancerMetadataService;
 import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
-import reactor.bus.Event;
-import reactor.bus.EventBus;
-
-import javax.inject.Inject;
-import java.util.List;
 
 @Component
 public class CollectLoadBalancerMetadataHandler implements CloudPlatformEventHandler<CollectLoadBalancerMetadataRequest> {
@@ -43,7 +46,7 @@ public class CollectLoadBalancerMetadataHandler implements CloudPlatformEventHan
             eventBus.notify(collectLBMetadataResult.selector(), new Event<>(collectLBMetadataRequestEvent.getHeaders(), collectLBMetadataResult));
             LOGGER.debug("Load balancer metadata collection successfully finished");
         } catch (RuntimeException e) {
-            LOGGER.error("Collecting metadata failed", e);
+            LOGGER.error("Collecting load balancer metadata failed", e);
             CollectLoadBalancerMetadataResult failure = new CollectLoadBalancerMetadataResult(e, request.getResourceId());
             request.getResult().onNext(failure);
             eventBus.notify(failure.selector(), new Event<>(collectLBMetadataRequestEvent.getHeaders(), failure));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/StackCreationFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/StackCreationFlowConfig.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack.provision;
 
+import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.COLLECT_LOADBALANCER_METADATA_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.COLLECT_LOADBALANCER_METADATA_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.COLLECT_METADATA_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.COLLECT_METADATA_FINISHED_EVENT;
@@ -73,7 +74,7 @@ public class StackCreationFlowConfig extends AbstractFlowConfiguration<StackCrea
                     .failureEvent(LAUNCH_LOAD_BALANCER_FAILED_EVENT)
             .from(PROVISIONING_FINISHED_STATE).to(COLLECTMETADATA_STATE).event(COLLECT_METADATA_FINISHED_EVENT).failureEvent(COLLECT_METADATA_FAILED_EVENT)
             .from(COLLECTMETADATA_STATE).to(COLLECTMETADATA_LOADBALANCER_STATE).event(COLLECT_LOADBALANCER_METADATA_FINISHED_EVENT)
-                    .failureEvent(COLLECT_METADATA_FAILED_EVENT)
+                    .failureEvent(COLLECT_LOADBALANCER_METADATA_FAILED_EVENT)
             .from(COLLECTMETADATA_LOADBALANCER_STATE).to(GET_TLS_INFO_STATE).event(GET_TLS_INFO_FINISHED_EVENT).failureEvent(GET_TLS_INFO_FAILED_EVENT)
             .from(GET_TLS_INFO_STATE).to(TLS_SETUP_STATE).event(SSHFINGERPRINTS_EVENT).failureEvent(SSHFINGERPRINTS_FAILED_EVENT)
             .from(TLS_SETUP_STATE).to(STACK_CREATION_FINISHED_STATE).event(TLS_SETUP_FINISHED_EVENT).defaultFailureEvent()


### PR DESCRIPTION
Fixes an error in the StackCreation flow so that it handles the COLLECT_LOADBALANCER_METADATA_FAILED_EVENT
correctly. Tested by running CB locally and inducing a LB metadata collection failure.