### PR TITLE
CB-12459 Salt state update flow for FreeIPA

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack;
 
+import static com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaOperationDescriptions.UPDATE_SALT;
+
 import java.util.List;
 
 import javax.validation.Valid;
@@ -176,7 +178,13 @@ public interface FreeIpaV1Endpoint {
     @PUT
     @Path("change_image")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = FreeIpaOperationDescriptions.BIND_USER_CREATE, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
+    @ApiOperation(value = FreeIpaOperationDescriptions.CHANGE_IMAGE, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "changeImageV1")
     FlowIdentifier changeImage(@Valid @NotNull ImageChangeRequest request);
+
+    @PUT
+    @Path("salt_update")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = UPDATE_SALT, nickname = "updateSaltV1")
+    FlowIdentifier updateSaltByName(@QueryParam("environment") @NotEmpty String environmentCrn, @AccountId @QueryParam("accountId") String accountId);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -20,6 +20,9 @@ public final class FreeIpaOperationDescriptions {
     public static final String REBOOT = "Reboot one or more instances";
     public static final String REPAIR = "Repair one or more instances";
     public static final String BIND_USER_CREATE = "Creates kerberos and ldap bind users for cluster";
+    public static final String UPDATE_SALT = "Update salt states on FreeIPA instances";
+    public static final String CHANGE_IMAGE = "Changes the image used for creating instances";
+
 
     private FreeIpaOperationDescriptions() {
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/DetailedStackStatus.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/common/DetailedStackStatus.java
@@ -70,7 +70,9 @@ public enum DetailedStackStatus {
     WAIT_FOR_SYNC(Status.WAIT_FOR_SYNC, AvailabilityStatus.UNAVAILABLE),
     UNREACHABLE(Status.UNREACHABLE, AvailabilityStatus.UNAVAILABLE),
     DELETED_ON_PROVIDER_SIDE(Status.DELETED_ON_PROVIDER_SIDE, AvailabilityStatus.UNAVAILABLE),
-    UNHEALTHY(Status.UNHEALTHY, AvailabilityStatus.AVAILABLE);
+    UNHEALTHY(Status.UNHEALTHY, AvailabilityStatus.AVAILABLE),
+    SALT_STATE_UPDATE_IN_PROGRESS(Status.UPDATE_IN_PROGRESS, AvailabilityStatus.AVAILABLE),
+    SALT_STATE_UPDATE_FAILED(Status.UPDATE_FAILED, AvailabilityStatus.AVAILABLE);
 
     public static final Collection<DetailedStackStatus> AVAILABLE_STATUSES;
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
@@ -14,6 +14,7 @@ import com.sequenceiq.freeipa.flow.freeipa.diagnostics.config.DiagnosticsCollect
 import com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowConfig;
+import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateFlowConfig;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowConfig;
 import com.sequenceiq.freeipa.flow.instance.reboot.RebootFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.image.change.ImageChangeFlowConfig;
@@ -39,7 +40,8 @@ public class FreeIpaFlowInformation implements ApplicationFlowInformation {
             UpscaleFlowConfig.class,
             ChangePrimaryGatewayFlowConfig.class,
             DiagnosticsCollectionFlowConfig.class,
-            RebootFlowConfig.class);
+            RebootFlowConfig.class,
+            SaltUpdateFlowConfig.class);
 
     private static final List<String> PARALLEL_FLOWS = List.of(
             FreeIpaCleanupEvent.CLEANUP_EVENT.event(),

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateActions.java
@@ -1,0 +1,121 @@
+package com.sequenceiq.freeipa.flow.freeipa.salt.update;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.bootstrap.BootstrapMachinesRequest;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.bootstrap.BootstrapMachinesSuccess;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.orchestrator.OrchestratorConfigRequest;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.orchestrator.OrchestratorConfigSuccess;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.services.InstallFreeIpaServicesRequest;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.services.InstallFreeIpaServicesSuccess;
+import com.sequenceiq.freeipa.flow.stack.AbstractStackFailureAction;
+import com.sequenceiq.freeipa.flow.stack.StackContext;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.StackFailureContext;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.flow.stack.provision.action.AbstractStackProvisionAction;
+import com.sequenceiq.freeipa.service.stack.StackUpdater;
+
+@Configuration
+public class SaltUpdateActions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaltUpdateActions.class);
+
+    @Inject
+    private StackUpdater stackUpdater;
+
+    @Bean(name = "UPDATE_SALT_STATE_FILES_STATE")
+    public Action<?, ?> updateSaltFilesAction() {
+        return new AbstractStackProvisionAction<>(StackEvent.class) {
+            @Override
+            protected void doExecute(StackContext context, StackEvent payload, Map<Object, Object> variables) {
+                stackUpdater.updateStackStatus(payload.getResourceId(), DetailedStackStatus.SALT_STATE_UPDATE_IN_PROGRESS, "Salt state update in progress");
+                LOGGER.info("Reupload salt state files");
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackContext context) {
+                return new BootstrapMachinesRequest(context.getStack().getId());
+            }
+        };
+    }
+
+    @Bean(name = "UPDATE_ORCHESTRATOR_CONFIG_STATE")
+    public Action<?, ?> orchestratorConfig() {
+        return new AbstractStackProvisionAction<>(BootstrapMachinesSuccess.class) {
+
+            @Override
+            protected void doExecute(StackContext context, BootstrapMachinesSuccess payload, Map<Object, Object> variables) {
+                LOGGER.info("Reupload pillar files");
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackContext context) {
+                return new OrchestratorConfigRequest(context.getStack().getId());
+            }
+        };
+    }
+
+    @Bean(name = "RUN_HIGHSTATE_STATE")
+    public Action<?, ?> runHighstateAction() {
+        return new AbstractStackProvisionAction<>(OrchestratorConfigSuccess.class) {
+            @Override
+            protected void doExecute(StackContext context, OrchestratorConfigSuccess payload, Map<Object, Object> variables) throws Exception {
+                LOGGER.info("Run highstate");
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackContext context) {
+                return new InstallFreeIpaServicesRequest(context.getStack().getId());
+            }
+        };
+    }
+
+    @Bean(name = "SALT_UPDATE_FINISHED_STATE")
+    public Action<?, ?> saltUpdateFinishedAction() {
+        return new AbstractStackProvisionAction<>(InstallFreeIpaServicesSuccess.class) {
+            @Override
+            protected void doExecute(StackContext context, InstallFreeIpaServicesSuccess payload, Map<Object, Object> variables) {
+                stackUpdater.updateStackStatus(payload.getResourceId(), DetailedStackStatus.AVAILABLE, "Salt update finished");
+                LOGGER.info("Salt state update finished successfully");
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackContext context) {
+                return new StackEvent(SaltUpdateEvent.SALT_UPDATE_FINISHED_EVENT.event(), context.getStack().getId());
+            }
+        };
+    }
+
+    @Bean(name = "SALT_UPDATE_FAILED_STATE")
+    public Action<?, ?> saltUpdateFailedAction() {
+        return new AbstractStackFailureAction<SaltUpdateState, SaltUpdateEvent>() {
+            @Override
+            protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) {
+                LOGGER.error("Salt state update failed", payload.getException());
+                stackUpdater.updateStackStatus(payload.getResourceId(), DetailedStackStatus.SALT_STATE_UPDATE_FAILED,
+                        "Salt update failed with: " + payload.getException().getMessage());
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackFailureContext context) {
+                return new StackEvent(SaltUpdateEvent.SALT_UPDATE_FAILURE_HANDLED_EVENT.event(), context.getStack().getId());
+            }
+        };
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateEvent.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.freeipa.flow.freeipa.salt.update;
+
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.bootstrap.BootstrapMachinesFailed;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.bootstrap.BootstrapMachinesSuccess;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.orchestrator.OrchestratorConfigFailed;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.orchestrator.OrchestratorConfigSuccess;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.services.InstallFreeIpaServicesFailed;
+import com.sequenceiq.freeipa.flow.freeipa.provision.event.services.InstallFreeIpaServicesSuccess;
+
+public enum SaltUpdateEvent implements FlowEvent {
+
+    SALT_UPDATE_EVENT,
+    BOOTSTRAP_MACHINES_FINISHED_EVENT(EventSelectorUtil.selector(BootstrapMachinesSuccess.class)),
+    BOOTSTRAP_MACHINES_FAILED_EVENT(EventSelectorUtil.selector(BootstrapMachinesFailed.class)),
+    UPDATE_ORCHESTRATOR_CONFIG_FINISHED_EVENT(EventSelectorUtil.selector(OrchestratorConfigSuccess.class)),
+    UPDATE_ORCHESTRATOR_CONFIG_FAILED_EVENT(EventSelectorUtil.selector(OrchestratorConfigFailed.class)),
+    HIGHSTATE_FINISHED_EVENT(EventSelectorUtil.selector(InstallFreeIpaServicesSuccess.class)),
+    HIGHSTATE_FAILED_EVENT(EventSelectorUtil.selector(InstallFreeIpaServicesFailed.class)),
+    SALT_UPDATE_FAILED_EVENT,
+    SALT_UPDATE_FINISHED_EVENT,
+    SALT_UPDATE_FAILURE_HANDLED_EVENT;
+
+    private final String event;
+
+    SaltUpdateEvent(String event) {
+        this.event = event;
+    }
+
+    SaltUpdateEvent() {
+        this.event = name();
+    }
+
+    @Override
+    public String event() {
+        return event;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateFlowConfig.java
@@ -1,0 +1,88 @@
+package com.sequenceiq.freeipa.flow.freeipa.salt.update;
+
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.BOOTSTRAP_MACHINES_FAILED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.BOOTSTRAP_MACHINES_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.HIGHSTATE_FAILED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.HIGHSTATE_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.SALT_UPDATE_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.SALT_UPDATE_FAILED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.SALT_UPDATE_FAILURE_HANDLED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.SALT_UPDATE_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.UPDATE_ORCHESTRATOR_CONFIG_FAILED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.UPDATE_ORCHESTRATOR_CONFIG_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateState.FINAL_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateState.INIT_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateState.RUN_HIGHSTATE_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateState.SALT_UPDATE_FAILED_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateState.SALT_UPDATE_FINISHED_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateState.UPDATE_ORCHESTRATOR_CONFIG_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateState.UPDATE_SALT_STATE_FILES_STATE;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
+
+@Component
+public class SaltUpdateFlowConfig extends AbstractFlowConfiguration<SaltUpdateState, SaltUpdateEvent> {
+
+    private static final List<Transition<SaltUpdateState, SaltUpdateEvent>> TRANSITIONS =
+            new Builder<SaltUpdateState, SaltUpdateEvent>().defaultFailureEvent(SALT_UPDATE_FAILED_EVENT)
+                    .from(INIT_STATE)
+                    .to(UPDATE_SALT_STATE_FILES_STATE)
+                    .event(SALT_UPDATE_EVENT)
+                    .defaultFailureEvent()
+
+                    .from(UPDATE_SALT_STATE_FILES_STATE)
+                    .to(UPDATE_ORCHESTRATOR_CONFIG_STATE)
+                    .event(BOOTSTRAP_MACHINES_FINISHED_EVENT)
+                    .failureEvent(BOOTSTRAP_MACHINES_FAILED_EVENT)
+
+                    .from(UPDATE_ORCHESTRATOR_CONFIG_STATE)
+                    .to(RUN_HIGHSTATE_STATE)
+                    .event(UPDATE_ORCHESTRATOR_CONFIG_FINISHED_EVENT)
+                    .failureEvent(UPDATE_ORCHESTRATOR_CONFIG_FAILED_EVENT)
+
+                    .from(RUN_HIGHSTATE_STATE)
+                    .to(SALT_UPDATE_FINISHED_STATE)
+                    .event(HIGHSTATE_FINISHED_EVENT)
+                    .failureEvent(HIGHSTATE_FAILED_EVENT)
+
+                    .from(SALT_UPDATE_FINISHED_STATE)
+                    .to(FINAL_STATE)
+                    .event(SALT_UPDATE_FINISHED_EVENT)
+                    .noFailureEvent()
+
+                    .build();
+
+    public SaltUpdateFlowConfig() {
+        super(SaltUpdateState.class, SaltUpdateEvent.class);
+    }
+
+    @Override
+    protected List<Transition<SaltUpdateState, SaltUpdateEvent>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<SaltUpdateState, SaltUpdateEvent> getEdgeConfig() {
+        return new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, SALT_UPDATE_FAILED_STATE, SALT_UPDATE_FAILURE_HANDLED_EVENT);
+    }
+
+    @Override
+    public SaltUpdateEvent[] getEvents() {
+        return SaltUpdateEvent.values();
+    }
+
+    @Override
+    public SaltUpdateEvent[] getInitEvents() {
+        return new SaltUpdateEvent[]{SALT_UPDATE_EVENT};
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Salt update";
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/SaltUpdateState.java
@@ -1,0 +1,20 @@
+package com.sequenceiq.freeipa.flow.freeipa.salt.update;
+
+import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
+
+public enum SaltUpdateState implements FlowState {
+    INIT_STATE,
+    UPDATE_SALT_STATE_FILES_STATE,
+    UPDATE_ORCHESTRATOR_CONFIG_STATE,
+    RUN_HIGHSTATE_STATE,
+    SALT_UPDATE_FINISHED_STATE,
+    FINAL_STATE,
+    SALT_UPDATE_FAILED_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/SaltUpdateService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/orchestrator/SaltUpdateService.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.freeipa.orchestrator;
+
+import static com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent.SALT_UPDATE_EVENT;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Service
+public class SaltUpdateService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaltUpdateService.class);
+
+    @Inject
+    private FreeIpaFlowManager flowManager;
+
+    @Inject
+    private StackService stackService;
+
+    public FlowIdentifier updateSaltStates(String environmentCrn, String accountId) {
+        Stack stack = stackService.getByEnvironmentCrnAndAccountId(environmentCrn, accountId);
+        MDCBuilder.buildMdcContext(stack);
+        StackEvent event = new StackEvent(SALT_UPDATE_EVENT.event(), stack.getId());
+        LOGGER.info("Triggering salt update flow with event: {}", event);
+        return flowManager.notify(event.selector(), event);
+    }
+}


### PR DESCRIPTION
A new flow introduced with an endpoint to enable FreeIPA salt states update. Steps:
- push down state files
- push down the pillars
- run highstate

See detailed description in the commit message.