### PR TITLE
CDPAM-1763 | Ship jumpgate agent logs from access and out logs at the time of env creation

### DIFF
--- a/core/src/main/resources/defaults/vm-logs.json
+++ b/core/src/main/resources/defaults/vm-logs.json
@@ -299,7 +299,11 @@
     "label": "generate_agent_token"
   },
   {
-    "path": "/var/log/ccmv2-inverting-proxy-agent.log",
-    "label": "ccmv2_inverting_proxy_agent"
+    "path": "/var/log/jumpgate/access.log",
+    "label": "jumpgate_agent_access"
+  },
+  {
+    "path": "/var/log/jumpgate/out.log",
+    "label": "jumpgate_agent_out"
   }
 ]

--- a/freeipa/src/main/resources/defaults/vm-logs.json
+++ b/freeipa/src/main/resources/defaults/vm-logs.json
@@ -83,7 +83,11 @@
     "label": "ipa_replica_install"
   },
   {
-    "path": "/var/log/ccmv2-inverting-proxy-agent.log",
-    "label": "ccmv2_inverting_proxy_agent"
+    "path": "/var/log/jumpgate/access.log",
+    "label": "jumpgate_agent_access"
+  },
+  {
+    "path": "/var/log/jumpgate/out.log",
+    "label": "jumpgate_agent_out"
   }
 ]


### PR DESCRIPTION
The log locations to collect the info is updated based on the recent changes where we introduced two log files(access, out) for jumpgate agent in [CDPAM-1553](https://jira.cloudera.com/browse/CDPAM-1553)