### PR TITLE
CB-12669 Cluster upgrade should update the paywall pillar

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -225,7 +225,10 @@ public class ClusterHostServiceRunner {
             Json blueprint = new Json(cluster.getBlueprint().getBlueprintText());
             ambariRepoMap.put("stack_version", blueprint.getValue("Blueprints.stack_version"));
             ambariRepoMap.put("stack_type", blueprint.getValue("Blueprints.stack_name").toString().toLowerCase());
-            servicePillar.put("ambari-repo", new SaltPillarProperties("/ambari/repo.sls", singletonMap("ambari", singletonMap("repo", ambariRepoMap))));
+            servicePillar.put("ambari-repo", new SaltPillarProperties("/ambari/repo.sls",
+                    Map.of(
+                            "ambari", singletonMap("repo", ambariRepoMap),
+                            "paywall", paywallCredentialService.getCredential())));
             boolean setupLdapAndSsoOnApi = ambariRepositoryVersionService.isVersionNewerOrEqualThanLimited(ambariRepo::getVersion, AMBARI_VERSION_2_7_0_0);
             servicePillar.put("setup-ldap-and-sso-on-api", new SaltPillarProperties("/ambari/config.sls",
                     singletonMap("ambari", singletonMap("setup_ldap_and_sso_on_api", setupLdapAndSsoOnApi))));
@@ -242,7 +245,7 @@ public class ClusterHostServiceRunner {
         }
         saveDockerPillar(cluster.getExecutorType(), servicePillar);
         saveHDPPillar(cluster.getId(), servicePillar);
-        paywallCredentialService.getPaywallCredential(servicePillar);
+        paywallCredentialService.setPaywallCredentialMoved(servicePillar);
         Map<String, Object> credentials = new HashMap<>();
         credentials.put("username", ambariSecurityConfigProvider.getAmbariUserName(stack.getCluster()));
         credentials.put("password", ambariSecurityConfigProvider.getAmbariPassword(stack.getCluster()));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/credential/PaywallCredentialService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/credential/PaywallCredentialService.java
@@ -44,15 +44,16 @@ public class PaywallCredentialService {
         return result;
     }
 
-    public void getPaywallCredential(Map<String, SaltPillarProperties> servicePillar) {
-        servicePillar.put("paywall", new SaltPillarProperties("/hdp/paywall.sls", singletonMap("paywall", createCredential())));
+    public void setPaywallCredentialMoved(Map<String, SaltPillarProperties> servicePillar) {
+        servicePillar.put("paywall-moved-to-ambari-repo",
+                new SaltPillarProperties("/hdp/paywall.sls", singletonMap("paywall-moved-to-ambari-repo", getCredential())));
     }
 
     public String getBasicAuthorizationEncoded() {
         return Base64.getEncoder().encodeToString(String.format("%s:%s", paywallUserName, paywallPassword).getBytes());
     }
 
-    private Map<String, String> createCredential() {
+    public Map<String, String> getCredential() {
         return Map.of(
                 "paywallUser", paywallUserName,
                 "paywallPassword", paywallPassword);


### PR DESCRIPTION
During upgrade paywall pillar was not updated, which resulted in failed upgrades.
I've moved the "paywall" entity from paywall.sls to ambari/repo.sls because in legacy cases the top.sls is not updated even if paywall.sls is, moving "paywall" to the repo.sls solved this. 
I've still kept the paywall.sls but renamed the items in it because there could be clusters which already have been upgraded and this way I could avoid having two properties with the same name. 