### PR TITLE
CDPSDX-2953: Add necessary permission for Data Lake backup and restore

### DIFF
--- a/cloud-aws-cloudformation/src/main/resources/definitions/cdp/aws-cdp-ranger-audit-s3-policy.json
+++ b/cloud-aws-cloudformation/src/main/resources/definitions/cdp/aws-cdp-ranger-audit-s3-policy.json
@@ -11,6 +11,12 @@
       "Resource": "arn:aws:s3:::${STORAGE_LOCATION_BASE}/ranger/audit/*"
     },
     {
+      "Sid": "AccessToDatalakeBackupRestoreDirectory",
+      "Effect": "Allow",
+      "Action": ["s3:PutObject"],
+      "Resource": "arn:aws:s3:::${LOGS_LOCATION_BASE}/*"
+    },
+    {
       "Sid": "LimitedAccessToDataLakeBucket",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
Fixes part of [CDPSDX-2953](https://jira.cloudera.com/browse/CDPSDX-2953).

Update AWS policy to allow Ranger Audit `s3:PutObject`.