### PR TITLE
CB-12098: explicit gcp backup location validation

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/cloudstorage/EnvironmentLogStorageLocationValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/cloudstorage/EnvironmentLogStorageLocationValidator.java
@@ -34,6 +34,6 @@ public class EnvironmentLogStorageLocationValidator {
     }
 
     private boolean isCloudStorageEnabled(EnvironmentLogging logging) {
-        return logging.getS3() != null || logging.getAdlsGen2() != null;
+        return logging.getS3() != null || logging.getAdlsGen2() != null || logging.getGcs() != null;
     }
 }


### PR DESCRIPTION
Currently user may use gcs://cloudbreak-dev/rdoktorics/telemetry insteand of gs:// url. We should be explicit to enforce a gs:// protocol.

See detailed description in the commit message.