### PR TITLE
CDPCP-4714. Add enabled state to FMS user model

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProvider.java
@@ -89,7 +89,8 @@ public class FreeIpaUsersStateProvider {
         return new FmsUser()
                 .withName(ipaUser.getUid())
                 .withFirstName(ipaUser.getGivenname())
-                .withLastName(ipaUser.getSn());
+                .withLastName(ipaUser.getSn())
+                .withState(ipaUser.getNsAccountLock() ? FmsUser.State.ENABLED : FmsUser.State.DISABLED);
     }
 
     @VisibleForTesting

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverter.java
@@ -17,7 +17,8 @@ public class FmsUserConverter {
     public FmsUser toFmsUser(UserManagementProto.User umsUser) {
         return createFmsUser(umsUser.getWorkloadUsername(),
                 umsUser.getFirstName(),
-                umsUser.getLastName());
+                umsUser.getLastName(),
+                umsUser.getState());
     }
 
     public FmsUser toFmsUser(UserManagementProto.MachineUser umsMachineUser) {
@@ -25,22 +26,42 @@ public class FmsUserConverter {
         // Store the machine user name and id instead.
         return createFmsUser(umsMachineUser.getWorkloadUsername(),
                 umsMachineUser.getMachineUserName(),
-                umsMachineUser.getMachineUserId());
+                umsMachineUser.getMachineUserId(),
+                umsMachineUser.getState());
     }
 
     public FmsUser toFmsUser(
             UserManagementProto.UserSyncActorDetails actorDetails) {
         return createFmsUser(actorDetails.getWorkloadUsername(),
                 actorDetails.getFirstName(),
-                actorDetails.getLastName());
+                actorDetails.getLastName(),
+                actorDetails.getState());
     }
 
