### PR TITLE
CB-12971 Make freeipa backup work for GCP environment with log bucket…

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_backup
@@ -249,23 +249,29 @@ elif [[ "${config[backup_platform]}" = "AZURE" ]]; then
     fi
     remove_local_backups
 elif [[ "${config[backup_platform]}" = "GCP" ]]; then
-    # To avoid storage.objects.list permission for logger we must sync backups to the bucket instead of the object
     BACKUP_PATH="/${BACKUP_LOCATION#*://*/}"
     BACKUP_BUCKET=$(echo "${BACKUP_LOCATION}" | cut -f-3 -d '/')
-    doLog "INFO Copy backup to ${BACKUP_PATH} before moving it to cloud storage"
     if [[ "${BACKUP_PATH}" = / ]]; then
       BACKUP_PATH="/cluster-backups/freeipa"
     elif [[ "${BACKUP_PATH}" != /* ]]; then
       BACKUP_PATH="/${BACKUP_PATH}"
     fi
-    mkdir -p "${BACKUP_PATH}"
-    cp -r "${config[backup_path]}/${BACKUPDIR}" "${BACKUP_PATH}"
-    # shellcheck disable=SC2012
-    BACKUP_ROOT_FOLDER="/"$(ls -d "${BACKUP_PATH}" | cut -f 2 -d '/')
-    doLog "INFO Syncing backups to Google Cloud Storage"
-    /bin/gsutil -m mv "${BACKUP_ROOT_FOLDER}" "${BACKUP_BUCKET}" >> "${LOGFILE}" 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
-    rm -rf "${BACKUP_PATH}"
-    remove_local_backups
+    BACKUP_ROOT_FOLDER="/"$(echo "${BACKUP_PATH}" | cut -f 2 -d '/')
+    if [ -d "${BACKUP_ROOT_FOLDER}" ]; then
+      # The backup root folder already exists in this operating system, logger service account needs storage.objects.list permission also
+      doLog "INFO Syncing backups to Google Cloud Storage"
+      /bin/gsutil cp -r "${config[backup_path]}/${BACKUPDIR}" "${BACKUP_LOCATION}" >> "${LOGFILE}" 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
+      remove_local_backups
+    else
+      # To avoid storage.objects.list permission for logger we must sync backups to the bucket instead of the object
+      mkdir -p "${BACKUP_PATH}"
+      doLog "INFO Copy backup to ${BACKUP_PATH} before moving it to cloud storage"
+      cp -r "${config[backup_path]}/${BACKUPDIR}" "${BACKUP_PATH}"
+      doLog "INFO Syncing backups to Google Cloud Storage"
+      /bin/gsutil -m mv "${BACKUP_ROOT_FOLDER}" "${BACKUP_BUCKET}" >> "${LOGFILE}" 2>&1 || error_exit "Sync of backups to ${BACKUP_LOCATION} failed!"
+      rm -rf "${BACKUP_ROOT_FOLDER}"
+      remove_local_backups
+    fi
 fi
 
 doLog "INFO Backup ${PERMISSIONS_CHECK}completed."


### PR DESCRIPTION
… path root location already exists in operating system

1. To avoid storage.objects.list permission for logger we were syncing backups to the bucket instead of the object by staging it in a similar folder structure locally.
2. This is a dangerous idea to begin with because if the root location already exists in operating system then it will sync the entire OS system content.
3. In this change we avoid this mistake by checking if the folder already exists and do a cp instead of mv.
4. But this needs a new permission for logger service account which needs to be documented.
5. We keep the old behaviour as is in the normal scenarios for backward compatibility purposes.