### PR TITLE
CB-12783. Use max_retry_interval for fluentd exponential backoff retr…

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
@@ -36,6 +36,7 @@
       chunk_limit_size 600k
       flush_at_shutdown true
       retry_forever true
+      retry_max_interval 1200
     </buffer>
   </store>
 </match>

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_monitoring.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_monitoring.conf.j2
@@ -35,6 +35,7 @@
       timekey_wait 0s
       chunk_limit_size 600k
       flush_at_shutdown true
+      retry_max_interval 1200
     </buffer>
   </store>
 </match>

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
@@ -27,6 +27,7 @@
       timekey_wait 0s
       chunk_limit_size 600k
       flush_at_shutdown true
+      retry_max_interval 1200
     </buffer>
   </store>
 </match>


### PR DESCRIPTION
…ies.

See detailed description in the commit message.