### PR TITLE
CB-9924 Create user documentation for setting up freeipa backup bucke…

### DIFF
--- a/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-backup-policy.json
+++ b/cloud-aws/src/main/resources/definitions/cdp/aws-cdp-backup-policy.json
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts",
+        "s3:PutObject"
+      ],
+      "Resource": "arn:aws:s3:::${BACKUP_LOCATION_BASE}/*"
+    }
+  ]
+}


### PR DESCRIPTION
…t and policy

Add a aws-cdp-backup-policy.json policy file. The policy will be attached to LOG_ROLE and also the datalake master node so they can put the backup data to the backup bucket.

See detailed description in the commit message.