### PR TITLE
CB-12410 adding base medium duty SDX testcase to our testsuite

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
@@ -181,13 +181,12 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
     }
 
     public void createCloudBlobContainer() {
-        CloudBlobContainer cloudBlobContainer = null;
+        CloudBlobContainer cloudBlobContainer;
         String containerName = getContainerName();
 
         try {
             int limit = 0;
             do {
-                Thread.sleep(6000);
                 try {
                     cloudBlobContainer = createCloudBlobClient().getContainerReference(containerName);
                     if (cloudBlobContainer.createIfNotExists()) {
@@ -198,10 +197,11 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
                     limit = 60;
                 } catch (StorageException | URISyntaxException createAfterWaitException) {
                     limit++;
-                    if (limit >= 60) {
-                        LOGGER.error("Azure Adls Gen2 Blob Storage Container: {} create cannot be succeed during 360000 ms!\n",
+                    if (limit >= 10) {
+                        LOGGER.error("Azure Adls Gen2 Blob Storage Container: {} create cannot be succeed during 60000 ms!\n",
                                 containerName, createAfterWaitException);
                     }
+                    Thread.sleep(6000);
                 }
             } while (limit < 60);
         } catch (InterruptedException waitException) {

--- a/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-e2e-tests.yaml
@@ -7,3 +7,5 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXRepairTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
+        excludedMethods:
+          - testSDXMediumDutyCreation


### PR DESCRIPTION
Minor refactor added to azure storage creator to reduce time to fail. 60 seconds should be enough.
- [x] AWS test ran locally
- [x] Azuere test ran locally

GCP test will be skipped in first iteration