### PR TITLE
CB-12296 BP set to null during the finalization of termiantion but we…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/ServiceEndpointCollector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/ServiceEndpointCollector.java
@@ -6,7 +6,6 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -36,6 +35,7 @@ import com.sequenceiq.cloudbreak.api.service.ExposedServiceCollector;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.SecurityConfig;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -78,6 +78,9 @@ public class ServiceEndpointCollector {
 
     public Collection<ExposedServiceV4Response> getKnoxServices(Long workspaceId, String blueprintName) {
         Blueprint blueprint = blueprintService.getByNameForWorkspaceId(blueprintName, workspaceId);
+        if (blueprint == null) {
+            throw new NotFoundException(String.format("Blueprint could not be find by name: '%s'.", blueprintName));
+        }
         return getKnoxServices(blueprint, entitlementService.getEntitlements(blueprint.getWorkspace().getTenant().getName()));
     }
 
@@ -104,13 +107,13 @@ public class ServiceEndpointCollector {
 
     public Map<String, Collection<ClusterExposedServiceV4Response>> prepareClusterExposedServices(Cluster cluster, String managerIp) {
         String blueprintText = getBlueprintString(cluster);
+        Map<String, Collection<ClusterExposedServiceV4Response>> clusterExposedServiceMap = new HashMap<>();
         if (!Strings.isNullOrEmpty(blueprintText)) {
             BlueprintTextProcessor processor = cmTemplateProcessorFactory.get(blueprintText);
             Collection<ExposedService> knownExposedServices = getExposedServices(
-                    cluster.getBlueprint(),
+                    blueprintText,
                     entitlementService.getEntitlements(cluster.getWorkspace().getTenant().getName()));
             Gateway gateway = cluster.getGateway();
-            Map<String, Collection<ClusterExposedServiceV4Response>> clusterExposedServiceMap = new HashMap<>();
             Map<String, List<String>> privateIps = componentLocatorService.getComponentLocation(cluster.getId(), processor,
                     knownExposedServices.stream().map(ExposedService::getServiceName).collect(Collectors.toSet()));
             LOGGER.debug("The private IPs in the cluster {}", privateIps);
@@ -119,42 +122,46 @@ public class ServiceEndpointCollector {
             }
             if (gateway != null) {
                 for (GatewayTopology gatewayTopology : gateway.getTopologies()) {
-                    LOGGER.debug("Generating the topology for '{}' topologies", gatewayTopology.getTopologyName());
-                    Set<String> exposedServicesInTopology = gateway.getTopologies().stream()
-                            .flatMap(this::getExposedServiceStream)
-                            .filter(Objects::nonNull)
-                            .collect(Collectors.toSet());
-                    List<ClusterExposedServiceV4Response> uiServices = new ArrayList<>();
-                    List<ClusterExposedServiceV4Response> apiServices = new ArrayList<>();
-                    boolean autoTlsEnabled = cluster.getAutoTlsEnabled();
-                    LOGGER.debug("AutoTls enabled '{}' for the cluster", autoTlsEnabled);
-                    SecurityConfig securityConfig = cluster.getStack().getSecurityConfig();
-                    String managerServerUrl = getManagerServerUrl(cluster, managerIp);
-                    for (ExposedService exposedService : knownExposedServices) {
-                        if (exposedService.isCmProxied()) {
-                            List<ClusterExposedServiceV4Response> uiServiceOnPrivateIps = createCmProxiedServiceEntries(exposedService, gateway,
-                                    gatewayTopology, managerServerUrl, cluster.getName());
-                            uiServices.addAll(uiServiceOnPrivateIps);
-                        } else {
-                            if (!exposedService.isApiOnly()) {
-                                List<ClusterExposedServiceV4Response> uiServiceOnPrivateIps = createServiceEntries(exposedService, gateway, gatewayTopology,
-                                        managerIp, privateIps, exposedServicesInTopology, false, autoTlsEnabled, securityConfig);
-                                uiServices.addAll(uiServiceOnPrivateIps);
-                            }
-                            if (exposedService.isApiIncluded()) {
-                                List<ClusterExposedServiceV4Response> apiServiceOnPrivateIps = createServiceEntries(exposedService, gateway, gatewayTopology,
-                                        managerIp, privateIps, exposedServicesInTopology, true, autoTlsEnabled, securityConfig);
-                                apiServices.addAll(apiServiceOnPrivateIps);
-                            }
-                        }
-                    }
-                    clusterExposedServiceMap.put(gatewayTopology.getTopologyName(), uiServices);
-                    clusterExposedServiceMap.put(gatewayTopology.getTopologyName() + API_TOPOLOGY_POSTFIX, apiServices);
+                    generateGatewayTopology(cluster, managerIp, clusterExposedServiceMap, knownExposedServices, gateway, privateIps, gatewayTopology);
                 }
             }
-            return clusterExposedServiceMap;
         }
-        return Collections.emptyMap();
+        return clusterExposedServiceMap;
+    }
+
+    private void generateGatewayTopology(Cluster cluster, String managerIp, Map<String, Collection<ClusterExposedServiceV4Response>> clusterExposedServiceMap,
+            Collection<ExposedService> knownExposedServices, Gateway gateway, Map<String, List<String>> privateIps, GatewayTopology gatewayTopology) {
+        LOGGER.debug("Generating the topology for '{}' topologies", gatewayTopology.getTopologyName());
+        Set<String> exposedServicesInTopology = gateway.getTopologies().stream()
+                .flatMap(this::getExposedServiceStream)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        List<ClusterExposedServiceV4Response> uiServices = new ArrayList<>();
+        List<ClusterExposedServiceV4Response> apiServices = new ArrayList<>();
+        boolean autoTlsEnabled = cluster.getAutoTlsEnabled();
+        LOGGER.debug("AutoTls enabled '{}' for the cluster", autoTlsEnabled);
+        SecurityConfig securityConfig = cluster.getStack().getSecurityConfig();
+        String managerServerUrl = getManagerServerUrl(cluster, managerIp);
+        for (ExposedService exposedService : knownExposedServices) {
+            if (exposedService.isCmProxied()) {
+                List<ClusterExposedServiceV4Response> uiServiceOnPrivateIps = createCmProxiedServiceEntries(exposedService, gateway,
+                        gatewayTopology, managerServerUrl, cluster.getName());
+                uiServices.addAll(uiServiceOnPrivateIps);
+            } else {
+                if (!exposedService.isApiOnly()) {
+                    List<ClusterExposedServiceV4Response> uiServiceOnPrivateIps = createServiceEntries(exposedService, gateway, gatewayTopology,
+                            managerIp, privateIps, exposedServicesInTopology, false, autoTlsEnabled, securityConfig);
+                    uiServices.addAll(uiServiceOnPrivateIps);
+                }
+                if (exposedService.isApiIncluded()) {
+                    List<ClusterExposedServiceV4Response> apiServiceOnPrivateIps = createServiceEntries(exposedService, gateway, gatewayTopology,
+                            managerIp, privateIps, exposedServicesInTopology, true, autoTlsEnabled, securityConfig);
+                    apiServices.addAll(apiServiceOnPrivateIps);
+                }
+            }
+        }
+        clusterExposedServiceMap.put(gatewayTopology.getTopologyName(), uiServices);
+        clusterExposedServiceMap.put(gatewayTopology.getTopologyName() + API_TOPOLOGY_POSTFIX, apiServices);
     }
 
     private String getBlueprintString(Cluster cluster) {
@@ -219,7 +226,7 @@ public class ServiceEndpointCollector {
     }
 
     private List<ClusterExposedServiceV4Response> createCmProxiedServiceEntries(ExposedService exposedService, Gateway gateway,
-        GatewayTopology gatewayTopology, String managerIp, String clusterName) {
+            GatewayTopology gatewayTopology, String managerIp, String clusterName) {
         List<ClusterExposedServiceV4Response> services = new ArrayList<>();
         String serviceUrlsForService = getCmProxiedServiceUrlsForService(exposedService, gateway, gatewayTopology.getTopologyName(), managerIp, clusterName);
         if (!Strings.isNullOrEmpty(serviceUrlsForService)) {
@@ -262,11 +269,10 @@ public class ServiceEndpointCollector {
     /**
      * Get all exposed services for blueprint, there are filtered by visibility
      *
-     * @param blueprint given blueprint
+     * @param blueprintText given blueprintText
      * @return all visible exposed services for the given blueprint
      */
-    private Collection<ExposedService> getExposedServices(Blueprint blueprint, List<String> entitlements) {
-        String blueprintText = blueprint.getBlueprintText();
+    private Collection<ExposedService> getExposedServices(String blueprintText, List<String> entitlements) {
         CmTemplateProcessor processor = cmTemplateProcessorFactory.get(blueprintText);
         List<String> components = processor.getAllComponents().stream().map(ServiceComponent::getComponent).collect(Collectors.toList());
         return exposedServiceCollector.knoxServicesForComponents(processor.getVersion(), components)
@@ -278,7 +284,7 @@ public class ServiceEndpointCollector {
 
     private Collection<ExposedServiceV4Response> getKnoxServices(Blueprint blueprint, List<String> entitlements) {
         return ExposedServiceV4Response.fromExposedServices(
-                getExposedServices(blueprint, entitlements));
+                getExposedServices(blueprint.getBlueprintText(), entitlements));
     }
 
     private Stream<String> getExposedServiceStream(GatewayTopology gatewayTopology) {
@@ -368,60 +374,85 @@ public class ServiceEndpointCollector {
     }
 
     private void addNameNodeUrl(String managerIp, Gateway gateway, Map<String, List<String>> privateIps, boolean autoTlsEnabled, List<String> urls) {
-        LOGGER.debug("Select {} service from {}", exposedServiceCollector.getNameNodeService().getServiceName(), privateIps);
-        List<String> hdfsUrls = privateIps.get(exposedServiceCollector.getNameNodeService().getServiceName())
-                .stream()
-                .map(namenodeIp -> getHdfsUIUrl(gateway, managerIp, namenodeIp, autoTlsEnabled))
-                .flatMap(Optional::stream)
-                .collect(Collectors.toList());
-        urls.addAll(hdfsUrls);
+        String serviceName = exposedServiceCollector.getNameNodeService().getServiceName();
+        if (!privateIps.containsKey(serviceName)) {
+            LOGGER.info("Cannot find private ip for the {} exposed service", serviceName);
+        } else {
+            LOGGER.debug("Select {} service from {}", serviceName, privateIps);
+            List<String> hdfsUrls = privateIps.get(serviceName)
+                    .stream()
+                    .map(namenodeIp -> getHdfsUIUrl(gateway, managerIp, namenodeIp, autoTlsEnabled))
+                    .flatMap(Optional::stream)
+                    .collect(Collectors.toList());
+            urls.addAll(hdfsUrls);
+        }
     }
 
     private void addHbaseUrl(String managerIp, Gateway gateway, Map<String, List<String>> privateIps, List<String> urls) {
-        List<String> hbaseUrls = privateIps.get(exposedServiceCollector.getHBaseUIService().getServiceName())
-                .stream()
-                .map(hbaseIp -> getHBaseServiceUrl(gateway, managerIp, hbaseIp))
-                .flatMap(Optional::stream)
-                .collect(Collectors.toList());
-        urls.addAll(hbaseUrls);
+        String serviceName = exposedServiceCollector.getHBaseUIService().getServiceName();
+        if (!privateIps.containsKey(serviceName)) {
+            LOGGER.info("Cannot find private ip for the {} exposed service", serviceName);
+        } else {
+            List<String> hbaseUrls = privateIps.get(serviceName)
+                    .stream()
+                    .map(hbaseIp -> getHBaseServiceUrl(gateway, managerIp, hbaseIp))
+                    .flatMap(Optional::stream)
+                    .collect(Collectors.toList());
+            urls.addAll(hbaseUrls);
+        }
     }
 
     private void addHbaseJarsUrl(String managerIp, Gateway gateway, Map<String, List<String>> privateIps, List<String> urls) {
-        // Grab the first HBase master. Any will do, so we'll take the first
-        privateIps.get(exposedServiceCollector.getHBaseJarsService().getServiceName())
-            .stream()
-            .map(hbaseIp -> getHBaseJarsServiceUrl(gateway, managerIp, hbaseIp))
-            .flatMap(Optional::stream)
-            .findFirst()
-            .ifPresent(hbaseUrl -> urls.add(hbaseUrl));
+        String serviceName = exposedServiceCollector.getHBaseJarsService().getServiceName();
+        if (!privateIps.containsKey(serviceName)) {
+            LOGGER.info("Cannot find private ip for the {} exposed service", serviceName);
+        } else {
+            // Grab the first HBase master. Any will do, so we'll take the first
+            privateIps.get(serviceName)
+                    .stream()
+                    .map(hbaseIp -> getHBaseJarsServiceUrl(gateway, managerIp, hbaseIp))
+                    .flatMap(Optional::stream)
+                    .findFirst()
+                    .ifPresent(hbaseUrl -> urls.add(hbaseUrl));
+        }
     }
 
     private void addResourceManagerUrl(ExposedService exposedService, String managerIp, Gateway gateway, String topologyName, boolean api,
-        List<String> urls) {
+            List<String> urls) {
         String knoxUrl = api ? "/resourcemanager/" : exposedService.getKnoxUrl();
         String topology = api ? topologyName + API_TOPOLOGY_POSTFIX : topologyName;
         urls.add(buildKnoxUrl(managerIp, gateway, knoxUrl, topology, !exposedService.isWithoutProxyPath()));
     }
 
     private void addImplaDebugUrl(String managerIp, Gateway gateway, Map<String, List<String>> privateIps, boolean autoTlsEnabled, List<String> urls) {
-        Optional<String> coordinatorUrl = privateIps.get(exposedServiceCollector.getImpalaDebugUIService().getServiceName())
-                .stream()
-                .map(coordinator -> getImpalaCoordinatorUrl(gateway, managerIp, coordinator, autoTlsEnabled))
-                .flatMap(Optional::stream)
-                .findFirst();
-        if (coordinatorUrl.isPresent()) {
-            urls.add(coordinatorUrl.get());
+        String serviceName = exposedServiceCollector.getImpalaDebugUIService().getServiceName();
+        if (!privateIps.containsKey(serviceName)) {
+            LOGGER.info("Cannot find private ip for the {} exposed service", serviceName);
+        } else {
+            Optional<String> coordinatorUrl = privateIps.get(serviceName)
+                    .stream()
+                    .map(coordinator -> getImpalaCoordinatorUrl(gateway, managerIp, coordinator, autoTlsEnabled))
+                    .flatMap(Optional::stream)
+                    .findFirst();
+            if (coordinatorUrl.isPresent()) {
+                urls.add(coordinatorUrl.get());
+            }
         }
     }
 
     private void addKuduUrl(String managerIp, Gateway gateway, Map<String, List<String>> privateIps, boolean autoTlsEnabled, List<String> urls) {
-        Optional<String> coordinatorUrl = privateIps.get(exposedServiceCollector.getKuduService().getServiceName())
-                .stream()
-                .map(coordinator -> getKuduUrl(gateway, managerIp, coordinator, autoTlsEnabled))
-                .flatMap(Optional::stream)
-                .findFirst();
-        if (coordinatorUrl.isPresent()) {
-            urls.add(coordinatorUrl.get());
+        String serviceName = exposedServiceCollector.getKuduService().getServiceName();
+        if (!privateIps.containsKey(serviceName)) {
+            LOGGER.info("Cannot find private ip for the {} exposed service", serviceName);
+        } else {
+            Optional<String> coordinatorUrl = privateIps.get(serviceName)
+                    .stream()
+                    .map(coordinator -> getKuduUrl(gateway, managerIp, coordinator, autoTlsEnabled))
+                    .flatMap(Optional::stream)
+                    .findFirst();
+            if (coordinatorUrl.isPresent()) {
+                urls.add(coordinatorUrl.get());
+            }
         }
     }
 


### PR DESCRIPTION
… want to access it and throw a NPE. Furthermore, the private ips are empty when the cluster does not have any hostgroup but we want to access by the servicename and it throw a NPE.

I have fixed the CM API issues