### PR TITLE
CB-13013 WaitOperationChecker exitWaiting does not throw exception in case of isCreateFailed

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitFailedChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitFailedChecker.java
@@ -30,6 +30,10 @@ public class WaitFailedChecker<T extends WaitObject> extends ExceptionChecker<T>
             throw new TestFailException(String.format("Cluster '%s' has been terminated. Status: '%s' statusReason: '%s'",
                     name, actualStatuses, actualStatusReasons));
         }
+        if (waitObject.isInDesiredStatus()) {
+            LOGGER.info("Cluster '{}' is in desired state (status:'{}').", name, actualStatuses);
+            return true;
+        }
         return waitObject.isInDesiredStatus();
     }
 
@@ -44,7 +48,7 @@ public class WaitFailedChecker<T extends WaitObject> extends ExceptionChecker<T>
 
     @Override
     public String successMessage(T waitObject) {
-        return String.format("Wait operation was successfully done. '%s' %s is in the desired state '%s'", waitObject.getName(),
+        return String.format("Wait operation was successfully done. '%s' %s is in desired state '%s'", waitObject.getName(),
                 waitObject.getClass().getSimpleName(), waitObject.getDesiredStatuses());
     }
 
@@ -55,7 +59,7 @@ public class WaitFailedChecker<T extends WaitObject> extends ExceptionChecker<T>
             LOGGER.info("'{}' {} was not found. Exit waiting!", waitObject.getClass().getSimpleName(), name);
             return true;
         }
-        return false;
+        return waitObject.isInDesiredStatus();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitObject.java
@@ -8,6 +8,10 @@ public interface WaitObject {
 
     String STATUS_REASON = "statusReason";
 
+    String CLUSTER_STATUS = "clusterStatus";
+
+    String CLUSTER_STATUS_REASON = "clusterStatusReason";
+
     void fetchData();
 
     boolean isDeleteFailed();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
@@ -35,7 +35,7 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
             LOGGER.info("Cluster '{}' is in desired state (status:'{}').", name, actualStatuses);
             return true;
         }
-        return waitObject.isFailed();
+        return waitObject.isInDesiredStatus();
     }
 
     @Override
@@ -65,10 +65,12 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
             return true;
         }
         if (waitObject.isCreateFailed()) {
-            LOGGER.info("'{}' the polled resource entered into creation failed state. Exit waiting!", name);
-            return true;
+            Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
+            LOGGER.error("Cluster '{}' entered into creation failed state (status:'{}'). Exit waiting!", name, actualStatuses);
+            throw new TestFailException(String.format("Cluster '%s' entered into creation failed state. Status: '%s' statusReason: '%s'",
+                    name, actualStatuses, actualStatusReasons));
         }
-        return waitObject.isFailed();
+        return waitObject.isInDesiredStatus();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceTerminationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceTerminationChecker.java
@@ -6,8 +6,6 @@ import java.util.NoSuchElementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.instancemetadata.InstanceMetaDataV4Response;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.util.wait.service.ExceptionChecker;
 
@@ -22,26 +20,26 @@ public class InstanceTerminationChecker<T extends InstanceWaitObject> extends Ex
         if (deleted) {
             return true;
         }
