### PR TITLE
CB-13130: Fix the creation/deletion of disk encryption set for multi-RG in Azure.

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/encryption/EnvironmentEncryptionService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/encryption/EnvironmentEncryptionService.java
@@ -3,6 +3,7 @@ package com.sequenceiq.environment.environment.encryption;
 import static com.sequenceiq.cloudbreak.cloud.model.Location.location;
 import static com.sequenceiq.cloudbreak.cloud.model.Region.region;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -119,9 +120,16 @@ public class EnvironmentEncryptionService {
     }
 
     private List<CloudResource> getResourcesForDeletion(EnvironmentDto environment) {
+        List<CloudResource> resources = new ArrayList<>();
         Optional<CloudResource> desCloudResourceOptional = resourceRetriever.findByEnvironmentIdAndType(environment.getId(),
                 ResourceType.AZURE_DISK_ENCRYPTION_SET);
-        return desCloudResourceOptional.map(List::of).orElse(List.of());
-    }
+        desCloudResourceOptional.ifPresent(resources::add);
 
+        // Resource group is persisted in cloudResource only when it is created by CDP, as part of disk encryption set creation in case of
+        // multi-resource group.
+        Optional<CloudResource> rgCloudResourceOptional = resourceRetriever.findByEnvironmentIdAndType(environment.getId(),
+                ResourceType.AZURE_RESOURCE_GROUP);
+        rgCloudResourceOptional.ifPresent(resources::add);
+        return resources;
+    }
 }


### PR DESCRIPTION
CB-13130: Fix the creation/deletion of disk encryption set for multi-RG in Azure.
With multi-RG i.e; when `--resource-group-name` is not provided by the user, each of the resources creates its own resource group.
Following requirements should hold:
1. The RG for DES will be created.
2. User must provide ` --encryption-key-resource-group-name` - The RG where the encryption key is present.

This JIRA validates the encryption parameters for multi-RG and creates/deletes the resoure group for des by appending "-CDP_DES-" to resource group name.

Attaching a few screenshots for reference:

**1. For multi-RG, a new RG is created and DES is created within the newly created RG.** 
<img width="1770" alt="Screenshot 2021-07-12 at 3 57 12 PM" src="https://user-images.githubusercontent.com/32215750/125276917-6d7f6b80-e32e-11eb-9554-b926864db399.png">

**2. CDP created resource group for DES and freeIPA.**
<img width="1446" alt="Screenshot 2021-07-12 at 3 58 02 PM" src="https://user-images.githubusercontent.com/32215750/125277048-97389280-e32e-11eb-8942-136b8b3314c7.png">

**3. `Resource` table having DES and DES's RG resource entries.**
<img width="1428" alt="Screenshot 2021-07-12 at 4 05 24 PM" src="https://user-images.githubusercontent.com/32215750/125277716-6d33a000-e32f-11eb-89f5-d1a82618ba82.png">

