### PR TITLE
CB-12784 iam:Passrole separated into an other block just to make sure…

### DIFF
--- a/cloud-aws/src/main/resources/definitions/environment-minimal-policy.json
+++ b/cloud-aws/src/main/resources/definitions/environment-minimal-policy.json
@@ -156,7 +156,6 @@
         "iam:GetInstanceProfile",
         "iam:SimulatePrincipalPolicy",
         "iam:GetRole",
-        "iam:PassRole",
         "rds:AddTagsToResource",
         "rds:CreateDBInstance",
         "rds:CreateDBSubnetGroup",
@@ -178,6 +177,13 @@
         "kms:ListAliases",
         "ec2:ModifyInstanceAttribute",
         "ec2:CreateLaunchTemplateVersion"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:PassRole"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
… we can easily mention in the public doc how customers can restrict it more.

See detailed description in the commit message.