### PR TITLE
CB-12449 Improve quartz metrics to monitor jobs and triggers

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/JobCountMetricConfigurator.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/JobCountMetricConfigurator.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.quartz.metric;
 
+import static com.sequenceiq.cloudbreak.quartz.metric.QuartzMetricTag.JOB_GROUP;
+
 import java.util.Map;
 
 import javax.annotation.PostConstruct;
@@ -32,7 +34,7 @@ public class JobCountMetricConfigurator {
         try {
             for (String groupName : scheduler.getJobGroupNames()) {
                 metricService.registerGaugeMetric(QuartzMetricType.JOB_COUNT, groupName, groupNameToJobCountFunction,
-                        Map.of("group", groupName));
+                        Map.of(JOB_GROUP.name(), groupName));
             }
         } catch (SchedulerException e) {
             LOGGER.error("Cannot create job count metrics", e);

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/JobMetricsListener.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/JobMetricsListener.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.quartz.metric;
 
+import static com.sequenceiq.cloudbreak.quartz.metric.QuartzMetricTag.JOB_GROUP;
+
 import java.time.Duration;
 
 import javax.inject.Inject;
@@ -33,17 +35,18 @@ public class JobMetricsListener extends JobListenerSupport {
         LOGGER.trace("Job will be executed with group: {}, name: {}, class: {}",
                 jobKey.getGroup(), jobKey.getName(), context.getJobDetail().getJobClass().getName());
         metricService.incrementMetricCounter(QuartzMetricType.JOB_TRIGGERED,
-                "group", jobKey.getGroup());
+                JOB_GROUP.name(), jobKey.getGroup());
     }
 
     @Override
     public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
         JobKey jobKey = context.getJobDetail().getKey();
-        LOGGER.trace("Job was executed with group: {}, name: {}, class: {} in {} ms",
-                jobKey.getGroup(), jobKey.getName(), context.getJobDetail().getJobClass().getName(), context.getJobRunTime());
+        LOGGER.debug("Job was executed with group: {}, name: {}, class: {} in {} ms, exception: {}",
+                jobKey.getGroup(), jobKey.getName(), context.getJobDetail().getJobClass().getName(), context.getJobRunTime(),
+                jobException == null ? "without exception" : jobException.getMessage());
         QuartzMetricType metricType = jobException == null ? QuartzMetricType.JOB_FINISHED : QuartzMetricType.JOB_FAILED;
         Duration jobRunTime = Duration.ofMillis(context.getJobRunTime());
         metricService.recordTimerMetric(metricType, jobRunTime,
-                "group", jobKey.getGroup());
+                JOB_GROUP.name(), jobKey.getGroup());
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/QuartzMetricTag.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/metric/QuartzMetricTag.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.quartz.metric;
+
+public enum QuartzMetricTag {
+
+    JOB_GROUP,
+    TRIGGER_GROUP
+}


### PR DESCRIPTION
Change metric tags in order to use different selectors for jobs and triggers in DataDog.
Fix trigger delay calculation.

See detailed description in the commit message.