### PR TITLE
CB-12939 Always request instance storage on AWS

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceStoreMetadata.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/InstanceStoreMetadata.java
@@ -2,28 +2,33 @@ package com.sequenceiq.cloudbreak.cloud.model;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class InstanceStoreMetadata {
 
-    private Map<String, Integer> instaceStoreCountMap = new HashMap<>();
+    private Map<String, VolumeParameterConfig> instaceStoreConfigMap = new HashMap<>();
 
     public InstanceStoreMetadata() {
     }
 
-    public InstanceStoreMetadata(Map<String, Integer> instaceStoreCountMap) {
-        this.instaceStoreCountMap = instaceStoreCountMap;
+    public InstanceStoreMetadata(Map<String, VolumeParameterConfig> instaceStoreConfigMap) {
+        this.instaceStoreConfigMap = Optional.ofNullable(instaceStoreConfigMap).orElse(new HashMap<>());
     }
 
-    public void addInstanceStoreCountToInstanceType(String instanceType, Integer instanceStoreCount) {
-        instaceStoreCountMap.put(instanceType, instanceStoreCount);
+    public void addInstanceStoreConfigToInstanceType(String instanceType, VolumeParameterConfig instanceStoreConfig) {
+        instaceStoreConfigMap.put(instanceType, instanceStoreConfig);
     }
 
     public Integer mapInstanceTypeToInstanceStoreCount(String instanceType) {
-        return instaceStoreCountMap.get(instanceType);
+        return instaceStoreConfigMap.getOrDefault(instanceType, VolumeParameterConfig.EMPTY).maximumNumber();
     }
 
     public Integer mapInstanceTypeToInstanceStoreCountNullHandled(String instanceType) {
-        Integer instanceStoreCount = instaceStoreCountMap.get(instanceType);
+        Integer instanceStoreCount = instaceStoreConfigMap.getOrDefault(instanceType, VolumeParameterConfig.EMPTY).maximumNumber();
         return instanceStoreCount != null ? instanceStoreCount : 0;
+    }
+
+    public Map<String, VolumeParameterConfig> getInstaceStoreConfigMap() {
+        return instaceStoreConfigMap;
     }
 }

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/InstanceStoreMetadataTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/model/InstanceStoreMetadataTest.java
@@ -18,9 +18,11 @@ public class InstanceStoreMetadataTest {
 
     @Test
     public void testConstructorCreated() {
-        Map<String, Integer> testMap = new HashMap<>();
-        testMap.put("instance1", 1);
-        testMap.put("instance2", 2);
+        Map<String, VolumeParameterConfig> testMap = new HashMap<>();
+        VolumeParameterConfig firstConfig = new VolumeParameterConfig(VolumeParameterType.EPHEMERAL, 1, 1, 1, 1);
+        VolumeParameterConfig secondConfig = new VolumeParameterConfig(VolumeParameterType.EPHEMERAL, 1, 1, 2, 2);
+        testMap.put("instance1", firstConfig);
+        testMap.put("instance2", secondConfig);
 
         InstanceStoreMetadata instanceStoreMetadata = new InstanceStoreMetadata(testMap);
 
@@ -31,12 +33,14 @@ public class InstanceStoreMetadataTest {
     @Test
     public void testAddingSameEntries() {
         InstanceStoreMetadata instanceStoreMetadata = new InstanceStoreMetadata();
-        instanceStoreMetadata.addInstanceStoreCountToInstanceType("instance1", 1);
+        VolumeParameterConfig singleStorage = new VolumeParameterConfig(VolumeParameterType.EPHEMERAL, 1, 1, 1, 1);
+        instanceStoreMetadata.addInstanceStoreConfigToInstanceType("instance1", singleStorage);
 
         Assertions.assertEquals(1, instanceStoreMetadata.mapInstanceTypeToInstanceStoreCount("instance1"));
         Assertions.assertEquals(1, instanceStoreMetadata.mapInstanceTypeToInstanceStoreCountNullHandled("instance1"));
 
-        instanceStoreMetadata.addInstanceStoreCountToInstanceType("instance1", 2);
+        VolumeParameterConfig multipleStorage = new VolumeParameterConfig(VolumeParameterType.EPHEMERAL, 1, 1, 2, 2);
+        instanceStoreMetadata.addInstanceStoreConfigToInstanceType("instance1", multipleStorage);
 
         Assertions.assertEquals(2, instanceStoreMetadata.mapInstanceTypeToInstanceStoreCount("instance1"));
         Assertions.assertEquals(2, instanceStoreMetadata.mapInstanceTypeToInstanceStoreCountNullHandled("instance1"));

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsAttachmentResourceBuilder.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsAttachmentResourceBuilder.java
@@ -20,10 +20,9 @@ import com.amazonaws.services.ec2.model.AttachVolumeRequest;
 import com.amazonaws.services.ec2.model.DescribeVolumesRequest;
 import com.amazonaws.services.ec2.model.DescribeVolumesResult;
 import com.sequenceiq.cloudbreak.cloud.aws.AwsCloudFormationClient;
-import com.sequenceiq.cloudbreak.cloud.aws.common.AwsPlatformParameters.AwsDiskType;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
-import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.aws.common.context.AwsContext;
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
@@ -35,6 +34,7 @@ import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cloud.template.compute.PreserveResourceException;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
+import com.sequenceiq.common.model.AwsDiskType;
 
 @Component
 public class AwsAttachmentResourceBuilder extends AbstractAwsComputeBuilder {

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilder.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilder.java
@@ -44,12 +44,11 @@ import com.amazonaws.services.ec2.model.ModifyInstanceAttributeResult;
 import com.amazonaws.services.ec2.model.Subnet;
 import com.amazonaws.services.ec2.model.TagSpecification;
 import com.sequenceiq.cloudbreak.cloud.aws.AwsCloudFormationClient;
-import com.sequenceiq.cloudbreak.cloud.aws.common.AwsPlatformParameters.AwsDiskType;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsTaggingService;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
-import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.aws.common.context.AwsContext;
 import com.sequenceiq.cloudbreak.cloud.aws.common.service.AwsResourceNameService;
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsInstanceView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
@@ -69,6 +68,7 @@ import com.sequenceiq.cloudbreak.cloud.template.compute.PreserveResourceExceptio
 import com.sequenceiq.cloudbreak.util.DeviceNameGenerator;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
+import com.sequenceiq.common.model.AwsDiskType;
 
 @Component
 public class AwsVolumeResourceBuilder extends AbstractAwsComputeBuilder {

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilderTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/AwsVolumeResourceBuilderTest.java
@@ -29,11 +29,10 @@ import com.amazonaws.services.ec2.model.CreateVolumeResult;
 import com.amazonaws.services.ec2.model.Tag;
 import com.amazonaws.services.ec2.model.TagSpecification;
 import com.sequenceiq.cloudbreak.cloud.aws.AwsCloudFormationClient;
-import com.sequenceiq.cloudbreak.cloud.aws.common.AwsPlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsTaggingService;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
-import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.aws.common.context.AwsContext;
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
@@ -53,6 +52,7 @@ import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
+import com.sequenceiq.common.model.AwsDiskType;
 
 @ExtendWith(MockitoExtension.class)
 class AwsVolumeResourceBuilderTest {
@@ -77,9 +77,9 @@ class AwsVolumeResourceBuilderTest {
 
     private static final int VOLUME_SIZE = 78;
 
-    private static final String TYPE_GP2 = AwsPlatformParameters.AwsDiskType.Gp2.value();
+    private static final String TYPE_GP2 = AwsDiskType.Gp2.value();
 
-    private static final String TYPE_EPHEMERAL = AwsPlatformParameters.AwsDiskType.Ephemeral.value();
+    private static final String TYPE_EPHEMERAL = AwsDiskType.Ephemeral.value();
 
     private static final String VOLUME_SET_NAME = "volumeName";
 

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsPlatformParameters.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsPlatformParameters.java
@@ -38,9 +38,10 @@ import com.sequenceiq.cloudbreak.cloud.model.TagSpecification;
 import com.sequenceiq.cloudbreak.cloud.model.VmRecommendations;
 import com.sequenceiq.cloudbreak.cloud.model.VmType;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.common.type.OrchestratorConstants;
 import com.sequenceiq.cloudbreak.service.CloudbreakResourceReaderService;
-import com.sequenceiq.cloudbreak.common.json.JsonUtil;
+import com.sequenceiq.common.model.AwsDiskType;
 
 @Service
 public class AwsPlatformParameters implements PlatformParameters {
@@ -128,17 +129,17 @@ public class AwsPlatformParameters implements PlatformParameters {
 
     private Map<String, VolumeParameterType> diskMappings() {
         Map<String, VolumeParameterType> map = new HashMap<>();
-        map.put(AwsDiskType.Standard.value, VolumeParameterType.MAGNETIC);
-        map.put(AwsDiskType.Gp2.value, VolumeParameterType.SSD);
-        map.put(AwsDiskType.Ephemeral.value, VolumeParameterType.EPHEMERAL);
-        map.put(AwsDiskType.St1.value, VolumeParameterType.ST1);
+        map.put(AwsDiskType.Standard.value(), VolumeParameterType.MAGNETIC);
+        map.put(AwsDiskType.Gp2.value(), VolumeParameterType.SSD);
+        map.put(AwsDiskType.Ephemeral.value(), VolumeParameterType.EPHEMERAL);
+        map.put(AwsDiskType.St1.value(), VolumeParameterType.ST1);
         return map;
     }
 
     private Collection<DiskType> getDiskTypes() {
         Collection<DiskType> disks = Lists.newArrayList();
         for (AwsDiskType diskType : AwsDiskType.values()) {
-            disks.add(diskType(diskType.value));
+            disks.add(diskType(diskType.value()));
         }
         return disks;
     }
@@ -220,30 +221,6 @@ public class AwsPlatformParameters implements PlatformParameters {
 
     public String getCdpRangerAuditS3PolicyJson() {
         return cdpRangerAuditS3PolicyJson;
-    }
-
-    public enum AwsDiskType {
-        Standard("standard", "Magnetic"),
-        Ephemeral("ephemeral", "Ephemeral"),
-        Gp2("gp2", "General Purpose (SSD)"),
-        St1("st1", "Throughput Optimized HDD");
-
-        private final String value;
-
-        private final String displayName;
-
-        AwsDiskType(String value, String displayName) {
-            this.value = value;
-            this.displayName = displayName;
-        }
-
-        public String value() {
-            return value;
-        }
-
-        public String displayName() {
-            return displayName;
-        }
     }
 
     private VmRecommendations initVmRecommendations() {

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/view/AwsGroupView.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/view/AwsGroupView.java
@@ -3,8 +3,8 @@ package com.sequenceiq.cloudbreak.cloud.aws.common.view;
 import java.util.List;
 import java.util.Map;
 
-import com.sequenceiq.cloudbreak.cloud.aws.common.AwsPlatformParameters.AwsDiskType;
 import com.sequenceiq.cloudbreak.cloud.model.SecurityRule;
+import com.sequenceiq.common.model.AwsDiskType;
 
 public class AwsGroupView {
 

--- a/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
+++ b/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
@@ -28,7 +28,6 @@ import com.amazonaws.services.ec2.model.Tag;
 import com.amazonaws.services.ec2.model.TagSpecification;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import com.sequenceiq.cloudbreak.cloud.aws.AwsMethodExecutor;
-import com.sequenceiq.cloudbreak.cloud.aws.common.AwsPlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsTaggingService;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.context.AwsContext;
@@ -45,6 +44,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Volume;
 import com.sequenceiq.cloudbreak.cloud.model.filesystem.CloudS3View;
 import com.sequenceiq.common.api.type.CommonStatus;
 import com.sequenceiq.common.api.type.ResourceType;
+import com.sequenceiq.common.model.AwsDiskType;
 
 @Service
 public class AwsNativeInstanceResourceBuilder extends AbstractAwsNativeComputeBuilder {
@@ -196,7 +196,7 @@ public class AwsNativeInstanceResourceBuilder extends AbstractAwsNativeComputeBu
 
     private Boolean isEbsOptimized(InstanceTemplate instanceTemplate) {
         Set<String> types = instanceTemplate.getVolumes().stream().map(Volume::getType).collect(Collectors.toSet());
-        return types.contains(AwsPlatformParameters.AwsDiskType.St1.value());
+        return types.contains(AwsDiskType.St1.value());
     }
 
     private String getInstanceProfile(Group group) {

--- a/common-model/src/main/java/com/sequenceiq/common/model/AwsDiskType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/model/AwsDiskType.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.common.model;
+
+public enum AwsDiskType {
+    Standard("standard", "Magnetic"),
+    Ephemeral("ephemeral", "Ephemeral"),
+    Gp2("gp2", "General Purpose (SSD)"),
+    St1("st1", "Throughput Optimized HDD");
+
+    private final String value;
+
+    private final String displayName;
+
+    AwsDiskType(String value, String displayName) {
+        this.value = value;
+        this.displayName = displayName;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+}

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
@@ -91,6 +91,7 @@ import com.sequenceiq.cloudbreak.workspace.model.WorkspaceStatus;
 import com.sequenceiq.common.api.type.AdjustmentType;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.ResourceType;
+import com.sequenceiq.common.model.AwsDiskType;
 
 public class TestUtil {
 
@@ -149,7 +150,7 @@ public class TestUtil {
     public static Stack setEphemeral(Stack stack) {
         if (stack.cloudPlatform().equals(AWS)) {
             for (InstanceGroup instanceGroup : stack.getInstanceGroups()) {
-                (instanceGroup.getTemplate()).getVolumeTemplates().iterator().next().setVolumeType("ephemeral");
+                (instanceGroup.getTemplate()).getVolumeTemplates().iterator().next().setVolumeType(AwsDiskType.Ephemeral.value());
             }
         }
         return stack;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairService.java
@@ -59,8 +59,9 @@ import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsClientService;
 import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
-import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.common.model.AwsDiskType;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
@@ -70,7 +71,7 @@ public class ClusterRepairService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterRepairService.class);
 
-    private static final List<String> REATTACH_NOT_SUPPORTED_VOLUME_TYPES = List.of("ephemeral");
+    private static final List<String> REATTACH_NOT_SUPPORTED_VOLUME_TYPES = List.of(AwsDiskType.Ephemeral.value());
 
     private static final String RECOVERY = "RECOVERY";
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackStopRestrictionService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackStopRestrictionService.java
@@ -6,20 +6,19 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.domain.StopRestrictionReason;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.common.model.AwsDiskType;
 
 @Service
 public class StackStopRestrictionService {
 
     private static final String SUPPORTED_CLOUD_PLATFORM = "AWS";
 
-    private static final String EPHEMERAL_VOLUME = "ephemeral";
-
     public StopRestrictionReason isInfrastructureStoppable(String cloudPlatform, Set<InstanceGroup> instanceGroups) {
         StopRestrictionReason reason = StopRestrictionReason.NONE;
         if (SUPPORTED_CLOUD_PLATFORM.equals(cloudPlatform)) {
             for (InstanceGroup instanceGroup : instanceGroups) {
                 if (instanceGroup.getTemplate().getVolumeTemplates().stream()
-                        .anyMatch(volume -> EPHEMERAL_VOLUME.equals(volume.getVolumeType()))) {
+                        .anyMatch(volume -> AwsDiskType.Ephemeral.value().equals(volume.getVolumeType()))) {
                     reason = StopRestrictionReason.EPHEMERAL_VOLUMES;
                     break;
                 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/service/StackCreationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/service/StackCreationServiceTest.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.cloudbreak.core.flow2.stack.provision.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.Authenticator;
+import com.sequenceiq.cloudbreak.cloud.CloudConnector;
+import com.sequenceiq.cloudbreak.cloud.MetadataCollector;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStoreMetadata;
+import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterConfig;
+import com.sequenceiq.cloudbreak.cloud.model.VolumeParameterType;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.core.flow2.stack.StackContext;
+import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.service.template.TemplateService;
+import com.sequenceiq.common.model.AwsDiskType;
+
+@ExtendWith(MockitoExtension.class)
+class StackCreationServiceTest {
+
+    @Mock
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Mock
+    private TemplateService templateService;
+
+    @InjectMocks
+    private StackCreationService underTest;
+
+    @Test
+    void setInstanceStoreCount() {
+        CloudConnector<Object> cloudConnector = Mockito.mock(CloudConnector.class);
+        when(cloudPlatformConnectors.get(any())).thenReturn(cloudConnector);
+        MetadataCollector metadataCollector = Mockito.mock(MetadataCollector.class);
+        when(cloudConnector.metadata()).thenReturn(metadataCollector);
+        Authenticator authenticator = Mockito.mock(Authenticator.class);
+        when(cloudConnector.authentication()).thenReturn(authenticator);
+
+        InstanceStoreMetadata instanceStoreMetadata = getInstanceStoreMetadata();
+        when(metadataCollector.collectInstanceStorageCount(any(), any())).thenReturn(instanceStoreMetadata);
+
+        StackContext context = getStackContext();
+        underTest.setInstanceStoreCount(context);
+
+        ArgumentCaptor<Template> savedTemplate = ArgumentCaptor.forClass(Template.class);
+        verify(templateService).savePure(savedTemplate.capture());
+
+        Set<VolumeTemplate> savedVolumeTemplates = savedTemplate.getValue().getVolumeTemplates();
+        assertEquals(2, savedVolumeTemplates.size());
+
+        Set<String> expectedTypes = new HashSet<>(Set.of(AwsDiskType.Standard.value(), AwsDiskType.Ephemeral.value()));
+        savedVolumeTemplates.stream().map(VolumeTemplate::getVolumeType).forEach(expectedTypes::remove);
+        assertTrue(expectedTypes.isEmpty());
+    }
+
+    private InstanceStoreMetadata getInstanceStoreMetadata() {
+        InstanceStoreMetadata instanceStoreMetadata = new InstanceStoreMetadata();
+        VolumeParameterConfig instanceStorageConfig = new VolumeParameterConfig(VolumeParameterType.EPHEMERAL, 100, 100, 100, 100);
+        instanceStoreMetadata.getInstaceStoreConfigMap().put("vm.type", instanceStorageConfig);
+        return instanceStoreMetadata;
+    }
+
+    private StackContext getStackContext() {
+        Stack stack = new Stack();
+        InstanceGroup group = new InstanceGroup();
+        Template template = new Template();
+        template.setInstanceType("vm.type");
+        VolumeTemplate volumeTemplate = new VolumeTemplate();
+        volumeTemplate.setVolumeType(AwsDiskType.Standard.value());
+        template.setVolumeTemplates(new HashSet<>(Set.of(volumeTemplate)));
+        group.setTemplate(template);
+        stack.setInstanceGroups(Set.of(group));
+
+        CloudContext cloudContext = CloudContext.Builder.builder().withPlatform(CloudPlatform.AWS.name()).build();
+        return new StackContext(null, stack, cloudContext, null, null);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackStopRestrictionServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackStopRestrictionServiceTest.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.domain.StopRestrictionReason;
 import com.sequenceiq.cloudbreak.domain.Template;
 import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.common.model.AwsDiskType;
 
 public class StackStopRestrictionServiceTest {
 
@@ -22,7 +23,7 @@ public class StackStopRestrictionServiceTest {
     public void infrastructureShouldNotBeStoppableForEphemeralStorage() {
         Set<InstanceGroup> groups = new HashSet<>();
         groups.add(createGroup("ebs"));
-        groups.add(createGroup("ephemeral"));
+        groups.add(createGroup(AwsDiskType.Ephemeral.value()));
 
         StopRestrictionReason actual = underTest.isInfrastructureStoppable("AWS", groups);
 


### PR DESCRIPTION
Instance storage/ephemeral storage should be requested always, regardless of storage type selected.