### PR TITLE
CB-12543: sourceImageDate missing from custom images

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/customimage/request/CustomImageCatalogV4CreateImageRequest.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/customimage/request/CustomImageCatalogV4CreateImageRequest.java
@@ -26,14 +26,13 @@ public class CustomImageCatalogV4CreateImageRequest {
     private String imageType;
 
     @Size(max = 255, min = 1, message = "The length of the sourceImageId must be between 1 and 255")
-    @Pattern(regexp = "(^[a-z][-a-z0-9]*[a-z0-9]$)",
+    @Pattern(regexp = "(^[a-z0-9][-a-z0-9]*[a-z0-9]$)",
             message = "The sourceImageId can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character")
     @NotNull
     @ApiModelProperty(value = SOURCE_IMAGE_ID, required = true)
     private String sourceImageId;
 
     @Size(max = 255, min = 1, message = "The length of the baseParcelUrl must be between 1 and 255")
-    @NotNull
     @ApiModelProperty(value = BASE_PARCEL_URL, required = true)
     private String baseParcelUrl;
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/customimage/request/CustomImageCatalogV4UpdateImageRequest.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/customimage/request/CustomImageCatalogV4UpdateImageRequest.java
@@ -24,7 +24,7 @@ public class CustomImageCatalogV4UpdateImageRequest {
     private String imageType;
 
     @Size(max = 255, message = "The length of the sourceImageId must be less than 255")
-    @Pattern(regexp = "(^[a-z][-a-z0-9]*[a-z0-9]$)",
+    @Pattern(regexp = "(^[a-z0-9][-a-z0-9]*[a-z0-9]$)",
             message = "The sourceImageId can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character")
     @ApiModelProperty(value = SOURCE_IMAGE_ID)
     private String sourceImageId;

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/customimage/response/CustomImageCatalogV4GetImageResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/customimage/response/CustomImageCatalogV4GetImageResponse.java
@@ -24,6 +24,9 @@ public class CustomImageCatalogV4GetImageResponse implements JsonEntity {
     private String sourceImageId;
 
     @JsonProperty
+    private Long sourceImageDate;
+
+    @JsonProperty
     private String baseParcelUrl;
 
     @JsonProperty
@@ -51,6 +54,14 @@ public class CustomImageCatalogV4GetImageResponse implements JsonEntity {
 
     public void setSourceImageId(String sourceImageId) {
         this.sourceImageId = sourceImageId;
+    }
+
+    public Long getSourceImageDate() {
+        return sourceImageDate;
+    }
+
+    public void setSourceImageDate(Long sourceImageDate) {
+        this.sourceImageDate = sourceImageDate;
     }
 
     public String getBaseParcelUrl() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/CustomImageCatalogV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/CustomImageCatalogV4Controller.java
@@ -22,6 +22,7 @@ import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.authorization.ImageCatalogFiltering;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.domain.CustomImage;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.service.image.CustomImageCatalogService;
@@ -87,8 +88,11 @@ public class CustomImageCatalogV4Controller implements CustomImageCatalogV4Endpo
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public CustomImageCatalogV4GetImageResponse getCustomImage(@ResourceName String name, String imageId, @AccountId String accountId) {
         CustomImage customImage = customImageCatalogService.getCustomImage(restRequestThreadLocalService.getRequestedWorkspaceId(), name, imageId);
+        Image sourceImage = customImageCatalogService.getSourceImage(customImage);
+        CustomImageCatalogV4GetImageResponse response = converterUtil.convert(customImage, CustomImageCatalogV4GetImageResponse.class);
+        response.setSourceImageDate(sourceImage.getCreated());
 
-        return converterUtil.convert(customImage, CustomImageCatalogV4GetImageResponse.class);
+        return response;
     }
 
     @Override
@@ -106,7 +110,7 @@ public class CustomImageCatalogV4Controller implements CustomImageCatalogV4Endpo
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.EDIT_IMAGE_CATALOG)
     public CustomImageCatalogV4UpdateImageResponse updateCustomImage(@ResourceName String name, String imageId,
-            CustomImageCatalogV4UpdateImageRequest request, @AccountId String accountId) {
+            @Valid CustomImageCatalogV4UpdateImageRequest request, @AccountId String accountId) {
         String creator = ThreadBasedUserCrnProvider.getUserCrn();
         CustomImage customImage = converterUtil.convert(request, CustomImage.class);
         customImage.setName(imageId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogService.java
@@ -2,9 +2,12 @@ package com.sequenceiq.cloudbreak.service.image;
 
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.CrnResourceDescriptor;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.CustomImage;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.domain.VmImage;
@@ -59,6 +62,18 @@ public class CustomImageCatalogService {
         LOGGER.debug(String.format("Get custom image '%s' from catalog '%s' in workspace '%d'", imageId, imageCatalogName, workspaceId));
         ImageCatalog imageCatalog = getImageCatalog(workspaceId, imageCatalogName);
         return getCustomImageFromCatalog(imageCatalog, imageId);
+    }
+
+    public Image getSourceImage(CustomImage image) {
+        String imageId = image.getCustomizedImageId();
+        LOGGER.debug(String.format("Get source image '%s' from default catalog", imageId));
+        try {
+            StatedImage sourceStatedImage = imageCatalogService.getSourceImageByImageType(image);
+            return sourceStatedImage.getImage();
+        } catch (CloudbreakImageNotFoundException | CloudbreakImageCatalogException e) {
+            LOGGER.error(String.format("Failed to get source image: %s", e.getMessage()));
+            throw new NotFoundException(String.format("Could not find source image with id: '%s'", imageId));
+        }
     }
 
     public CustomImage createCustomImage(Long workspaceId, String accountId, String creator, String imageCatalogName, CustomImage customImage) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
@@ -78,6 +78,8 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
 
     public static final String CDP_DEFAULT_CATALOG_NAME = "cdp-default";
 
+    public static final String FREEIPA_DEFAULT_CATALOG_NAME = "freeipa-default";
+
     static final String CLOUDBREAK_DEFAULT_CATALOG_NAME = "cloudbreak-default";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ImageCatalogService.class);
@@ -702,7 +704,7 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
         if (optionalCustomImage.isPresent()) {
             CustomImage customImage = optionalCustomImage.get();
             LOGGER.info("Custom image is available with id '{}'. Searching for source image '{}',", imageId);
-            StatedImage sourceImage = getSourceImageByImageType(customImage, catalogName);
+            StatedImage sourceImage = getSourceImageByImageType(customImage);
             LOGGER.info("Custom image '{}' is a {} image '{}' customization.", imageId, customImage.getImageType(), customImage.getCustomizedImageId());
             image = customImageProvider.mergeSourceImageAndCustomImageProperties(
                     sourceImage, customImage, imageCatalog.getImageCatalogUrl(), imageCatalog.getName());
@@ -717,12 +719,12 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
         return imageCatalog.getCustomImages().stream().filter(i -> i.getName().equalsIgnoreCase(imageId)).findFirst();
     }
 
-    private StatedImage getSourceImageByImageType(CustomImage customImage, String catalogName)
+    public StatedImage getSourceImageByImageType(CustomImage customImage)
             throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
         StatedImage sourceImage;
         switch (customImage.getImageType()) {
             case FREEIPA:
-                sourceImage = getImage(defaultFreeIpaCatalogUrl, catalogName, customImage.getCustomizedImageId());
+                sourceImage = getImage(defaultFreeIpaCatalogUrl, FREEIPA_DEFAULT_CATALOG_NAME, customImage.getCustomizedImageId());
                 break;
             case DATAHUB:
             case DATALAKE:

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/CustomImageCatalogV4ControllerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/CustomImageCatalogV4ControllerTest.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.customimage.response.CustomImag
 import com.sequenceiq.cloudbreak.api.endpoint.v4.customimage.response.CustomImageCatalogV4UpdateImageResponse;
 import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.domain.CustomImage;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.service.image.CustomImageCatalogService;
@@ -131,11 +132,15 @@ public class CustomImageCatalogV4ControllerTest {
     @Test
     public void testGetCustomImage() {
         CustomImage customImage = new CustomImage();
+        Image sourceImage = createTestImage();
+
         CustomImageCatalogV4GetImageResponse expected = new CustomImageCatalogV4GetImageResponse();
+        expected.setSourceImageDate(12345L);
 
         when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(WORKSPACE_ID);
         when(customImageCatalogService.getCustomImage(WORKSPACE_ID, IMAGE_CATALOG_NAME, IMAGE_ID)).thenReturn(customImage);
         when(converterUtil.convert(customImage, CustomImageCatalogV4GetImageResponse.class)).thenReturn(expected);
+        when(customImageCatalogService.getSourceImage(customImage)).thenReturn(sourceImage);
 
         CustomImageCatalogV4GetImageResponse actual = victim.getCustomImage(IMAGE_CATALOG_NAME, IMAGE_ID, ACCOUNT_ID);
 
@@ -194,5 +199,9 @@ public class CustomImageCatalogV4ControllerTest {
         CustomImageCatalogV4DeleteImageResponse actual = victim.deleteCustomImage(IMAGE_CATALOG_NAME, IMAGE_ID, ACCOUNT_ID);
 
         assertEquals(expected, actual);
+    }
+
+    private static Image createTestImage() {
+        return new Image(null, 12345L, null, null, null, null, null, null, null, null, null, null, null, null, true, null, null);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogServiceTest.java
@@ -1,8 +1,11 @@
 package com.sequenceiq.cloudbreak.service.image;
 
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.CustomImage;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.domain.VmImage;
@@ -146,6 +149,20 @@ public class CustomImageCatalogServiceTest {
         when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
 
         assertThrows(NotFoundException.class, () -> victim.getCustomImage(WORKSPACE_ID, IMAGE_CATALOG_NAME, IMAGE_NAME));
+    }
+
+    @Test
+    public void testGetSourceImage() throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        CustomImage customImage = new CustomImage();
+        customImage.setCustomizedImageId(CUSTOMIZED_IMAGE_ID);
+        Image expected = createTestImage();
+        StatedImage statedImage = StatedImage.statedImage(expected, null, IMAGE_CATALOG_NAME);
+
+        when(imageCatalogService.getSourceImageByImageType(customImage)).thenReturn(statedImage);
+
+        Image actual = victim.getSourceImage(customImage);
+
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -311,5 +328,9 @@ public class CustomImageCatalogServiceTest {
         customImage.setVmImage(Collections.singleton(vmImage));
 
         return customImage;
+    }
+
+    private Image createTestImage() {
+        return new Image(null, null, null, null, CUSTOMIZED_IMAGE_ID, null, null, null, null, null, null, null, null, null, true, null, null);
     }
 }


### PR DESCRIPTION
In case of custom image's query operation the related source creation date is also provided.
One option was to persist the date in the database, but this value can change so it should always be updated, so only this value will be retrieved at the moment of the query and sent as part of the response.