### PR TITLE
CFM-2014 Increase default value for 'Maximum Process File Descriptors…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-flow-management-small.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-flow-management-small.bp
@@ -170,7 +170,7 @@
               },
               {
                 "name": "rlimit_fds",
-                "value": "50000"
+                "value": "500000"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-flow-management.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-flow-management.bp
@@ -146,7 +146,7 @@
               },
               {
                 "name": "rlimit_fds",
-                "value": "50000"
+                "value": "500000"
               }
             ]
           }


### PR DESCRIPTION
…' property for NiFi Node Groups in Data HubNiFi. Increased count of max process file descriptors because customers asked for this.

See detailed description in the commit message.