### PR TITLE
CB-12764: Create separate properties for distrox upgrade e2e test to set the proper runtime versions

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonClusterManagerProperties.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CommonClusterManagerProperties.java
@@ -67,6 +67,10 @@ public class CommonClusterManagerProperties {
         this.internalDistroXBlueprintName = internalDistroXBlueprintName;
     }
 
+    public String getInternalDistroXBlueprintType() {
+        return internalDistroXBlueprintName;
+    }
+
     public UpgradeProperties getUpgrade() {
         return upgrade;
     }
@@ -109,6 +113,10 @@ public class CommonClusterManagerProperties {
 
         private String targetRuntimeVersion;
 
+        private String distroXUpgradeCurrentVersion;
+
+        private String distroXUpgradeTargetVersion;
+
         public String getCurrentRuntimeVersion() {
             return currentRuntimeVersion;
         }
@@ -123,6 +131,22 @@ public class CommonClusterManagerProperties {
 
         public void setTargetRuntimeVersion(String targetRuntimeVersion) {
             this.targetRuntimeVersion = targetRuntimeVersion;
+        }
+
+        public String getDistroXUpgradeCurrentVersion() {
+            return distroXUpgradeCurrentVersion;
+        }
+
+        public void setDistroXUpgradeCurrentVersion(String distroXUpgradeCurrentVersion) {
+            this.distroXUpgradeCurrentVersion = distroXUpgradeCurrentVersion;
+        }
+
+        public String getDistroXUpgradeTargetVersion() {
+            return distroXUpgradeTargetVersion;
+        }
+
+        public void setDistroXUpgradeTargetVersion(String distroXUpgradeTargetVersion) {
+            this.distroXUpgradeTargetVersion = distroXUpgradeTargetVersion;
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXUpgradeTests.java
@@ -62,8 +62,8 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
 
         String sdxName = resourcePropertyProvider().getName();
         String distroXName = resourcePropertyProvider().getName();
-        String currentRuntimeVersion = commonClusterManagerProperties.getUpgrade().getCurrentRuntimeVersion();
-        String targetRuntimeVersion = commonClusterManagerProperties.getUpgrade().getTargetRuntimeVersion();
+        String currentRuntimeVersion = commonClusterManagerProperties.getUpgrade().getDistroXUpgradeCurrentVersion();
+        String targetRuntimeVersion = commonClusterManagerProperties.getUpgrade().getDistroXUpgradeTargetVersion();
         testContext
                 .given(sdxName, SdxTestDto.class)
                 .withCloudStorage()
@@ -74,7 +74,7 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
                 .validate();
         testContext
                 .given(distroXName, DistroXTestDto.class)
-                .withTemplate(commonClusterManagerProperties.getInternalDistroXBlueprintName())
+                .withTemplate(String.format(commonClusterManagerProperties.getInternalDistroXBlueprintType(), currentRuntimeVersion))
                 .when(distroXTestClient.create(), key(distroXName))
                 .await(STACK_AVAILABLE)
                 .awaitForInstance(InstanceUtil.getHealthyDistroXInstances())

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -79,6 +79,8 @@ integrationtest:
   upgrade:
     currentRuntimeVersion: 7.2.0
     targetRuntimeVersion: 7.2.9
+    distroXUpgradeCurrentVersion: 7.2.7
+    distroXUpgradeTargetVersion: 7.2.9
   privateEndpointEnabled: false
 
   spot:


### PR DESCRIPTION
Create separate properties for distrox upgrade e2e test to set the proper runtime versions