### PR TITLE
CB-12817 Test flow event classes for public constructor

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/userpasswd/ClusterCredentialChangeActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/userpasswd/ClusterCredentialChangeActions.java
@@ -23,6 +23,7 @@ import com.sequenceiq.cloudbreak.core.flow2.stack.StackFailureContext;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.ClusterCredentialChangeRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.resource.ClusterCredentialChangeRequest.Type;
 import com.sequenceiq.cloudbreak.reactor.api.event.resource.ClusterCredentialChangeResult;
 
 @Configuration
@@ -44,10 +45,10 @@ public class ClusterCredentialChangeActions {
                 ClusterCredentialChangeRequest request;
                 switch (payload.getType()) {
                     case REPLACE:
-                        request = ClusterCredentialChangeRequest.replaceUserRequest(ctx.getStackId(), payload.getUser(), payload.getPassword());
+                        request = new ClusterCredentialChangeRequest(ctx.getStackId(), payload.getUser(), payload.getPassword(), Type.REPLACE);
                         break;
                     case UPDATE:
-                        request = ClusterCredentialChangeRequest.changePasswordRequest(ctx.getStackId(), payload.getPassword());
+                        request = new ClusterCredentialChangeRequest(ctx.getStackId(), null, payload.getPassword(), Type.UPDATE);
                         break;
                     default:
                         throw new UnsupportedOperationException("Ambari credential update request not supported: " + payload.getType());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/event/CmDiagnosticsCollectionEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cmdiagnostics/event/CmDiagnosticsCollectionEvent.java
@@ -10,12 +10,12 @@ public class CmDiagnosticsCollectionEvent extends BaseFlowEvent {
 
     private final CmDiagnosticsParameters parameters;
 
-    CmDiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, CmDiagnosticsParameters parameters) {
+    public CmDiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, CmDiagnosticsParameters parameters) {
         super(selector, resourceId, resourceCrn);
         this.parameters = parameters;
     }
 
-    CmDiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, Promise<AcceptResult> accepted,
+    public CmDiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, Promise<AcceptResult> accepted,
             CmDiagnosticsParameters parameters) {
         super(selector, resourceId, resourceCrn, accepted);
         this.parameters = parameters;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/event/DiagnosticsCollectionEvent.java
@@ -18,7 +18,7 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
 
     private final Set<String> excludeHosts;
 
-    DiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, DiagnosticParameters parameters,
+    public DiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, DiagnosticParameters parameters,
             Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts) {
         super(selector, resourceId, resourceCrn);
         this.parameters = parameters;
@@ -27,7 +27,7 @@ public class DiagnosticsCollectionEvent extends BaseFlowEvent {
         this.excludeHosts = excludeHosts;
     }
 
-    DiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, Promise<AcceptResult> accepted,
+    public DiagnosticsCollectionEvent(String selector, Long resourceId, String resourceCrn, Promise<AcceptResult> accepted,
             DiagnosticParameters parameters, Set<String> hosts, Set<String> hostGroups, Set<String> excludeHosts) {
         super(selector, resourceId, resourceCrn, accepted);
         this.parameters = parameters;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterCredentialChangeTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterCredentialChangeTriggerEvent.java
@@ -9,19 +9,11 @@ public class ClusterCredentialChangeTriggerEvent extends StackEvent {
 
     private final Type type;
 
-    private ClusterCredentialChangeTriggerEvent(String selector, Long stackId, String user, String password, Type type) {
+    public ClusterCredentialChangeTriggerEvent(String selector, Long stackId, String user, String password, Type type) {
         super(selector, stackId);
         this.user = user;
         this.password = password;
         this.type = type;
-    }
-
-    public static ClusterCredentialChangeTriggerEvent replaceUserEvent(String selector, Long stackId, String user, String password) {
-        return new ClusterCredentialChangeTriggerEvent(selector, stackId, user, password, Type.REPLACE);
-    }
-
-    public static ClusterCredentialChangeTriggerEvent changePasswordEvent(String selector, Long stackId, String password) {
-        return new ClusterCredentialChangeTriggerEvent(selector, stackId, null, password, Type.UPDATE);
     }
 
     public String getUser() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -38,6 +38,7 @@ import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.EphemeralClusterEve
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterAndStackDownscaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterCertificatesRotationTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterCredentialChangeTriggerEvent;
+import com.sequenceiq.cloudbreak.core.flow2.event.ClusterCredentialChangeTriggerEvent.Type;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterDownscaleDetails;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterScaleTriggerEvent;
 import com.sequenceiq.cloudbreak.core.flow2.event.DatabaseBackupTriggerEvent;
@@ -175,13 +176,13 @@ public class ReactorFlowManager {
 
     public FlowIdentifier triggerClusterCredentialReplace(Long stackId, String userName, String password) {
         String selector = CLUSTER_CREDENTIALCHANGE_EVENT.event();
-        ClusterCredentialChangeTriggerEvent event = ClusterCredentialChangeTriggerEvent.replaceUserEvent(selector, stackId, userName, password);
+        ClusterCredentialChangeTriggerEvent event = new ClusterCredentialChangeTriggerEvent(selector, stackId, userName, password, Type.REPLACE);
         return reactorNotifier.notify(stackId, selector, event);
     }
 
     public FlowIdentifier triggerClusterCredentialUpdate(Long stackId, String password) {
         String selector = CLUSTER_CREDENTIALCHANGE_EVENT.event();
-        ClusterCredentialChangeTriggerEvent event = ClusterCredentialChangeTriggerEvent.changePasswordEvent(selector, stackId, password);
+        ClusterCredentialChangeTriggerEvent event = new ClusterCredentialChangeTriggerEvent(selector, stackId, null, password, Type.UPDATE);
         return reactorNotifier.notify(stackId, selector, event);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterCredentialChangeRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/ClusterCredentialChangeRequest.java
@@ -9,19 +9,11 @@ public class ClusterCredentialChangeRequest extends ClusterPlatformRequest {
 
     private final Type type;
 
-    private ClusterCredentialChangeRequest(Long stackId, String user, String password, Type type) {
+    public ClusterCredentialChangeRequest(Long stackId, String user, String password, Type type) {
         super(stackId);
         this.user = user;
         this.password = password;
         this.type = type;
-    }
-
-    public static ClusterCredentialChangeRequest replaceUserRequest(Long stackId, String user, String password) {
-        return new ClusterCredentialChangeRequest(stackId, user, password, Type.REPLACE);
-    }
-
-    public static ClusterCredentialChangeRequest changePasswordRequest(Long stackId, String password) {
-        return new ClusterCredentialChangeRequest(stackId, null, password, Type.UPDATE);
     }
 
     public String getUser() {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/FlowPayloadConstructorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/FlowPayloadConstructorTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.reflections.ReflectionUtils;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+import com.sequenceiq.cloudbreak.common.event.Acceptable;
+
+class FlowPayloadConstructorTest {
+
+    @Test
+    void constructorAccessible() {
+        Reflections reflections = new Reflections("com.sequenceiq", new SubTypesScanner(true));
+        Set<Class<? extends Acceptable>> eventClasses = reflections.getSubTypesOf(Acceptable.class);
+        eventClasses.stream()
+                .filter(c -> !c.isInterface() && !isAbstract(c) && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
+                .filter(c -> !c.getName().endsWith("Test"))
+                .forEach(this::checkForConstructor);
+    }
+
+    private void checkForConstructor(Class<? extends Acceptable> clazz) {
+        Set<Constructor> constructors = ReflectionUtils.getConstructors(clazz, this::isPublic);
+        assertFalse(constructors.isEmpty(), String.format("%s class has no visible public constructor!", clazz.getName()));
+    }
+
+    private boolean isPublic(Constructor<?> c) {
+        return Modifier.isPublic(c.getModifiers());
+    }
+
+    private boolean isAbstract(Class<?> clazz) {
+        return Modifier.isAbstract(clazz.getModifiers());
+    }
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/FlowPayloadConstructorTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/FlowPayloadConstructorTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.datalake;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.reflections.ReflectionUtils;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+import com.sequenceiq.cloudbreak.common.event.Acceptable;
+
+class FlowPayloadConstructorTest {
+
+    @Test
+    void constructorAccessible() {
+        Reflections reflections = new Reflections("com.sequenceiq", new SubTypesScanner(true));
+        Set<Class<? extends Acceptable>> eventClasses = reflections.getSubTypesOf(Acceptable.class);
+        eventClasses.stream()
+                .filter(c -> !c.isInterface() && !isAbstract(c) && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
+                .filter(c -> !c.getName().endsWith("Test"))
+                .forEach(this::checkForConstructor);
+    }
+
+    private void checkForConstructor(Class<? extends Acceptable> clazz) {
+        Set<Constructor> constructors = ReflectionUtils.getConstructors(clazz, this::isPublic);
+        assertFalse(constructors.isEmpty(), String.format("%s class has no visible public constructor!", clazz.getName()));
+    }
+
+    private boolean isPublic(Constructor<?> c) {
+        return Modifier.isPublic(c.getModifiers());
+    }
+
+    private boolean isAbstract(Class<?> clazz) {
+        return Modifier.isAbstract(clazz.getModifiers());
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/FlowPayloadConstructorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/FlowPayloadConstructorTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.environment;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.reflections.ReflectionUtils;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+import com.sequenceiq.cloudbreak.common.event.Acceptable;
+
+class FlowPayloadConstructorTest {
+
+    @Test
+    void constructorAccessible() {
+        Reflections reflections = new Reflections("com.sequenceiq", new SubTypesScanner(true));
+        Set<Class<? extends Acceptable>> eventClasses = reflections.getSubTypesOf(Acceptable.class);
+        eventClasses.stream()
+                .filter(c -> !c.isInterface() && !isAbstract(c) && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
+                .filter(c -> !c.getName().endsWith("Test"))
+                .forEach(this::checkForConstructor);
+    }
+
+    private void checkForConstructor(Class<? extends Acceptable> clazz) {
+        Set<Constructor> constructors = ReflectionUtils.getConstructors(clazz, this::isPublic);
+        assertFalse(constructors.isEmpty(), String.format("%s class has no visible public constructor!", clazz.getName()));
+    }
+
+    private boolean isPublic(Constructor<?> c) {
+        return Modifier.isPublic(c.getModifiers());
+    }
+
+    private boolean isAbstract(Class<?> clazz) {
+        return Modifier.isAbstract(clazz.getModifiers());
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/FlowPayloadConstructorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/FlowPayloadConstructorTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.freeipa;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.reflections.ReflectionUtils;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+import com.sequenceiq.cloudbreak.common.event.Acceptable;
+
+class FlowPayloadConstructorTest {
+
+    @Test
+    void constructorAccessible() {
+        Reflections reflections = new Reflections("com.sequenceiq", new SubTypesScanner(true));
+        Set<Class<? extends Acceptable>> eventClasses = reflections.getSubTypesOf(Acceptable.class);
+        eventClasses.stream()
+                .filter(c -> !c.isInterface() && !isAbstract(c) && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
+                .filter(c -> !c.getName().endsWith("Test"))
+                .forEach(this::checkForConstructor);
+    }
+
+    private void checkForConstructor(Class<? extends Acceptable> clazz) {
+        Set<Constructor> constructors = ReflectionUtils.getConstructors(clazz, this::isPublic);
+        assertFalse(constructors.isEmpty(), String.format("%s class has no visible public constructor!", clazz.getName()));
+    }
+
+    private boolean isPublic(Constructor<?> c) {
+        return Modifier.isPublic(c.getModifiers());
+    }
+
+    private boolean isAbstract(Class<?> clazz) {
+        return Modifier.isAbstract(clazz.getModifiers());
+    }
+}

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/FlowPayloadConstructorTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/FlowPayloadConstructorTest.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.redbeams;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.reflections.ReflectionUtils;
+import org.reflections.Reflections;
+import org.reflections.scanners.SubTypesScanner;
+
+import com.sequenceiq.cloudbreak.common.event.Acceptable;
+
+class FlowPayloadConstructorTest {
+
+    @Test
+    void constructorAccessible() {
+        Reflections reflections = new Reflections("com.sequenceiq", new SubTypesScanner(true));
+        Set<Class<? extends Acceptable>> eventClasses = reflections.getSubTypesOf(Acceptable.class);
+        eventClasses.stream()
+                .filter(c -> !c.isInterface() && !isAbstract(c) && !c.isAnonymousClass() && !c.isLocalClass() && !c.isMemberClass())
+                .filter(c -> !c.getName().endsWith("Test"))
+                .forEach(this::checkForConstructor);
+    }
+
+    private void checkForConstructor(Class<? extends Acceptable> clazz) {
+        Set<Constructor> constructors = ReflectionUtils.getConstructors(clazz, this::isPublic);
+        assertFalse(constructors.isEmpty(), String.format("%s class has no visible public constructor!", clazz.getName()));
+    }
+
+    private boolean isPublic(Constructor<?> c) {
+        return Modifier.isPublic(c.getModifiers());
+    }
+
+    private boolean isAbstract(Class<?> clazz) {
+        return Modifier.isAbstract(clazz.getModifiers());
+    }
+}


### PR DESCRIPTION
In case of flow redistribution and restart (e.g. pod restart) the payload classes
stored in the 'flowlog' table cannot be deserialized in case of missing public
constructors.

See detailed description in the commit message.