### PR TITLE
CB-13081 DL upgrade on azure: package version check still throws

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateActions.java
@@ -72,7 +72,7 @@ public class StackImageUpdateActions {
             protected void doExecute(StackContext context, ImageUpdateEvent payload, Map<Object, Object> variables) {
                 CheckResult checkResult = getStackImageUpdateService().checkPackageVersions(context.getStack(), payload.getImage());
                 if (checkResult.getStatus() == EventStatus.FAILED) {
-                    throw new OperationException(checkResult.getMessage());
+                    LOGGER.info("Check package versions failed: {}", checkResult);
                 }
                 sendEvent(context, new ImageUpdateEvent(StackImageUpdateEvent.CHECK_PACKAGE_VERSIONS_FINISHED_EVENT.event(),
                         context.getStack().getId(), payload.getImage()));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateService.java
@@ -177,17 +177,20 @@ public class StackImageUpdateService {
 
         CheckResult instanceHaveMultipleVersionResult = packageVersionChecker.checkInstancesHaveMultiplePackageVersions(instanceMetaDataSet);
         if (instanceHaveMultipleVersionResult.getStatus() == EventStatus.FAILED) {
+            LOGGER.debug("Check packages - Instances do have multiple package versions: {}", instanceHaveMultipleVersionResult);
             return instanceHaveMultipleVersionResult;
         }
 
         CheckResult instancesHaveAllMandatoryPackageVersionResult = packageVersionChecker.checkInstancesHaveAllMandatoryPackageVersion(instanceMetaDataSet);
         if (instancesHaveAllMandatoryPackageVersionResult.getStatus() == EventStatus.FAILED) {
+            LOGGER.debug("Check packages - Instances are missing one or more package versions: {}", instancesHaveAllMandatoryPackageVersionResult);
             return instancesHaveAllMandatoryPackageVersionResult;
         }
 
         CheckResult compareImageAndInstancesMandatoryPackageVersion =
                 packageVersionChecker.compareImageAndInstancesMandatoryPackageVersion(newImage, instanceMetaDataSet);
         if (compareImageAndInstancesMandatoryPackageVersion.getStatus() == EventStatus.FAILED) {
+            LOGGER.debug("Check packages - Image and instances mandatory packages do differ: {}", compareImageAndInstancesMandatoryPackageVersion);
             return compareImageAndInstancesMandatoryPackageVersion;
         }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
@@ -273,6 +273,9 @@ public class InstanceMetadataUpdater {
                     packagesWithMultipleVersions.add(pkg);
                 }
             }
+            if (!packagesWithMultipleVersions.isEmpty()) {
+                LOGGER.debug("Packages unfortunately do have multiple versions: {}", pkgVersionsMMap);
+            }
             return packagesWithMultipleVersions;
         } catch (IOException ex) {
             LOGGER.warn("Cannot collect package versions from hosts", ex);
@@ -281,7 +284,7 @@ public class InstanceMetadataUpdater {
     }
 
     public Map<String, List<String>> collectInstancesWithMissingPackageVersions(Collection<InstanceMetaData> instanceMetaDatas) {
-        Map<String, List<String>> instancesWithMissingPackagVersions = new HashMap<>();
+        Map<String, List<String>> instancesWithMissingPackageVersions = new HashMap<>();
 
         for (InstanceMetaData instanceMetaData : instanceMetaDatas) {
             try {
@@ -290,14 +293,14 @@ public class InstanceMetadataUpdater {
                 List<String> missingPackageVersions = this.packages.stream().map(Package::getName).collect(Collectors.toList());
                 missingPackageVersions.removeAll(packages);
                 if (!missingPackageVersions.isEmpty()) {
-                    instancesWithMissingPackagVersions.put(instanceMetaData.getInstanceId(), missingPackageVersions);
+                    instancesWithMissingPackageVersions.put(instanceMetaData.getInstanceId(), missingPackageVersions);
                 }
             } catch (IOException e) {
                 LOGGER.warn("Missing image information for instance: " + instanceMetaData.getInstanceId(), e);
             }
         }
 
-        return instancesWithMissingPackagVersions;
+        return instancesWithMissingPackageVersions;
     }
 
     public List<Package> getPackages() {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/image/update/StackImageUpdateActionsTest.java
@@ -298,8 +298,8 @@ public class StackImageUpdateActionsTest {
         checkPackageVersionsAction.execute(stateContext);
 
         verify(stackImageUpdateService, times(1)).checkPackageVersions(any(Stack.class), any(StatedImage.class));
-        verify(eventBus, times(0)).notify(eq(StackImageUpdateEvent.CHECK_PACKAGE_VERSIONS_FINISHED_EVENT.event()), any(Event.class));
-        verify(eventBus, times(1)).notify(eq(StackImageUpdateEvent.STACK_IMAGE_UPDATE_FAILED_EVENT.event()), any(Event.class));
+        verify(eventBus, times(1)).notify(eq(StackImageUpdateEvent.CHECK_PACKAGE_VERSIONS_FINISHED_EVENT.event()), any(Event.class));
+        verify(eventBus, times(0)).notify(eq(StackImageUpdateEvent.STACK_IMAGE_UPDATE_FAILED_EVENT.event()), any(Event.class));
     }
 
     @Test


### PR DESCRIPTION
Previous CB-12684 disabled package version check during upgrade only in one part. There was another invocation of check package versions. This commit turns of checking package versions also for that other invocation

See detailed description in the commit message.