### PR TITLE
CRB-1587 Release a first version of Oozie HA from 7.2.11

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerModelBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerModelBuilder.java
@@ -7,6 +7,7 @@ import com.sequenceiq.cloudbreak.cloud.azure.loadbalancer.AzureLoadBalancingRule
 import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,10 +74,13 @@ public class AzureLoadBalancerModelBuilder {
 
     private List<AzureLoadBalancingRule> collectLoadBalancingRules(CloudLoadBalancer cloudLoadBalancer) {
         return cloudLoadBalancer.getPortToTargetGroupMapping()
-                .keySet()
-                .stream()
-                .map(AzureLoadBalancingRule::new)
-                .collect(toList());
+            .entrySet().stream()
+            .map(entry -> {
+                TargetGroupPortPair pair = entry.getKey();
+                Group firstGroup = entry.getValue().stream().findFirst().orElse(null);
+                return new AzureLoadBalancingRule(pair, firstGroup);
+            })
+            .collect(toList());
     }
 
     private AzureLoadBalancer buildAzureLb(LoadBalancerType type, Set<String> instanceGroupNames, List<AzureLoadBalancingRule> rules, String stackName) {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancingRule.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancingRule.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.cloud.azure.loadbalancer;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 
 public final class AzureLoadBalancingRule {
@@ -11,11 +14,14 @@ public final class AzureLoadBalancingRule {
 
     private final AzureLoadBalancerProbe probe;
 
-    public AzureLoadBalancingRule(TargetGroupPortPair portPair) {
+    private final String groupName;
+
+    public AzureLoadBalancingRule(TargetGroupPortPair portPair, Group group) {
         this.backendPort = portPair.getTrafficPort();
         this.frontendPort = portPair.getTrafficPort();
         this.name = defaultNameFromPort(portPair.getTrafficPort());
         this.probe = new AzureLoadBalancerProbe(portPair.getHealthCheckPort());
+        this.groupName = checkNotNull(group, "Group must be provided.").getName();
     }
 
     private String defaultNameFromPort(int port) {
@@ -38,6 +44,10 @@ public final class AzureLoadBalancingRule {
         return probe;
     }
 
+    public String getGroupName() {
+        return groupName;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -46,6 +56,7 @@ public final class AzureLoadBalancingRule {
         sb.append("    backendPort: ").append(backendPort).append("\n");
         sb.append("    frontendPort: ").append(frontendPort).append("\n");
         sb.append("    probe: ").append(toIndentedString(probe)).append("\n");
+        sb.append("    groupName: ").append(toIndentedString(groupName)).append("\n");
         sb.append("}");
 
         return sb.toString();

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -578,9 +578,9 @@ public class AzureTemplateBuilderTest {
         assertEquals(2, StringUtils.countMatches(templateString,
             "\"[resourceId('Microsoft.Network/loadBalancers'"));
         assertEquals(2, StringUtils.countMatches(templateString,
-            "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'LoadBalancertestStackPUBLIC', 'address-pool')]"));
+            "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'LoadBalancertestStackPUBLIC', 'gateway-group-pool')]"));
         assertEquals(2, StringUtils.countMatches(templateString,
-            "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'LoadBalancertestStackPRIVATE', 'address-pool')]"));
+            "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'LoadBalancertestStackPRIVATE', 'gateway-group-pool')]"));
         assertEquals(2, StringUtils.countMatches(templateString,
             "\"type\": \"Microsoft.Network/loadBalancers\","));
         assertEquals(1, StringUtils.countMatches(templateString,

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/TargetGroupType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/TargetGroupType.java
@@ -2,5 +2,6 @@ package com.sequenceiq.common.api.type;
 
 public enum TargetGroupType {
     KNOX,
-    CM
+    CM,
+    OOZIE
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/kerberos/CmServiceKeytabRequestFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/kerberos/CmServiceKeytabRequestFactory.java
@@ -27,7 +27,7 @@ public class CmServiceKeytabRequestFactory {
         request.setDoNotRecreateKeytab(Boolean.TRUE);
         RoleRequest roleRequest = new RoleRequest();
         roleRequest.setRoleName("hadoopadminrole-" + stack.getName());
-        roleRequest.setPrivileges(Set.of("Service Administrators", "Certificate Administrators", "CA Administrator"));
+        roleRequest.setPrivileges(Set.of("Service Administrators", "Certificate Administrators", "Host Administrators", "CA Administrator"));
         request.setRoleRequest(roleRequest);
         return request;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/FreeIPAEndpointManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/FreeIPAEndpointManagementService.java
@@ -77,6 +77,7 @@ public class FreeIPAEndpointManagementService extends BasePublicEndpointManageme
         request.setHostname(endpoint);
         request.setIp(ip);
         request.setEnvironmentCrn(stack.getEnvironmentCrn());
+        request.setCreateReverse(true);
         LOGGER.debug("Registering load balancer with target IP {} in FreeIPA with A record {}", ip, endpoint);
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         ThreadBasedUserCrnProvider.doAsInternalActor(() -> dnsV1Endpoint.addDnsARecordInternal(accountId, request));

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-ha.bp
@@ -494,8 +494,7 @@
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",
           "hms-HIVEMETASTORE-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "hue-HUE_SERVER-BASE",
+          "oozie-OOZIE_SERVER-BASE",
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
@@ -520,7 +519,6 @@
           "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "tez-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",
-          "oozie-OOZIE_SERVER-BASE",
           "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
           "zeppelin-ZEPPELIN_SERVER-BASE",
           "das-DAS_EVENT_PROCESSOR",
@@ -529,7 +527,9 @@
           "zookeeper-SERVER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
           "yarn-QUEUEMANAGER_STORE-BASE",
-          "yarn-GATEWAY-BASE"
+          "yarn-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE"
         ]
       },
       {
@@ -551,7 +551,9 @@
         "refName": "manager",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
-          "knox-KNOX_GATEWAY-BASE"
+          "knox-KNOX_GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE"
         ]
       }
     ]

--- a/core/src/test/resources/input/de-ha.bp
+++ b/core/src/test/resources/input/de-ha.bp
@@ -1,6 +1,4 @@
 {
-  "description": "7.2.11 - Data Engineering HA",
-  "blueprint": {
     "cdhVersion": "7.2.11",
     "displayName": "dataengineering ha",
     "services": [
@@ -20,45 +18,19 @@
         "serviceType": "HDFS",
         "serviceConfigs": [
           {
+            "name": "redaction_policy_enabled",
+            "value": "false"
+          },
+          {
             "name": "zookeeper_service",
             "ref": "zookeeper"
-          },
-          {
-            "name": "hdfs_verify_ec_with_topology_enabled",
-            "value": false
-          },
-          {
-            "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
           }
         ],
         "roleConfigGroups": [
           {
             "refName": "hdfs-NAMENODE-BASE",
             "roleType": "NAMENODE",
-            "base": true,
-            "configs": [
-              {
-                "name": "role_config_suppression_namenode_java_heapsize_minimum_validator",
-                "value": "true"
-              },
-              {
-                "name": "role_config_suppression_fs_trash_interval_minimum_validator",
-                "value": "true"
-              },
-              {
-                "name": "fs_trash_interval",
-                "value": "0"
-              },
-              {
-                "name": "fs_trash_checkpoint_interval",
-                "value": "0"
-              },
-              {
-                "name": "erasure_coding_default_policy",
-                "value": " "
-              }
-            ]
+            "base": true
           },
           {
             "refName": "hdfs-FAILOVERCONTROLLER-BASE",
@@ -99,21 +71,8 @@
               {
                 "name": "dfs_client_use_trash",
                 "value": false
-              },
-              {
-                "name": "role_config_suppression_hdfs_trash_disabled_validator",
-                "value": "true"
-              },
-              {
-                "name": "hdfs_client_env_safety_valve",
-                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
               }
             ]
-          },
-          {
-            "refName": "hdfs-HTTPFS-BASE",
-            "roleType": "HTTPFS",
-            "base": true
           }
         ]
       },
@@ -140,14 +99,16 @@
         "displayName": "Hive",
         "serviceConfigs": [
           {
+            "name": "tez_container_size",
+            "value": "4096"
+          },
+          {
             "name": "tez_auto_reducer_parallelism",
             "value": "false"
           },
           {
             "name": "hive_service_config_safety_valve",
-            "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
-                        <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>
-                        <property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+            "value": "<property><name>hive.server2.tez.sessions.per.default.queue</name><value>4</value></property>"
           }
         ],
         "roleConfigGroups": [
@@ -166,16 +127,12 @@
                 "value": "http"
               },
               {
-                "name": "hiveserver2_mv_files_thread",
-                "value": 20
+                 "name": "hiveserver2_mv_files_thread",
+                 "value": 20
               },
               {
-                "name": "hiveserver2_load_dynamic_partitions_thread_count",
-                "value": 20
-              },
-              {
-                "name": "hiveserver2_idle_session_timeout",
-                "value": 14400000
+                 "name": "hiveserver2_load_dynamic_partitions_thread_count",
+                 "value": 20
               }
             ]
           }
@@ -226,24 +183,6 @@
           {
             "refName": "oozie-OOZIE_SERVER-BASE",
             "roleType": "OOZIE_SERVER",
-            "configs": [
-              {
-                "name": "oozie_config_safety_valve",
-                "value": "<property><name>oozie.service.HadoopAccessorService.nameNode.whitelist</name><value></value></property>"
-              }
-            ],
-            "base": true
-          }
-        ]
-      },
-      {
-        "refName": "sqoop",
-        "serviceType": "SQOOP_CLIENT",
-        "roleConfigGroups": [
-          {
-            "refName": "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
-            "roleType": "GATEWAY",
-            "configs": [ ],
             "base": true
           }
         ]
@@ -257,8 +196,8 @@
             "value": "yarn,hive,hdfs,mapred"
           },
           {
-            "name": "yarn_service_mapred_safety_valve",
-            "value": "<property><name>mapreduce.fileoutputcommitter.algorithm.version</name><value>1</value></property><property><name>mapreduce.input.fileinputformat.list-status.num-threads</name><value>100</value></property>"
+            "name": "yarn_log_aggregation_IFile_remote_app_log_dir",
+            "value": ""
           }
         ],
         "roleConfigGroups": [
@@ -269,7 +208,7 @@
             "configs": [
               {
                 "name": "resourcemanager_config_safety_valve",
-                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>zk</value></property>"
+                "value": "<property><name>yarn.scheduler.configuration.store.class</name><value>file</value></property>"
               },
               {
                 "name": "yarn_resourcemanager_scheduler_class",
@@ -306,8 +245,12 @@
             "base": true,
             "configs": [
               {
-                "name": "mapreduce_client_env_safety_valve",
-                "value": "HADOOP_OPTS=\"-Dorg.wildfly.openssl.path=/usr/lib64 ${HADOOP_OPTS}\""
+                "name": "mapreduce_map_memory_mb",
+                "value": 4096
+              },
+              {
+                "name": "mapreduce_reduce_memory_mb",
+                "value": 4096
               }
             ]
           }
@@ -325,13 +268,7 @@
           {
             "refName": "spark_on_yarn-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true,
-            "configs": [
-              {
-                "name": "spark-conf/spark-defaults.conf_client_config_safety_valve",
-                "value": "spark.hadoop.fs.s3a.ssl.channel.mode=openssl\nspark.hadoop.mapreduce.fileoutputcommitter.algorithm.version=1"
-              }
-            ]
+            "base": true
           }
         ]
       },
@@ -358,31 +295,13 @@
           {
             "name": "tez.task.launch.cmd-opts",
             "value": "-XX:+PrintGCDetails -verbose:gc -XX:+UseNUMA -XX:+UseG1GC -XX:+ResizeTLAB"
-          },
-          {
-            "name": "tez.grouping.split-waves",
-            "value": 1.4
-          },
-          {
-            "name": "tez.grouping.min-size",
-            "value": 268435456
-          },
-          {
-            "name": "tez.grouping.max-size",
-            "value": 268435456
           }
         ],
         "roleConfigGroups": [
           {
             "refName": "tez-GATEWAY-BASE",
             "roleType": "GATEWAY",
-            "base": true,
-            "configs": [
-              {
-                "name": "tez-conf/tez-site.xml_client_config_safety_valve",
-                "value": "<property><name>tez.runtime.pipelined.sorter.lazy-allocate.memory</name><value>true</value></property>"
-              }
-            ]
+            "base": true
           }
         ]
       },
