### PR TITLE
CB-12562 Script to increase root volume to 100GB

### DIFF
--- a/cloud-aws-cloudformation/scripts/vertical-scaling/root-volume/README.md
+++ b/cloud-aws-cloudformation/scripts/vertical-scaling/root-volume/README.md
@@ -1,0 +1,70 @@
+# Goal
+
+This script helps to:
+* increase the root volume of instances
+* increase root volume size in launch template so that a repair does not bring back the original root volume size
+  
+By default most of them is 100GB, but some older DL may still have 50GB.
+
+# Usage
+
+## Prerequisites
+
+* ```aws-cli```
+* ```jq```
+* all instances need to be in stopped state
+
+## Invocation
+
+ ```./increase-root-volume.sh <NEW_ROOT_VOLUME_SIZE> <INSTANCE_ID_LIST>```
+
+* ```NEW_ROOT_VOLUME_SIZE```: The size of the new root volumes, in GB (do NOT specify the unit, just the numbers, please). It is recommended to have at least 100GB space available on the root volume
+* ```INSTANCE_ID_LIST```: instance ids, separated by space, e.g.: ```instance1 instance2``` (please see how to get instance ids in the next section) 
+
+
+The script only modifies settings if the size of root volumes is smaller than the requested value.
+
+Dry run: please modify the script and set the DRY_RUN variable to true. In this way nothing will be changed.
+
+### Get all VMs from cluster
+You will need to get the VM names of a DH or DL. You can do that with cdp-cli as shown below:
+
+#### Datalake
+
+
+```
+cdp datalake describe-datalake \
+    --datalake-name <YOUR_DATALAKE_NAME> > describe-datalake-result.json
+cat describe-datalake-result.json | jq -r '.datalake.instanceGroups[] | .instances[] | .id' | tr '\n' ' ' 
+```
+
+#### Datahub
+
+```
+cdp datahub describe-cluster  \
+--cluster-name <YOUR_CLUSTER_NAME> > describe-dh-result.json
+
+cat describe-dh-result.json | jq -r '.cluster.instanceGroups[] | .instances[] | .id' | tr '\n' ' '
+```
+
+### Example
+
+```./increase-root-volume.sh 150 instance1 instance2 instance3```
+
+This will increase root volume for instances instance1,2,3 and their launch templates.
+
+## Known limitations
+
+* there is a per volume rate limit on modifying EBS volumes. Once you hit that, you need to wait 6 hours.
+* after an upgrade the original root volume size will be created => you will need to rerun this script.
+
+## Output 
+
+ Please save and zip following outputs and files (if they exist):
+
+* STDOUT 
+* the log file increase-root-volume.log
+* output file increase-root-volume-describe-instances-result.json
+* output file increase-root-volume-describe-volumes-result.json
+* output file increase-root-volume-describe-autoscaling-groups-result.json
+

