### PR TITLE
CB-12750: Fix azure repair to not stop salt minions when the IP add...

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -220,11 +221,11 @@ public class SaltStates {
         return measure(() -> sc.run(Glob.ALL, "test.ping", LOCAL, PingResponse.class), LOGGER, "Ping took {}ms");
     }
 
-    public static void stopMinions(SaltConnector sc, Map<String, String> privateIPsByFQDN) {
+    public static void stopMinions(SaltConnector sc, Set<String> privateIPs) {
         SaltAction saltAction = new SaltAction(SaltActionType.STOP);
-        for (Entry<String, String> entry : privateIPsByFQDN.entrySet()) {
+        for (String entry : privateIPs) {
             Minion minion = new Minion();
-            minion.setAddress(entry.getValue());
+            minion.setAddress(entry);
             saltAction.addMinion(minion);
         }
         sc.action(saltAction);

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStatesTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStatesTest.java
@@ -296,11 +296,11 @@ public class SaltStatesTest {
 
     @Test
     public void stopMinionsTest() {
-        Map<String, String> privateIpsByFQDN = new HashMap<>();
-        privateIpsByFQDN.put("10-0-0-1.example.com", "10.0.0.1");
-        privateIpsByFQDN.put("10-0-0-2.example.com", "10.0.0.2");
-        privateIpsByFQDN.put("10-0-0-3.example.com", "10.0.0.3");
-        SaltStates.stopMinions(saltConnector, privateIpsByFQDN);
+        Set<String> privateIps = new HashSet<>();
+        privateIps.add("10.0.0.1");
+        privateIps.add("10.0.0.2");
+        privateIps.add("10.0.0.3");
+        SaltStates.stopMinions(saltConnector, privateIps);
 
         ArgumentCaptor<SaltAction> saltActionArgumentCaptor = ArgumentCaptor.forClass(SaltAction.class);
         verify(saltConnector, times(1)).action(saltActionArgumentCaptor.capture());


### PR DESCRIPTION
...ress is resused

When Azure reuses IP addresses, it is possible that the primary
gateway's IP address is reused. This resulted in a command being
issued to stop salt on the old instance but instaned it was issued by
IP addresss. This resulted in the current primary gateway's salt
minion being stopped.

This was tested with unit tests and it was also tested manually with a
local deployment of cloudbreak.

See detailed description in the commit message.