### PR TITLE
CB-12118: Environment backend change: Add converters, validation and persistence for encryptionKeyResourceGroupName on Azure

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -106,7 +106,7 @@ public class EnvironmentModelDescription {
     public static final String ENCRYPTION_KEY_URL = "URL of the Customer Managed Key to encrypt Azure resources";
     public static final String ENCRYPTION_KEY_RESOURCE_GROUP_NAME = "Name of the Azure resource group of the Customer Managed Key to encrypt Azure resources";
     public static final String DISK_ENCRYPTION_SET_ID = "Resource Id of the disk encryption set used to encrypt Azure disks.";
-    public static final String RESOURCE_ENCRYPTION_PARAMETERS = "Parameter 'encryptionKeyUrl' - to encrypt Azure resources.";
+    public static final String RESOURCE_ENCRYPTION_PARAMETERS = "Azure resource encryption parameters.";
     public static final String PARENT_ENVIRONMENT_CRN = "Parent environment global identifier";
     public static final String PARENT_ENVIRONMENT_NAME = "Parent environment name";
     public static final String PARENT_ENVIRONMENT_CLOUD_PLATFORM = "Parent environment cloud platform";

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
@@ -224,9 +224,10 @@ public class EnvironmentApiConverter {
 
     private AzureResourceEncryptionParametersDto azureResourceEncryptionParametersToAzureEncryptionParametersDto(
             AzureResourceEncryptionParameters azureResourceEncryptionParameters) {
-        return AzureResourceEncryptionParametersDto.builder()
+        AzureResourceEncryptionParametersDto.Builder azureResourceEncryptionParametersDto = AzureResourceEncryptionParametersDto.builder()
                 .withEncryptionKeyUrl(azureResourceEncryptionParameters.getEncryptionKeyUrl())
-                .build();
+                .withEncryptionKeyResourceGroupName(azureResourceEncryptionParameters.getEncryptionKeyResourceGroupName());
+        return azureResourceEncryptionParametersDto.build();
     }
 
     private AzureResourceGroupDto buildDefaultResourceGroupDto() {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -223,6 +223,7 @@ public class EnvironmentResponseConverter {
         return AzureResourceEncryptionParameters.builder()
                 .withEncryptionKeyUrl(azureResourceEncryptionParametersDto.getEncryptionKeyUrl())
                 .withDiskEncryptionSetId(azureResourceEncryptionParametersDto.getDiskEncryptionSetId())
+                .withEncryptionKeyResourceGroupName(azureResourceEncryptionParametersDto.getEncryptionKeyResourceGroupName())
                 .build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/AzureParameters.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/AzureParameters.java
@@ -31,17 +31,6 @@ public class AzureParameters extends BaseParameters implements AccountIdAwareRes
     @Convert(converter = ResourceGroupUsagePatternConverter.class)
     private ResourceGroupUsagePattern resourceGroupUsagePattern;
 
-    /**
-     * This field is not used anymore
-     * @deprecated This field is no longer in use.
-     * Use {@link #encryptionKeyUrl} instead.
-     */
-    @Column(name = "encryption_keyurl")
-    @Convert(converter = SecretToString.class)
-    @Deprecated(since = "CB 2.41.0", forRemoval = true)
-    @SecretValue
-    private Secret encryptionKeyUrlDummy = Secret.EMPTY;
-
     @Column(name = "encryption_key_url")
     @Convert(converter = SecretToString.class)
     @SecretValue
@@ -49,6 +38,9 @@ public class AzureParameters extends BaseParameters implements AccountIdAwareRes
 
     @Column(name = "disk_encryption_set_id")
     private String diskEncryptionSetId;
+
+    @Column(name = "encryption_key_resource_group_name")
+    private String encryptionKeyResourceGroupName;
 
     public String getResourceGroupName() {
         return resourceGroupName;
@@ -92,5 +84,13 @@ public class AzureParameters extends BaseParameters implements AccountIdAwareRes
 
     public void setDiskEncryptionSetId(String diskEncryptionSetId) {
         this.diskEncryptionSetId = diskEncryptionSetId;
+    }
+
+    public String getEncryptionKeyResourceGroupName() {
+        return encryptionKeyResourceGroupName;
+    }
+
+    public void setEncryptionKeyResourceGroupName(String encryptionKeyResourceGroupName) {
+        this.encryptionKeyResourceGroupName = encryptionKeyResourceGroupName;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverter.java
@@ -48,6 +48,10 @@ public class AzureEnvironmentParametersConverter extends BaseEnvironmentParamete
                 .map(AzureParametersDto::getAzureResourceEncryptionParametersDto)
                 .map(AzureResourceEncryptionParametersDto::getEncryptionKeyUrl)
                 .orElse(null));
+        azureParameters.setEncryptionKeyResourceGroupName(azureParametersDto
+                .map(AzureParametersDto::getAzureResourceEncryptionParametersDto)
+                .map(AzureResourceEncryptionParametersDto::getEncryptionKeyResourceGroupName)
+                .orElse(null));
     }
 
     @Override
@@ -65,6 +69,7 @@ public class AzureEnvironmentParametersConverter extends BaseEnvironmentParamete
                         AzureResourceEncryptionParametersDto.builder()
                                 .withEncryptionKeyUrl(azureParameters.getEncryptionKeyUrl())
                                 .withDiskEncryptionSetId(azureParameters.getDiskEncryptionSetId())
+                                .withEncryptionKeyResourceGroupName(azureParameters.getEncryptionKeyResourceGroupName())
                                 .build())
                 .build());
     }

--- a/environment/src/main/resources/schema/app/20210525113034_CB-12118_persistence_for_encryptionKeyResourceGroupName_on_Azure.sql
+++ b/environment/src/main/resources/schema/app/20210525113034_CB-12118_persistence_for_encryptionKeyResourceGroupName_on_Azure.sql
@@ -1,0 +1,11 @@
+-- // CB-12118 persistence for encryptionKeyResourceGroupName on Azure
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_parameters DROP COLUMN IF EXISTS encryption_keyurl;
+ALTER TABLE environment_parameters ADD COLUMN IF NOT EXISTS encryption_key_resource_group_name varchar(255);
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE environment_parameters DROP COLUMN IF EXISTS encryption_key_resource_group_name;
+ALTER TABLE environment_parameters ADD COLUMN IF NOT EXISTS encryption_keyurl text;
+

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
@@ -286,6 +286,7 @@ public class EnvironmentApiConverterTest {
                 .withResourceEncryptionParameters(
                         AzureResourceEncryptionParameters.builder()
                                 .withEncryptionKeyUrl("dummy-key-url")
+                                .withEncryptionKeyResourceGroupName("dummyResourceGroupName")
                                 .build())
                 .build());
         FreeIpaCreationDto freeIpaCreationDto = mock(FreeIpaCreationDto.class);
@@ -307,6 +308,8 @@ public class EnvironmentApiConverterTest {
 
         assertEquals("dummy-key-url",
                 actual.getParameters().getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl());
+        assertEquals("dummyResourceGroupName",
+                actual.getParameters().getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
     }
 
     private void assertLocation(LocationRequest request, LocationDto actual) {
@@ -341,6 +344,8 @@ public class EnvironmentApiConverterTest {
                 actual.getAzureParametersDto().getAzureResourceGroupDto().getName());
         assertEquals(request.getAzure().getResourceEncryptionParameters().getEncryptionKeyUrl(),
                 actual.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl());
+        assertEquals(request.getAzure().getResourceEncryptionParameters().getEncryptionKeyResourceGroupName(),
+                actual.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
     }
 
     private void assertAwsParameters(EnvironmentRequest request, ParametersDto actual) {
@@ -422,6 +427,7 @@ public class EnvironmentApiConverterTest {
         azureEnvironmentParameters.setResourceEncryptionParameters(
                 AzureResourceEncryptionParameters.builder()
                         .withEncryptionKeyUrl("dummy-key-url")
+                        .withEncryptionKeyResourceGroupName("dummyResourceGroupName")
                         .build()
         );
         return azureEnvironmentParameters;

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
@@ -240,6 +240,7 @@ public class EnvironmentResponseConverterTest {
         assertEquals(azureParametersDto.getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl(),
                 azureEnvironmentParameters.getResourceEncryptionParameters().getEncryptionKeyUrl());
         assertEquals("dummy-des-id", azureEnvironmentParameters.getResourceEncryptionParameters().getDiskEncryptionSetId());
+        assertEquals("dummyResourceGroupName", azureEnvironmentParameters.getResourceEncryptionParameters().getEncryptionKeyResourceGroupName());
     }
 
     private EnvironmentDto createEnvironmentDto(CloudPlatform cloudPlatform) {
@@ -305,6 +306,7 @@ public class EnvironmentResponseConverterTest {
                                 AzureResourceEncryptionParametersDto.builder()
                                         .withEncryptionKeyUrl("dummy-key-url")
                                         .withDiskEncryptionSetId("dummy-des-id")
+                                        .withEncryptionKeyResourceGroupName("dummyResourceGroupName")
                                         .build())
                         .build())
                 .build();

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/AzureEnvironmentParametersConverterTest.java
@@ -29,6 +29,8 @@ public class AzureEnvironmentParametersConverterTest {
 
         private static final String KEY_URL = "dummy-key-url";
 
+        private static final String KEY_RESOURCE_GROUP_NAME = "dummyResourceGroupName";
+
         private static final EnvironmentView ENVIRONMENT_VIEW = new EnvironmentView();
 
         private static final long ID = 10L;
@@ -56,7 +58,9 @@ public class AzureEnvironmentParametersConverterTest {
                     .withId(ID)
                     .withAzureParameters(AzureParametersDto.builder()
                             .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
-                                    .withEncryptionKeyUrl(KEY_URL).build())
+                                    .withEncryptionKeyUrl(KEY_URL)
+                                    .withEncryptionKeyResourceGroupName(KEY_RESOURCE_GROUP_NAME)
+                                    .build())
                             .build())
                     .build();
             Environment environment = new Environment();
@@ -72,6 +76,7 @@ public class AzureEnvironmentParametersConverterTest {
             assertEquals(ENVIRONMENT_VIEW, azureResult.getEnvironment());
             assertEquals(ID, azureResult.getId());
             assertEquals(KEY_URL, azureResult.getEncryptionKeyUrl());
+            assertEquals(KEY_RESOURCE_GROUP_NAME, azureResult.getEncryptionKeyResourceGroupName());
         }
 
         @Test
@@ -84,6 +89,7 @@ public class AzureEnvironmentParametersConverterTest {
             parameters.setName(ENV_NAME);
             parameters.setEncryptionKeyUrl(KEY_URL);
             parameters.setDiskEncryptionSetId("DummyDesId");
+            parameters.setEncryptionKeyResourceGroupName(KEY_RESOURCE_GROUP_NAME);
 
             ParametersDto result = underTest.convertToDto(parameters);
 
@@ -92,5 +98,6 @@ public class AzureEnvironmentParametersConverterTest {
             assertEquals(ENV_NAME, result.getName());
             assertEquals(KEY_URL, result.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl());
             assertEquals("DummyDesId", result.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getDiskEncryptionSetId());
+            assertEquals(KEY_RESOURCE_GROUP_NAME, result.getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
         }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AzureParameterValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AzureParameterValidatorTest.java
@@ -38,6 +38,12 @@ import com.sequenceiq.environment.parameters.validation.validators.parameter.Azu
 
 public class AzureParameterValidatorTest {
 
+    private static final String KEY_URL = "dummyKeyUrl";
+
+    private static final String RESOURCE_GROUP_NAME = "myResourceGroup";
+
+    private static final String ENCRYPTION_KEY_RESOURCE_GROUP_NAME = "dummyEncryptionKeyResourceGroup";
+
     @Mock
     private CloudPlatformConnectors cloudPlatformConnectors;
 
@@ -105,7 +111,7 @@ public class AzureParameterValidatorTest {
                         .withResourceGroup(AzureResourceGroupDto.builder()
                                 .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_SINGLE)
                                 .withResourceGroupCreation(ResourceGroupCreation.USE_EXISTING)
-                                .withName("myResourceGroup").build())
+                                .withName(RESOURCE_GROUP_NAME).build())
                         .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder().build())
                         .build())
                 .build();
@@ -114,7 +120,7 @@ public class AzureParameterValidatorTest {
         when(credentialToCloudCredentialConverter.convert(any())).thenReturn(new CloudCredential());
         AzureClient azureClient = mock(AzureClient.class);
         when(azureClientService.getClient(any())).thenReturn(azureClient);
-        when(azureClient.resourceGroupExists("myResourceGroup")).thenReturn(true);
+        when(azureClient.resourceGroupExists(RESOURCE_GROUP_NAME)).thenReturn(true);
 
         ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
 
@@ -137,7 +143,7 @@ public class AzureParameterValidatorTest {
         when(credentialToCloudCredentialConverter.convert(any())).thenReturn(new CloudCredential());
         AzureClient azureClient = mock(AzureClient.class);
         when(azureClientService.getClient(any())).thenReturn(azureClient);
-        when(azureClient.resourceGroupExists("myResourceGroup")).thenReturn(true);
+        when(azureClient.resourceGroupExists(RESOURCE_GROUP_NAME)).thenReturn(true);
 
         ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
 
@@ -151,7 +157,7 @@ public class AzureParameterValidatorTest {
                         .withResourceGroup(AzureResourceGroupDto.builder()
                                 .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_MULTIPLE)
                                 .withResourceGroupCreation(ResourceGroupCreation.USE_EXISTING)
-                                .withName("myResourceGroup").build())
+                                .withName(RESOURCE_GROUP_NAME).build())
                         .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder().build())
                         .build())
                 .build();
@@ -160,13 +166,13 @@ public class AzureParameterValidatorTest {
         when(credentialToCloudCredentialConverter.convert(any())).thenReturn(new CloudCredential());
         AzureClient azureClient = mock(AzureClient.class);
         when(azureClientService.getClient(any())).thenReturn(azureClient);
-        when(azureClient.resourceGroupExists("myResourceGroup")).thenReturn(false);
+        when(azureClient.resourceGroupExists(RESOURCE_GROUP_NAME)).thenReturn(false);
 
         ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
 
         assertTrue(validationResult.hasError());
-        assertEquals("You specified to use multiple resource groups for your resources, " +
-                        "but then the single resource group name 'myResourceGroup' cannot not be specified.",
+        assertEquals(String.format("You specified to use multiple resource groups for your resources, " +
+                        "but then the single resource group name '%s' cannot not be specified.", RESOURCE_GROUP_NAME),
                 validationResult.getFormattedErrors());
     }
 
@@ -200,7 +206,7 @@ public class AzureParameterValidatorTest {
                 .withAzureParameters(AzureParametersDto.builder()
                         .withResourceGroup(AzureResourceGroupDto.builder()
                                 .withResourceGroupCreation(ResourceGroupCreation.USE_EXISTING)
-                                .withName("myResourceGroup").build())
+                                .withName(RESOURCE_GROUP_NAME).build())
                         .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder().build())
                         .build())
                 .build();
@@ -224,7 +230,7 @@ public class AzureParameterValidatorTest {
                         .withResourceGroup(AzureResourceGroupDto.builder()
                                 .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_SINGLE)
                                 .withResourceGroupCreation(ResourceGroupCreation.USE_EXISTING)
-                                .withName("myResourceGroup").build())
+                                .withName(RESOURCE_GROUP_NAME).build())
                         .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder().build())
                         .build())
                 .build();
@@ -233,12 +239,13 @@ public class AzureParameterValidatorTest {
         when(credentialToCloudCredentialConverter.convert(any())).thenReturn(new CloudCredential());
         AzureClient azureClient = mock(AzureClient.class);
         when(azureClientService.getClient(any())).thenReturn(azureClient);
-        when(azureClient.resourceGroupExists("myResourceGroup")).thenReturn(false);
+        when(azureClient.resourceGroupExists(RESOURCE_GROUP_NAME)).thenReturn(false);
 
         ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
 
         assertTrue(validationResult.hasError());
-        assertEquals("Resource group 'myResourceGroup' does not exist or insufficient permission to access it.", validationResult.getFormattedErrors());
+        assertEquals(String.format("Resource group '%s' does not exist or insufficient permission to access it.", RESOURCE_GROUP_NAME),
+                validationResult.getFormattedErrors());
     }
 
     @Test
@@ -255,7 +262,7 @@ public class AzureParameterValidatorTest {
         when(credentialToCloudCredentialConverter.convert(any())).thenReturn(new CloudCredential());
         AzureClient azureClient = mock(AzureClient.class);
         when(azureClientService.getClient(any())).thenReturn(azureClient);
-        when(azureClient.resourceGroupExists("myResourceGroup")).thenReturn(false);
+        when(azureClient.resourceGroupExists(RESOURCE_GROUP_NAME)).thenReturn(false);
         when(entitlementService.azureSingleResourceGroupDeploymentEnabled(anyString())).thenReturn(false);
 
         ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
@@ -273,7 +280,7 @@ public class AzureParameterValidatorTest {
                         .withResourceGroup(AzureResourceGroupDto.builder()
                                 .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_SINGLE)
                                 .withResourceGroupCreation(ResourceGroupCreation.USE_EXISTING)
-                                .withName("myResourceGroup").build())
+                                .withName(RESOURCE_GROUP_NAME).build())
                         .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder().build())
                         .build())
                 .build();