@@ -443,28 +362,6 @@
             "base": true
           }
         ]
-      },
-      {
-        "refName": "queuemanager",
-        "serviceType": "QUEUEMANAGER",
-        "serviceConfigs": [
-          {
-            "name": "kerberos.auth.enabled",
-            "value": "true"
-          }
-        ],
-        "roleConfigGroups": [
-          {
-            "refName": "yarn-QUEUEMANAGER_WEBAPP-BASE",
-            "roleType": "QUEUEMANAGER_WEBAPP",
-            "base": true
-          },
-          {
-            "refName": "yarn-QUEUEMANAGER_STORE-BASE",
-            "roleType": "QUEUEMANAGER_STORE",
-            "base": true
-          }
-        ]
       }
     ],
     "hostTemplates": [
@@ -478,8 +375,7 @@
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
-          "yarn-GATEWAY-BASE",
-          "sqoop-SQOOP_CLIENT-GATEWAY-BASE"
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -489,47 +385,43 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
-          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",
           "hms-HIVEMETASTORE-BASE",
+          "hue-HUE_SERVER-BASE",
           "oozie-OOZIE_SERVER-BASE",
+          "knox-KNOX_GATEWAY-BASE",
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "hdfs-JOURNALNODE-BASE",
           "zookeeper-SERVER-BASE",
-          "yarn-GATEWAY-BASE",
-          "sqoop-SQOOP_CLIENT-GATEWAY-BASE"
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
-        "refName": "masterx",
+        "refName": "manager",
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "hdfs-BALANCER-BASE",
           "hdfs-GATEWAY-BASE",
           "hive-GATEWAY-BASE",
           "hms-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
           "livy-GATEWAY-BASE",
           "livy-LIVY_SERVER-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "tez-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",
-          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
           "zeppelin-ZEPPELIN_SERVER-BASE",
           "das-DAS_EVENT_PROCESSOR",
           "das-DAS_WEBAPP",
           "hdfs-JOURNALNODE-BASE",
           "zookeeper-SERVER-BASE",
-          "yarn-QUEUEMANAGER_WEBAPP-BASE",
-          "yarn-QUEUEMANAGER_STORE-BASE",
-          "yarn-GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "hue-HUE_SERVER-BASE"
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -537,25 +429,29 @@
         "cardinality": 3,
         "roleConfigGroupsRefNames": [
           "hdfs-DATANODE-BASE",
-          "yarn-NODEMANAGER-WORKER"
+          "hdfs-GATEWAY-BASE",
+          "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-NODEMANAGER-WORKER",
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
         "refName": "compute",
         "cardinality": 0,
         "roleConfigGroupsRefNames": [
-          "yarn-NODEMANAGER-COMPUTE"
-        ]
-      },
-      {
-        "refName": "manager",
-        "cardinality": 1,
-        "roleConfigGroupsRefNames": [
-          "knox-KNOX_GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "hue-HUE_SERVER-BASE"
+          "hdfs-GATEWAY-BASE",
+          "hive-GATEWAY-BASE",
+          "hms-GATEWAY-BASE",
+          "livy-GATEWAY-BASE",
+          "spark_on_yarn-GATEWAY-BASE",
+          "tez-GATEWAY-BASE",
+          "yarn-NODEMANAGER-COMPUTE",
+          "yarn-GATEWAY-BASE"
         ]
       }
     ]
