### PR TITLE
CB-12631: Add tags to Azure Load balancers.

### DIFF
--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -436,6 +436,13 @@
                   ],
                   "location": "[parameters('region')]",
                   "name": "${loadBalancer.name}",
+                  "tags": {
+                    <#if userDefinedTags?? && userDefinedTags?has_content>
+                        <#list userDefinedTags?keys as key>
+                            "${key}": "${userDefinedTags[key]}"<#if key_has_next>,</#if>
+                        </#list>
+                    </#if>
+                  },
                   "properties": {
                     "backendAddressPools": [
                       {


### PR DESCRIPTION
Closes [CB-12631](https://jira.cloudera.com/browse/CB-12631).
Add user created tags to Load Balancers deployed in Azure.

See screenshot for example:
<img width="1370" alt="Screen Shot 2021-06-10 at 1 04 01 PM" src="https://user-images.githubusercontent.com/14059838/121590064-b4efa080-c9ec-11eb-8efb-18e07d0fac24.png">
