### PR TITLE
CB-10914 Create config provider for Cruise Control

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProvider.java
@@ -1,0 +1,106 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol;
+
+
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_11;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmHostGroupRoleConfigProvider;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+
+@Component
+public class CruiseControlRoleConfigProvider implements CmHostGroupRoleConfigProvider {
+
+    private static final String DEFAULT_GOALS = "default.goals";
+
+    private static final String HARD_GOALS = "hard.goals";
+
+    private static final String ANOMALY_DETECTION_GOALS = "anomaly.detection.goals";
+
+    private static final String SELF_HEALING_ENABLED = "self.healing.enabled";
+
+    private static final String ANOMALY_NOTIFIER_CLASS = "anomaly.notifier.class";
+
+    private static final String METRIC_ANOMALY_FINDER_CLASS = "metric.anomaly.finder.class";
+
+    private static final String CPU_BALANCE_THRESHOLD = "cpu.balance.threshold";
+
+    private static final String DISK_BALANCE_THRESHOLD = "disk.balance.threshold";
+
+    private static final String NETWORK_INBOUND_BALANCE_THRESHOLD = "network.inbound.balance.threshold";
+
+    private static final String NETWORK_OUTBOUND_BALANCE_THRESHOLD = "network.outbound.balance.threshold";
+
+    private static final String REPLICA_COUNT_BALANCE_THRESHOLD = "replica.count.balance.threshold";
+
+    private static final String CPU_CAPACITY_THRESHOLD = "cpu.capacity.threshold";
+
+    private static final String DISK_CAPACITY_THRESHOLD = "disk.capacity.threshold";
+
+    private static final String NETWORK_INBOUND_CAPACITY_THRESHOLD = "network.inbound.capacity.threshold";
+
+    private static final String NETWORK_OUTBOUND_CAPACITY_THRESHOLD = "network.outbound.capacity.threshold";
+
+    private static final String LEADER_REPLICA_COUNT_BALANCE_THRESHOLD = "leader.replica.count.balance.threshold";
+
+    @Override
+    public String getServiceType() {
+        return CruiseControlRoles.CRUISECONTROL;
+    }
+
+    @Override
+    public Set<String> getRoleTypes() {
+        return Set.of(CruiseControlRoles.CRUISE_CONTROL_SERVER);
+    }
+
+    @Override
+    public boolean sharedRoleType(String roleType) {
+        return false;
+    }
+
+    @Override
+    public List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source) {
+        String cdpVersion = source.getBlueprintView().getProcessor().getStackVersion() == null ?
+                "" : source.getBlueprintView().getProcessor().getStackVersion();
+
+        if (isVersionNewerOrEqualThanLimited(cdpVersion, CLOUDERA_STACK_VERSION_7_2_11)) {
+            return List.of(config(SELF_HEALING_ENABLED, "true"),
+                    config(ANOMALY_NOTIFIER_CLASS, "com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHealingNotifier"),
+                    config(METRIC_ANOMALY_FINDER_CLASS, "com.cloudera.kafka.cruisecontrol.detector.EmptyBrokerAnomalyFinder"),
+                    config(CPU_BALANCE_THRESHOLD, "1.5"),
+                    config(DISK_BALANCE_THRESHOLD, "1.5"),
+                    config(NETWORK_INBOUND_BALANCE_THRESHOLD, "1.5"),
+                    config(NETWORK_OUTBOUND_BALANCE_THRESHOLD, "1.5"),
+                    config(REPLICA_COUNT_BALANCE_THRESHOLD, "1.5"),
+                    config(DISK_CAPACITY_THRESHOLD, "0.85"),
+                    config(CPU_CAPACITY_THRESHOLD, "0.75"),
+                    config(NETWORK_INBOUND_CAPACITY_THRESHOLD, "0.85"),
+                    config(NETWORK_OUTBOUND_CAPACITY_THRESHOLD, "0.85"),
+                    config(LEADER_REPLICA_COUNT_BALANCE_THRESHOLD, "1.5"),
+                    config(ANOMALY_DETECTION_GOALS, "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal"),
+                    config(DEFAULT_GOALS, "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal"),
+                    config(HARD_GOALS, "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal")
+            );
+        }
+        return List.of();
+    }
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoles.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoles.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol;
+
+public class CruiseControlRoles {
+
+    public static final String CRUISECONTROL = "CRUISE_CONTROL";
+
+    public static final String CRUISE_CONTROL_SERVER = "CRUISE_CONTROL_SERVER";
+
+    private CruiseControlRoles() { }
+
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProviderTest.java
@@ -1,0 +1,92 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+
+@ExtendWith(MockitoExtension.class)
+public class CruiseControlRoleConfigProviderTest {
+
+    private final CruiseControlRoleConfigProvider provider = new CruiseControlRoleConfigProvider();
+
+    @Mock
+    private BlueprintView blueprintView;
+
+    @Mock
+    private CmTemplateProcessor processor;
+
+    @Test
+    void testRoleConfigWithCdpVersionIsAtLeast7211() {
+        cdpMainVersionIs("7.2.11");
+        HostgroupView hostGroup = new HostgroupView("test group");
+        assertEquals(createExpectedConfigWithStackVersionAtLeast7211(),
+                provider.getRoleConfigs(CruiseControlRoles.CRUISE_CONTROL_SERVER, hostGroup, getTemplatePreparationObject(hostGroup)));
+    }
+
+    @Test
+    void testRoleConfigWithCdpVersionIsLowerThan7211() {
+        cdpMainVersionIs("7.2.10");
+        HostgroupView hostGroup = new HostgroupView("test group");
+        assertEquals(List.of(), provider.getRoleConfigs(CruiseControlRoles.CRUISE_CONTROL_SERVER, hostGroup, getTemplatePreparationObject(hostGroup)));
+    }
+
+    private TemplatePreparationObject getTemplatePreparationObject(HostgroupView hostGroup) {
+        TemplatePreparationObject preparationObject = TemplatePreparationObject.Builder.builder()
+                .withHostgroupViews(Set.of(hostGroup))
+                .withBlueprintView(blueprintView)
+                .build();
+        return preparationObject;
+    }
+
+    private void cdpMainVersionIs(String version) {
+        when(blueprintView.getProcessor()).thenReturn(processor);
+        when(processor.getStackVersion()).thenReturn(version);
+    }
+
+    private List<ApiClusterTemplateConfig> createExpectedConfigWithStackVersionAtLeast7211() {
+        return List.of(config("self.healing.enabled", "true"),
+                config("anomaly.notifier.class", "com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHealingNotifier"),
+                config("metric.anomaly.finder.class", "com.cloudera.kafka.cruisecontrol.detector.EmptyBrokerAnomalyFinder"),
+                config("cpu.balance.threshold", "1.5"),
+                config("disk.balance.threshold", "1.5"),
+                config("network.inbound.balance.threshold", "1.5"),
+                config("network.outbound.balance.threshold", "1.5"),
+                config("replica.count.balance.threshold", "1.5"),
+                config("disk.capacity.threshold", "0.85"),
+                config("cpu.capacity.threshold", "0.75"),
+                config("network.inbound.capacity.threshold", "0.85"),
+                config("network.outbound.capacity.threshold", "0.85"),
+                config("leader.replica.count.balance.threshold", "1.5"),
+                config("anomaly.detection.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal"),
+                config("default.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal"),
+                config("hard.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal")
+        );
+    }
+
+}


### PR DESCRIPTION
Created a configuration provider for Cruise Control. It sets the self healing goals and their parameters which is specific in DataHub and cannot go as defaults into the CSD.

Update:
Commit 4e03a23 resolves a merge conflict in _CMRepositoryVersionUtil.java._
Commit d4413ed adds unit tests and modifies commit message as recommended