### PR TITLE
CB-12505 Mount ephemeral volumes to different file path based on temporary storage value

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/util/StackUtil.java
@@ -9,6 +9,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -29,6 +30,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudVolumeUsageType;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes.Volume;
 import com.sequenceiq.cloudbreak.cluster.util.ResourceAttributeUtil;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.converter.spi.CredentialToCloudCredentialConverter;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -156,9 +158,11 @@ public class StackUtil {
                         String fstab = getOrDefault(instanceToVolumeInfoMap, instanceId, "fstab", "");
                         String uuids = getOrDefault(instanceToVolumeInfoMap, instanceId, "uuids", "");
                         Integer databaseVolumeIndex = getOrDefault(instanceToVolumeInfoMap, instanceId, "dataBaseVolumeIndex", -1);
+                        TemporaryStorage temporaryStorage =
+                                Optional.ofNullable(instanceGroup.getTemplate().getTemporaryStorage()).orElse(TemporaryStorage.ATTACHED_VOLUMES);
                         NodeVolumes nodeVolumes = new NodeVolumes(databaseVolumeIndex, dataVolumes, serialIds, fstab, uuids);
                         agents.add(new Node(im.getPrivateIp(), im.getPublicIp(), instanceId, instanceType, im.getDiscoveryFQDN(), im.getInstanceGroupName(),
-                                nodeVolumes));
+                                nodeVolumes, temporaryStorage));
                     }
                 }
             }

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/Node.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/model/Node.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.orchestrator.model;
 
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
+
 public class Node {
     private final String privateIp;
 
@@ -17,13 +19,17 @@ public class Node {
 
     private NodeVolumes nodeVolumes;
 
+    private TemporaryStorage temporaryStorage;
+
     public Node(String privateIp, String publicIp, String instanceId, String instanceType, String fqdn, String hostGroup) {
         this(privateIp, publicIp, instanceId, instanceType, fqdn, null, hostGroup);
     }
 
-    public Node(String privateIp, String publicIp, String instanceId, String instanceType, String fqdn, String hostGroup, NodeVolumes nodeVolumes) {
+    public Node(String privateIp, String publicIp, String instanceId, String instanceType, String fqdn, String hostGroup, NodeVolumes nodeVolumes,
+            TemporaryStorage temporaryStorage) {
         this(privateIp, publicIp, instanceId, instanceType, fqdn, null, hostGroup);
         this.nodeVolumes = nodeVolumes;
+        this.temporaryStorage = temporaryStorage;
     }
 
     public Node(String privateIp, String publicIp, String instanceId, String instanceType, String fqdn, String domain, String hostGroup) {
@@ -76,6 +82,10 @@ public class Node {
         return nodeVolumes;
     }
 
+    public TemporaryStorage getTemporaryStorage() {
+        return temporaryStorage;
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("Node{");
@@ -86,7 +96,8 @@ public class Node {
         sb.append(", hostname='").append(hostname).append('\'');
         sb.append(", domain='").append(domain).append('\'');
         sb.append(", hostGroup='").append(hostGroup).append('\'');
-        sb.append(", nodeVolumes=").append(nodeVolumes);
+        sb.append(", nodeVolumes=").append(nodeVolumes).append('\'');
+        sb.append(", temporaryStorage=").append(temporaryStorage);
         sb.append('}');
         return sb.toString();
     }

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.type.RecipeExecutionPhase;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.orchestrator.OrchestratorBootstrap;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
@@ -203,6 +204,7 @@ public class SaltOrchestrator implements HostOrchestrator {
             Map<String, String> dataVolumeMap = nodes.stream().collect(Collectors.toMap(Node::getHostname, node -> node.getNodeVolumes().getDataVolumes()));
             Map<String, String> serialIdMap = nodes.stream().collect(Collectors.toMap(Node::getHostname, node -> node.getNodeVolumes().getSerialIds()));
             Map<String, String> fstabMap = nodes.stream().collect(Collectors.toMap(Node::getHostname, node -> node.getNodeVolumes().getFstab()));
+            Map<String, String> temporaryStorageMap = nodes.stream().collect(Collectors.toMap(Node::getHostname, node -> node.getTemporaryStorage().name()));
             Map<String, Integer> dataBaseVolumeIndexMap =
                     nodes.stream().collect(Collectors.toMap(Node::getHostname, node -> node.getNodeVolumes().getDatabaseVolumeIndex()));
 
@@ -211,7 +213,8 @@ public class SaltOrchestrator implements HostOrchestrator {
                     "attached_volume_serial_list", serialIdMap.getOrDefault(hn, ""),
                     "cloud_platform", platformVariant,
                     "previous_fstab", fstabMap.getOrDefault(hn, ""),
-                    "database_volume_index", dataBaseVolumeIndexMap.getOrDefault(hn, -1)
+                    "database_volume_index", dataBaseVolumeIndexMap.getOrDefault(hn, -1),
+                    "temporary_storage", temporaryStorageMap.getOrDefault(hn, TemporaryStorage.ATTACHED_VOLUMES.name())
             )));
 
             SaltPillarProperties mounDiskProperties = new SaltPillarProperties("/mount/disk.sls", Collections.singletonMap("mount_data", hostnameDiskMountMap));

--- a/orchestrator-salt/src/main/resources/salt/salt/disks/mount/scripts/mount-disks.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/disks/mount/scripts/mount-disks.j2
@@ -3,6 +3,7 @@
 DATABASE_VOLUME_INDEX="{{ (salt['pillar.get']('mount_data')[salt['grains.get']('fqdn')])['database_volume_index'] }}"
 ATTACHED_VOLUME_NAME_LIST="{{ (salt['pillar.get']('mount_data')[salt['grains.get']('fqdn')])['attached_volume_name_list'] }}"
 ATTACHED_VOLUME_SERIAL_LIST="{{ (salt['pillar.get']('mount_data')[salt['grains.get']('fqdn')])['attached_volume_serial_list'] }}"
+TEMPORARY_STORAGE="{{ (salt['pillar.get']('mount_data')[salt['grains.get']('fqdn')])['temporary_storage'] }}"
 CLOUD_PLATFORM={{ (salt['pillar.get']('mount_data')[salt['grains.get']('fqdn')])['cloud_platform'] }}
 PREVIOUS_FSTAB="{{ (salt['pillar.get']('mount_data')[salt['grains.get']('fqdn')])['previous_fstab'] }}"
 
@@ -14,6 +15,7 @@ VERSION="V1.0"
 # INPUT
 #   ATTACHED_VOLUME_UUID_LIST - contains a list of uuids of volumes attached to the instance, format: space separated list
 #   PREVIOUS_FSTAB - contains the fstab if any from a previous instance, format: the file contents as is
+#   TEMPORARY_STORAGE - tells if volumes should be mounted in a mixed fashion (/hadoopfs/fsX vs /hadoopfs/ephfsX) or not
 #
 # OUTPUT
 #   happy path:
@@ -25,6 +27,7 @@ VERSION="V1.0"
 
 mount_remaining() {
       local hadoop_fs_dir_counter=$1
+      local hadoop_ephfs_dir_counter=1
       local return_value=0
       if [[ "$CLOUD_PLATFORM" == "AZURE" ]]; then
         not_mounted_volume_names=$(lsblk_command --noheadings --raw -o NAME,MOUNTPOINT | awk '$1~/[[:digit:]]/ && $2 == ""')
@@ -36,10 +39,17 @@ mount_remaining() {
       for volume in $not_mounted_volume_names; do
           uuid=$(get_disk_uuid "/dev/$volume")
           if [[ $root_disk != "/dev/$volume" && "$uuid" != ""  ]] && not_elastic_block_store "/dev/$volume" $LOG_FILE; then
+            if [[ "$TEMPORARY_STORAGE" == "EPHEMERAL_VOLUMES" ]]; then
+                mount_one "UUID=$uuid /hadoopfs/ephfs${hadoop_ephfs_dir_counter} $FS_TYPE defaults,noatime,nofail 0 2"
+                return_value=$(($? || return_value ))
+                log $LOG_FILE result of all mounting: $return_value
+                ((hadoop_ephfs_dir_counter++))
+            else
                 mount_one "UUID=$uuid /hadoopfs/fs${hadoop_fs_dir_counter} $FS_TYPE defaults,noatime,nofail 0 2"
                 return_value=$(($? || return_value ))
                 log $LOG_FILE result of all mounting: $return_value
                 ((hadoop_fs_dir_counter++))
+            fi
            elif [[ "$root_disk" == "/dev/$volume" ]]; then
                 log $LOG_FILE volume $volume is the root volume, skipping it
            elif ! not_elastic_block_store "/dev/$volume" $LOG_FILE ; then


### PR DESCRIPTION
When the temporaryStorage attribute (coming from an internal datahub post request) is set to EPHEMERAL_VOLUMES, instance storage should be mounted on the nodes under /hadoopfs/ephfsX.