### PR TITLE
CB-13039 Introduce a CM version syncer

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
@@ -26,4 +26,7 @@ public interface ClusterStatusService {
     boolean isClusterManagerRunning();
 
     boolean isClusterManagerRunningQuickCheck();
+
+    String getClusterManagerVersion();
+
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
@@ -44,6 +44,7 @@ import com.cloudera.api.swagger.model.ApiRoleRef;
 import com.cloudera.api.swagger.model.ApiRoleState;
 import com.cloudera.api.swagger.model.ApiService;
 import com.cloudera.api.swagger.model.ApiServiceState;
+import com.cloudera.api.swagger.model.ApiVersionInfo;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimaps;
@@ -398,6 +399,17 @@ public class ClouderaManagerClusterStatusService implements ClusterStatusService
         } catch (ApiException e) {
             LOGGER.info("Failed to get version from CM", e);
             return false;
+        }
+    }
+
+    @Override
+    public String getClusterManagerVersion() {
+        try {
+            ApiVersionInfo apiVersionInfo = cmApiRetryTemplate.execute(context -> clouderaManagerApiFactory.getClouderaManagerResourceApi(client).getVersion());
+            return apiVersionInfo.getVersion();
+        } catch (ApiException e) {
+            LOGGER.info("Failed to get version from CM", e);
+            return "";
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeActions.java
@@ -1,14 +1,15 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade;
 
-import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeEvent.CLUSTER_UPGRADE_FAIL_HANDLED_EVENT;
-
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.StateContext;
@@ -24,6 +25,8 @@ import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterManagerUpgradeRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterManagerUpgradeSuccess;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgradeFailHandledRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgradeFailedCmSyncRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgradeFailedEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgradeInitRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgradeInitSuccess;
@@ -64,7 +67,7 @@ public class ClusterUpgradeActions {
                     variables.put(TARGET_IMAGE, images.getTargetStatedImage());
                     clusterUpgradeService.initUpgradeCluster(context.getStackId(), getTargetImage(variables));
                     Selectable event = new ClusterUpgradeInitRequest(context.getStackId(), isPatchUpgrade(images.getCurrentStatedImage().getImage(),
-                                    images.getTargetStatedImage().getImage()));
+                            images.getTargetStatedImage().getImage()));
                     sendEvent(context, event.selector(), event);
                 } catch (Exception e) {
                     LOGGER.error("Error during updating cluster components with image id: [{}]", payload.getImageId(), e);
@@ -179,6 +182,9 @@ public class ClusterUpgradeActions {
     public Action<?, ?> clusterUpgradeFailedAction() {
         return new AbstractClusterUpgradeAction<>(ClusterUpgradeFailedEvent.class) {
 
+            @Value("${cb.upgrade.failure.sync.sdx.enabled}")
+            private boolean syncAfterFailureEnabled;
+
             @Override
             protected ClusterUpgradeContext createFlowContext(FlowParameters flowParameters, StateContext<FlowState, FlowEvent> stateContext,
                     ClusterUpgradeFailedEvent payload) {
@@ -192,7 +198,24 @@ public class ClusterUpgradeActions {
             @Override
             protected void doExecute(ClusterUpgradeContext context, ClusterUpgradeFailedEvent payload, Map<Object, Object> variables) {
                 clusterUpgradeService.handleUpgradeClusterFailure(context.getStackId(), payload.getException().getMessage(), payload.getDetailedStatus());
-                sendEvent(context, CLUSTER_UPGRADE_FAIL_HANDLED_EVENT.event(), payload);
+                if (syncAfterFailureEnabled) {
+                    LOGGER.debug("Starting syncing parcel and CM version from CM to DB.");
+                    try {
+                        Set<Image> candidateImages = new HashSet<>();
+                        Optional.ofNullable(getCurrentImage(variables)).ifPresent(si -> candidateImages.add(si.getImage()));
+                        Optional.ofNullable(getTargetImage(variables)).ifPresent(si -> candidateImages.add(si.getImage()));
+                        ClusterUpgradeFailedCmSyncRequest cmSyncRequest =
+                                new ClusterUpgradeFailedCmSyncRequest(payload.getResourceId(), payload.getException(), payload.getDetailedStatus(),
+                                        candidateImages);
+                        sendEvent(context, cmSyncRequest);
+                    } catch (Exception e) {
+                        LOGGER.warn("Error starting syncing CM version to DB, syncing skipped: ", e);
+                        sendEvent(context, new ClusterUpgradeFailHandledRequest(payload.getResourceId(), payload.getException(), payload.getDetailedStatus()));
+                    }
+                } else {
+                    LOGGER.debug("Syncing from CM to DB is not enabled.");
+                    sendEvent(context, new ClusterUpgradeFailHandledRequest(payload.getResourceId(), payload.getException(), payload.getDetailedStatus()));
+                }
             }
 
             @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailHandledRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailHandledRequest.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade;
+
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.ClusterUpgradeEvent.CLUSTER_UPGRADE_FAIL_HANDLED_EVENT;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class ClusterUpgradeFailHandledRequest  extends StackEvent {
+
+    private final Exception exception;
+
+    private final DetailedStackStatus detailedStatus;
+
+    public ClusterUpgradeFailHandledRequest(Long stackId, Exception e, DetailedStackStatus detailedStackStatus) {
+        super(CLUSTER_UPGRADE_FAIL_HANDLED_EVENT.event(), stackId);
+        this.exception = e;
+        this.detailedStatus = detailedStackStatus;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+
+    public DetailedStackStatus getDetailedStatus() {
+        return detailedStatus;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailedCmSyncRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/ClusterUpgradeFailedCmSyncRequest.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade;
+
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class ClusterUpgradeFailedCmSyncRequest extends StackEvent {
+
+    private final Exception exception;
+
+    private final DetailedStackStatus detailedStatus;
+
+    private final Set<Image> candidateImages;
+
+    public ClusterUpgradeFailedCmSyncRequest(Long stackId, Exception exception, DetailedStackStatus detailedStackStatus, Set<Image> candidateImages) {
+        super(stackId);
+        this.exception = exception;
+        this.detailedStatus = detailedStackStatus;
+        this.candidateImages = candidateImages;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+
+    public DetailedStackStatus getDetailedStatus() {
+        return detailedStatus;
+    }
+
+    public Set<Image> getCandidateImages() {
+        return candidateImages;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterUpgradeFailedCmSyncHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterUpgradeFailedCmSyncHandler.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgradeFailHandledRequest;
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.ClusterUpgradeFailedCmSyncRequest;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.upgrade.sync.CmSyncerService;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+import reactor.bus.Event;
+
+@Component
+public class ClusterUpgradeFailedCmSyncHandler extends ExceptionCatcherEventHandler<ClusterUpgradeFailedCmSyncRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterUpgradeFailedCmSyncHandler.class);
+
+    @Inject
+    private CmSyncerService cmSyncerService;
+
+    @Inject
+    private StackService stackService;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(ClusterUpgradeFailedCmSyncRequest.class);
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<ClusterUpgradeFailedCmSyncRequest> event) {
+        ClusterUpgradeFailedCmSyncRequest request = event.getData();
+        return new ClusterUpgradeFailHandledRequest(resourceId, request.getException(), request.getDetailedStatus());
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent<ClusterUpgradeFailedCmSyncRequest> event) {
+        ClusterUpgradeFailedCmSyncRequest request = event.getData();
+        try {
+            Stack stack = stackService.getById(request.getResourceId());
+            cmSyncerService.syncFromCmToDb(stack, request.getCandidateImages());
+        } catch (Exception e) {
+            LOGGER.warn("Error during syncing CM version to DB, syncing skipped.", e);
+        }
+        return new ClusterUpgradeFailHandledRequest(request.getResourceId(), request.getException(), request.getDetailedStatus());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ComponentConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ComponentConverter.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import static com.sequenceiq.cloudbreak.common.type.ComponentType.CDH_PRODUCT_DETAILS;
+import static com.sequenceiq.cloudbreak.common.type.ComponentType.CM_REPO_DETAILS;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cloud.model.component.StackType;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.domain.stack.Component;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+
+/**
+ * Converts between various types and Component, where Component can be persisted to Component table in cbdb
+ */
+@org.springframework.stereotype.Component
+public class ComponentConverter {
+
+    public Set<Component> fromClouderaManagerProductList(Set<ClouderaManagerProduct> clouderaManagerProductList, Stack stack) {
+        return clouderaManagerProductList.stream()
+                .map(cmp -> fromClouderaManagerProduct(cmp, stack))
+                .collect(Collectors.toSet());
+    }
+
+    public Component fromClouderaManagerRepo(ClouderaManagerRepo clouderaManagerRepo, Stack stack) {
+        return new Component(CM_REPO_DETAILS, CM_REPO_DETAILS.name(), new Json(clouderaManagerRepo), stack);
+    }
+
+    private Component fromClouderaManagerProduct(ClouderaManagerProduct clouderaManagerProduct, Stack stack) {
+        if (StackType.CDH.name().equals(clouderaManagerProduct.getName())) {
+            return new Component(CDH_PRODUCT_DETAILS, CDH_PRODUCT_DETAILS.name(), new Json(clouderaManagerProduct), stack);
+        }
+        return new Component(CDH_PRODUCT_DETAILS, clouderaManagerProduct.getName(), new Json(clouderaManagerProduct), stack);
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.service.image;
 
 import static com.sequenceiq.cloudbreak.cloud.model.Platform.platform;
 import static com.sequenceiq.cloudbreak.common.type.ComponentType.CDH_PRODUCT_DETAILS;
+import static com.sequenceiq.cloudbreak.common.type.ComponentType.CM_REPO_DETAILS;
+import static com.sequenceiq.cloudbreak.common.type.ComponentType.IMAGE;
 import static com.sequenceiq.cloudbreak.service.image.ImageCatalogService.CDP_DEFAULT_CATALOG_NAME;
 
 import java.io.IOException;
@@ -37,6 +39,7 @@ import com.sequenceiq.cloudbreak.cloud.model.catalog.StackDetails;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackType;
 import com.sequenceiq.cloudbreak.cmtemplate.utils.BlueprintUtils;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
@@ -46,9 +49,9 @@ import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
 import com.sequenceiq.cloudbreak.domain.stack.Component;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.StackMatrixService;
+import com.sequenceiq.cloudbreak.service.parcel.ClouderaManagerProductTransformer;
 import com.sequenceiq.cloudbreak.workspace.model.User;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 
@@ -76,10 +79,13 @@ public class ImageService {
     private StackMatrixService stackMatrixService;
 
     @Inject
-    private PreWarmParcelParser preWarmParcelParser;
+    private CloudPlatformConnectors cloudPlatformConnectors;
 
     @Inject
-    private CloudPlatformConnectors cloudPlatformConnectors;
+    private ComponentConverter componentConverter;
+
+    @Inject
+    private ClouderaManagerProductTransformer clouderaManagerProductTransformer;
 
     public Image getImage(Long stackId) throws CloudbreakImageNotFoundException {
         return componentConfigProviderService.getImage(stackId);
@@ -95,7 +101,7 @@ public class ImageService {
         LOGGER.debug("Selected VM image for CloudPlatform '{}' and region '{}' is: {} from: {} image catalog",
                 platformString, region, imageName, imgFromCatalog.getImageCatalogUrl());
 
-        Set<Component> components = getComponents(stack, Map.of(), imgFromCatalog, imageName);
+        Set<Component> components = getComponents(stack, Map.of(), imgFromCatalog, EnumSet.of(IMAGE, CDH_PRODUCT_DETAILS, CM_REPO_DETAILS));
         componentConfigProviderService.store(components);
         return components;
     }
@@ -218,27 +224,58 @@ public class ImageService {
                 .findFirst();
     }
 
-    public Set<Component> getComponents(Stack stack, Map<InstanceGroupType, String> userData, StatedImage statedImage, String imageName)
-            throws CloudbreakImageCatalogException {
+    public Set<Component> getComponents(Stack stack, Map<InstanceGroupType, String> userData, StatedImage statedImage,
+            EnumSet<ComponentType> requestedComponents)
+            throws CloudbreakImageCatalogException, CloudbreakImageNotFoundException {
         Set<Component> components = new HashSet<>();
         com.sequenceiq.cloudbreak.cloud.model.catalog.Image catalogBasedImage = statedImage.getImage();
-        Image image = new Image(imageName, userData, catalogBasedImage.getOs(), catalogBasedImage.getOsType(),
-                statedImage.getImageCatalogUrl(), statedImage.getImageCatalogName(), catalogBasedImage.getUuid(),
-                catalogBasedImage.getPackageVersions());
-        Component imageComponent = new Component(ComponentType.IMAGE, ComponentType.IMAGE.name(), new Json(image), stack);
-        components.add(imageComponent);
+        if (requestedComponents.contains(IMAGE)) {
+            String imageName = determineImageName(stack.cloudPlatform(), stack.getRegion(), statedImage.getImage());
+            addImage(stack, userData, statedImage, imageName, catalogBasedImage, components);
+        }
+        if (requestedComponents.contains(CDH_PRODUCT_DETAILS)) {
+            addStackRepo(stack, components, catalogBasedImage);
+            addPrewarmParcels(stack, statedImage, components);
+        }
+        if (requestedComponents.contains(CM_REPO_DETAILS)) {
+            addCmRepo(stack, components, catalogBasedImage);
+        }
+        return components;
+    }
+
+    private void addPrewarmParcels(Stack stack, StatedImage statedImage, Set<Component> components) {
+        Set<ClouderaManagerProduct> prewarmParcels = clouderaManagerProductTransformer.transform(statedImage.getImage(), false, true);
+        components.addAll(componentConverter.fromClouderaManagerProductList(prewarmParcels, stack));
+    }
+
+    private void addStackRepo(Stack stack, Set<Component> components, com.sequenceiq.cloudbreak.cloud.model.catalog.Image catalogBasedImage)
+            throws CloudbreakImageCatalogException {
         if (catalogBasedImage.getStackDetails() != null) {
             StackDetails stackDetails = catalogBasedImage.getStackDetails();
             StackType stackType = determineStackType(stackDetails);
             Component stackRepoComponent = getStackComponent(stack, stackDetails, stackType, catalogBasedImage.getOsType());
             components.add(stackRepoComponent);
-            components.add(getClusterManagerComponent(stack, catalogBasedImage, stackType));
         }
-        catalogBasedImage.getPreWarmParcels().forEach(parcel -> {
-            Optional<ClouderaManagerProduct> product = preWarmParcelParser.parseProductFromParcel(parcel, catalogBasedImage.getPreWarmCsd());
-            product.ifPresent(p -> components.add(new Component(CDH_PRODUCT_DETAILS, p.getName(), new Json(p), stack)));
-        });
-        return components;
+    }
+
+    private void addCmRepo(Stack stack, Set<Component> components, com.sequenceiq.cloudbreak.cloud.model.catalog.Image catalogBasedImage)
+            throws CloudbreakImageCatalogException {
+        if (catalogBasedImage.getStackDetails() != null) {
+            StackDetails stackDetails = catalogBasedImage.getStackDetails();
+            StackType stackType = determineStackType(stackDetails);
+            ClouderaManagerRepo clouderaManagerRepo = getClouderaManagerRepo(catalogBasedImage, stackType);
+            components.add(new Component(CM_REPO_DETAILS, CM_REPO_DETAILS.name(), new Json(clouderaManagerRepo), stack));
+        } else {
+            LOGGER.debug("There are no stackDetails for stack {}, cannot determine CM repo version.", stack.getName());
+        }
+    }
+
+    private void addImage(Stack stack, Map<InstanceGroupType, String> userData, StatedImage statedImage, String imageName,
+            com.sequenceiq.cloudbreak.cloud.model.catalog.Image catalogBasedImage, Set<Component> components) {
+        Image image = new Image(imageName, userData, catalogBasedImage.getOs(), catalogBasedImage.getOsType(),
+                statedImage.getImageCatalogUrl(), statedImage.getImageCatalogName(), catalogBasedImage.getUuid(),
+                catalogBasedImage.getPackageVersions());
+        components.add(new Component(IMAGE, IMAGE.name(), new Json(image), stack));
     }
 
     private Component getStackComponent(Stack stack, StackDetails stackDetails, StackType stackType, String osType) {
@@ -252,7 +289,14 @@ public class ImageService {
         }
     }
 
-    private Component getClusterManagerComponent(Stack stack, com.sequenceiq.cloudbreak.cloud.model.catalog.Image imgFromCatalog, StackType stackType)
+    public Optional<ClouderaManagerRepo> getClouderaManagerRepo(com.sequenceiq.cloudbreak.cloud.model.catalog.Image imgFromCatalog)
+            throws CloudbreakImageCatalogException {
+        return imgFromCatalog.getStackDetails() != null
+                ? Optional.of(getClouderaManagerRepo(imgFromCatalog, determineStackType(imgFromCatalog.getStackDetails())))
+                : Optional.empty();
+    }
+
+    private ClouderaManagerRepo getClouderaManagerRepo(com.sequenceiq.cloudbreak.cloud.model.catalog.Image imgFromCatalog, StackType stackType)
             throws CloudbreakImageCatalogException {
         if (imgFromCatalog.getRepo() != null) {
             if (StackType.CDH.equals(stackType)) {
@@ -261,7 +305,7 @@ public class ImageService {
                     throw new CloudbreakImageCatalogException(
                             String.format("Cloudera Manager repo was not found in image for os: '%s'.", imgFromCatalog.getOsType()));
                 }
-                return new Component(ComponentType.CM_REPO_DETAILS, ComponentType.CM_REPO_DETAILS.name(), new Json(clouderaManagerRepo), stack);
+                return clouderaManagerRepo;
             } else {
                 throw new CloudbreakImageCatalogException(String.format("Invalid Ambari repo present in image catalog: '%s'.", imgFromCatalog.getRepo()));
             }
@@ -302,7 +346,7 @@ public class ImageService {
     public void decorateImageWithUserDataForStack(Stack stack, Map<InstanceGroupType, String> userData) throws CloudbreakImageNotFoundException {
         Image image = componentConfigProviderService.getImage(stack.getId());
         image.setUserdata(userData);
-        Component imageComponent = new Component(ComponentType.IMAGE, ComponentType.IMAGE.name(), new Json(image), stack);
+        Component imageComponent = new Component(IMAGE, IMAGE.name(), new Json(image), stack);
         componentConfigProviderService.replaceImageComponentWithNew(imageComponent);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ClouderaManagerProductTransformer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ClouderaManagerProductTransformer.java
@@ -21,10 +21,14 @@ public class ClouderaManagerProductTransformer {
     @Inject
     private PreWarmParcelParser preWarmParcelParser;
 
-    public Set<ClouderaManagerProduct> transform(Image image) {
+    public Set<ClouderaManagerProduct> transform(Image image, boolean getCdhParcel, boolean getPrewarmParcels) {
         Set<ClouderaManagerProduct> products = new HashSet<>();
-        products.add(getCdhParcel(image));
-        products.addAll(getPreWarmParcels(image));
+        if (getCdhParcel) {
+            products.add(getCdhParcel(image));
+        }
+        if (getPrewarmParcels) {
+            products.addAll(getPreWarmParcels(image));
+        }
         return products;
     }
 
@@ -44,4 +48,5 @@ public class ClouderaManagerProductTransformer {
                 .withName(stackInfo.get(StackRepoDetails.REPO_ID_TAG).split("-")[0])
                 .withParcel(stackInfo.get(image.getOsType()));
     }
+
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/parcel/ParcelService.java
@@ -80,7 +80,8 @@ public class ParcelService {
             return getDataLakeClusterComponents(components);
         } else {
             Map<String, ClusterComponent> cmProductMap = collectClusterComponentsByName(components);
-            Set<ClouderaManagerProduct> cmProducts = clouderaManagerProductTransformer.transform(image);
+            Set<ClouderaManagerProduct> cmProducts = clouderaManagerProductTransformer
+                    .transform(image, true, true);
             cmProducts = filterParcelsByBlueprint(cmProducts, stack.getCluster().getBlueprint(), false);
             LOGGER.debug("The following parcels are used in CM based on blueprint: {}", cmProducts);
             return getComponentsByRequiredProducts(cmProductMap, cmProducts);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterComponentUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterComponentUpdater.java
@@ -26,11 +26,13 @@ public class ClusterComponentUpdater {
     @Inject
     private ClusterComponentConfigProvider clusterComponentConfigProvider;
 
-    public void updateClusterComponentsByStackId(Stack stack, Set<Component> targetComponents) {
+    public void updateClusterComponentsByStackId(Stack stack, Set<Component> targetComponents, boolean removeUnused) {
         Set<ClusterComponent> clusterComponentsFromDb = clusterComponentConfigProvider.getComponentsByClusterId(stack.getCluster().getId());
         targetComponents.forEach(targetComponent -> updateComponentFromDbAttributeField(clusterComponentsFromDb, targetComponent));
         clusterComponentConfigProvider.store(clusterComponentsFromDb);
-        removeUnusedComponents(targetComponents, clusterComponentsFromDb);
+        if (removeUnused) {
+            removeUnusedComponents(targetComponents, clusterComponentsFromDb);
+        }
         LOGGER.info("Updated cluster components:" + clusterComponentsFromDb);
     }
 
@@ -77,6 +79,7 @@ public class ClusterComponentUpdater {
                 .filter(component -> ComponentType.CDH_PRODUCT_DETAILS.equals(component.getComponentType()))
                 .filter(filterDiffBetweenComponentsFromImageAndDatabase(targetComponents))
                 .collect(Collectors.toSet());
+        LOGGER.debug("Removing unused components: {}", unusedCdhProductDetails);
         clusterComponentConfigProvider.deleteClusterComponents(unusedCdhProductDetails);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageComponentUpdaterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageComponentUpdaterService.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.cloudbreak.service.upgrade;
 
 import static com.sequenceiq.cloudbreak.common.exception.NotFoundException.notFoundException;
+import static com.sequenceiq.cloudbreak.common.type.ComponentType.CDH_PRODUCT_DETAILS;
+import static com.sequenceiq.cloudbreak.common.type.ComponentType.CM_REPO_DETAILS;
 
+import java.util.EnumSet;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -14,6 +17,7 @@ import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Component;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.image.ImageService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
 
@@ -35,6 +39,9 @@ public class ImageComponentUpdaterService {
     private UpgradeImageInfoFactory upgradeImageInfoFactory;
 
     @Inject
+    private ImageService imageService;
+
+    @Inject
     private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
 
     public UpgradeImageInfo updateForUpgrade(String imageId, Long stackId) {
@@ -44,9 +51,12 @@ public class ImageComponentUpdaterService {
                 restRequestThreadLocalService.setRequestedWorkspaceId(stack.getWorkspace().getId());
             }
             UpgradeImageInfo upgradeImageInfo = upgradeImageInfoFactory.create(imageId, stackId);
-            Set<Component> targetComponents = stackComponentUpdater.updateComponentsByStackId(
-                    stack, upgradeImageInfo.getTargetStatedImage(), upgradeImageInfo.getCurrentImage().getUserdata());
-            clusterComponentUpdater.updateClusterComponentsByStackId(stack, targetComponents);
+            Set<Component> targetComponents = imageService.getComponents(
+                    stack, upgradeImageInfo.getCurrentImage().getUserdata(), upgradeImageInfo.getTargetStatedImage(),
+                    EnumSet.of(CDH_PRODUCT_DETAILS, CM_REPO_DETAILS)
+            );
+            stackComponentUpdater.updateComponentsByStackId(stack, targetComponents, true);
+            clusterComponentUpdater.updateClusterComponentsByStackId(stack, targetComponents, true);
             return upgradeImageInfo;
         } catch (CloudbreakImageNotFoundException | CloudbreakImageCatalogException e) {
             LOGGER.warn(String.format("Image was not found for stack %s", stack.getName()), e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/StackComponentUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/StackComponentUpdater.java
@@ -1,7 +1,8 @@
 package com.sequenceiq.cloudbreak.service.upgrade;
 
+import static com.sequenceiq.cloudbreak.common.type.ComponentType.CDH_PRODUCT_DETAILS;
+
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -13,15 +14,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.common.type.ComponentType;
-import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
-import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Component;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
-import com.sequenceiq.cloudbreak.service.image.ImageService;
-import com.sequenceiq.cloudbreak.service.image.StatedImage;
-import com.sequenceiq.common.api.type.InstanceGroupType;
 
 @Service
 public class StackComponentUpdater {
@@ -29,20 +24,16 @@ public class StackComponentUpdater {
     private static final Logger LOGGER = LoggerFactory.getLogger(StackComponentUpdater.class);
 
     @Inject
-    private ImageService imageService;
-
-    @Inject
     private ComponentConfigProviderService componentConfigProviderService;
 
-    public Set<Component> updateComponentsByStackId(Stack stack, StatedImage targetImage, Map<InstanceGroupType, String> userData)
-            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
-        String imageName = imageService.determineImageName(stack.cloudPlatform(), stack.getRegion(), targetImage.getImage());
+    public Set<Component> updateComponentsByStackId(Stack stack, Set<Component> targetComponents, boolean removeUnused) {
         Set<Component> componentsFromDb = componentConfigProviderService.getComponentsByStackId(stack.getId());
-        Set<Component> targetComponents = imageService.getComponents(stack, userData, targetImage, imageName);
         componentsFromDb.forEach(component -> setComponentIdIfAlreadyExists(targetComponents, component));
         componentConfigProviderService.store(targetComponents);
-        LOGGER.info("Updated components:" + targetComponents);
-        removeUnusedComponents(componentsFromDb, targetComponents);
+        LOGGER.info("Updated components: {}", targetComponents);
+        if (removeUnused) {
+            removeUnusedCdhComponents(componentsFromDb, targetComponents);
+        }
         return targetComponents;
     }
 
@@ -74,11 +65,12 @@ public class StackComponentUpdater {
         return targetComponent.getComponentType() == component.getComponentType();
     }
 
-    private void removeUnusedComponents(Set<Component> componentsFromDb, Set<Component> targetComponents) {
+    private void removeUnusedCdhComponents(Set<Component> componentsFromDb, Set<Component> targetComponents) {
         Set<Component> unusedCdhProductDetails = componentsFromDb.stream()
-                .filter(component -> ComponentType.CDH_PRODUCT_DETAILS.equals(component.getComponentType()))
+                .filter(component -> CDH_PRODUCT_DETAILS.equals(component.getComponentType()))
                 .filter(filterDiffBetweenComponentsFromImageAndDatabase(targetComponents))
                 .collect(Collectors.toSet());
+        LOGGER.debug("Removing unused Cdh components: {}", unusedCdhProductDetails);
         componentConfigProviderService.deleteComponents(unusedCdhProductDetails);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmInstalledComponentFinderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmInstalledComponentFinderService.java
@@ -1,0 +1,46 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.domain.stack.Component;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.image.ComponentConverter;
+
+@Service
+public class CmInstalledComponentFinderService {
+
+    @Inject
+    private ImageReaderService imageReaderService;
+
+    @Inject
+    private CmProductChooserService cmProductChooserService;
+
+    @Inject
+    private ComponentConverter componentConverter;
+
+    @Inject
+    private CmServerQueryService cmServerQueryService;
+
+    Set<Component> findParcelComponents(Stack stack, Set<Image> candidateImages) {
+        Set<ClouderaManagerProduct> candidateProducts = imageReaderService.getParcels(candidateImages, stack.isDatalake());
+        Set<ParcelInfo> installedParcels = cmServerQueryService.queryActiveParcels(stack);
+        Set<ClouderaManagerProduct> installedProducts = cmProductChooserService.chooseParcelProduct(installedParcels, candidateProducts);
+        return componentConverter.fromClouderaManagerProductList(installedProducts, stack);
+    }
+
+    Optional<Component> findCmRepoComponent(Stack stack, Set<Image> candidateImages) {
+        Set<ClouderaManagerRepo> candidateCmRepos = imageReaderService.getCmRepos(candidateImages);
+        String cmVersion = cmServerQueryService.queryCmVersion(stack);
+        return cmProductChooserService.chooseCmRepo(cmVersion, candidateCmRepos)
+                .map(cmRepo -> componentConverter.fromClouderaManagerRepo(cmRepo, stack));
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmProductChooserService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmProductChooserService.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+
+@Service
+public class CmProductChooserService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CmProductChooserService.class);
+
+    /**
+     * Using the CM parcel versions, will look for a matching product among the provided candidateProducts
+     * A product is matching if the name and version both match.
+     * @param installedParcels parcels installed on the CM server
+     * @param candidateProducts A list of ClouderaManagerProducts extracted from image catalog
+     * @return List of ClouderaManagerProducts installed on the DL / DH
+     */
+    Set<ClouderaManagerProduct> chooseParcelProduct(Set<ParcelInfo> installedParcels, Set<ClouderaManagerProduct> candidateProducts) {
+        Set<ClouderaManagerProduct> foundProducts = installedParcels.stream()
+                .map(ip -> findMatchingClouderaManagerProduct(candidateProducts, ip))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+        LOGGER.debug("ClouderaManagerProducts found based on active parcels installed on the server: {}", foundProducts);
+        return foundProducts;
+    }
+
+    /**
+     * Using the installedCMVersion, will look for a matching clouderaManagerRepo.
+     * @param installedCmVersion The version of the CM used for lookup
+     * @param candidateCmVersions The candidate cloudera manager repos
+     * @return The found clouderaManagerRepo as an Optional, or empty
+     */
+    Optional<ClouderaManagerRepo> chooseCmRepo(String installedCmVersion, Set<ClouderaManagerRepo> candidateCmVersions) {
+        Optional<ClouderaManagerRepo> foundClouderaManagerRepo = candidateCmVersions.stream()
+                .filter(candidateCmVersion -> installedCmVersion.equals(candidateCmVersion.getVersion()))
+                .findFirst();
+        LOGGER.debug("ClouderaManagerRepo found based on the CM server version: {}", foundClouderaManagerRepo);
+        return foundClouderaManagerRepo;
+    }
+
+    private Optional<ClouderaManagerProduct> findMatchingClouderaManagerProduct(Set<ClouderaManagerProduct> candidateProducts, ParcelInfo ip) {
+        List<ClouderaManagerProduct> matchingProducts = candidateProducts.stream()
+                .filter(cp -> ip.getName().equals(cp.getName()))
+                .filter(cp -> ip.getVersion().equals(cp.getVersion()))
+                .collect(Collectors.toList());
+        return matchingProducts.stream().findFirst();
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmServerQueryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmServerQueryService.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+
+@Service
+public class CmServerQueryService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CmServerQueryService.class);
+
+    @Inject
+    private ClusterApiConnectors apiConnectors;
+
+    /**
+     * Will query all active parcels (CDH and non-CDH as well) from the CM server. Received format:
+     * CDH -> 7.2.7-1.cdh7.2.7.p7.12569826
+     * <p>
+     * TODO: the call is blocking for some time. Check if it is possible to block for shorter period of time.
+     *
+     * @param stack The stack, to get the coordinates of the CM to query
+     * @return List of parcels found in the CM
+     */
+    Set<ParcelInfo> queryActiveParcels(Stack stack) {
+        Map<String, String> installedParcels = apiConnectors.getConnector(stack).gatherInstalledParcels(stack.getName());
+        LOGGER.debug("Reading parcel info from CM server, found parcels: " + installedParcels);
+        return installedParcels.entrySet().stream()
+                .map(es -> new ParcelInfo(es.getKey(), es.getValue()))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Will query the CM server for the CM version
+     * @param stack The stack, to get the coordinates of the CM to query
+     * @return The actual CM version
+     */
+    String queryCmVersion(Stack stack) {
+        String cmVersion = apiConnectors.getConnector(stack).clusterStatusService().getClusterManagerVersion();
+        LOGGER.debug("Reading CM version info from CM server, found version: {}", cmVersion);
+        return cmVersion;
+    }
+
+    boolean isCmServerRunning(Stack stack) {
+        return apiConnectors.getConnector(stack).clusterStatusService().isClusterManagerRunning();
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmSyncerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmSyncerService.java
@@ -1,0 +1,74 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.domain.stack.Component;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.upgrade.ClusterComponentUpdater;
+import com.sequenceiq.cloudbreak.service.upgrade.StackComponentUpdater;
+
+@Service
+public class CmSyncerService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CmSyncerService.class);
+
+    @Inject
+    private StackComponentUpdater stackComponentUpdater;
+
+    @Inject
+    private ClusterComponentUpdater clusterComponentUpdater;
+
+    @Inject
+    private CmInstalledComponentFinderService cmInstalledComponentFinderService;
+
+    @Inject
+    private CmServerQueryService cmServerQueryService;
+
+    /**
+     * Will retrieve (if CM server is reachable):
+     * - all the active parcels, CDH and prewarm parcels as well
+     * - CM version
+     * from the CM server and will try to find matching products in stated images.
+     * The found products will then be used to update the Component and ClusterComponent table in DB
+     *
+     * @param stack           The stack that needs to be synced
+     * @param candidateImages Set of candidate images whose products are used to match against the parcel version received from CM server.
+     */
+    public void syncFromCmToDb(Stack stack, Set<Image> candidateImages) {
+        if (!cmServerQueryService.isCmServerRunning(stack)) {
+            LOGGER.info("CM server is down, it is not possible to sync parcels and CM version to DB.");
+            return;
+        }
+        if (candidateImages.isEmpty()) {
+            LOGGER.info("No candidate images supplied, skipping syncing CM parcels and CM version to DB.");
+            return;
+        }
+        syncInternal(stack, candidateImages);
+    }
+
+    private void syncInternal(Stack stack, Set<Image> candidateImages) {
+        Optional<Component> cmRepoComponents = cmInstalledComponentFinderService.findCmRepoComponent(stack, candidateImages);
+        Set<Component> parcelComponents = cmInstalledComponentFinderService.findParcelComponents(stack, candidateImages);
+        Set<Component> syncedFromServer = mergeFoundComponents(cmRepoComponents, parcelComponents);
+        LOGGER.debug("Active components read from CM server and persisting now to the DB: {}", syncedFromServer);
+        stackComponentUpdater.updateComponentsByStackId(stack, syncedFromServer, false);
+        clusterComponentUpdater.updateClusterComponentsByStackId(stack, syncedFromServer, false);
+    }
+
+    private Set<Component> mergeFoundComponents(Optional<Component> cmRepoComponents, Set<Component> parcelComponents) {
+        Set<Component> syncedFromServer = new HashSet<>();
+        cmRepoComponents.ifPresent(syncedFromServer::add);
+        syncedFromServer.addAll(parcelComponents);
+        return syncedFromServer;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/ImageReaderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/ImageReaderService.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.service.image.ImageService;
+import com.sequenceiq.cloudbreak.service.parcel.ClouderaManagerProductTransformer;
+
+@Service
+public class ImageReaderService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageReaderService.class);
+
+    @Inject
+    private ClouderaManagerProductTransformer clouderaManagerProductTransformer;
+
+    @Inject
+    private ImageService imageService;
+
+    /**
+     * Will extract the parcel info from the supplied images. If the stack is a datalake, then only the CDH parcel is extracted.
+     * @param statedImages images to get parcels from
+     * @param datalake true if the stack is a datalake
+     * @return a set of ClouderaManagerProducts present on the image
+     */
+    public Set<ClouderaManagerProduct> getParcels(Set<Image> statedImages, boolean datalake) {
+        Set<ClouderaManagerProduct> foundParcelProducts = statedImages.stream()
+                .map(im -> clouderaManagerProductTransformer.transform(im, true, !datalake))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+        LOGGER.debug("Found following candidate parcels: {}", foundParcelProducts);
+        return foundParcelProducts;
+    }
+
+    /**
+     * Will extract the CM repos from the supplied images
+     * @param images images to get CM repos
+     * @return a set of found CM repos
+     */
+    Set<ClouderaManagerRepo> getCmRepos(Set<Image> images) {
+        Set<ClouderaManagerRepo> foundClouderaManagerRepos = images.stream()
+                .map(this::getCmComponent)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
+        LOGGER.debug("Found following CM repos in images: {}", foundClouderaManagerRepos);
+        return foundClouderaManagerRepos;
+    }
+
+    private Optional<ClouderaManagerRepo> getCmComponent(Image image) {
+        try {
+            return imageService.getClouderaManagerRepo(image);
+        } catch (CloudbreakImageCatalogException e) {
+            LOGGER.info("Failed to get CM component from stated image {}", image);
+            return Optional.empty();
+        }
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/ParcelInfo.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/ParcelInfo.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+/**
+ * Parcel info received from the CM server is presented in this class
+ */
+class ParcelInfo {
+
+    private final String name;
+
+    private final String version;
+
+    ParcelInfo(String name, String version) {
+        this.name = name;
+        this.version = version;
+    }
+
+    String getName() {
+        return name;
+    }
+
+    String getVersion() {
+        return version;
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -724,6 +724,8 @@ cb:
     supportedPlatforms: AWS,YARN,AZURE
 
   upgrade:
+    failure.sync:
+      sdx.enabled: false
     validation:
       distrox:
         enabled: false

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/StackComponentUpdaterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/StackComponentUpdaterTest.java
@@ -2,10 +2,6 @@ package com.sequenceiq.cloudbreak.service.upgrade;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -79,10 +75,9 @@ class StackComponentUpdaterTest {
         Component originalImageComponent = new Component(ComponentType.IMAGE, ComponentType.IMAGE.name(), new Json(originalImage), stack);
 
         when(componentConfigProviderService.getComponentsByStackId(stack.getId())).thenReturn(Set.of(originalImageComponent));
-        when(imageService.determineImageName(anyString(), anyString(), any(Image.class))).thenReturn("imageName");
-        when(imageService.getComponents(eq(stack), anyMap(), any(StatedImage.class), anyString())).thenReturn(createComponents(stack, targetImage));
+        Set<Component> targetComponents = createComponents(stack, targetImage);
 
-        underTest.updateComponentsByStackId(stack, targetImage, Map.of(InstanceGroupType.GATEWAY, "gw user data"));
+        underTest.updateComponentsByStackId(stack, targetComponents, true);
 
         ArgumentCaptor<Set<Component>> componentCatcher = ArgumentCaptor.forClass(Set.class);
         verify(componentConfigProviderService, times(1)).store(componentCatcher.capture());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmInstalledComponentFinderServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmInstalledComponentFinderServiceTest.java
@@ -1,0 +1,99 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.type.ComponentType;
+import com.sequenceiq.cloudbreak.domain.stack.Component;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.image.ComponentConverter;
+
+@ExtendWith(MockitoExtension.class)
+public class CmInstalledComponentFinderServiceTest {
+
+    public static final String CM_VERSION = "cmVersion";
+
+    @Mock
+    private CmProductChooserService cmProductChooserService;
+
+    @Mock
+    private ComponentConverter componentConverter;
+
+    @Mock
+    private CmServerQueryService cmInfoRetriever;
+
+    @Mock
+    private ImageReaderService imageReaderService;
+
+    @InjectMocks
+    private CmInstalledComponentFinderService underTest;
+
+    @Mock
+    private Stack stack;
+
+    @Test
+    void testFindCmRepoComponent() {
+        Set<Image> candidateImages = Set.of(mock(Image.class));
+        Set<ClouderaManagerRepo> candidateCmRepos = Set.of();
+        ClouderaManagerRepo chosenClouderaManagerRepo = new ClouderaManagerRepo().withVersion(CM_VERSION);
+        Component cmRepoComponent = new Component(ComponentType.CM_REPO_DETAILS, "cmRepoDetails", new Json("{}"), stack);
+        when(imageReaderService.getCmRepos(eq(candidateImages))).thenReturn(candidateCmRepos);
+        when(cmInfoRetriever.queryCmVersion(eq(stack))).thenReturn(CM_VERSION);
+        when(cmProductChooserService.chooseCmRepo(eq(CM_VERSION), eq(candidateCmRepos))).thenReturn(Optional.of(chosenClouderaManagerRepo));
+        when(componentConverter.fromClouderaManagerRepo(chosenClouderaManagerRepo, stack)).thenReturn(cmRepoComponent);
+
+        Optional<Component> foundComponentOptional = underTest.findCmRepoComponent(stack, candidateImages);
+
+        assertTrue(foundComponentOptional.isPresent());
+        assertThat(foundComponentOptional.get(), hasProperty("componentType", is(ComponentType.CM_REPO_DETAILS)));
+        verify(imageReaderService).getCmRepos(eq(candidateImages));
+        verify(cmInfoRetriever).queryCmVersion(eq(stack));
+        verify(cmProductChooserService).chooseCmRepo(eq(CM_VERSION), eq(candidateCmRepos));
+        verify(componentConverter).fromClouderaManagerRepo(eq(chosenClouderaManagerRepo), eq(stack));
+    }
+
+    @Test
+    void testFindParcelComponents() {
+        Set<Image> candidateImages = Set.of(mock(Image.class));
+        Set<ClouderaManagerProduct> candidateCmProduct = Set.of();
+        Set<ParcelInfo> queriedParcelInfo = Set.of();
+        Set<ClouderaManagerProduct> chosenClouderaManagerProducts = Set.of();
+        Set<Component> chosenComponents = Set.of(new Component(ComponentType.CDH_PRODUCT_DETAILS, "cdhProductDetails", new Json("{}"), stack));
+        when(imageReaderService.getParcels(eq(candidateImages), anyBoolean())).thenReturn(candidateCmProduct);
+        when(cmInfoRetriever.queryActiveParcels(eq(stack))).thenReturn(queriedParcelInfo);
+        when(cmProductChooserService.chooseParcelProduct(queriedParcelInfo, candidateCmProduct)).thenReturn(chosenClouderaManagerProducts);
+        when(componentConverter.fromClouderaManagerProductList(chosenClouderaManagerProducts, stack)).thenReturn(chosenComponents);
+
+        Set<Component> resultSet = underTest.findParcelComponents(stack, candidateImages);
+
+        assertThat(resultSet, hasSize(1));
+        assertThat(resultSet, contains(hasProperty("componentType", is(ComponentType.CDH_PRODUCT_DETAILS))));
+        verify(imageReaderService).getParcels(eq(candidateImages), anyBoolean());
+        verify(cmInfoRetriever).queryActiveParcels(eq(stack));
+        verify(cmProductChooserService).chooseParcelProduct(eq(queriedParcelInfo), eq(candidateCmProduct));
+        verify(componentConverter).fromClouderaManagerProductList(eq(chosenClouderaManagerProducts), eq(stack));
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmProductChooserServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmProductChooserServiceTest.java
@@ -1,0 +1,131 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+
+@ExtendWith(MockitoExtension.class)
+public class CmProductChooserServiceTest {
+    private static final String PARCEL_VERSION_1 = "Version1";
+
+    private static final String PARCEL_VERSION_2 = "Version2";
+
+    private static final String PARCEL_NAME_1 = "ParcelName1";
+
+    private static final String PARCEL_NAME_2 = "ParcelName2";
+
+    private final CmProductChooserService underTest = new CmProductChooserService();
+
+    @Test
+    void testChooseParcelProductWhenMatchingNameAndVersionThenReturns() {
+        Set<ParcelInfo> installedParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_1));
+        Set<ClouderaManagerProduct> candidateProducts = Set.of(new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1));
+
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(installedParcels, candidateProducts);
+
+        assertThat(foundProducts, hasSize(1));
+        ClouderaManagerProduct foundProduct = foundProducts.iterator().next();
+        assertEquals(PARCEL_NAME_1, foundProduct.getName());
+        assertEquals(PARCEL_VERSION_1, foundProduct.getVersion());
+    }
+
+    @Test
+    void testChooseParcelProductWhenMultipleMatchingNameAndVersionThenReturnsAllMatches() {
+        Set<ParcelInfo> installedParcels = Set.of(
+                new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_1),
+                new ParcelInfo(PARCEL_NAME_2, PARCEL_VERSION_2)
+        );
+        Set<ClouderaManagerProduct> candidateProducts = Set.of(
+                new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1),
+                new ClouderaManagerProduct().withName(PARCEL_NAME_2).withVersion(PARCEL_VERSION_2)
+        );
+
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(installedParcels, candidateProducts);
+
+        assertThat(foundProducts, hasSize(2));
+        List<ClouderaManagerProduct> foundProductList = new ArrayList<>(foundProducts);
+        foundProductList.sort(Comparator.comparing(ClouderaManagerProduct::getName));
+        assertEquals(PARCEL_NAME_1, foundProductList.get(0).getName());
+        assertEquals(PARCEL_VERSION_1, foundProductList.get(0).getVersion());
+        assertEquals(PARCEL_NAME_2, foundProductList.get(1).getName());
+        assertEquals(PARCEL_VERSION_2, foundProductList.get(1).getVersion());
+    }
+
+    @Test
+    void testChooseParcelProductWhenMultipleMatchingNameAndVersionThenReturnsOne() {
+        Set<ParcelInfo> installedParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_1));
+        Set<ClouderaManagerProduct> candidateProducts = Set.of(
+                new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1),
+                new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1)
+        );
+
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(installedParcels, candidateProducts);
+
+        assertThat(foundProducts, hasSize(1));
+        ClouderaManagerProduct foundProduct = foundProducts.iterator().next();
+        assertEquals(PARCEL_NAME_1, foundProduct.getName());
+        assertEquals(PARCEL_VERSION_1, foundProduct.getVersion());
+    }
+
+    @Test
+    void testChooseParcelProductWhenMatchingNameButDifferentVersionThenEmptyResult() {
+        Set<ParcelInfo> installedParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_2));
+        Set<ClouderaManagerProduct> candidateProducts = Set.of(new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1));
+
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(installedParcels, candidateProducts);
+
+        assertThat(foundProducts, hasSize(0));
+    }
+
+    @Test
+    void testChooseParcelProductWhenDifferentNameButSameVersionThenEmptyResult() {
+        Set<ParcelInfo> installedParcels = Set.of(new ParcelInfo(PARCEL_NAME_2, PARCEL_VERSION_1));
+        Set<ClouderaManagerProduct> candidateProducts = Set.of(new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1));
+
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(installedParcels, candidateProducts);
+
+        assertThat(foundProducts, hasSize(0));
+    }
+
+    @Test
+    void testChooseCmRepoWhenRepoWithMatchingVersionPresentThenRepoChosen() {
+        String installedCmVersion = "cmVersion1";
+        Set<ClouderaManagerRepo> candidateCmRepos = Set.of(
+                new ClouderaManagerRepo().withVersion("cmVersion1"),
+                new ClouderaManagerRepo().withVersion("cmVersion2")
+        );
+
+        Optional<ClouderaManagerRepo> foundCmRepo = underTest.chooseCmRepo(installedCmVersion, candidateCmRepos);
+
+        assertTrue(foundCmRepo.isPresent());
+        assertEquals("cmVersion1", foundCmRepo.get().getVersion());
+    }
+
+    @Test
+    void testChooseCmRepoWhenRepoWithMatchingVersionMissingThenNoRepoChosen() {
+        String installedCmVersion = "cmVersion9";
+        Set<ClouderaManagerRepo> candidateCmRepos = Set.of(
+                new ClouderaManagerRepo().withVersion("cmVersion1"),
+                new ClouderaManagerRepo().withVersion("cmVersion2")
+        );
+
+        Optional<ClouderaManagerRepo> foundCmRepo = underTest.chooseCmRepo(installedCmVersion, candidateCmRepos);
+
+        assertTrue(foundCmRepo.isEmpty());
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmServerQueryServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmServerQueryServiceTest.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+
+@ExtendWith(MockitoExtension.class)
+public class CmServerQueryServiceTest {
+
+    private static final String STACK_NAME = "stackName";
+
+    @Mock
+    private ClusterApiConnectors apiConnectors;
+
+    @InjectMocks
+    private CmServerQueryService underTest;
+
+    @Mock
+    private ClusterApi clusterApi;
+
+    @Mock
+    private Stack stack;
+
+    @BeforeEach
+    void setup() {
+        when(stack.getName()).thenReturn(STACK_NAME);
+        when(apiConnectors.getConnector(any(Stack.class))).thenReturn(clusterApi);
+    }
+
+    @Test
+    void testGetActiveParcelsWhenParcelReturnedThenParsedIntoParcelInfo() {
+        Map<String, String> parcelNameToVersionMap = Map.of("CDH", "7.2.7-1.cdh7.2.7.p7.12569826");
+        when(clusterApi.gatherInstalledParcels(STACK_NAME)).thenReturn(parcelNameToVersionMap);
+
+        Set<ParcelInfo> foundParcels = underTest.queryActiveParcels(stack);
+
+        assertThat(foundParcels, hasSize(1));
+        ParcelInfo activeParcel = foundParcels.iterator().next();
+        assertEquals("CDH", activeParcel.getName());
+        assertEquals("7.2.7-1.cdh7.2.7.p7.12569826", activeParcel.getVersion());
+    }
+
+    @Test
+    void testGetActiveParcelsWhenNoParcelReturnedThenEmptyList() {
+        Map<String, String> parcelNameToVersionMap = Map.of();
+        when(clusterApi.gatherInstalledParcels(STACK_NAME)).thenReturn(parcelNameToVersionMap);
+
+        Set<ParcelInfo> foundParcels = underTest.queryActiveParcels(stack);
+
+        assertThat(foundParcels, hasSize(0));
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmSyncerServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmSyncerServiceTest.java
@@ -1,0 +1,118 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.type.ComponentType;
+import com.sequenceiq.cloudbreak.domain.stack.Component;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.upgrade.ClusterComponentUpdater;
+import com.sequenceiq.cloudbreak.service.upgrade.StackComponentUpdater;
+
+@ExtendWith(MockitoExtension.class)
+public class CmSyncerServiceTest {
+
+    @Mock
+    private StackComponentUpdater stackComponentUpdater;
+
+    @Mock
+    private ClusterComponentUpdater clusterComponentUpdater;
+
+    @Mock
+    private CmInstalledComponentFinderService cmInstalledComponentFinderService;
+
+    @Mock
+    private CmServerQueryService cmServerQueryService;
+
+    @InjectMocks
+    private CmSyncerService underTest;
+
+    @Mock
+    private Stack stack;
+
+    private final Component cdhComponent = new Component(ComponentType.CDH_PRODUCT_DETAILS, "CDH", new Json("{}"), new Stack());
+
+    private final Component cmRepoComponent = new Component(ComponentType.CM_REPO_DETAILS, "CmRepoDetails", new Json("{}"), new Stack());
+
+    @Test
+    void testSyncFromCmToDbWhenCmServerRunningThenSyncIsExecuted() {
+        when(cmServerQueryService.isCmServerRunning(stack)).thenReturn(true);
+        Set<Image> candidateImages = Set.of(mock(Image.class));
+        when(cmInstalledComponentFinderService.findParcelComponents(stack, candidateImages)).thenReturn(Set.of(cdhComponent));
+        when(cmInstalledComponentFinderService.findCmRepoComponent(stack, candidateImages)).thenReturn(Optional.of(cmRepoComponent));
+
+        underTest.syncFromCmToDb(stack, candidateImages);
+
+        verify(cmInstalledComponentFinderService).findCmRepoComponent(eq(stack), eq(candidateImages));
+        verify(cmInstalledComponentFinderService).findParcelComponents(eq(stack), eq(candidateImages));
+
+        ArgumentCaptor<Set<Component>> componentArgumentCaptor = ArgumentCaptor.forClass(Set.class);
+        verify(stackComponentUpdater).updateComponentsByStackId(eq(stack), componentArgumentCaptor.capture(), anyBoolean());
+        Set<Component> componentsToPersist = componentArgumentCaptor.getValue();
+        assertThat(componentsToPersist, hasSize(2));
+        assertThat(componentsToPersist, containsInAnyOrder(
+                hasProperty("componentType", is(ComponentType.CDH_PRODUCT_DETAILS)),
+                hasProperty("componentType", is(ComponentType.CM_REPO_DETAILS))
+        ));
+
+        ArgumentCaptor<Set<Component>> clusterComponentArgumentCaptor = ArgumentCaptor.forClass(Set.class);
+        verify(clusterComponentUpdater).updateClusterComponentsByStackId(eq(stack), clusterComponentArgumentCaptor.capture(), anyBoolean());
+        Set<Component> clusterComponentsToPersist = clusterComponentArgumentCaptor.getValue();
+        assertThat(clusterComponentsToPersist, hasSize(2));
+        assertThat(componentsToPersist, containsInAnyOrder(
+                hasProperty("componentType", is(ComponentType.CDH_PRODUCT_DETAILS)),
+                hasProperty("componentType", is(ComponentType.CM_REPO_DETAILS))
+        ));
+    }
+
+    @Test
+    void testSyncFromCmToDbWhenCmServerDownThenSyncSkipped() {
+        when(cmServerQueryService.isCmServerRunning(stack)).thenReturn(false);
+        Set<Image> candidateImages = Set.of(mock(Image.class));
+
+        underTest.syncFromCmToDb(stack, candidateImages);
+
+        verify(cmServerQueryService).isCmServerRunning(eq(stack));
+        verify(cmInstalledComponentFinderService, never()).findCmRepoComponent(any(), any());
+        verify(cmInstalledComponentFinderService, never()).findParcelComponents(any(), any());
+        verify(stackComponentUpdater, never()).updateComponentsByStackId(any(), any(), anyBoolean());
+        verify(clusterComponentUpdater, never()).updateClusterComponentsByStackId(any(), any(), anyBoolean());
+    }
+
+    @Test
+    void testSyncFromCmToDbWhenNoCandidateImagesThenSyncSkipped() {
+        when(cmServerQueryService.isCmServerRunning(stack)).thenReturn(true);
+        Set<Image> candidateImages = Set.of();
+
+        underTest.syncFromCmToDb(stack, candidateImages);
+
+        verify(cmServerQueryService).isCmServerRunning(eq(stack));
+        verify(cmInstalledComponentFinderService, never()).findCmRepoComponent(any(), any());
+        verify(cmInstalledComponentFinderService, never()).findParcelComponents(any(), any());
+        verify(stackComponentUpdater, never()).updateComponentsByStackId(any(), any(), anyBoolean());
+        verify(clusterComponentUpdater, never()).updateClusterComponentsByStackId(any(), any(), anyBoolean());
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/ImageReaderServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/ImageReaderServiceTest.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.cloudbreak.service.upgrade.sync;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.service.image.ImageService;
+import com.sequenceiq.cloudbreak.service.parcel.ClouderaManagerProductTransformer;
+
+@ExtendWith(MockitoExtension.class)
+public class ImageReaderServiceTest {
+
+    @Mock
+    private ClouderaManagerProductTransformer clouderaManagerProductTransformer;
+
+    @Mock
+    private ImageService imageService;
+
+    @InjectMocks
+    private ImageReaderService underTest;
+
+    @Test
+    void testGetCandidateParcelsWhenMultipleImagesThenProductTransformerIsCalledEachTime() {
+        Set<Image> candidateImages = Set.of(mock(Image.class), mock(Image.class));
+        when(clouderaManagerProductTransformer.transform(any(), eq(true), eq(false)))
+                .thenReturn(Set.of(new ClouderaManagerProduct()))
+                .thenReturn(Set.of(new ClouderaManagerProduct()));
+
+        Set<ClouderaManagerProduct> candidateProducts = underTest.getParcels(candidateImages, true);
+
+        assertThat(candidateProducts, hasSize(2));
+        verify(clouderaManagerProductTransformer, times(2)).transform(any(Image.class), eq(true), eq(false));
+    }
+
+    @Test
+    void testGetCandidateParcelsWhenNoImagesThenProductTransformerIsNotCalled() {
+        Set<Image> candidateImages = Set.of();
+
+        Set<ClouderaManagerProduct> candidateProducts = underTest.getParcels(candidateImages, true);
+
+        assertThat(candidateProducts, hasSize(0));
+        verify(clouderaManagerProductTransformer, never()).transform(any(Image.class), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    void testGetCandidateCmReposWhenMultipleImagesThenGetCmRepoIsCalledEachTime() throws CloudbreakImageCatalogException {
+        Set<Image> candidateImages = Set.of(mock(Image.class), mock(Image.class));
+        when(imageService.getClouderaManagerRepo(any(Image.class)))
+                .thenReturn(Optional.of(new ClouderaManagerRepo()))
+                .thenReturn(Optional.of(new ClouderaManagerRepo()));
+
+        Set<ClouderaManagerRepo> candidateRepos = underTest.getCmRepos(candidateImages);
+
+        assertThat(candidateRepos, hasSize(2));
+        verify(imageService, times(2)).getClouderaManagerRepo(any(Image.class));
+    }
+
+    @Test
+    void testGetCandidateCmReposWhenNoImagesThenGetCmRepoIsNotCalled() throws CloudbreakImageCatalogException {
+        Set<Image> candidateImages = Set.of();
+
+        Set<ClouderaManagerRepo> candidateRepos = underTest.getCmRepos(candidateImages);
+
+        assertThat(candidateRepos, empty());
+        verify(imageService, never()).getClouderaManagerRepo(any(Image.class));
+    }
+
+}


### PR DESCRIPTION
If a datalake or DH upgrade fails, versions stored in the DB itself and parcel versions on the CM may slip apart. To fix that, there should be a syncer that:
- queries the CM for activated parcels
- persists the current parcel versions, including CDH, to the component AND clusterComponent tables

This syncer is then called in the flow in the failure handler path

See detailed description in the commit message.