-  }
 }

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/generate_agent_tokens.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/generate_agent_tokens.sh.j2
@@ -1,3 +1,4 @@
+{%- set internal_loadbalancer_san = salt['pillar.get']('cloudera-manager:communication:internal_loadbalancer_san') %}
 #!/bin/bash
 
 set -ex
@@ -7,6 +8,7 @@ date '+%Y-%m-%d %H:%M:%S'
 CERTMANAGER_DIR="/etc/cloudera-scm-server/certs"
 declare -A AGENT_FQDN_TOKENDIR_MAP=( {%- for ip, args in pillar.get('hosts', {}).items() %}["{{ args['fqdn'] }}"]="{{ args['fqdn'] }}-{{ args['instance_id'] }}" {% endfor %})
 TOKEN_DIR="/srv/salt/agent-tls-tokens"
+LOADBALANCER_SAN={{ internal_loadbalancer_san }}
 
 source /bin/activate_salt_env
 
@@ -14,9 +16,13 @@ for fqdn in "${!AGENT_FQDN_TOKENDIR_MAP[@]}"
 do
   tokendir=$TOKEN_DIR/${AGENT_FQDN_TOKENDIR_MAP[${fqdn}]}
   if [[ ! -e ${tokendir}/agent_token_generated ]]; then
