### PR TITLE
CB-12691 Introduce new step for default environment create method with Cluster Proxy

### DIFF
--- a/integration-test/integcb/Profile_template
+++ b/integration-test/integcb/Profile_template
@@ -15,12 +15,11 @@ export ENVIRONMENT_ENABLEDPLATFORMS=AZURE,AWS,YARN,MOCK
 export CB_DEFAULT_SUBSCRIPTION_ADDRESS=""
 export CB_CLIENT_SECRET=cloudbreak
 export INGRESS_URLS=dev-gateway,localhost
-export CLUSTERPROXY_ENABLED=false
+export CLUSTERPROXY_ENABLED=true
 export ENVIRONMENT_AUTOSYNC_ENABLED=false
 export ENVIRONMENT_FREEIPA_SYNCHRONIZEONSTART=false
 export ENVIRONMENT_EXPERIENCE_SCAN_ENABLED=true
 
-export CLUSTERPROXY_ENABLED=false
 export ALTUS_AUDIT_ENDPOINT=thunderhead-mock
 export MOCK_INFRASTRUCTURE_HOST=mock-infrastructure
 
@@ -35,4 +34,4 @@ export PERISCOPE_JAVA_OPTS="-Dperiscope.hibernate.circuitbreaker=BREAK -Dhiberna
 export FREEIPA_JAVA_OPTS="-Dfreeipa.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=25 -Dhibernate.session.circuitbreak.max.count=50"
 export REDBEAMS_JAVA_OPTS="-Dredbeams.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=10 -Dhibernate.session.circuitbreak.max.count=25"
 export DATALAKE_JAVA_OPTS="-Ddatalake.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=10 -Dhibernate.session.circuitbreak.max.count=25"
-export ENVIRONMENT_JAVA_OPTS="-Denvironment.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=10 -Dhibernate.session.circuitbreak.max.count=25"
+export ENVIRONMENT_JAVA_OPTS="-Denvironment.hibernate.circuitbreaker=BREAK -Dhibernate.session.warning.max.count=10 -Dhibernate.session.circuitbreak.max.count=25 -Denvironment.tunnel.default=CLUSTER_PROXY"

--- a/integration-test/scripts/docker-compose.sh
+++ b/integration-test/scripts/docker-compose.sh
@@ -41,7 +41,7 @@ unset HTTPS_PROXY
 env
 
 TRACE=1 ./cbd regenerate
-./cbd start-wait traefik dev-gateway core-gateway commondb vault cloudbreak environment periscope freeipa redbeams datalake haveged mock-infrastructure
+./cbd start-wait traefik dev-gateway core-gateway commondb vault cloudbreak environment periscope freeipa redbeams datalake haveged mock-infrastructure idbmms cluster-proxy cadence cluster-proxy-health-check-worker
 
 docker ps --format ‘{{.Image}}’
 

--- a/integration-test/scripts/stop-containers.sh
+++ b/integration-test/scripts/stop-containers.sh
@@ -5,3 +5,7 @@
 echo -e "\n\033[1;96m--- Stop cbd containers"
 cd $INTEGCB_LOCATION;
 .deps/bin/docker-compose --compatibility stop;
+
+echo -e "\n\033[1;96m--- Save Cluster Proxy log to cluster-proxy.log file"
+docker logs cbreak_cluster-proxy_1 &> ../cluster-proxy.log;
+docker logs cbreak_cluster-proxy-health-check-worker_1 &> ../cluster-proxy-health.log;


### PR DESCRIPTION
The [default CB communication tunnel](cloudbreak/environment/src/main/resources/application.yml) type is `DIRECT`, but on [QA Cloud Test Environment](https://qa-cloud-canary.eng.hortonworks.com) it has been changed to `CLUSTER_PROXY`. However, all of our tests still use `DIRECT` connection. So we need to change our tests' default environment creation steps to include `with Cluster Proxy`.