### PR TITLE
CB-13156 Create update_load_balancers_status API

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -22,6 +22,14 @@ public class EnvironmentModelDescription {
     public static final String ENDPOINT_ACCESS_GATEWAY_SUBNET_METAS = "Subnet metadata for the Public Endpoint Access Gateway. If provided, these " +
         "are the subnets that will be used to create a public Knox endpoint for out-of-network UI/API access. If not provided, public subnets will be " +
         "selected from the subnet list provided for environment creation. (Optional)";
+    public static final String LB_UPDATE_STATUS = "Overall status of load balancer update oeration.";
+    public static final String LB_UPDATE_ERROR = "An error string if any load balancer update operation has failed.";
+    public static final String LB_UPDATE_FLOWID = "The flow id of the environment load balancer update flow.";
+    public static final String LB_UPDATE_CHILD_NAME = "Name of the cluster undergoing load balancer update.";
+    public static final String LB_UPDATE_CHILD_CRN = "CRN of the cluster undergoing load balancer update.";
+    public static final String LB_UPDATE_CHILD_FLOWID = "Flow id of the cluster load balancer update flow.";
+    public static final String LB_UPDATE_CHILD_STATUS = "Status for each data lake/data hub that is part of the update operation.";
+    public static final String LB_UPDATE_CHILD_STATE = "The current state of the update flow. Used to track the current operation.";
     public static final String OUTBOUND_INTERNET_TRAFFIC = "A flag to enable or disable the outbound internet traffic from the instances.";
     public static final String AWS_SPECIFIC_PARAMETERS = "AWS-specific properties of the network";
     public static final String AZURE_SPECIFIC_PARAMETERS = "Azure-specific properties of the network";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
@@ -29,6 +29,10 @@ public class EnvironmentOpDescription {
         "Endpoint Access Gateway if it's enabled. Environment is specified by name.";
     public static final String UPDATE_LOAD_BALANCERS_BY_ENV_CRN = "Updates all cluster in an environment with load balancers, including adding the " +
         "Endpoint Access Gateway if it's enabled. Environment is specified by CRN.";
+    public static final String LOAD_BALANCERS_UPDATE_STATUS_BY_ENV_NAME = "Gets the status of the most recent load balancer update operation " +
+        "by environment name.";
+    public static final String LOAD_BALANCERS_UPDATE_STATUS_BY_ENV_CRN = "Gets the status of the most recent load balancer update operation " +
+        "by environment CRN.";
     public static final String GET_LAST_FLOW_PROGRESS = "Get last flow operation progress details for resource by resource crn";
     public static final String LIST_FLOW_PROGRESS = "List recent flow operations progress details for resource by resource crn";
 

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
@@ -35,6 +35,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLo
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentLbUpdateStatusResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponses;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
@@ -247,6 +248,21 @@ public interface EnvironmentEndpoint {
         nickname = "updateEnvironmentLoadBalancersByCrnV1")
     void updateEnvironmentLoadBalancersByCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @PathParam("crn") String crn,
             @NotNull EnvironmentLoadBalancerUpdateRequest request);
+
+    @GET
+    @Path("/name/{name}/update_load_balancers_status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.LOAD_BALANCERS_UPDATE_STATUS_BY_ENV_NAME, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+        nickname = "getLoadBalancerUpdateStatusByEnvironmentNameV1")
+    EnvironmentLbUpdateStatusResponse getLoadBalancerUpdateStatusByEnvironmentName(@PathParam("name") String envName);
+
+    @GET
+    @Path("/crn/{crn}/update_load_balancers_status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.LOAD_BALANCERS_UPDATE_STATUS_BY_ENV_CRN, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+        nickname = "getLoadBalancerUpdateStatusByEnvironmentCrnV1")
+    EnvironmentLbUpdateStatusResponse getLoadBalancerUpdateStatusByEnvironmentCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+            @PathParam("crn") String crn);
 
     @GET
     @Path("/progress/resource/crn/{resourceCrn}/last")

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/LoadBalancerUpdateStatus.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/base/LoadBalancerUpdateStatus.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.environment.api.v1.environment.model.base;
+
+public enum LoadBalancerUpdateStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    FAILED,
+    FINISHED,
+    COULD_NOT_START,
+    AMBIGUOUS;
+
+    public static boolean isErrorCase(LoadBalancerUpdateStatus status) {
+        return status == FAILED ||
+            status == COULD_NOT_START;
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/ClusterLbUpdateStatus.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/ClusterLbUpdateStatus.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.environment.api.v1.environment.model.response;
+
+import java.util.Objects;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+import com.sequenceiq.environment.api.v1.environment.model.base.LoadBalancerUpdateStatus;
+
+@ApiModel(value = "ClusterLbUpdateStatus")
+public class ClusterLbUpdateStatus {
+
+    @ApiModelProperty(EnvironmentModelDescription.LB_UPDATE_CHILD_NAME)
+    private String clusterName;
+
+    @ApiModelProperty(EnvironmentModelDescription.LB_UPDATE_CHILD_CRN)
+    private String clusterCrn;
+
+    @ApiModelProperty(EnvironmentModelDescription.LB_UPDATE_CHILD_FLOWID)
+    private String flowId;
+
+    @ApiModelProperty(EnvironmentModelDescription.LB_UPDATE_CHILD_STATUS)
+    private LoadBalancerUpdateStatus status;
+
+    @ApiModelProperty(EnvironmentModelDescription.LB_UPDATE_CHILD_STATE)
+    private String currentState;
+
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+    }
+
+    public String getClusterCrn() {
+        return clusterCrn;
+    }
+
+    public void setClusterCrn(String clusterCrn) {
+        this.clusterCrn = clusterCrn;
+    }
+
+    public String getFlowId() {
+        return flowId;
+    }
+
+    public void setFlowId(String flowId) {
+        this.flowId = flowId;
+    }
+
+    public LoadBalancerUpdateStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(LoadBalancerUpdateStatus status) {
+        this.status = status;
+    }
+
+    public String getCurrentState() {
+        return currentState;
+    }
+
+    public void setCurrentState(String currentState) {
+        this.currentState = currentState;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ClusterLbUpdateStatus that = (ClusterLbUpdateStatus) o;
+        return Objects.equals(clusterName, that.clusterName) &&
+            Objects.equals(clusterCrn, that.clusterCrn) &&
+            Objects.equals(flowId, that.flowId) &&
+            status == that.status &&
+            Objects.equals(currentState, that.currentState);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterName, clusterCrn, flowId, status, currentState);
+    }
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentLbUpdateStatusResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentLbUpdateStatusResponse.java
@@ -1,0 +1,144 @@
+package com.sequenceiq.environment.api.v1.environment.model.response;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+import com.sequenceiq.environment.api.v1.environment.model.base.LoadBalancerUpdateStatus;
+
+@ApiModel(value = "EnvironmentLbUpdateStatusResponse")
+public class EnvironmentLbUpdateStatusResponse {
+
+    public static final String NO_ERROR = "None";
+
+    public static final String ENV_ERROR = "The environment update failed. There may have been an error persisting the updates " +
+        "to the database, or starting the cluster update processes. Please review the environment logs.";
+
+    public static final String FINISHED_NO_CHILDREN = "Flow finished with no child processes. If any data lakes or data hubs are attached " +
+        "to the environment, they have not been updated. Try re-running the process.";
+
+    public static final String NO_CLUSTER_STATUS = "Cluster process status is not yet available. Check again in a few minutes.";
+
+    public static final String CLUSTER_ERROR = "One or more clusters are in a failed state. Please review individual cluster " +
+        "event history/logs for more details.";
+
+    public static final String IN_PROGRESS = "Update is running in data lake/data hub clusters.";
+
+    public static final String FINISHED = "Update completed successfully.";
+
+    public static final String MISSING_CHILD_FLOWS = "Status is in an ambiguous state because one or more flows could not be queried. Try running " +
+        "the status command again in a few minutes. If this message persists, the update operation may be in a failed state.";
+
+    @ApiModelProperty(EnvironmentModelDescription.LB_UPDATE_CHILD_STATUS)
+    private List<ClusterLbUpdateStatus> clusterStatus = new ArrayList<>();
+
+    @ApiModelProperty(EnvironmentModelDescription.LB_UPDATE_STATUS)
+    private LoadBalancerUpdateStatus overallStatus = LoadBalancerUpdateStatus.NOT_STARTED;
+
+    @ApiModelProperty(EnvironmentModelDescription.LB_UPDATE_ERROR)
+    private String statusReason = NO_ERROR;
+
+    @ApiModelProperty(EnvironmentModelDescription.LB_UPDATE_FLOWID)
+    private String environmentFlowId;
+
+    public List<ClusterLbUpdateStatus> getClusterStatus() {
+        return clusterStatus;
+    }
+
+    public void setClusterStatus(List<ClusterLbUpdateStatus> clusterStatus) {
+        this.clusterStatus = clusterStatus;
+    }
+
+    public void addChildStatus(String name, String crn, String flowId, LoadBalancerUpdateStatus updateStatus, String currentState) {
+        ClusterLbUpdateStatus status = new ClusterLbUpdateStatus();
+        status.setClusterName(name);
+        status.setClusterCrn(crn);
+        status.setFlowId(flowId);
+        status.setStatus(updateStatus);
+        status.setCurrentState(currentState);
+        clusterStatus.add(status);
+    }
+
+    public LoadBalancerUpdateStatus getOverallStatus() {
+        return overallStatus;
+    }
+
+    public void setOverallStatus(LoadBalancerUpdateStatus overallStatus) {
+        this.overallStatus = overallStatus;
+    }
+
+    public String getStatusReason() {
+        return statusReason;
+    }
+
+    public void setStatusReason(String statusReason) {
+        this.statusReason = statusReason;
+    }
+
+    public String getEnvironmentFlowId() {
+        return environmentFlowId;
+    }
+
+    public void setEnvironmentFlowId(String environmentFlowId) {
+        this.environmentFlowId = environmentFlowId;
+    }
+
+    public void markEnvironmentUpdateFailed() {
+        overallStatus = LoadBalancerUpdateStatus.FAILED;
+        statusReason = ENV_ERROR;
+    }
+
+    public void markClusterUpdateFailed() {
+        overallStatus = LoadBalancerUpdateStatus.FAILED;
+        statusReason = CLUSTER_ERROR;
+    }
+
+    public void markFinishedNoChildren() {
+        overallStatus = LoadBalancerUpdateStatus.FINISHED;
+        statusReason = FINISHED_NO_CHILDREN;
+    }
+
+    public void markNoClusterStatus() {
+        overallStatus = LoadBalancerUpdateStatus.IN_PROGRESS;
+        statusReason = NO_CLUSTER_STATUS;
+    }
+
+    public void markInProgress() {
+        overallStatus = LoadBalancerUpdateStatus.IN_PROGRESS;
+        statusReason = IN_PROGRESS;
+    }
+
+    public void markFinished() {
+        overallStatus = LoadBalancerUpdateStatus.FINISHED;
+        statusReason = FINISHED;
+    }
+
+    public void markAmbiguous() {
+        overallStatus = LoadBalancerUpdateStatus.AMBIGUOUS;
+        statusReason = MISSING_CHILD_FLOWS;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        EnvironmentLbUpdateStatusResponse that = (EnvironmentLbUpdateStatusResponse) o;
+        return Objects.equals(clusterStatus, that.clusterStatus) &&
+            overallStatus == that.overallStatus &&
+            Objects.equals(statusReason, that.statusReason) &&
+            Objects.equals(environmentFlowId, that.environmentFlowId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterStatus, overallStatus, statusReason, environmentFlowId);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/LbUpdateFlowLog.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/LbUpdateFlowLog.java
@@ -1,0 +1,68 @@
+package com.sequenceiq.environment.environment.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "lbupdate_flowlog")
+public class LbUpdateFlowLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "lbupdate_flowlog_generator")
+    @SequenceGenerator(name = "lbupdate_flowlog_generator", sequenceName = "lbupdate_flowlog_id_seq", allocationSize = 1)
+    private Long id;
+
+    private String environmentCrn;
+
+    private String parentFlowId;
+
+    private String childFlowId;
+
+    private String childResourceName;
+
+    private String childResourceCrn;
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public void setEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+    }
+
+    public String getParentFlowId() {
+        return parentFlowId;
+    }
+
+    public void setParentFlowId(String parentFlowId) {
+        this.parentFlowId = parentFlowId;
+    }
+
+    public String getChildFlowId() {
+        return childFlowId;
+    }
+
+    public void setChildFlowId(String childFlowId) {
+        this.childFlowId = childFlowId;
+    }
+
+    public String getChildResourceName() {
+        return childResourceName;
+    }
+
+    public void setChildResourceName(String childResourceName) {
+        this.childResourceName = childResourceName;
+    }
+
+    public String getChildResourceCrn() {
+        return childResourceCrn;
+    }
+
+    public void setChildResourceCrn(String childResourceCrn) {
+        this.childResourceCrn = childResourceCrn;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentLoadBalancerDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentLoadBalancerDto.java
@@ -15,6 +15,8 @@ public class EnvironmentLoadBalancerDto implements Payload {
 
     private Set<String> endpointGatewaySubnetIds;
 
+    private String flowId;
+
     public void setId(Long id) {
         this.id = id;
     }
@@ -48,6 +50,14 @@ public class EnvironmentLoadBalancerDto implements Payload {
         this.endpointGatewaySubnetIds = endpointGatewaySubnetIds;
     }
 
+    public String getFlowId() {
+        return flowId;
+    }
+
+    public void setFlowId(String flowId) {
+        this.flowId = flowId;
+    }
+
     @Override
     public String toString() {
         return "EnvironmentLoadBalancerDto{" +
@@ -71,6 +81,8 @@ public class EnvironmentLoadBalancerDto implements Payload {
 
         private Set<String> endpointGatewaySubnetIds;
 
+        private String flowId;
+
         public Builder withId(Long id) {
             this.id = id;
             return this;
@@ -91,12 +103,18 @@ public class EnvironmentLoadBalancerDto implements Payload {
             return this;
         }
 
+        public Builder withFlowId(String flowId) {
+            this.flowId = flowId;
+            return this;
+        }
+
         public EnvironmentLoadBalancerDto build() {
             EnvironmentLoadBalancerDto environmentLoadBalancerDto = new EnvironmentLoadBalancerDto();
             environmentLoadBalancerDto.setId(id);
             environmentLoadBalancerDto.setEnvironmentDto(environmentDto);
             environmentLoadBalancerDto.setEndpointAccessGateway(endpointAccessGateway);
             environmentLoadBalancerDto.setEndpointGatewaySubnetIds(endpointGatewaySubnetIds);
+            environmentLoadBalancerDto.setFlowId(flowId);
             return environmentLoadBalancerDto;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/loadbalancer/LoadBalancerUpdateActions.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/loadbalancer/LoadBalancerUpdateActions.java
@@ -76,6 +76,7 @@ public class LoadBalancerUpdateActions {
                     .withEnvironmentDto(payload.getEnvironmentDto())
                     .withEndpointAccessGateway(payload.getEndpointAccessGateway())
                     .withEndpointGatewaySubnetIds(payload.getSubnetIds())
+                    .withFlowId(context.getFlowId())
                     .build();
                 sendEvent(context, LoadBalancerUpdateHandlerSelectors.STACK_UPDATE_HANDLER_EVENT.selector(), environmentLoadBalancerDto);
             }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/loadbalancer/event/LoadBalancerUpdateEvent.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/loadbalancer/event/LoadBalancerUpdateEvent.java
@@ -20,22 +20,28 @@ public class LoadBalancerUpdateEvent extends BaseNamedFlowEvent {
 
     private final Set<String> subnetIds;
 
+    private String flowId;
+
     public LoadBalancerUpdateEvent(String selector, Long resourceId, String resourceName, String resourceCrn,
-            Environment environment, EnvironmentDto environmentDto, PublicEndpointAccessGateway endpointAccessGateway, Set<String> subnetIds) {
+            Environment environment, EnvironmentDto environmentDto, PublicEndpointAccessGateway endpointAccessGateway,
+            Set<String> subnetIds, String flowId) {
         super(selector, resourceId, resourceName, resourceCrn);
         this.environment = environment;
         this.environmentDto = environmentDto;
         this.endpointAccessGateway = endpointAccessGateway;
         this.subnetIds = subnetIds;
+        this.flowId = flowId;
     }
 
-    public LoadBalancerUpdateEvent(String selector, Long resourceId, Promise<AcceptResult> accepted, String resourceName, String resourceCrn,
-            Environment environment, EnvironmentDto environmentDto, PublicEndpointAccessGateway endpointAccessGateway, Set<String> subnetIds) {
+    public LoadBalancerUpdateEvent(String selector, Long resourceId, Promise<AcceptResult> accepted, String resourceName,
+            String resourceCrn, Environment environment, EnvironmentDto environmentDto, PublicEndpointAccessGateway endpointAccessGateway,
+            Set<String> subnetIds, String flowId) {
         super(selector, resourceId, accepted, resourceName, resourceCrn);
         this.environment = environment;
         this.environmentDto = environmentDto;
         this.endpointAccessGateway = endpointAccessGateway;
         this.subnetIds = subnetIds;
+        this.flowId = flowId;
     }
 
     public Environment getEnvironment() {
@@ -52,6 +58,10 @@ public class LoadBalancerUpdateEvent extends BaseNamedFlowEvent {
 
     public Set<String> getSubnetIds() {
         return subnetIds;
+    }
+
+    public String getFlowId() {
+        return flowId;
     }
 
     public static final class LoadBalancerUpdateEventBuilder {
@@ -73,6 +83,8 @@ public class LoadBalancerUpdateEvent extends BaseNamedFlowEvent {
         private PublicEndpointAccessGateway endpointAccessGateway;
 
         private Set<String> subnetIds;
+
+        private String flowId;
 
         private LoadBalancerUpdateEventBuilder() {
         }
@@ -126,9 +138,14 @@ public class LoadBalancerUpdateEvent extends BaseNamedFlowEvent {
             return this;
         }
 
+        public LoadBalancerUpdateEventBuilder withFlowId(String flowId) {
+            this.flowId = flowId;
+            return this;
+        }
+
         public LoadBalancerUpdateEvent build() {
             LoadBalancerUpdateEvent event = new LoadBalancerUpdateEvent(selector, resourceId, accepted,
-                resourceName, resourceCrn, environment, environmentDto, endpointAccessGateway, subnetIds);
+                resourceName, resourceCrn, environment, environmentDto, endpointAccessGateway, subnetIds, flowId);
             return event;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/loadbalancer/handler/LoadBalancerStackUpdateHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/loadbalancer/handler/LoadBalancerStackUpdateHandler.java
@@ -41,7 +41,7 @@ public class LoadBalancerStackUpdateHandler extends EventSenderAwareHandler<Envi
         try {
             LOGGER.debug("Initating stack load balancer update");
             loadBalancerPollerService.updateStackWithLoadBalancer(environmentDto.getId(), environmentDto.getResourceCrn(),
-                environmentDto.getName(), environmentLoadBalancerDto.getEndpointAccessGateway());
+                environmentDto.getName(), environmentLoadBalancerDto.getEndpointAccessGateway(), environmentLoadBalancerDto.getFlowId());
 
             LOGGER.debug("Stack load balancer update complete.");
             LoadBalancerUpdateEvent loadBalancerUpdateEvent = LoadBalancerUpdateEvent.LoadBalancerUpdateEventBuilder.aLoadBalancerUpdateEvent()

--- a/environment/src/main/java/com/sequenceiq/environment/environment/repository/LbUpdateFlowLogRepository.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/repository/LbUpdateFlowLogRepository.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.environment.environment.repository;
+
+import java.util.Set;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import com.sequenceiq.environment.environment.domain.LbUpdateFlowLog;
+
+@Transactional(Transactional.TxType.REQUIRED)
+public interface LbUpdateFlowLogRepository extends CrudRepository<LbUpdateFlowLog, Long> {
+
+    Set<LbUpdateFlowLog> findByParentFlowId(@Param("parentFlowId") String parentFlowId);
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerService.java
@@ -1,26 +1,44 @@
 package com.sequenceiq.environment.environment.service;
 
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
+import static com.sequenceiq.environment.environment.service.LoadBalancerPollerService.LOAD_BALANCER_UPDATE_FAILED_STATE;
 import static java.util.Objects.requireNonNull;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.v1.environment.model.base.LoadBalancerUpdateStatus;
+import com.sequenceiq.environment.api.v1.environment.model.response.ClusterLbUpdateStatus;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentLbUpdateStatusResponse;
 import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.environment.domain.LbUpdateFlowLog;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
 import com.sequenceiq.environment.environment.flow.EnvironmentReactorFlowManager;
+import com.sequenceiq.environment.environment.flow.loadbalancer.config.LoadBalancerUpdateFlowConfig;
+import com.sequenceiq.environment.network.service.LbUpdateFlowLogService;
 import com.sequenceiq.environment.network.service.LoadBalancerEntitlementService;
+import com.sequenceiq.flow.api.FlowEndpoint;
+import com.sequenceiq.flow.api.model.FlowLogResponse;
+import com.sequenceiq.flow.service.FlowService;
 
 @Service
 public class EnvironmentLoadBalancerService {
+
+    static final String UNKNOWN_STATE = "UNKNOWN";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentLoadBalancerService.class);
 
@@ -32,15 +50,27 @@ public class EnvironmentLoadBalancerService {
 
     private final LoadBalancerEntitlementService loadBalancerEntitlementService;
 
+    private final FlowService flowService;
+
+    private final FlowEndpoint flowEndpoint;
+
+    private final LbUpdateFlowLogService lbUpdateFlowLogService;
+
     public EnvironmentLoadBalancerService(
             EnvironmentService environmentService,
             EnvironmentReactorFlowManager reactorFlowManager,
             EntitlementService entitlementService,
-            LoadBalancerEntitlementService loadBalancerEntitlementService) {
+            LoadBalancerEntitlementService loadBalancerEntitlementService,
+            FlowService flowService,
+            FlowEndpoint flowEndpoint,
+            LbUpdateFlowLogService lbUpdateFlowLogService) {
         this.environmentService = environmentService;
         this.reactorFlowManager = reactorFlowManager;
         this.entitlementService = entitlementService;
         this.loadBalancerEntitlementService = loadBalancerEntitlementService;
+        this.flowService = flowService;
+        this.flowEndpoint = flowEndpoint;
+        this.lbUpdateFlowLogService = lbUpdateFlowLogService;
     }
 
     public void updateLoadBalancerInEnvironmentAndStacks(EnvironmentDto environmentDto, EnvironmentLoadBalancerDto environmentLbDto) {
@@ -69,6 +99,116 @@ public class EnvironmentLoadBalancerService {
                 environmentLbDto.getEndpointAccessGateway(), environmentLbDto.getEndpointGatewaySubnetIds(), userCrn);
     }
 
+    public EnvironmentLbUpdateStatusResponse getLoadBalancerUpdateStatus(EnvironmentDto environmentDto) {
+        FlowLogResponse flowLogResponse = getLatestLoadBalancerUpdateFlowConfigLogs(environmentDto.getResourceCrn());
+        if (flowLogResponse == null) {
+            throw new BadRequestException("No LoadBalancerUpdateFlowConfig flows found on " + environmentDto.getResourceCrn());
+        }
+
+        String flowId = flowLogResponse.getFlowId();
+        EnvironmentLbUpdateStatusResponse envLbUpdateStatusResponse = new EnvironmentLbUpdateStatusResponse();
+        envLbUpdateStatusResponse.setEnvironmentFlowId(flowId);
+        List<FlowLogResponse> flowLogResponses = flowService.getFlowLogsByFlowId(flowId);
+
+        LOGGER.debug("Checking if status information has already been saved to database.");
+        Set<LbUpdateFlowLog> lbUpdateFlowLogs = lbUpdateFlowLogService.findByParentFlowId(flowId);
+        if (lbUpdateFlowLogs.isEmpty()) {
+            LOGGER.debug("No database entries found. Child processes may not have started. Getting parent status instead.");
+            convertParentFlowLogs(envLbUpdateStatusResponse, flowLogResponses, flowId);
+        } else {
+            LOGGER.debug("Found database entries for child cluster update processes.");
+            convertChildFlowLogs(envLbUpdateStatusResponse, lbUpdateFlowLogs, flowId);
+        }
+
+        return envLbUpdateStatusResponse;
+    }
+
+    @VisibleForTesting
+    FlowLogResponse getLatestLoadBalancerUpdateFlowConfigLogs(String environmentCrn) {
+        return getLatestFlowLog(flowService.getFlowLogsByCrnAndType(environmentCrn, LoadBalancerUpdateFlowConfig.class));
+    }
+
+    private FlowLogResponse getLatestFlowLog(List<FlowLogResponse> flowLogResponses) {
+        return flowLogResponses.stream()
+            .max(Comparator.comparing(FlowLogResponse::getCreated))
+            .orElse(null);
+    }
+
+    private void convertParentFlowLogs(EnvironmentLbUpdateStatusResponse envLbUpdateStatusResponse,
+            List<FlowLogResponse> flowLogResponses, String flowId) {
+        if (hasFlowFailed(flowLogResponses)) {
+            LOGGER.debug("Found failed parent flow {}", flowId);
+            envLbUpdateStatusResponse.markEnvironmentUpdateFailed();
+        } else if (!hasActiveFlow(flowId)) {
+            LOGGER.debug("Found finished parent flow [{}] with no child process status", flowId);
+            envLbUpdateStatusResponse.markFinishedNoChildren();
+        } else {
+            LOGGER.debug("Flow {} is still running, but has no child status to report.", flowId);
+            envLbUpdateStatusResponse.markNoClusterStatus();
+        }
+    }
+
+    private void convertChildFlowLogs(EnvironmentLbUpdateStatusResponse envLbUpdateStatusResponse, Set<LbUpdateFlowLog> lbUpdateFlowLogs, String flowId) {
+        for (LbUpdateFlowLog lbUpdateFlowLog : lbUpdateFlowLogs) {
+            String childName = lbUpdateFlowLog.getChildResourceName();
+            String childCrn = lbUpdateFlowLog.getChildResourceCrn();
+            String childFlowId = lbUpdateFlowLog.getChildFlowId();
+            if (childFlowId == null) {
+                LOGGER.debug("Flow for cluster {} failed to start", childName);
+                envLbUpdateStatusResponse.addChildStatus(childName, childCrn, null, LoadBalancerUpdateStatus.COULD_NOT_START, null);
+            } else {
+                LOGGER.debug("Fetching flow logs for child {} flow {}", childName, childFlowId);
+                List<FlowLogResponse> childFlowLogResponses = ThreadBasedUserCrnProvider.doAsInternalActor(() ->
+                    flowEndpoint.getFlowLogsByFlowId(childFlowId));
+                updateChildFlowStatus(childFlowLogResponses, envLbUpdateStatusResponse, lbUpdateFlowLog);
+            }
+        }
+        updateParentFlowStatus(envLbUpdateStatusResponse);
+    }
+
+    private void updateChildFlowStatus(List<FlowLogResponse> childFlowLogResponses, EnvironmentLbUpdateStatusResponse envLbUpdateStatusResponse,
+            LbUpdateFlowLog lbUpdateFlowLog) {
+        String childName = lbUpdateFlowLog.getChildResourceName();
+        String childCrn = lbUpdateFlowLog.getChildResourceCrn();
+        String childFlowId = lbUpdateFlowLog.getChildFlowId();
+        FlowLogResponse flowLogResponse = getLatestFlowLog(childFlowLogResponses);
+        String currentState = UNKNOWN_STATE;
+        if (flowLogResponse != null) {
+            currentState = flowLogResponse.getCurrentState();
+        }
+
+        if (childFlowLogResponses.isEmpty()) {
+            LOGGER.debug("Did not find matching flow logs for flow id {}", childFlowId);
+            envLbUpdateStatusResponse.addChildStatus(childName, childCrn, childFlowId, LoadBalancerUpdateStatus.AMBIGUOUS, currentState);
+        } else {
+            if (hasFlowFailed(childFlowLogResponses)) {
+                LOGGER.debug("Found failed flow [{}] for resource {}, crn {}", childFlowId, childName, childCrn);
+                envLbUpdateStatusResponse.addChildStatus(childName, childCrn, childFlowId, LoadBalancerUpdateStatus.FAILED, currentState);
+            } else if (!hasActiveFlow(childFlowId)) {
+                LOGGER.debug("Found finished flow [{}] for resource {}, crn {}", childFlowId, childName, childCrn);
+                envLbUpdateStatusResponse.addChildStatus(childName, childCrn, childFlowId, LoadBalancerUpdateStatus.FINISHED, currentState);
+            } else {
+                LOGGER.debug("Flow {} still in progress for resource {}, crn {}", childFlowId, childName, childCrn);
+                envLbUpdateStatusResponse.addChildStatus(childName, childCrn, childFlowId, LoadBalancerUpdateStatus.IN_PROGRESS, currentState);
+            }
+        }
+    }
+
+    private void updateParentFlowStatus(EnvironmentLbUpdateStatusResponse envLbUpdateStatusResponse) {
+        List<LoadBalancerUpdateStatus> childStatuses = envLbUpdateStatusResponse.getClusterStatus().stream()
+            .map(ClusterLbUpdateStatus::getStatus)
+            .collect(Collectors.toList());
+        if (childStatuses.stream().anyMatch(LoadBalancerUpdateStatus::isErrorCase)) {
+            envLbUpdateStatusResponse.markClusterUpdateFailed();
+        } else if (childStatuses.stream().anyMatch(LoadBalancerUpdateStatus.AMBIGUOUS::equals)) {
+            envLbUpdateStatusResponse.markAmbiguous();
+        } else if (childStatuses.stream().allMatch(LoadBalancerUpdateStatus.FINISHED::equals)) {
+            envLbUpdateStatusResponse.markFinished();
+        } else {
+            envLbUpdateStatusResponse.markInProgress();
+        }
+    }
+
     private boolean isLoadBalancerEnabledForDatalake(String accountId, String cloudPlatform, PublicEndpointAccessGateway endpointEnum) {
         return !isLoadBalancerEntitlementRequiredForCloudProvider(cloudPlatform) ||
                 entitlementService.datalakeLoadBalancerEnabled(accountId) ||
@@ -77,5 +217,14 @@ public class EnvironmentLoadBalancerService {
 
     private boolean isLoadBalancerEntitlementRequiredForCloudProvider(String cloudPlatform) {
         return !(AWS.equalsIgnoreCase(cloudPlatform));
+    }
+
+    private boolean hasFlowFailed(List<FlowLogResponse> flowLogs) {
+        return flowLogs.stream().map(FlowLogResponse::getCurrentState).anyMatch(LOAD_BALANCER_UPDATE_FAILED_STATE::equals);
+    }
+
+    private Boolean hasActiveFlow(String flowId) {
+        return ThreadBasedUserCrnProvider.doAsInternalActor(() ->
+            flowEndpoint.hasFlowRunningByFlowId(flowId).getHasActiveFlow());
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/LoadBalancerPollerService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/LoadBalancerPollerService.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.environment.environment.service;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -19,10 +22,12 @@ import com.dyngr.exception.PollerStoppedException;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.environment.domain.LbUpdateFlowLog;
 import com.sequenceiq.environment.environment.service.datahub.DatahubService;
 import com.sequenceiq.environment.environment.service.sdx.SdxService;
 import com.sequenceiq.environment.environment.service.stack.StackService;
 import com.sequenceiq.environment.exception.UpdateFailedException;
+import com.sequenceiq.environment.network.service.LbUpdateFlowLogService;
 import com.sequenceiq.environment.util.PollingConfig;
 import com.sequenceiq.flow.api.FlowEndpoint;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
@@ -44,6 +49,8 @@ public class LoadBalancerPollerService {
 
     private final FlowEndpoint flowEndpoint;
 
+    private final LbUpdateFlowLogService lbUpdateFlowLogService;
+
     @Value("${env.loadbalancer.update.polling.maximum.seconds:7200}")
     private Integer maxTime;
 
@@ -54,16 +61,18 @@ public class LoadBalancerPollerService {
             DatahubService datahubService,
             SdxService sdxService,
             StackService stackService,
-            FlowEndpoint flowEndpoint) {
+            FlowEndpoint flowEndpoint,
+            LbUpdateFlowLogService lbUpdateFlowLogService) {
         this.datahubService = datahubService;
         this.sdxService = sdxService;
         this.stackService = stackService;
         this.flowEndpoint = flowEndpoint;
+        this.lbUpdateFlowLogService = lbUpdateFlowLogService;
     }
 
     public void updateStackWithLoadBalancer(Long environmentId, String environmentCrn, String environmentName,
-            PublicEndpointAccessGateway endpointAccessGateway) {
-        Set<String> stackNames;
+            PublicEndpointAccessGateway endpointAccessGateway, String flowId) {
+        Map<String, String> stackNames;
         if (PublicEndpointAccessGateway.ENABLED.equals(endpointAccessGateway)) {
             LOGGER.debug("Updating load balancers for endpoint gateway on Data Lake and Data Hubs.");
             stackNames = getDataLakeAndDataHubNames(environmentCrn, environmentName);
@@ -77,7 +86,8 @@ public class LoadBalancerPollerService {
             LOGGER.debug("No Data Lake or Data Hub clusters found for environment.");
         } else {
             try {
-                List<FlowIdentifier> failedFlows = waitStackLoadBalancerUpdate(getPollingConfig(), stackNames, environmentName);
+                Map<String, FlowIdentifier> failedFlows = waitStackLoadBalancerUpdate(getPollingConfig(), stackNames, environmentName,
+                    flowId, environmentCrn);
                 LOGGER.debug("Data Lake and Data Hub load balancer update finished.");
                 if (!failedFlows.isEmpty()) {
                     LOGGER.error("Found failed flows for Data Lake or Data Hub load balancer updates: " + failedFlows);
@@ -89,12 +99,36 @@ public class LoadBalancerPollerService {
         }
     }
 
-    private List<FlowIdentifier> waitStackLoadBalancerUpdate(PollingConfig pollingConfig, Set<String> stackNames, String environmentName) {
-        LOGGER.debug("Attempting to initiate load balancer update for {} clusters for environment id {}",
-            stackNames.size(), environmentName);
-        List<FlowIdentifier> flowIdentifiers = stackService.updateLoadBalancer(stackNames);
-        LOGGER.debug("Monitoring load balancer update flows: {}", flowIdentifiers);
+    private Map<String, FlowIdentifier> waitStackLoadBalancerUpdate(PollingConfig pollingConfig, Map<String, String> stackNameCrnMap,
+            String environmentName, String parentFlowId, String environmentCrn) {
 
+        LOGGER.debug("Attempting to initiate load balancer update for {} clusters for environment id {}",
+            stackNameCrnMap.size(), environmentName);
+        Map<String, FlowIdentifier> flowIdentifiers = stackService.updateLoadBalancer(stackNameCrnMap.keySet());
+
+        LOGGER.debug("Creating database entries to track update status.");
+        List<LbUpdateFlowLog> lbUpdateFlowLogs = new ArrayList<>();
+        flowIdentifiers.forEach((name, flowId) -> {
+            LbUpdateFlowLog lbUpdateFlowLog = new LbUpdateFlowLog();
+            lbUpdateFlowLog.setParentFlowId(parentFlowId);
+            lbUpdateFlowLog.setChildResourceName(name);
+            lbUpdateFlowLog.setChildResourceCrn(stackNameCrnMap.get(name));
+            lbUpdateFlowLog.setChildFlowId(flowId == null ? null : flowId.getPollableId());
+            lbUpdateFlowLog.setEnvironmentCrn(environmentCrn);
+            lbUpdateFlowLogs.add(lbUpdateFlowLog);
+        });
+        lbUpdateFlowLogService.saveAll(lbUpdateFlowLogs);
+
+        LOGGER.debug("Checking to see if all flows were started correctly.");
+        Set<String> failedClusters = flowIdentifiers.entrySet().stream()
+            .filter(entry -> entry.getValue() == null)
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toSet());
+        if (!failedClusters.isEmpty()) {
+            LOGGER.error("Flows for clusters [{}] failed to start.", failedClusters);
+        }
+
+        LOGGER.debug("Monitoring load balancer update flows: {}", flowIdentifiers);
         LOGGER.debug("Starting poller to check all data lake and data hub stacks for environment {} are updated", environmentName);
         return Polling.stopAfterDelay(pollingConfig.getTimeout(), pollingConfig.getTimeoutTimeUnit())
             .stopIfException(pollingConfig.getStopPollingIfExceptionOccured())
@@ -102,26 +136,32 @@ public class LoadBalancerPollerService {
             .run(() -> periodicCheckForCompletion(flowIdentifiers));
     }
 
-    private AttemptResult<List<FlowIdentifier>> periodicCheckForCompletion(List<FlowIdentifier> flowIdentifiers) {
+    private AttemptResult<Map<String, FlowIdentifier>> periodicCheckForCompletion(Map<String, FlowIdentifier> flowIdentifiers) {
         try {
             boolean anyFlowsActive = false;
-            for (FlowIdentifier flowIdentifier: flowIdentifiers) {
-                Boolean hasActiveFlow = ThreadBasedUserCrnProvider.doAsInternalActor(() ->
-                    flowEndpoint.hasFlowRunningByFlowId(flowIdentifier.getPollableId()).getHasActiveFlow());
-                if (hasActiveFlow) {
-                    LOGGER.debug("Flow {} is still running", flowIdentifier.getPollableId());
-                } else {
-                    LOGGER.debug("Flow {} is complete", flowIdentifier.getPollableId());
+            for (Map.Entry<String, FlowIdentifier> entry : flowIdentifiers.entrySet()) {
+                FlowIdentifier flowIdentifier = entry.getValue();
+                if (flowIdentifier != null) {
+                    Boolean hasActiveFlow = ThreadBasedUserCrnProvider.doAsInternalActor(() ->
+                        flowEndpoint.hasFlowRunningByFlowId(flowIdentifier.getPollableId()).getHasActiveFlow());
+                    if (hasActiveFlow) {
+                        LOGGER.debug("Flow {} is still running", flowIdentifier.getPollableId());
+                    } else {
+                        LOGGER.debug("Flow {} is complete", flowIdentifier.getPollableId());
+                    }
+                    anyFlowsActive = anyFlowsActive || hasActiveFlow;
                 }
-                anyFlowsActive = anyFlowsActive || hasActiveFlow;
             }
             if (anyFlowsActive) {
                 return AttemptResults.justContinue();
             } else {
-                List<FlowIdentifier> failedFlows = flowIdentifiers.stream()
-                    .filter(flowId -> hasFlowFailed(ThreadBasedUserCrnProvider.doAsInternalActor(() ->
-                        flowEndpoint.getFlowLogsByFlowId(flowId.getPollableId()))))
-                    .collect(Collectors.toList());
+                Map<String, FlowIdentifier> failedFlows = new HashMap<>();
+                for (Map.Entry<String, FlowIdentifier> entry : flowIdentifiers.entrySet()) {
+                    if (entry.getValue() == null || hasFlowFailed(ThreadBasedUserCrnProvider.doAsInternalActor(() ->
+                        flowEndpoint.getFlowLogsByFlowId(entry.getValue().getPollableId())))) {
+                        failedFlows.put(entry.getKey(), entry.getValue());
+                    }
+                }
                 return AttemptResults.finishWith(failedFlows);
             }
         } catch (Exception e) {
@@ -141,22 +181,25 @@ public class LoadBalancerPollerService {
             .build();
     }
 
-    private Set<String> getDataLakeAndDataHubNames(String environmentCrn, String environmentName) {
-        return Stream.of(getAttachedDatahubClusters(environmentCrn), getAttachedDatalakeClusters(environmentName))
-            .flatMap(Collection::stream)
-            .collect(Collectors.toSet());
+    private Map<String, String> getDataLakeAndDataHubNames(String environmentCrn, String environmentName) {
+        Map<String, String> dataHubs = getAttachedDatahubClusters(environmentCrn);
+        Map<String, String> dataLakes = getAttachedDatalakeClusters(environmentName);
+        return Stream.concat(dataHubs.entrySet().stream(), dataLakes.entrySet().stream())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
-    private Set<String> getAttachedDatahubClusters(String environmentCrn) {
+    private Map<String, String> getAttachedDatahubClusters(String environmentCrn) {
         LOGGER.debug("Getting Datahub clusters for environment: '{}'", environmentCrn);
         Collection<StackViewV4Response> responses = datahubService.list(environmentCrn).getResponses();
-        return responses.stream().map(StackViewV4Response::getName).collect(Collectors.toSet());
+        return responses.stream()
+            .collect(Collectors.toMap(StackViewV4Response::getName, StackViewV4Response::getCrn));
     }
 
-    private Set<String> getAttachedDatalakeClusters(String environmentName) {
+    private Map<String, String> getAttachedDatalakeClusters(String environmentName) {
         LOGGER.debug("Getting SDX clusters for environment: '{}'", environmentName);
         Collection<SdxClusterResponse> responses = sdxService.list(environmentName);
-        return responses.stream().map(SdxClusterResponse::getName).collect(Collectors.toSet());
+        return responses.stream()
+            .collect(Collectors.toMap(SdxClusterResponse::getName, SdxClusterResponse::getCrn));
     }
 
     private boolean hasFlowFailed(List<FlowLogResponse> flowLogs) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/stack/StackService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/stack/StackService.java
@@ -1,8 +1,9 @@
 package com.sequenceiq.environment.environment.service.stack;
 
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.ws.rs.WebApplicationException;
@@ -70,19 +71,19 @@ public class StackService {
         }
     }
 
-    public List<FlowIdentifier> updateLoadBalancer(Set<String> names) {
+    public Map<String, FlowIdentifier> updateLoadBalancer(Set<String> names) {
         String initiatorUserCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        List<FlowIdentifier> flowIdentifiers = new ArrayList<>();
+        Map<String, FlowIdentifier> flowIdentifiers = new HashMap<>();
         for (String name : names) {
             try {
                 ThreadBasedUserCrnProvider.doAsInternalActor(() -> {
                     FlowIdentifier flowidentifier = stackV4Endpoint.updateLoadBalancersInternal(0L, name, initiatorUserCrn);
-                    flowIdentifiers.add(flowidentifier);
+                    flowIdentifiers.put(name, flowidentifier);
                 });
             } catch (WebApplicationException e) {
                 String errorMessage = messageExtractor.getErrorMessage(e);
-                LOGGER.error(String.format("Failed update load balancer for stack %s due to: '%s'.", name, errorMessage), e);
-                throw e;
+                LOGGER.error(String.format("Failed to update load balancer for stack %s due to: '%s'.", name, errorMessage), e);
+                flowIdentifiers.put(name, null);
             }
         }
         return flowIdentifiers;

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
@@ -52,6 +52,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLo
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentLbUpdateStatusResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponses;
 import com.sequenceiq.environment.authorization.EnvironmentFiltering;
@@ -395,6 +396,23 @@ public class EnvironmentController implements EnvironmentEndpoint {
         EnvironmentDto environmentDto = environmentService.getByCrnAndAccountId(crn, accountId);
         EnvironmentLoadBalancerDto environmentLoadBalancerDto = environmentApiConverter.initLoadBalancerDto(request);
         environmentLoadBalancerService.updateLoadBalancerInEnvironmentAndStacks(environmentDto, environmentLoadBalancerDto);
+    }
+
+    @Override
+    @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)
+    public EnvironmentLbUpdateStatusResponse getLoadBalancerUpdateStatusByEnvironmentName(@ResourceName String envName) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        EnvironmentDto environmentDto = environmentService.getByNameAndAccountId(envName, accountId);
+        return environmentLoadBalancerService.getLoadBalancerUpdateStatus(environmentDto);
+    }
+
+    @Override
+    @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_ENVIRONMENT)
+    public EnvironmentLbUpdateStatusResponse getLoadBalancerUpdateStatusByEnvironmentCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+            @ResourceCrn @TenantAwareParam String crn) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        EnvironmentDto environmentDto = environmentService.getByCrnAndAccountId(crn, accountId);
+        return environmentLoadBalancerService.getLoadBalancerUpdateStatus(environmentDto);
     }
 
     @Override

--- a/environment/src/main/java/com/sequenceiq/environment/network/service/LbUpdateFlowLogService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/network/service/LbUpdateFlowLogService.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.environment.network.service;
+
+import java.util.Set;
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.environment.environment.domain.LbUpdateFlowLog;
+import com.sequenceiq.environment.environment.repository.LbUpdateFlowLogRepository;
+
+@Service
+public class LbUpdateFlowLogService {
+
+    @Inject
+    private LbUpdateFlowLogRepository repository;
+
+    public LbUpdateFlowLog save(LbUpdateFlowLog lbUpdateFlowLog) {
+        return repository.save(lbUpdateFlowLog);
+    }
+
+    public Iterable<LbUpdateFlowLog> saveAll(Iterable<LbUpdateFlowLog> lbUpdateFlowLogs) {
+        return repository.saveAll(lbUpdateFlowLogs);
+    }
+
+    public Set<LbUpdateFlowLog> findByParentFlowId(String parentFlowId) {
+        return repository.findByParentFlowId(parentFlowId);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/dao/converter/LoadBalancerUpdateStatusConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/dao/converter/LoadBalancerUpdateStatusConverter.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.environment.parameters.dao.converter;
+
+import com.sequenceiq.cloudbreak.converter.DefaultEnumConverter;
+import com.sequenceiq.environment.api.v1.environment.model.base.LoadBalancerUpdateStatus;
+
+public class LoadBalancerUpdateStatusConverter extends DefaultEnumConverter<LoadBalancerUpdateStatus> {
+
+    @Override
+    public LoadBalancerUpdateStatus getDefault() {
+        return LoadBalancerUpdateStatus.NOT_STARTED;
+    }
+}

--- a/environment/src/main/resources/schema/app/20210615153347_CB-13156_Add_flow_tracking_table_for_update_load_balancers_API.sql
+++ b/environment/src/main/resources/schema/app/20210615153347_CB-13156_Add_flow_tracking_table_for_update_load_balancers_API.sql
@@ -1,0 +1,17 @@
+-- // CB-13156 Add flow tracking table for update_load_balancers API
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE IF NOT EXISTS lbupdate_flowlog (
+    id                  bigserial NOT NULL,
+    environmentcrn      character varying(255),
+    parentflowid        character varying(255),
+    childflowid         character varying(255),
+    childresourcename   character varying(255),
+    childresourcecrn    character varying(255),
+    PRIMARY KEY (id)
+);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP TABLE IF EXISTS lbupdate_flowlog;

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentLoadBalancerServiceTest.java
@@ -1,15 +1,21 @@
 package com.sequenceiq.environment.environment.service;
 
+import static com.sequenceiq.environment.environment.service.EnvironmentLoadBalancerService.UNKNOWN_STATE;
+import static com.sequenceiq.environment.environment.service.LoadBalancerPollerService.LOAD_BALANCER_UPDATE_FAILED_STATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,11 +28,20 @@ import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.api.v1.environment.model.base.LoadBalancerUpdateStatus;
+import com.sequenceiq.environment.api.v1.environment.model.response.ClusterLbUpdateStatus;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentLbUpdateStatusResponse;
 import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.environment.domain.LbUpdateFlowLog;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
 import com.sequenceiq.environment.environment.flow.EnvironmentReactorFlowManager;
+import com.sequenceiq.environment.network.service.LbUpdateFlowLogService;
 import com.sequenceiq.environment.network.service.LoadBalancerEntitlementService;
+import com.sequenceiq.flow.api.FlowEndpoint;
+import com.sequenceiq.flow.api.model.FlowCheckResponse;
+import com.sequenceiq.flow.api.model.FlowLogResponse;
+import com.sequenceiq.flow.service.FlowService;
 
 @ExtendWith(SpringExtension.class)
 public class EnvironmentLoadBalancerServiceTest {
@@ -36,6 +51,16 @@ public class EnvironmentLoadBalancerServiceTest {
     private static final String ENV_NAME = "environment-name";
 
     private static final String ENV_CRN = "crn:cdp:environments:us-west-1:accountId:environment:4c5ba74b-c35e-45e9-9f47-123456789876";
+
+    private static final String FLOW_ID = "flowid-1";
+
+    private static final String ENVIRONMENT_UPDATE_STATE = "ENVIRONMENT_UPDATE_STATE";
+
+    private static final String STACK_UPDATE_STATE = "STACK_UPDATE_STATE";
+
+    private static final String CHILD_FLOW_ID1 = "childflowid-1";
+
+    private static final String CHILD_FLOW_ID2 = "childflowid-2";
 
     @Mock
     private EnvironmentService environmentService;
@@ -48,6 +73,15 @@ public class EnvironmentLoadBalancerServiceTest {
 
     @Mock
     private LoadBalancerEntitlementService loadBalancerEntitlementService;
+
+    @Mock
+    private FlowService flowService;
+
+    @Mock
+    private FlowEndpoint flowEndpoint;
+
+    @Mock
+    private LbUpdateFlowLogService lbUpdateFlowLogService;
 
     @InjectMocks
     private EnvironmentLoadBalancerService underTest;
@@ -141,5 +175,364 @@ public class EnvironmentLoadBalancerServiceTest {
         });
 
         assertEquals(expectedError, exception[0].getMessage());
+    }
+
+    @Test
+    public void testFlowStartedNoChildren() {
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withName(ENV_NAME)
+            .withResourceCrn(ENV_CRN)
+            .build();
+        FlowLogResponse flowLogResponse = new FlowLogResponse();
+        flowLogResponse.setCreated(1L);
+        flowLogResponse.setFlowId(FLOW_ID);
+        flowLogResponse.setCurrentState(ENVIRONMENT_UPDATE_STATE);
+        List<FlowLogResponse> flowLogResponses = List.of(flowLogResponse);
+        FlowCheckResponse flowCheckResponse = new FlowCheckResponse();
+        flowCheckResponse.setHasActiveFlow(true);
+
+        when(lbUpdateFlowLogService.findByParentFlowId(any())).thenReturn(Set.of());
+        when(flowService.getFlowLogsByCrnAndType(any(), any())).thenReturn(flowLogResponses);
+        when(flowService.getFlowLogsByFlowId(eq(FLOW_ID))).thenReturn(flowLogResponses);
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(FLOW_ID))).thenReturn(flowCheckResponse);
+
+        EnvironmentLbUpdateStatusResponse response = underTest.getLoadBalancerUpdateStatus(environmentDto);
+
+        assertEquals(LoadBalancerUpdateStatus.IN_PROGRESS, response.getOverallStatus());
+        assertEquals(EnvironmentLbUpdateStatusResponse.NO_CLUSTER_STATUS, response.getStatusReason());
+        assertEquals(FLOW_ID, response.getEnvironmentFlowId());
+        assertTrue(response.getClusterStatus().isEmpty());
+    }
+
+    @Test
+    public void testFlowInFailedState() {
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withName(ENV_NAME)
+            .withResourceCrn(ENV_CRN)
+            .build();
+        FlowLogResponse flowLogResponse = new FlowLogResponse();
+        flowLogResponse.setCreated(1L);
+        flowLogResponse.setFlowId(FLOW_ID);
+        flowLogResponse.setCurrentState(LOAD_BALANCER_UPDATE_FAILED_STATE);
+        List<FlowLogResponse> flowLogResponses = List.of(flowLogResponse);
+        FlowCheckResponse flowCheckResponse = new FlowCheckResponse();
+        flowCheckResponse.setHasActiveFlow(true);
+
+        when(lbUpdateFlowLogService.findByParentFlowId(any())).thenReturn(Set.of());
+        when(flowService.getFlowLogsByCrnAndType(any(), any())).thenReturn(flowLogResponses);
+        when(flowService.getFlowLogsByFlowId(eq(FLOW_ID))).thenReturn(flowLogResponses);
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(FLOW_ID))).thenReturn(flowCheckResponse);
+
+        EnvironmentLbUpdateStatusResponse response = underTest.getLoadBalancerUpdateStatus(environmentDto);
+
+        assertEquals(LoadBalancerUpdateStatus.FAILED, response.getOverallStatus());
+        assertEquals(EnvironmentLbUpdateStatusResponse.ENV_ERROR, response.getStatusReason());
+        assertEquals(FLOW_ID, response.getEnvironmentFlowId());
+        assertTrue(response.getClusterStatus().isEmpty());
+    }
+
+    @Test
+    public void testFlowFinishedNoChildren() {
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withName(ENV_NAME)
+            .withResourceCrn(ENV_CRN)
+            .build();
+        FlowLogResponse flowLogResponse = new FlowLogResponse();
+        flowLogResponse.setCreated(1L);
+        flowLogResponse.setFlowId(FLOW_ID);
+        flowLogResponse.setCurrentState(ENVIRONMENT_UPDATE_STATE);
+        List<FlowLogResponse> flowLogResponses = List.of(flowLogResponse);
+        FlowCheckResponse flowCheckResponse = new FlowCheckResponse();
+        flowCheckResponse.setHasActiveFlow(false);
+
+        when(lbUpdateFlowLogService.findByParentFlowId(any())).thenReturn(Set.of());
+        when(flowService.getFlowLogsByCrnAndType(any(), any())).thenReturn(flowLogResponses);
+        when(flowService.getFlowLogsByFlowId(eq(FLOW_ID))).thenReturn(flowLogResponses);
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(FLOW_ID))).thenReturn(flowCheckResponse);
+
+        EnvironmentLbUpdateStatusResponse response = underTest.getLoadBalancerUpdateStatus(environmentDto);
+
+        assertEquals(LoadBalancerUpdateStatus.FINISHED, response.getOverallStatus());
+        assertEquals(EnvironmentLbUpdateStatusResponse.FINISHED_NO_CHILDREN, response.getStatusReason());
+        assertEquals(FLOW_ID, response.getEnvironmentFlowId());
+        assertTrue(response.getClusterStatus().isEmpty());
+    }
+
+    @Test
+    public void testNoEnvFlow() {
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withName(ENV_NAME)
+            .withResourceCrn(ENV_CRN)
+            .build();
+        String expectedError = "No LoadBalancerUpdateFlowConfig flows found on " + ENV_CRN;
+
+        when(lbUpdateFlowLogService.findByParentFlowId(any())).thenReturn(Set.of());
+        when(flowService.getFlowLogsByCrnAndType(any(), any())).thenReturn(List.of());
+
+        BadRequestException exception = assertThrows(BadRequestException.class, () ->
+            underTest.getLoadBalancerUpdateStatus(environmentDto));
+
+        assertEquals(expectedError, exception.getMessage());
+    }
+
+    @Test
+    public void testAllChildrenInProgress() {
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withName(ENV_NAME)
+            .withResourceCrn(ENV_CRN)
+            .build();
+        FlowLogResponse parentFlowLogResponse = createFlowLogResponse(FLOW_ID, ENVIRONMENT_UPDATE_STATE);
+        FlowLogResponse child1FlowLogResponse = createFlowLogResponse(CHILD_FLOW_ID1, STACK_UPDATE_STATE);
+        FlowCheckResponse child1FlowCheckResponse = createFlowCheckResponse(true);
+        FlowLogResponse child2FlowLogResponse = createFlowLogResponse(CHILD_FLOW_ID2, STACK_UPDATE_STATE);
+        FlowCheckResponse child2FlowCheckResponse = createFlowCheckResponse(true);
+        LbUpdateFlowLog lbUpdateFlowLog1 = createLbUpdateFlowLog(CHILD_FLOW_ID1);
+        LbUpdateFlowLog lbUpdateFlowLog2 = createLbUpdateFlowLog(CHILD_FLOW_ID2);
+
+        ClusterLbUpdateStatus expectedChild1Status = createClusterLbUpdateStatus(STACK_UPDATE_STATE,
+            LoadBalancerUpdateStatus.IN_PROGRESS, CHILD_FLOW_ID1);
+        ClusterLbUpdateStatus expectedChild2Status = createClusterLbUpdateStatus(STACK_UPDATE_STATE,
+            LoadBalancerUpdateStatus.IN_PROGRESS, CHILD_FLOW_ID2);
+
+        when(lbUpdateFlowLogService.findByParentFlowId(any())).thenReturn(Set.of(lbUpdateFlowLog1, lbUpdateFlowLog2));
+        when(flowService.getFlowLogsByCrnAndType(any(), any())).thenReturn(List.of(parentFlowLogResponse));
+        when(flowService.getFlowLogsByFlowId(eq(FLOW_ID))).thenReturn(List.of(parentFlowLogResponse));
+        when(flowEndpoint.getFlowLogsByFlowId(eq(CHILD_FLOW_ID1))).thenReturn(List.of(child1FlowLogResponse));
+        when(flowEndpoint.getFlowLogsByFlowId(eq(CHILD_FLOW_ID2))).thenReturn(List.of(child2FlowLogResponse));
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(CHILD_FLOW_ID1))).thenReturn(child1FlowCheckResponse);
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(CHILD_FLOW_ID2))).thenReturn(child2FlowCheckResponse);
+
+        EnvironmentLbUpdateStatusResponse response = underTest.getLoadBalancerUpdateStatus(environmentDto);
+
+        assertEquals(LoadBalancerUpdateStatus.IN_PROGRESS, response.getOverallStatus());
+        assertEquals(EnvironmentLbUpdateStatusResponse.IN_PROGRESS, response.getStatusReason());
+        assertEquals(FLOW_ID, response.getEnvironmentFlowId());
+        assertEquals(2, response.getClusterStatus().size());
+        assertTrue(response.getClusterStatus().containsAll(Set.of(expectedChild1Status, expectedChild2Status)));
+    }
+
+    @Test
+    public void testOneChildInProgress() {
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withName(ENV_NAME)
+            .withResourceCrn(ENV_CRN)
+            .build();
+        FlowLogResponse parentFlowLogResponse = createFlowLogResponse(FLOW_ID, ENVIRONMENT_UPDATE_STATE);
+        FlowLogResponse child1FlowLogResponse = createFlowLogResponse(CHILD_FLOW_ID1, STACK_UPDATE_STATE);
+        FlowCheckResponse child1FlowCheckResponse = createFlowCheckResponse(true);
+        FlowLogResponse child2FlowLogResponse = createFlowLogResponse(CHILD_FLOW_ID2, STACK_UPDATE_STATE);
+        FlowCheckResponse child2FlowCheckResponse = createFlowCheckResponse(false);
+        LbUpdateFlowLog lbUpdateFlowLog1 = createLbUpdateFlowLog(CHILD_FLOW_ID1);
+        LbUpdateFlowLog lbUpdateFlowLog2 = createLbUpdateFlowLog(CHILD_FLOW_ID2);
+
+        ClusterLbUpdateStatus expectedChild1Status = createClusterLbUpdateStatus(STACK_UPDATE_STATE,
+            LoadBalancerUpdateStatus.IN_PROGRESS, CHILD_FLOW_ID1);
+        ClusterLbUpdateStatus expectedChild2Status = createClusterLbUpdateStatus(STACK_UPDATE_STATE,
+            LoadBalancerUpdateStatus.FINISHED, CHILD_FLOW_ID2);
+
+        when(lbUpdateFlowLogService.findByParentFlowId(any())).thenReturn(Set.of(lbUpdateFlowLog1, lbUpdateFlowLog2));
+        when(flowService.getFlowLogsByCrnAndType(any(), any())).thenReturn(List.of(parentFlowLogResponse));
+        when(flowService.getFlowLogsByFlowId(eq(FLOW_ID))).thenReturn(List.of(parentFlowLogResponse));
+        when(flowEndpoint.getFlowLogsByFlowId(eq(CHILD_FLOW_ID1))).thenReturn(List.of(child1FlowLogResponse));
+        when(flowEndpoint.getFlowLogsByFlowId(eq(CHILD_FLOW_ID2))).thenReturn(List.of(child2FlowLogResponse));
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(CHILD_FLOW_ID1))).thenReturn(child1FlowCheckResponse);
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(CHILD_FLOW_ID2))).thenReturn(child2FlowCheckResponse);
+
+        EnvironmentLbUpdateStatusResponse response = underTest.getLoadBalancerUpdateStatus(environmentDto);
+
+        assertEquals(LoadBalancerUpdateStatus.IN_PROGRESS, response.getOverallStatus());
+        assertEquals(EnvironmentLbUpdateStatusResponse.IN_PROGRESS, response.getStatusReason());
+        assertEquals(FLOW_ID, response.getEnvironmentFlowId());
+        assertEquals(2, response.getClusterStatus().size());
+        assertTrue(response.getClusterStatus().containsAll(Set.of(expectedChild1Status, expectedChild2Status)));
+    }
+
+    @Test
+    public void testOneChildFailedOthersInProgress() {
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withName(ENV_NAME)
+            .withResourceCrn(ENV_CRN)
+            .build();
+        FlowLogResponse parentFlowLogResponse = createFlowLogResponse(FLOW_ID, ENVIRONMENT_UPDATE_STATE);
+        FlowLogResponse child1FlowLogResponse = createFlowLogResponse(CHILD_FLOW_ID1, STACK_UPDATE_STATE);
+        FlowCheckResponse child1FlowCheckResponse = createFlowCheckResponse(true);
+        FlowLogResponse child2FlowLogResponse = createFlowLogResponse(CHILD_FLOW_ID2, LOAD_BALANCER_UPDATE_FAILED_STATE);
+        FlowCheckResponse child2FlowCheckResponse = createFlowCheckResponse(false);
+        LbUpdateFlowLog lbUpdateFlowLog1 = createLbUpdateFlowLog(CHILD_FLOW_ID1);
+        LbUpdateFlowLog lbUpdateFlowLog2 = createLbUpdateFlowLog(CHILD_FLOW_ID2);
+
+        ClusterLbUpdateStatus expectedChild1Status = createClusterLbUpdateStatus(STACK_UPDATE_STATE,
+            LoadBalancerUpdateStatus.IN_PROGRESS, CHILD_FLOW_ID1);
+        ClusterLbUpdateStatus expectedChild2Status = createClusterLbUpdateStatus(LOAD_BALANCER_UPDATE_FAILED_STATE,
+            LoadBalancerUpdateStatus.FAILED, CHILD_FLOW_ID2);
+
+        when(lbUpdateFlowLogService.findByParentFlowId(any())).thenReturn(Set.of(lbUpdateFlowLog1, lbUpdateFlowLog2));
+        when(flowService.getFlowLogsByCrnAndType(any(), any())).thenReturn(List.of(parentFlowLogResponse));
+        when(flowService.getFlowLogsByFlowId(eq(FLOW_ID))).thenReturn(List.of(parentFlowLogResponse));
+        when(flowEndpoint.getFlowLogsByFlowId(eq(CHILD_FLOW_ID1))).thenReturn(List.of(child1FlowLogResponse));
+        when(flowEndpoint.getFlowLogsByFlowId(eq(CHILD_FLOW_ID2))).thenReturn(List.of(child2FlowLogResponse));
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(CHILD_FLOW_ID1))).thenReturn(child1FlowCheckResponse);
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(CHILD_FLOW_ID2))).thenReturn(child2FlowCheckResponse);
+
+        EnvironmentLbUpdateStatusResponse response = underTest.getLoadBalancerUpdateStatus(environmentDto);
+
+        assertEquals(LoadBalancerUpdateStatus.FAILED, response.getOverallStatus());
+        assertEquals(EnvironmentLbUpdateStatusResponse.CLUSTER_ERROR, response.getStatusReason());
+        assertEquals(FLOW_ID, response.getEnvironmentFlowId());
+        assertEquals(2, response.getClusterStatus().size());
+        assertTrue(response.getClusterStatus().containsAll(Set.of(expectedChild1Status, expectedChild2Status)));
+    }
+
+    @Test
+    public void testOneChildFailedOthersFinished() {
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withName(ENV_NAME)
+            .withResourceCrn(ENV_CRN)
+            .build();
+        FlowLogResponse parentFlowLogResponse = createFlowLogResponse(FLOW_ID, ENVIRONMENT_UPDATE_STATE);
+        FlowLogResponse child1FlowLogResponse = createFlowLogResponse(CHILD_FLOW_ID1, STACK_UPDATE_STATE);
+        FlowCheckResponse child1FlowCheckResponse = createFlowCheckResponse(false);
+        FlowLogResponse child2FlowLogResponse = createFlowLogResponse(CHILD_FLOW_ID2, LOAD_BALANCER_UPDATE_FAILED_STATE);
+        FlowCheckResponse child2FlowCheckResponse = createFlowCheckResponse(false);
+        LbUpdateFlowLog lbUpdateFlowLog1 = createLbUpdateFlowLog(CHILD_FLOW_ID1);
+        LbUpdateFlowLog lbUpdateFlowLog2 = createLbUpdateFlowLog(CHILD_FLOW_ID2);
+
+        ClusterLbUpdateStatus expectedChild1Status = createClusterLbUpdateStatus(STACK_UPDATE_STATE,
+            LoadBalancerUpdateStatus.FINISHED, CHILD_FLOW_ID1);
+        ClusterLbUpdateStatus expectedChild2Status = createClusterLbUpdateStatus(LOAD_BALANCER_UPDATE_FAILED_STATE,
+            LoadBalancerUpdateStatus.FAILED, CHILD_FLOW_ID2);
+
+        when(lbUpdateFlowLogService.findByParentFlowId(any())).thenReturn(Set.of(lbUpdateFlowLog1, lbUpdateFlowLog2));
+        when(flowService.getFlowLogsByCrnAndType(any(), any())).thenReturn(List.of(parentFlowLogResponse));
+        when(flowService.getFlowLogsByFlowId(eq(FLOW_ID))).thenReturn(List.of(parentFlowLogResponse));
+        when(flowEndpoint.getFlowLogsByFlowId(eq(CHILD_FLOW_ID1))).thenReturn(List.of(child1FlowLogResponse));
+        when(flowEndpoint.getFlowLogsByFlowId(eq(CHILD_FLOW_ID2))).thenReturn(List.of(child2FlowLogResponse));
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(CHILD_FLOW_ID1))).thenReturn(child1FlowCheckResponse);
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(CHILD_FLOW_ID2))).thenReturn(child2FlowCheckResponse);
+
+        EnvironmentLbUpdateStatusResponse response = underTest.getLoadBalancerUpdateStatus(environmentDto);
+
+        assertEquals(LoadBalancerUpdateStatus.FAILED, response.getOverallStatus());
+        assertEquals(EnvironmentLbUpdateStatusResponse.CLUSTER_ERROR, response.getStatusReason());
+        assertEquals(FLOW_ID, response.getEnvironmentFlowId());
+        assertEquals(2, response.getClusterStatus().size());
+        assertTrue(response.getClusterStatus().containsAll(Set.of(expectedChild1Status, expectedChild2Status)));
+    }
+
+    @Test
+    public void testAllChildrenFinished() {
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withName(ENV_NAME)
+            .withResourceCrn(ENV_CRN)
+            .build();
+        FlowLogResponse parentFlowLogResponse = createFlowLogResponse(FLOW_ID, ENVIRONMENT_UPDATE_STATE);
+        FlowLogResponse child1FlowLogResponse = createFlowLogResponse(CHILD_FLOW_ID1, STACK_UPDATE_STATE);
+        FlowCheckResponse child1FlowCheckResponse = createFlowCheckResponse(false);
+        FlowLogResponse child2FlowLogResponse = createFlowLogResponse(CHILD_FLOW_ID2, STACK_UPDATE_STATE);
+        FlowCheckResponse child2FlowCheckResponse = createFlowCheckResponse(false);
+        LbUpdateFlowLog lbUpdateFlowLog1 = createLbUpdateFlowLog(CHILD_FLOW_ID1);
+        LbUpdateFlowLog lbUpdateFlowLog2 = createLbUpdateFlowLog(CHILD_FLOW_ID2);
+
+        ClusterLbUpdateStatus expectedChild1Status = createClusterLbUpdateStatus(STACK_UPDATE_STATE,
+            LoadBalancerUpdateStatus.FINISHED, CHILD_FLOW_ID1);
+        ClusterLbUpdateStatus expectedChild2Status = createClusterLbUpdateStatus(STACK_UPDATE_STATE,
+            LoadBalancerUpdateStatus.FINISHED, CHILD_FLOW_ID2);
+
+        when(lbUpdateFlowLogService.findByParentFlowId(any())).thenReturn(Set.of(lbUpdateFlowLog1, lbUpdateFlowLog2));
+        when(flowService.getFlowLogsByCrnAndType(any(), any())).thenReturn(List.of(parentFlowLogResponse));
+        when(flowService.getFlowLogsByFlowId(eq(FLOW_ID))).thenReturn(List.of(parentFlowLogResponse));
+        when(flowEndpoint.getFlowLogsByFlowId(eq(CHILD_FLOW_ID1))).thenReturn(List.of(child1FlowLogResponse));
+        when(flowEndpoint.getFlowLogsByFlowId(eq(CHILD_FLOW_ID2))).thenReturn(List.of(child2FlowLogResponse));
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(CHILD_FLOW_ID1))).thenReturn(child1FlowCheckResponse);
+        when(flowEndpoint.hasFlowRunningByFlowId(eq(CHILD_FLOW_ID2))).thenReturn(child2FlowCheckResponse);
+
+        EnvironmentLbUpdateStatusResponse response = underTest.getLoadBalancerUpdateStatus(environmentDto);
+
+        assertEquals(LoadBalancerUpdateStatus.FINISHED, response.getOverallStatus());
+        assertEquals(EnvironmentLbUpdateStatusResponse.FINISHED, response.getStatusReason());
+        assertEquals(FLOW_ID, response.getEnvironmentFlowId());
+        assertEquals(2, response.getClusterStatus().size());
+        assertTrue(response.getClusterStatus().containsAll(Set.of(expectedChild1Status, expectedChild2Status)));
+    }
+
+    @Test
+    public void testChildFlowIdIsNull() {
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withName(ENV_NAME)
+            .withResourceCrn(ENV_CRN)
+            .build();
+        FlowLogResponse parentFlowLogResponse = createFlowLogResponse(FLOW_ID, ENVIRONMENT_UPDATE_STATE);
+        LbUpdateFlowLog lbUpdateFlowLog1 = createLbUpdateFlowLog(null);
+
+        ClusterLbUpdateStatus expectedChild1Status = createClusterLbUpdateStatus(null,
+            LoadBalancerUpdateStatus.COULD_NOT_START, null);
+
+        when(lbUpdateFlowLogService.findByParentFlowId(any())).thenReturn(Set.of(lbUpdateFlowLog1));
+        when(flowService.getFlowLogsByCrnAndType(any(), any())).thenReturn(List.of(parentFlowLogResponse));
+        when(flowService.getFlowLogsByFlowId(eq(FLOW_ID))).thenReturn(List.of(parentFlowLogResponse));
+
+        EnvironmentLbUpdateStatusResponse response = underTest.getLoadBalancerUpdateStatus(environmentDto);
+
+        assertEquals(LoadBalancerUpdateStatus.FAILED, response.getOverallStatus());
+        assertEquals(EnvironmentLbUpdateStatusResponse.CLUSTER_ERROR, response.getStatusReason());
+        assertEquals(FLOW_ID, response.getEnvironmentFlowId());
+        assertEquals(1, response.getClusterStatus().size());
+        assertTrue(response.getClusterStatus().contains(expectedChild1Status));
+    }
+
+    @Test
+    public void testChildFlowLogsAreEmpty() {
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+            .withName(ENV_NAME)
+            .withResourceCrn(ENV_CRN)
+            .build();
+        FlowLogResponse parentFlowLogResponse = createFlowLogResponse(FLOW_ID, ENVIRONMENT_UPDATE_STATE);
+        LbUpdateFlowLog lbUpdateFlowLog1 = createLbUpdateFlowLog(CHILD_FLOW_ID1);
+
+        ClusterLbUpdateStatus expectedChild1Status = createClusterLbUpdateStatus(UNKNOWN_STATE,
+            LoadBalancerUpdateStatus.AMBIGUOUS, CHILD_FLOW_ID1);
+
+        when(lbUpdateFlowLogService.findByParentFlowId(any())).thenReturn(Set.of(lbUpdateFlowLog1));
+        when(flowService.getFlowLogsByCrnAndType(any(), any())).thenReturn(List.of(parentFlowLogResponse));
+        when(flowService.getFlowLogsByFlowId(eq(FLOW_ID))).thenReturn(List.of(parentFlowLogResponse));
+        when(flowEndpoint.getFlowLogsByFlowId(eq(CHILD_FLOW_ID1))).thenReturn(List.of());
+
+        EnvironmentLbUpdateStatusResponse response = underTest.getLoadBalancerUpdateStatus(environmentDto);
+
+        assertEquals(LoadBalancerUpdateStatus.AMBIGUOUS, response.getOverallStatus());
+        assertEquals(EnvironmentLbUpdateStatusResponse.MISSING_CHILD_FLOWS, response.getStatusReason());
+        assertEquals(FLOW_ID, response.getEnvironmentFlowId());
+        assertEquals(1, response.getClusterStatus().size());
+        assertTrue(response.getClusterStatus().contains(expectedChild1Status));
+    }
+
+    private FlowLogResponse createFlowLogResponse(String flowId, String state) {
+        FlowLogResponse flowLogResponse = new FlowLogResponse();
+        flowLogResponse.setCreated(1L);
+        flowLogResponse.setFlowId(flowId);
+        flowLogResponse.setCurrentState(state);
+        return flowLogResponse;
+    }
+
+    private FlowCheckResponse createFlowCheckResponse(boolean active) {
+        FlowCheckResponse flowCheckResponse = new FlowCheckResponse();
+        flowCheckResponse.setHasActiveFlow(active);
+        return flowCheckResponse;
+    }
+
+    private LbUpdateFlowLog createLbUpdateFlowLog(String childFlow) {
+        LbUpdateFlowLog lbUpdateFlowLog = new LbUpdateFlowLog();
+        lbUpdateFlowLog.setParentFlowId(FLOW_ID);
+        lbUpdateFlowLog.setChildFlowId(childFlow);
+        lbUpdateFlowLog.setEnvironmentCrn(ENV_CRN);
+        return lbUpdateFlowLog;
+    }
+
+    private ClusterLbUpdateStatus createClusterLbUpdateStatus(String state, LoadBalancerUpdateStatus status, String flow) {
+        ClusterLbUpdateStatus clusterLbUpdateStatus = new ClusterLbUpdateStatus();
+        clusterLbUpdateStatus.setCurrentState(state);
+        clusterLbUpdateStatus.setStatus(status);
+        clusterLbUpdateStatus.setFlowId(flow);
+        return clusterLbUpdateStatus;
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/LoadBalancerPollerServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/LoadBalancerPollerServiceTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.environment.environment.service;
 import static com.sequenceiq.environment.environment.service.LoadBalancerPollerService.LOAD_BALANCER_UPDATE_FAILED_STATE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -11,15 +12,16 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -27,10 +29,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
 import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
+import com.sequenceiq.environment.environment.domain.LbUpdateFlowLog;
 import com.sequenceiq.environment.environment.service.datahub.DatahubService;
 import com.sequenceiq.environment.environment.service.sdx.SdxService;
 import com.sequenceiq.environment.environment.service.stack.StackService;
 import com.sequenceiq.environment.exception.UpdateFailedException;
+import com.sequenceiq.environment.network.service.LbUpdateFlowLogService;
 import com.sequenceiq.flow.api.FlowEndpoint;
 import com.sequenceiq.flow.api.model.FlowCheckResponse;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
@@ -51,9 +55,19 @@ public class LoadBalancerPollerServiceTest {
 
     private static final String DL_NAME = "datalakeName";
 
+    private static final String DL_CRN = "datalakeCrn";
+
     private static final String DH_NAME1 = "datahubName1";
 
     private static final String DH_NAME2 = "datahubName2";
+
+    private static final String DH_CRN1 = "datahubCrn1";
+
+    private static final String DH_CRN2 = "datahubCrn2";
+
+    private static final String FLOW_ID = "flowid-1";
+
+    private static final String PARENT_FLOW_ID = "parentflowid-1";
 
     private final DatahubService datahubService = Mockito.mock(DatahubService.class);
 
@@ -63,8 +77,10 @@ public class LoadBalancerPollerServiceTest {
 
     private final FlowEndpoint flowEndpoint = Mockito.mock(FlowEndpoint.class);
 
+    private final LbUpdateFlowLogService lbUpdateFlowLogService = Mockito.mock(LbUpdateFlowLogService.class);
+
     private final LoadBalancerPollerService underTest =
-        new LoadBalancerPollerService(datahubService, sdxService, stackService, flowEndpoint);
+        new LoadBalancerPollerService(datahubService, sdxService, stackService, flowEndpoint, lbUpdateFlowLogService);
 
     @BeforeEach
     public void before() {
@@ -77,7 +93,7 @@ public class LoadBalancerPollerServiceTest {
         when(sdxService.list(ENV_NAME)).thenReturn(List.of());
         when(datahubService.list(ENV_CRN)).thenReturn(new StackViewV4Responses());
 
-        underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.DISABLED);
+        underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.DISABLED, PARENT_FLOW_ID);
 
         verify(stackService, never()).updateLoadBalancer(anySet());
     }
@@ -88,13 +104,15 @@ public class LoadBalancerPollerServiceTest {
         when(datahubService.list(ENV_CRN)).thenReturn(new StackViewV4Responses());
         when(stackService.updateLoadBalancer(anySet())).thenReturn(setupFlowIdentifiers(1));
         when(flowEndpoint.hasFlowRunningByFlowId(anyString())).thenReturn(setupFinishedFlowCheckResponse());
-        when(flowEndpoint.getFlowLogsByFlowId(anyString())).thenReturn(List.of(setupSuccessFlowLogResponse()));
+        when(flowEndpoint.getFlowLogsByFlowId(anyString())).thenReturn(List.of(setupSuccessFlowLogResponse(FLOW_ID + 0)));
+        when(lbUpdateFlowLogService.saveAll(any())).thenReturn(Set.of());
 
-        underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.ENABLED);
+        underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.ENABLED, PARENT_FLOW_ID);
 
         verify(stackService, times(1)).updateLoadBalancer(eq(Set.of(DL_NAME)));
         verify(flowEndpoint, times(1)).hasFlowRunningByFlowId(anyString());
         verify(flowEndpoint, times(1)).getFlowLogsByFlowId(anyString());
+        verify(lbUpdateFlowLogService, times(1)).saveAll(any());
     }
 
     @Test
@@ -103,13 +121,15 @@ public class LoadBalancerPollerServiceTest {
         setupDatahubResponse();
         when(stackService.updateLoadBalancer(eq(Set.of(DL_NAME, DH_NAME1, DH_NAME2)))).thenReturn(setupFlowIdentifiers(3));
         when(flowEndpoint.hasFlowRunningByFlowId(anyString())).thenReturn(setupFinishedFlowCheckResponse());
-        when(flowEndpoint.getFlowLogsByFlowId(anyString())).thenReturn(List.of(setupSuccessFlowLogResponse()));
+        when(flowEndpoint.getFlowLogsByFlowId(anyString())).thenReturn(List.of(setupSuccessFlowLogResponse(FLOW_ID)));
+        when(lbUpdateFlowLogService.saveAll(any())).thenReturn(Set.of());
 
-        underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.ENABLED);
+        underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.ENABLED, PARENT_FLOW_ID);
 
         verify(stackService, times(1)).updateLoadBalancer(eq(Set.of(DL_NAME, DH_NAME1, DH_NAME2)));
         verify(flowEndpoint, times(3)).hasFlowRunningByFlowId(anyString());
         verify(flowEndpoint, times(3)).getFlowLogsByFlowId(anyString());
+        verify(lbUpdateFlowLogService, times(1)).saveAll(any());
     }
 
     @Test
@@ -118,35 +138,38 @@ public class LoadBalancerPollerServiceTest {
         setupDatahubResponse();
         when(stackService.updateLoadBalancer(eq(Set.of(DL_NAME)))).thenReturn(setupFlowIdentifiers(1));
         when(flowEndpoint.hasFlowRunningByFlowId(anyString())).thenReturn(setupFinishedFlowCheckResponse());
-        when(flowEndpoint.getFlowLogsByFlowId(anyString())).thenReturn(List.of(setupSuccessFlowLogResponse()));
+        when(flowEndpoint.getFlowLogsByFlowId(anyString())).thenReturn(List.of(setupSuccessFlowLogResponse(FLOW_ID + 0)));
+        when(lbUpdateFlowLogService.saveAll(any())).thenReturn(Set.of());
 
-        underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.DISABLED);
+        underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.DISABLED, PARENT_FLOW_ID);
 
         verify(stackService, times(1)).updateLoadBalancer(eq(Set.of(DL_NAME)));
         verify(flowEndpoint, times(1)).hasFlowRunningByFlowId(anyString());
         verify(flowEndpoint, times(1)).getFlowLogsByFlowId(anyString());
+        verify(lbUpdateFlowLogService, times(1)).saveAll(any());
     }
 
     @Test
     public void testPollingSingleFailure() {
-        List<FlowIdentifier> flowIdentifiers = setupFlowIdentifiers(3);
-        Iterator<FlowIdentifier> iterator = flowIdentifiers.iterator();
-        FlowIdentifier failFlowId = iterator.next();
-        String successFlowId1 = iterator.next().getPollableId();
-        String successFlowId2 = iterator.next().getPollableId();
-        String expectedError = "Data Lake or Data Hub update flows failed: " + List.of(failFlowId);
+        Map<String, FlowIdentifier> flowIdentifiers = setupFlowIdentifiers(3);
+        Iterator<Map.Entry<String, FlowIdentifier>> iterator = flowIdentifiers.entrySet().iterator();
+        Map.Entry<String, FlowIdentifier> failedCluster = iterator.next();
+        FlowIdentifier failFlowId = failedCluster.getValue();
+        String successFlowId1 = iterator.next().getValue().getPollableId();
+        String successFlowId2 = iterator.next().getValue().getPollableId();
+        String expectedError = "Data Lake or Data Hub update flows failed: " + Map.of(failedCluster.getKey(), failedCluster.getValue());
 
         setupDatalakeResponse();
         setupDatahubResponse();
         when(stackService.updateLoadBalancer(eq(Set.of(DL_NAME, DH_NAME1, DH_NAME2)))).thenReturn(flowIdentifiers);
         when(flowEndpoint.hasFlowRunningByFlowId(anyString())).thenReturn(setupFinishedFlowCheckResponse());
-        when(flowEndpoint.getFlowLogsByFlowId(failFlowId.getPollableId())).thenReturn(List.of(setupFailFlowLogResponse()));
-        when(flowEndpoint.getFlowLogsByFlowId(successFlowId1)).thenReturn(List.of(setupSuccessFlowLogResponse()));
-        when(flowEndpoint.getFlowLogsByFlowId(successFlowId2)).thenReturn(List.of(setupSuccessFlowLogResponse()));
+        when(flowEndpoint.getFlowLogsByFlowId(failFlowId.getPollableId())).thenReturn(List.of(setupFailFlowLogResponse(failFlowId.getPollableId())));
+        when(flowEndpoint.getFlowLogsByFlowId(successFlowId1)).thenReturn(List.of(setupSuccessFlowLogResponse(successFlowId1)));
+        when(flowEndpoint.getFlowLogsByFlowId(successFlowId2)).thenReturn(List.of(setupSuccessFlowLogResponse(successFlowId2)));
 
         UpdateFailedException exception =
             assertThrows(UpdateFailedException.class, () ->
-                underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.ENABLED));
+                underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.ENABLED, PARENT_FLOW_ID));
 
         verify(flowEndpoint, times(3)).hasFlowRunningByFlowId(anyString());
         verify(flowEndpoint, times(3)).getFlowLogsByFlowId(anyString());
@@ -164,43 +187,90 @@ public class LoadBalancerPollerServiceTest {
 
         UpdateFailedException exception =
             assertThrows(UpdateFailedException.class, () ->
-                underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.ENABLED));
+                underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.ENABLED, PARENT_FLOW_ID));
 
         verify(flowEndpoint, times(18)).hasFlowRunningByFlowId(anyString());
         assertEquals(expectedError, exception.getMessage());
     }
 
