### PR TITLE
CB-12877. Salt Failure When Creating Datalake.

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/JidInfoResponseTransformer.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/JidInfoResponseTransformer.java
@@ -152,7 +152,7 @@ public class JidInfoResponseTransformer {
             String internalFieldNameStr = internalFieldName.next();
             JsonNode internalJsonField = returnFieldNode.get(internalFieldNameStr);
             if (internalJsonField.isArray()) {
-                throw new UnsupportedOperationException("Not supported Salt highstate response: " + internalJsonField);
+                throw new SaltExecutionWentWrongException("Salt execution went wrong:: " + internalJsonField);
             }
             if (internalJsonField.isTextual()) {
                 LOGGER.debug("Found textual salt minion response for '{}' node: {}", internalFieldNameStr, internalJsonField);

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
@@ -50,9 +50,9 @@ import com.sequenceiq.cloudbreak.service.Retry;
 
 public class SaltStates {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SaltStates.class);
+    public static final Pattern RUNNING_HIGHSTATE_JID = Pattern.compile(".*The function .*state\\.highstate.* is running as PID.*with jid (\\d+).*");
 
-    private static final Pattern RUNNING_HIGHSTATE_JID = Pattern.compile(".*The function \"state\\.highstate\" is running as PID.*with jid (\\d+)");
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaltStates.class);
 
     private SaltStates() {
     }

--- a/orchestrator-salt/src/test/resources/jid_highstate_already_running_response.json
+++ b/orchestrator-salt/src/test/resources/jid_highstate_already_running_response.json
@@ -1,0 +1,9 @@
+{
+  "return": [
+    {"data": {
+      "host-10-0-0-6.openstacklocal": [
+        "The function \"state.highstate\" is running as PID 4417 and was started at 2021, Jun 02 13:35:59.917341 with jid 123456"
+      ]}
+    }
+  ]
+}


### PR DESCRIPTION
details:
- there is a use case when jid has already running, then the response format is a string in an array.
- by default it means an error, but this is a specific edge case, that needs to be handled.
- also checked some UTs, to make sure this is parsed afrer JSON based transformations (with files for UTs) updated the regex

See detailed description in the commit message.