### PR TITLE
CB-12843 Make sure we have PKs on every CB table

### DIFF
--- a/autoscale/src/main/resources/schema/app/20210603143940_CB-12843_Make_sure_we_have_PKs_on_every_CB_table.sql
+++ b/autoscale/src/main/resources/schema/app/20210603143940_CB-12843_Make_sure_we_have_PKs_on_every_CB_table.sql
@@ -1,0 +1,10 @@
+-- // CB-12843 Make sure we have PKs on every CB table
+-- Migration SQL that makes the change goes here.
+
+alter table subscription drop constraint if exists subscription_pkey;
+alter table subscription add primary key (id);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+alter table subscription drop constraint if exists subscription_pkey;

--- a/core/src/main/resources/schema/app/20210603141929_CB-12843_Make_sure_we_have_PKs_on_every_CB_table.sql
+++ b/core/src/main/resources/schema/app/20210603141929_CB-12843_Make_sure_we_have_PKs_on_every_CB_table.sql
@@ -1,0 +1,26 @@
+-- // CB-12843 Make sure we have PKs on every CB table
+-- Migration SQL that makes the change goes here.
+
+alter table volumetemplate drop constraint if exists volumetemplate_pkey;
+alter table volumetemplate add primary key (id);
+
+alter table userprofile drop constraint if exists userprofile_pkey;
+alter table userprofile add primary key (id);
+
+alter table securitygroup_securitygroupids drop constraint if exists securitygroup_securitygroupids_pkey;
+alter table securitygroup_securitygroupids add primary key (securitygroup_id, securitygroupid_value);
+
+alter table user_workspace_permissions_bkp drop constraint if exists user_workspace_permissions_bkp_pkey;
+alter table user_workspace_permissions_bkp add primary key (id);
+
+alter table topology_records drop constraint if exists topology_records_pkey;
+alter table topology_records add primary key (topology_id, hypervisor, rack);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+alter table volumetemplate drop constraint if exists volumetemplate_pkey;
+alter table userprofile drop constraint if exists userprofile_pkey;
+alter table securitygroup_securitygroupids drop constraint if exists securitygroup_securitygroupids_pkey;
+alter table user_workspace_permissions_bkp drop constraint if exists user_workspace_permissions_bkp_pkey;
+alter table topology_records drop constraint if exists topology_records_pkey;

--- a/freeipa/src/main/resources/schema/app/20210603143524_CB-12843_Make_sure_we_have_PKs_on_every_CB_table.sql
+++ b/freeipa/src/main/resources/schema/app/20210603143524_CB-12843_Make_sure_we_have_PKs_on_every_CB_table.sql
@@ -1,0 +1,10 @@
+-- // CB-12843 Make sure we have PKs on every CB table
+-- Migration SQL that makes the change goes here.
+
+alter table securitygroup_securitygroupids drop constraint if exists securitygroup_securitygroupids_pkey;
+alter table securitygroup_securitygroupids add primary key (securitygroup_id, securitygroupid_value);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+alter table securitygroup_securitygroupids drop constraint if exists securitygroup_securitygroupids_pkey;

--- a/redbeams/src/main/resources/schema/app/20210603144403_CB-12843_Make_sure_we_have_PKs_on_every_CB_table.sql
+++ b/redbeams/src/main/resources/schema/app/20210603144403_CB-12843_Make_sure_we_have_PKs_on_every_CB_table.sql
@@ -1,0 +1,15 @@
+-- // CB-12843 Make sure we have PKs on every CB table
+-- Migration SQL that makes the change goes here.
+
+alter table securitygroup_securitygroupids drop constraint if exists securitygroup_securitygroupids_pkey;
+alter table securitygroup_securitygroupids add primary key (securitygroup_id, securitygroupid_value);
+
+alter table sslconfig_sslcertificates drop constraint if exists sslconfig_sslcertificates_pkey;
+alter table sslconfig_sslcertificates add primary key (sslconfig_id, sslcertificate_value);
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+alter table securitygroup_securitygroupids drop constraint if exists securitygroup_securitygroupids_pkey;
+alter table sslconfig_sslcertificates drop constraint if exists sslconfig_sslcertificates_pkey;


### PR DESCRIPTION
Public key is necessary for maintaining replica identity in postgres, in this pull request I've added pkey where it was missing.