+    @Test
+    public void testSaveFlowLogs() {
+        setupDatalakeResponse();
+        ArgumentCaptor<List<LbUpdateFlowLog>> flowLogArgumentCaptor = ArgumentCaptor.forClass(List.class);
+        Map<String, FlowIdentifier> flowIdentifiers = Map.of(
+            DL_NAME, new FlowIdentifier(FlowType.FLOW, FLOW_ID)
+        );
+
+        when(datahubService.list(ENV_CRN)).thenReturn(new StackViewV4Responses());
+        when(stackService.updateLoadBalancer(anySet())).thenReturn(flowIdentifiers);
+        when(flowEndpoint.hasFlowRunningByFlowId(anyString())).thenReturn(setupFinishedFlowCheckResponse());
+        when(flowEndpoint.getFlowLogsByFlowId(anyString())).thenReturn(List.of(setupSuccessFlowLogResponse(FLOW_ID)));
+        when(lbUpdateFlowLogService.saveAll(flowLogArgumentCaptor.capture())).thenReturn(Set.of());
+
+        underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.ENABLED, PARENT_FLOW_ID);
+
+        verify(lbUpdateFlowLogService, times(1)).saveAll(any());
+        List<LbUpdateFlowLog> flowLogs = flowLogArgumentCaptor.getValue();
+        assertEquals(1, flowLogs.size());
+        assertEquals(FLOW_ID, flowLogs.get(0).getChildFlowId());
+        assertEquals(DL_CRN, flowLogs.get(0).getChildResourceCrn());
+        assertEquals(DL_NAME, flowLogs.get(0).getChildResourceName());
+        assertEquals(ENV_CRN, flowLogs.get(0).getEnvironmentCrn());
+        assertEquals(PARENT_FLOW_ID, flowLogs.get(0).getParentFlowId());
+    }
+
+    @Test
+    public void testFlowFailedToStart() {
+        setupDatalakeResponse();
+        Map<String, FlowIdentifier> flowIdentifiers = new HashMap<>();
+        flowIdentifiers.put(DL_NAME, null);
+
+        when(datahubService.list(ENV_CRN)).thenReturn(new StackViewV4Responses());
+        when(stackService.updateLoadBalancer(anySet())).thenReturn(flowIdentifiers);
+        when(flowEndpoint.hasFlowRunningByFlowId(anyString())).thenReturn(setupFinishedFlowCheckResponse());
+        when(flowEndpoint.getFlowLogsByFlowId(anyString())).thenReturn(List.of(setupSuccessFlowLogResponse(FLOW_ID + 0)));
+        when(lbUpdateFlowLogService.saveAll(any())).thenReturn(Set.of());
+
+        assertThrows(UpdateFailedException.class, () ->
+            underTest.updateStackWithLoadBalancer(ENV_ID, ENV_CRN, ENV_NAME, PublicEndpointAccessGateway.ENABLED, PARENT_FLOW_ID));
+    }
+
     private void setupDatalakeResponse() {
         SdxClusterResponse sdxClusterResponse = new SdxClusterResponse();
         sdxClusterResponse.setName(DL_NAME);
+        sdxClusterResponse.setCrn(DL_CRN);
         when(sdxService.list(ENV_NAME)).thenReturn(List.of(sdxClusterResponse));
     }
 
     private void setupDatahubResponse() {
         StackViewV4Response response1 = new StackViewV4Response();
         response1.setName(DH_NAME1);
+        response1.setCrn(DH_CRN1);
         StackViewV4Response response2 = new StackViewV4Response();
         response2.setName(DH_NAME2);
+        response2.setCrn(DH_CRN2);
         when(datahubService.list(ENV_CRN)).thenReturn(new StackViewV4Responses(Set.of(response1, response2)));
     }
 
