### PR TITLE
CB-12852 DH couldn't be created because of n+1 query error

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/BatchProperties.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/BatchProperties.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.common.database;
+
+public class BatchProperties {
+
+    private final Integer batchSize;
+
+    private final Boolean orderInserts;
+
+    private final Boolean orderUpdates;
+
+    private final Boolean batchVersionedData;
+
+    public BatchProperties(Integer batchSize, Boolean orderInserts, Boolean orderUpdates, Boolean batchVersionedData) {
+        this.batchSize = batchSize;
+        this.orderInserts = orderInserts;
+        this.orderUpdates = orderUpdates;
+        this.batchVersionedData = batchVersionedData;
+    }
+
+    public Integer getBatchSize() {
+        return batchSize;
+    }
+
+    public Boolean getOrderInserts() {
+        return orderInserts;
+    }
+
+    public Boolean getOrderUpdates() {
+        return orderUpdates;
+    }
+
+    public Boolean getBatchVersionedData() {
+        return batchVersionedData;
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/database/JpaPropertiesFacory.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/database/JpaPropertiesFacory.java
@@ -16,8 +16,8 @@ public class JpaPropertiesFacory {
     private JpaPropertiesFacory() {
     }
 
-    public static Properties create(String hbm2ddlStrategy,
-            boolean debug, String dbSchemaName, CircuitBreakerType circuitBreakerType) {
+    public static Properties create(String hbm2ddlStrategy, boolean debug, String dbSchemaName, CircuitBreakerType circuitBreakerType,
+            BatchProperties batchProperties) {
         Properties properties = new Properties();
         properties.setProperty("hibernate.hbm2ddl.auto", hbm2ddlStrategy);
         properties.setProperty("hibernate.show_sql", Boolean.toString(debug));
@@ -26,6 +26,18 @@ public class JpaPropertiesFacory {
         properties.setProperty("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect");
         properties.setProperty("hibernate.default_schema", dbSchemaName);
         properties.setProperty("hibernate.jdbc.lob.non_contextual_creation", Boolean.toString(true));
+        if (batchProperties.getBatchSize() != null) {
+            properties.setProperty("hibernate.jdbc.batch_size", Integer.toString(batchProperties.getBatchSize()));
+        }
+        if (batchProperties.getOrderInserts() != null) {
+            properties.setProperty("hibernate.order_inserts", Boolean.toString(batchProperties.getOrderInserts()));
+        }
+        if (batchProperties.getOrderUpdates() != null) {
+            properties.setProperty("hibernate.order_updates", Boolean.toString(batchProperties.getOrderUpdates()));
+        }
+        if (batchProperties.getBatchVersionedData() != null) {
+            properties.setProperty("hibernate.jdbc.batch_versioned_data", Boolean.toString(batchProperties.getBatchVersionedData()));
+        }
 
         LOGGER.info("Hibernate NPlusOne Circuit Breaker type: {}", circuitBreakerType);
         switch (circuitBreakerType) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/DatabaseConfig.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.core.env.Environment;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.JpaVendorAdapter;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -26,6 +27,7 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.sequenceiq.cloudbreak.common.database.BatchProperties;
 import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
 import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
@@ -83,6 +85,9 @@ public class DatabaseConfig {
     @Inject
     private NodeConfig nodeConfig;
 
+    @Inject
+    private Environment environment;
+
     @Bean
     public DataSource dataSource() throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
@@ -128,7 +133,7 @@ public class DatabaseConfig {
         entityManagerFactory.setDataSource(dataSource());
 
         entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());
-        entityManagerFactory.setJpaProperties(JpaPropertiesFacory.create(hbm2ddlStrategy, debug, dbSchemaName, circuitBreakerType));
+        entityManagerFactory.setJpaProperties(JpaPropertiesFacory.create(hbm2ddlStrategy, debug, dbSchemaName, circuitBreakerType, createBatchProperties()));
         entityManagerFactory.afterPropertiesSet();
         return entityManagerFactory;
     }
@@ -139,5 +144,12 @@ public class DatabaseConfig {
         hibernateJpaVendorAdapter.setShowSql(true);
         hibernateJpaVendorAdapter.setDatabase(Database.POSTGRESQL);
         return hibernateJpaVendorAdapter;
+    }
+
+    private BatchProperties createBatchProperties() {
+        return new BatchProperties(environment.getProperty("spring.jpa.properties.hibernate.jdbc.batch_size", Integer.class),
+                environment.getProperty("spring.jpa.properties.hibernate.order_inserts", Boolean.class),
+                environment.getProperty("spring.jpa.properties.hibernate.order_updates", Boolean.class),
+                environment.getProperty("spring.jpa.properties.hibernate.jdbc.batch_versioned_data", Boolean.class));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/FinalizeClusterInstallHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/install/FinalizeClusterInstallHandler.java
@@ -11,6 +11,7 @@ import com.sequenceiq.cloudbreak.core.cluster.ClusterBuilderService;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.FinalizeClusterInstallFailed;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.FinalizeClusterInstallRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.install.FinalizeClusterInstallSuccess;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
@@ -44,6 +45,9 @@ public class FinalizeClusterInstallHandler extends ExceptionCatcherEventHandler<
             clusterBuilderService.finalizeClusterInstall(stackId);
             response = new FinalizeClusterInstallSuccess(stackId);
         } catch (RuntimeException e) {
+            LOGGER.error("ClusterInstallSuccessHandler step failed with the following message: {}", e.getMessage());
+            response = new FinalizeClusterInstallFailed(stackId, e);
+        } catch (CloudbreakException e) {
             LOGGER.error("ClusterInstallSuccessHandler step failed with the following message: {}", e.getMessage());
             response = new FinalizeClusterInstallFailed(stackId, e);
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -328,8 +328,8 @@ public class ClusterService {
     public Cluster updateClusterMetadata(Long stackId) {
         Stack stack = stackService.getById(stackId);
         ClusterApi connector = clusterApiConnectors.getConnector(stack);
-        Set<InstanceMetaData> notTerminatedInstanceMetaDatas = instanceMetaDataService.findNotTerminatedForStack(stackId);
         if (!connector.clusterStatusService().isClusterManagerRunning()) {
+            Set<InstanceMetaData> notTerminatedInstanceMetaDatas = instanceMetaDataService.findNotTerminatedForStack(stackId);
             InstanceMetaData cmInstance = updateClusterManagerHostStatus(notTerminatedInstanceMetaDatas);
             eventService.fireCloudbreakEvent(stack.getId(), AVAILABLE.name(), CLUSTER_HOST_STATUS_UPDATED,
                     Arrays.asList(cmInstance.getDiscoveryFQDN(), cmInstance.getInstanceStatus().name()));
@@ -340,6 +340,7 @@ public class ClusterService {
             Map<HostName, ClusterManagerState> hostStatuses = extendedHostStatuses.getHostHealth();
             try {
                 return transactionService.required(() -> {
+                    Set<InstanceMetaData> notTerminatedInstanceMetaDatas = instanceMetaDataService.findNotTerminatedForStack(stackId);
                     List<InstanceMetaData> updatedInstanceMetaData = updateInstanceStatuses(notTerminatedInstanceMetaDatas, hostStatuses);
                     instanceMetaDataService.saveAll(updatedInstanceMetaData);
                     fireHostStatusUpdateNotification(stack, updatedInstanceMetaData);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.service.stack;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
@@ -107,6 +108,20 @@ public class InstanceMetaDataService {
 
     public Set<InstanceMetaData> getAllInstanceMetadataByStackId(Long stackId) {
         return repository.findAllInStack(stackId);
+    }
+
+    public Set<InstanceMetaData> getNotDeletedInstanceMetadataByStackId(Long stackId) {
+        return repository.findAllInStack(stackId)
+                .stream()
+                .filter(metaData -> !metaData.isTerminated() && !metaData.isDeletedOnProvider())
+                .collect(Collectors.toSet());
+    }
+
+    public Set<InstanceMetaData> getReachableInstanceMetadataByStackId(Long stackId) {
+        return repository.findAllInStack(stackId)
+                .stream()
+                .filter(InstanceMetaData::isReachable)
+                .collect(Collectors.toSet());
     }
 
     public Set<InstanceMetaData> getAllInstanceMetadataWithoutInstaceGroupByStackId(Long stackId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TerminationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TerminationService.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.service.stack.flow;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -139,7 +140,8 @@ public class TerminationService {
 
     private void terminateMetaDataInstances(Stack stack) {
         List<InstanceMetaData> instanceMetaDatas = new ArrayList<>();
-        for (InstanceMetaData metaData : stack.getNotDeletedInstanceMetaDataSet()) {
+        Set<InstanceMetaData> notDeletedInstanceMetadataSet = instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(stack.getId());
+        for (InstanceMetaData metaData : notDeletedInstanceMetadataSet) {
             metaData.setTerminationDate(clock.getCurrentTimeMillis());
             metaData.setInstanceStatus(InstanceStatus.TERMINATED);
             instanceMetaDatas.add(metaData);

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -49,8 +49,10 @@ spring:
   jpa:
     properties:
       hibernate:
-        jdbc.batch_size: 50
+        jdbc:
+          batch_size: 50
         order_inserts: true
+        order_updates: true
   lifecycle:
     timeout-per-shutdown-phase: 60
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/DatabaseConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/DatabaseConfig.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.core.env.Environment;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.JpaVendorAdapter;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -24,6 +25,7 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.sequenceiq.cloudbreak.common.database.BatchProperties;
 import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
 import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
@@ -81,6 +83,9 @@ public class DatabaseConfig {
     @Inject
     private NodeConfig nodeConfig;
 
+    @Inject
+    private Environment environment;
+
     @Bean
     public DataSource dataSource() throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
@@ -121,7 +126,7 @@ public class DatabaseConfig {
         entityManagerFactory.setDataSource(dataSource());
 
         entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());
-        entityManagerFactory.setJpaProperties(JpaPropertiesFacory.create(hbm2ddlStrategy, debug, dbSchemaName, circuitBreakerType));
+        entityManagerFactory.setJpaProperties(JpaPropertiesFacory.create(hbm2ddlStrategy, debug, dbSchemaName, circuitBreakerType, createBatchProperties()));
         entityManagerFactory.afterPropertiesSet();
         return entityManagerFactory.getObject();
     }
@@ -132,6 +137,13 @@ public class DatabaseConfig {
         hibernateJpaVendorAdapter.setShowSql(true);
         hibernateJpaVendorAdapter.setDatabase(Database.POSTGRESQL);
         return hibernateJpaVendorAdapter;
+    }
+
+    private BatchProperties createBatchProperties() {
+        return new BatchProperties(environment.getProperty("spring.jpa.properties.hibernate.jdbc.batch_size", Integer.class),
+                environment.getProperty("spring.jpa.properties.hibernate.order_inserts", Boolean.class),
+                environment.getProperty("spring.jpa.properties.hibernate.order_updates", Boolean.class),
+                environment.getProperty("spring.jpa.properties.hibernate.jdbc.batch_versioned_data", Boolean.class));
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterUpscaleDownscaleTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/DistroXClusterUpscaleDownscaleTest.java
@@ -114,7 +114,7 @@ public class DistroXClusterUpscaleDownscaleTest extends AbstractClouderaManagerT
                 .given("dx-1000-ig-worker", DistroXInstanceGroupTestDto.class)
                 .withHostGroup(HostGroupType.WORKER)
                 .withTemplate("dx-5-volume-ig-template")
-                .withNodeCount(125)
+                .withNodeCount(300)
                 .given("dx-ig-master", DistroXInstanceGroupTestDto.class)
                 .withHostGroup(HostGroupType.MASTER)
                 .given("dx-ig-gw", DistroXInstanceGroupTestDto.class)

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/DatabaseConfig.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.core.env.Environment;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.JpaVendorAdapter;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
@@ -24,6 +25,7 @@ import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+import com.sequenceiq.cloudbreak.common.database.BatchProperties;
 import com.sequenceiq.cloudbreak.common.database.JpaPropertiesFacory;
 import com.sequenceiq.cloudbreak.common.tx.CircuitBreakerType;
 import com.sequenceiq.cloudbreak.util.DatabaseUtil;
@@ -81,6 +83,9 @@ public class DatabaseConfig {
     @Inject
     private NodeConfig nodeConfig;
 
+    @Inject
+    private Environment environment;
+
     @Bean
     public DataSource dataSource() throws SQLException {
         DatabaseUtil.createSchemaIfNeeded("postgresql", databaseAddress, dbName, dbUser, dbPassword, dbSchemaName);
@@ -121,7 +126,7 @@ public class DatabaseConfig {
         entityManagerFactory.setDataSource(dataSource());
 
         entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());
-        entityManagerFactory.setJpaProperties(JpaPropertiesFacory.create(hbm2ddlStrategy, debug, dbSchemaName, circuitBreakerType));
+        entityManagerFactory.setJpaProperties(JpaPropertiesFacory.create(hbm2ddlStrategy, debug, dbSchemaName, circuitBreakerType, createBatchProperties()));
         entityManagerFactory.afterPropertiesSet();
         return entityManagerFactory.getObject();
     }
@@ -132,5 +137,12 @@ public class DatabaseConfig {
         hibernateJpaVendorAdapter.setShowSql(true);
         hibernateJpaVendorAdapter.setDatabase(Database.POSTGRESQL);
         return hibernateJpaVendorAdapter;
+    }
+
+    private BatchProperties createBatchProperties() {
+        return new BatchProperties(environment.getProperty("spring.jpa.properties.hibernate.jdbc.batch_size", Integer.class),
+                environment.getProperty("spring.jpa.properties.hibernate.order_inserts", Boolean.class),
+                environment.getProperty("spring.jpa.properties.hibernate.order_updates", Boolean.class),
+                environment.getProperty("spring.jpa.properties.hibernate.jdbc.batch_versioned_data", Boolean.class));
     }
 }


### PR DESCRIPTION
Increase test node count for upscale and downscale to check large clusters.
Enable batch inserts and updates.
Run fetch and saveAll in one transaction otherwise hibernate detaches the loaded entites and it will run a select for every entity during saveAll.

See detailed description in the commit message.