@@ -282,7 +289,7 @@ public class AzureParameterValidatorTest {
         when(credentialToCloudCredentialConverter.convert(any())).thenReturn(new CloudCredential());
         AzureClient azureClient = mock(AzureClient.class);
         when(azureClientService.getClient(any())).thenReturn(azureClient);
-        when(azureClient.resourceGroupExists("myResourceGroup")).thenReturn(false);
+        when(azureClient.resourceGroupExists(RESOURCE_GROUP_NAME)).thenReturn(false);
         when(entitlementService.azureSingleResourceGroupDeploymentEnabled(anyString())).thenReturn(false);
 
         ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
@@ -299,7 +306,7 @@ public class AzureParameterValidatorTest {
                         .withResourceGroup(AzureResourceGroupDto.builder()
                                 .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_SINGLE_WITH_DEDICATED_STORAGE_ACCOUNT)
                                 .withResourceGroupCreation(ResourceGroupCreation.USE_EXISTING)
-                                .withName("myResourceGroup").build())
+                                .withName(RESOURCE_GROUP_NAME).build())
                         .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder().build())
                         .build())
                 .build();
@@ -308,7 +315,7 @@ public class AzureParameterValidatorTest {
         when(credentialToCloudCredentialConverter.convert(any())).thenReturn(new CloudCredential());
         AzureClient azureClient = mock(AzureClient.class);
         when(azureClientService.getClient(any())).thenReturn(azureClient);
-        when(azureClient.resourceGroupExists("myResourceGroup")).thenReturn(false);
+        when(azureClient.resourceGroupExists(RESOURCE_GROUP_NAME)).thenReturn(false);
         when(entitlementService.azureSingleResourceGroupDeploymentEnabled(anyString())).thenReturn(true);
         when(entitlementService.azureSingleResourceGroupDedicatedStorageAccountEnabled(anyString())).thenReturn(false);
 
@@ -326,7 +333,7 @@ public class AzureParameterValidatorTest {
                         .withResourceGroup(AzureResourceGroupDto.builder()
                                 .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_MULTIPLE).build())
                         .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
-                                .withEncryptionKeyUrl("DummyKeyUrl").build())
+                                .withEncryptionKeyUrl(KEY_URL).build())
                         .build())
                 .build();
         EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
