### PR TITLE
CB-12965. Create individual API for env/DL/DH installation flow progress

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/event/PayloadContext.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/event/PayloadContext.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.cloudbreak.common.event;
+
+import java.io.Serializable;
+
+public class PayloadContext implements Serializable {
+
+    private final String resourceCrn;
+
+    private final String environmentCrn;
+
+    private final String cloudPlatform;
+
+    private PayloadContext(String resourceCrn, String environmentCrn, String cloudPlatform) {
+        this.resourceCrn = resourceCrn;
+        this.environmentCrn = environmentCrn;
+        this.cloudPlatform = cloudPlatform;
+    }
+
+    public static PayloadContext create(String resourceCrn, String cloudPlatform) {
+        return new PayloadContext(resourceCrn, null, cloudPlatform);
+    }
+
+    public static PayloadContext create(String resourceCrn, String environmentCrn, String cloudPlatform) {
+        return new PayloadContext(resourceCrn, environmentCrn, cloudPlatform);
+    }
+
+    public String getResourceCrn() {
+        return resourceCrn;
+    }
+
+    public String getCloudPlatform() {
+        return cloudPlatform;
+    }
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    @Override
+    public String toString() {
+        return "PayloadContext{" +
+                "resourceCrn='" + resourceCrn + '\'' +
+                ", environmentCrn='" + environmentCrn + '\'' +
+                ", cloudPlatform='" + cloudPlatform + '\'' +
+                '}';
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/operation/OperationV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/operation/OperationV4Endpoint.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.operation;
+
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.operation.docs.OperationOpDescriptions.GET_OPERATIONS;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.operation.docs.OperationOpDescriptions.NOTES;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Path("/v4/operation")
+@RetryAndMetrics
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(value = "/v4/operation", description = "Get operation progression", protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+public interface OperationV4Endpoint {
+
+    @GET
+    @Path("/resource/crn/{resourceCrn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = GET_OPERATIONS, produces = "application/json", notes = NOTES,
+            nickname = "getStackOperationProgressByResourceCrn")
+    OperationView getOperationProgressByResourceCrn(@PathParam("resourceCrn") String resourceCrn,
+            @DefaultValue("false") @QueryParam("detailed") boolean detailed);
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/operation/docs/OperationOpDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/operation/docs/OperationOpDescriptions.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.operation.docs;
+
+public class OperationOpDescriptions {
+
+    public static final String NOTES = "Flow operation details";
+    public static final String GET_OPERATIONS = "Get flow operation progress details for resource by resource crn";
+
+    private OperationOpDescriptions() {
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakApiKeyEndpoints.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakApiKeyEndpoints.java
@@ -12,6 +12,8 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.database.DatabaseV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.filesystems.FileSystemV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.ImageCatalogV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.info.CloudbreakInfoV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.operation.OperationV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.progress.ProgressV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.providerservices.CloudProviderServicesV4Endopint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.RecipeV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.DatalakeV4Endpoint;
@@ -116,6 +118,16 @@ public class CloudbreakApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint i
     @Override
     public FlowPublicEndpoint flowPublicEndpoint() {
         return getEndpoint(FlowPublicEndpoint.class);
+    }
+
+    @Override
+    public ProgressV4Endpoint progressV4Endpoint() {
+        return getEndpoint(ProgressV4Endpoint.class);
+    }
+
+    @Override
+    public OperationV4Endpoint operationV4Endpoint() {
+        return getEndpoint(OperationV4Endpoint.class);
     }
 
     @Override

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakClient.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakClient.java
@@ -9,6 +9,8 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.database.DatabaseV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.filesystems.FileSystemV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.ImageCatalogV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.info.CloudbreakInfoV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.operation.OperationV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.progress.ProgressV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.providerservices.CloudProviderServicesV4Endopint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.RecipeV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.DatalakeV4Endpoint;
@@ -61,6 +63,10 @@ public interface CloudbreakClient {
     FlowEndpoint flowEndpoint();
 
     FlowPublicEndpoint flowPublicEndpoint();
+
+    ProgressV4Endpoint progressV4Endpoint();
+
+    OperationV4Endpoint operationV4Endpoint();
 
     DistroXDatabaseServerV1Endpoint distroXDatabaseServerV1Endpoint();
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakServiceCrnEndpoints.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/client/CloudbreakServiceCrnEndpoints.java
@@ -12,6 +12,8 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.database.DatabaseV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.filesystems.FileSystemV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.ImageCatalogV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.info.CloudbreakInfoV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.operation.OperationV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.progress.ProgressV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.providerservices.CloudProviderServicesV4Endopint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.recipes.RecipeV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.DatalakeV4Endpoint;
@@ -120,6 +122,16 @@ public class CloudbreakServiceCrnEndpoints extends AbstractUserCrnServiceEndpoin
     @Override
     public FlowPublicEndpoint flowPublicEndpoint() {
         return getEndpoint(FlowPublicEndpoint.class);
+    }
+
+    @Override
+    public ProgressV4Endpoint progressV4Endpoint() {
+        return getEndpoint(ProgressV4Endpoint.class);
+    }
+
+    @Override
+    public OperationV4Endpoint operationV4Endpoint() {
+        return getEndpoint(OperationV4Endpoint.class);
     }
 
     @Override

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/client/internal/CloudbreakApiClientConfig.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/client/internal/CloudbreakApiClientConfig.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.database.DatabaseConfigV4Endpoi
 import com.sequenceiq.cloudbreak.api.endpoint.v4.diagnostics.DiagnosticsV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.filesystems.FileSystemV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.ImageCatalogV4Endpoint;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.operation.OperationV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.progress.ProgressV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.providerservices.CloudProviderServicesV4Endopint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.DatalakeV4Endpoint;
@@ -114,6 +115,12 @@ public class CloudbreakApiClientConfig {
     @ConditionalOnBean(name = "cloudbreakApiClientWebTarget")
     ProgressV4Endpoint progressV4Endpoint(WebTarget cloudbreakApiClientWebTarget) {
         return new WebTargetEndpointFactory().createEndpoint(cloudbreakApiClientWebTarget, ProgressV4Endpoint.class);
+    }
+
+    @Bean
+    @ConditionalOnBean(name = "cloudbreakApiClientWebTarget")
+    OperationV4Endpoint operationV4Endpoint(WebTarget cloudbreakApiClientWebTarget) {
+        return new WebTargetEndpointFactory().createEndpoint(cloudbreakApiClientWebTarget, OperationV4Endpoint.class);
     }
 
     @Bean

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/doc/DistroXOpDescription.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/doc/DistroXOpDescription.java
@@ -43,6 +43,7 @@ public class DistroXOpDescription {
     public static final String GET_DATABASE_SERVER_BY_CLUSTER_CRN = "get database server for Distrox cluster by cluster crn";
     public static final String GET_LAST_FLOW_PROGRESS = "Get last flow operation progress details for resource by resource crn";
     public static final String LIST_FLOW_PROGRESS = "List recent flow operations progress details for resource by resource crn";
+    public static final String GET_OPERATION = "Get flow operation progress details for resource by resource crn";
 
     private DistroXOpDescription() {
     }

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
@@ -16,6 +16,7 @@ import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.DEL
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET_BY_CRN;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET_BY_NAME;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET_LAST_FLOW_PROGRESS;
+import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET_OPERATION;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET_STACK_REQUEST_BY_CRN;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET_STACK_REQUEST_BY_NAME;
 import static com.sequenceiq.distrox.api.v1.distrox.doc.DistroXOpDescription.GET_STATUS_BY_CRN;
@@ -78,6 +79,7 @@ import com.sequenceiq.distrox.api.v1.distrox.model.diagnostics.model.CmDiagnosti
 import com.sequenceiq.distrox.api.v1.distrox.model.diagnostics.model.DiagnosticsCollectionV1Request;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
+import com.sequenceiq.flow.api.model.operation.OperationView;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -407,6 +409,14 @@ public interface DistroXV1Endpoint {
     @ApiOperation(value = LIST_FLOW_PROGRESS, produces = "application/json", notes = Notes.FLOW_OPERATION_PROGRESS_NOTES,
             nickname = "getDistroXFlowLogsProgressByResourceCrn")
     List<FlowProgressResponse> getFlowLogsProgressByResourceCrn(@PathParam("resourceCrn") String resourceCrn);
+
+    @GET
+    @Path("operation/resource/crn/{resourceCrn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = GET_OPERATION, produces = "application/json", notes = Notes.FLOW_OPERATION_PROGRESS_NOTES,
+            nickname = "getDistroXOperationProgressByResourceCrn")
+    OperationView getOperationProgressByResourceCrn(@PathParam("resourceCrn") String resourceCrn,
+            @DefaultValue("false") @QueryParam("detailed") boolean detailed);
 
     @POST
     @Path("crn/{crn}/renew_certificate")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/EndpointConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/EndpointConfig.java
@@ -32,6 +32,7 @@ import com.sequenceiq.cloudbreak.controller.v4.DiagnosticsV4Controller;
 import com.sequenceiq.cloudbreak.controller.v4.EventV4Controller;
 import com.sequenceiq.cloudbreak.controller.v4.FileSystemV4Controller;
 import com.sequenceiq.cloudbreak.controller.v4.ImageCatalogV4Controller;
+import com.sequenceiq.cloudbreak.controller.v4.OperationV4Controller;
 import com.sequenceiq.cloudbreak.controller.v4.ProgressV4Controller;
 import com.sequenceiq.cloudbreak.controller.v4.RecipesV4Controller;
 import com.sequenceiq.cloudbreak.controller.v4.StackV4Controller;
@@ -80,6 +81,7 @@ public class EndpointConfig extends ResourceConfig {
             DatalakeV4Controller.class,
             DiagnosticsV4Controller.class,
             ProgressV4Controller.class,
+            OperationV4Controller.class,
             CloudProviderServicesV4Controller.class,
             FlowController.class,
             FlowPublicController.class,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/OperationV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/OperationV4Controller.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.controller.v4;
+
+import static com.sequenceiq.authorization.resource.AuthorizationResourceAction.DESCRIBE_DATALAKE;
+
+import org.springframework.stereotype.Controller;
+
+import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
+import com.sequenceiq.authorization.annotation.ResourceCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.operation.OperationV4Endpoint;
+import com.sequenceiq.cloudbreak.service.operation.OperationService;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+
+@Controller
+public class OperationV4Controller implements OperationV4Endpoint {
+
+    private final OperationService operationService;
+
+    public OperationV4Controller(OperationService operationService) {
+        this.operationService = operationService;
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = DESCRIBE_DATALAKE)
+    public OperationView getOperationProgressByResourceCrn(@ResourceCrn String resourceCrn, boolean detailed) {
+        return operationService.getOperationProgressByResourceCrn(resourceCrn, detailed);
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ProgressV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ProgressV4Controller.java
@@ -11,24 +11,24 @@ import org.springframework.stereotype.Controller;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.progress.ProgressV4Endpoint;
+import com.sequenceiq.cloudbreak.service.progress.ProgressService;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
-import com.sequenceiq.flow.service.FlowService;
 
 @Controller
 public class ProgressV4Controller implements ProgressV4Endpoint {
 
     @Inject
-    private FlowService flowService;
+    private ProgressService progressService;
 
     @Override
     @CheckPermissionByResourceCrn(action = DESCRIBE_DATALAKE)
     public FlowProgressResponse getLastFlowLogProgressByResourceCrn(@ResourceCrn String resourceCrn) {
-        return flowService.getLastFlowProgressByResourceCrn(resourceCrn);
+        return progressService.getLastFlowProgressByResourceCrn(resourceCrn);
     }
 
     @Override
     @CheckPermissionByResourceCrn(action = DESCRIBE_DATALAKE)
     public List<FlowProgressResponse> getFlowLogsProgressByResourceCrn(@ResourceCrn String resourceCrn) {
-        return flowService.getFlowProgressListByResourceCrn(resourceCrn);
+        return progressService.getFlowProgressListByResourceCrn(resourceCrn);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ProvisionFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ProvisionFlowEventChainFactory.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
@@ -33,5 +34,10 @@ public class ProvisionFlowEventChainFactory implements FlowEventChainFactory<Sta
         flowEventChain.add(new StackEvent(START_CREATION_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new StackEvent(CLUSTER_CREATION_EVENT.event(), event.getResourceId()));
         return new FlowTriggerEventQueue(getName(), flowEventChain);
+    }
+
+    @Override
+    public OperationType getFlowOperationType() {
+        return OperationType.PROVISION;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/config/DiagnosticsCollectionFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/config/DiagnosticsCollectionFlowConfig.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.DiagnosticsCollectionsState;
 import com.sequenceiq.cloudbreak.core.flow2.diagnostics.event.DiagnosticsCollectionStateSelectors;
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
 
@@ -114,6 +115,11 @@ public class DiagnosticsCollectionFlowConfig extends AbstractFlowConfiguration<D
         return new DiagnosticsCollectionStateSelectors[] {
                 START_DIAGNOSTICS_SALT_VALIDATION_EVENT
         };
+    }
+
+    @Override
+    public OperationType getFlowOperationType() {
+        return OperationType.DIAGNOSTICS;
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/database/DatabaseService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/database/DatabaseService.java
@@ -2,25 +2,36 @@ package com.sequenceiq.cloudbreak.service.database;
 
 import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFound;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.StackDatabaseServerResponse;
 import com.sequenceiq.distrox.v1.distrox.StackOperations;
 import com.sequenceiq.distrox.v1.distrox.converter.DatabaseServerConverter;
+import com.sequenceiq.flow.api.model.operation.OperationView;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
+import com.sequenceiq.redbeams.api.endpoint.v4.operation.OperationV4Endpoint;
 
 @Service
 public class DatabaseService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseService.class);
 
     @Inject
     private StackOperations stackOperations;
 
     @Inject
     private DatabaseServerV4Endpoint databaseServerV4Endpoint;
+
+    @Inject
+    private OperationV4Endpoint operationV4Endpoint;
 
     @Inject
     private DatabaseServerConverter databaseServerConverter;
@@ -36,6 +47,18 @@ public class DatabaseService {
         DatabaseServerV4Response databaseServerV4Response = databaseServerV4Endpoint.getByCrn(stack.getCluster().getDatabaseServerCrn());
 
         return databaseServerConverter.convert(databaseServerV4Response);
+    }
+
+    public Optional<OperationView> getRemoteDatabaseOperationProgress(Stack stack, boolean detailed) {
+        Optional<OperationView> result = Optional.empty();
+        if (stack.getCluster() == null) {
+            LOGGER.debug("Cannot find cluster with crn: {}. Use empty response.", stack.getResourceCrn());
+        } else if (stack.getCluster().getDatabaseServerCrn() == null) {
+            LOGGER.debug("Not found database for cluster with crn: {}). Use empty response.",  stack.getResourceCrn());
+        } else {
+            result = Optional.ofNullable(operationV4Endpoint.getRedbeamsOperationProgressByResourceCrn(stack.getCluster().getDatabaseServerCrn(), detailed));
+        }
+        return result;
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/operation/OperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/operation/OperationService.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.cloudbreak.service.operation;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationFlowConfig;
+import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.provision.config.ExternalDatabaseCreationFlowConfig;
+import com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationFlowConfig;
+import com.sequenceiq.cloudbreak.core.flow2.validate.cloud.config.CloudConfigValidationFlowConfig;
+import com.sequenceiq.cloudbreak.core.flow2.validate.kerberosconfig.config.KerberosConfigValidationFlowConfig;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.database.DatabaseService;
+import com.sequenceiq.distrox.v1.distrox.StackOperations;
+import com.sequenceiq.flow.api.model.operation.OperationCondition;
+import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
+import com.sequenceiq.flow.api.model.operation.OperationResource;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+import com.sequenceiq.flow.converter.OperationDetailsPopulator;
+import com.sequenceiq.flow.service.FlowService;
+
+@Component
+public class OperationService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OperationService.class);
+
+    private final FlowService flowService;
+
+    private final DatabaseService databaseService;
+
+    private final StackOperations stackOperations;
+
+    private final OperationDetailsPopulator operationDetailsPopulator;
+
+    public OperationService(FlowService flowService, DatabaseService databaseService, StackOperations stackOperations,
+            OperationDetailsPopulator operationDetailsPopulator) {
+        this.flowService = flowService;
+        this.databaseService = databaseService;
+        this.stackOperations = stackOperations;
+        this.operationDetailsPopulator = operationDetailsPopulator;
+    }
+
+    public OperationView getOperationProgressByResourceCrn(String resourceCrn, boolean detailed) {
+        OperationView stackOperationView = new OperationView();
+        try {
+            OperationResource operationResource = OperationResource.fromCrn(Crn.safeFromString(resourceCrn));
+            Optional<OperationFlowsView> operationFlowsViewOpt = flowService.getLastFlowOperationByResourceCrn(resourceCrn);
+            if (operationFlowsViewOpt.isPresent()) {
+                OperationFlowsView operationFlowsView = operationFlowsViewOpt.get();
+                OperationType operationType = operationFlowsView.getOperationType();
+                if (OperationType.PROVISION.equals(operationType)) {
+                    stackOperationView = handleProvisionOperation(resourceCrn, operationResource, operationFlowsView, detailed);
+                } else {
+                    stackOperationView = operationDetailsPopulator.createOperationView(operationFlowsView, operationResource);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.debug(String.format("Could not fetch remote database details for stack with crn %s", resourceCrn), e);
+        }
+        return stackOperationView;
+    }
+
+    private OperationView handleProvisionOperation(String resourceCrn, OperationResource operationResource,
+            OperationFlowsView operationFlowsView, boolean detailed) {
+        OperationView stackOperationView;
+        stackOperationView = operationDetailsPopulator.createOperationView(operationFlowsView, operationResource, List.of(
+                CloudConfigValidationFlowConfig.class,
+                KerberosConfigValidationFlowConfig.class,
+                ExternalDatabaseCreationFlowConfig.class,
+                StackCreationFlowConfig.class,
+                ClusterCreationFlowConfig.class
+        ));
+        if (detailed && !OperationResource.DATALAKE.equals(operationResource)) {
+            Stack stack = stackOperations.getStackByCrn(resourceCrn);
+            DatabaseAvailabilityType databaseAvailabilityType = stack.getExternalDatabaseCreationType();
+            Map<OperationResource, OperationCondition> conditionMap = new HashMap<>();
+            Map<OperationResource, OperationView> subOperations = new HashMap<>();
+            if (!DatabaseAvailabilityType.NONE.equals(databaseAvailabilityType)) {
+                conditionMap.put(OperationResource.REMOTEDB, OperationCondition.REQUIRED);
+                subOperations.put(OperationResource.REMOTEDB, databaseService.getRemoteDatabaseOperationProgress(stack, detailed).orElse(null));
+            } else {
+                conditionMap.put(OperationResource.REMOTEDB, OperationCondition.NONE);
+            }
+            stackOperationView.setSubOperationConditions(conditionMap);
+            stackOperationView.setSubOperations(subOperations);
+        }
+        return stackOperationView;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/progress/ProgressService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/progress/ProgressService.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.service.progress;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.api.model.FlowProgressResponse;
+import com.sequenceiq.flow.service.FlowService;
+
+@Component
+public class ProgressService {
+
+    private final FlowService flowService;
+
+    public ProgressService(FlowService flowService) {
+        this.flowService = flowService;
+    }
+
+    public FlowProgressResponse getLastFlowProgressByResourceCrn(String resourceCrn) {
+        return flowService.getLastFlowProgressByResourceCrn(resourceCrn);
+    }
+
+    public List<FlowProgressResponse> getFlowProgressListByResourceCrn(String resourceCrn) {
+        return flowService.getFlowProgressListByResourceCrn(resourceCrn);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
@@ -63,6 +63,8 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.retry.RetryableFlow;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterDiagnosticsService;
 import com.sequenceiq.cloudbreak.service.diagnostics.DiagnosticsService;
+import com.sequenceiq.cloudbreak.service.operation.OperationService;
+import com.sequenceiq.cloudbreak.service.progress.ProgressService;
 import com.sequenceiq.cloudbreak.service.stack.flow.StackOperationService;
 import com.sequenceiq.cloudbreak.service.workspace.WorkspaceService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
@@ -89,7 +91,7 @@ import com.sequenceiq.distrox.v1.distrox.converter.cli.DelegatingRequestToCliReq
 import com.sequenceiq.distrox.v1.distrox.service.DistroXService;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
-import com.sequenceiq.flow.service.FlowService;
+import com.sequenceiq.flow.api.model.operation.OperationView;
 
 @Controller
 public class DistroXV1Controller implements DistroXV1Endpoint {
@@ -125,7 +127,10 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
     private DiagnosticsService diagnosticsService;
 
     @Inject
-    private FlowService flowService;
+    private ProgressService progressService;
+
+    @Inject
+    private OperationService operationService;
 
     @Inject
     private VmLogsService vmLogsService;
@@ -531,13 +536,19 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
     @Override
     @CheckPermissionByResourceCrn(action = DESCRIBE_DATAHUB)
     public FlowProgressResponse getLastFlowLogProgressByResourceCrn(@TenantAwareParam @ResourceCrn String resourceCrn) {
-        return flowService.getLastFlowProgressByResourceCrn(resourceCrn);
+        return progressService.getLastFlowProgressByResourceCrn(resourceCrn);
     }
 
     @Override
     @CheckPermissionByResourceCrn(action = DESCRIBE_DATAHUB)
     public List<FlowProgressResponse> getFlowLogsProgressByResourceCrn(@TenantAwareParam @ResourceCrn String resourceCrn) {
-        return flowService.getFlowProgressListByResourceCrn(resourceCrn);
+        return progressService.getFlowProgressListByResourceCrn(resourceCrn);
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = DESCRIBE_DATAHUB)
+    public OperationView getOperationProgressByResourceCrn(@TenantAwareParam @ResourceCrn String resourceCrn, boolean detailed) {
+        return operationService.getOperationProgressByResourceCrn(resourceCrn, detailed);
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/OperationRetryServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/OperationRetryServiceTest.java
@@ -32,6 +32,7 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.message.CloudbreakMessagesService;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.Flow2Handler;
 import com.sequenceiq.flow.domain.FlowLog;
 import com.sequenceiq.flow.domain.StateStatus;
@@ -92,7 +93,7 @@ public class OperationRetryServiceTest {
     }
 
     private FlowLog createFlowLog(String currentState, StateStatus stateStatus, long created, String name) {
-        FlowLog flowLog = new FlowLog(STACK_ID, FLOW_ID, currentState, true, stateStatus);
+        FlowLog flowLog = new FlowLog(STACK_ID, FLOW_ID, currentState, true, stateStatus, OperationType.UNKNOWN);
         flowLog.setCreated(created);
         flowLog.setFlowType(flowConfig.getClass());
         flowLog.setNextEvent(name);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/operation/OperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/operation/OperationServiceTest.java
@@ -1,0 +1,142 @@
+package com.sequenceiq.cloudbreak.service.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.database.DatabaseAvailabilityType;
+import com.sequenceiq.cloudbreak.core.flow2.chain.ProvisionFlowEventChainFactory;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.provision.ClusterCreationFlowConfig;
+import com.sequenceiq.cloudbreak.core.flow2.externaldatabase.provision.config.ExternalDatabaseCreationFlowConfig;
+import com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationFlowConfig;
+import com.sequenceiq.cloudbreak.core.flow2.validate.cloud.config.CloudConfigValidationFlowConfig;
+import com.sequenceiq.cloudbreak.core.flow2.validate.kerberosconfig.config.KerberosConfigValidationFlowConfig;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+import com.sequenceiq.cloudbreak.service.database.DatabaseService;
+import com.sequenceiq.distrox.v1.distrox.StackOperations;
+import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
+import com.sequenceiq.flow.api.model.operation.OperationResource;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+import com.sequenceiq.flow.converter.OperationDetailsPopulator;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
+import com.sequenceiq.flow.service.FlowService;
+
+@ExtendWith(MockitoExtension.class)
+public class OperationServiceTest {
+
+    private static final String TEST_CLUSTER_CRN = "crn:cdp:datahub:us-west-1:autoscale:cluster:ffff";
+
+    private static final String TEST_DATALAKE_CRN = "crn:cdp:datalake:us-west-1:autoscale:cluster:ffff";
+
+    private static final List<Class<?>> EXPECTED_TYPE_LIST =  List.of(
+            CloudConfigValidationFlowConfig .class,
+            KerberosConfigValidationFlowConfig .class,
+            ExternalDatabaseCreationFlowConfig .class,
+            StackCreationFlowConfig .class,
+            ClusterCreationFlowConfig .class
+    );
+
+    private OperationService underTest;
+
+    @Mock
+    private FlowService flowService;
+
+    @Mock
+    private DatabaseService databaseService;
+
+    @Mock
+    private StackOperations stackOperations;
+
+    @Mock
+    private OperationDetailsPopulator operationDetailsPopulator;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private OperationFlowsView operationFlowsView;
+
+    @Mock
+    private OperationView operationView;
+
+    @Mock
+    private OperationView remoteDatabaseOperationView;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new OperationService(flowService, databaseService, stackOperations, operationDetailsPopulator);
+    }
+
+    @Test
+    public void testGetOperationProgressByResourceCrnWithDatalake() {
+        // GIVEN
+        ProvisionFlowEventChainFactory provisionFlowEventChainFactory = new ProvisionFlowEventChainFactory();
+        FlowTriggerEventQueue eventQueue = provisionFlowEventChainFactory.createFlowTriggerEventQueue(new StackEvent(null, null));
+        given(flowService.getLastFlowOperationByResourceCrn(anyString()))
+                .willReturn(Optional.of(operationFlowsView));
+        given(operationFlowsView.getOperationType()).willReturn(OperationType.PROVISION);
+        given(operationDetailsPopulator.createOperationView(operationFlowsView, OperationResource.DATALAKE, EXPECTED_TYPE_LIST))
+                .willReturn(operationView);
+        // WHEN
+        OperationView result = underTest.getOperationProgressByResourceCrn(TEST_DATALAKE_CRN, true);
+        // THEN
+        assertEquals(operationView, result);
+        verify(operationDetailsPopulator, times(1))
+                .createOperationView(operationFlowsView, OperationResource.DATALAKE, EXPECTED_TYPE_LIST);
+        // Checks that the number of provision flows are the same as in the operation check
+        assertEquals(eventQueue.getQueue().size(), EXPECTED_TYPE_LIST.size());
+    }
+
+    @Test
+    public void testGetOperationProgressByResourceCrnWithDatahub() {
+        // GIVEN
+        given(flowService.getLastFlowOperationByResourceCrn(anyString()))
+                .willReturn(Optional.of(operationFlowsView));
+        given(operationFlowsView.getOperationType()).willReturn(OperationType.PROVISION);
+        given(operationDetailsPopulator.createOperationView(operationFlowsView, OperationResource.DATAHUB, EXPECTED_TYPE_LIST))
+                .willReturn(new OperationView());
+        given(stackOperations.getStackByCrn(anyString())).willReturn(stack);
+        given(stack.getExternalDatabaseCreationType()).willReturn(DatabaseAvailabilityType.NON_HA);
+        given(databaseService.getRemoteDatabaseOperationProgress(any(), anyBoolean())).willReturn(Optional.of(remoteDatabaseOperationView));
+        // WHEN
+        OperationView result = underTest.getOperationProgressByResourceCrn(TEST_CLUSTER_CRN, true);
+        // THEN
+        assertEquals(remoteDatabaseOperationView, result.getSubOperations().get(OperationResource.REMOTEDB));
+        verify(databaseService, times(1)).getRemoteDatabaseOperationProgress(any(), anyBoolean());
+        verify(operationDetailsPopulator, times(1)).createOperationView(operationFlowsView,
+                OperationResource.DATAHUB, EXPECTED_TYPE_LIST);
+    }
+
+    @Test
+    public void testGetOperationProgressByResourceCrnWithFailedRemoteDbResponse() {
+        // GIVEN
+        given(flowService.getLastFlowOperationByResourceCrn(anyString()))
+                .willReturn(Optional.of(operationFlowsView));
+        given(operationFlowsView.getOperationType()).willReturn(OperationType.PROVISION);
+        given(operationDetailsPopulator.createOperationView(operationFlowsView, OperationResource.DATAHUB, EXPECTED_TYPE_LIST))
+                .willReturn(new OperationView());
+        given(stackOperations.getStackByCrn(anyString())).willReturn(stack);
+        given(stack.getExternalDatabaseCreationType()).willReturn(DatabaseAvailabilityType.NON_HA);
+        given(databaseService.getRemoteDatabaseOperationProgress(any(), anyBoolean())).willThrow(new RuntimeException("my ex"));
+        // WHEN
+        OperationView result = underTest.getOperationProgressByResourceCrn(TEST_CLUSTER_CRN, true);
+        // THEN
+        assertNull(result.getSubOperations().get(OperationResource.REMOTEDB));
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/RestUrlParserTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/RestUrlParserTest.java
@@ -91,7 +91,7 @@ public class RestUrlParserTest {
     private List<LegacyRestUrlParser> restUrlParsers;
 
     private String[] excludes = {"/v1/distrox", "/v1/internal/distrox", "/flow-public", "/autoscale",
-            "cluster_templates", "/v4/events", "/v4/diagnostics", "/v4/progress"};
+            "cluster_templates", "/v4/events", "/v4/diagnostics", "/v4/progress", "/v4/operation"};
 
     @Test
     public void testEventUrlParser() {

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/OperationEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/OperationEndpoint.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.sdx.api.endpoint;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Path("/operation")
+@RetryAndMetrics
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(value = "/operation", description = "Get progression details of (flow) operations on SDX cluster",
+        protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+public interface OperationEndpoint {
+
+    @GET
+    @Path("/resource/crn/{resourceCrn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Get provision flow operation progress details for resource by resource crn", produces = "application/json",
+            notes = "Flow operations progress", nickname = "getOperationProgressByResourceCrn")
+    OperationView getOperationProgressByResourceCrn(@PathParam("resourceCrn") String resourceCrn,
+            @DefaultValue("false") @QueryParam("detailed") boolean detailed);
+}

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxClient.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxClient.java
@@ -5,6 +5,8 @@ import com.sequenceiq.flow.api.FlowEndpoint;
 import com.sequenceiq.flow.api.FlowPublicEndpoint;
 import com.sequenceiq.sdx.api.endpoint.DatabaseServerEndpoint;
 import com.sequenceiq.sdx.api.endpoint.DiagnosticsEndpoint;
+import com.sequenceiq.sdx.api.endpoint.OperationEndpoint;
+import com.sequenceiq.sdx.api.endpoint.ProgressEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxInternalEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxUpgradeEndpoint;
@@ -18,6 +20,10 @@ public interface SdxClient {
     SdxUpgradeEndpoint sdxUpgradeEndpoint();
 
     FlowEndpoint flowEndpoint();
+
+    ProgressEndpoint progressEndpoint();
+
+    OperationEndpoint operationEndpoint();
 
     FlowPublicEndpoint flowPublicEndpoint();
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxServiceApiKeyEndpoints.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxServiceApiKeyEndpoints.java
@@ -8,6 +8,8 @@ import com.sequenceiq.flow.api.FlowEndpoint;
 import com.sequenceiq.flow.api.FlowPublicEndpoint;
 import com.sequenceiq.sdx.api.endpoint.DatabaseServerEndpoint;
 import com.sequenceiq.sdx.api.endpoint.DiagnosticsEndpoint;
+import com.sequenceiq.sdx.api.endpoint.OperationEndpoint;
+import com.sequenceiq.sdx.api.endpoint.ProgressEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxInternalEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxUpgradeEndpoint;
@@ -36,6 +38,16 @@ public class SdxServiceApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint i
     @Override
     public FlowEndpoint flowEndpoint() {
         return getEndpoint(FlowEndpoint.class);
+    }
+
+    @Override
+    public ProgressEndpoint progressEndpoint() {
+        return getEndpoint(ProgressEndpoint.class);
+    }
+
+    @Override
+    public OperationEndpoint operationEndpoint() {
+        return getEndpoint(OperationEndpoint.class);
     }
 
     @Override

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxServiceCrnEndpoints.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxServiceCrnEndpoints.java
@@ -8,6 +8,8 @@ import com.sequenceiq.flow.api.FlowEndpoint;
 import com.sequenceiq.flow.api.FlowPublicEndpoint;
 import com.sequenceiq.sdx.api.endpoint.DatabaseServerEndpoint;
 import com.sequenceiq.sdx.api.endpoint.DiagnosticsEndpoint;
+import com.sequenceiq.sdx.api.endpoint.OperationEndpoint;
+import com.sequenceiq.sdx.api.endpoint.ProgressEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxInternalEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxUpgradeEndpoint;
@@ -36,6 +38,16 @@ public class SdxServiceCrnEndpoints extends AbstractUserCrnServiceEndpoint imple
     @Override
     public FlowEndpoint flowEndpoint() {
         return getEndpoint(FlowEndpoint.class);
+    }
+
+    @Override
+    public ProgressEndpoint progressEndpoint() {
+        return getEndpoint(ProgressEndpoint.class);
+    }
+
+    @Override
+    public OperationEndpoint operationEndpoint() {
+        return getEndpoint(OperationEndpoint.class);
     }
 
     @Override

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/client/internal/SdxApiClientConfig.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/client/internal/SdxApiClientConfig.java
@@ -11,6 +11,8 @@ import com.sequenceiq.cloudbreak.client.ThreadLocalUserCrnWebTargetBuilder;
 import com.sequenceiq.cloudbreak.client.ApiClientRequestFilter;
 import com.sequenceiq.cloudbreak.client.WebTargetEndpointFactory;
 import com.sequenceiq.sdx.api.SdxApi;
+import com.sequenceiq.sdx.api.endpoint.OperationEndpoint;
+import com.sequenceiq.sdx.api.endpoint.ProgressEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
 
 import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
@@ -41,5 +43,17 @@ public class SdxApiClientConfig {
     @ConditionalOnBean(name = "sdxApiClientWebTarget")
     SdxEndpoint createSdxV1Endpoint(WebTarget sdxApiClientWebTarget) {
         return new WebTargetEndpointFactory().createEndpoint(sdxApiClientWebTarget, SdxEndpoint.class);
+    }
+
+    @Bean
+    @ConditionalOnBean(name = "sdxApiClientWebTarget")
+    ProgressEndpoint createSdxV1ProgressEndpoint(WebTarget sdxApiClientWebTarget) {
+        return new WebTargetEndpointFactory().createEndpoint(sdxApiClientWebTarget, ProgressEndpoint.class);
+    }
+
+    @Bean
+    @ConditionalOnBean(name = "sdxApiClientWebTarget")
+    OperationEndpoint createSdxV1OperationEndpoint(WebTarget sdxApiClientWebTarget) {
+        return new WebTargetEndpointFactory().createEndpoint(sdxApiClientWebTarget, OperationEndpoint.class);
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/EndpointConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/EndpointConfig.java
@@ -17,6 +17,7 @@ import com.sequenceiq.authorization.info.AuthorizationUtilEndpoint;
 import com.sequenceiq.datalake.controller.diagnostics.DiagnosticsController;
 import com.sequenceiq.datalake.controller.mapper.DefaultExceptionMapper;
 import com.sequenceiq.datalake.controller.mapper.WebApplicaitonExceptionMapper;
+import com.sequenceiq.datalake.controller.operation.OperationController;
 import com.sequenceiq.datalake.controller.progress.ProgressController;
 import com.sequenceiq.datalake.controller.sdx.DatabaseConfigController;
 import com.sequenceiq.datalake.controller.sdx.DatabaseServerController;
@@ -49,6 +50,7 @@ public class EndpointConfig extends ResourceConfig {
             AuthorizationInfoController.class,
             DiagnosticsController.class,
             ProgressController.class,
+            OperationController.class,
             AuthorizationUtilEndpoint.class,
             DatabaseServerController.class);
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/operation/OperationController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/operation/OperationController.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.datalake.controller.operation;
+
+import static com.sequenceiq.authorization.resource.AuthorizationResourceAction.DESCRIBE_DATALAKE;
+
+import org.springframework.stereotype.Controller;
+
+import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
+import com.sequenceiq.authorization.annotation.ResourceCrn;
+import com.sequenceiq.datalake.service.sdx.operation.OperationService;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+import com.sequenceiq.sdx.api.endpoint.OperationEndpoint;
+
+@Controller
+public class OperationController implements OperationEndpoint {
+
+    private final OperationService operationService;
+
+    public OperationController(OperationService operationService) {
+        this.operationService = operationService;
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = DESCRIBE_DATALAKE)
+    public OperationView getOperationProgressByResourceCrn(@ResourceCrn String resourceCrn, boolean detailed) {
+        return operationService.getOperationProgressByResourceCrn(resourceCrn, detailed);
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/SdxCreateFlowConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/SdxCreateFlowConfig.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
 import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
@@ -93,5 +94,10 @@ public class SdxCreateFlowConfig extends AbstractFlowConfiguration<SdxCreateStat
     @Override
     public SdxCreateEvent getRetryableEvent() {
         return SDX_CREATE_FAILED_HANDLED_EVENT;
+    }
+
+    @Override
+    public OperationType getFlowOperationType() {
+        return OperationType.PROVISION;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/diagnostics/SdxDiagnosticsFlowConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/diagnostics/SdxDiagnosticsFlowConfig.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
 
@@ -83,5 +84,10 @@ public class SdxDiagnosticsFlowConfig extends AbstractFlowConfiguration<SdxDiagn
     @Override
     public SdxDiagnosticsEvent getRetryableEvent() {
         return SDX_DIAGNOSTICS_COLLECTION_FAILED_HANDLED_EVENT;
+    }
+
+    @Override
+    public OperationType getFlowOperationType() {
+        return OperationType.DIAGNOSTICS;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/DatabaseService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/database/DatabaseService.java
@@ -41,12 +41,14 @@ import com.sequenceiq.datalake.service.sdx.SdxDatabaseOperation;
 import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.flow.api.model.operation.OperationView;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.AllocateDatabaseServerV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslConfigV4Request;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.requests.SslMode;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerStatusV4Response;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
+import com.sequenceiq.redbeams.api.endpoint.v4.operation.OperationV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.stacks.DatabaseServerV4StackRequest;
 
 @Service
@@ -87,6 +89,9 @@ public class DatabaseService {
 
     @Inject
     private DatabaseServerV4Endpoint databaseServerV4Endpoint;
+
+    @Inject
+    private OperationV4Endpoint operationV4Endpoint;
 
     @Inject
     private EntitlementService entitlementService;
@@ -248,6 +253,10 @@ public class DatabaseService {
                     }
                 });
         return response;
+    }
+
+    public OperationView getOperationProgressStatus(String databaseCrn, boolean detailed) {
+        return ThreadBasedUserCrnProvider.doAsInternalActor(() -> operationV4Endpoint.getRedbeamsOperationProgressByResourceCrn(databaseCrn, detailed));
     }
 
     private DatabaseServerStatusV4Response getDatabaseStatus(String databaseCrn) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/operation/OperationService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/operation/OperationService.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.datalake.service.sdx.operation;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.operation.OperationV4Endpoint;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.service.sdx.SdxService;
+import com.sequenceiq.datalake.service.sdx.database.DatabaseService;
+import com.sequenceiq.flow.api.model.operation.OperationCondition;
+import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
+import com.sequenceiq.flow.api.model.operation.OperationResource;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+import com.sequenceiq.flow.converter.OperationDetailsPopulator;
+import com.sequenceiq.flow.service.FlowService;
+
+@Component
+public class OperationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OperationService.class);
+
+    private final OperationV4Endpoint operationV4Endpoint;
+
+    private final SdxService sdxService;
+
+    private final DatabaseService databaseService;
+
+    private final FlowService flowService;
+
+    private final OperationDetailsPopulator operationDetailsPopulator;
+
+    public OperationService(OperationV4Endpoint operationV4Endpoint, SdxService sdxService, DatabaseService databaseService, FlowService flowService,
+            OperationDetailsPopulator operationDetailsPopulator) {
+        this.operationV4Endpoint = operationV4Endpoint;
+        this.sdxService = sdxService;
+        this.databaseService = databaseService;
+        this.flowService = flowService;
+        this.operationDetailsPopulator = operationDetailsPopulator;
+    }
+
+    public OperationView getOperationProgressByResourceCrn(String resourceCrn, boolean detailed) {
+        OperationView sdxOperationView = new OperationView();
+        Optional<OperationFlowsView> operationFlowsViewOpt = flowService.getLastFlowOperationByResourceCrn(resourceCrn);
+        if (operationFlowsViewOpt.isPresent()) {
+            OperationFlowsView operationFlowsView = operationFlowsViewOpt.get();
+            OperationType operationType = operationFlowsView.getOperationType();
+            sdxOperationView = operationDetailsPopulator.createOperationView(operationFlowsView, OperationResource.DATALAKE);
+            if (OperationType.PROVISION.equals(operationType)) {
+                if (detailed) {
+                    handleProvisionOperation(resourceCrn, sdxOperationView, detailed);
+                } else {
+                    LOGGER.debug("Skipping detailed SDX provision operation response");
+                }
+            }
+        }
+        return sdxOperationView;
+    }
+
+    private void handleProvisionOperation(String resourceCrn, OperationView sdxOperationView, boolean detailed) {
+        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
+        SdxCluster sdxCluster = sdxService.getByCrn(userCrn, resourceCrn);
+        boolean createDb = sdxCluster.isCreateDatabase();
+        Map<OperationResource, OperationView> subOperations = new HashMap<>();
+        Map<OperationResource, OperationCondition> conditionMap = new HashMap<>();
+        conditionMap.put(OperationResource.DATALAKE, OperationCondition.REQUIRED);
+        if (createDb) {
+            conditionMap.put(OperationResource.REMOTEDB, OperationCondition.REQUIRED);
+            try {
+                OperationView rdbOperationView = databaseService.getOperationProgressStatus(sdxCluster.getDatabaseCrn(), detailed);
+                if (OperationType.PROVISION.equals(rdbOperationView.getOperationType())) {
+                    subOperations.put(OperationResource.REMOTEDB, rdbOperationView);
+                }
+            } catch (Exception e) {
+                LOGGER.warn("Error during fetching provision progress from remote database API. Skip filling remote database response.", e);
+            }
+        } else {
+            conditionMap.put(OperationResource.REMOTEDB, OperationCondition.NONE);
+        }
+        sdxOperationView.setSubOperationConditions(conditionMap);
+        try {
+            OperationView stackOperationProgressView = operationV4Endpoint.getOperationProgressByResourceCrn(resourceCrn, detailed);
+            if (OperationType.PROVISION.equals(stackOperationProgressView.getOperationType())) {
+                subOperations.put(OperationResource.DATALAKE, stackOperationProgressView);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Error during fetching provision progress from stack API. Skip filling stack progress response.", e);
+        }
+        sdxOperationView.setSubOperations(subOperations);
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
@@ -31,6 +31,7 @@ public class EnvironmentOpDescription {
         "Endpoint Access Gateway if it's enabled. Environment is specified by CRN.";
     public static final String GET_LAST_FLOW_PROGRESS = "Get last flow operation progress details for resource by resource crn";
     public static final String LIST_FLOW_PROGRESS = "List recent flow operations progress details for resource by resource crn";
+    public static final String GET_OPERATION = "Get flow operation progress details for resource by resource crn";
 
     private EnvironmentOpDescription() {
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/operation/endpoint/OperationEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/operation/endpoint/OperationEndpoint.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.environment.api.v1.operation.endpoint;
+
+import static com.sequenceiq.environment.api.doc.environment.EnvironmentDescription.ENVIRONMENT_NOTES;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.environment.api.doc.environment.EnvironmentOpDescription;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Path("/v1/operation")
+@RetryAndMetrics
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(value = "/v1/operation", protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+public interface OperationEndpoint {
+
+    @GET
+    @Path("/resource/crn/{resourceCrn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.GET_OPERATION, produces = "application/json", notes = ENVIRONMENT_NOTES,
+            nickname = "getOperationProgressByResourceCrn")
+    OperationView getOperationProgressByResourceCrn(@PathParam("resourceCrn") String resourceCrn,
+            @DefaultValue("false") @QueryParam("detailed") boolean detailed);
+}

--- a/environment/src/main/java/com/sequenceiq/environment/configuration/api/EndpointConfig.java
+++ b/environment/src/main/java/com/sequenceiq/environment/configuration/api/EndpointConfig.java
@@ -18,6 +18,7 @@ import com.sequenceiq.environment.credential.v1.AuditCredentialV1Controller;
 import com.sequenceiq.environment.credential.v1.CredentialInternalV1Controller;
 import com.sequenceiq.environment.credential.v1.CredentialV1Controller;
 import com.sequenceiq.environment.environment.v1.EnvironmentController;
+import com.sequenceiq.environment.operation.v1.OperationController;
 import com.sequenceiq.environment.platformresource.v1.CredentialPlatformResourceController;
 import com.sequenceiq.environment.platformresource.v1.EnvironmentPlatformResourceController;
 import com.sequenceiq.environment.proxy.v1.controller.ProxyController;
@@ -45,6 +46,7 @@ public class EndpointConfig extends ResourceConfig {
             AccountTelemetryController.class,
             ProxyController.class,
             EnvironmentController.class,
+            OperationController.class,
             CredentialPlatformResourceController.class,
             EnvironmentPlatformResourceController.class,
             UtilController.class,

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/config/EnvCreationFlowConfig.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/config/EnvCreationFlowConfig.java
@@ -27,6 +27,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.environment.environment.flow.creation.EnvCreationState;
 import com.sequenceiq.environment.environment.flow.creation.event.EnvCreationStateSelectors;
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
 
@@ -116,5 +117,10 @@ public class EnvCreationFlowConfig extends AbstractFlowConfiguration<EnvCreation
     @Override
     protected FlowEdgeConfig<EnvCreationState, EnvCreationStateSelectors> getEdgeConfig() {
         return EDGE_CONFIG;
+    }
+
+    @Override
+    public OperationType getFlowOperationType() {
+        return OperationType.PROVISION;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentProgressService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentProgressService.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.environment.environment.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import com.sequenceiq.flow.converter.OperationDetailsPopulator;
+import com.sequenceiq.environment.environment.service.freeipa.FreeIpaService;
+import com.sequenceiq.flow.api.model.FlowProgressResponse;
+import com.sequenceiq.flow.service.FlowService;
+
+@Service
+public class EnvironmentProgressService {
+
+    private final EnvironmentService environmentService;
+
+    private final FlowService flowService;
+
+    private final FreeIpaService freeIpaService;
+
+    private final OperationDetailsPopulator operationDetailsPopulator;
+
+    public EnvironmentProgressService(EnvironmentService environmentService, FlowService flowService, FreeIpaService freeIpaService,
+            OperationDetailsPopulator operationDetailsPopulator) {
+        this.environmentService = environmentService;
+        this.flowService = flowService;
+        this.freeIpaService = freeIpaService;
+        this.operationDetailsPopulator = operationDetailsPopulator;
+    }
+
+    public FlowProgressResponse getLastFlowProgressByResourceCrn(String resourceCrn) {
+        return flowService.getLastFlowProgressByResourceCrn(resourceCrn);
+    }
+
+    public List<FlowProgressResponse> getFlowProgressListByResourceCrn(String resourceCrn) {
+        return flowService.getFlowProgressListByResourceCrn(resourceCrn);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentService.java
@@ -34,6 +34,7 @@ import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.altus.service.RoleCrnGenerator;
 import com.sequenceiq.cloudbreak.cloud.model.CloudRegions;
 import com.sequenceiq.cloudbreak.cloud.model.Coordinate;
+import com.sequenceiq.cloudbreak.common.event.PayloadContext;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
@@ -53,13 +54,15 @@ import com.sequenceiq.environment.environment.v1.cli.DelegatingCliEnvironmentReq
 import com.sequenceiq.environment.environment.validation.EnvironmentValidatorService;
 import com.sequenceiq.environment.platformresource.PlatformParameterService;
 import com.sequenceiq.environment.platformresource.PlatformResourceRequest;
+import com.sequenceiq.flow.core.PayloadContextProvider;
 import com.sequenceiq.flow.core.ResourceIdProvider;
 
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 
 @Service
-public class EnvironmentService extends AbstractAccountAwareResourceService<Environment> implements ResourceIdProvider, ResourcePropertyProvider {
+public class EnvironmentService extends AbstractAccountAwareResourceService<Environment>
+        implements ResourceIdProvider, ResourcePropertyProvider, PayloadContextProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentService.class);
 
@@ -348,6 +351,16 @@ public class EnvironmentService extends AbstractAccountAwareResourceService<Envi
     @Override
     public Long getResourceIdByResourceName(String resourceName) {
         return getByNameAndAccountId(resourceName, ThreadBasedUserCrnProvider.getAccountId()).getId();
+    }
+
+    @Override
+    public PayloadContext getPayloadContext(Long resourceId) {
+        Optional<EnvironmentDto> environmentDtoOpt = findById(resourceId);
+        if (environmentDtoOpt.isPresent()) {
+            EnvironmentDto environmentDto = environmentDtoOpt.get();
+            return PayloadContext.create(environmentDto.getResourceCrn(), environmentDto.getCloudPlatform());
+        }
+        return null;
     }
 
     @Override

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/freeipa/FreeIpaService.java
@@ -14,6 +14,7 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.common.exception.ExceptionResponse;
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
+import com.sequenceiq.flow.api.model.operation.OperationView;
 import com.sequenceiq.environment.exception.FreeIpaOperationFailedException;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.attachchildenv.AttachChildEnvironmentRequest;
@@ -24,6 +25,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFre
 import com.sequenceiq.freeipa.api.v1.freeipa.user.UserV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SyncOperationStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SynchronizeAllUsersRequest;
+import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
 
 @Service
 public class FreeIpaService {
@@ -32,14 +34,18 @@ public class FreeIpaService {
 
     private final FreeIpaV1Endpoint freeIpaV1Endpoint;
 
+    private final OperationV1Endpoint operationV1Endpoint;
+
     private final UserV1Endpoint userV1Endpoint;
 
     private final WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor;
 
     public FreeIpaService(FreeIpaV1Endpoint freeIpaV1Endpoint,
+            OperationV1Endpoint operationV1Endpoint,
             UserV1Endpoint userV1Endpoint,
             WebApplicationExceptionMessageExtractor webApplicationExceptionMessageExtractor) {
         this.freeIpaV1Endpoint = freeIpaV1Endpoint;
+        this.operationV1Endpoint = operationV1Endpoint;
         this.userV1Endpoint = userV1Endpoint;
         this.webApplicationExceptionMessageExtractor = webApplicationExceptionMessageExtractor;
     }
@@ -139,6 +145,14 @@ public class FreeIpaService {
             LOGGER.error(String.format("Failed to get health details for the freeIpa of the given environment: '%s' due to: '%s'",
                     environmentCrn, errorMessage), e);
             throw new FreeIpaOperationFailedException(errorMessage, e);
+        }
+    }
+
+    public Optional<OperationView> getFreeIpaOperation(String environmentCrn, boolean detailed) {
+        try {
+            return Optional.ofNullable(operationV1Endpoint.getOperationProgressByEnvironmentCrn(environmentCrn, detailed));
+        } catch (WebApplicationException e) {
+            return Optional.empty();
         }
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
@@ -52,6 +52,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLo
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
+import com.sequenceiq.environment.environment.service.EnvironmentProgressService;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponses;
 import com.sequenceiq.environment.authorization.EnvironmentFiltering;
@@ -77,7 +78,6 @@ import com.sequenceiq.environment.environment.service.cloudstorage.CloudStorageV
 import com.sequenceiq.environment.environment.v1.converter.EnvironmentApiConverter;
 import com.sequenceiq.environment.environment.v1.converter.EnvironmentResponseConverter;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
-import com.sequenceiq.flow.service.FlowService;
 
 @Controller
 @Transactional(TxType.NEVER)
@@ -112,7 +112,7 @@ public class EnvironmentController implements EnvironmentEndpoint {
 
     private final EnvironmentLoadBalancerService environmentLoadBalancerService;
 
-    private final FlowService flowService;
+    private final EnvironmentProgressService environmentProgressService;
 
     private final EnvironmentFiltering environmentFiltering;
 
@@ -124,6 +124,7 @@ public class EnvironmentController implements EnvironmentEndpoint {
             EnvironmentService environmentService,
             EnvironmentCreationService environmentCreationService,
             EnvironmentDeletionService environmentDeletionService,
+            EnvironmentProgressService environmentProgressService,
             EnvironmentModificationService environmentModificationService,
             EnvironmentStartService environmentStartService,
             EnvironmentStopService environmentStopService,
@@ -132,7 +133,6 @@ public class EnvironmentController implements EnvironmentEndpoint {
             EnvironmentStackConfigUpdateService stackConfigUpdateService,
             EntitlementService entitlementService,
             EnvironmentLoadBalancerService environmentLoadBalancerService,
-            FlowService flowService,
             EnvironmentFiltering environmentFiltering,
             CloudStorageValidator cloudStorageValidator) {
         this.environmentApiConverter = environmentApiConverter;
@@ -140,6 +140,7 @@ public class EnvironmentController implements EnvironmentEndpoint {
         this.environmentService = environmentService;
         this.environmentCreationService = environmentCreationService;
         this.environmentDeletionService = environmentDeletionService;
+        this.environmentProgressService = environmentProgressService;
         this.environmentModificationService = environmentModificationService;
         this.environmentStartService = environmentStartService;
         this.environmentStopService = environmentStopService;
@@ -148,7 +149,6 @@ public class EnvironmentController implements EnvironmentEndpoint {
         this.stackConfigUpdateService = stackConfigUpdateService;
         this.entitlementService = entitlementService;
         this.environmentLoadBalancerService = environmentLoadBalancerService;
-        this.flowService = flowService;
         this.environmentFiltering = environmentFiltering;
         this.cloudStorageValidator = cloudStorageValidator;
     }
@@ -400,13 +400,13 @@ public class EnvironmentController implements EnvironmentEndpoint {
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)
     public FlowProgressResponse getLastFlowLogProgressByResourceCrn(@ResourceCrn String resourceCrn) {
-        return flowService.getLastFlowProgressByResourceCrn(resourceCrn);
+        return environmentProgressService.getLastFlowProgressByResourceCrn(resourceCrn);
     }
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)
     public List<FlowProgressResponse> getFlowLogsProgressByResourceCrn(@ResourceCrn String resourceCrn) {
-        return flowService.getFlowProgressListByResourceCrn(resourceCrn);
+        return environmentProgressService.getFlowProgressListByResourceCrn(resourceCrn);
     }
 
     @Override

--- a/environment/src/main/java/com/sequenceiq/environment/operation/service/OperationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/operation/service/OperationService.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.environment.operation.service;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.service.EnvironmentService;
+import com.sequenceiq.environment.environment.service.freeipa.FreeIpaService;
+import com.sequenceiq.flow.api.model.operation.OperationCondition;
+import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
+import com.sequenceiq.flow.api.model.operation.OperationResource;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+import com.sequenceiq.flow.converter.OperationDetailsPopulator;
+import com.sequenceiq.flow.service.FlowService;
+
+@Service
+public class OperationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OperationService.class);
+
+    private final EnvironmentService environmentService;
+
+    private final FlowService flowService;
+
+    private final FreeIpaService freeIpaService;
+
+    private final OperationDetailsPopulator operationDetailsPopulator;
+
+    public OperationService(EnvironmentService environmentService, FlowService flowService, FreeIpaService freeIpaService,
+            OperationDetailsPopulator operationDetailsPopulator) {
+        this.environmentService = environmentService;
+        this.flowService = flowService;
+        this.freeIpaService = freeIpaService;
+        this.operationDetailsPopulator = operationDetailsPopulator;
+    }
+
+    public OperationView getOperationProgressByResourceCrn(String resourceCrn, boolean detailed) {
+        OperationView response = new OperationView();
+        Optional<OperationFlowsView> operationFlowsViewOpt = flowService.getLastFlowOperationByResourceCrn(resourceCrn);
+        if (operationFlowsViewOpt.isPresent()) {
+            OperationFlowsView operationFlowsView = operationFlowsViewOpt.get();
+            OperationType operationType = operationFlowsView.getOperationType();
+            response = operationDetailsPopulator.createOperationView(operationFlowsView, OperationResource.ENVIRONMENT);
+            if (OperationType.PROVISION.equals(operationType)) {
+                if (detailed) {
+                    handleProvisionOperation(resourceCrn, response, detailed);
+                } else {
+                    LOGGER.debug("Skipping detailed environment provision operation response");
+                }
+            }
+        }
+        return response;
+    }
+
+    private void handleProvisionOperation(String resourceCrn, OperationView response, boolean detailed) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        EnvironmentDto envDto = environmentService.getByCrnAndAccountId(resourceCrn, accountId);
+        boolean needsFreeipa = envDto.getFreeIpaCreation().getCreate();
+        if (needsFreeipa) {
+            Optional<OperationView> freeIpaFlows = freeIpaService.getFreeIpaOperation(resourceCrn, detailed);
+            response.setSubOperationConditions(Map.of(OperationResource.FREEIPA, OperationCondition.REQUIRED));
+            if (freeIpaFlows.isPresent()) {
+                OperationView freeIpaOpView = freeIpaFlows.get();
+                if (OperationType.PROVISION.equals(freeIpaOpView.getOperationType())) {
+                    response.setSubOperations(Map.of(OperationResource.FREEIPA, freeIpaOpView));
+                }
+            }
+        } else {
+            response.setSubOperationConditions(Map.of(OperationResource.FREEIPA, OperationCondition.NONE));
+        }
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/operation/v1/OperationController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/operation/v1/OperationController.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.environment.operation.v1;
+
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Controller;
+
+import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
+import com.sequenceiq.authorization.annotation.ResourceCrn;
+import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
+import com.sequenceiq.environment.api.v1.operation.endpoint.OperationEndpoint;
+import com.sequenceiq.environment.operation.service.OperationService;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+
+@Controller
+@Transactional(Transactional.TxType.NEVER)
+public class OperationController implements OperationEndpoint {
+
+    private final OperationService operationService;
+
+    public OperationController(OperationService operationService) {
+        this.operationService = operationService;
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)
+    public OperationView getOperationProgressByResourceCrn(@ResourceCrn String resourceCrn, boolean detailed) {
+        return operationService.getOperationProgressByResourceCrn(resourceCrn, detailed);
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/service/integration/CredentialExperienceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/service/integration/CredentialExperienceTest.java
@@ -70,6 +70,7 @@ import com.sequenceiq.environment.metrics.EnvironmentMetricService;
 import com.sequenceiq.environment.user.UserPreferences;
 import com.sequenceiq.environment.user.UserPreferencesRepository;
 import com.sequenceiq.environment.user.UserPreferencesService;
+import com.sequenceiq.flow.core.stats.FlowOperationStatisticsService;
 import com.sequenceiq.flow.repository.FlowChainLogRepository;
 import com.sequenceiq.flow.repository.FlowLogRepository;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
@@ -297,6 +298,9 @@ public class CredentialExperienceTest {
 
         @MockBean
         private Scheduler scheduler;
+
+        @MockBean
+        private FlowOperationStatisticsService flowOperationStatisticsService;
 
         @Bean
         public Dispatcher dispatcher(MDCCleanerThreadPoolExecutor threadPoolExecutor) {

--- a/flow-api/src/main/java/com/sequenceiq/flow/api/model/FlowProgressResponse.java
+++ b/flow-api/src/main/java/com/sequenceiq/flow/api/model/FlowProgressResponse.java
@@ -24,6 +24,8 @@ public class FlowProgressResponse implements Serializable {
 
     private Boolean finalized;
 
+    private Integer maxNumberOfTransitions;
+
     public Integer getProgress() {
         return progress;
     }
@@ -86,5 +88,13 @@ public class FlowProgressResponse implements Serializable {
 
     public void setResourceCrn(String resourceCrn) {
         this.resourceCrn = resourceCrn;
+    }
+
+    public Integer getMaxNumberOfTransitions() {
+        return maxNumberOfTransitions;
+    }
+
+    public void setMaxNumberOfTransitions(Integer maxNumberOfTransitions) {
+        this.maxNumberOfTransitions = maxNumberOfTransitions;
     }
 }

--- a/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationCondition.java
+++ b/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationCondition.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.flow.api.model.operation;
+
+public enum OperationCondition {
+    NONE, REQUIRED;
+
+    public static OperationCondition fromBoolean(boolean value) {
+        return value ? REQUIRED : NONE;
+    }
+}

--- a/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationFlowsView.java
+++ b/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationFlowsView.java
@@ -1,0 +1,122 @@
+package com.sequenceiq.flow.api.model.operation;
+
+import java.util.List;
+import java.util.Map;
+
+import com.sequenceiq.flow.api.model.FlowProgressResponse;
+
+public class OperationFlowsView {
+
+    private final OperationType operationType;
+
+    private final Map<String, FlowProgressResponse> flowTypeProgressMap;
+
+    private final List<String> typeOrderList;
+
+    private final boolean inMemory;
+
+    private final Integer progressFromHistory;
+
+    private final String operationId;
+
+    private OperationFlowsView(Builder builder) {
+        this.operationType = builder.operationType;
+        this.flowTypeProgressMap = builder.flowTypeProgressMap;
+        this.typeOrderList = builder.typeOrderList;
+        this.inMemory = builder.inMemory;
+        this.progressFromHistory = builder.progressFromHistory;
+        this.operationId = builder.operationId;
+    }
+
+    public OperationType getOperationType() {
+        return operationType;
+    }
+
+    public Map<String, FlowProgressResponse> getFlowTypeProgressMap() {
+        return flowTypeProgressMap;
+    }
+
+    public List<String> getTypeOrderList() {
+        return typeOrderList;
+    }
+
+    public Integer getProgressFromHistory() {
+        return progressFromHistory;
+    }
+
+    public boolean isInMemory() {
+        return inMemory;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    @Override
+    public String toString() {
+        return "OperationFlowsView{" +
+                "operationType=" + operationType +
+                ", flowTypeProgressMap=" + flowTypeProgressMap +
+                ", typeOrderList=" + typeOrderList +
+                ", inMemory=" + inMemory +
+                ", progressFromHistory=" + progressFromHistory +
+                ", operationId='" + operationId + '\'' +
+                '}';
+    }
+
+    public static class Builder {
+
+        private OperationType operationType;
+
+        private Map<String, FlowProgressResponse> flowTypeProgressMap;
+
+        private List<String> typeOrderList;
+
+        private boolean inMemory;
+
+        private Integer progressFromHistory;
+
+        private String operationId;
+
+        private Builder() {
+        }
+
+        public static Builder newBuilder() {
+            return new Builder();
+        }
+
+        public OperationFlowsView build() {
+            return new OperationFlowsView(this);
+        }
+
+        public Builder withOperationType(OperationType operationType) {
+            this.operationType = operationType;
+            return this;
+        }
+
+        public Builder withFlowTypeProgressMap(Map<String, FlowProgressResponse> flowTypeProgressMap) {
+            this.flowTypeProgressMap = flowTypeProgressMap;
+            return this;
+        }
+
+        public Builder withTypeOrderList(List<String> typeOrderList) {
+            this.typeOrderList = typeOrderList;
+            return this;
+        }
+
+        public Builder withInMemory(boolean inMemory) {
+            this.inMemory = inMemory;
+            return this;
+        }
+
+        public Builder withProgressFromHistory(Integer progressFromHistory) {
+            this.progressFromHistory = progressFromHistory;
+            return this;
+        }
+
+        public Builder withOperationId(String operationId) {
+            this.operationId = operationId;
+            return this;
+        }
+    }
+}

--- a/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationProgressStatus.java
+++ b/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationProgressStatus.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.flow.api.model.operation;
+
+public enum OperationProgressStatus {
+    UNKNOWN, RUNNING, FINISHED, CANCELLED, FAILED;
+}

--- a/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationResource.java
+++ b/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationResource.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.flow.api.model.operation;
+
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+
+public enum OperationResource {
+    UNKNOWN, ENVIRONMENT, FREEIPA, DATALAKE, DATAHUB, REMOTEDB;
+
+    public static OperationResource fromCrn(Crn crn) {
+        Crn.Service service = crn.getService();
+        if (Crn.Service.DATALAKE.equals(service)) {
+            return DATALAKE;
+        } else if (Crn.Service.DATAHUB.equals(service)) {
+            return DATAHUB;
+        } else if (Crn.Service.ENVIRONMENTS.equals(service)) {
+            return ENVIRONMENT;
+        } else if (Crn.Service.FREEIPA.equals(service)) {
+            return FREEIPA;
+        } else if (Crn.Service.REDBEAMS.equals(service)) {
+            return REMOTEDB;
+        } else {
+            return UNKNOWN;
+        }
+    }
+
+}

--- a/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationType.java
+++ b/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationType.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.flow.api.model.operation;
+
+public enum OperationType {
+    UNKNOWN, PROVISION, DIAGNOSTICS;
+}

--- a/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationView.java
+++ b/flow-api/src/main/java/com/sequenceiq/flow/api/model/operation/OperationView.java
@@ -1,0 +1,110 @@
+package com.sequenceiq.flow.api.model.operation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.sequenceiq.flow.api.model.FlowProgressResponse;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OperationView implements Serializable {
+
+    private static final int DEFAULT_PROGRESS = -1;
+
+    private String operationId;
+
+    private OperationType operationType = OperationType.UNKNOWN;
+
+    private OperationResource operationResource = OperationResource.UNKNOWN;
+
+    private List<FlowProgressResponse> operations = new ArrayList<>();
+
+    private Map<OperationResource, OperationView> subOperations = new HashMap<>();
+
+    private Map<OperationResource, OperationCondition> subOperationConditions = new HashMap<>();
+
+    private OperationProgressStatus progressStatus = OperationProgressStatus.UNKNOWN;
+
+    private Integer progress = DEFAULT_PROGRESS;
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    public void setOperationId(String operationId) {
+        this.operationId = operationId;
+    }
+
+    public OperationType getOperationType() {
+        return operationType;
+    }
+
+    public void setOperationType(OperationType operationType) {
+        this.operationType = operationType;
+    }
+
+    public List<FlowProgressResponse> getOperations() {
+        return operations;
+    }
+
+    public void setOperations(List<FlowProgressResponse> operations) {
+        this.operations = operations;
+    }
+
+    public OperationResource getOperationResource() {
+        return operationResource;
+    }
+
+    public void setOperationResource(OperationResource operationResource) {
+        this.operationResource = operationResource;
+    }
+
+    public Map<OperationResource, OperationView> getSubOperations() {
+        return subOperations;
+    }
+
+    public void setSubOperations(Map<OperationResource, OperationView> subOperations) {
+        this.subOperations = subOperations;
+    }
+
+    public Map<OperationResource, OperationCondition> getSubOperationConditions() {
+        return subOperationConditions;
+    }
+
+    public void setSubOperationConditions(Map<OperationResource, OperationCondition> subOperationConditions) {
+        this.subOperationConditions = subOperationConditions;
+    }
+
+    public OperationProgressStatus getProgressStatus() {
+        return progressStatus;
+    }
+
+    public void setProgressStatus(OperationProgressStatus progressStatus) {
+        this.progressStatus = progressStatus;
+    }
+
+    public Integer getProgress() {
+        return progress;
+    }
+
+    public void setProgress(Integer progress) {
+        this.progress = progress;
+    }
+
+    @Override
+    public String toString() {
+        return "OperationView{" +
+                "operationId='" + operationId + '\'' +
+                ", operationType=" + operationType +
+                ", operationResource=" + operationResource +
+                ", operations=" + operations +
+                ", subOperations=" + subOperations +
+                ", subOperationConditions=" + subOperationConditions +
+                ", progressStatus=" + progressStatus +
+                ", progress=" + progress +
+                '}';
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/cleanup/InMemoryCleanup.java
+++ b/flow/src/main/java/com/sequenceiq/flow/cleanup/InMemoryCleanup.java
@@ -8,6 +8,7 @@ import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryResourceStateStore;
 import com.sequenceiq.flow.core.FlowRegister;
 import com.sequenceiq.flow.core.chain.FlowChains;
+import com.sequenceiq.flow.core.cache.FlowStatCache;
 
 @Component
 public class InMemoryCleanup {
@@ -17,6 +18,9 @@ public class InMemoryCleanup {
 
     @Inject
     private FlowChains flowChains;
+
+    @Inject
+    private FlowStatCache flowStatCache;
 
     public void cancelEveryFlowWithoutDbUpdate() {
         for (String resourceType : InMemoryResourceStateStore.getResourceTypes()) {
@@ -32,9 +36,10 @@ public class InMemoryCleanup {
     public void cancelFlowWithoutDbUpdate(String flowId) {
         String flowChainId = runningFlows.getFlowChainId(flowId);
         if (flowChainId != null) {
-            flowChains.removeFullFlowChain(flowChainId);
+            flowChains.removeFullFlowChain(flowChainId, false);
         }
         runningFlows.remove(flowId);
+        flowStatCache.remove(flowId, false);
     }
 
 }

--- a/flow/src/main/java/com/sequenceiq/flow/converter/FlowProgressResponseConverter.java
+++ b/flow/src/main/java/com/sequenceiq/flow/converter/FlowProgressResponseConverter.java
@@ -21,6 +21,8 @@ public class FlowProgressResponseConverter {
 
     private static final int UNKNOWN_PROGRESS_PERCENTAGE = -1;
 
+    private static final int FINISHED_PERCENTAGE = 100;
+
     private static final double MILLISEC_TO_SEC_DOUBLE_DEVIDER = 1000d;
 
     private final FlowProgressHolder flowProgressHolder;
@@ -51,6 +53,9 @@ public class FlowProgressResponseConverter {
             response.setProgress(flowTypeOpt.map(s ->
                     flowProgressHolder.getProgressPercentageForState(s, lastFlowLog.getCurrentState()))
                     .orElse(UNKNOWN_PROGRESS_PERCENTAGE));
+            response.setMaxNumberOfTransitions(flowTypeOpt
+                    .map(flowProgressHolder::getTransitionsSize)
+                    .orElse(null));
             List<FlowLog> reversedFlowLogs = flowLogs.stream().
                     sorted(Comparator.comparingLong(FlowLog::getCreated))
                     .collect(Collectors.toList());
@@ -59,6 +64,7 @@ public class FlowProgressResponseConverter {
             response.setCreated(firstFlowLog.getCreated());
             if (lastFlowLog.getFinalized()) {
                 response.setElapsedTimeInSeconds(getRoundedTimeInSeconds(firstFlowLog.getCreated(), lastFlowLog.getCreated()));
+                response.setProgress(FINISHED_PERCENTAGE);
             } else {
                 response.setElapsedTimeInSeconds(getRoundedTimeInSeconds(firstFlowLog.getCreated(), new Date().getTime()));
             }

--- a/flow/src/main/java/com/sequenceiq/flow/converter/OperationDetailsPopulator.java
+++ b/flow/src/main/java/com/sequenceiq/flow/converter/OperationDetailsPopulator.java
@@ -1,0 +1,127 @@
+package com.sequenceiq.flow.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
+import com.sequenceiq.flow.api.model.operation.OperationResource;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+import com.sequenceiq.flow.api.model.operation.OperationProgressStatus;
+import com.sequenceiq.flow.api.model.FlowProgressResponse;
+import com.sequenceiq.flow.api.model.FlowStateTransitionResponse;
+import com.sequenceiq.flow.api.model.StateStatus;
+
+@Component
+public class OperationDetailsPopulator {
+
+    private static final int DEFAULT_PROGRESS = -1;
+
+    private static final int DEFAULT_EXPECTED_NUMBER_OF_OPERATIONS = 1;
+
+    private static final int MAX_PROGRESS = 100;
+
+    public OperationView createOperationView(OperationFlowsView operationFlowsView,
+            OperationResource resource) {
+        return createOperationView(operationFlowsView, resource, new ArrayList<>());
+    }
+
+    public OperationView createOperationView(OperationFlowsView operationFlowsView,
+            OperationResource resource, List<Class<?>> expectedTypeOrder) {
+        OperationView response = new OperationView();
+        response.setOperationType(operationFlowsView.getOperationType());
+        response.setOperationResource(resource);
+        if (operationFlowsView.isInMemory()) {
+            response.setProgressStatus(OperationProgressStatus.RUNNING);
+            response.setProgress(operationFlowsView.getProgressFromHistory());
+            response.setOperationId(operationFlowsView.getOperationId());
+        } else {
+            List<String> typeOrderList = CollectionUtils.isNotEmpty(expectedTypeOrder)
+                    ? expectedTypeOrder.stream().map(Class::getCanonicalName).collect(Collectors.toList())
+                    : operationFlowsView.getTypeOrderList();
+            int expectedNumberOfFlows = typeOrderList.size();
+            Map<String, FlowProgressResponse> flowTypeProgressMap = operationFlowsView.getFlowTypeProgressMap();
+            List<Optional<FlowProgressResponse>> responseListToProcess = new ArrayList<>();
+            for (String typeName : typeOrderList) {
+                if (flowTypeProgressMap.containsKey(typeName)) {
+                    responseListToProcess.add(Optional.of(flowTypeProgressMap.get(typeName)));
+                } else {
+                    responseListToProcess.add(Optional.empty());
+                }
+            }
+            populateOperationDetails(response, responseListToProcess, expectedNumberOfFlows);
+        }
+        return response;
+    }
+
+    private void populateOperationDetails(OperationView source,
+            List<Optional<FlowProgressResponse>> operations, int expectedNumberOfFlows) {
+        int preProgress = 0;
+        int overallProgress = 0;
+        boolean foundFlow = false;
+        boolean expectFlowChainId = operations.size() > 1;
+        for (Optional<FlowProgressResponse> operationOpt : operations) {
+            if (operationOpt.isPresent()) {
+                if (!foundFlow) {
+                    overallProgress += preProgress;
+                    source.setOperationId(operationOpt.get().getFlowId());
+                }
+                foundFlow = true;
+                FlowProgressResponse flowProgress = operationOpt.get();
+                if (flowProgress.getProgress() != DEFAULT_PROGRESS) {
+                    overallProgress += flowProgress.getProgress();
+                }
+                source.getOperations().add(flowProgress);
+            } else if (expectFlowChainId && !foundFlow) {
+                preProgress += MAX_PROGRESS;
+                operationOpt.ifPresent(flowProgressResponse -> source.setOperationId(flowProgressResponse.getFlowChainId()));
+            }
+        }
+        if (CollectionUtils.isNotEmpty(source.getOperations())) {
+            int fullProgress = overallProgress / expectedNumberOfFlows;
+            source.setProgress(fullProgress);
+            if (fullProgress == MAX_PROGRESS) {
+                source.setProgressStatus(calculateProgress(source.getOperations()));
+            } else {
+                source.setProgressStatus(OperationProgressStatus.RUNNING);
+            }
+        } else {
+            source.setProgress(DEFAULT_PROGRESS);
+            source.setProgressStatus(OperationProgressStatus.UNKNOWN);
+        }
+    }
+
+    private OperationProgressStatus calculateProgress(List<FlowProgressResponse> provisionFlows) {
+        FlowProgressResponse lastFlowProgress = provisionFlows.get(provisionFlows.size() - 1);
+        if (lastFlowProgress.getTransitions() == null) {
+            return OperationProgressStatus.UNKNOWN;
+        }
+        OperationProgressStatus progressStatus = OperationProgressStatus.FINISHED;
+        boolean hasCancelState = false;
+        boolean hasFailedStatus = false;
+        boolean hasPendingStatus = false;
+        for (FlowStateTransitionResponse fsTransitionResp : lastFlowProgress.getTransitions()) {
+            if (OperationProgressStatus.CANCELLED.name().equals(fsTransitionResp.getStatus())) {
+                hasCancelState = true;
+            } else if (StateStatus.FAILED.name().equals(fsTransitionResp.getStatus())) {
+                hasFailedStatus = true;
+            } else if (StateStatus.PENDING.name().equals(fsTransitionResp.getStatus())) {
+                hasPendingStatus = true;
+            }
+        }
+        if (hasFailedStatus) {
+            progressStatus = OperationProgressStatus.FAILED;
+        } else if (hasCancelState) {
+            progressStatus = OperationProgressStatus.CANCELLED;
+        } else if (hasPendingStatus) {
+            progressStatus = OperationProgressStatus.RUNNING;
+        }
+        return progressStatus;
+    }
+
+}

--- a/flow/src/main/java/com/sequenceiq/flow/converter/OperationTypeConverter.java
+++ b/flow/src/main/java/com/sequenceiq/flow/converter/OperationTypeConverter.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.flow.converter;
+
+import com.sequenceiq.cloudbreak.converter.DefaultEnumConverter;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+
+public class OperationTypeConverter extends DefaultEnumConverter<OperationType> {
+
+    @Override
+    public OperationType getDefault() {
+        return OperationType.UNKNOWN;
+    }
+
+    @Override
+    public OperationType convertToEntityAttribute(String attribute) {
+        if (attribute == null) {
+            attribute = OperationType.UNKNOWN.name();
+        }
+        return super.convertToEntityAttribute(attribute);
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/AbstractAction.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/AbstractAction.java
@@ -166,6 +166,7 @@ public abstract class AbstractAction<S extends FlowState, E extends FlowEvent, C
         headers.put(FlowConstants.FLOW_ID, flowParameters.getFlowId());
         headers.put(FlowConstants.FLOW_TRIGGER_USERCRN, flowParameters.getFlowTriggerUserCrn());
         headers.put(FlowConstants.SPAN_CONTEXT, flowParameters.getSpanContext());
+        headers.put(FlowConstants.FLOW_OPERATION_TYPE, flowParameters.getFlowOperationType());
         String flowChainId = runningFlows.getFlowChainId(flowParameters.getFlowId());
         if (flowChainId != null) {
             headers.put(FlowConstants.FLOW_CHAIN_ID, flowChainId);

--- a/flow/src/main/java/com/sequenceiq/flow/core/Flow.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/Flow.java
@@ -13,7 +13,8 @@ public interface Flow {
 
     void stop();
 
-    void sendEvent(String key, String flowTriggerUserCrn, Object object, SpanContext spanContext);
+    void sendEvent(String key, String flowTriggerUserCrn, Object object,
+            SpanContext spanContext, String operationType);
 
     FlowState getCurrentState();
 

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowAdapter.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowAdapter.java
@@ -81,8 +81,8 @@ public class FlowAdapter<S extends FlowState, E extends FlowEvent> implements Fl
     }
 
     @Override
-    public void sendEvent(String key, String flowTriggerUserCrn, Object payload, SpanContext spanContext) {
-        flowMachine.sendEvent(messageFactory.createMessage(flowId, flowTriggerUserCrn, eventConverter.convert(key), payload, spanContext));
+    public void sendEvent(String key, String flowTriggerUserCrn, Object payload, SpanContext spanContext, String operationType) {
+        flowMachine.sendEvent(messageFactory.createMessage(flowId, flowTriggerUserCrn, eventConverter.convert(key), payload, spanContext, operationType));
     }
 
     @Override

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowConstants.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowConstants.java
@@ -29,6 +29,8 @@ public class FlowConstants {
 
     public static final String TERMINATED_STATE = "TERMINATED";
 
+    public static final String FLOW_OPERATION_TYPE = "FLOW_OPERATION_TYPE";
+
     private FlowConstants() {
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowParameters.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowParameters.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.flow.core;
 
+import com.sequenceiq.flow.api.model.operation.OperationType;
+
 import io.opentracing.SpanContext;
 
 public class FlowParameters {
@@ -7,11 +9,21 @@ public class FlowParameters {
 
     private String flowTriggerUserCrn;
 
+    private String flowOperationType;
+
     private SpanContext spanContext;
 
     public FlowParameters(String flowId, String flowTriggerUserCrn, SpanContext spanContext) {
         this.flowId = flowId;
         this.flowTriggerUserCrn = flowTriggerUserCrn;
+        this.flowOperationType = OperationType.UNKNOWN.name();
+        this.spanContext = spanContext;
+    }
+
+    public FlowParameters(String flowId, String flowTriggerUserCrn, String flowOperationType, SpanContext spanContext) {
+        this.flowId = flowId;
+        this.flowTriggerUserCrn = flowTriggerUserCrn;
+        this.flowOperationType = flowOperationType;
         this.spanContext = spanContext;
     }
 
@@ -37,5 +49,13 @@ public class FlowParameters {
 
     public void setSpanContext(SpanContext spanContext) {
         this.spanContext = spanContext;
+    }
+
+    public String getFlowOperationType() {
+        return flowOperationType;
+    }
+
+    public void setFlowOperationType(String flowOperationType) {
+        this.flowOperationType = flowOperationType;
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/MessageFactory.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/MessageFactory.java
@@ -14,10 +14,10 @@ public class MessageFactory<E> {
         FLOW_ID, FLOW_TRIGGER_USERCRN, DATA, FLOW_PARAMETERS
     }
 
-    public Message<E> createMessage(String flowId, String flowTriggerUserCrn, E key, Object data, SpanContext spanContext) {
+    public Message<E> createMessage(String flowId, String flowTriggerUserCrn, E key, Object data, SpanContext spanContext, String operationType) {
         Map<String, Object> headers = new HashMap<>();
         headers.put(HEADERS.DATA.name(), data);
-        headers.put(HEADERS.FLOW_PARAMETERS.name(), new FlowParameters(flowId, flowTriggerUserCrn, spanContext));
+        headers.put(HEADERS.FLOW_PARAMETERS.name(), new FlowParameters(flowId, flowTriggerUserCrn, operationType, spanContext));
         return new GenericMessage<>(key, headers);
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/PayloadContextProvider.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/PayloadContextProvider.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.flow.core;
+
+import org.apache.commons.lang3.NotImplementedException;
+
+import com.sequenceiq.cloudbreak.common.event.PayloadContext;
+
+public interface PayloadContextProvider {
+
+    default PayloadContext getPayloadContext(Long resourceId) {
+        throw new NotImplementedException("You have to implement getPayloadContext for your resource to be able "
+                + "to use Flow API to get the payload context!");
+    }
+
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/cache/FlowStat.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/cache/FlowStat.java
@@ -1,0 +1,88 @@
+package com.sequenceiq.flow.core.cache;
+
+import com.sequenceiq.cloudbreak.common.event.PayloadContext;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.core.config.FlowConfiguration;
+
+public class FlowStat {
+
+    private String flowId;
+
+    private String flowChainId;
+
+    private Long startTime;
+
+    private boolean restored;
+
+    private Class<? extends FlowConfiguration<?>> flowType;
+
+    private Long resourceId;
+
+    private OperationType operationType;
+
+    private PayloadContext payloadContext;
+
+    public Long getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Long startTime) {
+        this.startTime = startTime;
+    }
+
+    public boolean isRestored() {
+        return restored;
+    }
+
+    public void setRestored(boolean restored) {
+        this.restored = restored;
+    }
+
+    public Class<? extends FlowConfiguration<?>> getFlowType() {
+        return flowType;
+    }
+
+    public void setFlowType(Class<? extends FlowConfiguration<?>> flowType) {
+        this.flowType = flowType;
+    }
+
+    public PayloadContext getPayloadContext() {
+        return payloadContext;
+    }
+
+    public void setPayloadContext(PayloadContext payloadContext) {
+        this.payloadContext = payloadContext;
+    }
+
+    public Long getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(Long resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    public String getFlowId() {
+        return flowId;
+    }
+
+    public void setFlowId(String flowId) {
+        this.flowId = flowId;
+    }
+
+    public String getFlowChainId() {
+        return flowChainId;
+    }
+
+    public void setFlowChainId(String flowChainId) {
+        this.flowChainId = flowChainId;
+    }
+
+    public OperationType getOperationType() {
+        return operationType;
+    }
+
+    public void setOperationType(OperationType operationType) {
+        this.operationType = operationType;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/cache/FlowStatCache.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/cache/FlowStatCache.java
@@ -1,0 +1,218 @@
+package com.sequenceiq.flow.core.cache;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.PayloadContext;
+import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.core.PayloadContextProvider;
+import com.sequenceiq.flow.core.config.FlowConfiguration;
+import com.sequenceiq.flow.core.stats.FlowOperationStatisticsService;
+
+@Component
+public class FlowStatCache {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowStatCache.class);
+
+    private static final int ONE_DAY = 1;
+
+    private final Map<String, FlowStat> flowIdStatCache = new HashMap<>();
+
+    private final Map<String, FlowStat> flowChainIdStatCache = new HashMap<>();
+
+    private final Map<String, FlowStat> resourceCrnFlowStatCache =  new HashMap<>();
+
+    private final Map<String, FlowStat> resourceCrnFlowChainStatCache = new HashMap<>();
+
+    private final PayloadContextProvider payloadContextProvider;
+
+    private final FlowOperationStatisticsService flowOperationStatisticsService;
+
+    public FlowStatCache(FlowOperationStatisticsService flowOperationStatisticsService, PayloadContextProvider payloadContextProvider) {
+        this.flowOperationStatisticsService = flowOperationStatisticsService;
+        this.payloadContextProvider = payloadContextProvider;
+    }
+
+    public void put(String flowId, String flowChainId, Long resourceId,
+            String operationType, Class<? extends FlowConfiguration<?>> flowConfigType, boolean restored) {
+        PayloadContext payloadContext = payloadContextProvider.getPayloadContext(resourceId);
+        if (payloadContext != null) {
+            FlowStat flowStat = new FlowStat();
+            flowStat.setFlowId(flowId);
+            flowStat.setFlowChainId(flowChainId);
+            flowStat.setResourceId(resourceId);
+            flowStat.setStartTime(new Date().getTime());
+            flowStat.setFlowType(flowConfigType);
+            flowStat.setOperationType(OperationType.valueOf(operationType));
+            flowStat.setPayloadContext(payloadContext);
+            flowStat.setRestored(restored);
+            flowIdStatCache.put(flowId, flowStat);
+            if (StringUtils.isNotBlank(payloadContext.getEnvironmentCrn())) {
+                resourceCrnFlowStatCache.put(payloadContext.getEnvironmentCrn(), flowStat);
+            }
+            resourceCrnFlowStatCache.put(payloadContext.getResourceCrn(), flowStat);
+        }
+    }
+
+    public void putByFlowChainId(String flowChainId, Long resourceId, String operationType, boolean restored) {
+        if (!flowChainIdStatCache.containsKey(flowChainId)) {
+            PayloadContext payloadContext = payloadContextProvider.getPayloadContext(resourceId);
+            if (payloadContext != null) {
+                FlowStat flowStat = new FlowStat();
+                flowStat.setFlowChainId(flowChainId);
+                flowStat.setResourceId(resourceId);
+                flowStat.setStartTime(new Date().getTime());
+                flowStat.setOperationType(OperationType.valueOf(operationType));
+                flowStat.setPayloadContext(payloadContext);
+                flowStat.setRestored(restored);
+                flowChainIdStatCache.put(flowChainId, flowStat);
+                if (StringUtils.isNotBlank(payloadContext.getEnvironmentCrn())) {
+                    resourceCrnFlowChainStatCache.put(payloadContext.getEnvironmentCrn(), flowStat);
+                }
+                resourceCrnFlowChainStatCache.put(payloadContext.getResourceCrn(), flowStat);
+            }
+        }
+    }
+
+    public void remove(String flowId, boolean store) {
+        if (flowIdStatCache.containsKey(flowId)) {
+            FlowStat flowStat = flowIdStatCache.get(flowId);
+            if (store && StringUtils.isBlank(flowStat.getFlowChainId())) {
+                flowOperationStatisticsService.save(flowStat);
+            }
+            PayloadContext payloadContext = flowStat.getPayloadContext();
+            resourceCrnFlowStatCache.remove(payloadContext.getResourceCrn());
+            if (StringUtils.isNotBlank(payloadContext.getEnvironmentCrn())) {
+                resourceCrnFlowStatCache.remove(payloadContext.getEnvironmentCrn());
+            }
+            flowIdStatCache.remove(flowId);
+        }
+    }
+
+    public void removeByFlowChainId(String flowChainId, boolean store) {
+        if (flowChainIdStatCache.containsKey(flowChainId)) {
+            FlowStat flowStat = flowChainIdStatCache.get(flowChainId);
+            if (store) {
+                flowOperationStatisticsService.save(flowStat);
+            }
+            PayloadContext payloadContext = flowStat.getPayloadContext();
+            resourceCrnFlowChainStatCache.remove(payloadContext.getResourceCrn());
+            if (StringUtils.isNotBlank(payloadContext.getEnvironmentCrn())) {
+                resourceCrnFlowChainStatCache.remove(payloadContext.getEnvironmentCrn());
+            }
+            flowChainIdStatCache.remove(flowChainId);
+        }
+    }
+
+    public FlowStat getFlowStatByFlowId(String flowId) {
+        return flowIdStatCache.get(flowId);
+    }
+
+    public FlowStat getFlowStatByFlowChainId(String flowChainId) {
+        return flowChainIdStatCache.get(flowChainId);
+    }
+
+    public FlowStat getFlowStatByResourceCrn(String resourceCrn) {
+        return resourceCrnFlowStatCache.get(resourceCrn);
+    }
+
+    public FlowStat getFlowChainStatByResourceCrn(String resourceCrn) {
+        return resourceCrnFlowChainStatCache.get(resourceCrn);
+    }
+
+    public Map<String, FlowStat> getFlowIdStatCache() {
+        return flowIdStatCache;
+    }
+
+    public Map<String, FlowStat> getFlowChainIdStatCache() {
+        return flowChainIdStatCache;
+    }
+
+    public Map<String, FlowStat> getResourceCrnFlowStatCache() {
+        return resourceCrnFlowStatCache;
+    }
+
+    public Map<String, FlowStat> getResourceCrnFlowChainStatCache() {
+        return resourceCrnFlowChainStatCache;
+    }
+
+    public Optional<OperationFlowsView> getOperationFlowByResourceCrn(String resourceCrn) {
+        if (getFlowChainStatByResourceCrn(resourceCrn) != null) {
+            FlowStat flowStat = getFlowChainStatByResourceCrn(resourceCrn);
+            if (OperationType.UNKNOWN.equals(flowStat.getOperationType())) {
+                return Optional.empty();
+            }
+            Integer progressFromHistory = flowOperationStatisticsService.getProgressFromHistory(flowStat);
+            return Optional.of(OperationFlowsView.Builder.newBuilder()
+                    .withOperationType(flowStat.getOperationType())
+                    .withInMemory(true)
+                    .withProgressFromHistory(progressFromHistory)
+                    .withOperationId(flowStat.getFlowChainId())
+                    .build());
+        } else if (getFlowStatByResourceCrn(resourceCrn) != null) {
+            FlowStat flowStat = getFlowStatByResourceCrn(resourceCrn);
+            if (OperationType.UNKNOWN.equals(flowStat.getOperationType())) {
+                return Optional.empty();
+            }
+            Integer progressFromHistory = flowOperationStatisticsService.getProgressFromHistory(flowStat);
+            return Optional.of(OperationFlowsView.Builder.newBuilder()
+                    .withOperationType(flowStat.getOperationType())
+                    .withInMemory(true)
+                    .withProgressFromHistory(progressFromHistory)
+                    .withOperationId(flowStat.getFlowId())
+                    .build());
+        }
+        return Optional.empty();
+    }
+
+    public void cleanOldCacheEntries(Set<String> runningFlowIds) {
+        LOGGER.debug("Executing flow stat cache cleanup. (In case of any error during flow finalization " +
+                "- cache entries remained inside the stat cache)");
+        List<FlowStat> oldFlowStatsByFlowId = flowIdStatCache.values().stream().filter(this::isStartTimeTooOld).collect(Collectors.toList());
+        oldFlowStatsByFlowId.forEach(fs -> {
+            if (!runningFlowIds.contains(fs.getFlowId())) {
+                flowIdStatCache.remove(fs.getFlowId());
+            }
+        });
+        List<FlowStat> oldFlowStatsByFlowChainId = flowChainIdStatCache.values().stream().filter(this::isStartTimeTooOld).collect(Collectors.toList());
+        oldFlowStatsByFlowChainId.forEach(fs -> flowChainIdStatCache.remove(fs.getFlowChainId()));
+        removeOldResourceCrnBasedFlowStat(resourceCrnFlowStatCache);
+        removeOldResourceCrnBasedFlowStat(resourceCrnFlowChainStatCache);
+        LOGGER.debug("Old flow stat cache entry cleanup finished");
+    }
+
+    private void removeOldResourceCrnBasedFlowStat(Map<String, FlowStat> resourceCrnBasedMap) {
+        List<FlowStat> oldFlowStatsByResourceCrnForFlowChains = resourceCrnBasedMap.values().stream()
+                .filter(this::isStartTimeTooOld).collect(Collectors.toList());
+        oldFlowStatsByResourceCrnForFlowChains.forEach(fs -> {
+            String resourceCrn = fs.getPayloadContext().getResourceCrn();
+            LOGGER.debug("Remove old cache entry from flow stat cache with crn {}", resourceCrn);
+            resourceCrnBasedMap.remove(resourceCrn);
+            String environmentCrn = fs.getPayloadContext().getEnvironmentCrn();
+            if (StringUtils.isNotBlank(environmentCrn) && resourceCrnBasedMap.containsKey(environmentCrn)
+                    && isStartTimeTooOld(resourceCrnBasedMap.get(environmentCrn))) {
+                LOGGER.debug("Remove old cache entry from flow stat cache with environment crn {}", environmentCrn);
+                resourceCrnBasedMap.remove(environmentCrn);
+            }
+        });
+    }
+
+    private boolean isStartTimeTooOld(FlowStat flowStat) {
+        Instant beforeTime = Instant.now().minus(ONE_DAY, ChronoUnit.DAYS);
+        Instant startTime = new Date(flowStat.getStartTime()).toInstant();
+        return startTime.isBefore(beforeTime);
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowEventChainFactory.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/FlowEventChainFactory.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.flow.core.chain;
 
 import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 
 public interface FlowEventChainFactory<P extends Payload> {
@@ -11,5 +12,9 @@ public interface FlowEventChainFactory<P extends Payload> {
 
     default String getName() {
         return getClass().getSimpleName();
+    }
+
+    default OperationType getFlowOperationType() {
+        return OperationType.UNKNOWN;
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/chain/config/FlowChainOperationTypeConfig.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/chain/config/FlowChainOperationTypeConfig.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.flow.core.chain.config;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+
+import org.springframework.context.annotation.Configuration;
+
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
+
+@Configuration
+public class FlowChainOperationTypeConfig {
+
+    @Resource
+    private List<FlowEventChainFactory<?>> flowChainFactories;
+
+    private final Map<String, OperationType> flowTypeOperationTypeMap = new HashMap<>();
+
+    @PostConstruct
+    public void init() {
+        for (FlowEventChainFactory<?> flowEventChainFactory : flowChainFactories) {
+            String flowType = flowEventChainFactory.getName();
+            OperationType operationType = flowEventChainFactory.getFlowOperationType();
+            if (flowTypeOperationTypeMap.get(flowType) != null) {
+                throw new UnsupportedOperationException("Flow type already registered: " + flowType);
+            }
+            flowTypeOperationTypeMap.put(flowType, operationType);
+        }
+    }
+
+    public Map<String, OperationType> getFlowTypeOperationTypeMap() {
+        return flowTypeOperationTypeMap;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/core/config/FlowConfiguration.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/config/FlowConfiguration.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.flow.core.config;
 
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.Flow;
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowTriggerCondition;
@@ -18,4 +19,13 @@ public interface FlowConfiguration<E extends FlowEvent> {
     RestartAction getRestartAction(String event);
 
     String getDisplayName();
+
+    /**
+     * Obtain flow config operation type.
+     * Override this function to use a not UNKNOWN value for the flow config.
+     * If flow is in a flow chain, operation type of the flow chain will override this value.
+     */
+    default OperationType getFlowOperationType() {
+        return OperationType.UNKNOWN;
+    }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/config/FlowProgressHolder.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/config/FlowProgressHolder.java
@@ -22,6 +22,8 @@ public class FlowProgressHolder {
 
     private final Map<String, Map<String, Integer>> flowProgressState = new HashMap<>();
 
+    private final Map<String, Integer> transitionsSizeMap = new HashMap<>();
+
     private final List<? extends AbstractFlowConfiguration> flowConfigurations;
 
     public FlowProgressHolder(List<? extends AbstractFlowConfiguration> flowConfigurations) {
@@ -38,7 +40,9 @@ public class FlowProgressHolder {
             progressMap.put(edgeConfig.getInitState().toString(), MIN_PERCENT);
             progressMap.put(edgeConfig.getFinalState().toString(), MAX_PERCENT);
             progressMap.put(edgeConfig.getDefaultFailureState().toString(), MAX_PERCENT);
-            Iterator<AbstractFlowConfiguration.Transition> it = flowConfiguration.getTransitions().iterator();
+            List<AbstractFlowConfiguration.Transition> transitionList = flowConfiguration.getTransitions();
+            transitionsSizeMap.put(flowKey, transitionList.size());
+            Iterator<AbstractFlowConfiguration.Transition> it = transitionList.iterator();
             for (int index = 0; it.hasNext(); index++) {
                 AbstractFlowConfiguration.Transition transition = it.next();
                 double progress = calculatePercentage(index + 1, numberOfTransitions);
@@ -71,6 +75,10 @@ public class FlowProgressHolder {
             result = MAX_PERCENT;
         }
         return result;
+    }
+
+    public int getTransitionsSize(String className) {
+        return transitionsSizeMap.getOrDefault(className, 0);
     }
 
     private double calculatePercentage(double obtained, double total) {

--- a/flow/src/main/java/com/sequenceiq/flow/core/stats/FlowOperationStatisticsService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/stats/FlowOperationStatisticsService.java
@@ -1,0 +1,143 @@
+package com.sequenceiq.flow.core.stats;
+
+import java.text.DecimalFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.EvictingQueue;
+import com.sequenceiq.cloudbreak.common.event.PayloadContext;
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.core.cache.FlowStat;
+import com.sequenceiq.flow.domain.FlowOperationStats;
+import com.sequenceiq.flow.repository.FlowOperationStatsRepository;
+
+@Component
+public class FlowOperationStatisticsService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FlowOperationStatisticsService.class);
+
+    private static final double MILLISEC_TO_SEC_DOUBLE_DEVIDER = 1000d;
+
+    private static final double DEFAULT_GUESSED_AVG_TIME_SEC = 720d;
+
+    private static final Integer ALMOST_DONE_PROGRESS = 99;
+
+    private static final Integer DONE_PROGRESS = 100;
+
+    private static final Integer DEFAULT_PROGRESS = -1;
+
+    private static final Integer MAX_FLOW_STAT_SIZE = 10;
+
+    private final Map<String, Double> cloudOperationAverageTimeMap = new HashMap<>();
+
+    private final FlowOperationStatsRepository flowOperationStatsRepository;
+
+    private final TransactionService transactionService;
+
+    public FlowOperationStatisticsService(FlowOperationStatsRepository flowOperationStatsRepository, TransactionService transactionService) {
+        this.flowOperationStatsRepository = flowOperationStatsRepository;
+        this.transactionService = transactionService;
+    }
+
+    public Double getExpectedAverageTimeForOperation(OperationType operationType, String cloudPlatform) {
+        return cloudOperationAverageTimeMap.getOrDefault(createOperationCloudPlatformKey(operationType, cloudPlatform), DEFAULT_GUESSED_AVG_TIME_SEC);
+    }
+
+    public synchronized void updateOperationAverageTime(OperationType operationType, String cloudPlatform, String durationHistory) {
+        if (StringUtils.isNotBlank(durationHistory)) {
+            Double newExpectedAvgTime = Splitter.on(",").splitToList(durationHistory).stream()
+                    .mapToDouble(Double::parseDouble).average().orElse(0.0);
+            cloudOperationAverageTimeMap.put(createOperationCloudPlatformKey(operationType, cloudPlatform), newExpectedAvgTime);
+        }
+    }
+
+    @PostConstruct
+    public void load() {
+        LOGGER.debug("Load all flow statistics ...");
+        flowOperationStatsRepository.findAll()
+                .forEach(flowOpStat ->
+                        updateOperationAverageTime(flowOpStat.getOperationType(), flowOpStat.getCloudPlatform(), flowOpStat.getDurationHistory())
+                );
+        LOGGER.debug("Flow statistics map size: {}", cloudOperationAverageTimeMap.size());
+    }
+
+    public synchronized void save(FlowStat flowStat) {
+        if (OperationType.UNKNOWN.equals(flowStat.getOperationType()) || flowStat.getPayloadContext() == null) {
+            return;
+        }
+        if (flowStat.isRestored()) {
+            LOGGER.debug("Flow was restored, so statistics won't be saved about that. (operation: {})", flowStat.getOperationType());
+            return;
+        }
+        try {
+            OperationType operationType = flowStat.getOperationType();
+            PayloadContext payloadContext = flowStat.getPayloadContext();
+            Optional<FlowOperationStats> flowOpStatOpt = flowOperationStatsRepository.findFirstByOperationTypeAndCloudPlatform(
+                    operationType, payloadContext.getCloudPlatform());
+            final FlowOperationStats flowOperationStats;
+            if (flowOpStatOpt.isPresent()) {
+                flowOperationStats = flowOpStatOpt.get();
+            } else {
+                flowOperationStats = new FlowOperationStats();
+                flowOperationStats.setOperationType(operationType);
+                flowOperationStats.setCloudPlatform(payloadContext.getCloudPlatform());
+            }
+            String durationHistory = flowOperationStats.getDurationHistory();
+            Queue<Double> durationHistoryQueue = EvictingQueue.create(MAX_FLOW_STAT_SIZE);
+            if (StringUtils.isNotBlank(durationHistory)) {
+                Splitter.on(",").splitToList(durationHistory)
+                        .forEach(
+                                s -> {
+                                    durationHistoryQueue.add(Double.parseDouble(s));
+                                }
+                        );
+            }
+            Double elapsedOperationTime = getRoundedTimeInSeconds(flowStat.getStartTime(), new Date().getTime());
+            durationHistoryQueue.add(elapsedOperationTime);
+            durationHistory = StringUtils.join(durationHistoryQueue.stream()
+                    .map(Object::toString).collect(Collectors.toList()), ",");
+            flowOperationStats.setDurationHistory(durationHistory);
+            transactionService.required(() -> flowOperationStatsRepository.save(flowOperationStats));
+            updateOperationAverageTime(flowOperationStats.getOperationType(), flowOperationStats.getCloudPlatform(), flowOperationStats.getDurationHistory());
+        } catch (TransactionService.TransactionExecutionException e) {
+            LOGGER.warn("Cannot store flow operation statistics.", e);
+        } catch (Exception e) {
+            LOGGER.warn("Unexpected error happened during storing flow operation statistics", e);
+        }
+    }
+
+    public Integer getProgressFromHistory(FlowStat flowStat) {
+        if (flowStat != null && flowStat.getPayloadContext() != null && flowStat.getOperationType() != null) {
+            Double expectedAvgTime = getExpectedAverageTimeForOperation(flowStat.getOperationType(), flowStat.getPayloadContext().getCloudPlatform());
+            if (expectedAvgTime != null && expectedAvgTime != 0.0) {
+                Long currentTime = new Date().getTime();
+                Long startTime = flowStat.getStartTime();
+                Double diffTime = getRoundedTimeInSeconds(startTime, currentTime);
+                int percentForAverage = (int) ((diffTime / expectedAvgTime) * DONE_PROGRESS);
+                return percentForAverage >= ALMOST_DONE_PROGRESS ? ALMOST_DONE_PROGRESS : percentForAverage;
+            }
+        }
+        return DEFAULT_PROGRESS;
+    }
+
+    private Double getRoundedTimeInSeconds(Long from, Long to) {
+        return Double.valueOf(new DecimalFormat("#.###").format((to - from) / MILLISEC_TO_SEC_DOUBLE_DEVIDER));
+    }
+
+    private String createOperationCloudPlatformKey(OperationType operationType, String cloudPlatform) {
+        return String.format("%s_%s", operationType.name(), cloudPlatform.toUpperCase());
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/domain/FlowLog.java
+++ b/flow/src/main/java/com/sequenceiq/flow/domain/FlowLog.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.flow.domain;
 
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.converter.OperationTypeConverter;
 import com.sequenceiq.flow.converter.StateStatusConverter;
 
 import java.util.Date;
@@ -60,16 +62,20 @@ public class FlowLog {
 
     private String flowTriggerUserCrn;
 
+    @Convert(converter = OperationTypeConverter.class)
+    private OperationType operationType = OperationType.UNKNOWN;
+
     public FlowLog() {
 
     }
 
-    public FlowLog(Long resourceId, String flowId, String currentState, Boolean finalized, StateStatus stateStatus) {
+    public FlowLog(Long resourceId, String flowId, String currentState, Boolean finalized, StateStatus stateStatus, OperationType operationType) {
         this.resourceId = resourceId;
         this.flowId = flowId;
         this.currentState = currentState;
         this.finalized = finalized;
         this.stateStatus = stateStatus;
+        this.operationType = operationType;
     }
 
     public FlowLog(Long resourceId, String flowId, String flowChainId, String flowTriggerUserCrn, String nextEvent, String payload,
@@ -222,6 +228,14 @@ public class FlowLog {
         this.flowTriggerUserCrn = flowTriggerUserCrn;
     }
 
+    public OperationType getOperationType() {
+        return operationType;
+    }
+
+    public void setOperationType(OperationType operationType) {
+        this.operationType = operationType;
+    }
+
     public String minimizedString() {
         return "FlowLog{" +
                 "resourceId=" + resourceId +
@@ -230,6 +244,7 @@ public class FlowLog {
                 ", currentState='" + currentState + '\'' +
                 ", stateStatus=" + stateStatus +
                 ", nextEvent=" + nextEvent +
+                ", operationType=" + operationType +
                 '}';
     }
 

--- a/flow/src/main/java/com/sequenceiq/flow/domain/FlowOperationStats.java
+++ b/flow/src/main/java/com/sequenceiq/flow/domain/FlowOperationStats.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.flow.domain;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.converter.OperationTypeConverter;
+
+@Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"operationtype", "cloudplatform"}))
+public class FlowOperationStats implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "flowoperationstats_generator")
+    @SequenceGenerator(name = "flowoperationstats_generator", sequenceName = "flowoperationstats_id_seq", allocationSize = 1)
+    private Long id;
+
+    @Convert(converter = OperationTypeConverter.class)
+    @Column(nullable = false)
+    private OperationType operationType;
+
+    @Column(nullable = false)
+    private String cloudPlatform;
+
+    private String durationHistory;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public OperationType getOperationType() {
+        return operationType;
+    }
+
+    public void setOperationType(OperationType operationType) {
+        this.operationType = operationType;
+    }
+
+    public String getCloudPlatform() {
+        return cloudPlatform;
+    }
+
+    public void setCloudPlatform(String cloudPlatform) {
+        this.cloudPlatform = cloudPlatform;
+    }
+
+    public String getDurationHistory() {
+        return durationHistory;
+    }
+
+    public void setDurationHistory(String durationHistory) {
+        this.durationHistory = durationHistory;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/repository/FlowLogRepository.java
@@ -70,6 +70,8 @@ public interface FlowLogRepository extends CrudRepository<FlowLog, Long> {
 
     List<FlowLog> findAllByFlowIdOrderByCreatedDesc(String flowId);
 
+    List<FlowLog> findAllByFlowChainIdOrderByCreatedDesc(String flowChainId);
+
     List<FlowLog> findAllByResourceIdOrderByCreatedDesc(Long resourceId, Pageable page);
 
     @Query("SELECT COUNT(fl.id) > 0 FROM FlowLog fl WHERE fl.resourceId = :resourceId AND fl.stateStatus = :status")

--- a/flow/src/main/java/com/sequenceiq/flow/repository/FlowOperationStatsRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/repository/FlowOperationStatsRepository.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.flow.repository;
+
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.domain.FlowOperationStats;
+
+@Transactional(Transactional.TxType.REQUIRED)
+public interface FlowOperationStatsRepository extends CrudRepository<FlowOperationStats, Long> {
+
+    Optional<FlowOperationStats> findFirstByOperationTypeAndCloudPlatform(@Param("operationType") OperationType operationType,
+            @Param("cloudPlatform") String cloudPlatform);
+
+}

--- a/flow/src/main/resources/schema/flow/20210707114440_CB-12965_add_flow_operation_stats_and_op_type.sql
+++ b/flow/src/main/resources/schema/flow/20210707114440_CB-12965_add_flow_operation_stats_and_op_type.sql
@@ -1,0 +1,32 @@
+-- // CB-12965 add flow operation stats table & add operation type field for flowlog
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE IF EXISTS flowlog add COLUMN IF NOT EXISTS operationtype varchar(255);
+
+CREATE TABLE IF NOT EXISTS flowoperationstats (
+    id bigserial NOT NULL,
+    operationtype varchar(255) NOT NULL,
+    cloudplatform varchar(255) NOT NULL,
+    durationhistory text,
+    CONSTRAINT flowoperationstats_pkey PRIMARY KEY (id),
+    CONSTRAINT uk_flowoperationstats_operationtype_cloudplatform UNIQUE (operationtype, cloudplatform)
+);
+
+CREATE SEQUENCE IF NOT EXISTS flowoperationstats_id_seq START WITH 1
+  INCREMENT BY 1
+  NO MINVALUE
+  NO MAXVALUE
+  CACHE 1;
+
+CREATE INDEX IF NOT EXISTS idx_flowoperationstats_operationtype_cloudplatform ON flowoperationstats USING btree (operationtype, cloudplatform);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP INDEX IF EXISTS idx_flowoperationstats_operationtype_cloud_platform;
+
+DROP SEQUENCE IF EXISTS flowoperationstats_id_seq;
+
+DROP TABLE IF EXISTS flowoperationstats;
+
+ALTER TABLE IF EXISTS flowlog DROP COLUMN IF EXISTS operationtype;

--- a/flow/src/test/java/com/sequenceiq/cloudbreak/service/HeartbeatServiceTest.java
+++ b/flow/src/test/java/com/sequenceiq/cloudbreak/service/HeartbeatServiceTest.java
@@ -54,6 +54,7 @@ import com.sequenceiq.cloudbreak.ha.service.FlowDistributor;
 import com.sequenceiq.cloudbreak.ha.service.NodeService;
 import com.sequenceiq.cloudbreak.service.ha.HaApplication;
 import com.sequenceiq.cloudbreak.service.ha.HeartbeatService;
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.cleanup.InMemoryCleanup;
 import com.sequenceiq.flow.core.ApplicationFlowInformation;
 import com.sequenceiq.flow.core.Flow2Handler;
@@ -532,7 +533,8 @@ public class HeartbeatServiceTest {
         long stackId = random.nextInt(5000) + from;
         for (int i = 0; i < flowCount; i++) {
             for (int j = 0; j < random.nextInt(99) + 1; j++) {
-                FlowLog flowLog = new FlowLog(stackId + i, "" + flowId + i, "RUNNING", false, StateStatus.PENDING);
+                FlowLog flowLog = new FlowLog(stackId + i, "" + flowId + i, "RUNNING",
+                        false, StateStatus.PENDING, OperationType.UNKNOWN);
                 flowLog.setFlowType(FlowConfiguration.class);
                 flows.add(flowLog);
             }

--- a/flow/src/test/java/com/sequenceiq/cloudbreak/service/ha/EvenFlowDistributorTest.java
+++ b/flow/src/test/java/com/sequenceiq/cloudbreak/service/ha/EvenFlowDistributorTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.ha.domain.Node;
 import com.sequenceiq.cloudbreak.ha.service.EvenFlowDistributor;
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.domain.FlowLog;
 import com.sequenceiq.flow.domain.StateStatus;
 
@@ -103,7 +104,8 @@ public class EvenFlowDistributorTest {
         int flowId = random.nextInt(5000);
         long stackId = random.nextLong();
         for (int i = 0; i < flowCount; i++) {
-            flows.add(new FlowLog(stackId + i, "" + flowId + i, "RUNNING", false, StateStatus.PENDING));
+            flows.add(new FlowLog(stackId + i, "" + flowId + i, "RUNNING",
+                    false, StateStatus.PENDING, OperationType.UNKNOWN));
         }
         return flows;
     }

--- a/flow/src/test/java/com/sequenceiq/flow/cleanup/InMemoryCleanupTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/cleanup/InMemoryCleanupTest.java
@@ -22,7 +22,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.FlowRegister;
+import com.sequenceiq.flow.core.cache.FlowStatCache;
 import com.sequenceiq.flow.core.chain.FlowChains;
 import com.sequenceiq.flow.core.config.FlowConfiguration;
 import com.sequenceiq.flow.domain.FlowLog;
@@ -38,6 +40,9 @@ class InMemoryCleanupTest {
 
     @Mock
     private FlowChains flowChains;
+
+    @Mock
+    private FlowStatCache flowStatCache;
 
     @InjectMocks
     private InMemoryCleanup underTest;
@@ -78,7 +83,8 @@ class InMemoryCleanupTest {
         long stackId = random.nextInt(5000) + from;
         for (int i = 0; i < flowCount; i++) {
             for (int j = 0; j < random.nextInt(99) + 1; j++) {
-                FlowLog flowLog = new FlowLog(stackId + i, "" + flowId + i, "RUNNING", false, StateStatus.PENDING);
+                FlowLog flowLog = new FlowLog(stackId + i, "" + flowId + i, "RUNNING",
+                        false, StateStatus.PENDING, OperationType.UNKNOWN);
                 flowLog.setFlowType(FlowConfiguration.class);
                 flows.add(flowLog);
             }

--- a/flow/src/test/java/com/sequenceiq/flow/converter/OperationDetailsPopulatorTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/converter/OperationDetailsPopulatorTest.java
@@ -1,0 +1,149 @@
+package com.sequenceiq.flow.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.flow.api.model.FlowProgressResponse;
+import com.sequenceiq.flow.api.model.FlowStateTransitionResponse;
+import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
+import com.sequenceiq.flow.api.model.operation.OperationProgressStatus;
+import com.sequenceiq.flow.api.model.operation.OperationResource;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+
+@ExtendWith(MockitoExtension.class)
+public class OperationDetailsPopulatorTest {
+
+    private static final int DEFAULT_PROGRESS = -1;
+
+    private static final int MAX_PROGRESS = 100;
+
+    private static final int IN_PROGRESS = 66;
+
+    private static final String DUMMY_CLASS = "Sample";
+
+    private OperationDetailsPopulator underTest;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new OperationDetailsPopulator();
+    }
+
+    @Test
+    public void testCreateOperationView() {
+        // GIVEN
+        Map<String, FlowProgressResponse> flowProgressResponseMap = new HashMap<>();
+        flowProgressResponseMap.put(DUMMY_CLASS, createFlowProgressResponse("SUCCESSFUL", true).get());
+        OperationFlowsView operationFlowsView = createOperationFlowsView(flowProgressResponseMap);
+        // WHEN
+        OperationView operationView = underTest.createOperationView(operationFlowsView, OperationResource.ENVIRONMENT);
+        // THEN
+        assertEquals(MAX_PROGRESS, operationView.getProgress());
+        assertEquals(OperationProgressStatus.FINISHED, operationView.getProgressStatus());
+    }
+
+    @Test
+    public void testCreateOperationViewFromInMemoryResponse() {
+        // GIVEN
+        OperationFlowsView operationFlowsView = createOperationFlowsView(null);
+        // WHEN
+        OperationView operationView = underTest.createOperationView(operationFlowsView, OperationResource.ENVIRONMENT);
+        // THEN
+        assertEquals(OperationProgressStatus.RUNNING, operationView.getProgressStatus());
+        assertEquals(IN_PROGRESS, operationView.getProgress());
+    }
+
+    @Test
+    public void testCreateOperationViewWithFailedState() {
+        // GIVEN
+        Map<String, FlowProgressResponse> flowProgressResponseMap = new HashMap<>();
+        flowProgressResponseMap.put(DUMMY_CLASS, createFlowProgressResponse("FAILED", true).get());
+        OperationFlowsView operationFlowsView = createOperationFlowsView(flowProgressResponseMap);
+        // WHEN
+        OperationView operationView = underTest.createOperationView(operationFlowsView, OperationResource.ENVIRONMENT);
+        // THEN
+        assertEquals(MAX_PROGRESS, operationView.getProgress());
+        assertEquals(OperationProgressStatus.FAILED, operationView.getProgressStatus());
+    }
+
+    @Test
+    public void testCreateOperationViewWithPendingState() {
+        // GIVEN
+        Map<String, FlowProgressResponse> flowProgressResponseMap = new HashMap<>();
+        flowProgressResponseMap.put(DUMMY_CLASS, createFlowProgressResponse("SUCCESSFUL", false).get());
+        OperationFlowsView operationFlowsView = createOperationFlowsView(flowProgressResponseMap);
+        // WHEN
+        OperationView operationView = underTest.createOperationView(operationFlowsView, OperationResource.ENVIRONMENT);
+        // THEN
+        assertEquals(IN_PROGRESS, operationView.getProgress());
+        assertEquals(OperationProgressStatus.RUNNING, operationView.getProgressStatus());
+    }
+
+    @Test
+    public void testCreateOperationViewWithoutFlows() {
+        // GIVEN
+        OperationFlowsView operationFlowsView = createOperationFlowsView(new HashMap<>());
+        // WHEN
+        OperationView operationView = underTest.createOperationView(operationFlowsView, OperationResource.ENVIRONMENT);
+        // THEN
+        assertEquals(DEFAULT_PROGRESS, operationView.getProgress());
+        assertEquals(OperationProgressStatus.UNKNOWN, operationView.getProgressStatus());
+    }
+
+    private OperationFlowsView createOperationFlowsView(Map<String, FlowProgressResponse> flowProgressResponseMap) {
+        return createOperationFlowsView(flowProgressResponseMap, OperationType.PROVISION);
+    }
+
+    private OperationFlowsView createOperationFlowsView(Map<String, FlowProgressResponse> flowProgressResponseMap, OperationType operationType) {
+        if (flowProgressResponseMap == null) {
+            return OperationFlowsView.Builder.newBuilder()
+                    .withOperationType(operationType)
+                    .withTypeOrderList(List.of(DUMMY_CLASS))
+                    .withInMemory(true)
+                    .withProgressFromHistory(IN_PROGRESS)
+                    .build();
+        } else {
+            return OperationFlowsView.Builder.newBuilder()
+                    .withOperationType(operationType)
+                    .withFlowTypeProgressMap(flowProgressResponseMap)
+                    .withTypeOrderList(List.of(DUMMY_CLASS))
+                    .build();
+        }
+    }
+
+    private Optional<FlowProgressResponse> createFlowProgressResponse(String secondTransitionState, boolean finished) {
+        FlowProgressResponse response = new FlowProgressResponse();
+        List<FlowStateTransitionResponse> transitionResponseList = new ArrayList<>();
+        FlowStateTransitionResponse transitionResponse1 = new FlowStateTransitionResponse();
+        transitionResponse1.setState("state1");
+        transitionResponse1.setNextEvent("nextEvent1");
+        transitionResponse1.setStatus("SUCCESSFUL");
+        FlowStateTransitionResponse transitionResponse2 = new FlowStateTransitionResponse();
+        transitionResponse2.setStatus("state2");
+        transitionResponse2.setNextEvent("nextEvent2");
+        transitionResponse2.setStatus(secondTransitionState);
+        transitionResponseList.add(transitionResponse1);
+        transitionResponseList.add(transitionResponse2);
+        response.setTransitions(transitionResponseList);
+        if (finished) {
+            response.setProgress(MAX_PROGRESS);
+            response.setFinalized(false);
+            response.setMaxNumberOfTransitions(transitionResponseList.size());
+        } else {
+            response.setProgress(IN_PROGRESS);
+            response.setFinalized(true);
+            response.setMaxNumberOfTransitions(transitionResponseList.size() + 1);
+        }
+        return Optional.of(response);
+    }
+}

--- a/flow/src/test/java/com/sequenceiq/flow/core/cache/FlowStatCacheTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/cache/FlowStatCacheTest.java
@@ -1,0 +1,270 @@
+package com.sequenceiq.flow.core.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.PayloadContext;
+import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.core.PayloadContextProvider;
+import com.sequenceiq.flow.core.stats.FlowOperationStatisticsService;
+
+@ExtendWith(MockitoExtension.class)
+public class FlowStatCacheTest {
+
+    private static final String SAMPLE_RESOURCE_CRN = "crn:cdp:environments:us-west-1:12345-6789:environment:12345-6789";
+
+    private static final String SAMPLE_FREEIPA_CRN = "crn:cdp:freeipa:us-west-1:12345-6789:environment:12345-6789";
+
+    private static final Long SAMPLE_RESOURCE_ID = 1L;
+
+    private static final Integer SAMPLE_PROGRESS = 66;
+
+    private static final String SAMPLE_CLOUD_PLATFORM = "AWS";
+
+    private static final String SAMPLE_FLOW_ID = "flow-id";
+
+    private static final String SAMPLE_FLOW_CHAIN_ID = "flow-chain-id";
+
+    private static final Date OLD_DATE = new GregorianCalendar(2000, Calendar.JANUARY, 1).getTime();
+
+    @InjectMocks
+    private FlowStatCache underTest;
+
+    @Mock
+    private PayloadContextProvider payloadContextProvider;
+
+    @Mock
+    private FlowOperationStatisticsService flowOperationStatisticsService;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new FlowStatCache(flowOperationStatisticsService, payloadContextProvider);
+    }
+
+    @Test
+    public void testPutFlow() {
+        // GIVEN
+        PayloadContext payloadContext = PayloadContext.create(SAMPLE_RESOURCE_CRN, SAMPLE_CLOUD_PLATFORM);
+        given(payloadContextProvider.getPayloadContext(SAMPLE_RESOURCE_ID)).willReturn(payloadContext);
+        // WHEN
+        underTest.put(SAMPLE_FLOW_ID, null, SAMPLE_RESOURCE_ID, OperationType.PROVISION.name(), null, false);
+        FlowStat result = underTest.getFlowStatByResourceCrn(SAMPLE_RESOURCE_CRN);
+        FlowStat resultByFlowId = underTest.getFlowStatByFlowId(SAMPLE_FLOW_ID);
+        // THEN
+        assertEquals(SAMPLE_FLOW_ID, result.getFlowId());
+        assertEquals(OperationType.PROVISION, result.getOperationType());
+        assertNotNull(resultByFlowId);
+        verify(payloadContextProvider, times(1)).getPayloadContext(anyLong());
+    }
+
+    @Test
+    public void testPutFlowWithEnvironmentCrn() {
+        // GIVEN
+        given(payloadContextProvider.getPayloadContext(SAMPLE_RESOURCE_ID)).willReturn(
+                PayloadContext.create(SAMPLE_FREEIPA_CRN, SAMPLE_RESOURCE_CRN, SAMPLE_CLOUD_PLATFORM));
+        // WHEN
+        underTest.put(SAMPLE_FLOW_ID, null, SAMPLE_RESOURCE_ID, OperationType.PROVISION.name(), null, false);
+        FlowStat result = underTest.getFlowStatByResourceCrn(SAMPLE_FREEIPA_CRN);
+        FlowStat resultWithEnvCrn = underTest.getFlowStatByResourceCrn(SAMPLE_RESOURCE_CRN);
+        // THEN
+        assertEquals(SAMPLE_FLOW_ID, result.getFlowId());
+        assertEquals(OperationType.PROVISION, result.getOperationType());
+        assertEquals(SAMPLE_FLOW_ID, resultWithEnvCrn.getFlowId());
+        assertEquals(OperationType.PROVISION, resultWithEnvCrn.getOperationType());
+        verify(payloadContextProvider, times(1)).getPayloadContext(anyLong());
+    }
+
+    @Test
+    public void testPutFlowChain() {
+        // GIVEN
+        given(payloadContextProvider.getPayloadContext(SAMPLE_RESOURCE_ID)).willReturn(
+                PayloadContext.create(SAMPLE_FREEIPA_CRN, SAMPLE_RESOURCE_CRN, SAMPLE_CLOUD_PLATFORM));
+        // WHEN
+        underTest.putByFlowChainId(SAMPLE_FLOW_CHAIN_ID, SAMPLE_RESOURCE_ID, OperationType.PROVISION.name(), false);
+        FlowStat result = underTest.getFlowChainStatByResourceCrn(SAMPLE_FREEIPA_CRN);
+        FlowStat resultWithEnvCrn = underTest.getFlowChainStatByResourceCrn(SAMPLE_RESOURCE_CRN);
+        FlowStat resultByFlowChainId = underTest.getFlowStatByFlowChainId(SAMPLE_FLOW_CHAIN_ID);
+        // THEN
+        assertEquals(SAMPLE_FLOW_CHAIN_ID, result.getFlowChainId());
+        assertEquals(OperationType.PROVISION, result.getOperationType());
+        assertEquals(SAMPLE_FLOW_CHAIN_ID, resultWithEnvCrn.getFlowChainId());
+        assertEquals(OperationType.PROVISION, resultWithEnvCrn.getOperationType());
+        assertNotNull(resultByFlowChainId);
+        verify(payloadContextProvider, times(1)).getPayloadContext(anyLong());
+    }
+
+    @Test
+    public void testRemoveFlow() {
+        // GIVEN
+        given(payloadContextProvider.getPayloadContext(SAMPLE_RESOURCE_ID)).willReturn(
+                PayloadContext.create(SAMPLE_FREEIPA_CRN, SAMPLE_RESOURCE_CRN, SAMPLE_CLOUD_PLATFORM));
+        // WHEN
+        underTest.put(SAMPLE_FLOW_ID, null, SAMPLE_RESOURCE_ID, OperationType.PROVISION.name(), null, false);
+        underTest.remove(SAMPLE_FLOW_ID, false);
+        FlowStat result = underTest.getFlowStatByResourceCrn(SAMPLE_FREEIPA_CRN);
+        FlowStat resultWithEnvCrn = underTest.getFlowStatByResourceCrn(SAMPLE_RESOURCE_CRN);
+        FlowStat resultByFlowId = underTest.getFlowStatByFlowId(SAMPLE_FLOW_ID);
+        // THEN
+        assertNull(result);
+        assertNull(resultWithEnvCrn);
+        assertNull(resultByFlowId);
+        verify(payloadContextProvider, times(1)).getPayloadContext(anyLong());
+    }
+
+    @Test
+    public void testRemoveFlowChain() {
+        // GIVEN
+        given(payloadContextProvider.getPayloadContext(SAMPLE_RESOURCE_ID)).willReturn(
+                PayloadContext.create(SAMPLE_FREEIPA_CRN, SAMPLE_RESOURCE_CRN, SAMPLE_CLOUD_PLATFORM));
+        // WHEN
+        underTest.putByFlowChainId(SAMPLE_FLOW_CHAIN_ID, SAMPLE_RESOURCE_ID, OperationType.PROVISION.name(), false);
+        underTest.removeByFlowChainId(SAMPLE_FLOW_CHAIN_ID, false);
+        FlowStat result = underTest.getFlowStatByResourceCrn(SAMPLE_FREEIPA_CRN);
+        FlowStat resultWithEnvCrn = underTest.getFlowStatByResourceCrn(SAMPLE_RESOURCE_CRN);
+        FlowStat resultByFlowChainId = underTest.getFlowStatByFlowId(SAMPLE_FLOW_CHAIN_ID);
+        // THEN
+        assertNull(result);
+        assertNull(resultWithEnvCrn);
+        assertNull(resultByFlowChainId);
+        verify(payloadContextProvider, times(1)).getPayloadContext(anyLong());
+    }
+
+    @Test
+    public void testGetOperationFlowByResourceCrn() {
+        // GIVEN
+        given(payloadContextProvider.getPayloadContext(SAMPLE_RESOURCE_ID)).willReturn(
+                PayloadContext.create(SAMPLE_RESOURCE_CRN, SAMPLE_CLOUD_PLATFORM));
+        given(flowOperationStatisticsService.getProgressFromHistory(any())).willReturn(SAMPLE_PROGRESS);
+        // WHEN
+        underTest.put(SAMPLE_FLOW_ID, null, SAMPLE_RESOURCE_ID, OperationType.PROVISION.name(), null, false);
+        Optional<OperationFlowsView> resultOpt = underTest.getOperationFlowByResourceCrn(SAMPLE_RESOURCE_CRN);
+        // THEN
+        assertEquals(SAMPLE_FLOW_ID, resultOpt.get().getOperationId());
+        assertEquals(OperationType.PROVISION, resultOpt.get().getOperationType());
+        assertTrue(resultOpt.get().isInMemory());
+        verify(payloadContextProvider, times(1)).getPayloadContext(anyLong());
+        verify(flowOperationStatisticsService, times(1)).getProgressFromHistory(any());
+    }
+
+    @Test
+    public void testGetOperationFlowChainByResourceCrn() {
+        // GIVEN
+        given(payloadContextProvider.getPayloadContext(SAMPLE_RESOURCE_ID)).willReturn(
+                PayloadContext.create(SAMPLE_RESOURCE_CRN, SAMPLE_CLOUD_PLATFORM));
+        given(flowOperationStatisticsService.getProgressFromHistory(any())).willReturn(SAMPLE_PROGRESS);
+        // WHEN
+        underTest.putByFlowChainId(SAMPLE_FLOW_CHAIN_ID, SAMPLE_RESOURCE_ID, OperationType.PROVISION.name(), false);
+        Optional<OperationFlowsView> resultOpt = underTest.getOperationFlowByResourceCrn(SAMPLE_RESOURCE_CRN);
+        // THEN
+        assertEquals(SAMPLE_FLOW_CHAIN_ID, resultOpt.get().getOperationId());
+        assertEquals(OperationType.PROVISION, resultOpt.get().getOperationType());
+        assertEquals(SAMPLE_PROGRESS, resultOpt.get().getProgressFromHistory());
+        assertTrue(resultOpt.get().isInMemory());
+        verify(payloadContextProvider, times(1)).getPayloadContext(anyLong());
+        verify(flowOperationStatisticsService, times(1)).getProgressFromHistory(any());
+    }
+
+    @Test
+    public void testGetOperationFlowByResourceCrnWithUnknownOperation() {
+        // GIVEN
+        given(payloadContextProvider.getPayloadContext(SAMPLE_RESOURCE_ID)).willReturn(
+                PayloadContext.create(SAMPLE_RESOURCE_CRN, SAMPLE_CLOUD_PLATFORM));
+        // WHEN
+        underTest.put(SAMPLE_FLOW_ID, null, SAMPLE_RESOURCE_ID, OperationType.UNKNOWN.name(), null, false);
+        Optional<OperationFlowsView> resultOpt = underTest.getOperationFlowByResourceCrn(SAMPLE_RESOURCE_CRN);
+        // THEN
+        assertTrue(resultOpt.isEmpty());
+        verify(payloadContextProvider, times(1)).getPayloadContext(anyLong());
+        verify(flowOperationStatisticsService, times(0)).getProgressFromHistory(any());
+    }
+
+    @Test
+    public void testCleanOldCacheEntries() {
+        // GIVEN
+        underTest.getFlowIdStatCache().put("flowid1", createFlowStat("flowid1", null, SAMPLE_RESOURCE_CRN, true));
+        // WHEN
+        underTest.cleanOldCacheEntries(Set.of("flowid2"));
+        // THEN
+        assertTrue(underTest.getFlowIdStatCache().isEmpty());
+    }
+
+    @Test
+    public void testCleanOldCacheEntriesAgainstFlowChainIdCache() {
+        // GIVEN
+        underTest.getFlowChainIdStatCache().put("flowchainid1", createFlowStat("flowid1", "flowchainid1", SAMPLE_RESOURCE_CRN, true));
+        // WHEN
+        underTest.cleanOldCacheEntries(Set.of("flowid1"));
+        // THEN
+        assertTrue(underTest.getFlowChainIdStatCache().isEmpty());
+    }
+
+    @Test
+    public void testCleanOldCacheEntriesWithFlowIdsStillRunning() {
+        // GIVEN
+        underTest.getFlowIdStatCache().put("flowid1", createFlowStat("flowid1", null, SAMPLE_RESOURCE_CRN, true));
+        underTest.getFlowIdStatCache().put("flowid2", createFlowStat("flowid2", null, SAMPLE_RESOURCE_CRN + "1", false));
+        // WHEN
+        underTest.cleanOldCacheEntries(Set.of("flowid1", "flowid2"));
+        // THEN
+        assertEquals(2, underTest.getFlowIdStatCache().size());
+    }
+
+    @Test
+    public void testCleanOldCacheEntriesWithResourceCrn() {
+        // GIVEN
+        underTest.getResourceCrnFlowStatCache().put(SAMPLE_RESOURCE_CRN, createFlowStat("flowid1", null, SAMPLE_RESOURCE_CRN, true));
+        // WHEN
+        underTest.cleanOldCacheEntries(Set.of());
+        // THEN
+        assertTrue(underTest.getResourceCrnFlowStatCache().isEmpty());
+    }
+
+    @Test
+    public void testCleanOldCacheEntriesWithResourceCrnAndFlowChain() {
+        // GIVEN
+        underTest.getResourceCrnFlowChainStatCache().put(SAMPLE_RESOURCE_CRN, createFlowStat("flowid1", "flowchainid1",
+                SAMPLE_RESOURCE_CRN, true));
+        underTest.getResourceCrnFlowChainStatCache().put(SAMPLE_RESOURCE_CRN + "1", createFlowStat("flowid2", "flowchainid2",
+                SAMPLE_RESOURCE_CRN + "1", false));
+        // WHEN
+        underTest.cleanOldCacheEntries(Set.of());
+        // THEN
+        assertEquals(1, underTest.getResourceCrnFlowChainStatCache().size());
+        assertTrue(underTest.getResourceCrnFlowChainStatCache().containsKey(SAMPLE_RESOURCE_CRN + "1"));
+    }
+
+    private FlowStat createFlowStat(String flowId, String flowChainId, String crn, boolean old) {
+        FlowStat flowStat = new FlowStat();
+        flowStat.setFlowId(flowId);
+        flowStat.setFlowChainId(flowChainId);
+        PayloadContext payloadContext = PayloadContext.create(crn, SAMPLE_CLOUD_PLATFORM);
+        flowStat.setPayloadContext(payloadContext);
+        if (old) {
+            flowStat.setStartTime(OLD_DATE.getTime());
+        } else {
+            flowStat.setStartTime(new Date().getTime());
+        }
+        return flowStat;
+    }
+}

--- a/flow/src/test/java/com/sequenceiq/flow/core/config/AbstractFlowConfigurationTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/config/AbstractFlowConfigurationTest.java
@@ -83,52 +83,52 @@ public class AbstractFlowConfigurationTest {
 
     @Test
     public void testHappyFlowConfiguration() {
-        flow.sendEvent(Event.START.name(), null, null, null);
-        flow.sendEvent(Event.CONTINUE.name(), null, null, null);
-        flow.sendEvent(Event.FINISHED.name(), null, null, null);
-        flow.sendEvent(Event.FINALIZED.name(), null, null, null);
+        flow.sendEvent(Event.START.name(), null, null, null, null);
+        flow.sendEvent(Event.CONTINUE.name(), null, null, null, null);
+        flow.sendEvent(Event.FINISHED.name(), null, null, null, null);
+        flow.sendEvent(Event.FINALIZED.name(), null, null, null, null);
     }
 
     @Test
     public void testUnhappyFlowConfigurationWithDefaultFailureHandler() {
-        flow.sendEvent(Event.START.name(), null, null, null);
-        flow.sendEvent(Event.FAILURE.name(), null, null, null);
-        flow.sendEvent(Event.FAIL_HANDLED.name(), null, null, null);
+        flow.sendEvent(Event.START.name(), null, null, null, null);
+        flow.sendEvent(Event.FAILURE.name(), null, null, null, null);
+        flow.sendEvent(Event.FAIL_HANDLED.name(), null, null, null, null);
     }
 
     @Test
     public void testUnhappyFlowConfigurationWithCustomFailureHandler() {
-        flow.sendEvent(Event.START.name(), null, null, null);
-        flow.sendEvent(Event.CONTINUE.name(), null, null, null);
-        flow.sendEvent(Event.FAILURE2.name(), null, null, null);
+        flow.sendEvent(Event.START.name(), null, null, null, null);
+        flow.sendEvent(Event.CONTINUE.name(), null, null, null, null);
+        flow.sendEvent(Event.FAILURE2.name(), null, null, null, null);
         assertEquals("Must be on the FAILED2 state", State.FAILED2, flow.getCurrentState());
-        flow.sendEvent(Event.FAIL_HANDLED.name(), null, null, null);
+        flow.sendEvent(Event.FAIL_HANDLED.name(), null, null, null, null);
     }
 
     @Test(expected = NotAcceptedException.class)
     public void testUnacceptedFlowConfiguration1() {
-        flow.sendEvent(Event.START.name(), null, null, null);
-        flow.sendEvent(Event.FINISHED.name(), null, null, null);
+        flow.sendEvent(Event.START.name(), null, null, null, null);
+        flow.sendEvent(Event.FINISHED.name(), null, null, null, null);
     }
 
     @Test(expected = NotAcceptedException.class)
     public void testUnacceptedFlowConfiguration2() {
-        flow.sendEvent(Event.START.name(), null, null, null);
-        flow.sendEvent(Event.FAILURE2.name(), null, null, null);
+        flow.sendEvent(Event.START.name(), null, null, null, null);
+        flow.sendEvent(Event.FAILURE2.name(), null, null, null, null);
     }
 
     @Test(expected = NotAcceptedException.class)
     public void testUnacceptedFlowConfiguration3() {
-        flow.sendEvent(Event.START.name(), null, null, null);
-        flow.sendEvent(Event.CONTINUE.name(), null, null, null);
-        flow.sendEvent(Event.FAIL_HANDLED.name(), null, null, null);
+        flow.sendEvent(Event.START.name(), null, null, null, null);
+        flow.sendEvent(Event.CONTINUE.name(), null, null, null, null);
+        flow.sendEvent(Event.FAIL_HANDLED.name(), null, null, null, null);
     }
 
     @Test(expected = NotAcceptedException.class)
     public void testUnacceptedFlowConfiguration4() {
-        flow.sendEvent(Event.START.name(), null, null, null);
-        flow.sendEvent(Event.CONTINUE.name(), null, null, null);
-        flow.sendEvent(Event.FAILURE.name(), null, null, null);
+        flow.sendEvent(Event.START.name(), null, null, null, null);
+        flow.sendEvent(Event.CONTINUE.name(), null, null, null, null);
+        flow.sendEvent(Event.FAILURE.name(), null, null, null, null);
     }
 
     enum State implements FlowState {

--- a/flow/src/test/java/com/sequenceiq/flow/core/stats/FlowOperationStatisticsServiceTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/core/stats/FlowOperationStatisticsServiceTest.java
@@ -1,0 +1,77 @@
+package com.sequenceiq.flow.core.stats;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.event.PayloadContext;
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.core.cache.FlowStat;
+import com.sequenceiq.flow.repository.FlowOperationStatsRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class FlowOperationStatisticsServiceTest {
+
+    private static final String SAMPLE_RESOURCE_CRN = "crn:cdp:environments:us-west-1:12345-6789:environment:12345-6789";
+
+    private static final String SAMPLE_CLOUD_PLATFORM = "AWS";
+
+    private static final Date OLD_DATE = new GregorianCalendar(2000, Calendar.JANUARY, 1).getTime();
+
+    private static final Double EXPECTED_TWO_MINUTES = 120d;
+
+    private static final Integer EXPECTED_PROGRESS_PERCENT = 99;
+
+    @InjectMocks
+    private FlowOperationStatisticsService underTest;
+
+    @Mock
+    private FlowOperationStatsRepository flowOperationStatsRepository;
+
+    @Mock
+    private TransactionService transactionService;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new FlowOperationStatisticsService(flowOperationStatsRepository, transactionService);
+    }
+
+    @Test
+    public void testUpdateOperationAverageTime() {
+        // GIVEN
+        // WHEN
+        underTest.updateOperationAverageTime(OperationType.PROVISION, SAMPLE_CLOUD_PLATFORM, "120");
+        Double result = underTest.getExpectedAverageTimeForOperation(OperationType.PROVISION, SAMPLE_CLOUD_PLATFORM);
+        // THEN
+        assertEquals(EXPECTED_TWO_MINUTES, result);
+    }
+
+    @Test
+    public void testGetProgressFromHistory() {
+        // GIVEN
+        // WHEN
+        underTest.updateOperationAverageTime(OperationType.PROVISION, SAMPLE_CLOUD_PLATFORM, "120");
+        Integer result = underTest.getProgressFromHistory(createFlowStat());
+        // THEN
+        assertEquals(EXPECTED_PROGRESS_PERCENT, result);
+    }
+
+    private FlowStat createFlowStat() {
+        FlowStat flowStat = new FlowStat();
+        PayloadContext payloadContext = PayloadContext.create(SAMPLE_RESOURCE_CRN, SAMPLE_CLOUD_PLATFORM);
+        flowStat.setPayloadContext(payloadContext);
+        flowStat.setOperationType(OperationType.PROVISION);
+        flowStat.setStartTime(OLD_DATE.getTime());
+        return flowStat;
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiEndpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiEndpoint.java
@@ -7,6 +7,7 @@ import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.ldap.LdapConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.KerberosMgmtV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.progress.ProgressV1Endpoint;
 
 public interface FreeIpaApiEndpoint {
     FreeIpaV1Endpoint getFreeIpaV1Endpoint();
@@ -22,4 +23,6 @@ public interface FreeIpaApiEndpoint {
     KerberosMgmtV1Endpoint getKerberosMgmtV1Endpoint();
 
     OperationV1Endpoint getOperationV1Endpoint();
+
+    ProgressV1Endpoint getProgrsessV1Endpoint();
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiKeyEndpoints.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiKeyEndpoints.java
@@ -16,6 +16,7 @@ import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.KerberosMgmtV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.ldap.LdapConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.progress.ProgressV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.util.UtilV1Endpoint;
 
 public class FreeIpaApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint implements FreeIpaClient {
@@ -77,6 +78,11 @@ public class FreeIpaApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint impl
     @Override
     public FlowPublicEndpoint getFlowPublicEndpoint() {
         return getEndpoint(FlowPublicEndpoint.class);
+    }
+
+    @Override
+    public ProgressV1Endpoint getProgressV1Endpoint() {
+        return getEndpoint(ProgressV1Endpoint.class);
     }
 
     @Override

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiUserCrnEndpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaApiUserCrnEndpoint.java
@@ -16,6 +16,7 @@ import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.KerberosMgmtV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.ldap.LdapConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.progress.ProgressV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.util.UtilV1Endpoint;
 
 public class FreeIpaApiUserCrnEndpoint extends AbstractUserCrnServiceEndpoint implements FreeIpaClient {
@@ -76,6 +77,11 @@ public class FreeIpaApiUserCrnEndpoint extends AbstractUserCrnServiceEndpoint im
     @Override
     public FlowPublicEndpoint getFlowPublicEndpoint() {
         return getEndpoint(FlowPublicEndpoint.class);
+    }
+
+    @Override
+    public ProgressV1Endpoint getProgressV1Endpoint() {
+        return getEndpoint(ProgressV1Endpoint.class);
     }
 
     @Override

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaClient.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/FreeIpaClient.java
@@ -13,6 +13,7 @@ import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.KerberosMgmtV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.ldap.LdapConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.progress.ProgressV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.util.UtilV1Endpoint;
 
 public interface FreeIpaClient {
@@ -38,6 +39,8 @@ public interface FreeIpaClient {
     FlowEndpoint getFlowEndpoint();
 
     FlowPublicEndpoint getFlowPublicEndpoint();
+
+    ProgressV1Endpoint getProgressV1Endpoint();
 
     CDPStructuredEventV1Endpoint structuredEventsV1Endpoint();
 

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/internal/FreeIpaApiClientConfig.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/client/internal/FreeIpaApiClientConfig.java
@@ -19,6 +19,7 @@ import com.sequenceiq.freeipa.api.v1.kerberos.KerberosConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.kerberosmgmt.KerberosMgmtV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.ldap.LdapConfigV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.progress.ProgressV1Endpoint;
 
 import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
 
@@ -84,6 +85,12 @@ public class FreeIpaApiClientConfig {
     @ConditionalOnBean(name = "freeIpaApiClientWebTarget")
     OperationV1Endpoint operationV1Endpoint(WebTarget freeIpaApiClientWebTarget) {
         return new WebTargetEndpointFactory().createEndpoint(freeIpaApiClientWebTarget, OperationV1Endpoint.class);
+    }
+
+    @Bean
+    @ConditionalOnBean(name = "freeIpaApiClientWebTarget")
+    ProgressV1Endpoint progressV1Endpoint(WebTarget freeIpaApiClientWebTarget) {
+        return new WebTargetEndpointFactory().createEndpoint(freeIpaApiClientWebTarget, ProgressV1Endpoint.class);
     }
 
     @Bean

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/OperationV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/OperationV1Endpoint.java
@@ -2,14 +2,17 @@ package com.sequenceiq.freeipa.api.v1.operation;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.flow.api.model.operation.OperationView;
 import com.sequenceiq.freeipa.api.v1.operation.doc.OperationDescriptions;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 
@@ -29,4 +32,12 @@ public interface OperationV1Endpoint {
             nickname = "getOperationStatusV1")
     OperationStatus getOperationStatus(@NotNull @QueryParam("operationId") String operationId,
             @AccountId @QueryParam("accountId") String accountId);
+
+    @GET
+    @Path("/resource/crn/{environmentCrn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = OperationDescriptions.GET_OPERATION, produces = "application/json", notes = OperationDescriptions.NOTES,
+            nickname = "getOperationProgressByEnvironmentCrn")
+    OperationView getOperationProgressByEnvironmentCrn(@PathParam("environmentCrn") String environmentCrn,
+            @DefaultValue("false") @QueryParam("detailed") boolean detailed);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/doc/OperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/doc/OperationDescriptions.java
@@ -3,6 +3,7 @@ package com.sequenceiq.freeipa.api.v1.operation.doc;
 public final class OperationDescriptions {
     public static final String NOTES = "Operation management endpoint";
     public static final String OPERATION_STATUS = "Gets the status of an operation";
+    public static final String GET_OPERATION = "Get flow operation progress details for resource by resource crn";
 
     private OperationDescriptions() {
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/OperationV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/OperationV1Controller.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.controller;
 
+import static com.sequenceiq.authorization.resource.AuthorizationResourceAction.DESCRIBE_ENVIRONMENT;
+
 import java.util.Optional;
 
 import javax.inject.Inject;
@@ -8,9 +10,12 @@ import javax.validation.constraints.NotNull;
 import org.springframework.stereotype.Controller;
 
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
+import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
+import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
+import com.sequenceiq.flow.api.model.operation.OperationView;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 import com.sequenceiq.freeipa.converter.operation.OperationToOperationStatusConverter;
@@ -30,5 +35,11 @@ public class OperationV1Controller implements OperationV1Endpoint {
     public OperationStatus getOperationStatus(@NotNull String operationId, @AccountId String accountId) {
         String currentAccountId = Optional.ofNullable(accountId).orElseGet(ThreadBasedUserCrnProvider::getAccountId);
         return operationToOperationStatusConverter.convert(operationService.getOperationForAccountIdAndOperationId(currentAccountId, operationId));
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = DESCRIBE_ENVIRONMENT)
+    public OperationView getOperationProgressByEnvironmentCrn(@ResourceCrn String resourceCrn, boolean detailed) {
+        return operationService.getOperationProgressByEnvironmentCrn(resourceCrn, detailed);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/ProgressV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/ProgressV1Controller.java
@@ -11,24 +11,24 @@ import org.springframework.stereotype.Controller;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
-import com.sequenceiq.flow.service.FlowService;
 import com.sequenceiq.freeipa.api.v1.progress.ProgressV1Endpoint;
+import com.sequenceiq.freeipa.service.ProgressService;
 
 @Controller
 public class ProgressV1Controller implements ProgressV1Endpoint {
 
     @Inject
-    private FlowService flowService;
+    private ProgressService progressService;
 
     @Override
     @CheckPermissionByResourceCrn(action = DESCRIBE_ENVIRONMENT)
     public FlowProgressResponse getLastFlowLogProgressByResourceCrn(@ResourceCrn String resourceCrn) {
-        return flowService.getLastFlowProgressByResourceCrn(resourceCrn);
+        return progressService.getLastFlowProgressByResourceCrn(resourceCrn);
     }
 
     @Override
     @CheckPermissionByResourceCrn(action = DESCRIBE_ENVIRONMENT)
     public List<FlowProgressResponse> getFlowLogsProgressByResourceCrn(@ResourceCrn String resourceCrn) {
-        return flowService.getFlowProgressListByResourceCrn(resourceCrn);
+        return progressService.getFlowProgressListByResourceCrn(resourceCrn);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/ProvisionFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/ProvisionFlowEventChainFactory.java
@@ -6,6 +6,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionEvent;
@@ -26,5 +27,10 @@ public class ProvisionFlowEventChainFactory implements FlowEventChainFactory<Sta
         flowEventChain.add(new StackEvent(StackProvisionEvent.START_CREATION_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new StackEvent(FreeIpaProvisionEvent.FREEIPA_PROVISION_EVENT.event(), event.getResourceId()));
         return new FlowTriggerEventQueue(getName(), flowEventChain);
+    }
+
+    @Override
+    public OperationType getFlowOperationType() {
+        return OperationType.PROVISION;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/config/DiagnosticsCollectionFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/diagnostics/config/DiagnosticsCollectionFlowConfig.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
 import com.sequenceiq.freeipa.flow.freeipa.diagnostics.DiagnosticsCollectionsState;
@@ -124,5 +125,10 @@ public class DiagnosticsCollectionFlowConfig extends AbstractFlowConfiguration<D
     @Override
     public DiagnosticsCollectionStateSelectors getRetryableEvent() {
         return HANDLED_FAILED_DIAGNOSTICS_COLLECTION_EVENT;
+    }
+
+    @Override
+    public OperationType getFlowOperationType() {
+        return OperationType.DIAGNOSTICS;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/ProgressService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/ProgressService.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.freeipa.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import com.sequenceiq.flow.api.model.FlowProgressResponse;
+import com.sequenceiq.flow.service.FlowService;
+
+@Component
+public class ProgressService {
+
+    private final FlowService flowService;
+
+    public ProgressService(FlowService flowService) {
+        this.flowService = flowService;
+    }
+
+    public FlowProgressResponse getLastFlowProgressByResourceCrn(String resourceCrn) {
+        return flowService.getLastFlowProgressByResourceCrn(resourceCrn);
+    }
+
+    public List<FlowProgressResponse> getFlowProgressListByResourceCrn(String resourceCrn) {
+        return flowService.getFlowProgressListByResourceCrn(resourceCrn);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/FreeIpaService.java
@@ -7,7 +7,9 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.authorization.service.list.ResourceWithId;
+import com.sequenceiq.cloudbreak.common.event.PayloadContext;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.flow.core.PayloadContextProvider;
 import com.sequenceiq.flow.core.ResourceIdProvider;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerRequest;
 import com.sequenceiq.freeipa.converter.freeipa.FreeIpaServerRequestToFreeIpaConverter;
@@ -18,7 +20,7 @@ import com.sequenceiq.freeipa.service.stack.StackService;
 import com.sequenceiq.freeipa.util.CrnService;
 
 @Service
-public class FreeIpaService implements ResourceIdProvider {
+public class FreeIpaService implements ResourceIdProvider, PayloadContextProvider {
 
     @Inject
     private StackService stackService;
@@ -57,6 +59,17 @@ public class FreeIpaService implements ResourceIdProvider {
     @Override
     public Long getResourceIdByResourceCrn(String environmentCrn) {
         return stackService.getByEnvironmentCrnAndAccountId(environmentCrn, crnService.getCurrentAccountId()).getId();
+    }
+
+    @Override
+    public PayloadContext getPayloadContext(Long resourceId) {
+        try {
+            Stack stack = stackService.getStackById(resourceId);
+            return PayloadContext.create(stack.getResourceCrn(), stack.getEnvironmentCrn(), stack.getCloudPlatform());
+        } catch (NotFoundException notFoundException) {
+            // skip
+        }
+        return null;
     }
 
     public List<FreeIpa> getAllByIds(List<Long> ids) {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/operation/OperationServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/operation/OperationServiceTest.java
@@ -1,0 +1,75 @@
+package com.sequenceiq.freeipa.service.operation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
+import com.sequenceiq.flow.api.model.operation.OperationResource;
+import com.sequenceiq.flow.api.model.operation.OperationType;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+import com.sequenceiq.flow.converter.OperationDetailsPopulator;
+import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
+import com.sequenceiq.flow.service.FlowService;
+import com.sequenceiq.freeipa.flow.chain.ProvisionFlowEventChainFactory;
+import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionFlowConfig;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.provision.StackProvisionFlowConfig;
+
+@ExtendWith(MockitoExtension.class)
+public class OperationServiceTest {
+
+    private static final String TEST_ENV_CRN = "crn:cdp:environments:us-west-1:autoscale:cluster:ffff";
+
+    private static final List<Class<?>> EXPECTED_TYPE_LIST = List.of(StackProvisionFlowConfig.class, FreeIpaProvisionFlowConfig.class);
+
+    @InjectMocks
+    private OperationService underTest;
+
+    @Mock
+    private FlowService flowService;
+
+    @Mock
+    private OperationDetailsPopulator operationDetailsPopulator;
+
+    @Mock
+    private OperationFlowsView operationFlowsView;
+
+    @BeforeEach
+    public void setUp() {
+        underTest = new OperationService();
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testGetOperationProgressByResourceCrn() {
+        // GIVEN
+        ProvisionFlowEventChainFactory provisionFlowEventChainFactory = new ProvisionFlowEventChainFactory();
+        FlowTriggerEventQueue eventQueue = provisionFlowEventChainFactory.createFlowTriggerEventQueue(new StackEvent(null, null));
+        given(flowService.getLastFlowOperationByResourceCrn(anyString()))
+                .willReturn(Optional.of(operationFlowsView));
+        given(operationFlowsView.getOperationType()).willReturn(OperationType.PROVISION);
+        given(operationDetailsPopulator
+                .createOperationView(operationFlowsView, OperationResource.FREEIPA, EXPECTED_TYPE_LIST)).willReturn(new OperationView());
+        // WHEN
+        underTest.getOperationProgressByEnvironmentCrn(TEST_ENV_CRN, false);
+        // THEN
+        verify(operationDetailsPopulator, times(1))
+                .createOperationView(operationFlowsView, OperationResource.FREEIPA, EXPECTED_TYPE_LIST);
+        // Checks that the number of provision flows are the same as in the operation check
+        assertEquals(EXPECTED_TYPE_LIST.size(), eventQueue.getQueue().size());
+    }
+}

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/operation/OperationV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/operation/OperationV4Endpoint.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.redbeams.api.endpoint.v4.operation;
+
+import static com.sequenceiq.redbeams.doc.OperationDescriptions.OperationOpDescriptions.GET_OPERATIONS;
+import static com.sequenceiq.redbeams.doc.OperationDescriptions.OperationOpDescriptions.NOTES;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Path("/v4/operation")
+@RetryAndMetrics
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(value = "/v4/operation", description = "Get flow step progression", protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+public interface OperationV4Endpoint {
+
+    @GET
+    @Path("/resource/crn/{resourceCrn}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = GET_OPERATIONS, produces = "application/json", notes = NOTES,
+            nickname = "getRedbeamsOperationProgressByResourceCrn")
+    OperationView getRedbeamsOperationProgressByResourceCrn(@PathParam("resourceCrn") String resourceCrn,
+            @DefaultValue("false") @QueryParam("detailed") boolean detailed);
+}

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsApiKeyEndpoints.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsApiKeyEndpoints.java
@@ -5,6 +5,8 @@ import javax.ws.rs.client.WebTarget;
 import com.sequenceiq.cloudbreak.client.AbstractKeyBasedServiceEndpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.DatabaseV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
+import com.sequenceiq.redbeams.api.endpoint.v4.operation.OperationV4Endpoint;
+import com.sequenceiq.redbeams.api.endpoint.v4.progress.ProgressV4Endpoint;
 
 public class RedbeamsApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint implements RedbeamsClient {
 
@@ -20,6 +22,16 @@ public class RedbeamsApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint imp
     @Override
     public DatabaseServerV4Endpoint databaseServerV4Endpoint() {
         return getEndpoint(DatabaseServerV4Endpoint.class);
+    }
+
+    @Override
+    public ProgressV4Endpoint progressV4Endpoint() {
+        return getEndpoint(ProgressV4Endpoint.class);
+    }
+
+    @Override
+    public OperationV4Endpoint operationV4Endpoint() {
+        return getEndpoint(OperationV4Endpoint.class);
     }
 }
 

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsClient.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsClient.java
@@ -2,10 +2,16 @@ package com.sequenceiq.redbeams.client;
 
 import com.sequenceiq.redbeams.api.endpoint.v4.database.DatabaseV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
+import com.sequenceiq.redbeams.api.endpoint.v4.operation.OperationV4Endpoint;
+import com.sequenceiq.redbeams.api.endpoint.v4.progress.ProgressV4Endpoint;
 
 public interface RedbeamsClient {
 
     DatabaseV4Endpoint databaseV4Endpoint();
 
     DatabaseServerV4Endpoint databaseServerV4Endpoint();
+
+    ProgressV4Endpoint progressV4Endpoint();
+
+    OperationV4Endpoint operationV4Endpoint();
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsServiceCrnEndpoints.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/RedbeamsServiceCrnEndpoints.java
@@ -5,6 +5,8 @@ import javax.ws.rs.client.WebTarget;
 import com.sequenceiq.cloudbreak.client.AbstractUserCrnServiceEndpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.DatabaseV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
+import com.sequenceiq.redbeams.api.endpoint.v4.operation.OperationV4Endpoint;
+import com.sequenceiq.redbeams.api.endpoint.v4.progress.ProgressV4Endpoint;
 
 public class RedbeamsServiceCrnEndpoints extends AbstractUserCrnServiceEndpoint implements RedbeamsClient {
 
@@ -20,5 +22,15 @@ public class RedbeamsServiceCrnEndpoints extends AbstractUserCrnServiceEndpoint 
     @Override
     public DatabaseServerV4Endpoint databaseServerV4Endpoint() {
         return getEndpoint(DatabaseServerV4Endpoint.class);
+    }
+
+    @Override
+    public ProgressV4Endpoint progressV4Endpoint() {
+        return getEndpoint(ProgressV4Endpoint.class);
+    }
+
+    @Override
+    public OperationV4Endpoint operationV4Endpoint() {
+        return getEndpoint(OperationV4Endpoint.class);
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/internal/RedbeamsApiClientConfig.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/client/internal/RedbeamsApiClientConfig.java
@@ -12,6 +12,8 @@ import com.sequenceiq.cloudbreak.client.WebTargetEndpointFactory;
 import com.sequenceiq.redbeams.api.RedbeamsApi;
 import com.sequenceiq.redbeams.api.endpoint.v4.database.DatabaseV4Endpoint;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.DatabaseServerV4Endpoint;
+import com.sequenceiq.redbeams.api.endpoint.v4.operation.OperationV4Endpoint;
+import com.sequenceiq.redbeams.api.endpoint.v4.progress.ProgressV4Endpoint;
 
 import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
 
@@ -50,5 +52,17 @@ public class RedbeamsApiClientConfig {
     @ConditionalOnBean(RedbeamsApiClientParams.class)
     DatabaseServerV4Endpoint databaseServerV4Endpoint(WebTarget redbeamsApiClientWebTarget) {
         return new WebTargetEndpointFactory().createEndpoint(redbeamsApiClientWebTarget, DatabaseServerV4Endpoint.class);
+    }
+
+    @Bean
+    @ConditionalOnBean(RedbeamsApiClientParams.class)
+    ProgressV4Endpoint progressDatabaseServerV4Endpoint(WebTarget redbeamsApiClientWebTarget) {
+        return new WebTargetEndpointFactory().createEndpoint(redbeamsApiClientWebTarget, ProgressV4Endpoint.class);
+    }
+
+    @Bean
+    @ConditionalOnBean(RedbeamsApiClientParams.class)
+    OperationV4Endpoint operationDatabaseServerV4Endpoint(WebTarget redbeamsApiClientWebTarget) {
+        return new WebTargetEndpointFactory().createEndpoint(redbeamsApiClientWebTarget, OperationV4Endpoint.class);
     }
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
@@ -50,4 +50,13 @@ public final class OperationDescriptions {
         }
     }
 
+    public static final class OperationOpDescriptions {
+
+        public static final String NOTES = "Flow operation details";
+        public static final String GET_OPERATIONS = "Get flow operation progress details for resource by resource crn";
+
+        private OperationOpDescriptions() {
+        }
+    }
+
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/RedbeamsApplication.java
@@ -46,6 +46,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
         "com.sequenceiq.cloudbreak.common.dbmigration",
         "com.sequenceiq.cloudbreak.converter",
         "com.sequenceiq.cloudbreak.telemetry.fluent.cloud",
+        "com.sequenceiq.cloudbreak.progress",
+        "com.sequenceiq.cloudbreak.operation",
         "com.sequenceiq.cloudbreak.validation",
         "com.sequenceiq.cloudbreak.common.converter",
         "com.sequenceiq.cloudbreak.json",

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/EndpointConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/configuration/EndpointConfig.java
@@ -18,6 +18,7 @@ import com.sequenceiq.redbeams.controller.mapper.DefaultExceptionMapper;
 import com.sequenceiq.redbeams.controller.mapper.WebApplicationExceptionMapper;
 import com.sequenceiq.redbeams.controller.v4.database.DatabaseV4Controller;
 import com.sequenceiq.redbeams.controller.v4.databaseserver.DatabaseServerV4Controller;
+import com.sequenceiq.redbeams.controller.v4.operation.OperationV4Controller;
 import com.sequenceiq.redbeams.controller.v4.progress.ProgressV4Controller;
 
 import io.opentracing.contrib.jaxrs2.client.ClientTracingFeature;
@@ -31,6 +32,7 @@ public class EndpointConfig extends ResourceConfig {
             DatabaseV4Controller.class,
             DatabaseServerV4Controller.class,
             ProgressV4Controller.class,
+            OperationV4Controller.class,
             FlowController.class,
             FlowPublicController.class,
             AuthorizationInfoController.class

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/operation/OperationV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/operation/OperationV4Controller.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.redbeams.controller.v4.operation;
+
+import static com.sequenceiq.authorization.resource.AuthorizationResourceAction.DESCRIBE_DATABASE_SERVER;
+
+import javax.transaction.Transactional;
+
+import org.springframework.stereotype.Controller;
+
+import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
+import com.sequenceiq.authorization.annotation.ResourceCrn;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+import com.sequenceiq.redbeams.api.endpoint.v4.operation.OperationV4Endpoint;
+import com.sequenceiq.redbeams.service.operation.OperationService;
+
+@Controller
+@Transactional(Transactional.TxType.NEVER)
+public class OperationV4Controller implements OperationV4Endpoint {
+
+    private final OperationService operationService;
+
+    public OperationV4Controller(OperationService operationService) {
+        this.operationService = operationService;
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = DESCRIBE_DATABASE_SERVER)
+    public OperationView getRedbeamsOperationProgressByResourceCrn(@ResourceCrn String resourceCrn, boolean detailed) {
+        return operationService.getOperationProgressByResourceCrn(resourceCrn, detailed);
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/progress/ProgressV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/progress/ProgressV4Controller.java
@@ -12,25 +12,25 @@ import org.springframework.stereotype.Controller;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
-import com.sequenceiq.flow.service.FlowService;
 import com.sequenceiq.redbeams.api.endpoint.v4.progress.ProgressV4Endpoint;
+import com.sequenceiq.redbeams.service.progress.ProgressService;
 
 @Controller
 @Transactional(Transactional.TxType.NEVER)
 public class ProgressV4Controller implements ProgressV4Endpoint {
 
     @Inject
-    private FlowService flowService;
+    private ProgressService progressService;
 
     @Override
     @CheckPermissionByResourceCrn(action = DESCRIBE_DATABASE_SERVER)
     public FlowProgressResponse getLastFlowLogProgressByResourceCrn(@ResourceCrn String resourceCrn) {
-        return flowService.getLastFlowProgressByResourceCrn(resourceCrn);
+        return progressService.getLastFlowProgressByResourceCrn(resourceCrn);
     }
 
     @Override
     @CheckPermissionByResourceCrn(action = DESCRIBE_DATABASE_SERVER)
     public List<FlowProgressResponse> getFlowLogsProgressByResourceCrn(@ResourceCrn String resourceCrn) {
-        return flowService.getFlowProgressListByResourceCrn(resourceCrn);
+        return progressService.getFlowProgressListByResourceCrn(resourceCrn);
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/RedbeamsProvisionFlowConfig.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/flow/redbeams/provision/RedbeamsProvisionFlowConfig.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.flow.api.model.operation.OperationType;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
 import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
 import com.sequenceiq.flow.core.config.RetryableFlowConfiguration;
@@ -75,5 +76,10 @@ public class RedbeamsProvisionFlowConfig extends AbstractFlowConfiguration<Redbe
     @Override
     public RedbeamsProvisionEvent getRetryableEvent() {
         return REDBEAMS_PROVISION_FAILURE_HANDLED_EVENT;
+    }
+
+    @Override
+    public OperationType getFlowOperationType() {
+        return OperationType.PROVISION;
     }
 }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/operation/OperationService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/operation/OperationService.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.redbeams.service.operation;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
+import com.sequenceiq.flow.api.model.operation.OperationResource;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+import com.sequenceiq.flow.converter.OperationDetailsPopulator;
+import com.sequenceiq.flow.service.FlowService;
+
+@Component
+public class OperationService {
+
+    private final FlowService flowService;
+
+    private final OperationDetailsPopulator operationDetailsPopulator;
+
+    public OperationService(FlowService flowService, OperationDetailsPopulator operationDetailsPopulator) {
+        this.flowService = flowService;
+        this.operationDetailsPopulator = operationDetailsPopulator;
+    }
+
+    public OperationView getOperationProgressByResourceCrn(String resourceCrn, boolean detailed) {
+        OperationView response = new OperationView();
+        Optional<OperationFlowsView> operationFlowsViewOpt = flowService.getLastFlowOperationByResourceCrn(resourceCrn);
+        operationFlowsViewOpt.ifPresent(operationFlowsView -> operationDetailsPopulator.createOperationView(operationFlowsView, OperationResource.REMOTEDB));
+        return response;
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/progress/ProgressService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/progress/ProgressService.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.redbeams.service.progress;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.authorization.annotation.ResourceCrn;
+import com.sequenceiq.flow.api.model.FlowProgressResponse;
+import com.sequenceiq.flow.service.FlowService;
+
+@Component
+public class ProgressService {
+
+    private final FlowService flowService;
+
+    public ProgressService(FlowService flowService) {
+        this.flowService = flowService;
+    }
+
+    public FlowProgressResponse getLastFlowProgressByResourceCrn(@ResourceCrn String resourceCrn) {
+        return flowService.getLastFlowProgressByResourceCrn(resourceCrn);
+    }
+
+    public List<FlowProgressResponse> getFlowProgressListByResourceCrn(@ResourceCrn String resourceCrn) {
+        return flowService.getFlowProgressListByResourceCrn(resourceCrn);
+    }
+}

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/DBStackService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/stack/DBStackService.java
@@ -9,13 +9,15 @@ import javax.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.common.event.PayloadContext;
+import com.sequenceiq.flow.core.PayloadContextProvider;
 import com.sequenceiq.redbeams.api.model.common.Status;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 import com.sequenceiq.redbeams.exception.NotFoundException;
 import com.sequenceiq.redbeams.repository.DBStackRepository;
 
 @Service
-public class DBStackService {
+public class DBStackService implements PayloadContextProvider {
 
     @Inject
     private DBStackRepository dbStackRepository;
@@ -61,6 +63,16 @@ public class DBStackService {
 
     public DBStack save(DBStack dbStack) {
         return dbStackRepository.save(dbStack);
+    }
+
+    @Override
+    public PayloadContext getPayloadContext(Long resourceId) {
+        Optional<DBStack> dbStackOpt = findById(resourceId);
+        if (dbStackOpt.isPresent()) {
+            DBStack dbStack = dbStackOpt.get();
+            return PayloadContext.create(dbStack.getResourceCrn().toString(), dbStack.getCloudPlatform());
+        }
+        return null;
     }
 
     @Transactional


### PR DESCRIPTION
details:
- separate progress service from new operations (creaate progress service for every remaining progress api)
- add operation endpoints + controllers
- operation api always get back the latest operation (not by type, can be done later)
- add operationType field for flowlogs -> represents named operations for flows or flow chains
- create operation view models that holds detailed and simple flow progress results
- update flow2 handlers for supporting new operation type
- add new query with an operationid in the response (operationid is flowid or flowchain - based on the flow is in chain or not)
- operation type of flow chains will override the operation type of flows

Additional change: CB-13103. Operation API: Calculate progress percentage from flow time statistics
details:
- create new flow operation statistics table
- store only not UNKNOWN operations (per cloud platform)
- calculate average from the statistics (to guess a flow/operation time) - or if no duration history -> use 12 minutes
- provide additional payload information (resourceCrn/envCrn/cloudPlatform) by a new object: PayloadContext
- store flow stats + running flows/flowchains in memory (cache) -> use this if there is anything in the cache + the type of running operation is not UNKNOWN
- add additional cache cleanup to the flow cleanup job (it should not have old flows in the cache, but in case of any newly added features to flows, it's possible - with an unexpected exception - a cache remove operation can be skipped)