### PR TITLE
CB-12842 Azure disk SSE with CMK fix for DH request azure == null

### DIFF
--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
@@ -4,6 +4,8 @@ import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
 
 import java.util.Optional;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsEncryptionV4Parameters;
@@ -28,6 +30,7 @@ import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvi
 
 @Component
 public class InstanceTemplateParameterConverter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceTemplateParameterConverter.class);
 
     public AwsInstanceTemplateV4Parameters convert(AwsInstanceTemplateV1Parameters source) {
         AwsInstanceTemplateV4Parameters response = new AwsInstanceTemplateV4Parameters();
@@ -81,10 +84,13 @@ public class InstanceTemplateParameterConverter {
                 .map(AzureResourceEncryptionParameters::getDiskEncryptionSetId)
                 .orElse(null);
         if (diskEncryptionSetId != null) {
+            LOGGER.info("Applying SSE with CMK for Azure managed disks as per environment.");
             AzureEncryptionV4Parameters encryption = new AzureEncryptionV4Parameters();
             encryption.setType(EncryptionType.CUSTOM);
             encryption.setDiskEncryptionSetId(diskEncryptionSetId);
             response.setEncryption(encryption);
+        } else {
+            LOGGER.info("Environment has not requested for SSE with CMK for Azure managed disks.");
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateV1ToInstanceTemplateV4Converter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateV1ToInstanceTemplateV4Converter.java
@@ -2,11 +2,14 @@ package com.sequenceiq.distrox.v1.distrox.converter;
 
 import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
 
+import java.util.Objects;
+
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.InstanceTemplateV4Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AzureInstanceTemplateV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
@@ -25,7 +28,8 @@ public class InstanceTemplateV1ToInstanceTemplateV4Converter {
         response.setAttachedVolumes(getIfNotNull(source.getAttachedVolumes(), volumeConverter::convertTo));
         response.setEphemeralVolume(getIfNotNull(source.getEphemeralVolume(), volumeConverter::convert));
         response.setAws(getIfNotNull(source.getAws(), instanceTemplateParameterConverter::convert));
-        response.setAzure(getIfNotNull(source.getAzure(), environment, instanceTemplateParameterConverter::convert));
+        AzureInstanceTemplateV1Parameters azureParametersEffective = Objects.requireNonNullElse(source.getAzure(), new AzureInstanceTemplateV1Parameters());
+        response.setAzure(instanceTemplateParameterConverter.convert(azureParametersEffective, environment));
         response.setGcp(getIfNotNull(source.getGcp(), instanceTemplateParameterConverter::convert));
         response.setYarn(getIfNotNull(source.getYarn(), instanceTemplateParameterConverter::convert));
         response.setCloudPlatform(source.getCloudPlatform());

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateV1ToInstanceTemplateV4ConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateV1ToInstanceTemplateV4ConverterTest.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.distrox.v1.distrox.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -43,13 +45,18 @@ class InstanceTemplateV1ToInstanceTemplateV4ConverterTest {
     @Test
     void convertTestInstanceTemplateV1RequestToInstanceTemplateV4RequestWhenMinimal() {
         InstanceTemplateV1Request source = new InstanceTemplateV1Request();
+        source.setAzure(null);
         source.setInstanceType(INSTANCE_TYPE);
+
+        AzureInstanceTemplateV4Parameters azureInstanceTemplateV4Parameters = new AzureInstanceTemplateV4Parameters();
+        when(instanceTemplateParameterConverter.convert(any(AzureInstanceTemplateV1Parameters.class), eq(environment)))
+                .thenReturn(azureInstanceTemplateV4Parameters);
 
         InstanceTemplateV4Request instanceTemplateV4Request = underTest.convert(source, environment);
 
         assertThat(instanceTemplateV4Request).isNotNull();
         assertThat(instanceTemplateV4Request.getRootVolume()).isNull();
-        assertThat(instanceTemplateV4Request.getAzure()).isNull();
+        assertThat(instanceTemplateV4Request.getAzure()).isSameAs(azureInstanceTemplateV4Parameters);
         assertThat(instanceTemplateV4Request.getCloudPlatform()).isNull();
         assertThat(instanceTemplateV4Request.getInstanceType()).isEqualTo(INSTANCE_TYPE);
     }


### PR DESCRIPTION
* Handle the case when the input `InstanceTemplateV1Request` has `azure == null`; Azure disk SSE with CMK will be applied to the DH disks even in such scenarios if the environment has prescribed it so. This fixes the former broken logic of #10371 that failed to apply disk encryption for such requests.
* Testing: Manual verification in local CB; updated existing UT.