### PR TITLE
Revert "CB-12614 Validate at cluster creation time, that instance types support instance storage, when cluster was posted with ephemeral volumes as temporary storage"

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceTemplate.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.EncryptionType;
 
 public class InstanceTemplate extends DynamicModel {
@@ -61,8 +60,6 @@ public class InstanceTemplate extends DynamicModel {
 
     private final String imageId;
 
-    private final TemporaryStorage temporaryStorage;
-
     @JsonCreator
     public InstanceTemplate(@JsonProperty("flavor") String flavor,
             @JsonProperty("groupName") String groupName,
@@ -71,8 +68,7 @@ public class InstanceTemplate extends DynamicModel {
             @JsonProperty("status") InstanceStatus status,
             @JsonProperty("parameters") Map<String, Object> parameters,
             @JsonProperty("templateId") Long templateId,
-            @JsonProperty("imageId") String imageId,
-            @JsonProperty("temporaryStorage") TemporaryStorage temporaryStorage) {
+            @JsonProperty("imageId") String imageId) {
         super(parameters);
         this.flavor = flavor;
         this.templateId = templateId;
@@ -81,7 +77,6 @@ public class InstanceTemplate extends DynamicModel {
         this.volumes = ImmutableList.copyOf(volumes);
         this.status = status;
         this.imageId = imageId;
-        this.temporaryStorage = temporaryStorage;
     }
 
     public String getFlavor() {
@@ -110,10 +105,6 @@ public class InstanceTemplate extends DynamicModel {
 
     public String getImageId() {
         return imageId;
-    }
-
-    public TemporaryStorage getTemporaryStorage() {
-        return temporaryStorage;
     }
 
     @Override

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AwsInstanceTemplate.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 
 public class AwsInstanceTemplate extends InstanceTemplate {
 
@@ -81,8 +80,8 @@ public class AwsInstanceTemplate extends InstanceTemplate {
     public static final String PLACEMENT_GROUP_STRATEGY = "placementGroupStrategy";
 
     public AwsInstanceTemplate(String flavor, String groupName, Long privateId, Collection<Volume> volumes, InstanceStatus status,
-            Map<String, Object> parameters, Long templateId, String imageId, TemporaryStorage temporaryStorage) {
-        super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId, temporaryStorage);
+            Map<String, Object> parameters, Long templateId, String imageId) {
+        super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId);
     }
 
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AzureInstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AzureInstanceTemplate.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 
 public class AzureInstanceTemplate extends InstanceTemplate {
 
@@ -50,7 +49,7 @@ public class AzureInstanceTemplate extends InstanceTemplate {
 
     public AzureInstanceTemplate(String flavor, String groupName, Long privateId, Collection<Volume> volumes, InstanceStatus status,
             Map<String, Object> parameters, Long templateId, String imageId) {
-        super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId, TemporaryStorage.ATTACHED_VOLUMES);
+        super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId);
     }
 
 }

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackValidator.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackValidator.java
@@ -1,38 +1,20 @@
 package com.sequenceiq.cloudbreak.cloud.aws;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
-import com.amazonaws.services.ec2.model.DescribeInstanceTypesRequest;
-import com.amazonaws.services.ec2.model.DescribeInstanceTypesResult;
-import com.amazonaws.services.ec2.model.InstanceTypeInfo;
 import com.sequenceiq.cloudbreak.cloud.Validator;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationClient;
-import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
-import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
-import com.sequenceiq.cloudbreak.cloud.model.Group;
-import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 
 @Component
 public class AwsStackValidator implements Validator {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(AwsStackValidator.class);
 
     @Inject
     private LegacyAwsClient awsClient;
@@ -42,62 +24,15 @@ public class AwsStackValidator implements Validator {
 
     @Override
     public void validate(AuthenticatedContext ac, CloudStack cloudStack) {
-        validateStackNameAvailability(ac);
-        validateInstanceStorageOnInstanceTypes(ac, cloudStack);
-    }
-
-    private void validateStackNameAvailability(AuthenticatedContext ac) {
         AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
         String regionName = ac.getCloudContext().getLocation().getRegion().value();
         AmazonCloudFormationClient cfClient = awsClient.createCloudFormationClient(credentialView, regionName);
         String cFStackName = cfStackUtil.getCfStackName(ac);
         try {
-            LOGGER.debug("Checking stack name availability. [{}]", cFStackName);
             cfClient.describeStacks(new DescribeStacksRequest().withStackName(cFStackName));
             throw new CloudConnectorException(String.format("Stack is already exists with the given name: %s", cFStackName));
-        } catch (AmazonServiceException e) {
-            if (e.getMessage().toLowerCase().contains("not found")) {
-                LOGGER.info("Stack name is available, CF stack not found by name {}", cFStackName);
-            } else {
-                LOGGER.warn("Exception while checking stack name availability.", e);
-            }
-        }
-    }
+        } catch (AmazonServiceException ignored) {
 
-    private void validateInstanceStorageOnInstanceTypes(AuthenticatedContext ac, CloudStack cloudStack) {
-        LOGGER.debug("Check instance storage availability on instance types");
-        List<String> instanceTypes = cloudStack.getGroups().stream()
-                .map(Group::getInstances)
-                .flatMap(Collection::stream)
-                .filter(toEphemeralStorageTemplates())
-                .map(CloudInstance::getTemplate)
-                .map(InstanceTemplate::getFlavor)
-                .collect(Collectors.toList());
-        LOGGER.debug("Instance types to check: {}", instanceTypes);
-        List<String> notSupportedTypes = getInstanceStorageNotSupportedTypes(ac, instanceTypes);
-        if (!CollectionUtils.isEmpty(notSupportedTypes)) {
-            LOGGER.warn("The following instance types does not support instance storage: {}", notSupportedTypes);
-            throw new CloudConnectorException(String.format("The following instance types does not support instance storage: %s", notSupportedTypes));
-        }
-    }
-
-    private Predicate<CloudInstance> toEphemeralStorageTemplates() {
-        return instance -> instance.getTemplate().getTemporaryStorage() == TemporaryStorage.EPHEMERAL_VOLUMES;
-    }
-
-    private List<String> getInstanceStorageNotSupportedTypes(AuthenticatedContext authenticatedContext, List<String> instanceTypes) {
-        AwsCredentialView credentialView = new AwsCredentialView(authenticatedContext.getCloudCredential());
-        AmazonEc2Client amazonEC2Client = awsClient.createEc2Client(credentialView);
-        DescribeInstanceTypesRequest request = new DescribeInstanceTypesRequest().withInstanceTypes(instanceTypes);
-        try {
-            DescribeInstanceTypesResult result = amazonEC2Client.describeInstanceTypes(request);
-            return result.getInstanceTypes().stream()
-                    .filter(types -> !types.getInstanceStorageSupported())
-                    .map(InstanceTypeInfo::getInstanceType)
-                    .collect(Collectors.toList());
-        } catch (Exception ex) {
-            LOGGER.warn("Failed to describe instance types: {}", instanceTypes, ex);
-            throw ex;
         }
     }
 }

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsContextServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsContextServiceTest.java
@@ -25,7 +25,6 @@ import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.Security;
 import com.sequenceiq.cloudbreak.cloud.template.context.ResourceBuilderContext;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -94,8 +93,7 @@ class AwsContextServiceTest {
     }
 
     private InstanceTemplate getInstanceTemplate(long privateId, String group) {
-        return new InstanceTemplate("large", group, privateId, new ArrayList<>(), InstanceStatus.CREATED, null, 1L,
-                "image", TemporaryStorage.ATTACHED_VOLUMES);
+        return new InstanceTemplate("large", group, privateId, new ArrayList<>(), InstanceStatus.CREATED, null, 1L, "image");
     }
 
 }

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetaDataCollectorTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetaDataCollectorTest.java
@@ -46,7 +46,6 @@ import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -126,8 +125,7 @@ public class AwsMetaDataCollectorTest {
         List<Volume> volumes = new ArrayList<>();
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         vms.add(new CloudInstance("i-1",
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
-                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
                 instanceAuthentication));
 
 
@@ -169,16 +167,13 @@ public class AwsMetaDataCollectorTest {
         List<Volume> volumes = new ArrayList<>();
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         vms.add(new CloudInstance(null,
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
-                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
                 instanceAuthentication));
         vms.add(new CloudInstance(null,
-                new InstanceTemplate("fla", "cbgateway", 6L, volumes, InstanceStatus.CREATED, null, 0L,
-                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
+                new InstanceTemplate("fla", "cbgateway", 6L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
                 instanceAuthentication));
         vms.add(new CloudInstance(null,
-                new InstanceTemplate("fla", "cbgateway", 7L, volumes, InstanceStatus.CREATED, null, 0L,
-                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
+                new InstanceTemplate("fla", "cbgateway", 7L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
                 instanceAuthentication));
 
         when(awsClient.createCloudFormationClient(any(AwsCredentialView.class), eq("region"))).thenReturn(amazonCFClient);
@@ -229,12 +224,10 @@ public class AwsMetaDataCollectorTest {
         List<Volume> volumes = new ArrayList<>();
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         vms.add(new CloudInstance(null,
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
-                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
                 instanceAuthentication));
         vms.add(new CloudInstance("i-1",
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
-                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
                 instanceAuthentication));
 
 
@@ -290,15 +283,13 @@ public class AwsMetaDataCollectorTest {
         List<Volume> volumes = new ArrayList<>();
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         CloudInstance cloudInstance1 = new CloudInstance(null,
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
-                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
                 instanceAuthentication);
         everyVms.add(cloudInstance1);
         newVms.add(cloudInstance1);
 
         everyVms.add(new CloudInstance("i-1",
-                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L,
-                        "imageId", TemporaryStorage.ATTACHED_VOLUMES),
+                new InstanceTemplate("fla", "cbgateway", 5L, volumes, InstanceStatus.CREATED, null, 0L, "imageId"),
                 instanceAuthentication));
 
 

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsValidatorsTest.java
@@ -36,7 +36,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.cloudformation.AmazonCloudFormation;
-import com.amazonaws.services.ec2.model.DescribeInstanceTypesResult;
 import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsAuthenticator;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsDefaultZoneProvider;
@@ -45,7 +44,6 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.AwsPlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsSessionCredentialClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsTagValidator;
 import com.sequenceiq.cloudbreak.cloud.aws.common.CommonAwsClient;
-import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.mapper.SdkClientExceptionMapper;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsEncodedAuthorizationFailureMessageDecoder;
 import com.sequenceiq.cloudbreak.cloud.aws.conf.AwsConfig;
@@ -99,9 +97,6 @@ public class AwsValidatorsTest {
     @MockBean
     private AwsEncodedAuthorizationFailureMessageDecoder awsEncodedAuthorizationFailureMessageDecoder;
 
-    @Mock
-    private AmazonEc2Client amazonEc2Client;
-
     private AuthenticatedContext authenticatedContext;
 
     @BeforeEach
@@ -132,9 +127,7 @@ public class AwsValidatorsTest {
     public void testStackValidatorStackUnexistent() {
         doReturn(amazonCloudFormationClient).when(awsClient).createCloudFormationClient(any(), anyString());
         when(amazonCloudFormationClient.describeStacks(any())).thenThrow(new AmazonServiceException("test exist"));
-        doReturn(amazonEc2Client).when(awsClient).createEc2Client(any());
-        when(amazonEc2Client.describeInstanceTypes(any())).thenReturn(new DescribeInstanceTypesResult());
-        Assertions.assertDoesNotThrow(() -> awsStackValidatorUnderTest.validate(authenticatedContext, getTestCloudStackWithTags(Map.of())));
+        Assertions.assertDoesNotThrow(() -> awsStackValidatorUnderTest.validate(authenticatedContext, null));
     }
 
     @Test

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationTemplateBuilderTest.java
@@ -67,7 +67,6 @@ import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.efs.CloudEfsConfiguration;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
 import com.sequenceiq.common.api.placement.AwsPlacementGroupStrategy;
@@ -1606,7 +1605,7 @@ public class CloudFormationTemplateBuilderTest {
         List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
                 new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         return new InstanceTemplate("m1.medium", "master", 0L, volumes, InstanceStatus.CREATE_REQUESTED, new HashMap<>(), 0L,
-                "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
+                "cb-centos66-amb200-2015-05-25");
     }
 
     private Map<String, String> getDefaultCloudStackParameters() {

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/AwsRepairTest.java
@@ -94,7 +94,6 @@ import com.sequenceiq.cloudbreak.cloud.notification.ResourceNotifier;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.storage.LocationHelper;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -418,8 +417,7 @@ public class AwsRepairTest {
         when(amazonAutoScalingClient.describeAutoScalingGroups(any())).thenReturn(describeAutoScalingGroupsResult);
 
         List<Volume> volumes = List.of();
-        InstanceTemplate instanceTemplate = new InstanceTemplate("", WORKER_GROUP, 0L, volumes, InstanceStatus.STARTED, Map.of(), 0L,
-                IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
+        InstanceTemplate instanceTemplate = new InstanceTemplate("", WORKER_GROUP, 0L, volumes, InstanceStatus.STARTED, Map.of(), 0L, IMAGE_ID);
         InstanceAuthentication authentication = new InstanceAuthentication("publicKey", "publicKeyId", "cloudbreak");
         CloudInstance firstCloudInstance = new CloudInstance(INSTANCE_ID_1, instanceTemplate, authentication);
         CloudInstance secondCloudInstance = new CloudInstance(INSTANCE_ID_2, instanceTemplate, authentication);

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/ComponentTestUtil.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/ComponentTestUtil.java
@@ -40,7 +40,6 @@ import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
 import com.sequenceiq.cloudbreak.cloud.model.Subnet;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.efs.CloudEfsConfiguration;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.model.FileSystemType;
 
@@ -165,7 +164,7 @@ public class ComponentTestUtil {
                 new Volume("/hadoop/fs2", "HDD", SIZE_DISK_2, CloudVolumeUsageType.GENERAL)
         );
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", groupName, privateId, volumes, instanceStatus,
-                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
+                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25");
         Map<String, Object> params = new HashMap<>();
         return new CloudInstance(instanceId, instanceTemplate, instanceAuthentication, params);
     }

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilderTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilderTest.java
@@ -49,7 +49,6 @@ import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.common.api.type.InstanceGroupType;
@@ -280,7 +279,7 @@ class AwsVolumeResourceBuilderTest {
 
     private Group createGroup(List<Volume> volumes, Map<String, Object> templateParameters) {
         InstanceTemplate template = new InstanceTemplate(FLAVOR, GROUP_NAME, PRIVATE_ID, volumes, InstanceStatus.CREATE_REQUESTED, templateParameters,
-                TEMPLATE_ID, IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
+                TEMPLATE_ID, IMAGE_ID);
         CloudInstance instance = new CloudInstance(INSTANCE_ID, template, null);
         return new Group(GROUP_NAME, InstanceGroupType.GATEWAY, singletonList(instance), null, null, null, null, null, null, ROOT_VOLUME_SIZE, null);
     }

--- a/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/view/AwsInstanceViewTest.java
+++ b/cloud-aws-common/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/common/view/AwsInstanceViewTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.placement.AwsPlacementGroupStrategy;
 import com.sequenceiq.common.api.type.EncryptionType;
 
@@ -30,7 +29,7 @@ public class AwsInstanceViewTest {
         map.put(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.DEFAULT.name());
 
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                map, 0L, IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
+                map, 0L, IMAGE_ID);
 
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
 
@@ -48,7 +47,7 @@ public class AwsInstanceViewTest {
         map.put(AwsInstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, ENCRYPTION_KEY_ARN);
 
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                map, 0L, IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
+                map, 0L, IMAGE_ID);
 
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
 
@@ -63,7 +62,7 @@ public class AwsInstanceViewTest {
         Map<String, Object> map = new HashMap<>();
         map.put(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, 30);
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                map, 0L, IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
+                map, 0L, IMAGE_ID);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertThat(actual.getOnDemandPercentage()).isEqualTo(70);
     }
@@ -71,7 +70,7 @@ public class AwsInstanceViewTest {
     @Test
     public void testOnDemandMissingPercentage() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(), 0L, IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
+                Map.of(), 0L, IMAGE_ID);
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertThat(actual.getOnDemandPercentage()).isEqualTo(100);
     }
@@ -82,7 +81,7 @@ public class AwsInstanceViewTest {
         Double spotMaxPrice = 0.9;
         map.put(AwsInstanceTemplate.EC2_SPOT_MAX_PRICE, spotMaxPrice);
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                map, 0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
+                map, 0L, "imageId");
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals(spotMaxPrice, actual.getSpotMaxPrice());
     }
@@ -90,7 +89,7 @@ public class AwsInstanceViewTest {
     @Test
     public void testMissingSpotMaxPrice() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(), 0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
+                Map.of(), 0L, "imageId");
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertNull(actual.getSpotMaxPrice());
     }
@@ -98,8 +97,7 @@ public class AwsInstanceViewTest {
     @Test
     public void testPlacementGroupWhenPartition() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.PARTITION.name()),
-                0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.PARTITION.name()), 0L, "imageId");
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals("Placement Group Strategy should be partition.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.PARTITION);
     }
@@ -107,8 +105,7 @@ public class AwsInstanceViewTest {
     @Test
     public void testPlacementGroupWhenSpread() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.SPREAD.name()),
-                0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.SPREAD.name()), 0L, "imageId");
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals("Placement Group Strategy should be spread.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.SPREAD);
     }
@@ -116,8 +113,7 @@ public class AwsInstanceViewTest {
     @Test
     public void testPlacementGroupWhenCluster() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.CLUSTER.name()),
-                0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.CLUSTER.name()), 0L, "imageId");
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals("Placement Group Strategy should be cluster.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.CLUSTER);
     }
@@ -125,7 +121,7 @@ public class AwsInstanceViewTest {
     @Test
     public void testPlacementGroupWhenMissing() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(), 0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
+                Map.of(), 0L, "imageId");
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals("Placement Group Strategy should be none.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.NONE);
     }
@@ -133,8 +129,7 @@ public class AwsInstanceViewTest {
     @Test
     public void testPlacementGroupWhenNone() {
         InstanceTemplate instanceTemplate = new InstanceTemplate("", "", 0L, Collections.emptyList(), InstanceStatus.STARTED,
-                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.NONE.name()),
-                0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES);
+                Map.of(AwsInstanceTemplate.PLACEMENT_GROUP_STRATEGY, AwsPlacementGroupStrategy.NONE.name()), 0L, "imageId");
         AwsInstanceView actual = new AwsInstanceView(instanceTemplate);
         assertEquals("Placement Group Strategy should be none.", actual.getPlacementGroupStrategy(), AwsPlacementGroupStrategy.NONE);
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
@@ -36,7 +36,6 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -172,7 +171,7 @@ public class AzureMetadataCollectorTest {
 
     private CloudInstance createCloudInstance(String instanceId, Long privateId) {
         InstanceTemplate instanceTemplate = new InstanceTemplate(null, INSTANCE_GROUP_NAME, privateId, Collections.emptyList(), null, Collections.emptyMap(),
-                null, null, TemporaryStorage.ATTACHED_VOLUMES);
+                null, null);
         return new CloudInstance(instanceId, instanceTemplate, null);
     }
 

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureStackViewProviderTest.java
@@ -37,7 +37,6 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @RunWith(Parameterized.class)
@@ -149,8 +148,7 @@ public class AzureStackViewProviderTest {
     }
 
     private InstanceTemplate createInstanceTemplate() {
-        return new InstanceTemplate(null, INSTANCE_ID, 1L, Collections.emptyList(), null, Map.of("managedDisk", true), null,
-                IMAGE_ID, TemporaryStorage.ATTACHED_VOLUMES);
+        return new InstanceTemplate(null, INSTANCE_ID, 1L, Collections.emptyList(), null, Map.of("managedDisk", true), null, IMAGE_ID);
     }
 
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -75,7 +75,6 @@ import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudAdlsGen2View;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AzureInstanceTemplate;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
 import com.sequenceiq.cloudbreak.util.Version;
 import com.sequenceiq.common.api.type.InstanceGroupType;
@@ -216,7 +215,7 @@ public class AzureTemplateBuilderTest {
         List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
                 new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", name, 0L, volumes, InstanceStatus.CREATE_REQUESTED,
-                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
+                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25");
         Map<String, Object> params = new HashMap<>();
         params.put(CloudInstance.SUBNET_ID, "existingSubnet");
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureVirtualMachineTypeProviderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/util/AzureVirtualMachineTypeProviderTest.java
@@ -18,7 +18,6 @@ import com.sequenceiq.cloudbreak.cloud.azure.view.AzureInstanceView;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureStackView;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 
 public class AzureVirtualMachineTypeProviderTest {
 
@@ -89,7 +88,7 @@ public class AzureVirtualMachineTypeProviderTest {
 
     private AzureInstanceView createAzureInstanceView(String groupName, String flavour) {
         InstanceTemplate instanceTemplate = new InstanceTemplate(flavour, groupName, null,
-                Collections.emptyList(), null, Collections.emptyMap(), null, null, TemporaryStorage.ATTACHED_VOLUMES);
+                Collections.emptyList(), null, Collections.emptyMap(), null, null);
         CloudInstance cloudInstance = new CloudInstance(null, instanceTemplate, null);
         return AzureInstanceView.builder(cloudInstance).build();
     }

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpMetadataCollectorTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpMetadataCollectorTest.java
@@ -32,7 +32,6 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudVmMetaDataStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
 
@@ -182,7 +181,7 @@ public class GcpMetadataCollectorTest {
     }
 
     private InstanceTemplate createInstanceTemplate(Long privateId) {
-        return new InstanceTemplate(null, null, privateId, Collections.emptyList(), null, null, null, null, TemporaryStorage.ATTACHED_VOLUMES);
+        return new InstanceTemplate(null, null, privateId, Collections.emptyList(), null, null, null, null);
     }
 
     private Map<String, Optional<NetworkInterface>> createNetworkInterfaces() {

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnectorTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnectorTest.java
@@ -49,7 +49,6 @@ import com.sequenceiq.cloudbreak.cloud.template.context.ResourceBuilderContext;
 import com.sequenceiq.cloudbreak.cloud.template.group.GroupResourceService;
 import com.sequenceiq.cloudbreak.cloud.template.init.ContextBuilders;
 import com.sequenceiq.cloudbreak.cloud.template.network.NetworkResourceService;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -226,8 +225,7 @@ public class GcpResourceConnectorTest {
     }
 
     private InstanceTemplate instanceTemplate() {
-        return new InstanceTemplate("large", "master", 1L, new ArrayList<>(), InstanceStatus.CREATE_REQUESTED, null, 1L,
-                "image", TemporaryStorage.ATTACHED_VOLUMES);
+        return new InstanceTemplate("large", "master", 1L, new ArrayList<>(), InstanceStatus.CREATE_REQUESTED, null, 1L, "image");
     }
 
     private InstanceAuthentication instanceAuthentication() {

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpAttachedDiskResourceBuilderTest.java
@@ -59,7 +59,6 @@ import com.sequenceiq.cloudbreak.cloud.model.Security;
 import com.sequenceiq.cloudbreak.cloud.model.SecurityRule;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -160,7 +159,7 @@ public class GcpAttachedDiskResourceBuilderTest {
 
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         InstanceTemplate instanceTemplate = new InstanceTemplate(flavor, name, privateId, volumes, InstanceStatus.CREATE_REQUESTED, params,
-                0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
+                0L, "cb-centos66-amb200-2015-05-25");
         CloudInstance cloudInstance =  new CloudInstance(instanceId, instanceTemplate, instanceAuthentication);
         group = new Group(name, InstanceGroupType.CORE, Collections.singletonList(cloudInstance), security, null,
                 instanceAuthentication, instanceAuthentication.getLoginUserName(), instanceAuthentication.getPublicKey(), 50, Optional.empty());

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilderTest.java
@@ -58,7 +58,6 @@ import com.sequenceiq.cloudbreak.cloud.model.Region;
 import com.sequenceiq.cloudbreak.cloud.model.Security;
 import com.sequenceiq.cloudbreak.cloud.model.SecurityRule;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -153,7 +152,7 @@ class GcpDiskResourceBuilderTest {
 
         instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         instanceTemplate = new InstanceTemplate(flavor, name, privateId, volumes, InstanceStatus.CREATE_REQUESTED, params,
-                0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
+                0L, "cb-centos66-amb200-2015-05-25");
         group = createGroup(50);
 
         buildableResource = List.of(CloudResource.builder()

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
@@ -83,7 +83,6 @@ import com.sequenceiq.cloudbreak.cloud.model.SpiFileSystem;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudFileSystemView;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudGcsView;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.common.api.type.InstanceGroupType;
@@ -357,7 +356,7 @@ public class GcpInstanceResourceBuilderTest {
 
     public CloudInstance newCloudInstance(Map<String, Object> params, InstanceAuthentication instanceAuthentication) {
         InstanceTemplate instanceTemplate = new InstanceTemplate(flavor, name, privateId, volumes, InstanceStatus.CREATE_REQUESTED, params,
-                0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
+                0L, "cb-centos66-amb200-2015-05-25");
         return new CloudInstance(instanceId, instanceTemplate, instanceAuthentication, params);
     }
 

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/CustomGcpDiskEncryptionServiceTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/CustomGcpDiskEncryptionServiceTest.java
@@ -21,7 +21,6 @@ import com.google.api.services.compute.model.CustomerEncryptionKey;
 import com.google.api.services.compute.model.Disk;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.EncryptionType;
 
 @ExtendWith(MockitoExtension.class)
@@ -83,7 +82,7 @@ public class CustomGcpDiskEncryptionServiceTest {
         parameters.put(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, "testurl");
 
         InstanceTemplate instanceTemplate = new InstanceTemplate("large", "master", 1L,
-                new ArrayList<>(), InstanceStatus.CREATE_REQUESTED, parameters, 1L, "image", TemporaryStorage.ATTACHED_VOLUMES);
+                new ArrayList<>(), InstanceStatus.CREATE_REQUESTED, parameters, 1L, "image");
 
         return instanceTemplate;
     }

--- a/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackFlavorVerifierTest.java
+++ b/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackFlavorVerifierTest.java
@@ -25,7 +25,6 @@ import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -93,8 +92,7 @@ public class OpenStackFlavorVerifierTest {
     }
 
     private Group createGroup(String flavor) {
-        InstanceTemplate template =
-                new InstanceTemplate(flavor, null, null, new ArrayList<>(), null, null, null, null, TemporaryStorage.ATTACHED_VOLUMES);
+        InstanceTemplate template = new InstanceTemplate(flavor, null, null, new ArrayList<>(), null, null, null, null);
         CloudInstance skeleton = new CloudInstance("id1", template, null);
 
         Group group = new Group("name", InstanceGroupType.GATEWAY, new ArrayList<>(), null, skeleton,

--- a/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/HeatTemplateBuilderTest.java
+++ b/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/HeatTemplateBuilderTest.java
@@ -53,7 +53,6 @@ import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.openstack.common.OpenStackUtils;
 import com.sequenceiq.cloudbreak.cloud.openstack.heat.HeatTemplateBuilder.ModelContext;
 import com.sequenceiq.cloudbreak.cloud.openstack.view.NeutronNetworkView;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.tag.CostTagging;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.util.FreeMarkerTemplateUtils;
@@ -120,7 +119,7 @@ public class HeatTemplateBuilderTest {
         List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
                 new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", name, 0L, volumes, InstanceStatus.CREATE_REQUESTED,
-                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25", TemporaryStorage.ATTACHED_VOLUMES);
+                new HashMap<>(), 0L, "cb-centos66-amb200-2015-05-25");
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         CloudInstance instance = new CloudInstance("SOME_ID", instanceTemplate, instanceAuthentication);
         List<SecurityRule> rules = singletonList(new SecurityRule("0.0.0.0/0",

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ParameterGenerator.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/ParameterGenerator.java
@@ -38,7 +38,6 @@ import com.sequenceiq.cloudbreak.cloud.model.Security;
 import com.sequenceiq.cloudbreak.cloud.model.SecurityRule;
 import com.sequenceiq.cloudbreak.cloud.model.Subnet;
 import com.sequenceiq.cloudbreak.cloud.model.Volume;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.type.AdjustmentType;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
@@ -83,7 +82,7 @@ public class ParameterGenerator {
         List<Volume> volumes = Arrays.asList(new Volume("/hadoop/fs1", "HDD", 1, CloudVolumeUsageType.GENERAL),
                 new Volume("/hadoop/fs2", "HDD", 1, CloudVolumeUsageType.GENERAL));
         InstanceTemplate instanceTemplate = new InstanceTemplate("m1.medium", name, 0L, volumes, InstanceStatus.CREATE_REQUESTED,
-                new HashMap<>(), 0L, "default-id", TemporaryStorage.ATTACHED_VOLUMES);
+                new HashMap<>(), 0L, "default-id");
 
         InstanceAuthentication instanceAuthentication = new InstanceAuthentication("sshkey", "", "cloudbreak");
         CloudInstance instance = new CloudInstance("SOME_ID", instanceTemplate, instanceAuthentication);

--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/testcontext/TestApplicationContext.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/testcontext/TestApplicationContext.java
@@ -54,7 +54,6 @@ import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.service.Persister;
 import com.sequenceiq.cloudbreak.cloud.service.ResourceRetriever;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.grpc.ManagedChannelWrapper;
 import com.sequenceiq.common.api.type.ResourceType;
 import com.sequenceiq.flow.core.ApplicationFlowInformation;
@@ -75,11 +74,11 @@ public class TestApplicationContext {
 
     private final CloudInstance cloudInstance = new CloudInstance("instanceId",
             new InstanceTemplate("flavor", "groupName", 1L, Collections.emptyList(),
-                    InstanceStatus.CREATE_REQUESTED, new HashMap<>(), 0L, "imageId", TemporaryStorage.ATTACHED_VOLUMES), instanceAuthentication);
+                    InstanceStatus.CREATE_REQUESTED, new HashMap<>(), 0L, "imageId"), instanceAuthentication);
 
     private final CloudInstance cloudInstanceBad = new CloudInstance("instanceIdBad",
             new InstanceTemplate("flavor", "groupName", 1L, Collections.emptyList(),
-                    InstanceStatus.CREATE_REQUESTED, new HashMap<>(), 1L, "imageId", TemporaryStorage.ATTACHED_VOLUMES), instanceAuthentication);
+                    InstanceStatus.CREATE_REQUESTED, new HashMap<>(), 1L, "imageId"), instanceAuthentication);
 
     @Mock
     private CloudPlatformConnectors cloudPlatformConnectors;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -52,7 +52,6 @@ import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessorFactory;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.converter.InstanceMetadataToImageIdConverter;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.FileSystem;
@@ -200,8 +199,7 @@ public class StackToCloudStackConverter {
                 volumes.add(volume);
             }
         });
-        TemporaryStorage temporaryStorage = template.getTemporaryStorage();
-        return new InstanceTemplate(template.getInstanceType(), name, privateId, volumes, status, fields, template.getId(), instanceImageId, temporaryStorage);
+        return new InstanceTemplate(template.getInstanceType(), name, privateId, volumes, status, fields, template.getId(), instanceImageId);
     }
 
     private CloudVolumeUsageType getVolumeUsageType(VolumeUsageType volumeUsageType) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupServiceTest.java
@@ -36,7 +36,6 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.service.Clock;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
@@ -172,8 +171,7 @@ public class MetadataSetupServiceTest {
     }
 
     private Iterable<CloudVmMetaDataStatus> getCloudVmMetaDataStatuses(InstanceStatus instanceStatus) {
-        InstanceTemplate instanceTemplate = new InstanceTemplate(null, GROUP_NAME, PRIVATE_ID, List.of(), null, Map.of(), null, null,
-                TemporaryStorage.ATTACHED_VOLUMES);
+        InstanceTemplate instanceTemplate = new InstanceTemplate(null, GROUP_NAME, PRIVATE_ID, List.of(), null, Map.of(), null, null);
         Map<String, Object> params = new HashMap<>();
         params.put(CloudInstance.SUBNET_ID, SUBNET_ID);
         params.put(CloudInstance.INSTANCE_NAME, INSTANCE_NAME);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/cloud/StackToCloudStackConverter.java
@@ -51,7 +51,6 @@ import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudFileSystemView;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudGcsView;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
 import com.sequenceiq.cloudbreak.common.json.Json;
-import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
 import com.sequenceiq.common.api.telemetry.model.Logging;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
@@ -169,8 +168,7 @@ public class StackToCloudStackConverter implements Converter<Stack, CloudStack> 
             Volume volume = new Volume("/mnt/vol" + (i + 1), template.getVolumeType(), template.getVolumeSize(), CloudVolumeUsageType.GENERAL);
             volumes.add(volume);
         }
-        return new InstanceTemplate(template.getInstanceType(), name, privateId, volumes, status, fields, template.getId(), instanceImageId,
-                TemporaryStorage.ATTACHED_VOLUMES);
+        return new InstanceTemplate(template.getInstanceType(), name, privateId, volumes, status, fields, template.getId(), instanceImageId);
     }
 
     private Map<String, String> getUserDefinedTags(Stack stack) {

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/DefaultModelService.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/DefaultModelService.java
@@ -88,6 +88,6 @@ public class DefaultModelService {
     private InstanceTemplate getTemplateCreated(CloudInstance cloudInstance) {
         InstanceTemplate template = cloudInstance.getTemplate();
         return new InstanceTemplate(template.getFlavor(), template.getGroupName(), template.getPrivateId(), template.getVolumes(), InstanceStatus.CREATED,
-                template.getParameters(), template.getTemplateId(), template.getImageId(), template.getTemporaryStorage());
+                template.getParameters(), template.getTemplateId(), template.getImageId());
     }
 }


### PR DESCRIPTION
Reverts hortonworks/cloudbreak#10713