### PR TITLE
DISTX-642 Fix incorrect json element position for HTTPFS

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-data-engineering-ha.bp
@@ -107,13 +107,13 @@
               {
                 "name": "hdfs_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
-              },
-              {
-                "refName": "hdfs-HTTPFS-BASE",
-                "roleType": "HTTPFS",
-                "base": true
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
@@ -107,13 +107,13 @@
               {
                 "name": "hdfs_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
-              },
-              {
-                "refName": "hdfs-HTTPFS-BASE",
-                "roleType": "HTTPFS",
-                "base": true
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-data-engineering-ha.bp
@@ -107,13 +107,13 @@
               {
                 "name": "hdfs_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
-              },
-              {
-                "refName": "hdfs-HTTPFS-BASE",
-                "roleType": "HTTPFS",
-                "base": true
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-data-engineering-ha.bp
@@ -107,13 +107,13 @@
               {
                 "name": "hdfs_client_env_safety_valve",
                 "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
-              },
-              {
-                "refName": "hdfs-HTTPFS-BASE",
-                "roleType": "HTTPFS",
-                "base": true
               }
             ]
+          },
+          {
+            "refName": "hdfs-HTTPFS-BASE",
+            "roleType": "HTTPFS",
+            "base": true
           }
         ]
       },


### PR DESCRIPTION
1. Last time by mistake added the HTTPFS role into another role.
2. This time created a 7.2.9 cluster by creating a custom template to check its validity in CM.