### PR TITLE
[CB-12976] Add Resource Builder for GCP instance Groups

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/group/AbstractGcpGroupBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/group/AbstractGcpGroupBuilder.java
@@ -1,9 +1,17 @@
 package com.sequenceiq.cloudbreak.cloud.gcp.group;
 
+import java.io.IOException;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.compute.ComputeRequest;
+import com.google.api.services.compute.model.Operation;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.gcp.AbstractGcpResourceBuilder;
+import com.sequenceiq.cloudbreak.cloud.gcp.GcpResourceException;
 import com.sequenceiq.cloudbreak.cloud.gcp.context.GcpContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
@@ -11,9 +19,23 @@ import com.sequenceiq.cloudbreak.cloud.template.GroupResourceBuilder;
 
 public abstract class AbstractGcpGroupBuilder extends AbstractGcpResourceBuilder implements GroupResourceBuilder<GcpContext> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractGcpGroupBuilder.class);
+
     @Override
     public List<CloudResourceStatus> checkResources(GcpContext context, AuthenticatedContext auth, List<CloudResource> resources) {
         return checkResources(resourceType(), context, auth, resources);
     }
 
+    protected CloudResource executeOperationalRequest(CloudResource resource, ComputeRequest<Operation> request) throws IOException {
+        try {
+            Operation operation = request.execute();
+            if (operation.getHttpErrorStatusCode() != null) {
+                LOGGER.error("Error response in executing request, status {}, {}", operation.getHttpErrorStatusCode(), operation.getHttpErrorMessage());
+                throw new GcpResourceException(operation.getHttpErrorMessage(), resourceType(), resource.getName());
+            }
+            return createOperationAwareCloudResource(resource, operation);
+        } catch (GoogleJsonResponseException e) {
+            throw exceptionHandlerWithThrow(e, resource.getName(), resourceType());
+        }
+    }
 }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpFirewallInResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpFirewallInResourceBuilder.java
@@ -68,15 +68,7 @@ public class GcpFirewallInResourceBuilder extends AbstractGcpGroupBuilder {
                 && gcpStackUtil.isExistingNetwork(network))
                 ? updateExistingFirewallForNewTargets(context, auth, group)
                 : createNewFirewallRule(context, auth, group, network, security, buildableResource, projectId);