--- a/cloud-aws-cloudformation/scripts/vertical-scaling/root-volume/increase-root-volume.sh
+++ b/cloud-aws-cloudformation/scripts/vertical-scaling/root-volume/increase-root-volume.sh
@@ -1,0 +1,392 @@
+#!/bin/bash
+
+# For usage, please type 
+#   ./increase-root-volume.sh
+#
+# By default, dry run is turned off. To turn it on, please set it to true
+DRY_RUN=false
+
+SCRIPT_NAME_BASE=increase-root-volume
+SCRIPT_NAME=$SCRIPT_NAME_BASE.sh
+LOG_FILE=$SCRIPT_NAME_BASE.log
+DESCRIBE_INSTANCE_FILE="$SCRIPT_NAME_BASE-describe-instances-result.json"
+DESCRIBE_VOLUME_FILE="$SCRIPT_NAME_BASE-describe-volumes-result.json"
+DESCRIBE_AUTOSCALING_GROUP_FILE="$SCRIPT_NAME_BASE-describe-autoscaling-groups-result.json"
+
+TAB="    "
+
+
+show_usage() {
+    message
+    message PREREQUISITES
+    message =============
+    message
+    message "${TAB}- aws-cli"
+    message "${TAB}- jq"
+    message "${TAB}- all instances have to be in stopped state"
+    message 
+    message
+    message USAGE
+    message =====
+    message
+    message ./$SCRIPT_NAME \<TARGET_ROOT_VOLUME_SIZE\> \<INSTANCE_ID_LIST\>
+    message
+    message "${TAB}- TARGET_ROOT_VOLUME_SIZE: The size of the new root volumes, in GB \(do NOT specify the unit, just the numbers, please\). It is recommended to have at least 100GB space available on the root volume"
+    message "${TAB}- INSTANCE_ID_LIST: instance ids, separated by space (please see next section how to get them)"
+    message
+    message "The script only modifies settings if they are found to be below the target root volume size."
+    message
+    message "Dry run: please modify the script and set the DRY_RUN variable to true. In this way nothing will be changed. Default: false"
+    message
+    message "Note: there is a per volume rate limit on modifying EBS volumes. Once you hit that, you need to wait 6 hours."
+    message
+    message
+    message GET ALL INSTANCES FROM DL / DH
+    message ==============================
+    message 
+    message "- Datalake:"
+    message "${TAB}cdp datalake describe-datalake \ "
+    message "${TAB}${TAB}--datalake-name <YOUR_DATALAKE_NAME> > describe-datalake-result.json"
+    message "${TAB}cat describe-datalake-result.json | jq -r '.datalake.instanceGroups[] | .instances[] | .id' | tr '\n' ' '"
+    message
+    message "- Data Hub"
+    message "${TAB}cdp datahub describe-cluster  \ "
+    message "${TAB}${TAB}--cluster-name <YOUR_CLUSTER_NAME> > describe-dh-result.json"
+    message "${TAB}cat describe-dh-result.json | jq -r '.cluster.instanceGroups[] | .instances[] | .id' | tr '\n' ' '"
+    message
+    message
+    message Please save output of STDOUT / STDERR and all files generated in case of an error.
+}
+
+error_and_exit() {
+    message
+    message "*** ERROR: $@, exiting"
+    log ERROR: "$@"
+    message
+    message Please save and zip following outputs and files \(if they exist\):
+    message
+    message "  - STDOUT "
+    message "  - the log file $LOG_FILE"
+    message "  - output file $DESCRIBE_INSTANCE_FILE"
+    message "  - output file $DESCRIBE_VOLUME_FILE"
+    message "  - output file $DESCRIBE_AUTOSCALING_GROUP_FILE"
+    message
+    message and contact Cloudera support.
+    message Exiting.
+    exit
+}
+
+error_and_exit_no_log() {
+    message
+    message "*** ERROR: $@"
+    log ERROR: "$*"
+    message
+    message Exiting.
+    exit
+}
+
+greetings() {
+    message
+    message Increasing root volume, V1.0
+    message ============================
+    message
+    message This script takes a target root volume size and a list of instance ids and will icrease the root volumes to the target size.
+    message 
+    message Before proceeding please do stop the cluster where you want to resize root volumes:
+    message "${TAB}- DH: please stop the DH itself"
+    message "${TAB}- DL: please stop all the attached DHs and then the DL itself"
+    message
+
+}
+
+log() {
+    echo $(date) $* >> $LOG_FILE
+}
+
+message() {
+    echo "$*"
+    log "$*"
+}
+
+check_prerequisites() {
+    message 1. Checking prerequisites
+    aws_version=$(aws --version)
+    if [ -z "$aws_version" ]; then
+        error_and_exit_no_log It seems you do not have aws-cli installed. Please install it and rerun the script.
+    fi
+    message "    aws-cli version: '$aws_version'"
+
+    jq_version=$(jq --version)
+    if [ -z "$jq_version" ]; then
+        error_and_exit_no_log It seems you do not have jq installed. Please install it and rerun the script.
+    fi
+    message "    jq version: '$jq_version'"
+}
+
+describe_instances() {
+    aws ec2 describe-instances --instance-ids $instance_id_list > $DESCRIBE_INSTANCE_FILE
+    if [ $? -ne 0 ]; then 
+        error_and_exit could not retrieve instance info on instance $instance_id
+    fi
+    log ec2 instance data: $(cat $DESCRIBE_INSTANCE_FILE)
+}
+
+validate_instances_are_stopped() {
+    instance_id_to_instance_state=$(cat $DESCRIBE_INSTANCE_FILE | jq -r '.Reservations[] | .Instances[] | "        \(.InstanceId) => \(.State.Name)"')
+    message "${TAB}The state of instances:"
+    message "$instance_id_to_instance_state"
+    not_stopped_instances=$(cat $DESCRIBE_INSTANCE_FILE | jq -r '.Reservations[] | .Instances[] | select(.State.Name != "stopped") | .InstanceId' | tr '\n' ' ')
+    if [ ! -z "$not_stopped_instances" ]; then 
+        error_and_exit_no_log "Some instances are not in stopped state: $not_stopped_instances. Please stop them and rerun the script."
+    fi
+    message "${TAB}All instances are stopped, can proceed."
+    message
+}
+
+get_root_volume_of_instances() {
+    local instance_id_to_root_volume_name=$(cat $DESCRIBE_INSTANCE_FILE | jq -r '.Reservations[] | .Instances[] | "\(.InstanceId) \(.RootDeviceName)"' | tr '\n' ' ')
+    log instance id to root volume id list: "$instance_id_to_root_volume_name"
+    local root_volume_ids=$(get_root_volume_ids "$DESCRIBE_INSTANCE_FILE" $instance_id_to_root_volume_name)
+    echo "$root_volume_ids"
+}
+
+get_root_volume_ids() {
+    log Entering get_root_volume_ids
+    log get_root_volume_ids incoming parameters: $@
+    local describe_instances_result_file=$1
+    shift
+    local root_volume_ids=""
+    while [ ! -z "$1" ] && [ ! -z "$2" ]; do
+        local instance_id=$1
+        local root_volume_name=$2
+        log looking up root volume id, instance id: $instance_id, root volume name: $root_volume_name
+        root_volume_id=$(cat $describe_instances_result_file | \
+        jq -r \
+            --arg INSTANCE_ID "$instance_id" \
+            --arg VOLUME_NAME "$root_volume_name" \
+        '.Reservations[] | .Instances[] | select(.InstanceId==$INSTANCE_ID)| .BlockDeviceMappings[] | select(.DeviceName==$VOLUME_NAME) | .Ebs.VolumeId')
+        log found instance id: $instance_id, root volume name: $root_volume_name, root volume id: $root_volume_id
+        root_volume_ids="$root_volume_ids $root_volume_id"
+        shift 2
+    done
+    log exiting get_root_volume_ids
+    echo "$root_volume_ids"
+}
+
+show_root_volume_to_size_map() {
+    local volume_id_to_size_map=$(cat $DESCRIBE_VOLUME_FILE | jq -r '.Volumes[] | "        \(.VolumeId) => \(.Size) GB"')
+    message
+    message "${TAB}Root volume ids and their current size"
+    message "$volume_id_to_size_map"
+    message
+
+}
+
+set_root_volumes() {
+    local new_root_volume_size=$1
+    local new_root_volume_size_text="$2"
+    shift 2
+
+    while [ ! -z "$1" ]; do
+        vol=$1
+        message "${TAB}${TAB}now setting on $vol volume size to $new_root_volume_size_text"
+        if [ "$DRY_RUN" = true ]; then
+            echo "*** Dry run: disks not modified"
+            echo
+        else
+            modify_output=$(aws ec2 modify-volume --volume-id $vol --size $new_root_volume_size)
+            if [ ! $? -eq 0 ]; then
+                error_and_exit An error occurred when trying to modify volume
+            fi
+        fi
+
+        log result of modification: $modify_output
+        message "${TAB}${TAB}root volume $vol set to $new_root_volume_size_text"
+        message
+        shift
+    done
+}
+
+get_launch_template_version() {
+    local autoscaling_group="$1"
+    local launch_template_version=$(cat $DESCRIBE_AUTOSCALING_GROUP_FILE  | jq -r --arg ASG_NAME $autoscaling_group '.AutoScalingGroups[] | select(.AutoScalingGroupName == $ASG_NAME) | .MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.Version')
+    if [ "$launch_template_version" == "null" ]; then
+        launch_template_version=$(cat $DESCRIBE_AUTOSCALING_GROUP_FILE | jq -r --arg ASG_NAME $autoscaling_group '.AutoScalingGroups[] | select(.AutoScalingGroupName == $ASG_NAME) | .LaunchTemplate.Version')
+    fi
+
+    if [ "$launch_template_version" == "null" ]; then
+        error_and_exit could not retrieve launch template version for autoscaling group $autoscaling_group
+    fi
+
+    log launch template version is $launch_template_version
+    echo $launch_template_version
+}
+
+get_launch_template_id() {
+    local autoscaling_group="$1"
+    local launch_template_id=$(cat $DESCRIBE_AUTOSCALING_GROUP_FILE  | \
+        jq -r --arg ASG_NAME $autoscaling_group '.AutoScalingGroups[] | select(.AutoScalingGroupName == $ASG_NAME) | .MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification.LaunchTemplateId')
+
+    if [ "$launch_template_id" == "null" ]; then
+        launch_template_id=$(cat $DESCRIBE_AUTOSCALING_GROUP_FILE | jq -r --arg ASG_NAME $autoscaling_group '.AutoScalingGroups[] | select(.AutoScalingGroupName == $ASG_NAME) | .LaunchTemplate.LaunchTemplateId')
+    fi
+
+    if [ "$launch_template_id" == "null" ]; then
+        error_and_exit could not retrieve launch template id for autoscaling group $autoscaling_group
+    fi
+
+    log launch template id is $launch_template_id
+    echo $launch_template_id
+}
+
+create_new_launch_template_version() {
+    local lt_id=$1
+    local lt_latest_version=$2
+    local new_root_volume_size=$3
+    local latest_launch_template_version="$4"
+    log "latest launch template version: $latest_launch_template_version"
+    request_json=$(echo $latest_launch_template_version | jq --arg new_root_volume_size $new_root_volume_size  '.LaunchTemplateVersions[0] | .LaunchTemplateData|.BlockDeviceMappings[0].Ebs.VolumeSize |= ($new_root_volume_size | tonumber)')
+    log created request json: "$request_json"
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "*** Dry run: new launch template version not created"
+        echo
+    else
+        created_launch_template=$(aws ec2 create-launch-template-version \
+            --launch-template-id  $lt_id \
+            --version-description "vertical scaling of root disks" \
+            --source-version $lt_latest_version \
+            --launch-template-data "$request_json")
+        if [ $? -ne 0 ]; then
+            error_and_exit modifying launch template $lt_id failed. Response from AWS: "$created_launch_template"
+        fi
+    fi
+
+    log created launch template: $created_launch_template
+    created_launch_template_version=$(echo $created_launch_template | jq '.LaunchTemplateVersion.VersionNumber')
+    log created version: $created_launch_template_version
+
+    echo $created_launch_template_version
+}
+
+update_autoscaling_group_with_launch_template_version() {
+    local auto_scaling_group_name=$1
+    local launch_template_id=$2
+    local created_launch_template_version=$3
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "*** Dry run: autoscaling group not changed"
+        echo
+    else
+        aws autoscaling update-auto-scaling-group \
+            --auto-scaling-group-name $asg \
+            --launch-template LaunchTemplateId=$launch_template_id,Version=$created_launch_template_version
+        if [ $? -ne 0 ]; then 
+            error_and_exit modifying autoscaling group $autoscaling_group_id failed
+        fi
+    fi
+
+}
+
+main() {
+    greetings
+    log Invocation: $0 $*
+
+    # parse parameters
+    new_root_volume_size=$1
+    new_root_volume_size_text="$new_root_volume_size GB"
+    if [ -z "$new_root_volume_size" ]; then
+        show_usage
+        error_and_exit_no_log TARGET_ROOT_VOLUME_SIZE is missing
+    fi
+
+    instance_id_list=""
+    shift 1
+    while [ ! -z "$1" ]; do
+        instance_id_list="$instance_id_list $1"
+        shift
+    done
+
+    if [ -z "$instance_id_list" ]; then
+        show_usage
+        error_and_exit_no_log INSTANCE_ID_LIST is missing
+    fi
+
+    message
+    message Will set root volume to $new_root_volume_size_text on instances $instance_id_list and their launch templates
+    message
+
+    if [ "$DRY_RUN" = true ]; then
+        echo "========="
+        echo "Running in DRY_RUN mode, nothing will be changed"
+        echo "========="
+        echo
+    fi
+
+    check_prerequisites
+
+    # describe all instances
+    message
+    message 2. Checking instances
+    log get info of instance
+    describe_instances
+    validate_instances_are_stopped
+
+    # find root volumes of instances
+    message 3. Changing root volume size in the instances
+
+    root_volume_ids=$(get_root_volume_of_instances)
+    log found root volume ids: "$root_volume_ids"
+
+    # describe volumes, and get those where the size is smaller than the desired size
+    aws ec2 describe-volumes --volume-ids $root_volume_ids > $DESCRIBE_VOLUME_FILE
+    show_root_volume_to_size_map
+    root_volumes_to_set=$(cat $DESCRIBE_VOLUME_FILE | jq -r --arg VOLUME_SIZE "$new_root_volume_size" '.Volumes[] | select(.Size < ($VOLUME_SIZE|tonumber)) | .VolumeId' | tr '\n' ' ')
+
+    if [ -z "$root_volumes_to_set" ]; then
+        message
+        message RESULT: No root volumes found where the size is smaller than $new_root_volume_size_text.
+    else
+        message "    root volumes where the size is smaller than $new_root_volume_size_text: $root_volumes_to_set"
+
+        # modify volumes where the root disk size is maller than desired
+        set_root_volumes $new_root_volume_size "$new_root_volume_size_text" $root_volumes_to_set
+        message "    The required volumes were increased to $new_root_volume_size_text."
+    fi
+
+    # modify the launch template -- will update launch tempalte of all provided instances, regardless if its root disk is already big enough
+    message
+    message
+    message 4. Changing root volume size in the launch templates
+    message
+    all_autoscaling_groups=$(cat $DESCRIBE_INSTANCE_FILE | jq -r '.Reservations[] | .Instances[] | .Tags[] | select(.Key == "aws:autoscaling:groupName") | .Value' | sort | uniq | tr '\n' ' ')
+    log autoscaling groups: $all_autoscaling_groups
+    aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names $all_autoscaling_groups > $DESCRIBE_AUTOSCALING_GROUP_FILE
+
+    for asg in $all_autoscaling_groups; do
+        message "${TAB}Updating autoscaling group $asg to use new root volume size $new_root_volume_size"
+        lt_id=$(get_launch_template_id $asg)
+        lt_latest_version=$(get_launch_template_version $asg)
+        message "${TAB}${TAB}Autoscaling group $asg uses launch template $lt_id with current version $lt_latest_version"
+
+        aws ec2 describe-launch-template-versions --launch-template-id $lt_id --versions $lt_latest_version > latest-launch-template-version.json
+        current_root_volume_size=$(cat latest-launch-template-version.json | jq '.LaunchTemplateVersions[0] | .LaunchTemplateData|.BlockDeviceMappings[0].Ebs.VolumeSize')
+        message "${TAB}${TAB}The current root volume size is $current_root_volume_size GB"
+        if [ $current_root_volume_size -lt $new_root_volume_size ]; then 
+            latest_launch_template_version=$(aws ec2 describe-launch-template-versions --launch-template-id $lt_id --versions $lt_latest_version)
+            log "latest launch template version: $latest_launch_template_version"
+            created_launch_template_version=$(create_new_launch_template_version $lt_id $lt_latest_version $new_root_volume_size "$latest_launch_template_version")
+            message "${TAB}${TAB}Created new launch template version, latest version: '$created_launch_template_version'"
+            update_autoscaling_group_with_launch_template_version $asg $lt_id $created_launch_template_version
+            message "${TAB}${TAB}Autoscaling group $asg was updated to the new version $created_launch_template_version"
+        else
+            message "${TAB}${TAB}Launch template $lt_id in autoscaling group $asg already has root disk size $new_root_volume_size_text, nothing changed"
+        fi
+        message
+    done
+
+    message
+    message RESULT: Finished successfully. The required volumes were increased to $new_root_volume_size_text.
+}
+
+main $*

