### PR TITLE
CB-12853 Add `@Retryable` to LDAP and Kerberos bind user creation

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigV1Service.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/kerberos/v1/KerberosConfigV1Service.java
@@ -125,6 +125,10 @@ public class KerberosConfigV1Service {
         return convertKerberosConfigToDescribeKerberosConfigResponse(kerberosConfig);
     }
 
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public KerberosConfig createNewKerberosConfig(String environmentCrn, String clusterName, Stack existingStack, boolean ignoreExistingUser)
             throws FreeIpaClientException {
         LOGGER.debug("Kerberos config doesn't exists for cluster [{}] in env [{}]. Creating new in FreeIPA", clusterName, environmentCrn);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/v1/LdapConfigV1Service.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/ldap/v1/LdapConfigV1Service.java
@@ -207,6 +207,10 @@ public class LdapConfigV1Service {
         return convertLdapConfigToDescribeLdapConfigResponse(ldapConfig);
     }
 
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public LdapConfig createNewLdapConfig(String environmentCrn, String clusterName, Stack stack, boolean ignoreExistingUser) throws FreeIpaClientException {
         LOGGER.debug("Create new LDAP config for environment in FreeIPA");
         FreeIpaClient freeIpaClient = freeIpaClientFactory.getFreeIpaClientForStack(stack);


### PR DESCRIPTION
Sometimes bind user creation can fail with unexpected issues like timeout.
Adding `@Retryable` to provide a more stable experience during cluster provisioning.

See detailed description in the commit message.