### PR TITLE
CDPCP-4714. Add FreeIPA calls to enable and disable users

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -17,6 +17,8 @@ import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.sequenceiq.freeipa.client.operation.UserDisableOperation;
+import com.sequenceiq.freeipa.client.operation.UserEnableOperation;
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,6 +136,16 @@ public class FreeIpaClient {
         ParameterizedType type = TypeUtils
                 .parameterize(Set.class, User.class);
         return (Set<User>) invoke("user_find", flags, params, type).getResult();
+    }
+
+    public void userDisable(String user) throws FreeIpaClientException {
+        UserDisableOperation.create(user).invoke(this).orElseThrow(() ->
+                new FreeIpaClientException(String.format("User disable failed for user %s", user)));
+    }
+
+    public void userEnable(String user) throws FreeIpaClientException {
+        UserEnableOperation.create(user).invoke(this).orElseThrow(() ->
+                new FreeIpaClientException(String.format("User enable failed for user %s", user)));
     }
 
     public Set<Role> findAllRole() throws FreeIpaClientException {

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/User.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/User.java
@@ -29,6 +29,8 @@ public class User {
     @JsonDeserialize(using = ListFlatteningDeserializer.class)
     private String title;
 
+    private Boolean nsAccountLock;
+
     public String getDn() {
         return dn;
     }
@@ -85,6 +87,14 @@ public class User {
         this.title = title;
     }
 
+    public Boolean getNsAccountLock() {
+        return nsAccountLock;
+    }
+
+    public void setNsAccountLock(Boolean nsAccountLock) {
+        this.nsAccountLock = nsAccountLock;
+    }
+
     @Override
     public String toString() {
         return "User{"
@@ -95,6 +105,7 @@ public class User {
                 + ", memberOfGroup='" + memberOfGroup + '\''
                 + ", krbPasswordExpiration='" + krbPasswordExpiration + '\''
                 + ", title='" + title + '\''
+                + ", nsaccountlock='" + nsAccountLock + '\''
                 + '}';
     }
 }

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/UserDisableOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/UserDisableOperation.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.freeipa.client.operation;
+
+import com.sequenceiq.freeipa.client.FreeIpaChecks;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+public class UserDisableOperation extends AbstractFreeipaOperation<Object> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserDisableOperation.class);
+
+    private String userUid;
+
+    private UserDisableOperation(String userUid) {
+        this.userUid = userUid;
+    }
+
+    public static UserDisableOperation create(String userUid) {
+        return new UserDisableOperation(userUid);
+    }
+
+    @Override
+    public String getOperationName() {
+        return "user_disable";
+    }
+
+    @Override
+    protected List<Object> getFlags() {
+        return List.of(userUid);
+    }
+
+    @Override
+    public Optional<Object> invoke(FreeIpaClient freeIpaClient) throws FreeIpaClientException {
+        FreeIpaChecks.checkUserNotProtected(userUid, () -> String.format("User '%s' is protected and cannot be disabled in FreeIPA", userUid));
+        LOGGER.debug("disabling user {}", userUid);
+        Object response = invoke(freeIpaClient, Object.class);
+        LOGGER.debug("disabled user {}", userUid);
+        return Optional.of(response);
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/UserEnableOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/UserEnableOperation.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.freeipa.client.operation;
+
+import com.sequenceiq.freeipa.client.FreeIpaChecks;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+public class UserEnableOperation extends AbstractFreeipaOperation<Object> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserEnableOperation.class);
+
+    private String userUid;
+
+    private UserEnableOperation(String userUid) {
+        this.userUid = userUid;
+    }
+
+    public static UserEnableOperation create(String userUid) {
+        return new UserEnableOperation(userUid);
+    }
+
+    @Override
+    public String getOperationName() {
+        return "user_enable";
+    }
+
+    @Override
+    protected List<Object> getFlags() {
+        return List.of(userUid);
+    }
+
+    @Override
+    public Optional<Object> invoke(FreeIpaClient freeIpaClient) throws FreeIpaClientException {
+        FreeIpaChecks.checkUserNotProtected(userUid, () -> String.format("User '%s' is protected and cannot be enabled in FreeIPA", userUid));
+        LOGGER.debug("enabling user {}", userUid);
+        Object response = invoke(freeIpaClient, Object.class);
+        LOGGER.debug("enabled user {}", userUid);
+        return Optional.of(response);
+    }
+}

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/UserDisableOperationTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/UserDisableOperationTest.java
@@ -1,0 +1,48 @@
+package com.sequenceiq.freeipa.client.operation;
+
+import com.sequenceiq.cloudbreak.client.RPCResponse;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserDisableOperationTest {
+
+    private static final String USER_NAME = "user";
+
+    @Mock
+    private FreeIpaClient freeIpaClient;
+
+    @Test
+    public void testInvokeWhenUserProtected() {
+        assertThrows(FreeIpaClientException.class, () ->
+                UserDisableOperation.create("admin").invoke(freeIpaClient));
+        verifyNoInteractions(freeIpaClient);
+    }
+
+    @Test
+    public void testInvoke() throws FreeIpaClientException {
+        RPCResponse<Object> rpcResponse = new RPCResponse<>();
+        rpcResponse.setResult(new Object());
+
+        when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenReturn(rpcResponse);
+
+        UserDisableOperation operation = UserDisableOperation.create(USER_NAME);
+        operation.invoke(freeIpaClient);
+
+        assertTrue(operation.getFlags().contains(USER_NAME));
+        verify(freeIpaClient).invoke(eq("user_disable"), anyList(), any(), any());
+    }
+}

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/UserEnableOperationTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/UserEnableOperationTest.java
@@ -1,0 +1,48 @@
+package com.sequenceiq.freeipa.client.operation;
+
+import com.sequenceiq.cloudbreak.client.RPCResponse;
+import com.sequenceiq.freeipa.client.FreeIpaClient;
+import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserEnableOperationTest {
+
+    private static final String USER_NAME = "user";
+
+    @Mock
+    private FreeIpaClient freeIpaClient;
+
+    @Test
+    public void testInvokeWhenUserProtected() {
+        assertThrows(FreeIpaClientException.class, () ->
+                UserEnableOperation.create("admin").invoke(freeIpaClient));
+        verifyNoInteractions(freeIpaClient);
+    }
+
+    @Test
+    public void testInvoke() throws FreeIpaClientException {
+        RPCResponse<Object> rpcResponse = new RPCResponse<>();
+        rpcResponse.setResult(new Object());
+
+        when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenReturn(rpcResponse);
+
+        UserEnableOperation operation = UserEnableOperation.create(USER_NAME);
+        operation.invoke(freeIpaClient);
+
+        assertTrue(operation.getFlags().contains(USER_NAME));
+        verify(freeIpaClient).invoke(eq("user_enable"), anyList(), any(), any());
+    }
+}


### PR DESCRIPTION
The FreeIPA User model was updated to include the nsaccountlocked field.
This field is used by FreeIPA to enable/disable users. Operations and methods
were added to the FreeIpaClient to invoke the user_enable and user_disable
APIs.
