### PR TITLE
CB-13096 Environment DB encryption_keyurl schema bug fix

### DIFF
--- a/environment/src/main/resources/schema/app/20210525113034_CB-12118_persistence_for_encryptionKeyResourceGroupName_on_Azure.sql
+++ b/environment/src/main/resources/schema/app/20210525113034_CB-12118_persistence_for_encryptionKeyResourceGroupName_on_Azure.sql
@@ -1,6 +1,5 @@
 -- // CB-12118 persistence for encryptionKeyResourceGroupName on Azure
 -- Migration SQL that makes the change goes here.
-ALTER TABLE environment_parameters DROP COLUMN IF EXISTS encryption_keyurl;
 ALTER TABLE environment_parameters ADD COLUMN IF NOT EXISTS encryption_key_resource_group_name varchar(255);
 
 

--- a/environment/src/main/resources/schema/app/20210615104527_CB-13096_Environment_DB_encryption_keyurl_schema_bug_fix.sql
+++ b/environment/src/main/resources/schema/app/20210615104527_CB-13096_Environment_DB_encryption_keyurl_schema_bug_fix.sql
@@ -1,0 +1,11 @@
+-- // CB-13096 Environment DB encryption_keyurl schema bug fix
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE environment_parameters ADD COLUMN IF NOT EXISTS encryption_keyurl text;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+-- No undo steps this time; this script fixes the accidental & premature removal of the deprecated column "environment_parameters.encryption_keyurl"
+-- that took place in CB-12118.


### PR DESCRIPTION
Re-adds the deprecated column `environment_parameters.encryption_keyurl` that got accidentally and prematurely removed in #10756. The column removal is now postponed to a future release to keep schema compatibility across subsequent versions.