-    private FmsUser createFmsUser(String workloadUsername, String firstName, String lastName) {
+    private FmsUser createFmsUser(
+            String workloadUsername, String firstName, String lastName,
+            UserManagementProto.ActorState.Value actorState) {
         checkArgument(StringUtils.isNotBlank(workloadUsername));
         FmsUser fmsUser = new FmsUser();
         fmsUser.withName(workloadUsername);
         fmsUser.withFirstName(StringUtils.defaultIfBlank(StringUtils.strip(firstName), NONE_STRING));
         fmsUser.withLastName(StringUtils.defaultIfBlank(StringUtils.strip(lastName), NONE_STRING));
+        fmsUser.withState(toFmsUserState(actorState));
         return fmsUser;
+    }
+
+    private FmsUser.State toFmsUserState(UserManagementProto.ActorState.Value actorState) {
+        if (null == actorState) {
+            return FmsUser.State.ENABLED;
+        }
+        switch (actorState) {
+            case DEACTIVATED:
+                return FmsUser.State.DISABLED;
+            case ACTIVE:
+            case DELETING:
+            case UNRECOGNIZED:
+            default:
+                return FmsUser.State.ENABLED;
+        }
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsUser.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/model/FmsUser.java
@@ -4,11 +4,18 @@ import java.util.Objects;
 
 public class FmsUser {
 
+    public enum State {
+        ENABLED,
+        DISABLED
+    }
+
     private String name;
 
     private String firstName;
 
     private String lastName;
+
+    private State state;
 
     public String getName() {
         return name;
@@ -37,6 +44,15 @@ public class FmsUser {
         return this;
     }
 
+    public State getState() {
+        return state;
+    }
+
+    public FmsUser withState(State state) {
+        this.state = state;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -49,12 +65,13 @@ public class FmsUser {
         FmsUser other = (FmsUser) o;
         return Objects.equals(this.name, other.name)
                 && Objects.equals(this.firstName, other.firstName)
-                && Objects.equals(this.lastName, other.lastName);
+                && Objects.equals(this.lastName, other.lastName)
+                && Objects.equals(this.state, other.state);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, firstName, lastName);
+        return Objects.hash(name, firstName, lastName, state);
     }
 
     @Override
@@ -63,6 +80,7 @@ public class FmsUser {
                 + "name='" + name + '\''
                 + ", firstName='" + firstName + '\''
                 + ", lastName='" + lastName + '\''
+                + ", state=" + state
                 + '}';
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProviderTest.java
@@ -37,6 +37,10 @@ import com.sequenceiq.freeipa.service.freeipa.user.model.UsersState;
 @ExtendWith(MockitoExtension.class)
 class FreeIpaUsersStateProviderTest {
 
+    private static final boolean USER_ENABLED = true;
+
+    private static final boolean USER_DISABLED = false;
+
     @InjectMocks
     FreeIpaUsersStateProvider underTest;
 
@@ -176,14 +180,29 @@ class FreeIpaUsersStateProviderTest {
     }
 
     @Test
-    void testFromIpaUser() {
-        com.sequenceiq.freeipa.client.model.User ipaUser = createIpaUser("uid", List.of("group1", "group2"));
+    void testFromIpaUserEnabled() {
+        com.sequenceiq.freeipa.client.model.User ipaUser =
+                createIpaUser("uid", List.of("group1", "group2"), USER_ENABLED);
 
         FmsUser fmsUser = underTest.fromIpaUser(ipaUser);
 
         assertEquals(fmsUser.getName(), ipaUser.getUid());
         assertEquals(fmsUser.getLastName(), ipaUser.getSn());
         assertEquals(fmsUser.getFirstName(), ipaUser.getGivenname());
+        assertEquals(fmsUser.getState(), FmsUser.State.ENABLED);
+    }
+
+    @Test
+    void testFromIpaUserDisabled() {
+        com.sequenceiq.freeipa.client.model.User ipaUser =
+                createIpaUser("uid", List.of("group1", "group2"), USER_DISABLED);
+
+        FmsUser fmsUser = underTest.fromIpaUser(ipaUser);
+
+        assertEquals(fmsUser.getName(), ipaUser.getUid());
+        assertEquals(fmsUser.getLastName(), ipaUser.getSn());
+        assertEquals(fmsUser.getFirstName(), ipaUser.getGivenname());
+        assertEquals(fmsUser.getState(), FmsUser.State.DISABLED);
     }
 
     @Test
@@ -196,12 +215,18 @@ class FreeIpaUsersStateProviderTest {
     }
 
     private com.sequenceiq.freeipa.client.model.User createIpaUser(String uid, List<String> memberOfGroup) {
+        return createIpaUser(uid, memberOfGroup, USER_ENABLED);
+    }
+
+    private com.sequenceiq.freeipa.client.model.User createIpaUser(
+            String uid, List<String> memberOfGroup, boolean enabled) {
         com.sequenceiq.freeipa.client.model.User ipaUser = new com.sequenceiq.freeipa.client.model.User();
         ipaUser.setUid(uid);
         ipaUser.setDn(UUID.randomUUID().toString());
         ipaUser.setSn(UUID.randomUUID().toString());
         ipaUser.setGivenname(UUID.randomUUID().toString());
         ipaUser.setMemberOfGroup(memberOfGroup);
+        ipaUser.setNsAccountLock(enabled);
         return ipaUser;
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/conversion/FmsUserConverterTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class FmsUserConverterTest {
+    private static final int UNRECOGNIZED_STATE_VALUE = 99;
+
     private FmsUserConverter underTest = new FmsUserConverter();
 
     @Test
@@ -19,6 +21,7 @@ class FmsUserConverterTest {
                 .setFirstName(firstName)
                 .setLastName(lastName)
                 .setWorkloadUsername(workloadUsername)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsUser);
@@ -26,6 +29,7 @@ class FmsUserConverterTest {
         assertEquals(workloadUsername, fmsUser.getName());
         assertEquals(firstName, fmsUser.getFirstName());
         assertEquals(lastName, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
     }
 
     @Test
@@ -37,6 +41,7 @@ class FmsUserConverterTest {
                 .setFirstName(firstName)
                 .setLastName(lastName)
                 .setWorkloadUsername(workloadUsername)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsUser);
@@ -44,10 +49,75 @@ class FmsUserConverterTest {
         assertEquals("foobar", fmsUser.getName());
         assertEquals("Foo", fmsUser.getFirstName());
         assertEquals("Bar", fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
     }
 
     @Test
     public void testUserToFmsUserMissingNames() {
+        String workloadUsername = "foobar";
+        UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(umsUser);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testUserToFmsUserDeactivatedState() {
+        String workloadUsername = "foobar";
+        UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setState(UserManagementProto.ActorState.Value.DEACTIVATED)
+                .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(umsUser);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.DISABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testUserToFmsUserDeletingState() {
+        String workloadUsername = "foobar";
+        UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setState(UserManagementProto.ActorState.Value.DELETING)
+                .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(umsUser);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testUserToFmsUserUnrecognizedState() {
+        String workloadUsername = "foobar";
+        UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setStateValue(UNRECOGNIZED_STATE_VALUE)
+                .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(umsUser);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testUserToFmsUserMissingState() {
         String workloadUsername = "foobar";
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
                 .setWorkloadUsername(workloadUsername)
@@ -58,6 +128,7 @@ class FmsUserConverterTest {
         assertEquals(workloadUsername, fmsUser.getName());
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
     }
 
     @Test
@@ -67,6 +138,7 @@ class FmsUserConverterTest {
         UserManagementProto.User umsUser = UserManagementProto.User.newBuilder()
                 .setFirstName(firstName)
                 .setLastName(lastName)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
                 .build();
 
         assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(umsUser));
@@ -81,6 +153,7 @@ class FmsUserConverterTest {
                 .setMachineUserName(name)
                 .setMachineUserId(id)
                 .setWorkloadUsername(workloadUsername)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
@@ -88,6 +161,7 @@ class FmsUserConverterTest {
         assertEquals(workloadUsername, fmsUser.getName());
         assertEquals(name, fmsUser.getFirstName());
         assertEquals(id, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
     }
 
     @Test
@@ -99,6 +173,7 @@ class FmsUserConverterTest {
                 .setMachineUserName(name)
                 .setMachineUserId(id)
                 .setWorkloadUsername(workloadUsername)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
                 .build();
 
         FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
@@ -106,10 +181,75 @@ class FmsUserConverterTest {
         assertEquals("foobar", fmsUser.getName());
         assertEquals("Foo", fmsUser.getFirstName());
         assertEquals("Bar", fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
     }
 
     @Test
     public void testMachineUserToFmsUserMissingNames() {
+        String workloadUsername = "foobar";
+        UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testMachineUserToFmsUserDeactivatedState() {
+        String workloadUsername = "foobar";
+        UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setState(UserManagementProto.ActorState.Value.DEACTIVATED)
+                .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.DISABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testMachineUserToFmsUserDeletingState() {
+        String workloadUsername = "foobar";
+        UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setState(UserManagementProto.ActorState.Value.DELETING)
+                .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testMachineUserToFmsUserUnrecognizedState() {
+        String workloadUsername = "foobar";
+        UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
+                .setWorkloadUsername(workloadUsername)
+                .setStateValue(UNRECOGNIZED_STATE_VALUE)
+                .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(umsMachineUser);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testMachineUserToFmsUserMissingState() {
         String workloadUsername = "foobar";
         UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
                 .setWorkloadUsername(workloadUsername)
@@ -120,6 +260,7 @@ class FmsUserConverterTest {
         assertEquals(workloadUsername, fmsUser.getName());
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
     }
 
     @Test
@@ -129,6 +270,7 @@ class FmsUserConverterTest {
         UserManagementProto.MachineUser umsMachineUser = UserManagementProto.MachineUser.newBuilder()
                 .setMachineUserName(name)
                 .setMachineUserId(id)
+                .setState(UserManagementProto.ActorState.Value.ACTIVE)
                 .build();
 
         assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(umsMachineUser));
@@ -144,6 +286,7 @@ class FmsUserConverterTest {
                         .setFirstName(firstName)
                         .setLastName(lastName)
                         .setWorkloadUsername(workloadUsername)
+                        .setState(UserManagementProto.ActorState.Value.ACTIVE)
                         .build();
 
         FmsUser fmsUser = underTest.toFmsUser(actorDetails);
@@ -151,6 +294,7 @@ class FmsUserConverterTest {
         assertEquals(workloadUsername, fmsUser.getName());
         assertEquals(firstName, fmsUser.getFirstName());
         assertEquals(lastName, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
     }
 
     @Test
@@ -163,6 +307,7 @@ class FmsUserConverterTest {
                         .setFirstName(firstName)
                         .setLastName(lastName)
                         .setWorkloadUsername(workloadUsername)
+                        .setState(UserManagementProto.ActorState.Value.ACTIVE)
                         .build();
 
         FmsUser fmsUser = underTest.toFmsUser(actorDetails);
@@ -170,10 +315,79 @@ class FmsUserConverterTest {
         assertEquals("foobar", fmsUser.getName());
         assertEquals("Foo", fmsUser.getFirstName());
         assertEquals("Bar", fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
     }
 
     @Test
     public void testUserSyncActorDetailsToFmsUserMissingNames() {
+        String workloadUsername = "foobar";
+        UserManagementProto.UserSyncActorDetails actorDetails =
+                UserManagementProto.UserSyncActorDetails.newBuilder()
+                        .setWorkloadUsername(workloadUsername)
+                        .setState(UserManagementProto.ActorState.Value.ACTIVE)
+                        .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(actorDetails);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testUserSyncActorDetailsToFmsUserDeactivatedState() {
+        String workloadUsername = "foobar";
+        UserManagementProto.UserSyncActorDetails actorDetails =
+                UserManagementProto.UserSyncActorDetails.newBuilder()
+                        .setWorkloadUsername(workloadUsername)
+                        .setState(UserManagementProto.ActorState.Value.DEACTIVATED)
+                        .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(actorDetails);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.DISABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testUserSyncActorDetailsToFmsUserDeletingState() {
+        String workloadUsername = "foobar";
+        UserManagementProto.UserSyncActorDetails actorDetails =
+                UserManagementProto.UserSyncActorDetails.newBuilder()
+                        .setWorkloadUsername(workloadUsername)
+                        .setState(UserManagementProto.ActorState.Value.DELETING)
+                        .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(actorDetails);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testUserSyncActorDetailsToFmsUserUnrecognizedState() {
+        String workloadUsername = "foobar";
+        UserManagementProto.UserSyncActorDetails actorDetails =
+                UserManagementProto.UserSyncActorDetails.newBuilder()
+                        .setWorkloadUsername(workloadUsername)
+                        .setStateValue(UNRECOGNIZED_STATE_VALUE)
+                        .build();
+
+        FmsUser fmsUser = underTest.toFmsUser(actorDetails);
+
+        assertEquals(workloadUsername, fmsUser.getName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
+        assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
+    }
+
+    @Test
+    public void testUserSyncActorDetailsToFmsUserMissingState() {
         String workloadUsername = "foobar";
         UserManagementProto.UserSyncActorDetails actorDetails =
                 UserManagementProto.UserSyncActorDetails.newBuilder()
@@ -185,6 +399,7 @@ class FmsUserConverterTest {
         assertEquals(workloadUsername, fmsUser.getName());
         assertEquals(underTest.NONE_STRING, fmsUser.getFirstName());
         assertEquals(underTest.NONE_STRING, fmsUser.getLastName());
+        assertEquals(FmsUser.State.ENABLED, fmsUser.getState());
     }
 
     @Test
@@ -195,6 +410,7 @@ class FmsUserConverterTest {
                 UserManagementProto.UserSyncActorDetails.newBuilder()
                         .setFirstName(firstName)
                         .setLastName(lastName)
+                        .setState(UserManagementProto.ActorState.Value.ACTIVE)
                         .build();
 
         assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(actorDetails));
@@ -210,6 +426,7 @@ class FmsUserConverterTest {
                         .setFirstName(firstName)
                         .setLastName(lastName)
                         .setWorkloadUsername(workloadUserName)
+                        .setState(UserManagementProto.ActorState.Value.ACTIVE)
                         .build();
 
         assertThrows(IllegalArgumentException.class, () -> underTest.toFmsUser(actorDetails));

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersStateDifferenceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/model/UsersStateDifferenceTest.java
@@ -23,32 +23,51 @@ class UsersStateDifferenceTest {
     @Test
     void testCalculateUsersToAdd() {
         FmsUser userUms = new FmsUser().withName("userUms");
+        FmsUser userDisabledUms = new FmsUser().withName("userDisabledUms")
+                .withState(FmsUser.State.DISABLED);
         FmsUser userProtected = new FmsUser().withName(FreeIpaChecks.IPA_PROTECTED_USERS.get(0));
-        FmsUser userBoth = new FmsUser().withName("userBoth");
-        FmsUser userIPA = new FmsUser().withName("userIPA");
+        FmsUser userBothUms = new FmsUser().withName("userBoth");
+        FmsUser userBothIpa = new FmsUser().withName("userBoth");
+        FmsUser userIpa = new FmsUser().withName("userIPA");
+        FmsUser userSameStateUms = new FmsUser().withName("userSameState")
+                .withState(FmsUser.State.DISABLED);
+        FmsUser userSameStateIpa = new FmsUser().withName("userSameState")
+                .withState(FmsUser.State.DISABLED);
+        FmsUser userDifferentStateUms = new FmsUser().withName("userDifferentState")
+                .withState(FmsUser.State.ENABLED);
+        FmsUser userDifferentStateIpa = new FmsUser().withName("userDifferentState")
+                .withState(FmsUser.State.DISABLED);
 
         UmsUsersState umsUsersState = new UmsUsersState.Builder()
                 .setUsersState(new UsersState.Builder()
                         .addUser(userUms)
+                        .addUser(userDisabledUms)
                         .addUser(userProtected)
-                        .addUser(userBoth)
+                        .addUser(userBothUms)
+                        .addUser(userSameStateUms)
+                        .addUser(userDifferentStateUms)
                         .build())
                 .build();
 
         UsersState ipaUsersState = new UsersState.Builder()
-                .addUser(userBoth)
-                .addUser(userIPA)
+                .addUser(userBothIpa)
+                .addUser(userIpa)
+                .addUser(userSameStateIpa)
+                .addUser(userDifferentStateIpa)
                 .build();
 
         ImmutableSet<FmsUser> usersToAdd = UsersStateDifference.calculateUsersToAdd(umsUsersState, ipaUsersState);
 
         // the user that exists only in the UMS will be added
         assertTrue(usersToAdd.contains(userUms));
+        assertTrue(usersToAdd.contains(userDisabledUms));
         // protected users will be ignored
         assertFalse(usersToAdd.contains(userProtected));
         // users that exist in both or only in ipa will not be added
-        assertFalse(usersToAdd.contains(userBoth));
-        assertFalse(usersToAdd.contains(userIPA));
+        assertFalse(usersToAdd.contains(userBothUms));
+        assertFalse(usersToAdd.contains(userIpa));
+        assertFalse(usersToAdd.contains(userSameStateUms));
+        assertFalse(usersToAdd.contains(userDifferentStateUms));
     }
 
     @Test

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/BaseUmsUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/ums/BaseUmsUsersStateProviderTest.java
@@ -111,11 +111,11 @@ class BaseUmsUsersStateProviderTest {
                         groupsPerMember.get(u.getWorkloadUsername()),
                         state.getUsersWorkloadCredentialMap().get(u.getWorkloadUsername()),
                         usersState.getUserMetadataMap().get(u.getWorkloadUsername())));
-        testData.machineUsers.forEach(u ->
-                verifyActor(u.getCrn(), u.getWorkloadUsername(), workloadUsersWithAccess,
-                        groupsPerMember.get(u.getWorkloadUsername()),
-                        state.getUsersWorkloadCredentialMap().get(u.getWorkloadUsername()),
-                        usersState.getUserMetadataMap().get(u.getWorkloadUsername())));
+        testData.machineUsers.forEach(mu ->
+                verifyActor(mu.getCrn(), mu.getWorkloadUsername(), workloadUsersWithAccess,
+                        groupsPerMember.get(mu.getWorkloadUsername()),
+                        state.getUsersWorkloadCredentialMap().get(mu.getWorkloadUsername()),
+                        usersState.getUserMetadataMap().get(mu.getWorkloadUsername())));
 
         assertEquals(testData.servicePrincipalCloudIdentities, state.getServicePrincipalCloudIdentities());
     }
@@ -297,6 +297,7 @@ class BaseUmsUsersStateProviderTest {
                                         .toString())
                                 .setWorkloadUsername(userNameBasis + i)
                                 .addCloudIdentities(createCloudIdentity())
+                                .setState(UserManagementProto.ActorState.Value.ACTIVE)
                                 .build();
                     })
                     .collect(Collectors.toList());
@@ -316,6 +317,7 @@ class BaseUmsUsersStateProviderTest {
                                         .toString())
                                 .setWorkloadUsername(RandomStringUtils.randomAlphabetic(10))
                                 .addCloudIdentities(createCloudIdentity())
+                                .setState(UserManagementProto.ActorState.Value.ACTIVE)
                                 .build();
                     })
                     .collect(Collectors.toList());


### PR DESCRIPTION
Previous commits added the fields that represent whether an
actor is disabled to the models retrieved from the UMS and
from IPA. This commit now propagates those fields to the FMS's
internal user model for comparing users between the UMS and IPA.
The code for calculating the difference between the UMS and IPA
states was updated to not use the FmsUser.equals() method since
that method now includes the new field. The unit tests were
updated to ensure that the new calculation of users to add to
IPA works correctly.
