### PR TITLE
CB-12433 Currently, in RAZ-S3 clusters we see ADLS configurations as …

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -114,6 +114,12 @@ public class CMRepositoryVersionUtil {
         return isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_2_2);
     }
 
+    public static boolean isRazTokenConfigurationSupported(String cdhVersion, CloudPlatform cloudPlatform) {
+        LOGGER.info("ClouderaManagerRepo is compared for Raz Ranger token support in Data Hub and Data Lake");
+        return isVersionNewerOrEqualThanLimited(() -> cdhVersion, CLOUDERA_STACK_VERSION_7_2_10)
+                && (cloudPlatform.equals(CloudPlatform.AWS) || cloudPlatform.equals(CloudPlatform.AZURE));
+    }
+
     public static boolean isSudoAccessNeededForHostCertRotation(ClouderaManagerRepo clouderaManagerRepoDetails) {
         LOGGER.info("ClouderaManagerRepo is compared for Host certs rotation Sudo access");
         return isVersionOlderThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_2_6);

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazBaseConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazBaseConfigProvider.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.raz;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isRazTokenConfigurationSupported;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.getSafetyValveProperty;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.raz.RangerRazRoles.RANGER_RAZ;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.raz.RangerRazRoles.RANGER_RAZ_SERVER;
 
@@ -8,11 +11,17 @@ import java.util.List;
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.cloudera.api.swagger.model.ApiClusterTemplateRoleConfigGroup;
 import com.cloudera.api.swagger.model.ApiClusterTemplateService;