--- a/cloud-azure/scripts/vertical-scaling/root-volume/README.md
+++ b/cloud-azure/scripts/vertical-scaling/root-volume/README.md
@@ -1,0 +1,139 @@
+# Goal
+
+The two scripts help to:
+1. increase the root disks of virtual machines
+2. increase the root partition and filesystem to occupy the maximum allotted space.
+
+By default most of the root volumes are 100GB, but some older DL and DH may still have 50GB.
+
+# Limitation
+
+> After repair or upgrade, you will need to rerun the script to resize the root disk, partition and filesystem.
+
+# Usage
+
+## 1. Increasing the root disk size
+
+### Prerequisites
+
+All the needed VMs need to be in stopped (VM deallocated) state.
+
+The following tools need to be installed:
+* az-cli
+* jq
+* all VMs have to be in stopped state
+
+### Get all VMs from cluster
+You will need to get the VM names of a DH or DL. You can do that with cdp-cli as shown below:
+
+#### Datalake
+
+
+```
+cdp datalake describe-datalake \
+    --datalake-name <YOUR_DATALAKE_NAME> > describe-datalake-result.json
+cat describe-datalake-result.json | jq -r '.datalake.instanceGroups[] | .instances[] | .id' | tr '\n' ' ' 
+```
+
+#### Datahub
+
+```
+cdp datahub describe-cluster  \
+--cluster-name <YOUR_CLUSTER_NAME> > describe-dh-result.json
+
+cat describe-dh-result.json | jq -r '.cluster.instanceGroups[] | .instances[] | .id' | tr '\n' ' '
+```
+
+### Invocation
+
+```./increase-root-disk-1-azure.sh <NEW_ROOT_VOLUME_SIZE> <RESOURCE_GROUP> <VM_NAME_LIST>```
+
+Parameters:
+* ```NEW_ROOT_VOLUME_SIZE```: The size of the new root volumes, in GB (do NOT specify the unit, just the numbers, please). It is recommended to have at least 100GB space available on the root volume
+  
+* ```RESOURCE_GROUP```: the resource group where the virtual machines are
+* ```VM_NAME_LIST```: names of virtual machines, separated by space, e.g.: ```vm1 vm2```
+
+The script only modifies settings if they are found to be below the requested root volume size.
+
+Dry run: please modify the script and set the DRY_RUN variable to true. In this way nothing will be changed.
+
+#### Example
+
+```./increase-root-disk-1-azure.sh 150 rg-my-resource-group vm1 vm2 vm3```
+
+This will increase the root disk to 150 GB for virtual machines vm1, vm2 and vm3.
+
+## 2. Increasing the root partition and root file system
+
+### Prerequisites
+
+* All the needed VMs need to be in running state.
+
+**The script by default starts in DRY_RUN mode, as it has no parameters: please open the script and set variable ```DRY_RUN``` to false.**
+
+### Invocation
+
+This script has to be run on every node in the cluster. For that, please log in to the master node of the cluster and use salt to distribute and run the script:
+
+1. log in to the master node and make yourself root
+2. activate the salt environment with command ```source activate_salt_env```
+3. copy the script ```increase-root-disk-2-azure.sh``` to the master node
+4. distribute the script to all nodes: ```salt-cp '*' increase-root-disk-2-azure.sh /home/cloudbreak```
+5. make the script executable on all nodes: ```salt '*' cmd.run 'chmod 744 /home/cloudbreak/increase-root-disk-2-azure.sh'```
+6. run the script on every node and save output: ```salt '*' cmd.run './home/cloudbreak/increase-root-disk-2-azure.sh' > increase-root-disk-2-azure.out```
+7. check the output that it succeeded on every node (you can compare it with the sample output)
+
+It will only modify partition or file system size if it is smaller than the disk size.
+
+### Sample output
+Root disk was successfully increased from 100GB to 160GB.
+Output was taken 06/08/2021.
+
+    Increasing root volume, V1.0 - resizing partition and filesystem of OS Disk
+    =======================================
+    
+    Increasing the root volume on azure is composed of two steps:
+        1. increase the root disk itself
+        2. increase the partition on the running instance
+    
+    This script is part 2.
+    It will only increase partition or filesystem size if the current size is smaller than allowed by the disk.
+    
+    How to use it:
+        1. log in to the master node and make yourself root
+        2. activate the salt environment
+        3. distribute this script to all nodes: salt-cp '*' increase-root-disk-2-azure.sh /home/cloudbreak
+        4. make the script executable on all nodes: salt '*' cmd.run 'chmod 744 /home/cloudbreak/increase-root-disk-2-azure.sh'
+        5. run the script on every node and save output: salt '*' cmd.run './home/cloudbreak/increase-root-disk-2-azure.sh' > increase-root-disk-2-azure.out
+    
+    
+    root disk properties: 
+        * path: /dev/sda 
+        * size in bytes: 171798691840 (160G GB)
+    
+    root partition properties: 
+        * path: /dev/sda2
+        * number: 2
+        * size in bytes: 106848828928 (99.5G GB)
+    
+    The partition /dev/sda2 size 106848828928 (99.5G GB) is much smaller than the disk size 171798691840 (160G GB), resize is needed
+    executing growpart
+    CHANGED: partition=2 start=1026048 old: size=208689119 end=209715167 new: size=334518239 end=335544287
+    partition
+    
+    root file system size is 104329448 KB (100 GB)
+    
+    file system needs resizing
+    executing xfs_growfs
+    meta-data=/dev/sda2              isize=512    agcount=14, agsize=1934016 blks
+             =                       sectsz=512   attr=2, projid32bit=1
+             =                       crc=1        finobt=0 spinodes=0
+    data     =                       bsize=4096   blocks=26086139, imaxpct=25
+             =                       sunit=0      swidth=0 blks
+    naming   =version 2              bsize=4096   ascii-ci=0 ftype=1
+    log      =internal               bsize=4096   blocks=3777, version=2
+             =                       sectsz=512   sunit=0 blks, lazy-count=1
+    realtime =none                   extsz=4096   blocks=0, rtextents=0
+    data blocks changed from 26086139 to 41814779
+    Finished

