### PR TITLE
CB-13027 Handle already running saltstack jobs gracefully in case of …

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/RunningJobsResponse.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/domain/RunningJobsResponse.java
@@ -15,7 +15,7 @@ public class RunningJobsResponse {
     @SerializedName("return")
     private List<Map<String, Map<String, Object>>> result;
 
-    public Iterable<Map<String, Map<String, Object>>> getResult() {
+    public List<Map<String, Map<String, Object>>> getResult() {
         return result;
     }
 

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
@@ -179,9 +179,7 @@ public class SaltStates {
     }
 
     public static boolean jobIsRunning(SaltConnector sc, String jid) throws CloudbreakOrchestratorFailedException {
-        RunningJobsResponse runningInfo = sc.run("jobs.active", RUNNER, RunningJobsResponse.class);
-        LOGGER.debug("Active salt jobs: {}", runningInfo);
-        validateRunningInfoResultNotNull(runningInfo);
+        RunningJobsResponse runningInfo = getRunningJobs(sc);
         for (Map<String, Map<String, Object>> results : runningInfo.getResult()) {
             for (Entry<String, Map<String, Object>> stringMapEntry : results.entrySet()) {
                 if (stringMapEntry.getKey().equals(jid)) {
@@ -190,6 +188,13 @@ public class SaltStates {
             }
         }
         return false;
+    }
+
+    public static RunningJobsResponse getRunningJobs(SaltConnector sc) throws CloudbreakOrchestratorFailedException {
+        RunningJobsResponse runningInfo = sc.run("jobs.active", RUNNER, RunningJobsResponse.class);
+        LOGGER.debug("Active salt jobs: {}", runningInfo);
+        validateRunningInfoResultNotNull(runningInfo);
+        return runningInfo;
     }
 
     private static void validateRunningInfoResultNotNull(RunningJobsResponse runningInfo) throws CloudbreakOrchestratorFailedException {


### PR DESCRIPTION
…service restart

When a service restarted or upgraded to a new version the polling of an already running highstate is interrupted.
During the restart of the flow currently the service would try to initiate the highstate but it would fail, as there is an already running one.
There was a mitigation attempt to get the already running highstate's JID and use `jobs.lookup_jid` to get information about it.
Unfortunately while a highstate is running the above command fails with `Minion did not return` error.
To handle these restarts more gracefully, before submitting a new task to SaltStack, with this change we will check if there is an already running job.
This is done using `jobs.active` call. If it returns there is something running, the service won't submit the new job, will leave it in not started state
and throw a `CloudbreakOrchestratorInProgressException`. This means these cases won't be handled as an error by the framework but as normal prograss.
After the already running job is finished, the queued one would be started and polled as usual. As this should be the same as the already finished one,
we expect it to finish in a very short time and don't cause any timeout issues.

Tested with unit test and manually on a local dev environment.

See detailed description in the commit message.