### PR TITLE
 CB-12711 NPE if mediaType is null

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/JaxRSUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/JaxRSUtil.java
@@ -38,7 +38,7 @@ public class JaxRSUtil {
 
     public static <T> T response(Response response, Class<T> clazz) {
         if (Family.SUCCESSFUL != response.getStatusInfo().getFamily()) {
-            if (!response.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)) {
+            if (!MediaType.APPLICATION_JSON_TYPE.isCompatible(response.getMediaType())) {
                 throw handleUnexpectedError(response);
             }
         }

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/utils/JaxRSUtilTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/utils/JaxRSUtilTest.java
@@ -1,0 +1,48 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.utils;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status.Family;
+import javax.ws.rs.core.Response.StatusType;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.orchestrator.model.GenericResponses;
+import com.sequenceiq.cloudbreak.util.JaxRSUtil;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JaxRSUtilTest {
+
+    @Mock
+    private Response response;
+
+    @Mock
+    private StatusType statusType;
+
+    @Test
+    public void testNoMediaType() {
+        when(response.getMediaType()).thenReturn(null);
+        when(response.getStatusInfo()).thenReturn(statusType);
+        when(statusType.getFamily()).thenReturn(Family.SERVER_ERROR);
+        assertThrows(WebApplicationException.class, () ->
+                JaxRSUtil.response(response, GenericResponses.class));
+    }
+
+    @Test
+    public void testReadEntity() {
+        when(response.getStatusInfo()).thenReturn(statusType);
+        when(statusType.getFamily()).thenReturn(Family.SUCCESSFUL);
+        when(response.bufferEntity()).thenReturn(true);
+        GenericResponses value = new GenericResponses();
+        when(response.readEntity(GenericResponses.class)).thenReturn(value);
+        assertEquals(value, JaxRSUtil.response(response, GenericResponses.class));
+    }
+}


### PR DESCRIPTION
Encountered this NPE during a failed cluster creation, this NPE during error handling prevented further logs from being collected.