### PR TITLE
CB-13181 keep the original CM server flag after stop/start for the in…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
@@ -156,12 +156,12 @@ public class InstanceMetaDataService {
         }
     }
 
-    public InstanceMetaData save(InstanceMetaData instanceMetaData) {
-        return repository.save(instanceMetaData);
-    }
-
     public Set<InstanceMetaData> findNotTerminatedForStack(Long stackId) {
         return repository.findNotTerminatedForStack(stackId);
+    }
+
+    public InstanceMetaData save(InstanceMetaData instanceMetaData) {
+        return repository.save(instanceMetaData);
     }
 
     public Set<InstanceMetaData> findNotTerminatedForStackWithoutInstanceGroups(Long stackId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
@@ -148,7 +148,9 @@ public class MetadataSetupService {
                 instanceMetaDataEntry.setAvailabilityZone(cloudInstance.getStringParameter(CloudInstance.AVAILABILITY_ZONE));
                 instanceMetaDataEntry.setRackId(determineRackId(instanceMetaDataEntry.getSubnetId(), instanceMetaDataEntry.getAvailabilityZone()));
                 instanceMetaDataEntry.setInstanceName(cloudInstance.getStringParameter(CloudInstance.INSTANCE_NAME));
-                instanceMetaDataEntry.setServer(Boolean.FALSE);
+                if (instanceMetaDataEntry.getClusterManagerServer() == null) {
+                    instanceMetaDataEntry.setServer(Boolean.FALSE);
+                }
                 instanceMetaDataEntry.setLifeCycle(InstanceLifeCycle.fromCloudInstanceLifeCycle(md.getLifeCycle()));
                 if (instanceMetaDataEntry.getInstanceMetadataType() == null) {
                     if (ig != null) {
@@ -219,7 +221,7 @@ public class MetadataSetupService {
 
             for (CloudLoadBalancerMetadata cloudLoadBalancerMetadata : cloudLoadBalancerMetadataList) {
                 LoadBalancer loadBalancerEntry = createLoadBalancerMetadataIfAbsent(allLoadBalancerMetadata,
-                    stack, cloudLoadBalancerMetadata.getType());
+                        stack, cloudLoadBalancerMetadata.getType());
 
                 loadBalancerEntry.setDns(cloudLoadBalancerMetadata.getCloudDns());
                 loadBalancerEntry.setHostedZoneId(cloudLoadBalancerMetadata.getHostedZoneId());


### PR DESCRIPTION
…stance metadata

After the cluster is restarted the CM server flag is always set to false. QE relies
on this flag and causes issues for them checking which instance is the CM server.
As part of the PR this flag is only set to false when previously it didn't have
any value. This can only happen if this is a new instance, like during provisioning
or upscale.

See detailed description in the commit message.