### PR TITLE
CB-13091 We need to set 7.2.10 as default on Mow-Dev, Mow-Int, cloude…

### DIFF
--- a/datalake/src/main/resources/application.yml
+++ b/datalake/src/main/resources/application.yml
@@ -106,7 +106,7 @@ datalake:
       cert.file: database.crt
       ssl: false
   runtimes:
-    default: "7.2.9"
+    default: "7.2.10"
     advertised: "7.1.0,7.2.0,7.2.1,7.2.2,7.2.6,7.2.7,7.2.8,7.2.9,7.2.10,7.2.11"
     supported: "7.0.2,7.1.0,7.2.0,7.2.1,7.2.2,7.2.6,7.2.7,7.2.8,7.2.9,7.2.10,7.2.11"
 

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -75,12 +75,12 @@ integrationtest:
     defaultPassword: Admin123
     defaultPort: 7180
   cloudProvider: MOCK
-  runtimeVersion: 7.2.9
+  runtimeVersion: 7.2.10
   upgrade:
     currentRuntimeVersion: 7.2.0
-    targetRuntimeVersion: 7.2.9
+    targetRuntimeVersion: 7.2.10
     distroXUpgradeCurrentVersion: 7.2.7
-    distroXUpgradeTargetVersion: 7.2.9
+    distroXUpgradeTargetVersion: 7.2.10
   privateEndpointEnabled: false
 
   spot:


### PR DESCRIPTION
…ng and local because on 14th June, Cloudera has released 7.2.10 and made it default on prod.

See detailed description in the commit message.