### PR TITLE
CB-12935 Add missing flows to restartable list 

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
@@ -10,7 +10,12 @@ import com.sequenceiq.freeipa.flow.freeipa.binduser.create.CreateBindUserFlowCon
 import com.sequenceiq.freeipa.flow.freeipa.binduser.create.event.CreateBindUserFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupEvent;
 import com.sequenceiq.freeipa.flow.freeipa.cleanup.FreeIpaCleanupFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.diagnostics.config.DiagnosticsCollectionFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowConfig;
+import com.sequenceiq.freeipa.flow.instance.reboot.RebootFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.provision.StackProvisionFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.start.StackStartFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.stop.StackStopFlowConfig;
@@ -27,7 +32,12 @@ public class FreeIpaFlowInformation implements ApplicationFlowInformation {
             StackStartFlowConfig.class,
             StackStopFlowConfig.class,
             FreeIpaCleanupFlowConfig.class,
-            CreateBindUserFlowConfig.class);
+            CreateBindUserFlowConfig.class,
+            DownscaleFlowConfig.class,
+            UpscaleFlowConfig.class,
+            ChangePrimaryGatewayFlowConfig.class,
+            DiagnosticsCollectionFlowConfig.class,
+            RebootFlowConfig.class);
 
     private static final List<String> PARALLEL_FLOWS = List.of(
             FreeIpaCleanupEvent.CLEANUP_EVENT.event(),

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/FreeIpaHaApplication.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/FreeIpaHaApplication.java
@@ -10,12 +10,12 @@ import javax.inject.Inject;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
 import com.sequenceiq.cloudbreak.service.ha.HaApplication;
 import com.sequenceiq.flow.core.FlowRegister;
 import com.sequenceiq.flow.service.FlowCancelService;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.freeipa.dto.StackIdWithStatus;
 import com.sequenceiq.freeipa.service.stack.StackService;
 


### PR DESCRIPTION
Flows were never added as restartable, in case of a pod restart these won't be restarted.
Fixed a wrong import, which could caused invalid flows won't be canceled.

See detailed description in the commit message.