### PR TITLE
CB-13028 Not able to stop the environment after a data lake restore f…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreStatusService.java
@@ -62,7 +62,7 @@ public class BackupRestoreStatusService {
     }
 
     public void handleDatabaseRestoreFailure(long stackId, String errorReason, DetailedStackStatus detailedStatus) {
-        clusterService.updateClusterStatusByStackId(stackId, Status.RESTORE_FAILED, errorReason);
+        clusterService.updateClusterStatusByStackId(stackId, Status.AVAILABLE, errorReason);
         stackUpdater.updateStackStatus(stackId, detailedStatus, extractSaltErrorIfAvailable(errorReason));
         flowMessageService.fireEventAndLog(stackId, Status.UPDATE_FAILED.name(), DATALAKE_DATABASE_RESTORE_FAILED, errorReason);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/dr/BackupRestoreStatusServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/dr/BackupRestoreStatusServiceTest.java
@@ -101,7 +101,7 @@ public class BackupRestoreStatusServiceTest {
     public void testRestorepFailure() {
         ArgumentCaptor<ResourceEvent> captor = ArgumentCaptor.forClass(ResourceEvent.class);
         service.handleDatabaseRestoreFailure(STACK_ID, ERROR_MESSAGE, DetailedStackStatus.DATABASE_RESTORE_FAILED);
-        verify(clusterService, times(1)).updateClusterStatusByStackId(STACK_ID, Status.RESTORE_FAILED, ERROR_MESSAGE);
+        verify(clusterService, times(1)).updateClusterStatusByStackId(STACK_ID, Status.AVAILABLE, ERROR_MESSAGE);
         verify(flowMessageService).fireEventAndLog(eq(STACK_ID), eq(Status.UPDATE_FAILED.name()), captor.capture(), eq(ERROR_MESSAGE));
         assertEquals(DATALAKE_DATABASE_RESTORE_FAILED, captor.getValue());
     }


### PR DESCRIPTION
…ailure

When the datalake is in RESTORE_FAILED state, environment can not be stopped. It fails with the below error. "Can not stop stack, client error happened on Cloudbreak side: Error message: "Cannot update the status of the cluster to STOPPED when stack is in AVAILABLE and cluster is in RESTORE_FAILED state."" With this fix, the datalake cluster status will be AVAILABLE and user can perform further operations on a datalake.

See detailed description in the commit message.