--- a/cloud-azure/scripts/vertical-scaling/root-volume/increase-root-disk-1-azure.sh
+++ b/cloud-azure/scripts/vertical-scaling/root-volume/increase-root-disk-1-azure.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+
+# For usage, please type 
+#   ./increase-root-disk-1-azure.sh
+#
+# By default, dry run is turned off. To turn it on, please set it to true
+DRY_RUN=false
+
+SCRIPT_NAME_BASE=increase-root-disk-1-azure
+SCRIPT_NAME=$SCRIPT_NAME_BASE.sh
+LOG_FILE=$SCRIPT_NAME_BASE.log
+DESCRIBE_INSTANCE_FILE="$SCRIPT_NAME_BASE-describe-instances-result.json"
+DESCRIBE_VOLUME_FILE="$SCRIPT_NAME_BASE-describe-volumes-result.json"
+
+
+TAB="    "
+LI="- "
+
+show_usage() {
+    message
+    message USAGE
+    message =====
+    message
+    message ./$SCRIPT_NAME \<TARGET_ROOT_VOLUME_SIZE\> \<RESOURCE_GROUP_NAME\> \<VM_NAME_LIST\>
+    message
+    message "${TAB}${LI}TARGET_ROOT_VOLUME_SIZE: The size of the new root volumes, in GB (do NOT specify the unit, just the numbers, please). It is recommended to have at least 100GB space available on the root volume"
+    message "${TAB}${LI}RESOURCE_GROUP_NAME: name of the resource group where your VMs are"
+    message "${TAB}${LI}VM_NAME_LIST: name (not the full resource ID) of the VMs"
+    message
+    message
+    message GET ALL INSTANCES FROM DL / DH
+    message ==============================
+    message 
+    message "${LI}Datalake:"
+    message "${TAB}cdp datalake describe-datalake \ "
+    message "${TAB}${TAB}--datalake-name <YOUR_DATALAKE_NAME> > describe-datalake-result.json"
+    message "${TAB}cat describe-datalake-result.json | jq -r '.datalake.instanceGroups[] | .instances[] | .id' | tr '\n' ' '"
+    message
+    message "${LI}Data Hub"
+    message "${TAB}cdp datahub describe-cluster  \ "
+    message "${TAB}${TAB}--cluster-name <YOUR_CLUSTER_NAME> > describe-dh-result.json"
+    message "${TAB}cat describe-dh-result.json | jq -r '.cluster.instanceGroups[] | .instances[] | .id' | tr '\n' ' '"
+    message
+    message
+    message PREREQUISITES
+    message =============
+    message
+    message "${TAB}- az-cli"
+    message "${TAB}- jq"
+    message
+    message Please save output of STDOUT and log file change-image-in-lt.log in case there is an error.
+}
+
+error_and_exit() {
+    message
+    message "*** ERROR: "$*", exiting"
+    log ERROR: "$*"
+    message
+    message Please save and zip following outputs and files \(if they exist\):
+    message "${TAB}${LI} STDOUT"
+    message "${TAB}${LI} the log file $LOG_FILE"
+    message "${TAB}${LI} output file $DESCRIBE_INSTANCE_FILE"
+    message "${TAB}${LI} output file $DESCRIBE_VOLUME_FILE"
+    message and contact Cloudera support.
+    message Exiting.
+    exit
+}
+
+error_and_exit_no_log() {
+    message
+    message "*** ERROR: $*"
+    log ERROR: "$*"
+    message
+    message Exiting.
+    exit
+}
+
+error_and_exit_no_collect_info() {
+    message
+    message !!! ERROR: "$*"
+    log ERROR: "$*"
+    message
+    message Exiting.
+    exit
+}
+
+
+log() {
+    echo $(date) $* >> $LOG_FILE
+}
+
+message() {
+    echo "$*"
+    log "$*"
+}
+
+check_prerequisites() {
+    message 1. Checking prerequisites
+    message
+    az_version=$(az version | tr '\n' ' ')
+    if [ -z "$az_version" ]; then
+        error_and_exit_no_collect_info It seems you do not have az-cli installed. Please install it and rerun the script.
+    fi
+    message "${TAB}az-cli version: '$az_version'"
+
+    jq_version=$(jq --version)
+    if [ -z "$jq_version" ]; then
+        error_and_exit_no_collect_info It seems you do not have jq installed. Please install it and rerun the script.
+    fi
+    message "${TAB}jq version: '$jq_version'"
+}
+
+describe_instances() {
+    local rg=$1
+    local instance_id_list="$2"
+    log instance id list in describe isntances: $instance_id_list
+
+    az vm list \
+        --resource-group $rg \
+        --query "[?contains(\`[$instance_id_list]\`, name)].{Name:name, PowerState:powerState, OsDiskId:storageProfile.osDisk.managedDisk.id, OsDiskName:storageProfile.osDisk.name}" \
+        --show-details > $DESCRIBE_INSTANCE_FILE
+    if [ $? -ne 0 ]; then 
+        error_and_exit could not retrieve instance info on instance $instance_id_list
+    fi
+    log azure instance data: $(cat $DESCRIBE_INSTANCE_FILE)
+}
+
+validate_all_instances_are_present() {
+    expected_vms="$1"
+
+    present_vms=$(cat $DESCRIBE_INSTANCE_FILE | jq -r '.[] | .Name')
+    missing_vms=""
+    for vm in $expected_vms; do
+        echo $present_vms | grep $vm > /dev/null
+        if [ $? -ne 0 ]; then
+            missing_vms="$missing_vms $vm"
+        else
+            echo vm $vm is present
+        fi
+    done
+
+    if [ ! -z "$missing_vms" ]; then
+        error_and_exit "Could not retrieve info about one or more VMs from azure. Please make sure that RESOURCE_GROUP_NAME and VM_NAME_LIST are correct and try again. Missing VMs: $missing_vms"
+    fi
+}
+
+validate_instances_are_stopped() {
+    # $(cat $DESCRIBE_INSTANCE_FILE | jq -r '.[] | .Name, .PowerState' | sed "N;s/\n/${TAB}=>${TAB}/")
+    message
+    instance_id_to_instance_state=$(cat $DESCRIBE_INSTANCE_FILE | jq -r '.[] | "        \(.Name) => \(.PowerState)"')
+    message "${TAB}The state of instances:"
+    message "$instance_id_to_instance_state"
+    not_stopped_instances=$(cat $DESCRIBE_INSTANCE_FILE | jq -r '.[] | select(.PowerState != "VM deallocated") | .Name' | tr '\n' ' ')
+    if [ ! -z "$not_stopped_instances" ]; then 
+        error_and_exit_no_log "Some instances are not in stopped state: $not_stopped_instances. Please stop them and rerun the script."
+    fi
+    message "${TAB}All instances are stopped, can proceed."
+    message
+}
+
+describe_volumes() {
+    local rg=$1
+    local disk_name_list="$2"
+
+    az disk list \
+        --resource-group $rg \
+        --query "[?contains(\`[$disk_name_list]\`, name)].{Name:name,Size:diskSizeGb,Tier:sku.name}" \
+        --output json > $DESCRIBE_VOLUME_FILE
+
+    if [ $? -ne 0 ]; then 
+        error_and_exit could not retrieve disk info on one or more disks $disk_id_list
+    fi
+
+}
+
+show_root_volume_to_size_map() {
+    local volume_id_to_size_map=$(cat $DESCRIBE_VOLUME_FILE | jq -r '.[] | "        \(.Name) => \(.Size)"')
+    message
+    message "${TAB}Root volume ids and their current size"
+    message "$volume_id_to_size_map"
+    message
+}
+
+set_root_volumes() {
+    local rg=$1
+    local new_root_volume_size=$2
+    local new_root_volume_size_text="$3"
+    shift 3
+
+    while [ ! -z "$1" ]; do
+        disk_name=$1
+        message
+        message "${TAB}${TAB}now setting disk size to $new_root_volume_size_text on disk $disk_name"
+        if [ "$DRY_RUN" = true ]; then
+            echo "*** Dry run: disks not modified"
+        else
+            disk_update_output=$(az disk update \
+                --resource-group $rg \
+                --name $disk_name \
+                --size-gb $new_root_volume_size )
+            if [ ! $? -eq 0 ]; then
+                error_and_exit An error occurred when trying to set the new root disk size
+            fi
+        fi
+        log result of modification: $disk_update_output
+        message "${TAB}${TAB}root disk $disk_name was set to size $new_root_volume_size_text"
+        shift
+    done
+}
+
+main() {
+    message
+    message Increasing root volume, V1.0 - resizing OS disk
+    message ===============================================
+    message
+    message OVERVIEW
+    message ========
+    message
+    message Increasing the root volume on azure is composed of two steps:
+    message "${TAB}1. increase the root disk itself"
+    message "${TAB}2. increase the partition and file system on the running VM"
+    message
+    message This script is part 1.
+    message
+    message Takes a target root volume size, a resource group name and a list of VM names and will icrease the root volume of the specified VMs to the target size.
+    message Will increase the root volume only if the required TARGET_ROOT_VOLUME_SIZE is bigger than the actual size of the root disk on a VM.
+    message 
+    message Before proceeding please do stop the cluster where you want to resize root volumes:
+    message "${TAB}${LI}DH: please stop the DH itself"
+    message "${TAB}${LI}DL: please stop all the attahed DHs and then the DL itself"
+
+    if [ "$DRY_RUN" = true ]; then
+        message
+        message "========================================================"
+        message "*** Running in DRY_RUN mode, nothing will be changed ***"
+        message "========================================================"
+        message
+    fi
+
+    message
+
+    log Invocation: $0 $*
+
+    # parse parameters
+    new_root_volume_size=$1
+    new_root_volume_size_text="$new_root_volume_size GB"
+    if [ -z "$new_root_volume_size" ]; then
+        show_usage
+        error_and_exit_no_log TARGET_ROOT_VOLUME_SIZE is missing
+    fi
+
+    resource_group=$2    
+    if [ -z "$resource_group" ]; then
+        show_usage
+        error_and_exit_no_log RESOURCE_GROUP_NAME is missing
+    fi
+
+    instance_id_list=""
+    shift 2
+    while [ ! -z "$1" ]; do
+        instance_id_list="$instance_id_list $1"
+        shift
+    done
+
+    if [ -z "$instance_id_list" ]; then
+        show_usage
+        error_and_exit_no_log VM_NAME_LIST is missing
+    fi
+
+    message
+    message Will set root volume to $new_root_volume_size_text on instances $instance_id_list
+    message
+
+    check_prerequisites
+
+    # describe all instances
+    message
+    message 2. Checking instances
+    log get info of instance
+    describe_instances $resource_group "$instance_id_list"
+    validate_all_instances_are_present "$instance_id_list"
+
+    # assert all VMs are deallocated
+    validate_instances_are_stopped
+
+    # find root volumes of instances
+    message 3. Checking and changing root volume size in the instances
+    root_volume_names=$(cat $DESCRIBE_INSTANCE_FILE | jq -r '.[] | .OsDiskName' | tr '\n' " ")
+    log found root volume names: "$root_volume_names"
+
+    # describe volumes, and get those where the size is smaller than the desired size
+
+    describe_volumes $resource_group "$root_volume_names"
+    show_root_volume_to_size_map
+    root_volumes_to_set=$(cat $DESCRIBE_VOLUME_FILE | jq -r --arg VOLUME_SIZE "$new_root_volume_size" '.[] | select(.Size < ($VOLUME_SIZE|tonumber)) | .Name' | tr '\n' ' ')
+
+    if [ -z "$root_volumes_to_set" ]; then
+        message
+        message RESULT: No root volumes found where the size is smaller than $new_root_volume_size_text. Exiting
+        exit
+    fi
+
+    message "${TAB}Root volumes where the size is smaller than $new_root_volume_size_text: $root_volumes_to_set"
+    message "${TAB}Setting them to new_root_volume_size_text"
+
+    # modify volumes where the root disk size is maller than desired
+    set_root_volumes $resource_group $new_root_volume_size "$new_root_volume_size_text" $root_volumes_to_set
+
+    message
+    message RESULT: Finished successfully. The required volumes were increased to $new_root_volume_size_text.
+    message 
+    message Now please use increase-root-disk-2-azure.sh to increase partition and filesystem size to $new_root_volume_size_text.
+}
+
+main $*

