### PR TITLE
Revert "CB-12296 BP set to null during the finalization of termiantio…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ServiceEndpointCollector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ServiceEndpointCollector.java
@@ -6,6 +6,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -35,7 +36,6 @@ import com.sequenceiq.cloudbreak.api.service.ExposedServiceCollector;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
-import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -81,9 +81,6 @@ public class ServiceEndpointCollector {
 
     public Collection<ExposedServiceV4Response> getKnoxServices(Long workspaceId, String blueprintName) {
         Blueprint blueprint = blueprintService.getByNameForWorkspaceId(blueprintName, workspaceId);
-        if (blueprint == null) {
-            throw new NotFoundException(String.format("Blueprint could not be find by name: '%s'.", blueprintName));
-        }
         return getKnoxServices(blueprint, entitlementService.getEntitlements(blueprint.getWorkspace().getTenant().getName()));
     }
 
@@ -110,13 +107,13 @@ public class ServiceEndpointCollector {
 
     public Map<String, Collection<ClusterExposedServiceV4Response>> prepareClusterExposedServices(Cluster cluster, String managerIp) {
         String blueprintText = getBlueprintString(cluster);
-        Map<String, Collection<ClusterExposedServiceV4Response>> clusterExposedServiceMap = new HashMap<>();
         if (!Strings.isNullOrEmpty(blueprintText)) {
             BlueprintTextProcessor processor = cmTemplateProcessorFactory.get(blueprintText);
             Collection<ExposedService> knownExposedServices = getExposedServices(
-                    blueprintText,
+                    cluster.getBlueprint(),
                     entitlementService.getEntitlements(cluster.getWorkspace().getTenant().getName()));
             Gateway gateway = cluster.getGateway();
+            Map<String, Collection<ClusterExposedServiceV4Response>> clusterExposedServiceMap = new HashMap<>();
             Map<String, List<String>> privateIps = componentLocatorService.getComponentLocation(cluster.getId(), processor,
                     knownExposedServices.stream().map(ExposedService::getServiceName).collect(Collectors.toSet()));
             LOGGER.debug("The private IPs in the cluster {}", privateIps);
@@ -125,46 +122,42 @@ public class ServiceEndpointCollector {
             }
             if (gateway != null) {
                 for (GatewayTopology gatewayTopology : gateway.getTopologies()) {
-                    generateGatewayTopology(cluster, managerIp, clusterExposedServiceMap, knownExposedServices, gateway, privateIps, gatewayTopology);
+                    LOGGER.debug("Generating the topology for '{}' topologies", gatewayTopology.getTopologyName());
+                    Set<String> exposedServicesInTopology = gateway.getTopologies().stream()
+                            .flatMap(this::getExposedServiceStream)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toSet());
+                    List<ClusterExposedServiceV4Response> uiServices = new ArrayList<>();
+                    List<ClusterExposedServiceV4Response> apiServices = new ArrayList<>();
+                    boolean autoTlsEnabled = cluster.getAutoTlsEnabled();
+                    LOGGER.debug("AutoTls enabled '{}' for the cluster", autoTlsEnabled);
+                    SecurityConfig securityConfig = cluster.getStack().getSecurityConfig();
+                    String managerServerUrl = getManagerServerUrl(cluster, managerIp);
+                    for (ExposedService exposedService : knownExposedServices) {
+                        if (exposedService.isCmProxied()) {
+                            List<ClusterExposedServiceV4Response> uiServiceOnPrivateIps = createCmProxiedServiceEntries(exposedService, gateway,
+                                    gatewayTopology, managerServerUrl, cluster.getName());
+                            uiServices.addAll(uiServiceOnPrivateIps);
+                        } else {
+                            if (!exposedService.isApiOnly()) {
+                                List<ClusterExposedServiceV4Response> uiServiceOnPrivateIps = createServiceEntries(exposedService, gateway, gatewayTopology,
+                                        managerIp, privateIps, exposedServicesInTopology, false, autoTlsEnabled, securityConfig);
+                                uiServices.addAll(uiServiceOnPrivateIps);
+                            }
+                            if (exposedService.isApiIncluded()) {
+                                List<ClusterExposedServiceV4Response> apiServiceOnPrivateIps = createServiceEntries(exposedService, gateway, gatewayTopology,
+                                        managerIp, privateIps, exposedServicesInTopology, true, autoTlsEnabled, securityConfig);
+                                apiServices.addAll(apiServiceOnPrivateIps);
+                            }
+                        }
+                    }
+                    clusterExposedServiceMap.put(gatewayTopology.getTopologyName(), uiServices);
+                    clusterExposedServiceMap.put(gatewayTopology.getTopologyName() + API_TOPOLOGY_POSTFIX, apiServices);
                 }
             }
+            return clusterExposedServiceMap;
         }
-        return clusterExposedServiceMap;
-    }
-
-    private void generateGatewayTopology(Cluster cluster, String managerIp, Map<String, Collection<ClusterExposedServiceV4Response>> clusterExposedServiceMap,
-            Collection<ExposedService> knownExposedServices, Gateway gateway, Map<String, List<String>> privateIps, GatewayTopology gatewayTopology) {
-        LOGGER.debug("Generating the topology for '{}' topologies", gatewayTopology.getTopologyName());
-        Set<String> exposedServicesInTopology = gateway.getTopologies().stream()
-                .flatMap(this::getExposedServiceStream)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toSet());
-        List<ClusterExposedServiceV4Response> uiServices = new ArrayList<>();
-        List<ClusterExposedServiceV4Response> apiServices = new ArrayList<>();
-        boolean autoTlsEnabled = cluster.getAutoTlsEnabled();
-        LOGGER.debug("AutoTls enabled '{}' for the cluster", autoTlsEnabled);
-        SecurityConfig securityConfig = cluster.getStack().getSecurityConfig();
-        String managerServerUrl = getManagerServerUrl(cluster, managerIp);
-        for (ExposedService exposedService : knownExposedServices) {
-            if (exposedService.isCmProxied()) {
-                List<ClusterExposedServiceV4Response> uiServiceOnPrivateIps = createCmProxiedServiceEntries(exposedService, gateway,
-                        gatewayTopology, managerServerUrl, cluster.getName());
-                uiServices.addAll(uiServiceOnPrivateIps);
-            } else {
-                if (!exposedService.isApiOnly()) {
-                    List<ClusterExposedServiceV4Response> uiServiceOnPrivateIps = createServiceEntries(exposedService, gateway, gatewayTopology,
-                            managerIp, privateIps, exposedServicesInTopology, false, autoTlsEnabled, securityConfig);
-                    uiServices.addAll(uiServiceOnPrivateIps);
-                }
-                if (exposedService.isApiIncluded()) {
-                    List<ClusterExposedServiceV4Response> apiServiceOnPrivateIps = createServiceEntries(exposedService, gateway, gatewayTopology,
-                            managerIp, privateIps, exposedServicesInTopology, true, autoTlsEnabled, securityConfig);
-                    apiServices.addAll(apiServiceOnPrivateIps);
-                }
-            }
-        }
-        clusterExposedServiceMap.put(gatewayTopology.getTopologyName(), uiServices);
-        clusterExposedServiceMap.put(gatewayTopology.getTopologyName() + API_TOPOLOGY_POSTFIX, apiServices);
+        return Collections.emptyMap();
     }
 
     private String getBlueprintString(Cluster cluster) {
@@ -229,7 +222,7 @@ public class ServiceEndpointCollector {
     }
 
     private List<ClusterExposedServiceV4Response> createCmProxiedServiceEntries(ExposedService exposedService, Gateway gateway,
-            GatewayTopology gatewayTopology, String managerIp, String clusterName) {
+        GatewayTopology gatewayTopology, String managerIp, String clusterName) {
         List<ClusterExposedServiceV4Response> services = new ArrayList<>();
         String serviceUrlsForService = getCmProxiedServiceUrlsForService(exposedService, gateway, gatewayTopology.getTopologyName(), managerIp, clusterName);
         if (!Strings.isNullOrEmpty(serviceUrlsForService)) {
@@ -272,10 +265,11 @@ public class ServiceEndpointCollector {
     /**
      * Get all exposed services for blueprint, there are filtered by visibility
      *
-     * @param blueprintText given blueprintText
+     * @param blueprint given blueprint
      * @return all visible exposed services for the given blueprint
      */
-    private Collection<ExposedService> getExposedServices(String blueprintText, List<String> entitlements) {
+    private Collection<ExposedService> getExposedServices(Blueprint blueprint, List<String> entitlements) {
+        String blueprintText = blueprint.getBlueprintText();
         CmTemplateProcessor processor = cmTemplateProcessorFactory.get(blueprintText);
         List<String> components = processor.getAllComponents().stream().map(ServiceComponent::getComponent).collect(Collectors.toList());
         return exposedServiceCollector.knoxServicesForComponents(components)
@@ -292,7 +286,7 @@ public class ServiceEndpointCollector {
 
     private Collection<ExposedServiceV4Response> getKnoxServices(Blueprint blueprint, List<String> entitlements) {
         return ExposedServiceV4Response.fromExposedServices(
-                getExposedServices(blueprint.getBlueprintText(), entitlements));
+                getExposedServices(blueprint, entitlements));
     }
 
     private Stream<String> getExposedServiceStream(GatewayTopology gatewayTopology) {
@@ -311,9 +305,7 @@ public class ServiceEndpointCollector {
     private List<String> getServiceUrlsForService(ExposedService exposedService, String managerIp, Gateway gateway,
             String topologyName, Map<String, List<String>> privateIps, boolean api, boolean autoTlsEnabled) {
         List<String> urls = new ArrayList<>();
-        if (!privateIps.containsKey(exposedService.getServiceName())) {
-            LOGGER.info("Cannot find private ip for the {} exposed service", exposedService.getServiceName());
-        } else if (hasKnoxUrl(exposedService) && managerIp != null) {
+        if (hasKnoxUrl(exposedService) && managerIp != null) {
             switch (exposedService.getName()) {
                 case "NAMENODE":
                     addNameNodeUrl(managerIp, gateway, privateIps, autoTlsEnabled, urls);
@@ -405,15 +397,15 @@ public class ServiceEndpointCollector {
     private void addHbaseJarsUrl(String managerIp, Gateway gateway, Map<String, List<String>> privateIps, List<String> urls) {
         // Grab the first HBase master. Any will do, so we'll take the first
         privateIps.get(exposedServiceCollector.getHBaseJarsService().getServiceName())
-                .stream()
-                .map(hbaseIp -> getHBaseJarsServiceUrl(gateway, managerIp, hbaseIp))
-                .flatMap(Optional::stream)
-                .findFirst()
-                .ifPresent(hbaseUrl -> urls.add(hbaseUrl));
+            .stream()
+            .map(hbaseIp -> getHBaseJarsServiceUrl(gateway, managerIp, hbaseIp))
+            .flatMap(Optional::stream)
+            .findFirst()
+            .ifPresent(hbaseUrl -> urls.add(hbaseUrl));
     }
 
     private void addResourceManagerUrl(ExposedService exposedService, String managerIp, Gateway gateway, String topologyName, boolean api,
-            List<String> urls) {
+        List<String> urls) {
         String knoxUrl = api ? "/resourcemanager/" : exposedService.getKnoxUrl();
         String topology = api ? topologyName + API_TOPOLOGY_POSTFIX : topologyName;
         urls.add(buildKnoxUrl(managerIp, gateway, knoxUrl, topology, !exposedService.isWithoutProxyPath()));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/ServiceEndpointCollectorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/ServiceEndpointCollectorTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.service;
 
 import static com.sequenceiq.cloudbreak.controller.validation.stack.cluster.gateway.ExposedServiceUtil.exposedService;
-import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -111,13 +110,12 @@ public class ServiceEndpointCollectorTest {
         when(exposedServiceCollector.getClouderaManagerUIService()).thenReturn(getClouderaManagerUIService());
         when(exposedServiceCollector.getImpalaService()).thenReturn(exposedService("IMPALA"));
         when(exposedServiceCollector.knoxServicesForComponents(anyList())).thenReturn(
-                List.of(exposedService("CLOUDERA_MANAGER"), exposedService("CLOUDERA_MANAGER_UI"), exposedService("NAMENODE"), exposedService("HBASEJARS")));
+                List.of(exposedService("CLOUDERA_MANAGER"), exposedService("CLOUDERA_MANAGER_UI")));
         when(exposedServiceCollector.getFullServiceListBasedOnList(anyList())).thenAnswer(a -> Set.copyOf(a.getArgument(0)));
         when(serviceEndpointCollectorVersionComparator.maxVersionSupported(any(), any())).thenReturn(true);
         when(serviceEndpointCollectorVersionComparator.minVersionSupported(any(), any())).thenReturn(true);
         when(entitlementService.getEntitlements(anyString())).thenReturn(new ArrayList<>());
         when(serviceEndpointCollectorEntitlementComparator.entitlementSupported(anyList(), eq(null))).thenReturn(true);
-        when(exposedServiceCollector.getNameNodeService()).thenReturn(exposedService("NAMENODE"));
     }
 
     @Test
@@ -282,53 +280,20 @@ public class ServiceEndpointCollectorTest {
     }
 
     @Test
-    public void testPrepareClusterExposedServicesIfBlueprintNull() {
-        Cluster cluster = createClusterWithComponents(new ExposedService[]{exposedService("ATLAS")},
-                new ExposedService[]{exposedService("HIVE_SERVER"), exposedService("WEBHDFS")}, GatewayType.INDIVIDUAL);
-        cluster.getGateway().setGatewayPort(443);
-        cluster.setExtendedBlueprintText("extended-blueprint");
-        cluster.setBlueprint(null);
-        mockBlueprintTextProcessor();
-        mockComponentLocator(Lists.newArrayList("10.0.0.1"));
-
-        Map<String, Collection<ClusterExposedServiceV4Response>> clusterExposedServicesMap =
-                underTest.prepareClusterExposedServices(cluster, "10.0.0.1");
-
-        assertEquals(4L, clusterExposedServicesMap.keySet().size());
-    }
-
-
-    //If the private ip list is empty, cluster does not have any hostgroup.
-    @Test
-    public void testPrepareClusterExposedServicesIfPrivateIpsEmpty() {
-        Cluster cluster = createClusterWithComponents(new ExposedService[]{exposedService("ATLAS")},
-                new ExposedService[]{exposedService("HIVE_SERVER"), exposedService("WEBHDFS")}, GatewayType.INDIVIDUAL);
-        cluster.getGateway().setGatewayPort(443);
-        cluster.setExtendedBlueprintText("extended-blueprint");
-        mockBlueprintTextProcessor();
-        when(componentLocatorService.getComponentLocation(any(), any(), any())).thenReturn(emptyMap());
-
-        Map<String, Collection<ClusterExposedServiceV4Response>> clusterExposedServicesMap =
-                underTest.prepareClusterExposedServices(cluster, "10.0.0.1");
-
-        assertEquals(4L, clusterExposedServicesMap.keySet().size());
-    }
-
-    @Test
     public void testGetKnoxServices() {
         mockBlueprintTextProcessor();
         Collection<ExposedServiceV4Response> exposedServiceResponses = underTest.getKnoxServices(workspace.getId(), "blueprint");
-        assertEquals(4L, exposedServiceResponses.size());
+        assertEquals(2L, exposedServiceResponses.size());
 
         mockBlueprintTextProcessor();
 
         exposedServiceResponses = underTest.getKnoxServices(workspace.getId(), "blueprint");
-        assertEquals(4L, exposedServiceResponses.size());
+        assertEquals(2L, exposedServiceResponses.size());
 
         mockBlueprintTextProcessor();
 
         exposedServiceResponses = underTest.getKnoxServices(workspace.getId(), "blueprint");
-        assertEquals(4L, exposedServiceResponses.size());
+        assertEquals(2L, exposedServiceResponses.size());
     }
 
     @Test
@@ -336,12 +301,12 @@ public class ServiceEndpointCollectorTest {
         mockBlueprintTextProcessor();
 
         Collection<ExposedServiceV4Response> exposedServiceResponses = underTest.getKnoxServices(workspace.getId(), "blueprint");
-        assertEquals(4L, exposedServiceResponses.size());
+        assertEquals(2L, exposedServiceResponses.size());
 
         mockBlueprintTextProcessor();
 
         exposedServiceResponses = underTest.getKnoxServices(workspace.getId(), "blueprint");
-        assertEquals(4L, exposedServiceResponses.size());
+        assertEquals(2L, exposedServiceResponses.size());
     }
 
     private void mockBlueprintTextProcessor() {


### PR DESCRIPTION
…n but we want to access it and throw a NPE. Furthermore the private ips are empty when the cluster does not have any hostgroup but we want to access by the servicename and it throw a NPE."

This reverts commit 9c35c5facff6f44d678d07f4ab2cd7e7a995d071.

See detailed description in the commit message.