-    private List<FlowIdentifier> setupFlowIdentifiers(int count) {
-        List<FlowIdentifier> flowIdentifiers = new ArrayList<>();
+    private Map<String, FlowIdentifier> setupFlowIdentifiers(int count) {
+        Map<String, FlowIdentifier> flowIdentifiers = new HashMap<>();
         for (int i = 0; i < count; i++) {
-            flowIdentifiers.add(new FlowIdentifier(FlowType.FLOW, UUID.randomUUID().toString()));
+            flowIdentifiers.put("resourceName" + i, new FlowIdentifier(FlowType.FLOW, FLOW_ID + i));
         }
         return flowIdentifiers;
     }
 
-    private FlowLogResponse setupSuccessFlowLogResponse() {
+    private FlowLogResponse setupSuccessFlowLogResponse(String flowId) {
         FlowLogResponse flowLogResponse = new FlowLogResponse();
         flowLogResponse.setCurrentState(LOAD_BALANCER_UPDATE_FINISHED_STATE);
+        flowLogResponse.setFlowId(flowId);
         return flowLogResponse;
     }
 
-    private FlowLogResponse setupFailFlowLogResponse() {
+    private FlowLogResponse setupFailFlowLogResponse(String flowId) {
         FlowLogResponse flowLogResponse = new FlowLogResponse();
         flowLogResponse.setCurrentState(LOAD_BALANCER_UPDATE_FAILED_STATE);
+        flowLogResponse.setFlowId(flowId);
         return flowLogResponse;
     }
 


### PR DESCRIPTION
Adds the update_load_balancers_status to get the status of on-going and completed load balancer update operations.
The operations are tracked via  new database table that collects the environment flow id of the parent operation, and
the stack flow ids of all the child operations launched by the environment service. The status object collects
the flow ids, current flow states, and the status (FINISHED, IN_PROGRESS, etc.) of both the environment flow and
flows running on all data lakes and data hubs. Additionally, there is logic to provide a meaningful status message
for the overall state based on both the parent and the child flow states.

Tested via unit tests and by running an update operation on an environment and sending status messages during and
after the operation.

Note that this change conflicts with https://github.com/hortonworks/cloudbreak/pull/10958, and will need to be rebased and refactored after that is merged in.