--- a/cloud-azure/scripts/vertical-scaling/root-volume/increase-root-disk-2-azure.sh
+++ b/cloud-azure/scripts/vertical-scaling/root-volume/increase-root-disk-2-azure.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+# For usage, please type 
+#   ./increase-root-volume-azure.sh
+#
+
+# By default, dry run is turned on - the script has no parameters. To turn it on, please set it to true
+DRY_RUN=true
+
+SCRIPT_NAME_BASE=increase-root-disk-2-azure
+SCRIPT_NAME=$SCRIPT_NAME_BASE.sh
+LOG_FILE=$SCRIPT_NAME_BASE.log
+OUT_FILE=$SCRIPT_NAME_BASE.out
+
+SIZE_EPSILON=2
+SIZE_EPSILON_BYTES=2147483648
+KBYTES=1024
+TAB="    "
+
+error_and_exit() {
+    message
+    message !!! ERROR: "$*", exiting
+    log ERROR: "$*"
+    message
+    message Please save and zip following outputs and files \(if they exist\):
+    message "${TAB}- STDOUT"
+    message "${TAB}- the log file $LOG_FILE"
+    message "${TAB}- output file $DESCRIBE_INSTANCE_FILE"
+    message "${TAB}- output file $DESCRIBE_VOLUME_FILE"
+    message and contact Cloudera support.
+    message Exiting.
+    exit
+}
+
+log() {
+    echo $(date) $* >> $LOG_FILE
+}
+
+message() {
+    echo "$*"
+    log "$*"
+}
+
+main() {
+    message
+    message Increasing root volume, V1.0 - resizing partition and filesystem of OS Disk
+    message =======================================
+    message
+    message Increasing the root volume on azure is composed of two steps:
+    message "${TAB}1. increase the root disk itself"
+    message "${TAB}2. increase the partition on the running instance"
+    message
+    message This script is part 2.
+    message It will only increase partition or filesystem size if the current size is smaller than allowed by the disk.
+    message
+    message How to use it:
+    message "${TAB}1. log in to the master node and make yourself root"
+    message "${TAB}2. activate the salt environment"
+    message "${TAB}3. copy this script to the master node"
+    message "${TAB}4. distribute this script to all nodes: salt-cp '*' $SCRIPT_NAME /home/cloudbreak"
+    message "${TAB}5. make the script executable on all nodes: salt '*' cmd.run 'chmod 744 /home/cloudbreak/$SCRIPT_NAME'"
+    message "${TAB}6. run the script on every node and save output: salt '*' cmd.run './home/cloudbreak/$SCRIPT_NAME' > $OUT_FILE"
+    message "${TAB}7. check the output that it succeeded on every node (you can compare it with the sample output provided in the README)"
+    message ""
+    message started: $(date)
+
+    message 
+    if [ "$DRY_RUN" = true ]; then
+        message
+        message "========================================================"
+        message "*** Running in DRY_RUN mode, nothing will be changed ***"
+        message ""
+        message "    To turn it off, please open the script and set"
+        message "    variable DRY_RUN to false                     "
+        message "========================================================"
+        message
+    fi
+
+    partition_path=$(lsblk -lp -o NAME,SIZE,PKNAME,MOUNTPOINT | grep "/$" | tr -s ' ' | cut -f1 -d' ')
+    partition_size_bytes=$(lsblk -lpb -o NAME,SIZE,PKNAME,MOUNTPOINT | grep "/$" | tr -s ' ' | cut -f2 -d' ')
+    partition_size_gb=$(lsblk -lp -o NAME,SIZE,PKNAME,MOUNTPOINT | grep "/$" | tr -s ' ' | cut -f2 -d' ')
+    disk_path=$(lsblk -lp -o NAME,SIZE,PKNAME,MOUNTPOINT | grep "/$" | tr -s ' ' | cut -f3 -d' ')
+    disk_size_bytes=$(lsblk -lpb -o NAME,SIZE | grep -sw "$disk_path" | tr -s ' ' | cut -f2 -d' ')
+    disk_size_gb=$(lsblk -lp -o NAME,SIZE | grep -sw "$disk_path" | tr -s ' ' | cut -f2 -d' ')
+    message "root disk properties: "
+    message "${TAB}* path: $disk_path "
+    message "${TAB}* size in bytes: $disk_size_bytes ($disk_size_gb GB)"
+    message
+    partition_number=$(echo $partition_path | sed "s@$disk_path@@g")
+    message "root partition properties: "
+    message "${TAB}* path: $partition_path"
+    message "${TAB}* number: $partition_number"
+    message "${TAB}* size in bytes: $partition_size_bytes ($partition_size_gb GB)"
+    message
+    if (( disk_size_bytes - partition_size_bytes > SIZE_EPSILON_BYTES )); then
+        message "The partition $partition_path size $partition_size_bytes ($partition_size_gb GB) is much smaller than the disk size $disk_size_bytes ($disk_size_gb GB), resize is needed"
+        if [ "$DRY_RUN" = true ]; then
+            message "*** Running in DRY_RUN mode, command (growpart $disk_path $partition_number) not executed"
+        else
+            message executing growpart 
+            growpart $disk_path $partition_number
+            if [ ! $? -eq 0 ]; then
+                error_and_exit An error occurred when trying to grow partition
+            fi
+            partition_grown_size=$(lsblk -lp -o NAME,SIZE,PKNAME,MOUNTPOINT | grep "/$" | tr -s ' ' | cut -f2 -d' '| sed 's/[^0-9,]*//g')
+            message partition 
+
+        fi
+    else
+        message "The partition $partition_path size $partition_size_bytes ($partition_size_gb GB) is almost as big as the disk size $disk_size_bytes ($disk_size_gb GB), no resize is needed"
+    fi
+
+    message
+    filesystem_size_kb=$(df -h --block-size=1K --output=source,size | tr -s ' ' | grep $partition_path | cut -f2 -d' ')
+    filesystem_size_gb=$(df -h --block-size=1G --output=source,size | tr -s ' ' | grep $partition_path | cut -f2 -d' ')
+    message "root file system size is ${filesystem_size_kb} KB ($filesystem_size_gb GB)"
+    message
+    if (( disk_size_bytes - filesystem_size_kb * KBYTES > SIZE_EPSILON_BYTES )); then
+        message file system needs resizing
+        if [ "$DRY_RUN" = true ]; then
+            message "*** Running in DRY_RUN mode, command (xfs_growfs /) not executed"
+        else
+            message executing xfs_growfs
+            xfs_growfs /
+            if [ ! $? -eq 0 ]; then
+                error_and_exit An error occurred when trying to resize filesystem
+            fi
+        fi
+    else
+        message The file system on $partition_path size $partition_size_bytes is almost as big as the disk size $disk_size_bytes, no resize is needed
+    fi
+
+    message Finished
+}
+
+main $*


### PR DESCRIPTION
DH upgrades require more than 50GB root volume, and almost all prod clusters are at 50GB root disk. The steps to adjust the root size is manual. Given a DH with many nodes it is very cumbersome to go through each node manually and increase the root volume.

The scripts provided here for AWS and Azure help with that: they increase the root volume of provided instances. README files guide customers on how to use the scripts.

See detailed description in the commit message.