### PR TITLE
CB-13131 Fix for AWS CF trimming whitespaces from string parameters a…

### DIFF
--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsStackRequestHelper.java
@@ -173,14 +173,22 @@ public class AwsStackRequestHelper {
         } else {
             int len = parameterValue.length();
             int offset = 0;
-            int limit = CHUNK_SIZE;
+            int limit = CHUNK_SIZE + 1;
             // Add full chunks
             while ((chunk < chunkCount) && (len > limit)) {
-                parameters.add(new Parameter().withParameterKey(parameterKey).withParameterValue(parameterValue.substring(offset, limit)));
+                char c;
+                char c2;
+                do {
+                    c = parameterValue.charAt(--limit);
+                    c2 = parameterValue.charAt(limit - 1);
+                } while ((Character.isWhitespace(c) || Character.isWhitespace(c2)) && (offset <= limit - 2));
+
+                String slice = parameterValue.substring(offset, limit);
+                parameters.add(new Parameter().withParameterKey(parameterKey).withParameterValue(slice));
                 chunk++;
                 parameterKey = baseParameterKey + chunk;
                 offset = limit;
-                limit += CHUNK_SIZE;
+                limit += CHUNK_SIZE + 1;
             }
             // Add the final partial chunk
             parameters.add(new Parameter().withParameterKey(parameterKey).withParameterValue(parameterValue.substring(offset, len)));


### PR DESCRIPTION
…ffecting User Data concatenation

The issue is the following:
The user data script that is sent as parameter value to the AWS CloudFormation
template, is split into more (max 4) chunks.
The split boundary was the space character between the `export` keyword and
the variable name.
After joining back the chunks with Fn::Join in the CF template, it resulted
in an invalid state (the proper variable was not exported), but rather
a local variable is created with the following name and value:
exportCCM_V2_INVERTING_PROXY_HOST=hostname...
This is fixed by splitting the user data chunks between non-whitespace characters.

See detailed description in the commit message.