### PR TITLE
CB-12945 Remove unsupported Azure regions

### DIFF
--- a/cloud-azure/src/main/resources/definitions/azure-enabled-regions.json
+++ b/cloud-azure/src/main/resources/definitions/azure-enabled-regions.json
@@ -151,29 +151,14 @@
       "longitude": "28.218370"
     },
     {
-      "name": "South Africa West",
-      "latitude": "-34.075691",
-      "longitude": "18.843266"
-    },
-    {
       "name": "Switzerland North",
       "latitude": "47.451542",
       "longitude": "8.564572"
     },
     {
-      "name": "Germany North",
-      "latitude": "53.073635",
-      "longitude": "8.806422"
-    },
-    {
       "name": "Germany West Central",
       "latitude": "50.110924",
       "longitude": "8.682127"
-    },
-    {
-      "name": "Norway West",
-      "latitude": "58.969975",
-      "longitude": "5.733107"
     },
     {
       "name": "Norway East",


### PR DESCRIPTION
Azure no longer supports southafricawest, germanynorth and norwaywest regions.

See detailed description in the commit message.