+import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRoleConfigProvider;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 
 public abstract class RangerRazBaseConfigProvider extends AbstractRoleConfigProvider {
+
+    private static final String RANGER_RAZ_SITE_XML_ROLE_SAFETY_VALVE = "ranger-raz-conf/ranger-raz-site.xml_role_safety_valve";
+
+    private static final String RANGER_RAZ_BOOTSTRAP_SERVICETYPES = "ranger.raz.bootstrap.servicetypes";
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
@@ -31,7 +40,24 @@ public abstract class RangerRazBaseConfigProvider extends AbstractRoleConfigProv
 
     @Override
     protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
+        String cdhVersion = source.getBlueprintView().getProcessor().getVersion().orElse("");
+        CloudPlatform cloudPlatform = source.getCloudPlatform();
+        if (!Strings.isNullOrEmpty(cdhVersion) && isRazTokenConfigurationSupported(cdhVersion, cloudPlatform)) {
+            String safetyValveValue = getSafetyValveProperty(RANGER_RAZ_BOOTSTRAP_SERVICETYPES, getServiceType(cloudPlatform));
+            return List.of(config(RANGER_RAZ_SITE_XML_ROLE_SAFETY_VALVE, safetyValveValue));
+        }
         return List.of();
+    }
+
+    private String getServiceType(CloudPlatform cloudPlatform) {
+        switch (cloudPlatform) {
+            case AZURE:
+                return "adls";
+            case AWS:
+                return "s3";
+            default:
+                return null;
+        }
     }
 
     protected ApiClusterTemplateService createTemplate() {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazBaseConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/RangerRazBaseConfigProviderTest.java
@@ -1,0 +1,133 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.raz;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
+import com.sequenceiq.cloudbreak.template.processor.BlueprintTextProcessor;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
+import com.sequenceiq.cloudbreak.template.views.DatalakeView;
+
+@ExtendWith(MockitoExtension.class)
+public class RangerRazBaseConfigProviderTest {
+
+    @InjectMocks
+    private TestRangerRazBaseConfigProvider underTest;
+
+    @Test
+    public void getServiceTypesConfigWheAWSAnd7210ShouldAddProperty() {
+        BlueprintTextProcessor blueprintTextProcessor = mock(BlueprintTextProcessor.class);
+        when(blueprintTextProcessor.getVersion()).thenReturn(Optional.of("7.2.10"));
+
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withStackType(StackType.WORKLOAD)
+                .withBlueprintView(new BlueprintView("", "7.2.10", "CDH", blueprintTextProcessor))
+                .withCloudPlatform(CloudPlatform.AWS)
+                .withGeneralClusterConfigs(new GeneralClusterConfigs())
+                .withDataLakeView(new DatalakeView(false))
+                .build();
+        List<ApiClusterTemplateConfig> roleConfigs = underTest.getRoleConfigs("", preparationObject);
+
+        assertEquals(1, roleConfigs.size());
+        assertEquals("<property><name>ranger.raz.bootstrap.servicetypes</name><value>s3</value></property>", roleConfigs.get(0).getValue());
+    }
+
+    @Test
+    public void getServiceTypesConfigWheAzureAnd7210ShouldAddProperty() {
+        BlueprintTextProcessor blueprintTextProcessor = mock(BlueprintTextProcessor.class);
+        when(blueprintTextProcessor.getVersion()).thenReturn(Optional.of("7.2.10"));
+
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withStackType(StackType.WORKLOAD)
+                .withBlueprintView(new BlueprintView("", "7.2.10", "CDH", blueprintTextProcessor))
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withGeneralClusterConfigs(new GeneralClusterConfigs())
+                .withDataLakeView(new DatalakeView(false))
+                .build();
+        List<ApiClusterTemplateConfig> roleConfigs = underTest.getRoleConfigs("", preparationObject);
+
+        assertEquals(1, roleConfigs.size());
+        assertEquals("<property><name>ranger.raz.bootstrap.servicetypes</name><value>adls</value></property>", roleConfigs.get(0).getValue());
+    }
+
+    @Test
+    public void getServiceTypesConfigWheAzureAnd729ShouldNOTAddProperty() {
+        BlueprintTextProcessor blueprintTextProcessor = mock(BlueprintTextProcessor.class);
+        when(blueprintTextProcessor.getVersion()).thenReturn(Optional.of("7.2.9"));
+
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withStackType(StackType.WORKLOAD)
+                .withBlueprintView(new BlueprintView("", "7.2.9", "CDH", blueprintTextProcessor))
+                .withCloudPlatform(CloudPlatform.AZURE)
+                .withGeneralClusterConfigs(new GeneralClusterConfigs())
+                .withDataLakeView(new DatalakeView(false))
+                .build();
+        List<ApiClusterTemplateConfig> roleConfigs = underTest.getRoleConfigs("", preparationObject);
+
+        assertEquals(0, roleConfigs.size());
+    }
+
+    @Test
+    public void getServiceTypesConfigWheAAWSAnd729ShouldNOTAddProperty() {
+        BlueprintTextProcessor blueprintTextProcessor = mock(BlueprintTextProcessor.class);
+        when(blueprintTextProcessor.getVersion()).thenReturn(Optional.of("7.2.9"));
+
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withStackType(StackType.WORKLOAD)
+                .withBlueprintView(new BlueprintView("", "7.2.9", "CDH", blueprintTextProcessor))
+                .withCloudPlatform(CloudPlatform.AWS)
+                .withGeneralClusterConfigs(new GeneralClusterConfigs())
+                .withDataLakeView(new DatalakeView(false))
+                .build();
+        List<ApiClusterTemplateConfig> roleConfigs = underTest.getRoleConfigs("", preparationObject);
+
+        assertEquals(0, roleConfigs.size());
+    }
+
+    @Test
+    public void getServiceTypesConfigWheAGCPAnd729ShouldNOTAddProperty() {
+        BlueprintTextProcessor blueprintTextProcessor = mock(BlueprintTextProcessor.class);
+        when(blueprintTextProcessor.getVersion()).thenReturn(Optional.of("7.2.9"));
+
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withStackType(StackType.WORKLOAD)
+                .withBlueprintView(new BlueprintView("", "7.2.9", "CDH", blueprintTextProcessor))
+                .withCloudPlatform(CloudPlatform.GCP)
+                .withGeneralClusterConfigs(new GeneralClusterConfigs())
+                .withDataLakeView(new DatalakeView(false))
+                .build();
+        List<ApiClusterTemplateConfig> roleConfigs = underTest.getRoleConfigs("", preparationObject);
+
+        assertEquals(0, roleConfigs.size());
+    }
+
+    @Test
+    public void getServiceTypesConfigWheAGCPAnd7210ShouldNOTAddProperty() {
+        BlueprintTextProcessor blueprintTextProcessor = mock(BlueprintTextProcessor.class);
+        when(blueprintTextProcessor.getVersion()).thenReturn(Optional.of("7.2.10"));
+
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withStackType(StackType.WORKLOAD)
+                .withBlueprintView(new BlueprintView("", "7.2.10", "CDH", blueprintTextProcessor))
+                .withCloudPlatform(CloudPlatform.GCP)
+                .withGeneralClusterConfigs(new GeneralClusterConfigs())
+                .withDataLakeView(new DatalakeView(false))
+                .build();
+        List<ApiClusterTemplateConfig> roleConfigs = underTest.getRoleConfigs("", preparationObject);
+
+        assertEquals(0, roleConfigs.size());
+    }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/TestRangerRazBaseConfigProvider.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/raz/TestRangerRazBaseConfigProvider.java
@@ -1,0 +1,4 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.raz;
+
+public class TestRangerRazBaseConfigProvider extends RangerRazBaseConfigProvider {
+}


### PR DESCRIPTION
…well and vice versa and causing this issue https://jira.cloudera.com/browse/CB-12251 Ideally each cloud specific cluster should only contain those cloud specific configs. Adding anger.raz.bootstrap.servicetypes property which is s3 in case of aws and adls in case of azure

See detailed description in the commit message.