-        InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
-        InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
-        String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
-        String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
+        Map<String, String> desiredStatuses = waitObject.getDesiredStatuses();
+        String name = waitObject.getHostGroup();
+        Map<String, String> actualStatuses = waitObject.actualStatuses();
+        LOGGER.info("Waiting for the '{}' state of '{}' instance. Actual state is: '{}'", desiredStatuses, name, actualStatuses);
         if (waitObject.isDeleteFailed()) {
-            LOGGER.error("The '{}' instance group termination failed (status:'{}'), waiting is cancelled.", instanceGroupName, instanceStatus);
-            throw new TestFailException(String.format("The '%s' instance group termination failed, waiting is cancelled. " +
-                    "Status: '%s' statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
+            Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
+            LOGGER.error("Instance '{}' termination failed (status:'{}'), waiting is cancelled.", name, actualStatuses);
+            throw new TestFailException(String.format("Instance '%s' termination failed. Status: '%s' statusReason: '%s'",
+                    name, actualStatuses, actualStatusReasons));
         }
         return waitObject.isDeleted();
     }
 
     @Override
     public void handleTimeout(T waitObject) {
-        InstanceMetaDataV4Response instanceMetaDataV4Response = waitObject.getInstanceMetadata();
-        InstanceStatus instanceStatus = instanceMetaDataV4Response.getInstanceStatus();
-        String instanceGroupName = instanceMetaDataV4Response.getInstanceGroup();
-        String hostStatusReason = instanceMetaDataV4Response.getStatusReason();
-        throw new TestFailException(String.format("Wait operation timed out! '%s' instance group termination failed. Instance status: '%s' " +
-                "statusReason: '%s'", instanceGroupName, instanceStatus, hostStatusReason));
+        String name = waitObject.getHostGroup();
+        Map<String, String> actualStatuses = waitObject.actualStatuses();
+        Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
+        throw new TestFailException(String.format("Wait operation timed out! '%s' instance termination failed. Cluster status: '%s' " +
+                "statusReason: '%s'", name, actualStatuses, actualStatusReasons));
     }
 
     @Override
@@ -52,10 +50,19 @@ public class InstanceTerminationChecker<T extends InstanceWaitObject> extends Ex
 
     @Override
     public boolean exitWaiting(T waitObject) {
-        if (waitObject.isDeleteFailed()) {
-            return false;
+        String name = waitObject.getHostGroup();
+        Map<String, String> actualStatuses = waitObject.actualStatuses();
+        if (actualStatuses.isEmpty()) {
+            LOGGER.info("'{}' instance was not found. Exit waiting!", name);
+            return true;
         }
-        return waitObject.isFailed();
+        if (waitObject.isDeleteFailed()) {
+            Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
+            LOGGER.error("Instance '{}' termination failed (status:'{}'). Exit waiting!", name, actualStatuses);
+            throw new TestFailException(String.format("Instance '%s' termination failed. Status: '%s' statusReason: '%s'",
+                    name, actualStatuses, actualStatusReasons));
+        }
+        return waitObject.isDeleted();
     }
 
     @Override
@@ -65,15 +72,15 @@ public class InstanceTerminationChecker<T extends InstanceWaitObject> extends Ex
 
     @Override
     public void refresh(T waitObject) {
-        String hostGroup = waitObject.getHostGroup();
+        String name = waitObject.getHostGroup();
         try {
             waitObject.fetchData();
         } catch (NoSuchElementException e) {
-            LOGGER.warn("{} instance group is not present, may this was deleted.", hostGroup, e);
+            LOGGER.warn("{} instance group is not present, may this was deleted.", name, e);
             deleted = true;
         } catch (Exception e) {
-            LOGGER.error("'{}' instance group deletion has been failed, because of: {}", hostGroup, e.getMessage(), e);
-            throw new TestFailException(String.format("'%s' instance group deletion has been failed", hostGroup), e);
+            LOGGER.error("'{}' instance group deletion has been failed, because of: {}", name, e.getMessage(), e);
+            throw new TestFailException(String.format("'%s' instance group deletion has been failed", name), e);
         }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceWaitObject.java
@@ -7,6 +7,7 @@ import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStat
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.ORCHESTRATION_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.TERMINATED;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.DELETE_REQUESTED;
 
 import java.util.List;
 import java.util.Map;
@@ -63,8 +64,7 @@ public class InstanceWaitObject implements WaitObject {
 
     @Override
     public boolean isDeleteFailed() {
-        Set<InstanceStatus> failedStatuses = Set.of(FAILED, DECOMMISSION_FAILED);
-        return failedStatuses.contains(getInstanceStatus());
+        return getInstanceStatus().equals(DECOMMISSION_FAILED);
     }
 
     @Override
@@ -118,12 +118,12 @@ public class InstanceWaitObject implements WaitObject {
 
     @Override
     public boolean isDeletionInProgress() {
-        return false;
+        return getInstanceStatus().equals(DELETE_REQUESTED);
     }
 
     @Override
     public boolean isCreateFailed() {
-        return false;
+        return getInstanceStatus().equals(ORCHESTRATION_FAILED);
     }
 
     @Override


### PR DESCRIPTION
Azure API E2E DistroXEncryptedVolumeTest/testCreateDistroXWithEncryptedVolume is does not failing even the `status=CREATE_FAILED`.

I found that the [exitWaiting method](https://github.com/hortonworks/cloudbreak/blob/CB-2.44.0/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java#L67-L70) returns only a boolean:
```
if (waitObject.isCreateFailed()) {
     LOGGER.info("'{}' the polled resource entered into creation failed state. Exit waiting!", name);
     return true;
}
```
However here a `throw new TestFailException` would be expected as well.