@@ -335,6 +342,8 @@ public class AzureParameterValidatorTest {
         ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
 
         assertTrue(validationResult.hasError());
+        assertEquals(validationResult.getFormattedErrors(), "You specified encryptionKeyUrl to use Server Side Encryption for Azure Managed disks with CMK, " +
+                "but that feature is currently disabled. Get 'CDP_CB_AZURE_DISK_SSE_WITH_CMK' enabled for your account to use SSE with CMK.");
     }
 
     @Test
@@ -344,7 +353,7 @@ public class AzureParameterValidatorTest {
                         .withResourceGroup(AzureResourceGroupDto.builder()
                                 .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_MULTIPLE).build())
                         .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
-                                .withEncryptionKeyUrl("DummyKeyUrl").build())
+                                .withEncryptionKeyUrl(KEY_URL).build())
                         .build())
                 .build();
         EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
@@ -395,11 +404,99 @@ public class AzureParameterValidatorTest {
         ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
 
         assertTrue(validationResult.hasError());
+        assertEquals(validationResult.getFormattedErrors(), "Specifying diskEncryptionSetId in request is Invalid. " +
+                "Please specify encryptionKeyUrl to use Server Side Encryption for Azure Managed disks with CMK.");
     }
 
     @Test
     public void testCloudPlatform() {
         assertEquals(CloudPlatform.AZURE, underTest.getcloudPlatform());
+    }
+
+    @Test
+    public void testWhenUseMultipleResourceGroupsAndResourceEncryptionParameterKeyUrlAndEncryptionKeyResourceGroupNameAndEntitlementEnabledThenNoError() {
+        EnvironmentDto environmentDto = new EnvironmentDtoBuilder()
+                .withAzureParameters(AzureParametersDto.builder()
+                        .withResourceGroup(AzureResourceGroupDto.builder()
+                                .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_MULTIPLE).build())
+                        .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
+                                .withEncryptionKeyUrl(KEY_URL)
+                                .withEncryptionKeyResourceGroupName(ENCRYPTION_KEY_RESOURCE_GROUP_NAME)
+                                .build())
+                        .build())
+                .build();
+        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
+
+        when(entitlementService.isAzureDiskSSEWithCMKEnabled(anyString())).thenReturn(true);
+        ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
+
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    public void testWhenUseMultipleResourceGroupsAndResourceEncryptionParameterKeyUrlAndEncryptionKeyResourceGroupNameAndNoEntitlementThenError() {
+        EnvironmentDto environmentDto = new EnvironmentDtoBuilder()
+                .withAzureParameters(AzureParametersDto.builder()
+                        .withResourceGroup(AzureResourceGroupDto.builder()
+                                .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_MULTIPLE).build())
+                        .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
+                                .withEncryptionKeyUrl(KEY_URL)
+                                .withEncryptionKeyResourceGroupName(ENCRYPTION_KEY_RESOURCE_GROUP_NAME)
+                                .build())
+                        .build())
+                .build();
+        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
+
+        when(entitlementService.isAzureDiskSSEWithCMKEnabled(anyString())).thenReturn(false);
+        ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
+
+        assertTrue(validationResult.hasError());
+        assertEquals(validationResult.getFormattedErrors(), "You specified encryptionKeyUrl to use Server Side Encryption for Azure Managed disks " +
+                "with CMK, but that feature is currently disabled. Get 'CDP_CB_AZURE_DISK_SSE_WITH_CMK' enabled for your account to use SSE with CMK.");
+    }
+
+    @Test
+    public void testWhenUseMultipleResourceGroupsAndEncryptionKeyResourceGroupNameAndNoEntitlementThenError() {
+        EnvironmentDto environmentDto = new EnvironmentDtoBuilder()
+                .withAzureParameters(AzureParametersDto.builder()
+                        .withResourceGroup(AzureResourceGroupDto.builder()
+                                .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_MULTIPLE).build())
+                        .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
+                                .withEncryptionKeyResourceGroupName(ENCRYPTION_KEY_RESOURCE_GROUP_NAME)
+                                .build())
+                        .build())
+                .build();
+        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
+
+        when(entitlementService.isAzureDiskSSEWithCMKEnabled(anyString())).thenReturn(false);
+        ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
+
+        assertTrue(validationResult.hasError());
+        assertEquals(validationResult.getFormattedErrors(), "You specified encryptionKeyResourceGroupName to provide the resource group name which contains " +
+                "the encryption keyfor Server Side Encryption of Azure Managed disks, but that feature is currently disabled. " +
+                "Get 'CDP_CB_AZURE_DISK_SSE_WITH_CMK' enabled for your account to use SSE with CMK.");
+    }
+
+    @Test
+    public void testWhenUseMultipleResourceGroupsAndEncryptionKeyResourceGroupNameAndNoResourceEncryptionParameterKeyUrlAndEntitlementThenError() {
+        EnvironmentDto environmentDto = new EnvironmentDtoBuilder()
+                .withAzureParameters(AzureParametersDto.builder()
+                        .withResourceGroup(AzureResourceGroupDto.builder()
+                                .withResourceGroupUsagePattern(ResourceGroupUsagePattern.USE_MULTIPLE).build())
+                        .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
+                                .withEncryptionKeyResourceGroupName(ENCRYPTION_KEY_RESOURCE_GROUP_NAME)
+                                .build())
+                        .build())
+                .build();
+        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
+
+        when(entitlementService.isAzureDiskSSEWithCMKEnabled(anyString())).thenReturn(true);
+        ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
+
+        assertTrue(validationResult.hasError());
+        assertEquals(validationResult.getFormattedErrors(), "You specified encryptionKeyResourceGroupName to provide the resource group " +
+                "name which contains the encryption key for Server Side Encryption of Azure Managed disks. Please specify encryptionKeyUrl to use " +
+                "Server Side Encryption for Azure Managed disks with CMK.");
     }
 
     private static class EnvironmentDtoBuilder {

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AzureResourceEncryptionParametersDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AzureResourceEncryptionParametersDto.java
@@ -3,15 +3,22 @@ package com.sequenceiq.environment.parameter.dto;
 public class AzureResourceEncryptionParametersDto {
     private final String encryptionKeyUrl;
 
+    private final String encryptionKeyResourceGroupName;
+
     private final String diskEncryptionSetId;
 
     private AzureResourceEncryptionParametersDto(AzureResourceEncryptionParametersDto.Builder builder) {
         encryptionKeyUrl = builder.encryptionKeyUrl;
+        encryptionKeyResourceGroupName = builder.encryptionKeyResourceGroupName;
         diskEncryptionSetId = builder.diskEncryptionSetId;
     }
 
     public String getEncryptionKeyUrl() {
         return encryptionKeyUrl;
+    }
+
+    public String getEncryptionKeyResourceGroupName() {
+        return encryptionKeyResourceGroupName;
     }
 
     public String getDiskEncryptionSetId() {
@@ -26,7 +33,8 @@ public class AzureResourceEncryptionParametersDto {
     public String toString() {
         return "AzureResourceEncryptionParametersDto{" +
                 "encryptionKeyUrl=" + encryptionKeyUrl +
-                "diskEncryptionSetId=" + diskEncryptionSetId +
+                ", encryptionKeyResourceGroupName=" + encryptionKeyResourceGroupName +
+                ", diskEncryptionSetId=" + diskEncryptionSetId +
                 '}';
     }
 
@@ -35,8 +43,15 @@ public class AzureResourceEncryptionParametersDto {
 
         private String diskEncryptionSetId;
 
+        private String encryptionKeyResourceGroupName;
+
         public AzureResourceEncryptionParametersDto.Builder withEncryptionKeyUrl(String encryptionKeyUrl) {
             this.encryptionKeyUrl = encryptionKeyUrl;
+            return this;
+        }
+
+        public AzureResourceEncryptionParametersDto.Builder withEncryptionKeyResourceGroupName(String encryptionKeyResourceGroupName) {
+            this.encryptionKeyResourceGroupName = encryptionKeyResourceGroupName;
             return this;
         }
 

--- a/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/AzureParametersDtoTest.java
+++ b/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/AzureParametersDtoTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.environment.parameter.dto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,18 +11,26 @@ import org.mockito.junit.jupiter.MockitoExtension;
 public class AzureParametersDtoTest {
 
     @Test
-    void testAzureParametersDtowithEncryptionParameters() {
-        AzureParametersDto dummyAzureParametersDto = createAzureParametersDto();
+    void testAzureParametersDtoWithEncryptionParametersWithEncryptionKeyUrlAndEncryptionKeyResourceGroupName() {
+        AzureParametersDto dummyAzureParametersDto = AzureParametersDto.builder()
+                .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
+                        .withEncryptionKeyUrl("dummy-key-url")
+                        .withEncryptionKeyResourceGroupName("dummyResourceGroupName")
+                        .build())
+                .build();
         assertEquals(dummyAzureParametersDto.getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl(), "dummy-key-url");
+        assertEquals(dummyAzureParametersDto.getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName(), "dummyResourceGroupName");
     }
 
-    private AzureParametersDto createAzureParametersDto() {
-        return AzureParametersDto.builder()
-                        .withEncryptionParameters(
-                                AzureResourceEncryptionParametersDto.builder()
-                                        .withEncryptionKeyUrl("dummy-key-url")
-                                        .build())
-                        .build();
+    @Test
+    void testAzureParametersDtoWithEncryptionParametersWithEncryptionKeyUrl() {
+        AzureParametersDto dummyAzureParametersDto = AzureParametersDto.builder()
+                .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
+                        .withEncryptionKeyUrl("dummy-key-url")
+                        .build())
+                .build();
+        assertEquals(dummyAzureParametersDto.getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl(), "dummy-key-url");
+        assertNull(dummyAzureParametersDto.getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
     }
 
 }

--- a/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/AzureResourceEncryptionParametersDtoTest.java
+++ b/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/AzureResourceEncryptionParametersDtoTest.java
@@ -21,10 +21,17 @@ public class AzureResourceEncryptionParametersDtoTest {
         assertEquals(dummyAzureResourceEncryptionParametersDto.getDiskEncryptionSetId(), "dummy-des-id");
     }
 
+    @Test
+    void testAzureResourceEncryptionParametersDtowithEncryptionKeyResourceGroupName() {
+        AzureResourceEncryptionParametersDto dummyAzureResourceEncryptionParametersDto = createAzureResourceEncryptionParametersDto();
+        assertEquals(dummyAzureResourceEncryptionParametersDto.getEncryptionKeyResourceGroupName(), "dummyResourceGroupName");
+    }
+
     private AzureResourceEncryptionParametersDto createAzureResourceEncryptionParametersDto() {
         return AzureResourceEncryptionParametersDto.builder()
                 .withDiskEncryptionSetId("dummy-des-id")
                 .withEncryptionKeyUrl("dummy-key-url")
+                .withEncryptionKeyResourceGroupName("dummyResourceGroupName")
                 .build();
     }
 }


### PR DESCRIPTION
CB-12118: Environment backend change: Add converters, validation and persistence for encryptionKeyResourceGroupName on Azure

Followig changes are made as part of this PR.
1. EnvironmentApiConverter, AzureResourceEncryptionParametersDto, EnvironmentResponseConverter are updated to include encryptionKeyResourceGroupName.
2. encryptionKeyResourceGroupName can only be present if the entitlement 'CDP_CB_AZURE_DISK_SSE_WITH_CMK' is true and encryptionKeyUrl is present - a validation is added.
3. encryption_keyUrl was deprecated as part of CB-11874, relating code and DB column is dropped.
4. Unit tests are updated for above changes.