### PR TITLE
CB-11720 Tie volume sets to discovery FQDNs

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VolumeSetAttributes.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/VolumeSetAttributes.java
@@ -28,6 +28,8 @@ public class VolumeSetAttributes {
 
     private String volumeType;
 
+    private String discoveryFQDN;
+
     @JsonCreator
     public VolumeSetAttributes(@JsonProperty("availabilityZone") String availabilityZone, @JsonProperty("deleteOnTermination") Boolean deleteOnTermination,
             @JsonProperty("fstab") String fstab, @JsonProperty("volumes") List<Volume> volumes, @JsonProperty("volumeSize") Integer volumeSize,
@@ -94,6 +96,14 @@ public class VolumeSetAttributes {
 
     public void setVolumeType(String volumeType) {
         this.volumeType = volumeType;
+    }
+
+    public void setDiscoveryFQDN(String discoveryFQDN) {
+        this.discoveryFQDN = discoveryFQDN;
+    }
+
+    public String getDiscoveryFQDN() {
+        return discoveryFQDN;
     }
 
     @JsonAutoDetect(fieldVisibility = ANY, getterVisibility = NONE, setterVisibility = NONE)

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsContextService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsContextService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
@@ -16,6 +18,8 @@ import com.sequenceiq.common.api.type.ResourceType;
 
 @Service
 public class AwsContextService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsContextService.class);
 
     public void addInstancesToContext(List<CloudResource> instances, ResourceBuilderContext context, List<Group> groups) {
         groups.forEach(group -> {
@@ -46,10 +50,15 @@ public class AwsContextService {
             List<CloudResource> groupVolumeSets = getResourcesOfTypeInGroup(resources, group, ResourceType.AWS_VOLUMESET);
             for (int i = 0; i < ids.size(); i++) {
                 if (i < groupInstances.size()) {
+                    Long privateId = ids.get(i);
+                    CloudResource instanceResource = groupInstances.get(i);
                     if (i > groupVolumeSets.size() - 1) {
-                        context.addComputeResources(ids.get(i), List.of(groupInstances.get(i)));
+                        context.addComputeResources(privateId, List.of(instanceResource));
                     } else {
-                        context.addComputeResources(ids.get(i), List.of(groupInstances.get(i), groupVolumeSets.get(i)));
+                        CloudResource volumesetResource = groupVolumeSets.get(i);
+                        LOGGER.debug("Adding instance and volume set to context under private id: {}. "
+                                + "Instance: {}, Volume Set: {}", privateId, instanceResource, volumesetResource);
+                        context.addComputeResources(privateId, List.of(instanceResource, volumesetResource));
                     }
                 }
             }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsUpscaleService.java
@@ -289,10 +289,12 @@ public class AwsUpscaleService {
     }
 
     private List<CloudResource> getReattachableVolumeSets(List<Group> scaledGroups, List<CloudResource> resources) {
-        return resources.stream()
+        List<CloudResource> volumeSets = resources.stream()
                 .filter(cloudResource -> ResourceType.AWS_VOLUMESET.equals(cloudResource.getType()))
                 .filter(cloudResource -> CommonStatus.DETACHED.equals(cloudResource.getStatus()))
                 .collect(Collectors.toList());
+        LOGGER.debug("Collected detached volumesets for reattachment: {}", volumeSets);
+        return volumeSets;
     }
 
     private List<Group> getGroupsWithNewInstances(List<Group> scaledGroups) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -31,8 +30,10 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.service.HostDiscoveryService;
@@ -44,6 +45,7 @@ import com.sequenceiq.cloudbreak.core.bootstrap.service.host.HostClusterAvailabi
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.context.HostBootstrapApiContext;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.context.HostOrchestratorClusterContext;
 import com.sequenceiq.cloudbreak.domain.Orchestrator;
+import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
@@ -61,6 +63,7 @@ import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.orchestrator.OrchestratorService;
+import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackInstanceStatusChecker;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
@@ -126,6 +129,12 @@ public class ClusterBootstrapper {
 
     @Inject
     private InstanceMetaDataToCloudInstanceConverter cloudInstanceConverter;
+
+    @Inject
+    private ResourceAttributeUtil resourceAttributeUtil;
+
+    @Inject
+    private ResourceService resourceService;
 
     public void bootstrapMachines(Long stackId) throws CloudbreakException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
@@ -328,14 +337,15 @@ public class ClusterBootstrapper {
         Set<String> clusterNodeNames = stack.getNotTerminatedInstanceMetaDataList().stream()
                 .map(InstanceMetaData::getShortHostname).collect(Collectors.toSet());
 
-        Iterator<String> iterator = recoveryHostNames.iterator();
+        Map<String, Optional<String>> instanceIdToFQDN = createInstanceIdToFQDNMappingFromDiskResources(stack);
         for (InstanceMetaData im : metaDataSet) {
             Node node = createNodeAndInitFqdnInInstanceMetadata(stack, im, clusterDomain, hostGroupNodeIndexes, clusterNodeNames);
             if (upscaleCandidateAddresses.contains(im.getPrivateIp())) {
                 // use the hostname of the node we're recovering instead of generating a new one
                 // but only when we would have generated a hostname, otherwise use the cloud provider's default mechanism
-                if (recoveredNodes && isNoneBlank(node.getHostname())) {
-                    node.setHostname(iterator.next().split("\\.")[0]);
+                Optional<String> fqdnOptional = instanceIdToFQDN.getOrDefault(im.getInstanceId(), Optional.empty());
+                if (recoveredNodes && isNoneBlank(node.getHostname()) && fqdnOptional.isPresent()) {
+                    node.setHostname(fqdnOptional.get().split("\\.")[0]);
                     LOGGER.debug("Set the hostname to {} for address: {}", node.getHostname(), im.getPrivateIp());
                 }
                 nodes.add(node);
@@ -351,6 +361,16 @@ public class ClusterBootstrapper {
         } catch (CloudbreakOrchestratorException e) {
             throw new CloudbreakException(e);
         }
+    }
+
+    private Map<String, Optional<String>> createInstanceIdToFQDNMappingFromDiskResources(Stack stack) {
+        List<Resource> diskResources = resourceService.findByStackIdAndType(stack.getId(), stack.getDiskResourceType());
+        Map<String, Optional<String>> imIdToFQDN = diskResources.stream()
+                .collect(Collectors.toMap(Resource::getInstanceId, volumeSet -> {
+                    Optional<VolumeSetAttributes> volumeSetAttributes = resourceAttributeUtil.getTypedAttributes(volumeSet, VolumeSetAttributes.class);
+                    return volumeSetAttributes.map(VolumeSetAttributes::getDiscoveryFQDN);
+                }));
+        return imIdToFQDN;
     }
 
     private String getClusterDomain(Set<InstanceMetaData> metaDataSet, String customDomain) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/CollectDownscaleCandidatesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/CollectDownscaleCandidatesHandler.java
@@ -6,6 +6,7 @@ import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -15,10 +16,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.amazonaws.util.StringUtils;
+import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
+import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
 import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
+import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
@@ -27,6 +32,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.resource.CollectDownscaleCand
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
 import com.sequenceiq.cloudbreak.service.hostgroup.HostGroupService;
+import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.cloudbreak.service.stack.DefaultRootVolumeSizeProvider;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
@@ -65,6 +71,12 @@ public class CollectDownscaleCandidatesHandler implements EventHandler<CollectDo
     @Inject
     private TransactionService transactionService;
 
+    @Inject
+    private ResourceAttributeUtil resourceAttributeUtil;
+
+    @Inject
+    private ResourceService resourceService;
+
     @Override
     public String selector() {
         return EventSelectorUtil.selector(CollectDownscaleCandidatesRequest.class);
@@ -97,6 +109,7 @@ public class CollectDownscaleCandidatesHandler implements EventHandler<CollectDo
                             clusterApiConnectors.getConnector(stack).clusterDecomissionService()
                                     .verifyNodesAreRemovable(stack, removableAndNotDeletedInstances);
                         }
+                        fillDiscoveryFQDNForRepair(request, stack, removableInstances, removableAndNotDeletedInstances);
                     }
                     LOGGER.info("Moving ahead with " + CollectDownscaleCandidatesResult.class.getSimpleName() + " with the following request [{}] " +
                             "and private IDs: [{}]", request.toString(),
@@ -116,6 +129,35 @@ public class CollectDownscaleCandidatesHandler implements EventHandler<CollectDo
             throw e.getCause();
         }
         eventBus.notify(result.selector(), new Event<>(event.getHeaders(), result));
+    }
+
+    private void fillDiscoveryFQDNForRepair(CollectDownscaleCandidatesRequest request, Stack stack, List<InstanceMetaData> removableInstances,
+            List<InstanceMetaData> removableAndNotDeletedInstances) {
+        if (request.getDetails().isRepair()) {
+            List<Resource> diskResources = resourceService.findByStackIdAndType(stack.getId(), stack.getDiskResourceType());
+            List<String> removeableInstanceIds = removableAndNotDeletedInstances
+                    .stream().map(InstanceMetaData::getInstanceId).collect(Collectors.toList());
+            for (Resource volumeSet : diskResources) {
+                Optional<VolumeSetAttributes> attributes = resourceAttributeUtil.getTypedAttributes(volumeSet, VolumeSetAttributes.class);
+                attributes.ifPresent(volumeSetAttributes ->
+                        fillDiscoveryFQDNInVolumeSetIfEmpty(removableInstances, removeableInstanceIds, volumeSet, volumeSetAttributes));
+            }
+            resourceService.saveAll(diskResources);
+        }
+    }
+
+    private void fillDiscoveryFQDNInVolumeSetIfEmpty(List<InstanceMetaData> removableInstances, List<String> removeableInstanceIds, Resource volumeSet,
+            VolumeSetAttributes volumeSetAttributes) {
+        if (removeableInstanceIds.contains(volumeSet.getInstanceId())
+                && StringUtils.isNullOrEmpty(volumeSetAttributes.getDiscoveryFQDN())) {
+            Optional<InstanceMetaData> metaData = removableInstances.stream()
+                    .filter(instanceMetaData -> volumeSet.getInstanceId().equals(instanceMetaData.getInstanceId()))
+                    .findFirst();
+            metaData.ifPresent(im -> {
+                volumeSetAttributes.setDiscoveryFQDN(im.getDiscoveryFQDN());
+                resourceAttributeUtil.setTypedAttributes(volumeSet, volumeSetAttributes);
+            });
+        }
     }
 
     private Set<Long> collectCandidates(CollectDownscaleCandidatesRequest request, Stack stack, int defaultRootVolumeSize)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MountDisks.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MountDisks.java
@@ -112,7 +112,7 @@ public class MountDisks {
                     String uuids = value.getOrDefault("uuids", "");
                     String fstab = value.getOrDefault("fstab", "");
                     if (!StringUtils.isEmpty(uuids) && !StringUtils.isEmpty(fstab)) {
-                        persistUuidAndFstab(stack, instanceIdOptional.get(), uuids, fstab);
+                        persistUuidAndFstab(stack, instanceIdOptional.get(), hostname, uuids, fstab);
                     }
                 }
             });
@@ -122,12 +122,13 @@ public class MountDisks {
         }
     }
 
-    private void persistUuidAndFstab(Stack stack, String instanceId, String uuids, String fstab) {
+    private void persistUuidAndFstab(Stack stack, String instanceId, String discoveryFQDN, String uuids, String fstab) {
         resourceService.saveAll(stack.getDiskResources().stream()
                 .filter(volumeSet -> instanceId.equals(volumeSet.getInstanceId()))
                 .peek(volumeSet -> resourceAttributeUtil.getTypedAttributes(volumeSet, VolumeSetAttributes.class).ifPresent(volumeSetAttributes -> {
                     volumeSetAttributes.setUuids(uuids);
                     volumeSetAttributes.setFstab(fstab);
+                    volumeSetAttributes.setDiscoveryFQDN(discoveryFQDN);
                     resourceAttributeUtil.setTypedAttributes(volumeSet, volumeSetAttributes);
                 }))
                 .collect(Collectors.toList()));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperTest.java
@@ -12,10 +12,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
 import com.sequenceiq.cloudbreak.common.service.HostDiscoveryService;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.HostBootstrapApiCheckerTask;
@@ -35,6 +37,7 @@ import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.orchestrator.OrchestratorService;
+import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 
@@ -91,6 +94,12 @@ public class ClusterBootstrapperTest {
 
     @Mock
     private InstanceMetaDataService instanceMetaDataService;
+
+    @Spy
+    private ResourceAttributeUtil resourceAttributeUtil;
+
+    @Mock
+    private ResourceService resourceService;
 
     @Test
     public void shouldUseReachableInstances() throws CloudbreakException, CloudbreakImageNotFoundException {


### PR DESCRIPTION
    Some services are sensitive to have the volumes reattached to a machine
    with the same FQDN.

    * Discovery FQDN now also stored in volumesets
    * Discovery FQDN saved the same time as mount info
    * For already running clusters, discovery FQDN ges saved at the start of repair
    * During bootstraping new nodes, discovery FQDN gets read from volume sets to
    set the proper hostname based on instance id
