### PR TITLE
CB-13029 Introduce retry logic to resource role assignment

### DIFF
--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java
@@ -789,19 +789,20 @@ public class GrpcUmsClient {
         return resourceRoleAssignments;
     }
 
-    public void assignResourceRole(
-            String assigneeCrn, String resourceCrn, String resourceRoleCrn, Optional<String> requestId) {
+    public void assignResourceRole(String assigneeCrn, String resourceCrn, String resourceRoleCrn, Optional<String> requestId) {
         UmsClient client = makeClient(channelWrapper.getChannel());
-        LOGGER.info("Assigning {} role for resource {} to assignee {}", resourceRoleCrn, resourceCrn, assigneeCrn);
+        LOGGER.info("Assigning '{}' role at resource '{}' to assignee '{}'...", resourceRoleCrn, resourceCrn, assigneeCrn);
         client.assignResourceRole(RequestIdUtil.getOrGenerate(requestId), assigneeCrn, resourceCrn, resourceRoleCrn);
-        LOGGER.info("Assigned {} role for resource {} to assignee {}", resourceRoleCrn, resourceCrn, assigneeCrn);
+        LOGGER.info("Resource role assignment has been successfully done ::: Role: {} Resource: {} Assignee: {}",
+                resourceRoleCrn, resourceCrn, assigneeCrn);
     }
 
     public void unassignResourceRole(String assigneeCrn, String resourceCrn, String resourceRoleCrn, Optional<String> requestId) {
         UmsClient client = makeClient(channelWrapper.getChannel());
-        LOGGER.info("Unassigning {} role for resource {} from assignee {}", resourceRoleCrn, resourceCrn, assigneeCrn);
+        LOGGER.info("Unassigning '{}' role at resource '{}' from assignee '{}'...", resourceRoleCrn, resourceCrn, assigneeCrn);
         client.unassignResourceRole(RequestIdUtil.getOrGenerate(requestId), assigneeCrn, resourceCrn, resourceRoleCrn);
-        LOGGER.info("Unassigned {} role for resource {} from assignee {}", resourceRoleCrn, resourceCrn, assigneeCrn);
+        LOGGER.info("Resource role unassignment has been successfully done ::: Role: {} Resource: {} Assignee: {}",
+                resourceRoleCrn, resourceCrn, assigneeCrn);
     }
 
     public void notifyResourceDeleted(String resourceCrn, Optional<String> requestId) {

--- a/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
+++ b/auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/UmsClient.java
@@ -594,20 +594,54 @@ public class UmsClient {
                 .build());
     }
 
-    public void assignResourceRole(String requestId, String assigneeCrn, String resourceCrn, String resourceRoleCrn) {
-        newStub(requestId).assignResourceRole(UserManagementProto.AssignResourceRoleRequest.newBuilder()
-                .setAssignee(getAssignee(assigneeCrn))
-                .setResourceCrn(resourceCrn)
-                .setResourceRoleCrn(resourceRoleCrn)
-                .build());
+    /**
+     * Assign a resource role to an assignee
+     *
+     * @param requestId         id of the request
+     * @param assigneeCrn       user CRN who is going to be own the selected role on the resource
+     * @param resourceCrn       resource CRN where the resource role is going to be assigned to the user
+     * @param resourceRoleCrn   selected resource role CRN for user
+     * @return                  AssignResourceRoleResponse
+     */
+    public UserManagementProto.AssignResourceRoleResponse assignResourceRole(String requestId, String assigneeCrn, String resourceCrn,
+            String resourceRoleCrn) {
+        checkNotNull(requestId);
+        checkNotNull(assigneeCrn);
+        checkNotNull(resourceCrn);
+        checkNotNull(resourceRoleCrn);
+
+        UserManagementProto.AssignResourceRoleResponse assignResourceRoleResponse =
+                newStub(requestId).assignResourceRole(UserManagementProto.AssignResourceRoleRequest.newBuilder()
+                        .setAssignee(getAssignee(assigneeCrn))
+                        .setResourceCrn(resourceCrn)
+                        .setResourceRoleCrn(resourceRoleCrn)
+                        .build());
+        return assignResourceRoleResponse;
     }
 
-    public void unassignResourceRole(String requestId, String assigneeCrn, String resourceCrn, String resourceRoleCrn) {
-        newStub(requestId).unassignResourceRole(UserManagementProto.UnassignResourceRoleRequest.newBuilder()
-                .setAssignee(getAssignee(assigneeCrn))
-                .setResourceCrn(resourceCrn)
-                .setResourceRoleCrn(resourceRoleCrn)
-                .build());
+    /**
+     * Unassign a resource role from an assignee
+     *
+     * @param requestId         id of the request
+     * @param assigneeCrn       user CRN whom resource role is going to be revoked
+     * @param resourceCrn       resource CRN where the resource role is going to be revoked from the user
+     * @param resourceRoleCrn   selected resource role CRN for user
+     * @return                  UnassignResourceRoleResponse
+     */
+    public UserManagementProto.UnassignResourceRoleResponse unassignResourceRole(String requestId, String assigneeCrn, String resourceCrn,
+            String resourceRoleCrn) {
+        checkNotNull(requestId);
+        checkNotNull(assigneeCrn);
+        checkNotNull(resourceCrn);
+        checkNotNull(resourceRoleCrn);
+
+        UserManagementProto.UnassignResourceRoleResponse unassignResourceRoleResponse =
+                newStub(requestId).unassignResourceRole(UserManagementProto.UnassignResourceRoleRequest.newBuilder()
+                        .setAssignee(getAssignee(assigneeCrn))
+                        .setResourceCrn(resourceCrn)
+                        .setResourceRoleCrn(resourceRoleCrn)
+                        .build());
+        return unassignResourceRoleResponse;
     }
 
     /**

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AbstractUmsAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AbstractUmsAction.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.it.cloudbreak.action.ums;
+
+import com.sequenceiq.it.cloudbreak.UmsClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+
+public abstract class AbstractUmsAction<U extends UmsTestDto> implements Action<U, UmsClient> {
+
+    @Override
+    public U action(TestContext testContext, U testDto, UmsClient client) throws Exception {
+        Exception umsActionException = null;
+        int retries = 0;
+        int maxRetry = 10;
+        long pollingInterval = 7000;
+        while (retries <= maxRetry) {
+            try {
+                return umsAction(testContext, testDto, client);
+            } catch (Exception e) {
+                umsActionException = e;
+                Thread.sleep(pollingInterval);
+                retries++;
+            }
+        }
+        if (umsActionException != null) {
+            throw new TestFailException(String.format("EXCEEDING UMS ACTION MAX. RETRY (%s) ::: UMS action has been failed, because of: %s%n", retries,
+                    umsActionException.getMessage()), umsActionException);
+        } else {
+            throw new TestFailException(String.format("EXCEEDING UMS ACTION MAX. RETRY (%s) ::: UMS action has been failed!", retries));
+        }
+    }
+
+    protected abstract U umsAction(TestContext testContext, U testDto, UmsClient client) throws Exception;
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignResourceRoleGroupAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignResourceRoleGroupAction.java
@@ -8,12 +8,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.it.cloudbreak.UmsClient;
-import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
 
-public class AssignResourceRoleGroupAction implements Action<UmsTestDto, UmsClient> {
+public class AssignResourceRoleGroupAction extends AbstractUmsAction<UmsTestDto> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AssignResourceRoleGroupAction.class);
 
@@ -24,7 +23,7 @@ public class AssignResourceRoleGroupAction implements Action<UmsTestDto, UmsClie
     }
 
     @Override
-    public UmsTestDto action(TestContext testContext, UmsTestDto testDto, UmsClient client) throws Exception {
+    protected UmsTestDto umsAction(TestContext testContext, UmsTestDto testDto, UmsClient client) throws Exception {
         String resourceRole = testDto.getRequest().getRoleCrn();
         String resourceCrn = testDto.getRequest().getResourceCrn();
         Log.when(LOGGER, format(" Assigning resource role '%s' at resource '%s' for group '%s' ", resourceRole, resourceCrn, groupCrn));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignResourceRoleUserAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignResourceRoleUserAction.java
@@ -9,13 +9,12 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Multimap;
 import com.sequenceiq.it.cloudbreak.UmsClient;
-import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
 
-public class AssignResourceRoleUserAction implements Action<UmsTestDto, UmsClient> {
+public class AssignResourceRoleUserAction extends AbstractUmsAction<UmsTestDto> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AssignResourceRoleUserAction.class);
 
@@ -26,7 +25,7 @@ public class AssignResourceRoleUserAction implements Action<UmsTestDto, UmsClien
     }
 
     @Override
-    public UmsTestDto action(TestContext testContext, UmsTestDto testDto, UmsClient client) throws Exception {
+    protected UmsTestDto umsAction(TestContext testContext, UmsTestDto testDto, UmsClient client) throws Exception {
         CloudbreakUser user = testContext.getRealUmsUserByKey(userKey);
         String resourceRole = testDto.getRequest().getRoleCrn();
         String resourceCrn = testDto.getRequest().getResourceCrn();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/UnassignResourceRoleAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/UnassignResourceRoleAction.java
@@ -8,13 +8,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.sequenceiq.it.cloudbreak.UmsClient;
-import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ums.UmsTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
 
-public class UnassignResourceRoleAction implements Action<UmsTestDto, UmsClient> {
+public class UnassignResourceRoleAction extends AbstractUmsAction<UmsTestDto> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UnassignResourceRoleAction.class);
 
@@ -25,7 +24,7 @@ public class UnassignResourceRoleAction implements Action<UmsTestDto, UmsClient>
     }
 
     @Override
-    public UmsTestDto action(TestContext testContext, UmsTestDto testDto, UmsClient client) throws Exception {
+    protected UmsTestDto umsAction(TestContext testContext, UmsTestDto testDto, UmsClient client) throws Exception {
         CloudbreakUser user = testContext.getRealUmsUserByKey(userKey);
         String resourceRole = testDto.getRequest().getRoleCrn();
         String resourceCrn = testDto.getRequest().getResourceCrn();


### PR DESCRIPTION
This issue has been created because of [CB-12990](https://jira.cloudera.com/browse/CB-12990): Currently we just call these GRPC UMS operations from CB but not checking for response that could lead to issues regarding resources without proper assignment.

We do not want to add `@Retryable` to `assignResourceRole` and `unassignResourceRole` at `auth-connector/src/main/java/com/sequenceiq/cloudbreak/auth/altus/GrpcUmsClient.java`. So I've introduced the mentioned  `Retry logic` at test project level as `com/sequenceiq/it/cloudbreak/action/ums/AbstractUmsAction.java`. 