### PR TITLE
CB-13227 Create separate Ranger repo for each Kudu

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-rt-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-rt-data-mart.bp
@@ -42,6 +42,10 @@
           {
             "refName": "kudu-MASTER-BASE",
             "roleType": "KUDU_MASTER",
+            "configs": [ {
+              "name": "ranger_kudu_plugin_service_name",
+              "value": "{{GENERATED_RANGER_SERVICE_NAME}}"
+            } ],
             "base": true
           },
           {

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-rt-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-rt-data-mart.bp
@@ -42,6 +42,10 @@
           {
             "refName": "kudu-MASTER-BASE",
             "roleType": "KUDU_MASTER",
+            "configs": [ {
+              "name": "ranger_kudu_plugin_service_name",
+              "value": "{{GENERATED_RANGER_SERVICE_NAME}}"
+            } ],
             "base": true
           },
           {

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-rt-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-rt-data-mart.bp
@@ -42,6 +42,10 @@
           {
             "refName": "kudu-MASTER-BASE",
             "roleType": "KUDU_MASTER",
+            "configs": [ {
+              "name": "ranger_kudu_plugin_service_name",
+              "value": "{{GENERATED_RANGER_SERVICE_NAME}}"
+            } ],
             "base": true
           },
           {

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-rt-data-mart.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-rt-data-mart.bp
@@ -42,6 +42,10 @@
           {
             "refName": "kudu-MASTER-BASE",
             "roleType": "KUDU_MASTER",
+            "configs": [ {
+              "name": "ranger_kudu_plugin_service_name",
+              "value": "{{GENERATED_RANGER_SERVICE_NAME}}"
+            } ],
             "base": true
           },
           {


### PR DESCRIPTION
The Real Time DataMart blueprints use the default Ranger service
repository name for Kudu, which is cm_kudu. Each RTDM DataHub is
supposed to have its own Ranger service repo for Kudu.

Kudu CSD recognizes the "{{GENERATED_RANGER_SERVICE_NAME}}" magic string
and uses the CM-generated unique service repo name.

See detailed description in the commit message.