-    #host=$(echo ${fqdn} | cut -d"." -f1)
+    HOSTNAME=" --hostname ${fqdn} "
+    if [ -n "$LOADBALANCER_SAN" ]; then
+      PATTERN=" --hostname-pattern (${fqdn}|${LOADBALANCER_SAN}) "
+      HOSTNAME=${PATTERN//./\\.}
+    fi
     mkdir -p ${tokendir}
-    /opt/cloudera/cm-agent/bin/certmanager --location $CERTMANAGER_DIR gen_cert_request_token --output ${tokendir}/cmagent.token --hostname ${fqdn} --lifetime 3600
+    /opt/cloudera/cm-agent/bin/certmanager --location $CERTMANAGER_DIR gen_cert_request_token --output ${tokendir}/cmagent.token $HOSTNAME --lifetime 3600
     echo $(date +%Y-%m-%d:%H:%M:%S) >> ${tokendir}/agent_token_generated
   else
     echo "CM agnet token generation for ${fqdn} will be skipped as it was already generated in ${tokendir}."

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/setup-autotls.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/setup-autotls.sh.j2
@@ -1,5 +1,6 @@
 {%- set manager_server_hostname = salt['pillar.get']('hosts')[server_address]['hostname'] %}
 {%- set manager_server_fqdn = salt['pillar.get']('hosts')[server_address]['fqdn'] %}
+{%- set internal_loadbalancer_san = salt['pillar.get']('cloudera-manager:communication:internal_loadbalancer_san') %}
 #!/bin/bash
 
 set -ex
@@ -12,6 +13,7 @@ trap cleanup EXIT
 
 HOSTNAME={{ manager_server_hostname }}
 FQDN={{ manager_server_fqdn }}
+LOADBALANCER_SAN={{ internal_loadbalancer_san }}
 CM_KEYTAB_FILE={{ cm_keytab.path }}
 CM_PRINCIPAL={{ cm_keytab.principal }}
 CERTMANAGER_DIR="/etc/cloudera-scm-server/certs"
@@ -33,9 +35,14 @@ rm -f ${CACERTS_DIR}/cacerts.pem
 keytool -importkeystore -srckeystore ${JAVA_HOME}/jre/lib/security/cacerts -srcstorepass changeit -destkeystore ${CACERTS_DIR}/cacerts.p12 -deststorepass changeit -deststoretype PKCS12
 openssl pkcs12 -in ${CACERTS_DIR}/cacerts.p12 -passin pass:changeit -out ${CACERTS_DIR}/cacerts.pem
 
-/opt/cloudera/cm-agent/bin/certmanager --location $CERTMANAGER_DIR setup --configure-services $CERTMANAGER_ARGS --override ca_dn="CN=${HOSTNAME}" --stop-at-csr --altname DNS:${FQDN} --trusted-ca-certs ${CACERTS_DIR}/cacerts.pem
+ALTNAME=" --altname DNS:${FQDN} "
+if [ -n "$LOADBALANCER_SAN" ]; then
+  ALTNAME+="--altname ${LOADBALANCER_SAN} "
+fi
+
+/opt/cloudera/cm-agent/bin/certmanager --location $CERTMANAGER_DIR setup --configure-services $CERTMANAGER_ARGS --override ca_dn="CN=${HOSTNAME}" --stop-at-csr ${ALTNAME} --trusted-ca-certs ${CACERTS_DIR}/cacerts.pem
 /opt/cloudera/cm/bin/generate_intermediate_ca_ipa.sh $CM_PRINCIPAL ${CERTMANAGER_DIR}/CMCA/private/ca_csr.pem $OUT_FILE
-/opt/cloudera/cm-agent/bin/certmanager --location $CERTMANAGER_DIR setup --configure-services $CERTMANAGER_ARGS --override ca_dn="CN=${HOSTNAME}" --signed-ca-cert=$OUT_FILE --skip-cm-init --altname DNS:${FQDN} --trusted-ca-certs ${CACERTS_DIR}/cacerts.pem > $CERTMANAGER_DIR/auto-tls.init.txt
+/opt/cloudera/cm-agent/bin/certmanager --location $CERTMANAGER_DIR setup --configure-services $CERTMANAGER_ARGS --override ca_dn="CN=${HOSTNAME}" --signed-ca-cert=$OUT_FILE --skip-cm-init ${ALTNAME} --trusted-ca-certs ${CACERTS_DIR}/cacerts.pem > $CERTMANAGER_DIR/auto-tls.init.txt
 
 rm -rf $OUT_FILE
 

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -44,6 +44,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERAMANAGER_VERSION_7_4_2 = () -> "7.4.2";
 
+    public static final Versioned CLOUDERAMANAGER_VERSION_7_4_3 = () -> "7.4.3";
+
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_9 = () -> "7.2.9";
 
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_10 = () -> "7.2.10";

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
@@ -138,7 +138,6 @@ public class HueConfigProvider extends AbstractRdsRoleConfigProvider {
 
     private boolean externalFQDNShouldConfigured(GatewayView gateway, GeneralClusterConfigs generalClusterConfigs) {
         return gateway != null
-                && generalClusterConfigs.getKnoxUserFacingCertConfigured()
                 && ((StringUtils.isNotEmpty(generalClusterConfigs.getExternalFQDN())
                 && generalClusterConfigs.getPrimaryGatewayInstanceDiscoveryFQDN().isPresent())
                 || generalClusterConfigs.getLoadBalancerGatewayFqdn().isPresent());

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieHAConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieHAConfigProvider.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie.OozieRoleConfigProvider.isOozieHA;
+
+import java.util.List;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
+
+@Component
+public class OozieHAConfigProvider implements CmTemplateComponentConfigProvider {
+
+    public static final String OOZIE_HTTP_PORT = "11000";
+
+    public static final String OOZIE_HTTPS_PORT = "11443";
+
+    private static final String OOZIE_LB_HOST = "oozie_load_balancer";
+
+    private static final String OOZIE_LB_HTTP_PORT = "oozie_load_balancer_http_port";
+
+    private static final String OOZIE_LB_HTTPS_PORT = "oozie_load_balancer_https_port";
+
+    @Override
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
+        return List.of(
+            config(OOZIE_LB_HOST, oozieFQDN(source).orElse("")),
+            config(OOZIE_LB_HTTP_PORT, OOZIE_HTTP_PORT),
+            config(OOZIE_LB_HTTPS_PORT, OOZIE_HTTPS_PORT)
+        );
+    }
+
+    @Override
+    public String getServiceType() {
+        return OozieRoles.OOZIE;
+    }
+
+    @Override
+    public List<String> getRoleTypes() {
+        return List.of(OozieRoles.OOZIE_SERVER);
+    }
+
+    @Override
+    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        return cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes())
+            && isOozieHA(source)
+            && oozieFQDN(source).isPresent();
+    }
+
+    private static Optional<String> oozieFQDN(TemplatePreparationObject source) {
+        GeneralClusterConfigs generalClusterConfigs = source.getGeneralClusterConfigs();
+        if (generalClusterConfigs != null && generalClusterConfigs.getLoadBalancerGatewayFqdn().isPresent()) {
+            return generalClusterConfigs.getLoadBalancerGatewayFqdn();
+        }
+        return source.getHostGroupsWithComponent(OozieRoles.OOZIE_SERVER)
+            .flatMap(hostGroup -> hostGroup.getHosts().stream())
+            .findFirst();
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProvider.java
@@ -1,15 +1,21 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_11;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import com.sequenceiq.cloudbreak.template.views.RdsView;
 
 @Component
@@ -25,18 +31,28 @@ public class OozieRoleConfigProvider extends AbstractRdsRoleConfigProvider {
 
     private static final String OOZIE_DATABASE_PASSWORD = "oozie_database_password";
 
+    private static final String OOZIE_CONFIG_SAFETY_VALVE = "oozie_config_safety_valve";
+
     @Override
     protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
         switch (roleType) {
             case OozieRoles.OOZIE_SERVER:
                 RdsView oozieRdsView = getRdsView(source);
-                return List.of(
-                        config(OOZIE_DATABASE_HOST, oozieRdsView.getHost()),
-                        config(OOZIE_DATABASE_NAME, oozieRdsView.getDatabaseName()),
-                        config(OOZIE_DATABASE_TYPE, oozieRdsView.getSubprotocol()),
-                        config(OOZIE_DATABASE_USER, oozieRdsView.getConnectionUserName()),
-                        config(OOZIE_DATABASE_PASSWORD, oozieRdsView.getConnectionPassword())
-                );
+                List<ApiClusterTemplateConfig> config = new ArrayList<>(List.of(
+                    config(OOZIE_DATABASE_HOST, oozieRdsView.getHost()),
+                    config(OOZIE_DATABASE_NAME, oozieRdsView.getDatabaseName()),
+                    config(OOZIE_DATABASE_TYPE, oozieRdsView.getSubprotocol()),
+                    config(OOZIE_DATABASE_USER, oozieRdsView.getConnectionUserName()),
+                    config(OOZIE_DATABASE_PASSWORD, oozieRdsView.getConnectionPassword())));
+                if (isOozieHA(source) && CloudPlatform.GCP == source.getCloudPlatform()) {
+                    // There is no load-balancer for GCP yet. For base and callback urls use the hostname of the Oozie server.
+                    config.add(config(OOZIE_CONFIG_SAFETY_VALVE,
+                        "<property><name>oozie.base.url</name>"
+                            + "<value>https://${oozie.http.hostname}:${oozie.https.port}/oozie</value></property>"
+                            + "<property><name>oozie.service.CallbackService.base.url</name>"
+                            + "<value>https://${oozie.http.hostname}:${oozie.https.port}/oozie/callback</value></property>"));
+                }
+                return config;
             default:
                 return List.of();
         }
@@ -55,5 +71,17 @@ public class OozieRoleConfigProvider extends AbstractRdsRoleConfigProvider {
     @Override
     protected DatabaseType dbType() {
         return DatabaseType.OOZIE;
+    }
+
+    public static boolean isOozieHA(TemplatePreparationObject source) {
+        String cdhVersion = StringUtils.defaultString(source.getBlueprintView().getProcessor().getStackVersion());
+
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_11)) {
+            return source.getHostGroupsWithComponent(OozieRoles.OOZIE_SERVER)
+                .filter(hg -> hg.getNodeCount() > 1)
+                .mapToInt(HostgroupView::getNodeCount)
+                .sum() > 1;
+        }
+        return false;
     }
 }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieHAConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieHAConfigProviderTest.java
@@ -1,0 +1,63 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie.OozieRoleConfigProviderTest.getBlueprintText;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie.OozieRoleConfigProviderTest.getTemplatePreparationObject;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OozieHAConfigProviderTest {
+
+    private final OozieHAConfigProvider underTest = new OozieHAConfigProvider();
+
+    @Test
+    public void testGetServiceConfigsWithSingleRolesPerHostGroup() {
+        String inputJson = getBlueprintText("input/clouderamanager-db-config.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(inputJson, cmTemplateProcessor, 1);
+
+        assertFalse(underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject));
+    }
+
+    @Test
+    public void testGetServiceConfigsWithOozieHA() {
+        String inputJson = getBlueprintText("input/de-ha.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(inputJson, cmTemplateProcessor, 2);
+
+        assertTrue(underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject));
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(cmTemplateProcessor, preparationObject);
+
+        assertEquals(3, serviceConfigs.size());
+
+        assertEquals("oozie_load_balancer", serviceConfigs.get(0).getName());
+        assertEquals("master0.blah.timbuk2.dev.cldr.", serviceConfigs.get(0).getValue());
+
+        assertEquals("oozie_load_balancer_http_port", serviceConfigs.get(1).getName());
+        assertEquals("11000", serviceConfigs.get(1).getValue());
+
+        assertEquals("oozie_load_balancer_https_port", serviceConfigs.get(2).getName());
+        assertEquals("11443", serviceConfigs.get(2).getValue());
+    }
+
+    @Test
+    public void testGetServiceConfigsWithNoOozie() {
+        String inputJson = getBlueprintText("input/clouderamanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(inputJson, cmTemplateProcessor, 1);
+
+        assertFalse(underTest.isConfigurationNeeded(cmTemplateProcessor, preparationObject));
+    }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProviderTest.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.oozie;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -12,6 +14,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
@@ -26,9 +31,9 @@ public class OozieRoleConfigProviderTest {
 
     @Test
     public void testGetRoleConfigsWithSingleRolesPerHostGroup() {
-        TemplatePreparationObject preparationObject = getTemplatePreparationObject();
         String inputJson = getBlueprintText("input/clouderamanager-db-config.bp");
         CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(inputJson, cmTemplateProcessor, 1);
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
         List<ApiClusterTemplateConfig> oozieServer = roleConfigs.get("oozie-OOZIE_SERVER-BASE");
@@ -50,8 +55,57 @@ public class OozieRoleConfigProviderTest {
         assertEquals("testpassword", oozieServer.get(4).getValue());
     }
 
-    private TemplatePreparationObject getTemplatePreparationObject() {
-        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
+    @Test
+    public void testGetRoleConfigsWithOozieHA() {
+        String inputJson = getBlueprintText("input/de-ha.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(inputJson, cmTemplateProcessor, 2);
+
+        Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
+        List<ApiClusterTemplateConfig> oozieServer = roleConfigs.get("oozie-OOZIE_SERVER-BASE");
+
+        assertEquals(6, oozieServer.size());
+        assertEquals("oozie_database_host", oozieServer.get(0).getName());
+        assertEquals("testhost", oozieServer.get(0).getValue());
+
+        assertEquals("oozie_database_name", oozieServer.get(1).getName());
+        assertEquals("ooziedb", oozieServer.get(1).getValue());
+
+        assertEquals("oozie_database_type", oozieServer.get(2).getName());
+        assertEquals("postgresql", oozieServer.get(2).getValue());
+
+        assertEquals("oozie_database_user", oozieServer.get(3).getName());
+        assertEquals("testuser", oozieServer.get(3).getValue());
+
+        assertEquals("oozie_database_password", oozieServer.get(4).getName());
+        assertEquals("testpassword", oozieServer.get(4).getValue());
+
+        assertEquals("oozie_config_safety_valve", oozieServer.get(5).getName());
+        assertEquals("<property><name>oozie.base.url</name>"
+            + "<value>https://${oozie.http.hostname}:${oozie.https.port}/oozie</value></property>"
+            + "<property><name>oozie.service.CallbackService.base.url</name>"
+            + "<value>https://${oozie.http.hostname}:${oozie.https.port}/oozie/callback</value></property>", oozieServer.get(5).getValue());
+    }
+
+    @Test
+    public void testGetRoleConfigsWithNoOozie() {
+        String inputJson = getBlueprintText("input/clouderamanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = getTemplatePreparationObject(inputJson, cmTemplateProcessor, 1);
+
+        Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
+        List<ApiClusterTemplateConfig> oozieServer = roleConfigs.get("oozie-OOZIE_SERVER-BASE");
+
+        assertNull(oozieServer);
+    }
+
+    static TemplatePreparationObject getTemplatePreparationObject(String inputJson,
+        CmTemplateProcessor cmTemplateProcessor, int numMasters) {
+        List<String> hosts = new ArrayList<>();
+        for (int i = 0; i < numMasters; i++) {
+            hosts.add("master" + i + ".blah.timbuk2.dev.cldr.");
+        }
+        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, hosts);
         HostgroupView worker = new HostgroupView("worker", 2, InstanceGroupType.CORE, 2);
         RDSConfig rdsConfig = new RDSConfig();
         rdsConfig.setType(DatabaseType.OOZIE.toString());
@@ -59,11 +113,15 @@ public class OozieRoleConfigProviderTest {
         rdsConfig.setConnectionUserName("testuser");
         rdsConfig.setConnectionURL("jdbc:postgresql://testhost:5432/ooziedb");
 
-        return TemplatePreparationObject.Builder.builder()
-                .withHostgroupViews(Set.of(master, worker)).withRdsConfigs(Set.of(rdsConfig)).build();
+        return Builder.builder()
+                .withHostgroupViews(Set.of(master, worker))
+                .withRdsConfigs(Set.of(rdsConfig))
+                .withBlueprintView(new BlueprintView(inputJson, "CDP", "1.0", cmTemplateProcessor))
+                .withCloudPlatform(CloudPlatform.GCP)
+                .build();
     }
 
-    private String getBlueprintText(String path) {
+    static String getBlueprintText(String path) {
         return FileReaderUtils.readFileFromClasspathQuietly(path);
     }
 }

--- a/template-manager-cmtemplate/src/test/resources/input/de-ha.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/de-ha.bp
@@ -1,5 +1,5 @@
 {
-    "cdhVersion": "7.1.0",
+    "cdhVersion": "7.2.11",
     "displayName": "dataengineering ha",
     "services": [
       {
@@ -390,6 +390,7 @@
           "hms-GATEWAY-BASE",
           "hms-HIVEMETASTORE-BASE",
           "hue-HUE_SERVER-BASE",
+          "oozie-OOZIE_SERVER-BASE",
           "knox-KNOX_GATEWAY-BASE",
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
@@ -415,7 +416,6 @@
           "spark_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "tez-GATEWAY-BASE",
           "yarn-JOBHISTORY-BASE",
-          "oozie-OOZIE_SERVER-BASE",
           "zeppelin-ZEPPELIN_SERVER-BASE",
           "das-DAS_EVENT_PROCESSOR",
           "das-DAS_WEBAPP",


### PR DESCRIPTION
1. In public cloud all the requests go through Knox, so we do not need a external load-balancer for external clients.
2. CM configuration for multiple Oozie hosts demands a load-balancer to be configured.
3. This is for Hue and Yarn to access the Oozie in HA fashion.
4. For AWS and Azure use an internal load-balancer.
5. For GCP we do not have any load-balancers, so as a workaround use the current Oozie server address for url and callbacks.
6. To make Hue to Oozie interaction work via load-balancer, Hue is moved to a new hostgroup. Since there is only one instance for GCP for manager node, Hue is also added to masterx hostgroup.
7. CM is given ability to add hosts.
8. LB reverse IP is added.
9. Knox proxy hosts are configured even if we failed to acquire Let's Encrypt certificate. Rationale is, the common workaround for Let's Encrypt outages is to let the cluster be created and users are asked to click the renew certificate button.