### PR TITLE
CB-12843 Make sure we have PKs on every CB table, add jenkins check

### DIFF
--- a/integration-test/Makefile
+++ b/integration-test/Makefile
@@ -56,7 +56,7 @@ fetch-secrets-docker:
 	./scripts/fetch-ums-docker.sh
 
 docker-compose:
-	CB_VERSION=$(CB_VERSION) ./scripts/docker-compose.sh
+	CB_VERSION=$(CB_VERSION) CB_TARGET_BRANCH=$(CB_TARGET_BRANCH) ./scripts/docker-compose.sh
 
 check-results:
 	./scripts/check-results.sh


### PR DESCRIPTION
Add new checks to the pull-request-builder-schema-compatibility-test. These checks will ensure that new tables without PK are not allowed anymore.