-        try {
-            Operation operation = firewallRequest.execute();
-            if (operation.getHttpErrorStatusCode() != null) {
-                throw new GcpResourceException(operation.getHttpErrorMessage(), resourceType(), buildableResource.getName());
-            }
-            return createOperationAwareCloudResource(buildableResource, operation);
-        } catch (GoogleJsonResponseException e) {
-            throw new GcpResourceException(checkException(e), resourceType(), buildableResource.getName());
-        }
+        return executeOperationalRequest(buildableResource, firewallRequest);
     }
 
     private Update updateExistingFirewallForNewTargets(GcpContext context, AuthenticatedContext auth, Group group)

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilder.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.group;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.compute.Compute.InstanceGroups.Delete;
+import com.google.api.services.compute.Compute.InstanceGroups.Insert;
+import com.google.api.services.compute.model.InstanceGroup;
+import com.google.api.services.compute.model.Operation;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.gcp.context.GcpContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.cloud.model.Network;
+import com.sequenceiq.cloudbreak.cloud.model.Security;
+import com.sequenceiq.common.api.type.ResourceType;
+
+/**
+ * The Group Resource Builder that is responsible for the GCP API calls to manage an instance group
+ * This currently only defines unmanaged instance groups
+ * In GCP an instance group is a collection of Compute Instances in the same Zone and subnet
+ * An unmanaged instace group is only used to be applied as a target of a load balancer backend
+ * An instance shoup be added to at most 1 load balanced instance group
+ * This creates a Instance Group for every group defined in a stack.
+ */
+
+@Service
+public class GcpInstanceGroupResourceBuilder extends AbstractGcpGroupBuilder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GcpInstanceGroupResourceBuilder.class);
+
+    private static final int ORDER = 1;
+
+    @Override
+    public CloudResource create(GcpContext context, AuthenticatedContext auth, Group group, Network network) {
+        String resourceName = getResourceNameService().resourceName(resourceType(), context.getName(), group.getName());
+        return createNamedResource(resourceType(), resourceName, context.getLocation().getAvailabilityZone().value());
+    }
+
+    @Override
+    public CloudResource build(GcpContext context,
+            AuthenticatedContext auth, Group group,
+            Network network, Security security, CloudResource resource) throws Exception {
+        LOGGER.info("Building GCP instancegroup {} for project {}", group.getName(), context.getProjectId());
+
+
+        Insert insert = context.getCompute().instanceGroups().insert(context.getProjectId(),
+                context.getLocation().getAvailabilityZone().value(), new InstanceGroup().setName(resource.getName()));
+
+        return executeOperationalRequest(resource, insert);
+    }
+
+    @Override
+    public CloudResourceStatus update(GcpContext context, AuthenticatedContext auth, Group group, Network network, Security security, CloudResource resource) {
+        return null;
+    }
+
+    @Override
+    public CloudResource delete(GcpContext context, AuthenticatedContext auth, CloudResource resource, Network network) throws Exception {
+        LOGGER.info("Deleting GCP instancegroup {} for project {}", resource.getName(), context.getProjectId());
+
+        Delete delete = context.getCompute().instanceGroups().delete(context.getProjectId(),
+                context.getLocation().getAvailabilityZone().value(), resource.getName());
+        try {
+            Operation operation = delete.execute();
+            return createOperationAwareCloudResource(resource, operation);
+        } catch (GoogleJsonResponseException e) {
+            LOGGER.error("unable to delete instance group {}, error: {}", resource.getName(), e.getMessage());
+            exceptionHandler(e, resource.getName(), resourceType());
+            return null;
+        }
+    }
+
+    @Override
+    public ResourceType resourceType() {
+        return ResourceType.GCP_INSTANCE_GROUP;
+    }
+
+    @Override
+    public int order() {
+        return ORDER;
+    }
+}

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameService.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameService.java
@@ -27,6 +27,7 @@ public class GcpResourceNameService extends CloudbreakResourceNameService {
     private int maxResourceNameLength;
 
     @Override
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     public String resourceName(ResourceType resourceType, Object... parts) {
         String resourceName;
 
@@ -57,6 +58,9 @@ public class GcpResourceNameService extends CloudbreakResourceNameService {
                 break;
             case GCP_DATABASE:
                 resourceName = deploymentTemplateName(parts);
+                break;
+            case GCP_INSTANCE_GROUP:
+                resourceName = gcpGroupResourceName(parts);
                 break;
             default:
                 throw new IllegalStateException("Unsupported resource type: " + resourceType);
@@ -136,5 +140,18 @@ public class GcpResourceNameService extends CloudbreakResourceNameService {
         subnetName = appendHash(subnetName, new Date());
         subnetName = adjustBaseLength(subnetName, maxResourceNameLength);
         return subnetName;
+    }
+
+    private String gcpGroupResourceName(Object[] parts) {
+        checkArgs(2, parts);
+        String name;
+        String stackName = String.valueOf(parts[0]);
+        String groupName = String.valueOf(parts[1]);
+        name = normalize(stackName);
+        name = adjustPartLength(name);
+        name = appendPart(name, normalize(groupName));
+        name = appendHash(name, new Date());
+        name = adjustBaseLength(name, maxResourceNameLength);
+        return name;
     }
 }

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/group/GcpInstanceGroupResourceBuilderTest.java
@@ -1,0 +1,196 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.group;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.Compute.InstanceGroups;
+import com.google.api.services.compute.model.Operation;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.gcp.GcpResourceException;
+import com.sequenceiq.cloudbreak.cloud.gcp.context.GcpContext;
+import com.sequenceiq.cloudbreak.cloud.gcp.service.GcpResourceNameService;
+import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
+import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Network;
+import com.sequenceiq.cloudbreak.cloud.model.Security;
+import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.ResourceType;
+
+@ExtendWith(MockitoExtension.class)
+public class GcpInstanceGroupResourceBuilderTest {
+
+    @Mock
+    private GcpStackUtil gcpStackUtil;
+
+    @InjectMocks
+    private GcpInstanceGroupResourceBuilder underTest;
+
+    @Mock
+    private Network network;
+
+    @Mock
+    private GcpContext gcpContext;
+
+    @Mock
+    private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private Compute compute;
+
+    @Mock
+    private Location location;
+
+    @Mock
+    private AvailabilityZone availabilityZone;
+
+    @Mock
+    private InstanceGroups instanceGroups;
+
+    @Mock
+    private InstanceGroups.Delete instanceGroupsDelete;
+
+    @Mock
+    private Operation operation;
+
+    @Mock
+    private Security security;
+
+    @Mock
+    private Group group;
+
+    @BeforeEach
+    private void setup() {
+        GcpResourceNameService resourceNameService = new GcpResourceNameService();
+        ReflectionTestUtils.setField(resourceNameService, "maxResourceNameLength", 50);
+        ReflectionTestUtils.setField(underTest, "resourceNameService", resourceNameService);
+    }
+
+    @Test
+    public void testDeleteWhenEverythingGoesFine() throws Exception {
+        CloudResource resource = new CloudResource.Builder()
+                .type(ResourceType.GCP_INSTANCE_GROUP)
+                .status(CommonStatus.CREATED)
+                .group("master")
+                .name("super")
+                .instanceId("id-123")
+                .params(new HashMap<>())
+                .persistent(true)
+                .build();
+
+        when(gcpContext.getCompute()).thenReturn(compute);
+        when(gcpContext.getProjectId()).thenReturn("id");
+        when(gcpContext.getLocation()).thenReturn(location);
+        when(location.getAvailabilityZone()).thenReturn(availabilityZone);
+        when(availabilityZone.value()).thenReturn("zone");
+        when(compute.instanceGroups()).thenReturn(instanceGroups);
+        when(instanceGroups.delete(anyString(), anyString(), anyString())).thenReturn(instanceGroupsDelete);
+        when(instanceGroupsDelete.execute()).thenReturn(operation);
+        when(operation.getName()).thenReturn("name");
+
+        CloudResource delete = underTest.delete(gcpContext, authenticatedContext, resource, network);
+
+        Assert.assertEquals(ResourceType.GCP_INSTANCE_GROUP, delete.getType());
+        Assert.assertEquals(CommonStatus.CREATED, delete.getStatus());
+        Assert.assertEquals("super", delete.getName());
+        Assert.assertEquals("master", delete.getGroup());
+        Assert.assertEquals("id-123", delete.getInstanceId());
+    }
+
+    @Test
+    public void testCreateWhenEverythingGoesFine() throws Exception {
+        when(gcpContext.getName()).thenReturn("name");
+        when(group.getName()).thenReturn("group");
+        when(gcpContext.getLocation()).thenReturn(location);
+        when(location.getAvailabilityZone()).thenReturn(availabilityZone);
+        when(availabilityZone.value()).thenReturn("zone");
+
+        CloudResource cloudResource = underTest.create(gcpContext, authenticatedContext, group, network);
+
+        Assertions.assertTrue(cloudResource.getName().startsWith("name-group"));
+    }
+
+    @Test
+    public void testBuild() throws Exception {
+        CloudResource resource = new CloudResource.Builder()
+                .type(ResourceType.GCP_INSTANCE_GROUP)
+                .status(CommonStatus.CREATED)
+                .group("master")
+                .name("super")
+                .instanceId("id-123")
+                .params(new HashMap<>())
+                .persistent(true)
+                .build();
+        Compute.InstanceGroups.Insert instanceGroupsInsert = mock(Compute.InstanceGroups.Insert.class);
+
+        when(gcpContext.getCompute()).thenReturn(compute);
+        when(gcpContext.getProjectId()).thenReturn("id");
+        when(gcpContext.getLocation()).thenReturn(location);
+        when(location.getAvailabilityZone()).thenReturn(availabilityZone);
+        when(availabilityZone.value()).thenReturn("zone");
+
+        when(compute.instanceGroups()).thenReturn(instanceGroups);
+        when(instanceGroups.insert(anyString(), anyString(), any())).thenReturn(instanceGroupsInsert);
+        when(instanceGroupsInsert.execute()).thenReturn(operation);
+        when(operation.getName()).thenReturn("name");
+        when(operation.getHttpErrorStatusCode()).thenReturn(null);
+
+        CloudResource cloudResource = underTest.build(gcpContext, authenticatedContext, group, network, security, resource);
+
+        Assert.assertEquals("super", cloudResource.getName());
+
+    }
+
+    @Test
+    public void testBuildNoPermission() throws Exception {
+        CloudResource resource = new CloudResource.Builder()
+                .type(ResourceType.GCP_INSTANCE_GROUP)
+                .status(CommonStatus.CREATED)
+                .group("master")
+                .name("super")
+                .instanceId("id-123")
+                .params(new HashMap<>())
+                .persistent(true)
+                .build();
+        Compute.InstanceGroups.Insert instanceGroupsInsert = mock(Compute.InstanceGroups.Insert.class);
+
+        when(gcpContext.getCompute()).thenReturn(compute);
+        when(gcpContext.getProjectId()).thenReturn("id");
+        when(gcpContext.getLocation()).thenReturn(location);
+        when(location.getAvailabilityZone()).thenReturn(availabilityZone);
+        when(availabilityZone.value()).thenReturn("zone");
+
+        when(compute.instanceGroups()).thenReturn(instanceGroups);
+        when(instanceGroups.insert(anyString(), anyString(), any())).thenReturn(instanceGroupsInsert);
+        when(instanceGroupsInsert.execute()).thenReturn(operation);
+        when(operation.getHttpErrorStatusCode()).thenReturn(401);
+        when(operation.getHttpErrorMessage()).thenReturn("Not Authorized");
+
+        Assert.assertThrows("Not Authorized", GcpResourceException.class,
+                () -> underTest.build(gcpContext, authenticatedContext, group, network, security, resource));
+    }
+
+    @Test
+    public void testResourceType() {
+        Assert.assertTrue(underTest.resourceType().equals(ResourceType.GCP_INSTANCE_GROUP));
+    }
+
+}

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameServiceTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/service/GcpResourceNameServiceTest.java
@@ -131,4 +131,18 @@ public class GcpResourceNameServiceTest {
         Assert.assertTrue("The resource name length is wrong", resourceName.length() < Integer.parseInt(MAX_RESOURCE_NAME_LENGTH));
 
     }
+
+    @Test
+    public void shouldGenerateGcpInstanceGroupResourceWehenPartsProvided() {
+        // GIVEN
+        Object[] parts = {"stack", "group"};
+
+        // WHEN
+        String resourceName = subject.resourceName(ResourceType.GCP_INSTANCE_GROUP, parts);
+
+        // THEN
+        Assert.assertNotNull("The generated name must not be null!", resourceName);
+        Assert.assertEquals("The timestamp must be appended", 3L, resourceName.split("-").length);
+        Assert.assertTrue("The resource name is not the expected one!", resourceName.startsWith("stack-group"));
+    }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/ResourceType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/ResourceType.java
@@ -49,6 +49,7 @@ public enum ResourceType {
     GCP_FIREWALL_INTERNAL,
     GCP_INSTANCE,
     GCP_DATABASE,
+    GCP_INSTANCE_GROUP,
 
     //AZURE
     AZURE_INSTANCE,


### PR DESCRIPTION
Part of the first step for GCP loadbalancers, defining instance groups to be used to define service pools

Unit testing here, more verification coming.