### PR TITLE
CB-12549: Fix FreeIPA repair when old nodes are returned by salt

### DIFF
--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -81,7 +81,7 @@ public interface HostOrchestrator extends HostRecipeExecutor {
     void installFreeIpa(GatewayConfig primaryGateway, List<GatewayConfig> allGatewayConfigs, Set<Node> allNodes,
             ExitCriteriaModel exitCriteriaModel) throws CloudbreakOrchestratorException;
 
-    Optional<String> getFreeIpaMasterHostname(GatewayConfig primaryGateway) throws CloudbreakOrchestratorException;
+    Optional<String> getFreeIpaMasterHostname(GatewayConfig primaryGateway, Set<Node> allNodes) throws CloudbreakOrchestratorException;
 
     void leaveDomain(GatewayConfig gatewayConfig, Set<Node> allNodes, String roleToRemove, String roleToAdd, ExitCriteriaModel exitCriteriaModel)
             throws CloudbreakOrchestratorFailedException;

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/HostAndRoleTarget.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/HostAndRoleTarget.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.client.target;
+
+import java.util.Collection;
+
+public class HostAndRoleTarget implements Target<String> {
+
+    private static final String ROLE_PREFIX = "G@roles:";
+
+    private static final String COMPOUND_AND = " and ";
+
+    private static final String HOST_PREFIX = "L@";
+
+    private String role;
+
+    private Collection<String> hosts;
+
+    public HostAndRoleTarget(String role, Collection<String> hosts) {
+        this.role = role;
+        this.hosts = hosts;
+    }
+
+    @Override
+    public String getTarget() {
+        return ROLE_PREFIX + role + COMPOUND_AND + HOST_PREFIX + String.join(",", hosts);
+    }
+
+    @Override
+    public String getType() {
+        return "compound";
+    }
+
+        @Override
+    public String toString() {
+        return "HostAndRoleTarget{" +
+                "role=" + role +
+                ",hosts=" + hosts +
+                '}';
+    }
+}

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/HostAndRoleTargetTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/client/target/HostAndRoleTargetTest.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.orchestrator.salt.client.target;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HostAndRoleTargetTest {
+
+    @Test
+    public void testGetType() {
+        HostAndRoleTarget underTest = new HostAndRoleTarget("foo", List.of());
+        assertEquals("compound", underTest.getType());
+    }
+
+    @Test
+    public void testGetTarget() {
+        HostAndRoleTarget underTest = new HostAndRoleTarget("foo", List.of("example1.com", "example2.com"));
+        assertEquals("G@roles:foo and L@example1.com,example2.com", underTest.getTarget());
+    }
+}


### PR DESCRIPTION
In a FreeIPA HA repair, sometimes old instances are returned by salt
when the instances are checked for their roles. This was fixed by
applying a compound filter which filtered both the role name and the
current instances.

This was tested with unit tests and it was also tested using a local
cloudbreak.

See detailed description in the commit message.