### PR TITLE
CB-13233 Prepare UnassignResourceRoleAction for NOT_FOUND case

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignResourceRoleUserAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/AssignResourceRoleUserAction.java
@@ -27,22 +27,23 @@ public class AssignResourceRoleUserAction extends AbstractUmsAction<UmsTestDto> 
     @Override
     protected UmsTestDto umsAction(TestContext testContext, UmsTestDto testDto, UmsClient client) throws Exception {
         CloudbreakUser user = testContext.getRealUmsUserByKey(userKey);
+        String userCrn = user.getCrn();
         String resourceRole = testDto.getRequest().getRoleCrn();
         String resourceCrn = testDto.getRequest().getResourceCrn();
-        Log.when(LOGGER, format(" Assigning resource role '%s' at resource '%s' for user '%s' ", resourceRole, resourceCrn, user.getCrn()));
-        Log.whenJson(LOGGER, format(" Assign resource role request:%n "), testDto.getRequest());
 
-        Multimap<String, String> assignedResourceRoles = client.getDefaultClient().listAssignedResourceRoles(user.getCrn(), Optional.of(""));
-        LOGGER.info(format(" Assigned resource roles ['%s'] are present to user '%s' ", assignedResourceRoles, user.getCrn()));
+        Log.when(LOGGER, format(" Assigning resource role '%s' to user '%s' at resource '%s'... ", resourceRole, userCrn, resourceCrn));
+        Log.whenJson(LOGGER, format(" Assign resource role request:%n "), testDto.getRequest());
+        LOGGER.info(format(" Assigning resource role '%s' to user '%s' at resource '%s'... ", resourceRole, userCrn, resourceCrn));
+        Multimap<String, String> assignedResourceRoles = client.getDefaultClient().listAssignedResourceRoles(userCrn, Optional.of(""));
         if (assignedResourceRoles.get(resourceCrn).contains(resourceRole)) {
-            LOGGER.info(format(" Resource role '%s' has already been assigned to user '%s' for resource '%s' ", resourceRole, user.getCrn(), resourceCrn));
-            Log.when(LOGGER, format(" Resource role '%s' has already been assigned to user '%s' for resource '%s' ", resourceRole, user.getCrn(), resourceCrn));
+            LOGGER.info(format(" Resource role '%s' has already been assigned to user '%s' at resource '%s' ", resourceRole, userCrn, resourceCrn));
+            Log.when(LOGGER, format(" Resource role '%s' has already been assigned to user '%s' at resource '%s' ", resourceRole, userCrn, resourceCrn));
         } else {
-            client.getDefaultClient().assignResourceRole(user.getCrn(), resourceCrn, resourceRole, Optional.of(""));
+            client.getDefaultClient().assignResourceRole(userCrn, resourceCrn, resourceRole, Optional.of(""));
             // wait for UmsRightsCache to expire
             Thread.sleep(7000);
-            LOGGER.info(format(" Resource role '%s' has been assigned at resource '%s' for user '%s' ", resourceRole, resourceCrn, user.getCrn()));
-            Log.when(LOGGER, format(" Resource role '%s' has been assigned at resource '%s' for user '%s' ", resourceRole, resourceCrn, user.getCrn()));
+            LOGGER.info(format(" Resource role '%s' has been assigned to user '%s' at resource '%s' ", resourceRole, userCrn, resourceCrn));
+            Log.when(LOGGER, format(" Resource role '%s' has been assigned to user '%s' at resource '%s' ", resourceRole, userCrn, resourceCrn));
         }
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/UnassignResourceRoleAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/ums/UnassignResourceRoleAction.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.Multimap;
 import com.sequenceiq.it.cloudbreak.UmsClient;
 import com.sequenceiq.it.cloudbreak.actor.CloudbreakUser;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -26,15 +27,24 @@ public class UnassignResourceRoleAction extends AbstractUmsAction<UmsTestDto> {
     @Override
     protected UmsTestDto umsAction(TestContext testContext, UmsTestDto testDto, UmsClient client) throws Exception {
         CloudbreakUser user = testContext.getRealUmsUserByKey(userKey);
+        String userCrn = user.getCrn();
         String resourceRole = testDto.getRequest().getRoleCrn();
         String resourceCrn = testDto.getRequest().getResourceCrn();
-        Log.when(LOGGER, format(" Remove resource role '%s' at resource '%s' for user '%s' ", resourceRole, resourceCrn, user.getCrn()));
-        Log.whenJson(LOGGER, format(" Remove resource role request:%n "), testDto.getRequest());
-        client.getDefaultClient().unassignResourceRole(user.getCrn(), resourceCrn, resourceRole, Optional.of(""));
-        // wait for UmsRightsCache to expire
-        Thread.sleep(7000);
-        LOGGER.info(format(" Resource role '%s' has been removed at resource '%s' for user '%s' ", resourceRole, resourceCrn, user.getCrn()));
-        Log.when(LOGGER, format(" Resource role '%s' has been removed at resource '%s' for user '%s' ", resourceRole, resourceCrn, user.getCrn()));
+
+        Log.when(LOGGER, format(" Revoke resource role '%s' from user '%s' at resource '%s' ", resourceRole, userCrn, resourceCrn));
+        Log.whenJson(LOGGER, format(" Revoke resource role request:%n "), testDto.getRequest());
+        LOGGER.info(format(" Revoking resource role '%s' from user '%s' at resource '%s'... ", resourceRole, userCrn, resourceCrn));
+        Multimap<String, String> assignedResourceRoles = client.getDefaultClient().listAssignedResourceRoles(userCrn, Optional.of(""));
+        if (assignedResourceRoles.get(resourceCrn).contains(resourceRole)) {
+            client.getDefaultClient().unassignResourceRole(userCrn, resourceCrn, resourceRole, Optional.of(""));
+            // wait for UmsRightsCache to expire
+            Thread.sleep(7000);
+            LOGGER.info(format(" Resource role '%s' has been revoked from user '%s' at resource '%s' ", resourceRole, userCrn, resourceCrn));
+            Log.when(LOGGER, format(" Resource role '%s' has been revoked from user '%s' at resource '%s' ", resourceRole, userCrn, resourceCrn));
+        } else {
+            LOGGER.info(format(" Resource role '%s' has already been revoked from user '%s' at resource '%s' ", resourceRole, userCrn, resourceCrn));
+            Log.when(LOGGER, format(" Resource role '%s' has already been revoked from user '%s' at resource '%s' ", resourceRole, userCrn, resourceCrn));
+        }
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ums/UmsTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/ums/UmsTestDto.java
@@ -117,4 +117,8 @@ public class UmsTestDto extends AbstractTestDto<AssignResourceRequest, UserManag
     public UmsTestDto then(Assertion<UmsTestDto, UmsClient> assertion, RunningParameter runningParameter) {
         return getTestContext().then((UmsTestDto) this, UmsClient.class, assertion, runningParameter);
     }
+
+    public static String getIamGroupAdminCrn() {
+        return IAM_GROUP_ADMIN;
+    }
 }


### PR DESCRIPTION
MOW Dev API E2E test build is failing, because of testAddGroupsToEnvironment test is failing with:
```
com.sequenceiq.it.cloudbreak.exception.TestFailException: EXCEEDING UMS ACTION MAX. RETRY (11) ::: UMS action has been failed, because of: NOT_FOUND: Cannot find resource role...
```
So I'm introducing an additional step to the `UnassignResourceRoleAction` with a pre-check for resource role has already been revoked from user.