### PR TITLE
CB-11855:PowerBI compatibility: Setup default impala pathways for Knox

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
@@ -33,6 +33,11 @@ server {
     rewrite ^/hive2(.*)$ /{{ salt['pillar.get']('gateway:path') }}/cdp-proxy-api/hive$1;
 {%- endif %}
 
+{%- if 'IMPALAD' in salt['pillar.get']('gateway:location') %}
+    rewrite ^/cliservice(.*)$ /{{ salt['pillar.get']('gateway:path') }}/cdp-proxy-api/impala$1;
+    rewrite ^/hive2(.*)$ /{{ salt['pillar.get']('gateway:path') }}/cdp-proxy-api/impala$1;
+{%- endif %}
+
     # If hadoop-jwt cookie not set and favicon is requested return 403.
     if ($cookie_hadoop-jwt !~ .+) {
         rewrite ^/favicon.ico$ /favicon.403;


### PR DESCRIPTION
Before the change with the jdbc url `jdbc:impala://satyadh2-master0.satyates.xcu2-8y8x.dev.cldr.work:443;transportMode=http;httpPath=cliservice;ssl=1;AuthMech=3;AllowSelfSignedCerts=1;`
![image](https://user-images.githubusercontent.com/7271603/120310850-7410d100-c2f4-11eb-8e8a-218c08855090.png)Post the change screenshot below:

<img width="885" alt="Screenshot 2021-06-01 at 4 10 46 PM" src="https://user-images.githubusercontent.com/7271603/120310355-efbe4e00-c2f3-11eb-8211-f1cda1d398a4.png">


