### PR TITLE
CB-13246 We are storing non-sensitive data in the attributes field of…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/InstanceGroupToInstanceGroupDetailsConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/converter/InstanceGroupToInstanceGroupDetailsConverter.java
@@ -12,7 +12,7 @@ import com.sequenceiq.cloudbreak.structuredevent.event.SecurityGroupDetails;
 import com.sequenceiq.cloudbreak.structuredevent.event.VolumeDetails;
 
 @Component
-public class InstanceGroupToInstanceGroupDetailsConverter extends AbstractConversionServiceAwareConverter<InstanceGroup, InstanceGroupDetails>  {
+public class InstanceGroupToInstanceGroupDetailsConverter extends AbstractConversionServiceAwareConverter<InstanceGroup, InstanceGroupDetails> {
 
     @Override
     public InstanceGroupDetails convert(InstanceGroup source) {
@@ -22,14 +22,18 @@ public class InstanceGroupToInstanceGroupDetailsConverter extends AbstractConver
         instanceGroupDetails.setNodeCount(source.getNodeCount());
         Template template = source.getTemplate();
         if (template != null) {
-            instanceGroupDetails.setInstanceType(source.getTemplate().getInstanceType());
-            instanceGroupDetails.setVolumes(source.getTemplate().getVolumeTemplates().stream().map(volmue -> {
-                VolumeDetails volumeDetails = new VolumeDetails();
-                volumeDetails.setVolumeType(volmue.getVolumeType());
-                volumeDetails.setVolumeSize(volmue.getVolumeSize());
-                volumeDetails.setVolumeCount(volmue.getVolumeCount());
-                return volumeDetails;
-            }).collect(Collectors.toList()));
+            instanceGroupDetails.setInstanceType(template.getInstanceType());
+            instanceGroupDetails.setAttributes(template.getAttributes().getMap());
+            instanceGroupDetails.setRootVolumeSize(template.getRootVolumeSize());
+            if (template.getVolumeTemplates() != null) {
+                instanceGroupDetails.setVolumes(template.getVolumeTemplates().stream().map(volmue -> {
+                    VolumeDetails volumeDetails = new VolumeDetails();
+                    volumeDetails.setVolumeType(volmue.getVolumeType());
+                    volumeDetails.setVolumeSize(volmue.getVolumeSize());
+                    volumeDetails.setVolumeCount(volmue.getVolumeCount());
+                    return volumeDetails;
+                }).collect(Collectors.toList()));
+            }
             if (template.getTemporaryStorage() != null) {
                 instanceGroupDetails.setTemporaryStorage(template.getTemporaryStorage().name());
             }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/converter/InstanceGroupToInstanceGroupDetailsConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/structuredevent/converter/InstanceGroupToInstanceGroupDetailsConverterTest.java
@@ -1,0 +1,54 @@
+package com.sequenceiq.cloudbreak.structuredevent.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.convert.ConversionService;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.domain.Template;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.structuredevent.event.InstanceGroupDetails;
+
+@ExtendWith(MockitoExtension.class)
+public class InstanceGroupToInstanceGroupDetailsConverterTest {
+
+    @Mock
+    private ConversionService conversionService;
+
+    @InjectMocks
+    private InstanceGroupToInstanceGroupDetailsConverter underTest;
+
+    @Test
+    void convertEmptyNoNullPointer() {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        InstanceGroupDetails instanceGroupDetails = underTest.convert(instanceGroup);
+
+        assertThat(instanceGroupDetails).isNotNull();
+    }
+
+    @Test
+    void convert() {
+        InstanceGroupDetails instanceGroupDetails = underTest.convert(createInstanceGroup());
+
+        assertEquals("ATTACHED_VOLUMES", instanceGroupDetails.getTemporaryStorage());
+        assertEquals(Boolean.TRUE, instanceGroupDetails.getAttributes().get("encrypted"));
+    }
+
+    private InstanceGroup createInstanceGroup() {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        Template template = new Template();
+        Map<String, Object> attributes = Map.of("encrypted", Boolean.TRUE);
+        template.setAttributes(new Json(attributes));
+        template.setCloudPlatform("AWS");
+        instanceGroup.setTemplate(template);
+        return instanceGroup;
+    }
+}

--- a/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/InstanceGroupDetails.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/cloudbreak/structuredevent/event/InstanceGroupDetails.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.structuredevent.event;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -22,6 +23,10 @@ public class InstanceGroupDetails implements Serializable {
     private SecurityGroupDetails securityGroup;
 
     private String temporaryStorage;
+
+    private Integer rootVolumeSize;
+
+    private Map<String, Object> attributes;
 
     public String getGroupName() {
         return groupName;
@@ -77,5 +82,21 @@ public class InstanceGroupDetails implements Serializable {
 
     public void setTemporaryStorage(String temporaryStorage) {
         this.temporaryStorage = temporaryStorage;
+    }
+
+    public Integer getRootVolumeSize() {
+        return rootVolumeSize;
+    }
+
+    public void setRootVolumeSize(Integer rootVolumeSize) {
+        this.rootVolumeSize = rootVolumeSize;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
     }
 }


### PR DESCRIPTION
… the instancegroup objects. We shall make sure that these are sent o EDH to make it easier to reconstruct how the customer has created the cluster.

See detailed description in the commit message.