### PR TITLE
CB-12910 Populate rackId in InstanceMetaData (core)

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudInstance.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudInstance.java
@@ -24,7 +24,17 @@ public class CloudInstance extends DynamicModel {
 
     public static final String DISCOVERY_NAME = "DiscoveryName";
 
+    /**
+     * Key of the optional dynamic parameter denoting the ID of the subnet (in a cloud platform specific format) the cloud instance is deployed in.
+     * May be absent if the subnet assignment is not (yet) known.
+     */
     public static final String SUBNET_ID = "subnetId";
+
+    /**
+     * Key of the optional dynamic parameter denoting the name of the availability zone (in a cloud platform specific format) the cloud instance is deployed in.
+     * Absent if the cloud platform does not support this construct, or if the availability zone assignment is not (yet) known.
+     */
+    public static final String AVAILABILITY_ZONE = "availabilityZone";
 
     private final String instanceId;
 

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/generic/DynamicModel.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/generic/DynamicModel.java
@@ -8,9 +8,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
- * Generic mode to hold dynamic data, any data stored in the DynamicModel must be threadsafe in that sense that multiple threads might be
- * using it, but of course it is never used concurrently. In other words if you store anything in thread local then it might not be available
- * in a subsequent calls.
+ * Generic model to hold dynamic data. Any data stored in the DynamicModel must be thread safe in the sense that multiple threads might be
+ * using it, but of course it is never used concurrently. In other words, if you store anything in thread local then it might not be available
+ * in subsequent calls.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -18,40 +18,96 @@ public class DynamicModel {
 
     private final Map<String, Object> parameters;
 
+    /**
+     * Constructs a new {@link DynamicModel} with an empty initial map. The enclosed map is always mutable, so it is possible to add parameters later using
+     * {@link #putParameter(String, Object)} or {@link #putParameter(Class, Object)}.
+     */
     public DynamicModel() {
         parameters = new HashMap<>();
     }
 
+    /**
+     * Constructs a new {@link DynamicModel} with the initial map containing the entries of the supplied {@code parameters}. The enclosed map is always
+     * mutable (even if {@code parameters} is unmodifiable), so it is possible to add further parameters later using {@link #putParameter(String, Object)} or
+     * {@link #putParameter(Class, Object)}. Passing in {@code null} will be silently accepted and treated as if an empty map had been specified.
+     * @param parameters initial mappings; may be {@code null} (treated like an empty map); may be empty
+     */
     public DynamicModel(Map<String, Object> parameters) {
-        this.parameters = parameters;
+        this.parameters = parameters == null ? new HashMap<>() : new HashMap<>(parameters);
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Retrieves a parameter with key {@code key} and expected type represented by {@code clazz}.
+     * @param key parameter key
+     * @param clazz {@code Class} instance representing the expected type of the parameter value; must not be {@code null}
+     * @param <T> expected type of the parameter value
+     * @return parameter value, or {@code null} if the requested parameter is absent
+     * @throws NullPointerException if {@code clazz == null}
+     * @throws ClassCastException if the requested parameter exists but its value has a type incompatible with {@code T}
+     */
     public <T> T getParameter(String key, Class<T> clazz) {
-        return (T) parameters.get(key);
+        return clazz.cast(parameters.get(key));
     }
 
-    @SuppressWarnings("unchecked")
+    /**
+     * Retrieves a parameter with key {@code clazz.getName()} and expected type represented by {@code clazz}.
+     * @param clazz {@code Class} instance representing the expected type of the parameter value, and also determining the parameter key; must not be
+     *          {@code null}
+     * @param <T> expected type of the parameter value
+     * @return parameter value, or {@code null} if the requested parameter is absent
+     * @throws NullPointerException if {@code clazz == null}
+     * @throws ClassCastException if the requested parameter exists but its value has a type incompatible with {@code T}
+     */
     public <T> T getParameter(Class<T> clazz) {
-        return (T) parameters.get(clazz.getName());
+        return getParameter(clazz.getName(), clazz);
     }
 
+    /**
+     * Retrieves a parameter with key {@code key} and expected type {@code String}.
+     * @param key parameter key
+     * @return parameter value, or {@code null} if the requested parameter is absent
+     * @throws ClassCastException if the requested parameter exists but its value has a type different from {@code String}
+     */
     public String getStringParameter(String key) {
         return getParameter(key, String.class);
     }
 
+    /**
+     * Adds a parameter with key {@code key} and value {@code value}. If a parameter with such a key already exists, its old value will be replaced with
+     * {@code value}.
+     * @param key parameter key
+     * @param value parameter value; may be {@code null}
+     */
     public void putParameter(String key, Object value) {
         parameters.put(key, value);
     }
 
+    /**
+     * Adds a parameter with key {@code clazz.getName()} and value {@code value}. The actual type of {@code value} is not checked with respect to {@code clazz}.
+     * If a parameter with such a key already exists, its old value will be replaced with {@code value}.
+     * @param clazz {@code Class} instance determining the parameter key; must not be {@code null}
+     * @param value parameter value; may be {@code null}
+     * @throws NullPointerException if {@code clazz == null}
+     */
     public void putParameter(Class<?> clazz, Object value) {
         putParameter(clazz.getName(), value);
     }
 
+    /**
+     * Retrieves an immutable view of the parameter map enclosed by {@code this}. The result is a new object wrapping the internal parameter map so that it
+     * provides an immutable but live view (as opposed to being a simple "snapshot copy"), so adding new parameters to or replacing existing parameter values in
+     * {@code this} will be also reflected in the returned object.
+     * @return new unmodifiable view of the parameter map; never {@code null}; may be empty
+     */
     public Map<String, Object> getParameters() {
         return Collections.unmodifiableMap(parameters);
     }
 
+    /**
+     * Checks if a parameter with key {@code key} exists.
+     * @param key parameter key
+     * @return {@code true} if a parameter with key {@code key} exists; {@code false} otherwise
+     */
     public boolean hasParameter(String key) {
         return parameters.containsKey(key);
     }

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/generic/DynamicModelTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/generic/DynamicModelTest.java
@@ -1,0 +1,244 @@
+package com.sequenceiq.cloudbreak.cloud.model.generic;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DynamicModelTest {
+
+    private DynamicModel underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new DynamicModel();
+    }
+
+    @Test
+    void constructorTestWhenDefault() {
+        assertThat(underTest.getParameters()).isEmpty();
+    }
+
+    @Test
+    void constructorTestWhenInitialEmptyMapAndEmpty() {
+        DynamicModel underTest = new DynamicModel(Map.of());
+
+        assertThat(underTest.getParameters()).isEmpty();
+    }
+
+    @Test
+    void constructorTestWhenInitialEmptyImmutableMapAndMutability() {
+        DynamicModel underTest = new DynamicModel(Map.of());
+        underTest.putParameter("key", "value");
+
+        assertThat(underTest.getParameters()).containsOnly(entry("key", "value"));
+    }
+
+    @Test
+    void constructorTestWhenInitialMapAndParameters() {
+        DynamicModel underTest = new DynamicModel(Map.ofEntries(entry("key1", "value1"), entry("key2", "value2")));
+
+        assertThat(underTest.getParameters()).containsOnly(entry("key1", "value1"), entry("key2", "value2"));
+    }
+
+    @Test
+    void constructorTestWhenInitialMapAndParametersAndMutability() {
+        DynamicModel underTest = new DynamicModel(Map.ofEntries(entry("key1", "value1"), entry("key2", "value2")));
+        underTest.putParameter("key3", "value3");
+
+        assertThat(underTest.getParameters()).containsOnly(entry("key1", "value1"), entry("key2", "value2"), entry("key3", "value3"));
+    }
+
+    @Test
+    void constructorTestWhenNullInitialMap() {
+        DynamicModel underTest = new DynamicModel(null);
+
+        assertThat(underTest.getParameters()).isEmpty();
+    }
+
+    @Test
+    void getParameterTestWhenKeyAndClassAndSuccess() {
+        String value1 = "value1";
+        underTest.putParameter("key1", value1);
+        Integer value2 = 23;
+        underTest.putParameter("key2", value2);
+        Object value3 = new Object();
+        underTest.putParameter("key3", value3);
+
+        assertThat(underTest.getParameter("key_missing", String.class)).isNull();
+        assertThat(underTest.getParameter("key1", String.class)).isSameAs(value1);
+        assertThat(underTest.getParameter("key2", Integer.class)).isSameAs(value2);
+        assertThat(underTest.getParameter("key3", Object.class)).isSameAs(value3);
+    }
+
+    @Test
+    void getParameterTestWhenKeyAndClassAndCastFailure() {
+        underTest.putParameter("key", "value");
+
+        assertThrows(ClassCastException.class, () -> underTest.getParameter("key", Integer.class));
+    }
+
+    @Test
+    void getParameterTestWhenKeyAndNullClass() {
+        underTest.putParameter("key", "value");
+
+        assertThrows(NullPointerException.class, () -> underTest.getParameter("key", null));
+    }
+
+    @Test
+    void getParameterTestWhenClassAndSuccess() {
+        underTest.putParameter("java.lang.String", "value");
+
+        assertThat(underTest.getParameter(String.class)).isSameAs("value");
+    }
+
+    @Test
+    void getParameterTestWhenClassAndCastFailure() {
+        underTest.putParameter("java.lang.Integer", "value");
+
+        assertThrows(ClassCastException.class, () -> underTest.getParameter(Integer.class));
+    }
+
+    @Test
+    void getParameterTestWhenNullClass() {
+        underTest.putParameter("key", "value");
+
+        assertThrows(NullPointerException.class, () -> underTest.getParameter(null));
+    }
+
+    @Test
+    void getStringParameterTestWhenSuccess() {
+        underTest.putParameter("key", "value");
+
+        assertThat(underTest.getStringParameter("key")).isSameAs("value");
+    }
+
+    @Test
+    void getStringParameterTestWhenCastFailure() {
+        underTest.putParameter("key", 12);
+
+        assertThrows(ClassCastException.class, () -> underTest.getStringParameter("key"));
+    }
+
+    @Test
+    void putParameterTestWhenKeyAndNullValue() {
+        underTest.putParameter("key", null);
+
+        assertThat(underTest.getParameter("key", Object.class)).isNull();
+    }
+
+    @Test
+    void putParameterTestWhenKeyAndValueAndExisting() {
+        underTest.putParameter("key", "old_value");
+        String newValue = "new_value";
+        underTest.putParameter("key", newValue);
+
+        assertThat(underTest.getParameter("key", String.class)).isSameAs(newValue);
+    }
+
+    @Test
+    void putParameterTestWhenClassAndValue() {
+        String value = "value";
+        underTest.putParameter(String.class, value);
+        underTest.putParameter(Integer.class, null);
+
+        assertThat(underTest.getParameter(String.class)).isSameAs(value);
+        assertThat(underTest.getParameter(Integer.class)).isNull();
+        assertThat(underTest.getParameters()).containsOnly(entry("java.lang.String", value), new SimpleEntry<>("java.lang.Integer", null));
+    }
+
+    @Test
+    void putParameterTestWhenClassAndValueAndExisting() {
+        underTest.putParameter(String.class, "old_value");
+        String newValue = "new_value";
+        underTest.putParameter(String.class, newValue);
+
+        assertThat(underTest.getParameter(String.class)).isSameAs(newValue);
+    }
+
+    @Test
+    void putParameterTestWhenNullClassAndValue() {
+        assertThrows(NullPointerException.class, () -> underTest.putParameter((Class<?>) null, "value"));
+    }
+
+    @Test
+    void getParametersTestWhenContentsCheck() {
+        String value1 = "value1";
+        underTest.putParameter("key1", value1);
+        Integer value2 = 23;
+        underTest.putParameter("key2", value2);
+        Object value3 = new Object();
+        underTest.putParameter("key3", value3);
+        underTest.putParameter("key4", null);
+        String value5 = "value5";
+        underTest.putParameter(String.class, value5);
+        Long value6 = 456L;
+        underTest.putParameter(Long.class, value6);
+        underTest.putParameter(Integer.class, null);
+
+        assertThat(underTest.getParameters()).containsOnly(entry("key1", value1), entry("key2", value2), entry("key3", value3),
+                new SimpleEntry<>("key4", null), entry("java.lang.String", value5), entry("java.lang.Long", value6),
+                new SimpleEntry<>("java.lang.Integer", null));
+    }
+
+    @Test
+    void getParametersTestWhenImmutabilityCheck() {
+        Map<String, Object> parameters = underTest.getParameters();
+
+        assertThat(parameters).isNotNull();
+        assertThat(parameters).isEmpty();
+        assertThrows(UnsupportedOperationException.class, () -> parameters.put("key", "value"));
+    }
+
+    @Test
+    void getParametersTestWhenUpdatesCheck() {
+        Map<String, Object> parameters = underTest.getParameters();
+
+        assertThat(parameters).isNotNull();
+        assertThat(parameters).isEmpty();
+
+        String value = "value";
+        underTest.putParameter("key", value);
+
+        assertThat(parameters).containsOnly(entry("key", value));
+        assertThat(underTest.getParameter("key", String.class)).isSameAs(value);
+    }
+
+    @Test
+    void getParametersTestWhenNewInstanceCheck() {
+        Map<String, Object> parameters1 = underTest.getParameters();
+        Map<String, Object> parameters2 = underTest.getParameters();
+
+        assertThat(parameters1).isNotNull();
+        assertThat(parameters1).isEmpty();
+        assertThat(parameters2).isNotNull();
+        assertThat(parameters2).isEmpty();
+        assertThat(parameters1).isNotSameAs(parameters2);
+    }
+
+    @Test
+    void hasParameterTest() {
+        underTest.putParameter("key", "value");
+
+        assertThat(underTest.hasParameter("key")).isTrue();
+        assertThat(underTest.hasParameter("key_missing")).isFalse();
+    }
+
+    @Test
+    void toStringTest() {
+        underTest.putParameter("key1", "value1");
+        underTest.putParameter("key2", "value2");
+        String result = underTest.toString();
+
+        assertThat(result).contains("key1");
+        assertThat(result).contains("value1");
+        assertThat(result).contains("key2");
+        assertThat(result).contains("value2");
+    }
+
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/NullUtil.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/NullUtil.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.util;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -12,9 +11,9 @@ public class NullUtil {
     private NullUtil() {
     }
 
-    public static <T extends Throwable> void throwIfNull(Object o, Supplier<? extends T> exeption) throws T {
-        if (Objects.isNull(o)) {
-            throw exeption.get();
+    public static <T extends Throwable> void throwIfNull(Object o, Supplier<? extends T> exception) throws T {
+        if (o == null) {
+            throw exception.get();
         }
     }
 

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/NullUtilTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/NullUtilTest.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.cloudbreak.util;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class NullUtilTest {
+
+    @Test
+    void throwIfNullTestWhenNull() {
+        assertThrows(UnsupportedOperationException.class, () -> NullUtil.throwIfNull(null, UnsupportedOperationException::new));
+    }
+
+    @Test
+    void throwIfNullTestWhenNonNull() {
+        NullUtil.throwIfNull(12, UnsupportedOperationException::new);
+    }
+
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/instancegroup/instancemetadata/InstanceMetaDataV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/instancegroup/instancemetadata/InstanceMetaDataV4Response.java
@@ -42,6 +42,15 @@ public class InstanceMetaDataV4Response implements JsonEntity {
     @ApiModelProperty(InstanceGroupModelDescription.INSTANCE_GROUP_NAME)
     private String instanceGroup;
 
+    @ApiModelProperty(InstanceMetaDataModelDescription.SUBNET_ID)
+    private String subnetId;
+
+    @ApiModelProperty(InstanceMetaDataModelDescription.AVAILABILITY_ZONE)
+    private String availabilityZone;
+
+    @ApiModelProperty(InstanceMetaDataModelDescription.RACK_ID)
+    private String rackId;
+
     @ApiModelProperty(InstanceGroupModelDescription.STATUS)
     private InstanceStatus instanceStatus;
 
@@ -114,6 +123,30 @@ public class InstanceMetaDataV4Response implements JsonEntity {
 
     public void setDiscoveryFQDN(String discoveryFQDN) {
         this.discoveryFQDN = discoveryFQDN;
+    }
+
+    public String getSubnetId() {
+        return subnetId;
+    }
+
+    public void setSubnetId(String subnetId) {
+        this.subnetId = subnetId;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public void setAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+    }
+
+    public String getRackId() {
+        return rackId;
+    }
+
+    public void setRackId(String rackId) {
+        this.rackId = rackId;
     }
 
     public InstanceStatus getInstanceStatus() {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -556,10 +556,13 @@ public class ModelDescriptions {
     }
 
     public static class InstanceMetaDataModelDescription {
-        public static final String PRIVATE_IP = "private ip of the insctance";
-        public static final String PUBLIC_IP = "public ip of the instance";
-        public static final String INSTANCE_ID = "id of the instance";
+        public static final String PRIVATE_IP = "private IP of the instance";
+        public static final String PUBLIC_IP = "public IP of the instance";
+        public static final String INSTANCE_ID = "ID of the instance";
         public static final String DISCOVERY_FQDN = "the fully qualified domain name of the node in the service discovery cluster";
+        public static final String SUBNET_ID = "ID of the subnet the instance is deployed in";
+        public static final String AVAILABILITY_ZONE = "name of the availability zone the instance is deployed in";
+        public static final String RACK_ID = "ID of the virtual network rack the instance is deployed in";
     }
 
     public static class FailurePolicyModelDescription {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -89,6 +89,12 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource {
 
     private String region;
 
+    /**
+     * Name of the availability zone the stack is deployed in. May be {@code null} if the cloud platform does not support this construct.
+     *
+     * @deprecated Use {@code InstanceMetaData.availabilityZone} instead (reachable via {@code instanceGroups.instanceMetaData}).
+     */
+    @Deprecated(since = "2.45.0")
     private String availabilityZone;
 
     private Integer gatewayPort;

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
@@ -82,7 +82,22 @@ public class InstanceMetaData implements ProvisionEntity {
 
     private Long terminationDate;
 
+    /**
+     * ID of the subnet (in a cloud platform specific format) the cloud instance is deployed in.
+     */
     private String subnetId;
+
+    /**
+     * Name of the availability zone the cloud instance is deployed in. May be {@code null} if the cloud platform does not support this construct.
+     */
+    private String availabilityZone;
+
+    /**
+     * ID of the virtual network rack the cloud instance is deployed in. Interpretation and syntax are as per the
+     * <a href="https://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/RackAwareness.html">Hadoop Rack Awareness</a> page.
+     */
+    @Column(columnDefinition = "TEXT")
+    private String rackId;
 
     private String instanceName;
 
@@ -300,6 +315,22 @@ public class InstanceMetaData implements ProvisionEntity {
 
     public void setSubnetId(String subnetId) {
         this.subnetId = subnetId;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public void setAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+    }
+
+    public String getRackId() {
+        return rackId;
+    }
+
+    public void setRackId(String rackId) {
+        this.rackId = rackId;
     }
 
     public String getInstanceName() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/InstanceMetaDataToCloudInstanceConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/InstanceMetaDataToCloudInstanceConverter.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.converter.spi;
 
+import static com.sequenceiq.cloudbreak.util.NullUtil.putIfPresent;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -21,7 +23,7 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 
 @Component
-public class InstanceMetaDataToCloudInstanceConverter  {
+public class InstanceMetaDataToCloudInstanceConverter {
 
     @Inject
     private StackToCloudStackConverter stackToCloudStackConverter;
@@ -49,8 +51,9 @@ public class InstanceMetaDataToCloudInstanceConverter  {
                 stackAuthentication.getPublicKeyId(),
                 stackAuthentication.getLoginUserName());
         Map<String, Object> params = new HashMap<>();
-        params.put(CloudInstance.SUBNET_ID, metaDataEntity.getSubnetId());
-        params.put(CloudInstance.INSTANCE_NAME, metaDataEntity.getInstanceName());
+        putIfPresent(params, CloudInstance.SUBNET_ID, metaDataEntity.getSubnetId());
+        putIfPresent(params, CloudInstance.INSTANCE_NAME, metaDataEntity.getInstanceName());
+        putIfPresent(params, CloudInstance.AVAILABILITY_ZONE, metaDataEntity.getAvailabilityZone());
 
         Map<String, Object> cloudInstanceParameters = stackToCloudStackConverter.buildCloudInstanceParameters(
                 envCrn,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -8,6 +8,8 @@ import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.CREATE_REQUES
 import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.DELETE_REQUESTED;
 import static com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.TERMINATED;
 import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
+import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
+import static com.sequenceiq.cloudbreak.util.NullUtil.putIfPresent;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -418,19 +420,11 @@ public class StackToCloudStackConverter {
     }
 
     public Map<String, Object> buildCloudInstanceParameters(String environmentCrn, InstanceMetaData instanceMetaData, CloudPlatform platform) {
-        String hostName = instanceMetaData == null ? null : instanceMetaData.getShortHostname();
-        String subnetId = instanceMetaData == null ? null : instanceMetaData.getSubnetId();
-        String instanceName = instanceMetaData == null ? null : instanceMetaData.getInstanceName();
         Map<String, Object> params = new HashMap<>();
-        if (hostName != null) {
-            params.put(CloudInstance.DISCOVERY_NAME, hostName);
-        }
-        if (subnetId != null) {
-            params.put(CloudInstance.SUBNET_ID, subnetId);
-        }
-        if (instanceName != null) {
-            params.put(CloudInstance.INSTANCE_NAME, instanceName);
-        }
+        putIfPresent(params, CloudInstance.DISCOVERY_NAME, getIfNotNull(instanceMetaData, InstanceMetaData::getShortHostname));
+        putIfPresent(params, CloudInstance.SUBNET_ID, getIfNotNull(instanceMetaData, InstanceMetaData::getSubnetId));
+        putIfPresent(params, CloudInstance.AVAILABILITY_ZONE, getIfNotNull(instanceMetaData, InstanceMetaData::getAvailabilityZone));
+        putIfPresent(params, CloudInstance.INSTANCE_NAME, getIfNotNull(instanceMetaData, InstanceMetaData::getInstanceName));
         Optional<AzureResourceGroup> resourceGroupOptional = getAzureResourceGroup(environmentCrn, platform);
         if (resourceGroupOptional.isPresent() && !ResourceGroupUsage.MULTIPLE.equals(resourceGroupOptional.get().getResourceGroupUsage())) {
             AzureResourceGroup resourceGroup = resourceGroupOptional.get();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceMetaDataToInstanceMetaDataV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceMetaDataToInstanceMetaDataV4ResponseConverter.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.converter.v4.stacks.instancegroup;
 
 import org.springframework.stereotype.Component;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
@@ -10,7 +11,8 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 public class InstanceMetaDataToInstanceMetaDataV4ResponseConverter
         extends AbstractConversionServiceAwareConverter<InstanceMetaData, InstanceMetaDataV4Response> {
 
-    private static final String NOT_AVAILABLE = "N/A";
+    @VisibleForTesting
+    static final String NOT_AVAILABLE = "N/A";
 
     @Override
     public InstanceMetaDataV4Response convert(InstanceMetaData source) {
@@ -26,9 +28,13 @@ public class InstanceMetaDataToInstanceMetaDataV4ResponseConverter
         metaDataJson.setInstanceId(source.getInstanceId());
         metaDataJson.setDiscoveryFQDN(source.getDiscoveryFQDN());
         metaDataJson.setInstanceGroup(source.getInstanceGroup().getGroupName());
+        metaDataJson.setSubnetId(source.getSubnetId());
+        metaDataJson.setAvailabilityZone(source.getAvailabilityZone());
+        metaDataJson.setRackId(source.getRackId());
         metaDataJson.setInstanceStatus(source.getInstanceStatus());
         metaDataJson.setInstanceType(source.getInstanceMetadataType());
         metaDataJson.setLifeCycle(source.getLifeCycle());
         return metaDataJson;
     }
+
 }

--- a/core/src/main/resources/schema/app/20210604170759_CB-12910_Populate_rackId_in_InstanceMetaData_core.sql
+++ b/core/src/main/resources/schema/app/20210604170759_CB-12910_Populate_rackId_in_InstanceMetaData_core.sql
@@ -1,0 +1,77 @@
+-- // CB-12910 Populate rackId in InstanceMetaData core
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE instancemetadata
+    ADD COLUMN IF NOT EXISTS availabilityzone VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS rackid TEXT;
+
+
+WITH metadata_stack_temp AS (
+    SELECT
+        imd.id AS metadata_id,
+        s.network_id AS stack_network_id
+    FROM
+        instancemetadata AS imd,
+        instancegroup AS ig,
+        stack AS s
+    WHERE
+          imd.instancegroup_id = ig.id
+      AND
+          ig.stack_id = s.id
+), network_temp AS (
+    SELECT
+        id AS network_id,
+        attributes::jsonb ->> 'subnetId' AS network_subnetid
+    FROM
+        network
+)
+UPDATE instancemetadata
+SET
+    subnetid = nt.network_subnetid
+FROM
+    metadata_stack_temp AS mst,
+    network_temp AS nt
+WHERE
+      id = mst.metadata_id
+  AND
+      (subnetid IS NULL OR subnetid = '')
+  AND
+      mst.stack_network_id = nt.network_id;
+
+
+WITH metadata_stack_temp AS (
+    SELECT
+           imd.id AS metadata_id,
+           s.availabilityzone AS stack_availabilityzone
+    FROM
+         instancemetadata AS imd,
+         instancegroup AS ig,
+         stack AS s
+    WHERE
+          imd.instancegroup_id = ig.id
+      AND
+          ig.stack_id = s.id
+)
+UPDATE instancemetadata
+SET
+    availabilityzone = mst.stack_availabilityzone,
+    rackid = concat('/',
+        CASE WHEN (mst.stack_availabilityzone IS NULL OR mst.stack_availabilityzone = '')
+            THEN (CASE WHEN (subnetid IS NULL OR subnetid = '')
+                THEN 'default-rack'
+                ELSE subnetid
+                END)
+            ELSE mst.stack_availabilityzone
+            END)
+FROM
+     metadata_stack_temp AS mst
+WHERE
+      id = mst.metadata_id;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE instancemetadata
+    DROP COLUMN IF EXISTS availabilityzone,
+    DROP COLUMN IF EXISTS rackid;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/instance/InstanceMetaDataToInstanceMetaDataJsonConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/instance/InstanceMetaDataToInstanceMetaDataJsonConverterTest.java
@@ -1,27 +1,27 @@
 package com.sequenceiq.cloudbreak.converter.stack.instance;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.TestUtil;
-import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.cloudbreak.converter.AbstractEntityConverterTest;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.instancegroup.InstanceMetaDataToInstanceMetaDataV4ResponseConverter;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.common.api.type.InstanceGroupType;
 
 public class InstanceMetaDataToInstanceMetaDataJsonConverterTest extends AbstractEntityConverterTest<InstanceMetaData> {
 
     private InstanceMetaDataToInstanceMetaDataV4ResponseConverter underTest;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         underTest = new InstanceMetaDataToInstanceMetaDataV4ResponseConverter();
     }
@@ -38,7 +38,7 @@ public class InstanceMetaDataToInstanceMetaDataJsonConverterTest extends Abstrac
         assertNotNull(result);
         assertEquals("test-" + source.getInstanceGroupName() + "-1-1", result.getDiscoveryFQDN());
         assertTrue(result.getAmbariServer());
-        assertAllFieldsNotNull(result, List.of("state", "statusReason"));
+        assertAllFieldsNotNull(result, List.of("state", "statusReason", "subnetId", "availabilityZone", "rackId"));
     }
 
     @Override
@@ -46,4 +46,5 @@ public class InstanceMetaDataToInstanceMetaDataJsonConverterTest extends Abstrac
         return TestUtil.instanceMetaData(1L, 1L, InstanceStatus.SERVICES_RUNNING, true,
                 TestUtil.instanceGroup(1L, InstanceGroupType.GATEWAY, TestUtil.gcpTemplate(1L)));
     }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceMetaDataToInstanceMetaDataV4ResponseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/instancegroup/InstanceMetaDataToInstanceMetaDataV4ResponseConverterTest.java
@@ -1,0 +1,105 @@
+package com.sequenceiq.cloudbreak.converter.v4.stacks.instancegroup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceLifeCycle;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+
+class InstanceMetaDataToInstanceMetaDataV4ResponseConverterTest {
+
+    private static final String PRIVATE_IP = "10.1.2.3";
+
+    private static final String PUBLIC_IP = "1.2.3.4";
+
+    private static final Integer SSH_PORT = 5678;
+
+    private static final Boolean AMBARI_SERVER = false;
+
+    private static final String INSTANCE_ID = "instanceId";
+
+    private static final String DISCOVERY_FQDN = "host.foo.org";
+
+    private static final String INSTANCE_GROUP = "instanceGroup";
+
+    private static final String SUBNET_ID = "subnetId";
+
+    private static final String AVAILABILITY_ZONE = "availabilityZone";
+
+    private static final String RACK_ID = "/rackId";
+
+    private static final InstanceStatus INSTANCE_STATUS = InstanceStatus.CREATED;
+
+    private static final InstanceMetadataType INSTANCE_METADATA_TYPE = InstanceMetadataType.CORE;
+
+    private static final InstanceLifeCycle LIFE_CYCLE = InstanceLifeCycle.NORMAL;
+
+    private InstanceMetaDataToInstanceMetaDataV4ResponseConverter underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new InstanceMetaDataToInstanceMetaDataV4ResponseConverter();
+    }
+
+    static Object[][] convertTestDataProvider() {
+        return new Object[][]{
+                // testCaseName publicIp privateIp publicIpExpected
+                {"publicIp=null, privateIp=null", null, null, null},
+                {"publicIp=PUBLIC_IP, privateIp=null", PUBLIC_IP, null, PUBLIC_IP},
+                {"publicIp=null, privateIp=PRIVATE_IP", null, PRIVATE_IP, InstanceMetaDataToInstanceMetaDataV4ResponseConverter.NOT_AVAILABLE},
+                {"publicIp=PUBLIC_IP, privateIp=PRIVATE_IP", PUBLIC_IP, PRIVATE_IP, PUBLIC_IP},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("convertTestDataProvider")
+    void convertTest(String testCaseName, String publicIp, String privateIp, String publicIpExpected) {
+        InstanceMetaData instanceMetaData = createInstanceMetaData(publicIp, privateIp);
+
+        InstanceMetaDataV4Response result = underTest.convert(instanceMetaData);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getPrivateIp()).isEqualTo(privateIp);
+        assertThat(result.getPublicIp()).isEqualTo(publicIpExpected);
+        assertThat(result.getSshPort()).isEqualTo(SSH_PORT);
+        assertThat(result.getAmbariServer()).isEqualTo(AMBARI_SERVER);
+        assertThat(result.getInstanceId()).isEqualTo(INSTANCE_ID);
+        assertThat(result.getDiscoveryFQDN()).isEqualTo(DISCOVERY_FQDN);
+        assertThat(result.getInstanceGroup()).isEqualTo(INSTANCE_GROUP);
+        assertThat(result.getSubnetId()).isEqualTo(SUBNET_ID);
+        assertThat(result.getAvailabilityZone()).isEqualTo(AVAILABILITY_ZONE);
+        assertThat(result.getRackId()).isEqualTo(RACK_ID);
+        assertThat(result.getInstanceStatus()).isEqualTo(INSTANCE_STATUS);
+        assertThat(result.getInstanceType()).isEqualTo(INSTANCE_METADATA_TYPE);
+        assertThat(result.getLifeCycle()).isEqualTo(LIFE_CYCLE);
+    }
+
+    private InstanceMetaData createInstanceMetaData(String publicIp, String privateIp) {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setGroupName(INSTANCE_GROUP);
+
+        InstanceMetaData result = new InstanceMetaData();
+        result.setPrivateIp(privateIp);
+        result.setPublicIp(publicIp);
+        result.setSshPort(SSH_PORT);
+        result.setAmbariServer(AMBARI_SERVER);
+        result.setInstanceId(INSTANCE_ID);
+        result.setDiscoveryFQDN(DISCOVERY_FQDN);
+        result.setInstanceGroup(instanceGroup);
+        result.setSubnetId(SUBNET_ID);
+        result.setAvailabilityZone(AVAILABILITY_ZONE);
+        result.setRackId(RACK_ID);
+        result.setInstanceStatus(INSTANCE_STATUS);
+        result.setInstanceMetadataType(INSTANCE_METADATA_TYPE);
+        result.setLifeCycle(LIFE_CYCLE);
+        return result;
+    }
+
+}


### PR DESCRIPTION
* Changes to `InstanceMetadata` (core):
  * Add `availabilityZone` and `rackId`.
  * Migration for existing records:
    * Populate `subnetId` if unset from `Network.attributes`.
    * Populate `availabilityZone` from `Stack`.
    * Populate `rackId` using `availabilityZone`, falling back to `subnetId` if `availabilityZone` is `NULL` or `''`, and set to `'default-rack'` if `subnetId` is also `NULL` or `''`.
* Populate `subnetId` and `availabilityZone` in AWS `CloudInstance` objects using dynamic parameters.
* Changes to `DynamicModel`:
  * Make parameter map mutable.
  * Constructor treats `null` map argument as if an empty map had been passed in.
  * Eliminate unsafe casts.
  * Add javadoc.
* `MetadataSetupService.saveInstanceMetaData()` (core): Populate `availabilityZone` and `rackId` from `CloudInstance`. `rackId` is based on `availabilityZone`, falling back to `subnetId` if `availabilityZone == null` or `availabilityZone.isEmpty()`, and set to `"default-rack"` if `subnetId == null` or `subnetId.isEmpty()`.
* Mark `Stack.availabilityZone` (core) as `@Deprecated`.
* Expose `subnetId`, `availabilityZone` and `rackId` in `InstanceMetaDataV4Response`.
* Testing:
  * Manual verification in local CB (AWS, Azure, YCloud), including checking DB migration results.
  * Added new UT and updated existing ones.