### PR TITLE
CB-12943 Fix upgrade matrix to contain valid regex

### DIFF
--- a/core/src/main/resources/definitions/upgrade-matrix-definition.json
+++ b/core/src/main/resources/definitions/upgrade-matrix-definition.json
@@ -2,95 +2,95 @@
   "runtime_upgrade_matrix": [
     {
       "target_runtime": {
-        "version": "7.2.2"
+        "version": "7\\.2\\.2"
       },
       "source_runtime": [
         {
-          "version": "7.0.2"
+          "version": "7\\.0\\.2"
         },
         {
-          "version": "7.1.0"
+          "version": "7\\.1\\.0"
         },
         {
-          "version": "7.2.[0,1]"
+          "version": "7\\.2\\.(0|1)"
         }
       ]
     },
     {
       "target_runtime": {
-        "version": "7.2.6"
+        "version": "7\\.2\\.6"
       },
       "source_runtime": [
         {
-          "version": "7.1.0"
+          "version": "7\\.1\\.0"
         },
         {
-          "version": "7.2.[0,1,2]"
+          "version": "7\\.2\\.(0|1|2)"
         }
       ]
     },
     {
       "target_runtime": {
-        "version": "7.2.7"
+        "version": "7\\.2\\.7"
       },
       "source_runtime": [
         {
-          "version": "7.1.0"
+          "version": "7\\.1\\.0"
         },
         {
-          "version": "7.2.[0,1,2,6]"
+          "version": "7\\.2\\.(0|1|2|6)"
         }
       ]
     },
     {
       "target_runtime": {
-        "version": "7.2.8"
+        "version": "7\\.2\\.8"
       },
       "source_runtime": [
         {
-          "version": "7.1.0"
+          "version": "7\\.1\\.0"
         },
         {
-          "version": "7.2.[0,1,2,6,7]"
+          "version": "7\\.2\\.(0|1|2|6|7)"
         }
       ]
     },
     {
       "target_runtime": {
-        "version": "7.2.9"
+        "version": "7\\.2\\.9"
       },
       "source_runtime": [
         {
-          "version": "7.1.0"
+          "version": "7\\.1\\.0"
         },
         {
-          "version": "7.2.[0,1,2,6,7,8]"
+          "version": "7\\.2\\.(0|1|2|6|7|8)"
         }
       ]
     },
     {
       "target_runtime": {
-        "version": "7.2.10"
+        "version": "7\\.2\\.10"
       },
       "source_runtime": [
         {
-          "version": "7.1.0"
+          "version": "7\\.1\\.0"
         },
         {
-          "version": "7.2.[0,1,2,6,7,8,9]"
+          "version": "7\\.2\\.(0|1|2|6|7|8|9)"
         }
       ]
     },
     {
       "target_runtime": {
-        "version": "7.2.11"
+        "version": "7\\.2\\.11"
       },
       "source_runtime": [
         {
-          "version": "7.1.0"
+          "version": "7\\.1\\.0"
         },
         {
-          "version": "7.2.[0,1,2,6,7,8,9,10]"
+          "version": "7\\.2\\.(0|1|2|6|7|8|9|10)"
         }
       ]
     }


### PR DESCRIPTION
- `.` is replaced with `\\.` so it would be escaped in Java
- `[0,1,2,3,10]` like has been replaced with `(0|1|2|3|10)`. The first mean any of these: `0` `1` `2` `3` `,`

See detailed description in the commit message.