### PR TITLE
CB-13099 Improve environment update_load_balancers API response

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -22,6 +22,8 @@ public class EnvironmentModelDescription {
     public static final String ENDPOINT_ACCESS_GATEWAY_SUBNET_METAS = "Subnet metadata for the Public Endpoint Access Gateway. If provided, these " +
         "are the subnets that will be used to create a public Knox endpoint for out-of-network UI/API access. If not provided, public subnets will be " +
         "selected from the subnet list provided for environment creation. (Optional)";
+    public static final String LB_UPDATE_STATUS = "Overall status of load balancer update operation.";
+    public static final String LB_UPDATE_FLOWID = "The flow id of the environment load balancer update flow.";
     public static final String OUTBOUND_INTERNET_TRAFFIC = "A flag to enable or disable the outbound internet traffic from the instances.";
     public static final String AWS_SPECIFIC_PARAMETERS = "AWS-specific properties of the network";
     public static final String AZURE_SPECIFIC_PARAMETERS = "Azure-specific properties of the network";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
@@ -35,6 +35,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLo
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentLoadBalancerUpdateResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponses;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
@@ -238,15 +239,16 @@ public interface EnvironmentEndpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = EnvironmentOpDescription.UPDATE_LOAD_BALANCERS_BY_ENV_NAME, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
         nickname = "updateEnvironmentLoadBalancersByNameV11")
-    void updateEnvironmentLoadBalancersByName(@PathParam("name") String envName, @NotNull EnvironmentLoadBalancerUpdateRequest request);
+    EnvironmentLoadBalancerUpdateResponse updateEnvironmentLoadBalancersByName(@PathParam("name") String envName,
+            @NotNull EnvironmentLoadBalancerUpdateRequest request);
 
     @PUT
     @Path("/crn/{crn}/update_load_balancers")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = EnvironmentOpDescription.UPDATE_LOAD_BALANCERS_BY_ENV_CRN, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
         nickname = "updateEnvironmentLoadBalancersByCrnV1")
-    void updateEnvironmentLoadBalancersByCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @PathParam("crn") String crn,
-            @NotNull EnvironmentLoadBalancerUpdateRequest request);
+    EnvironmentLoadBalancerUpdateResponse updateEnvironmentLoadBalancersByCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+            @PathParam("crn") String crn, @NotNull EnvironmentLoadBalancerUpdateRequest request);
 
     @GET
     @Path("/progress/resource/crn/{resourceCrn}/last")

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/LoadBalancerUpdateStatus.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/LoadBalancerUpdateStatus.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.environment.api.v1.environment.model.base;
+
+public enum LoadBalancerUpdateStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    FAILED,
+    FINISHED,
+    COULD_NOT_START,
+    AMBIGUOUS;
+
+    public static boolean isErrorCase(LoadBalancerUpdateStatus status) {
+        return status == FAILED ||
+            status == COULD_NOT_START;
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentLoadBalancerUpdateResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentLoadBalancerUpdateResponse.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.environment.api.v1.environment.model.response;
+
+import java.util.Set;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+import com.sequenceiq.environment.api.v1.environment.model.base.LoadBalancerUpdateStatus;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+
+@ApiModel(value = "EnvironmentLoadBalancerUpdateResponse")
+public class EnvironmentLoadBalancerUpdateResponse {
+
+    @ApiModelProperty(EnvironmentModelDescription.PUBLIC_ENDPOINT_ACCESS_GATEWAY)
+    private PublicEndpointAccessGateway requestedPublicEndpointGateway = PublicEndpointAccessGateway.DISABLED;
+
+    @ApiModelProperty(EnvironmentModelDescription.ENDPOINT_ACCESS_GATEWAY_SUBNET_IDS)
+    private Set<String> requestedEndpointSubnetIds = Set.of();
+
+    @ApiModelProperty(EnvironmentModelDescription.LB_UPDATE_STATUS)
+    private LoadBalancerUpdateStatus status = LoadBalancerUpdateStatus.NOT_STARTED;
+
+    @ApiModelProperty(EnvironmentModelDescription.LB_UPDATE_FLOWID)
+    private FlowIdentifier flowId;
+
+    public PublicEndpointAccessGateway getRequestedPublicEndpointGateway() {
+        return requestedPublicEndpointGateway;
+    }
+
+    public void setRequestedPublicEndpointGateway(PublicEndpointAccessGateway requestedPublicEndpointGateway) {
+        this.requestedPublicEndpointGateway = requestedPublicEndpointGateway;
+    }
+
+    public Set<String> getRequestedEndpointSubnetIds() {
+        return requestedEndpointSubnetIds;
+    }
+
+    public void setRequestedEndpointSubnetIds(Set<String> requestedEndpointSubnetIds) {
+        this.requestedEndpointSubnetIds = requestedEndpointSubnetIds;
+    }
+
+    public LoadBalancerUpdateStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(LoadBalancerUpdateStatus status) {
+        this.status = status;
+    }
+
+    public FlowIdentifier getFlowId() {
+        return flowId;
+    }
+
+    public void setFlowId(FlowIdentifier flowId) {
+        this.flowId = flowId;
+    }
+
+    @Override
+    public String toString() {
+        return "EnvironmentLoadBalancerUpdateResponse{" +
+            "requestedPublicEndpointGateway=" + requestedPublicEndpointGateway +
+            ", requestedEndpointSubnetIds=" + requestedEndpointSubnetIds +
+            ", status=" + status +
+            ", flowId=" + flowId +
+            '}';
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManager.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/EnvironmentReactorFlowManager.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.environment.environment.flow.deletion.chain.FlowCha
 import static com.sequenceiq.environment.environment.flow.deletion.event.EnvDeleteStateSelectors.START_FREEIPA_DELETE_EVENT;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -27,6 +28,7 @@ import com.sequenceiq.environment.environment.flow.start.event.EnvStartStateSele
 import com.sequenceiq.environment.environment.flow.stop.event.EnvStopEvent;
 import com.sequenceiq.environment.environment.flow.stop.event.EnvStopStateSelectors;
 import com.sequenceiq.environment.environment.service.stack.StackService;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.core.FlowConstants;
 import com.sequenceiq.flow.reactor.api.event.EventSender;
 import com.sequenceiq.flow.service.FlowCancelService;
@@ -140,7 +142,7 @@ public class EnvironmentReactorFlowManager {
             new Event.Headers(getFlowTriggerUsercrn(userCrn)));
     }
 
-    public void triggerLoadBalancerUpdateFlow(EnvironmentDto environmentDto, Long envId, String envName, String envCrn,
+    public Optional<FlowIdentifier> triggerLoadBalancerUpdateFlow(EnvironmentDto environmentDto, Long envId, String envName, String envCrn,
             PublicEndpointAccessGateway endpointAccessGateway, Set<String> subnetIds, String userCrn) {
         LOGGER.info("Load balancer update flow triggered.");
         if (PublicEndpointAccessGateway.ENABLED.equals(endpointAccessGateway)) {
@@ -161,6 +163,6 @@ public class EnvironmentReactorFlowManager {
             .withSubnetIds(subnetIds)
             .build();
 
-        eventSender.sendEvent(loadBalancerUpdateEvent, new Event.Headers(getFlowTriggerUsercrn(userCrn)));
+        return eventSender.sendEvent(loadBalancerUpdateEvent, new Event.Headers(getFlowTriggerUsercrn(userCrn)));
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/loadbalancer/handler/LoadBalancerEnvUpdateHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/loadbalancer/handler/LoadBalancerEnvUpdateHandler.java
@@ -102,7 +102,7 @@ public class LoadBalancerEnvUpdateHandler extends EventSenderAwareHandler<Enviro
                 .build();
             eventSender().sendEvent(loadBalancerUpdateEvent, envLoadBalancerDtoEvent.getHeaders());
         } catch (Exception e) {
-            LOGGER.error("Caught exception while updating environment state with laod balancers.", e);
+            LOGGER.error("Caught exception while updating environment state with load balancers.", e);
             LoadBalancerUpdateFailedEvent failedEvent = new LoadBalancerUpdateFailedEvent(environmentDto, e,
                 EnvironmentStatus.LOAD_BALANCER_ENV_UPDATE_FAILED);
             eventSender().sendEvent(failedEvent, envLoadBalancerDtoEvent.getHeaders());

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerService.java
@@ -3,6 +3,7 @@ package com.sequenceiq.environment.environment.service;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -13,11 +14,14 @@ import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.v1.environment.model.base.LoadBalancerUpdateStatus;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentLoadBalancerUpdateResponse;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
 import com.sequenceiq.environment.environment.flow.EnvironmentReactorFlowManager;
 import com.sequenceiq.environment.network.service.LoadBalancerEntitlementService;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
 
 @Service
 public class EnvironmentLoadBalancerService {
@@ -43,7 +47,21 @@ public class EnvironmentLoadBalancerService {
         this.loadBalancerEntitlementService = loadBalancerEntitlementService;
     }
 
-    public void updateLoadBalancerInEnvironmentAndStacks(EnvironmentDto environmentDto, EnvironmentLoadBalancerDto environmentLbDto) {
+    public EnvironmentLoadBalancerUpdateResponse updateLoadBalancerInEnvironmentAndStacks(EnvironmentDto environmentDto,
+            EnvironmentLoadBalancerDto environmentLbDto) {
+        validateUpdateRequest(environmentDto, environmentLbDto);
+
+        Environment environment = getEnvironmentFromCrn(environmentDto);
+        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
+        LOGGER.info("Initiating load balancer update flow");
+        Optional<FlowIdentifier> flowIdentifier = reactorFlowManager
+            .triggerLoadBalancerUpdateFlow(environmentDto, environment.getId(), environment.getName(), environment.getResourceCrn(),
+                environmentLbDto.getEndpointAccessGateway(), environmentLbDto.getEndpointGatewaySubnetIds(), userCrn);
+
+        return createUpdateResponse(environmentLbDto, flowIdentifier);
+    }
+
+    private void validateUpdateRequest(EnvironmentDto environmentDto, EnvironmentLoadBalancerDto environmentLbDto) {
         requireNonNull(environmentDto);
         requireNonNull(environmentLbDto);
 
@@ -54,19 +72,30 @@ public class EnvironmentLoadBalancerService {
             environmentLbDto.getEndpointAccessGateway())) {
             throw new BadRequestException("Neither Endpoint Gateway nor Data Lake load balancer is enabled. Nothing to do.");
         }
+    }
 
+    private Environment getEnvironmentFromCrn(EnvironmentDto environmentDto) {
         LOGGER.debug("Trying to find environment based on name {}, CRN {}", environmentDto.getName(), environmentDto.getResourceCrn());
         String accountId = Crn.safeFromString(environmentDto.getResourceCrn()).getAccountId();
-        Environment environment = environmentService
+        return environmentService
             .findByResourceCrnAndAccountIdAndArchivedIsFalse(environmentDto.getResourceCrn(), accountId).
                 orElseThrow(() -> new NotFoundException(
                     String.format("Could not find environment '%s' using crn '%s'", environmentDto.getName(),
                         environmentDto.getResourceCrn())));
+    }
 
-        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        reactorFlowManager
-            .triggerLoadBalancerUpdateFlow(environmentDto, environment.getId(), environment.getName(), environment.getResourceCrn(),
-                environmentLbDto.getEndpointAccessGateway(), environmentLbDto.getEndpointGatewaySubnetIds(), userCrn);
+    private EnvironmentLoadBalancerUpdateResponse createUpdateResponse(EnvironmentLoadBalancerDto environmentLbDto,
+            Optional<FlowIdentifier> flowIdentifier) {
+        EnvironmentLoadBalancerUpdateResponse response = new EnvironmentLoadBalancerUpdateResponse();
+        response.setRequestedPublicEndpointGateway(environmentLbDto.getEndpointAccessGateway());
+        response.setRequestedEndpointSubnetIds(environmentLbDto.getEndpointGatewaySubnetIds());
+        if (flowIdentifier.isPresent()) {
+            response.setFlowId(flowIdentifier.get());
+            response.setStatus(LoadBalancerUpdateStatus.IN_PROGRESS);
+        } else {
+            throw new IllegalStateException("Unable to initiate update flow.");
+        }
+        return response;
     }
 
     private boolean isLoadBalancerEnabledForDatalake(String accountId, String cloudPlatform, PublicEndpointAccessGateway endpointEnum) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
@@ -52,6 +52,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLo
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentLoadBalancerUpdateResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponses;
 import com.sequenceiq.environment.authorization.EnvironmentFiltering;
@@ -380,21 +381,22 @@ public class EnvironmentController implements EnvironmentEndpoint {
 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.EDIT_ENVIRONMENT)
-    public void updateEnvironmentLoadBalancersByName(@ResourceName String envName, @NotNull EnvironmentLoadBalancerUpdateRequest request) {
+    public EnvironmentLoadBalancerUpdateResponse updateEnvironmentLoadBalancersByName(@ResourceName String envName,
+            @NotNull EnvironmentLoadBalancerUpdateRequest request) {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         EnvironmentDto environmentDto = environmentService.getByNameAndAccountId(envName, accountId);
         EnvironmentLoadBalancerDto environmentLoadBalancerDto = environmentApiConverter.initLoadBalancerDto(request);
-        environmentLoadBalancerService.updateLoadBalancerInEnvironmentAndStacks(environmentDto, environmentLoadBalancerDto);
+        return environmentLoadBalancerService.updateLoadBalancerInEnvironmentAndStacks(environmentDto, environmentLoadBalancerDto);
     }
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.EDIT_ENVIRONMENT)
-    public void updateEnvironmentLoadBalancersByCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @ResourceCrn @TenantAwareParam String crn,
-            @NotNull EnvironmentLoadBalancerUpdateRequest request) {
+    public EnvironmentLoadBalancerUpdateResponse updateEnvironmentLoadBalancersByCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+            @ResourceCrn @TenantAwareParam String crn, @NotNull EnvironmentLoadBalancerUpdateRequest request) {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         EnvironmentDto environmentDto = environmentService.getByCrnAndAccountId(crn, accountId);
         EnvironmentLoadBalancerDto environmentLoadBalancerDto = environmentApiConverter.initLoadBalancerDto(request);
-        environmentLoadBalancerService.updateLoadBalancerInEnvironmentAndStacks(environmentDto, environmentLoadBalancerDto);
+        return environmentLoadBalancerService.updateLoadBalancerInEnvironmentAndStacks(environmentDto, environmentLoadBalancerDto);
     }
 
     @Override

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/dao/converter/LoadBalancerUpdateStatusConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/dao/converter/LoadBalancerUpdateStatusConverter.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.environment.parameters.dao.converter;
+
+import com.sequenceiq.cloudbreak.converter.DefaultEnumConverter;
+import com.sequenceiq.environment.api.v1.environment.model.base.LoadBalancerUpdateStatus;
+
+public class LoadBalancerUpdateStatusConverter extends DefaultEnumConverter<LoadBalancerUpdateStatus> {
+
+    @Override
+    public LoadBalancerUpdateStatus getDefault() {
+        return LoadBalancerUpdateStatus.NOT_STARTED;
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerServiceTest.java
@@ -22,11 +22,15 @@ import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.v1.environment.model.base.LoadBalancerUpdateStatus;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentLoadBalancerUpdateResponse;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
 import com.sequenceiq.environment.environment.flow.EnvironmentReactorFlowManager;
 import com.sequenceiq.environment.network.service.LoadBalancerEntitlementService;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.flow.api.model.FlowType;
 
 @ExtendWith(SpringExtension.class)
 public class EnvironmentLoadBalancerServiceTest {
@@ -36,6 +40,8 @@ public class EnvironmentLoadBalancerServiceTest {
     private static final String ENV_NAME = "environment-name";
 
     private static final String ENV_CRN = "crn:cdp:environments:us-west-1:accountId:environment:4c5ba74b-c35e-45e9-9f47-123456789876";
+
+    private static final String FLOW_ID = "flowid-1";
 
     @Mock
     private EnvironmentService environmentService;
@@ -84,18 +90,24 @@ public class EnvironmentLoadBalancerServiceTest {
         EnvironmentDto environmentDto = EnvironmentDto.builder()
             .withResourceCrn(ENV_CRN)
             .build();
+        FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, FLOW_ID);
 
         when(environmentService.findByResourceCrnAndAccountIdAndArchivedIsFalse(anyString(), anyString()))
             .thenReturn(Optional.of(new Environment()));
-        doNothing().when(reactorFlowManager).triggerLoadBalancerUpdateFlow(any(), any(), any(), any(), any(), any(), anyString());
+        when(reactorFlowManager.triggerLoadBalancerUpdateFlow(any(), any(), any(), any(), any(), any(), anyString()))
+            .thenReturn(Optional.of(flowIdentifier));
         doNothing().when(loadBalancerEntitlementService).validateNetworkForEndpointGateway(any(), any(), any());
 
+        EnvironmentLoadBalancerUpdateResponse[] updateResponse = new EnvironmentLoadBalancerUpdateResponse[1];
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
-            underTest.updateLoadBalancerInEnvironmentAndStacks(environmentDto, environmentLbDto);
+            updateResponse[0] = underTest.updateLoadBalancerInEnvironmentAndStacks(environmentDto, environmentLbDto);
         });
 
         verify(reactorFlowManager, times(1))
             .triggerLoadBalancerUpdateFlow(any(), any(), any(), any(), any(), any(), anyString());
+        assertEquals(flowIdentifier, updateResponse[0].getFlowId());
+        assertEquals(PublicEndpointAccessGateway.ENABLED, updateResponse[0].getRequestedPublicEndpointGateway());
+        assertEquals(LoadBalancerUpdateStatus.IN_PROGRESS, updateResponse[0].getStatus());
     }
 
     @Test
@@ -106,19 +118,25 @@ public class EnvironmentLoadBalancerServiceTest {
         EnvironmentDto environmentDto = EnvironmentDto.builder()
             .withResourceCrn(ENV_CRN)
             .build();
+        FlowIdentifier flowIdentifier = new FlowIdentifier(FlowType.FLOW, FLOW_ID);
 
         when(entitlementService.datalakeLoadBalancerEnabled(anyString())).thenReturn(true);
         when(environmentService.findByResourceCrnAndAccountIdAndArchivedIsFalse(anyString(), anyString()))
             .thenReturn(Optional.of(new Environment()));
-        doNothing().when(reactorFlowManager).triggerLoadBalancerUpdateFlow(any(), any(), any(), any(), any(), any(), anyString());
+        when(reactorFlowManager.triggerLoadBalancerUpdateFlow(any(), any(), any(), any(), any(), any(), anyString()))
+            .thenReturn(Optional.of(flowIdentifier));
         doNothing().when(loadBalancerEntitlementService).validateNetworkForEndpointGateway(any(), any(), any());
 
+        EnvironmentLoadBalancerUpdateResponse[] updateResponse = new EnvironmentLoadBalancerUpdateResponse[1];
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
-            underTest.updateLoadBalancerInEnvironmentAndStacks(environmentDto, environmentLbDto);
+            updateResponse[0] = underTest.updateLoadBalancerInEnvironmentAndStacks(environmentDto, environmentLbDto);
         });
 
         verify(reactorFlowManager, times(1))
             .triggerLoadBalancerUpdateFlow(any(), any(), any(), any(), any(), any(), anyString());
+        assertEquals(flowIdentifier, updateResponse[0].getFlowId());
+        assertEquals(PublicEndpointAccessGateway.DISABLED, updateResponse[0].getRequestedPublicEndpointGateway());
+        assertEquals(LoadBalancerUpdateStatus.IN_PROGRESS, updateResponse[0].getStatus());
     }
 
     @Test
@@ -137,6 +155,31 @@ public class EnvironmentLoadBalancerServiceTest {
         final BadRequestException[] exception = new BadRequestException[1];
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
             exception[0] = assertThrows(BadRequestException.class, () ->
+                underTest.updateLoadBalancerInEnvironmentAndStacks(environmentDto, environmentLbDto));
+        });
+
+        assertEquals(expectedError, exception[0].getMessage());
+    }
+
+    @Test
+    public void testUnableToFindFlow() {
+        EnvironmentLoadBalancerDto environmentLbDto = EnvironmentLoadBalancerDto.builder()
+            .withEndpointAccessGateway(PublicEndpointAccessGateway.ENABLED)
+            .build();
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withResourceCrn(ENV_CRN)
+            .build();
+        String expectedError = "Unable to initiate update flow.";
+
+        when(environmentService.findByResourceCrnAndAccountIdAndArchivedIsFalse(anyString(), anyString()))
+            .thenReturn(Optional.of(new Environment()));
+        when(reactorFlowManager.triggerLoadBalancerUpdateFlow(any(), any(), any(), any(), any(), any(), anyString()))
+            .thenReturn(Optional.empty());
+        doNothing().when(loadBalancerEntitlementService).validateNetworkForEndpointGateway(any(), any(), any());
+
+        final IllegalStateException[] exception = new IllegalStateException[1];
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
+            exception[0] = assertThrows(IllegalStateException.class, () ->
                 underTest.updateLoadBalancerInEnvironmentAndStacks(environmentDto, environmentLbDto));
         });
 

--- a/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/EventSender.java
+++ b/flow/src/main/java/com/sequenceiq/flow/reactor/api/event/EventSender.java
@@ -1,10 +1,15 @@
 package com.sequenceiq.flow.reactor.api.event;
 
 import java.util.HashMap;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.flow.api.model.FlowType;
 import com.sequenceiq.flow.core.model.FlowAcceptResult;
 import com.sequenceiq.flow.core.model.ResultType;
 import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
@@ -14,6 +19,8 @@ import reactor.bus.EventBus;
 
 @Component
 public class EventSender {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EventSender.class);
 
     private static final long TIMEOUT = 10L;
 
@@ -26,15 +33,15 @@ public class EventSender {
         this.eventFactory = eventFactory;
     }
 
-    public void sendEvent(BaseNamedFlowEvent event, Event.Headers headers) {
-        doSend(event, headers, event.getResourceName());
+    public Optional<FlowIdentifier> sendEvent(BaseNamedFlowEvent event, Event.Headers headers) {
+        return doSend(event, headers, event.getResourceName());
     }
 
-    public void sendEvent(BaseFlowEvent event, Event.Headers headers) {
-        doSend(event, headers, null);
+    public Optional<FlowIdentifier> sendEvent(BaseFlowEvent event, Event.Headers headers) {
+        return doSend(event, headers, null);
     }
 
-    private void doSend(BaseFlowEvent event, Event.Headers headers, String resourceName) {
+    private Optional<FlowIdentifier> doSend(BaseFlowEvent event, Event.Headers headers, String resourceName) {
         Event<BaseFlowEvent> eventWithErrHandler = eventFactory.createEventWithErrHandler(new HashMap<>(headers.asMap()), event);
         reactor.notify(event.selector(), eventWithErrHandler);
         if (eventWithErrHandler.getData().accepted() != null) {
@@ -44,9 +51,20 @@ public class EventSender {
                     throw new IllegalStateException(String.format("Resource with name: '%s' and crn: '%s' has flow under operation, request is not allowed.",
                             resourceName, event.getResourceCrn()));
                 }
+                switch (accepted.getResultType()) {
+                    case RUNNING_IN_FLOW:
+                        return Optional.of(new FlowIdentifier(FlowType.FLOW, accepted.getAsFlowId()));
+                    case RUNNING_IN_FLOW_CHAIN:
+                        return Optional.of(new FlowIdentifier(FlowType.FLOW_CHAIN, accepted.getAsFlowChainId()));
+                    default:
+                        throw new IllegalStateException("Illegal resultType: " + accepted.getResultType());
+                }
             } catch (InterruptedException e) {
                 throw new IllegalStateException(e.getMessage());
             }
+        } else {
+            LOGGER.debug("Received event with no associated flow event. Nothing to do.");
+            return Optional.empty();
         }
     }
 }


### PR DESCRIPTION
Adds a new EnvironmentLoadBalancerUpdateResponse object that's returned when the update_load_balancer API is called.
The EnvironmentLoadBalancerService.updateLoadBalancerInEnvironmentAndStacks method now queries the flow service for
the most recent LoadBalancerUpdateFlowConfig flow, and includes that flow identifier in the response for tracking.

Tested by unit tests and running curl commands against the updated API.