### PR TITLE
CB-12779: Fix KnoxServiceConfigProviderTest unit test

### DIFF
--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/knox/KnoxServiceConfigProviderTest.java
@@ -1,8 +1,6 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.knox.KnoxRoles.KNOX;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -41,7 +39,7 @@ public class KnoxServiceConfigProviderTest {
 
     @Test
     public void testGetRoleConfigsShouldReturnEmptyList() {
-        Assert.assertTrue(underTest.getRoleConfigs(anyString(), any(TemplatePreparationObject.class)).isEmpty());
+        Assert.assertTrue(underTest.getRoleConfigs("", null).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
Mocking methods any() and anyString() cannot be used outside of mocks.

See detailed description in the commit message.