### PR TITLE
CB-12879-1: Add tests around GcpEnvironmentNetworkConverter

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AwsEnvironmentNetworkConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AwsEnvironmentNetworkConverterTest.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.cloudbreak.converter.v4.environment.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+
+@MockitoSettings
+class AwsEnvironmentNetworkConverterTest {
+
+    @Mock
+    private MissingResourceNameGenerator missingResourceNameGenerator;
+
+    @Mock
+    private SubnetSelector subnetSelector;
+
+    @InjectMocks
+    private AwsEnvironmentNetworkConverter converter;
+
+    @Test
+    void getAttributesForLegacyNetwork() {
+        EnvironmentNetworkResponse source = mock(EnvironmentNetworkResponse.class);
+        EnvironmentNetworkAwsParams aws = mock(EnvironmentNetworkAwsParams.class);
+        when(source.getAws()).thenReturn(aws);
+        when(aws.getVpcId()).thenReturn("my_vpc_id");
+
+        Map<String, Object> result = converter.getAttributesForLegacyNetwork(source);
+
+        assertEquals("my_vpc_id", result.get("vpcId"));
+    }
+
+    @Test
+    void getCloudPlatform() {
+        assertEquals(CloudPlatform.AWS, converter.getCloudPlatform());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/AzureEnvironmentNetworkConverterTest.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.converter.v4.environment.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+
+@MockitoSettings
+class AzureEnvironmentNetworkConverterTest {
+
+    @Mock
+    private MissingResourceNameGenerator missingResourceNameGenerator;
+
+    @Mock
+    private SubnetSelector subnetSelector;
+
+    @InjectMocks
+    private AzureEnvironmentNetworkConverter converter;
+
+    @Test
+    void testGetAttributesForLegacyNetwork() {
+        EnvironmentNetworkResponse environmentNetworkResponse = mock(EnvironmentNetworkResponse.class);
+        EnvironmentNetworkAzureParams azure = mock(EnvironmentNetworkAzureParams.class);
+        when(environmentNetworkResponse.getAzure()).thenReturn(azure);
+        when(azure.getNetworkId()).thenReturn("my_network_id");
+        when(azure.getResourceGroupName()).thenReturn("my_resource_group");
+        when(azure.getNoPublicIp()).thenReturn(true);
+
+        Map<String, Object> result = converter.getAttributesForLegacyNetwork(environmentNetworkResponse);
+
+        assertEquals("my_network_id", result.get("networkId"));
+        assertEquals("my_resource_group", result.get("resourceGroupName"));
+        assertEquals(true, result.get("noPublicIp"));
+    }
+
+    @Test
+    void testGetCloudPlatform() {
+        assertEquals(CloudPlatform.AZURE, converter.getCloudPlatform());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/GcpEnvironmentNetworkConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/environment/network/GcpEnvironmentNetworkConverterTest.java
@@ -1,0 +1,108 @@
+package com.sequenceiq.cloudbreak.converter.v4.environment.network;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkGcpParams;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+
+@ExtendWith(MockitoExtension.class)
+class GcpEnvironmentNetworkConverterTest {
+
+    public static final String GCP_NETWORK_ID = "my_gcp_network";
+
+    public static final String GCP_SHARED_PROJECT_ID = "my_shared_project";
+
+    @Mock
+    private MissingResourceNameGenerator missingResourceNameGenerator;
+
+    @Mock
+    private SubnetSelector subnetSelector;
+
+    @InjectMocks
+    private GcpEnvironmentNetworkConverter converter;
+
+    @Test
+    void selectPublicSubnetForEndpointGateway() {
+    }
+
+    @Test
+    void getNetworkIdForAttributeLegacyNetwork() {
+        EnvironmentNetworkResponse environmentNetworkResponse = mock(EnvironmentNetworkResponse.class);
+        EnvironmentNetworkGcpParams environmentNetworkGcpParams = mock(EnvironmentNetworkGcpParams .class);
+        when(environmentNetworkResponse.getGcp()).thenReturn(environmentNetworkGcpParams);
+        when(environmentNetworkGcpParams.getNetworkId()).thenReturn(GCP_NETWORK_ID);
+
+        Map<String, Object> result = converter.getAttributesForLegacyNetwork(environmentNetworkResponse);
+
+        assertEquals(GCP_NETWORK_ID, result.get("networkId"));
+    }
+
+    @Test
+    void getNoFirewallRulesAttributeForLegacyNetwork() {
+        EnvironmentNetworkResponse environmentNetworkResponse = mock(EnvironmentNetworkResponse.class);
+        EnvironmentNetworkGcpParams environmentNetworkGcpParams = mock(EnvironmentNetworkGcpParams .class);
+        when(environmentNetworkResponse.getGcp()).thenReturn(environmentNetworkGcpParams);
+        when(environmentNetworkGcpParams.getNoFirewallRules()).thenReturn(true);
+
+        Map<String, Object> result = converter.getAttributesForLegacyNetwork(environmentNetworkResponse);
+
+        assertEquals(true, result.get("noFirewallRules"));
+    }
+
+    @Test
+    void getNoPublicIpAttributeForLegacyNetwork() {
+        EnvironmentNetworkResponse environmentNetworkResponse = mock(EnvironmentNetworkResponse.class);
+        EnvironmentNetworkGcpParams environmentNetworkGcpParams = mock(EnvironmentNetworkGcpParams .class);
+        when(environmentNetworkResponse.getGcp()).thenReturn(environmentNetworkGcpParams);
+        when(environmentNetworkGcpParams.getNoPublicIp()).thenReturn(true);
+
+        Map<String, Object> result = converter.getAttributesForLegacyNetwork(environmentNetworkResponse);
+
+        assertEquals(true, result.get("noPublicIp"));
+    }
+
+    @Test
+    void getSharedProjectIdAttributeForLegacyNetwork() {
+        EnvironmentNetworkResponse environmentNetworkResponse = mock(EnvironmentNetworkResponse.class);
+        EnvironmentNetworkGcpParams environmentNetworkGcpParams = mock(EnvironmentNetworkGcpParams .class);
+        when(environmentNetworkResponse.getGcp()).thenReturn(environmentNetworkGcpParams);
+        when(environmentNetworkGcpParams.getSharedProjectId()).thenReturn(GCP_SHARED_PROJECT_ID);
+
+        Map<String, Object> result = converter.getAttributesForLegacyNetwork(environmentNetworkResponse);
+
+        assertEquals(GCP_SHARED_PROJECT_ID, result.get("sharedProjectId"));
+    }
+
+    @Test
+    void testAllNullAttributesForLegacyNetwork() {
+        EnvironmentNetworkResponse environmentNetworkResponse = mock(EnvironmentNetworkResponse.class);
+        EnvironmentNetworkGcpParams environmentNetworkGcpParams = mock(EnvironmentNetworkGcpParams.class);
+        when(environmentNetworkResponse.getGcp()).thenReturn(environmentNetworkGcpParams);
+        when(environmentNetworkGcpParams.getNetworkId()).thenReturn(null);
+        when(environmentNetworkGcpParams.getNoFirewallRules()).thenReturn(null);
+        when(environmentNetworkGcpParams.getNoPublicIp()).thenReturn(null);
+        when(environmentNetworkGcpParams.getSharedProjectId()).thenReturn(null);
+
+        Map<String, Object> result = converter.getAttributesForLegacyNetwork(environmentNetworkResponse);
+
+        assertFalse(result.containsKey("networkId"));
+    }
+
+    @Test
+    void getCloudPlatform() {
+        assertEquals(CloudPlatform.GCP, converter.getCloudPlatform());
+    }
+}


### PR DESCRIPTION
Related to [CB-12979](https://jira.cloudera.com/browse/CB-12879).

I'm touching code in the parent class, `EnvironmentBaseNetworkConverter.java` and want to add regression tests to make sure I don't break anything.