### PR TITLE
Revert "CB-12921 Run salt commands only on actually reachable minions…

### DIFF
--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -28,7 +28,7 @@ public interface HostOrchestrator extends HostRecipeExecutor {
 
     boolean isBootstrapApiAvailable(GatewayConfig gatewayConfig);
 
-    void initServiceRun(List<GatewayConfig> allGatewayConfigs, Set<Node> allNodes, Set<Node> reachableNodes,
+    void initServiceRun(List<GatewayConfig> allGatewayConfigs, Set<Node> allNodes,
             SaltConfig pillarConfig, ExitCriteriaModel exitCriteriaModel) throws CloudbreakOrchestratorException;
 
     void initSaltConfig(List<GatewayConfig> allGateway, Set<Node> allNodes, SaltConfig saltConfig, ExitCriteriaModel exitModel)

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -334,13 +334,13 @@ public class SaltOrchestrator implements HostOrchestrator {
 
     @SuppressFBWarnings("REC_CATCH_EXCEPTION")
     @Override
-    public void initServiceRun(List<GatewayConfig> allGateway, Set<Node> allNodes, Set<Node> reachableNodes, SaltConfig saltConfig,
-            ExitCriteriaModel exitModel) throws CloudbreakOrchestratorException {
+    public void initServiceRun(List<GatewayConfig> allGateway, Set<Node> allNodes, SaltConfig saltConfig, ExitCriteriaModel exitModel)
+            throws CloudbreakOrchestratorException {
         GatewayConfig primaryGateway = saltService.getPrimaryGatewayConfig(allGateway);
         Set<String> gatewayTargetIpAddresses = getGatewayPrivateIps(allGateway);
         Set<String> gatewayTargetHostnames = getGatewayHostnames(allGateway);
         Set<String> serverHostname = Sets.newHashSet(primaryGateway.getHostname());
-        Set<String> reachableHostnames = reachableNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
+        Set<String> allNodeHostname = allNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
         try (SaltConnector sc = saltService.createSaltConnector(primaryGateway)) {
             OrchestratorBootstrap hostSave = new PillarSave(sc, gatewayTargetIpAddresses, allNodes);
             Callable<Boolean> saltPillarRunner = saltRunner.runner(hostSave, exitCriteria, exitModel);
@@ -352,8 +352,8 @@ public class SaltOrchestrator implements HostOrchestrator {
                 saltPillarRunner.call();
             }
 
-            setAdMemberRoleIfNeeded(allNodes, saltConfig, exitModel, sc, reachableHostnames);
-            setIpaMemberRoleIfNeeded(allNodes, saltConfig, exitModel, sc, reachableHostnames);
+            setAdMemberRoleIfNeeded(allNodes, saltConfig, exitModel, sc, allNodeHostname);
+            setIpaMemberRoleIfNeeded(allNodes, saltConfig, exitModel, sc, allNodeHostname);
 
             // knox
             if (primaryGateway.getKnoxGatewayEnabled()) {
@@ -362,15 +362,15 @@ public class SaltOrchestrator implements HostOrchestrator {
 
             setPostgreRoleIfNeeded(allNodes, saltConfig, exitModel, sc, serverHostname);
 
-            addClusterManagerRoles(allNodes, exitModel, sc, serverHostname, reachableHostnames);
+            addClusterManagerRoles(allNodes, exitModel, sc, serverHostname, allNodeHostname);
 
             // kerberos
             if (saltConfig.getServicePillarConfig().containsKey("kerberos")) {
-                saltCommandRunner.runModifyGrainCommand(sc, new GrainAddRunner(reachableHostnames, allNodes, "kerberized"), exitModel, exitCriteria);
+                saltCommandRunner.runModifyGrainCommand(sc, new GrainAddRunner(allNodeHostname, allNodes, "kerberized"), exitModel, exitCriteria);
             }
             grainUploader.uploadGrains(allNodes, saltConfig.getGrainsProperties(), exitModel, sc, exitCriteria);
 
-            runSyncAll(sc, reachableHostnames, allNodes, exitModel);
+            runSyncAll(sc, allNodeHostname, allNodes, exitModel);
             saltCommandRunner.runSaltCommand(sc, new MineUpdateRunner(gatewayTargetHostnames, allNodes), exitModel, exitCriteria);
         } catch (ExecutionException e) {
             LOGGER.warn("Error occurred during bootstrap", e);
@@ -414,22 +414,22 @@ public class SaltOrchestrator implements HostOrchestrator {
     }
 
     private void addClusterManagerRoles(Set<Node> allNodes, ExitCriteriaModel exitModel,
-            SaltConnector sc, Set<String> serverHostnames, Set<String> reachableHostnames) throws Exception {
-        saltCommandRunner.runModifyGrainCommand(sc, new GrainAddRunner(reachableHostnames, allNodes, "manager_agent"), exitModel, exitCriteria);
+            SaltConnector sc, Set<String> serverHostnames, Set<String> allNodeHostname) throws Exception {
+        saltCommandRunner.runModifyGrainCommand(sc, new GrainAddRunner(allNodeHostname, allNodes, "manager_agent"), exitModel, exitCriteria);
         saltCommandRunner.runModifyGrainCommand(sc, new GrainAddRunner(serverHostnames, allNodes, "manager_server"), exitModel, exitCriteria);
     }
 
-    private void setAdMemberRoleIfNeeded(Set<Node> allNodes, SaltConfig saltConfig, ExitCriteriaModel exitModel, SaltConnector sc,
-            Set<String> reachableHostnames) throws Exception {
+    private void setAdMemberRoleIfNeeded(Set<Node> allNodes, SaltConfig saltConfig, ExitCriteriaModel exitModel, SaltConnector sc, Set<String> allHostnames)
+            throws Exception {
         if (saltConfig.getServicePillarConfig().containsKey("sssd-ad")) {
-            saltCommandRunner.runModifyGrainCommand(sc, new GrainAddRunner(reachableHostnames, allNodes, "ad_member"), exitModel, exitCriteria);
+            saltCommandRunner.runModifyGrainCommand(sc, new GrainAddRunner(allHostnames, allNodes, "ad_member"), exitModel, exitCriteria);
         }
     }
 
-    private void setIpaMemberRoleIfNeeded(Set<Node> allNodes, SaltConfig saltConfig, ExitCriteriaModel exitModel, SaltConnector sc,
-            Set<String> reachableHostnames) throws Exception {
+    private void setIpaMemberRoleIfNeeded(Set<Node> allNodes, SaltConfig saltConfig, ExitCriteriaModel exitModel, SaltConnector sc, Set<String> allHostnames)
+            throws Exception {
         if (saltConfig.getServicePillarConfig().containsKey("sssd-ipa")) {
-            saltCommandRunner.runModifyGrainCommand(sc, new GrainAddRunner(reachableHostnames, allNodes, "ipa_member"), exitModel, exitCriteria);
+            saltCommandRunner.runModifyGrainCommand(sc, new GrainAddRunner(allHostnames, allNodes, "ipa_member"), exitModel, exitCriteria);
         }
     }
 
@@ -442,7 +442,7 @@ public class SaltOrchestrator implements HostOrchestrator {
         try (SaltConnector sc = saltService.createSaltConnector(primaryGateway)) {
             retry.testWith2SecDelayMax5Times(() -> getRolesBeforeHighstateMagic(sc));
             Set<String> allHostnames = allNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
-            runNewService(sc, new HighStateRunner(allHostnames, allNodes), exitModel);
+            runNewService(sc, new HighStateAllRunner(allHostnames, allNodes), exitModel);
         } catch (ExecutionException e) {
             LOGGER.info("Error occurred during bootstrap", e);
             if (e.getCause() instanceof CloudbreakOrchestratorFailedException) {
@@ -689,7 +689,7 @@ public class SaltOrchestrator implements HostOrchestrator {
 
             Set<String> allHostnames = allNodes.stream().map(Node::getHostname).collect(Collectors.toSet());
             runSyncAll(sc, allHostnames, allNodes, exitCriteriaModel);
-            runNewService(sc, new HighStateRunner(allHostnames, allNodes), exitCriteriaModel, maxRetry, true);
+            runNewService(sc, new HighStateAllRunner(allHostnames, allNodes), exitCriteriaModel, maxRetry, true);
 
             // remove 'manager_upgrade' role from all nodes
             saltCommandRunner.runModifyGrainCommand(sc, new GrainRemoveRunner(targetHostnames, allNodes, "roles", "manager_upgrade"),

--- a/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
+++ b/orchestrator-salt/src/test/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestratorTest.java
@@ -80,7 +80,7 @@ import com.sequenceiq.cloudbreak.orchestrator.salt.poller.SaltCommandTracker;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.SaltJobIdTracker;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.GrainAddRunner;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.GrainRemoveRunner;
-import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.HighStateRunner;
+import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.HighStateAllRunner;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.MineUpdateRunner;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.ModifyGrainBase;
 import com.sequenceiq.cloudbreak.orchestrator.salt.poller.checker.SyncAllRunner;
@@ -206,8 +206,8 @@ public class SaltOrchestratorTest {
         SaltCommandTracker syncGrainsCheckerSaltCommandTracker = mock(SaltCommandTracker.class);
         whenNew(SaltCommandTracker.class).withArguments(eq(saltConnector), eq(syncAllRunner)).thenReturn(syncGrainsCheckerSaltCommandTracker);
 
-        HighStateRunner highStateRunner = mock(HighStateRunner.class);
-        whenNew(HighStateRunner.class).withAnyArguments().thenReturn(highStateRunner);
+        HighStateAllRunner highStateAllRunner = mock(HighStateAllRunner.class);
+        whenNew(HighStateAllRunner.class).withAnyArguments().thenReturn(highStateAllRunner);
 
         SaltJobIdTracker saltJobIdTracker = mock(SaltJobIdTracker.class);
         whenNew(SaltJobIdTracker.class).withAnyArguments().thenReturn(saltJobIdTracker);
@@ -222,7 +222,7 @@ public class SaltOrchestratorTest {
         PowerMockito.when(SaltStates.getGrains(any(), any(), any())).thenReturn(new HashMap<>());
 
         SaltConfig saltConfig = new SaltConfig();
-        saltOrchestrator.initServiceRun(Collections.singletonList(gatewayConfig), targets, targets, saltConfig, exitCriteriaModel);
+        saltOrchestrator.initServiceRun(Collections.singletonList(gatewayConfig), targets, saltConfig, exitCriteriaModel);
         saltOrchestrator.runService(Collections.singletonList(gatewayConfig), targets, saltConfig, exitCriteriaModel);
 
         Set<String> allNodes = targets.stream().map(Node::getHostname).collect(Collectors.toSet());
@@ -231,9 +231,9 @@ public class SaltOrchestratorTest {
         verifyNew(SyncAllRunner.class, times(1)).withArguments(eq(allNodes), eq(targets));
 
         // verify run new service
-        verifyNew(HighStateRunner.class, atLeastOnce()).withArguments(eq(allNodes),
+        verifyNew(HighStateAllRunner.class, atLeastOnce()).withArguments(eq(allNodes),
                 eq(targets));
-        verifyNew(SaltJobIdTracker.class, atLeastOnce()).withArguments(eq(saltConnector), eq(highStateRunner), eq(true));
+        verifyNew(SaltJobIdTracker.class, atLeastOnce()).withArguments(eq(saltConnector), eq(highStateAllRunner), eq(true));
         verify(saltCommandRunner, times(1)).runSaltCommand(any(SaltConnector.class), any(BaseSaltJobRunner.class),
                 any(ExitCriteriaModel.class), any(ExitCriteria.class));
         verify(saltCommandRunner, times(2)).runModifyGrainCommand(any(SaltConnector.class), any(ModifyGrainBase.class),


### PR DESCRIPTION
…. Save pillar data on master for all node. Use HighstateRunner and target reachabe nodes only instead of HighstateAllRunner which targets every node."

This reverts commit 876c7ecf1a5080f1c27596281e8f0614917e5d7f.

See detailed description in the commit message.