### PR TITLE
CB-12378: Incorrect exception text in AdvertisedImageService

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/AdvertisedImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/AdvertisedImageCatalogService.java
@@ -58,7 +58,7 @@ public class AdvertisedImageCatalogService implements ImageCatalogService {
         List<Image> freeipaImages = imageCatalogV3.getImages().getFreeIpaImages();
         List<Image> images = !freeipaImages.isEmpty() ? freeipaImages : cdhImages;
         if (images.stream().noneMatch(i -> i.isAdvertised())) {
-            throw new CloudbreakImageCatalogException("There should be at least one advertised cdh image.");
+            throw new CloudbreakImageCatalogException("There should be at least one advertised image.");
         }
     }
 }


### PR DESCRIPTION
As the freeipa catalog management is introduced due to the custom catalogs/images thus the related exception message should be updated into a general one.