### PR TITLE
CDPCP-4714. User sync disables and enables users

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -71,6 +71,8 @@ public class FreeIpaClient {
 
     private static final Pattern RESPONSE_CODE_PATTERN = Pattern.compile("^Server returned HTTP response code: (\\d+)");
 
+    private static final boolean USER_ENABLED = false;
+
     private JsonRpcHttpClient jsonRpcHttpClient;
 
     private final String apiVersion;
@@ -219,7 +221,20 @@ public class FreeIpaClient {
     }
 
     public User userAdd(String user, String firstName, String lastName) throws FreeIpaClientException {
-        return UserAddOperation.create(user, firstName, lastName).invoke(this).orElseThrow(() ->
+        return userAdd(user, firstName, lastName, USER_ENABLED);
+    }
+
+    /**
+     * Adds a user to FreeIPA. This overload allows the user to be created in a disabled state.
+     *
+     * @param user      the user
+     * @param firstName the user's first name
+     * @param lastName  the user's last name
+     * @param disabled  whether the user is disabled
+     * @return the user model
+     */
+    public User userAdd(String user, String firstName, String lastName, boolean disabled) throws FreeIpaClientException {
+        return UserAddOperation.create(user, firstName, lastName, disabled).invoke(this).orElseThrow(() ->
                 new FreeIpaClientException(String.format("User addition failed for user %s", user)));
     }
 

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/UserAddOperation.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/operation/UserAddOperation.java
@@ -24,14 +24,17 @@ public class UserAddOperation extends AbstractFreeipaOperation<User> {
 
     private String lastName;
 
-    private UserAddOperation(String user, String firstName, String lastName) {
+    private boolean disabled;
+
+    private UserAddOperation(String user, String firstName, String lastName, boolean disabled) {
         this.user = user;
         this.firstName = firstName;
         this.lastName = lastName;
+        this.disabled = disabled;
     }
 
-    public static UserAddOperation create(String user, String firstName, String lastName) {
-        return new UserAddOperation(user, firstName, lastName);
+    public static UserAddOperation create(String user, String firstName, String lastName, boolean disabled) {
+        return new UserAddOperation(user, firstName, lastName, disabled);
     }
 
     @Override
@@ -51,7 +54,8 @@ public class UserAddOperation extends AbstractFreeipaOperation<User> {
                 "sn", lastName,
                 "loginshell", "/bin/bash",
                 "random", true,
-                "setattr", "krbPasswordExpiration=" + MAX_PASSWORD_EXPIRATION_DATETIME
+                "setattr", List.of("krbPasswordExpiration=" + MAX_PASSWORD_EXPIRATION_DATETIME,
+                        "nsAccountLock=" + disabled)
         );
     }
 

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/BatchOperationTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/BatchOperationTest.java
@@ -47,7 +47,7 @@ public class BatchOperationTest {
 
         when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenReturn(rpcResponse);
 
-        operations.add(UserAddOperation.create("user", "first", "last").getOperationParamsForBatchCall());
+        operations.add(UserAddOperation.create("user", "first", "last", false).getOperationParamsForBatchCall());
         BatchOperation.create(operations, warnings::put, Set.of()).invoke(freeIpaClient);
 
         verify(freeIpaClient).invoke(eq("batch"), anyList(), any(), any());
@@ -61,7 +61,7 @@ public class BatchOperationTest {
         when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenThrow(
                 new FreeIpaClientException("error", new JsonRpcClientException(4002, "", null)));
 
-        operations.add(UserAddOperation.create("user", "first", "last").getOperationParamsForBatchCall());
+        operations.add(UserAddOperation.create("user", "first", "last", false).getOperationParamsForBatchCall());
         BatchOperation.create(operations, warnings::put, Set.of(FreeIpaErrorCodes.DUPLICATE_ENTRY)).invoke(freeIpaClient);
 
         verify(freeIpaClient).invoke(eq("batch"), anyList(), any(), any());
@@ -76,7 +76,7 @@ public class BatchOperationTest {
         when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenThrow(
                 new FreeIpaClientException("error", new JsonRpcClientException(5000, "", null)));
 
-        operations.add(UserAddOperation.create("user", "first", "last").getOperationParamsForBatchCall());
+        operations.add(UserAddOperation.create("user", "first", "last", false).getOperationParamsForBatchCall());
         BatchOperation.create(operations, warnings::put, Set.of(FreeIpaErrorCodes.NOT_FOUND)).invoke(freeIpaClient);
 
         verify(freeIpaClient).invoke(eq("batch"), anyList(), any(), any());

--- a/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/UserAddOperationTest.java
+++ b/freeipa-client/src/test/java/com/sequenceiq/freeipa/client/operation/UserAddOperationTest.java
@@ -29,7 +29,7 @@ public class UserAddOperationTest {
     @Test
     public void testInvokeWhenUserProtected() {
         assertThrows(FreeIpaClientException.class, () ->
-                UserAddOperation.create("admin", "admin", "admin").invoke(freeIpaClient));
+                UserAddOperation.create("admin", "admin", "admin", false).invoke(freeIpaClient));
         verifyNoInteractions(freeIpaClient);
     }
 
@@ -40,7 +40,7 @@ public class UserAddOperationTest {
 
         when(freeIpaClient.invoke(any(), anyList(), any(), any())).thenReturn(rpcResponse);
 
-        UserAddOperation.create(USER_NAME, USER_NAME, USER_NAME).invoke(freeIpaClient);
+        UserAddOperation.create(USER_NAME, USER_NAME, USER_NAME, false).invoke(freeIpaClient);
 
         verify(freeIpaClient).invoke(eq("user_add"), anyList(), any(), any());
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProvider.java
@@ -90,7 +90,7 @@ public class FreeIpaUsersStateProvider {
                 .withName(ipaUser.getUid())
                 .withFirstName(ipaUser.getGivenname())
                 .withLastName(ipaUser.getSn())
-                .withState(ipaUser.getNsAccountLock() ? FmsUser.State.ENABLED : FmsUser.State.DISABLED);
+                .withState(ipaUser.getNsAccountLock() ? FmsUser.State.DISABLED : FmsUser.State.ENABLED);
     }
 
     @VisibleForTesting

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/FreeIpaUsersStateProviderTest.java
@@ -37,9 +37,9 @@ import com.sequenceiq.freeipa.service.freeipa.user.model.UsersState;
 @ExtendWith(MockitoExtension.class)
 class FreeIpaUsersStateProviderTest {
 
-    private static final boolean USER_ENABLED = true;
+    private static final boolean USER_ENABLED = false;
 
-    private static final boolean USER_DISABLED = false;
+    private static final boolean USER_DISABLED = true;
 
     @InjectMocks
     FreeIpaUsersStateProvider underTest;
@@ -219,14 +219,14 @@ class FreeIpaUsersStateProviderTest {
     }
 
     private com.sequenceiq.freeipa.client.model.User createIpaUser(
-            String uid, List<String> memberOfGroup, boolean enabled) {
+            String uid, List<String> memberOfGroup, boolean disabled) {
         com.sequenceiq.freeipa.client.model.User ipaUser = new com.sequenceiq.freeipa.client.model.User();
         ipaUser.setUid(uid);
         ipaUser.setDn(UUID.randomUUID().toString());
         ipaUser.setSn(UUID.randomUUID().toString());
         ipaUser.setGivenname(UUID.randomUUID().toString());
         ipaUser.setMemberOfGroup(memberOfGroup);
-        ipaUser.setNsAccountLock(enabled);
+        ipaUser.setNsAccountLock(disabled);
         return ipaUser;
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/user/UserSyncServiceTest.java
@@ -192,6 +192,10 @@ class UserSyncServiceTest {
         FmsUser userToAdd2 = new FmsUser().withName("userToAdd2").withFirstName("peter").withLastName("parker");
         String userToRemove1 = "userToRemove1";
         String userToRemove2 = "userToRemove2";
+        String userToDisable1 = "userToDisable1";
+        String userToDisable2 = "userToDisable2";
+        String userToEnable1 = "userToEnable1";
+        String userToEnable2 = "userToEnable2";
         Multimap<String, String> warnings = ArrayListMultimap.create();
 
         doNothing().when(freeIpaClient).callBatch(any(), any(), any(), any());
@@ -209,12 +213,14 @@ class UserSyncServiceTest {
                 ImmutableMultimap.<String, String>builder()
                         .put(groupToRemove1.getName(), userToRemove1)
                         .put(groupToRemove2.getName(), userToRemove2)
-                        .build()
+                        .build(),
+                ImmutableSet.of(userToDisable1, userToDisable2),
+                ImmutableSet.of(userToEnable1, userToEnable2)
         );
 
         underTest.applyStateDifferenceToIpa(ENV_CRN, freeIpaClient, usersStateDifference, warnings::put, true);
 
-        verify(freeIpaClient, times(6)).callBatch(any(), any(), any(), any());
+        verify(freeIpaClient, times(8)).callBatch(any(), any(), any(), any());
 
         verifyNoMoreInteractions(freeIpaClient);
     }


### PR DESCRIPTION
The UserSyncService now enables and disables users based on their state
in the UMS.

UserDisableOperations are invoked for users that exist in IPA that need to be
disabled. The UserAddOperation is updated to add disabled users to IPA. This happens
as a single operation to avoid any potential issues if user sync fails between
adding a user and disabling a user.

UserEnableOperations are invoked for users that exist in IPA that need to be enabled.

The FreeIpaUserStateProvider was fixed to correctly set the enablement state.
The state is returned as a negative flag (true indicates disabled). The previous
commit introducing this to the model had the flag reversed.
