### PR TITLE
CB-12979 introduce a hidden internal flag on the upgrade request to a…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/InternalUpgradeSettings.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/InternalUpgradeSettings.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InternalUpgradeSettings {
+
+    private boolean skipValidations;
+
+    public InternalUpgradeSettings() {
+    }
+
+    public InternalUpgradeSettings(boolean skipValidations) {
+        this.skipValidations = skipValidations;
+    }
+
+    public boolean isSkipValidations() {
+        return skipValidations;
+    }
+
+    public void setSkipValidations(boolean skipValidations) {
+        this.skipValidations = skipValidations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        InternalUpgradeSettings that = (InternalUpgradeSettings) o;
+        return skipValidations == that.skipValidations;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(skipValidations);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", InternalUpgradeSettings.class.getSimpleName() + "[", "]")
+                .add("skipValidations=" + skipValidations)
+                .toString();
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/tags/upgrade/UpgradeV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/tags/upgrade/UpgradeV4Request.java
@@ -1,9 +1,11 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade;
 
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions.UpgradeModelDescription;
 import com.sequenceiq.cloudbreak.validation.ValidUpgradeRequest;
 import com.sequenceiq.common.model.UpgradeShowAvailableImages;
 
@@ -15,22 +17,25 @@ import io.swagger.annotations.ApiModelProperty;
 @ValidUpgradeRequest
 public class UpgradeV4Request {
 
-    @ApiModelProperty(ModelDescriptions.UpgradeModelDescription.IMAGE_ID)
+    @ApiModelProperty(UpgradeModelDescription.IMAGE_ID)
     private String imageId;
 
-    @ApiModelProperty(ModelDescriptions.UpgradeModelDescription.RUNTIME)
+    @ApiModelProperty(UpgradeModelDescription.RUNTIME)
     private String runtime;
 
-    @ApiModelProperty(ModelDescriptions.UpgradeModelDescription.LOCK_COMPONENTS)
+    @ApiModelProperty(UpgradeModelDescription.LOCK_COMPONENTS)
     private Boolean lockComponents;
 
-    @ApiModelProperty(ModelDescriptions.UpgradeModelDescription.DRY_RUN)
+    @ApiModelProperty(UpgradeModelDescription.DRY_RUN)
     private Boolean dryRun;
 
     private Boolean replaceVms = Boolean.TRUE;
 
-    @ApiModelProperty(ModelDescriptions.UpgradeModelDescription.SHOW_AVAILABLE_IMAGES)
+    @ApiModelProperty(UpgradeModelDescription.SHOW_AVAILABLE_IMAGES)
     private UpgradeShowAvailableImages showAvailableImages = UpgradeShowAvailableImages.DO_NOT_SHOW;
+
+    @ApiModelProperty(hidden = true)
+    private InternalUpgradeSettings internalUpgradeSettings;
 
     public String getImageId() {
         return imageId;
@@ -76,6 +81,14 @@ public class UpgradeV4Request {
         this.showAvailableImages = showAvailableImages;
     }
 
+    public InternalUpgradeSettings getInternalUpgradeSettings() {
+        return internalUpgradeSettings;
+    }
+
+    public void setInternalUpgradeSettings(InternalUpgradeSettings internalUpgradeSettings) {
+        this.internalUpgradeSettings = internalUpgradeSettings;
+    }
+
     public Boolean getReplaceVms() {
         return replaceVms;
     }
@@ -115,12 +128,14 @@ public class UpgradeV4Request {
 
     @Override
     public String toString() {
-        return "UpgradeV4Request{" +
-                "imageId='" + imageId + '\'' +
-                ", runtime='" + runtime + '\'' +
-                ", lockComponents=" + lockComponents +
-                ", dryRun=" + dryRun +
-                ", showAvailableImages=" + showAvailableImages +
-                '}';
+        return new StringJoiner(", ", UpgradeV4Request.class.getSimpleName() + "[", "]")
+                .add("imageId='" + imageId + "'")
+                .add("runtime='" + runtime + "'")
+                .add("lockComponents=" + lockComponents)
+                .add("dryRun=" + dryRun)
+                .add("replaceVms=" + replaceVms)
+                .add("showAvailableImages=" + showAvailableImages)
+                .add("internalUpgradeSettings=" + internalUpgradeSettings)
+                .toString();
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXUpgradeV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXUpgradeV1Endpoint.java
@@ -6,6 +6,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import org.springframework.validation.annotation.Validated;
@@ -34,6 +35,20 @@ public interface DistroXUpgradeV1Endpoint {
     @Path("/crn/{crn}/upgrade")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "upgrades the distrox cluster", nickname = "upgradeDistroxClusterByCrn")
-    DistroXUpgradeV1Response upgradeClusterByCrn(@PathParam("crn") String crn,  @Valid DistroXUpgradeV1Request distroxUpgradeRequest);
+    DistroXUpgradeV1Response upgradeClusterByCrn(@PathParam("crn") String crn, @Valid DistroXUpgradeV1Request distroxUpgradeRequest);
+
+    @POST
+    @Path("internal/{name}/upgrade")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "upgrades the distrox cluster internal", nickname = "upgradeDistroxClusterInternal")
+    DistroXUpgradeV1Response upgradeClusterByNameInternal(@PathParam("name") String name, @Valid DistroXUpgradeV1Request distroxUpgradeRequest,
+            @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+
+    @POST
+    @Path("internal/crn/{crn}/upgrade")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "upgrades the distrox cluster internal", nickname = "upgradeDistroxClusterByCrnInternal")
+    DistroXUpgradeV1Response upgradeClusterByCrnInternal(@PathParam("crn") String crn, @Valid DistroXUpgradeV1Request distroxUpgradeRequest,
+            @QueryParam("initiatorUserCrn") String initiatorUserCrn);
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactory.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cluster.service.ClouderaManagerProductsProvider;
@@ -32,7 +33,12 @@ public class ImageFilterParamsFactory {
     private ClouderaManagerProductsProvider clouderaManagerProductsProvider;
 
     public ImageFilterParams create(Image image, boolean lockComponents, Stack stack) {
-        return new ImageFilterParams(image, lockComponents, getStackRelatedParcels(stack), stack.getType(), getBlueprint(stack), stack.getId());
+        return create(image, lockComponents, stack, new InternalUpgradeSettings());
+    }
+
+    public ImageFilterParams create(Image image, boolean lockComponents, Stack stack, InternalUpgradeSettings internalUpgradeSettings) {
+        return new ImageFilterParams(image, lockComponents, getStackRelatedParcels(stack), stack.getType(),
+                getBlueprint(stack), stack.getId(), internalUpgradeSettings);
     }
 
     public Map<String, String> getStackRelatedParcels(Stack stack) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilter.java
@@ -160,7 +160,8 @@ public class ClusterUpgradeImageFilter {
             boolean canUpgradeMediumDuty = mediumDuty && entitlementService.haUpgradeEnabled(accountId);
             return new BlueprintValidationResult(!mediumDuty || canUpgradeMediumDuty, "The upgrade is not allowed for this template.");
         } else {
-            return blueprintUpgradeOptionValidator.isValidBlueprint(imageFilterParams.getBlueprint(), imageFilterParams.isLockComponents());
+            return blueprintUpgradeOptionValidator.isValidBlueprint(imageFilterParams.getBlueprint(), imageFilterParams.isLockComponents(),
+                    imageFilterParams.isSkipValidations());
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ImageFilterParams.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/ImageFilterParams.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 
@@ -21,14 +22,22 @@ public class ImageFilterParams {
 
     private final Long stackId;
 
+    private final InternalUpgradeSettings internalUpgradeSettings;
+
     public ImageFilterParams(Image currentImage, boolean lockComponents, Map<String, String> stackRelatedParcels, StackType stackType, Blueprint blueprint,
             Long stackId) {
+        this(currentImage, lockComponents, stackRelatedParcels, stackType, blueprint, stackId, new InternalUpgradeSettings());
+    }
+
+    public ImageFilterParams(Image currentImage, boolean lockComponents, Map<String, String> stackRelatedParcels, StackType stackType, Blueprint blueprint,
+            Long stackId, InternalUpgradeSettings internalUpgradeSettings) {
         this.currentImage = currentImage;
         this.lockComponents = lockComponents;
         this.stackRelatedParcels = stackRelatedParcels;
         this.stackType = stackType;
         this.blueprint = blueprint;
         this.stackId = stackId;
+        this.internalUpgradeSettings = internalUpgradeSettings;
     }
 
     public Image getCurrentImage() {
@@ -55,6 +64,10 @@ public class ImageFilterParams {
         return stackId;
     }
 
+    public boolean isSkipValidations() {
+        return internalUpgradeSettings != null && internalUpgradeSettings.isSkipValidations();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -65,6 +78,7 @@ public class ImageFilterParams {
         }
         ImageFilterParams that = (ImageFilterParams) o;
         return lockComponents == that.lockComponents &&
+                Objects.equals(internalUpgradeSettings, that.internalUpgradeSettings) &&
                 Objects.equals(currentImage, that.currentImage) &&
                 Objects.equals(stackRelatedParcels, that.stackRelatedParcels) &&
                 Objects.equals(stackType, that.stackType) &&
@@ -74,6 +88,6 @@ public class ImageFilterParams {
 
     @Override
     public int hashCode() {
-        return Objects.hash(currentImage, lockComponents, stackRelatedParcels, stackType, blueprint, stackId);
+        return Objects.hash(currentImage, lockComponents, stackRelatedParcels, stackType, blueprint, stackId, internalUpgradeSettings);
     }
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -270,7 +270,8 @@ public class StackOperations implements ResourcePropertyProvider {
         MDCBuilder.buildMdcContext(stack);
         boolean osUpgrade = upgradeService.isOsUpgrade(request);
         boolean replacevms = determineReplaceVmsParameter(stack, request.getReplaceVms());
-        UpgradeV4Response upgradeResponse = clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, osUpgrade, replacevms);
+        UpgradeV4Response upgradeResponse = clusterUpgradeAvailabilityService.checkForUpgradesByName(stack, osUpgrade, replacevms,
+                request.getInternalUpgradeSettings());
         if (CollectionUtils.isNotEmpty(upgradeResponse.getUpgradeCandidates())) {
             clusterUpgradeAvailabilityService.filterUpgradeOptions(accountId, upgradeResponse, request, stack.isDatalake());
         }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/UpgradeConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/UpgradeConverter.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
 import com.sequenceiq.common.model.UpgradeShowAvailableImages;
@@ -13,12 +14,13 @@ import com.sequenceiq.distrox.api.v1.distrox.model.upgrade.DistroXUpgradeV1Respo
 
 @Component
 public class UpgradeConverter {
-    public UpgradeV4Request convert(DistroXUpgradeV1Request source) {
+    public UpgradeV4Request convert(DistroXUpgradeV1Request source, InternalUpgradeSettings internalUpgradeSettings) {
         UpgradeV4Request request = new UpgradeV4Request();
         request.setImageId(source.getImageId());
         request.setRuntime(source.getRuntime());
         request.setDryRun(source.getDryRun());
         request.setLockComponents(source.getLockComponents());
+        request.setInternalUpgradeSettings(internalUpgradeSettings);
         Optional.ofNullable(source.getShowAvailableImages())
                 .ifPresent(value -> request.setShowAvailableImages(UpgradeShowAvailableImages.valueOf(value.name())));
         request.setReplaceVms(convertReplaceVms(source));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageComponentVersions;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageInfoV4Response;
@@ -154,7 +155,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImageFromCatalog, lockComponents, activatedParcels, stack.getType(), null, STACK_ID);
         UpgradeV4Response response = new UpgradeV4Response();
 
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, new InternalUpgradeSettings())).thenReturn(imageFilterParams);
         when(clusterRepairService.repairWithDryRun(stack.getId())).thenReturn(result);
         when(result.isError()).thenReturn(false);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
@@ -166,7 +167,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
                 currentImage.getImageCatalogName())).thenReturn(response);
         when(imageProvider.getCurrentImageFromCatalog(CURRENT_IMAGE_ID, imageCatalog)).thenReturn(currentImageFromCatalog);
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, Boolean.TRUE);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, new InternalUpgradeSettings());
 
         assertEquals(response, actual);
         verify(imageService).getImage(stack.getId());
@@ -189,7 +190,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImageFromCatalog, lockComponents, activatedParcels, stack.getType(), null, STACK_ID);
         UpgradeV4Response response = new UpgradeV4Response();
 
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, new InternalUpgradeSettings())).thenReturn(imageFilterParams);
         when(clusterRepairService.repairWithDryRun(stack.getId())).thenReturn(result);
         when(result.isError()).thenReturn(false);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
@@ -201,7 +202,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
                 currentImage.getImageCatalogName())).thenReturn(response);
         when(imageProvider.getCurrentImageFromCatalog(CURRENT_IMAGE_ID, imageCatalog)).thenReturn(currentImageFromCatalog);
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, Boolean.TRUE);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, new InternalUpgradeSettings());
 
         assertEquals(response, actual);
         verify(imageService).getImage(stack.getId());
@@ -228,13 +229,13 @@ public class ClusterUpgradeAvailabilityServiceTest {
         when(imageCatalogProvider.getImageCatalogV3(CATALOG_URL)).thenReturn(imageCatalog);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImageFromCatalog, lockComponents, activatedParcels, stack.getType(), null, STACK_ID);
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, new InternalUpgradeSettings())).thenReturn(imageFilterParams);
         when(clusterUpgradeImageFilter.filter(accountId, imageCatalog, stack.getCloudPlatform(), imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
                 currentImage.getImageCatalogName())).thenReturn(response);
         when(imageProvider.getCurrentImageFromCatalog(CURRENT_IMAGE_ID, imageCatalog)).thenReturn(currentImageFromCatalog);
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, Boolean.FALSE);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, false, new InternalUpgradeSettings());
 
         assertEquals(response, actual);
         verify(imageService).getImage(stack.getId());
@@ -250,7 +251,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         Stack stack = createStack(createStackStatus(Status.AVAILABLE), DATALAKE_STACK_TYPE);
         when(imageService.getImage(stack.getId())).thenThrow(new CloudbreakImageNotFoundException("Image not found."));
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, Boolean.TRUE);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, new InternalUpgradeSettings());
 
         assertNull(actual.getCurrent());
         assertNull(actual.getUpgradeCandidates());
@@ -277,14 +278,14 @@ public class ClusterUpgradeAvailabilityServiceTest {
         when(imageCatalogService.get(stack.getWorkspace().getId(), CATALOG_NAME)).thenReturn(imageCatalogDomain);
         when(imageCatalogProvider.getImageCatalogV3(CATALOG_URL)).thenReturn(imageCatalog);
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImageFromCatalog, lockComponents, activatedParcels, stack.getType(), null, STACK_ID);
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, new InternalUpgradeSettings())).thenReturn(imageFilterParams);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         when(clusterUpgradeImageFilter.filter(accountId, imageCatalog, stack.getCloudPlatform(), imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
                 currentImage.getImageCatalogName())).thenReturn(response);
         when(imageProvider.getCurrentImageFromCatalog(CURRENT_IMAGE_ID, imageCatalog)).thenReturn(currentImageFromCatalog);
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, Boolean.TRUE);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, new InternalUpgradeSettings());
 
         assertNull(actual.getCurrent());
         assertEquals(1, actual.getUpgradeCandidates().size());
@@ -320,7 +321,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         when(imageCatalogProvider.getImageCatalogV3(CATALOG_URL)).thenReturn(imageCatalog);
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImageFromCatalog, lockComponents, activatedParcels, stack.getType(), null, STACK_ID);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
-        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(currentImageFromCatalog, lockComponents, stack, new InternalUpgradeSettings())).thenReturn(imageFilterParams);
         when(clusterUpgradeImageFilter.filter(accountId, imageCatalog, stack.getCloudPlatform(), imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(currentImageFromCatalog, filteredImages, stack.getCloudPlatform(), stack.getRegion(),
                 currentImage.getImageCatalogName())).thenReturn(response);
@@ -329,7 +330,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         when(result.getError()).thenReturn(repairValidation);
         when(repairValidation.getValidationErrors()).thenReturn(Collections.singletonList(validationError));
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, Boolean.TRUE);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, new InternalUpgradeSettings());
 
         assertNull(actual.getCurrent());
         assertEquals(1, actual.getUpgradeCandidates().size());
@@ -492,12 +493,12 @@ public class ClusterUpgradeAvailabilityServiceTest {
 
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
         when(imageCatalogService.getImage(null, CATALOG_NAME, currentImage.getImageId())).thenReturn(StatedImage.statedImage(image, null, null));
-        when(imageFilterParamsFactory.create(image, lockComponents, stack)).thenReturn(imageFilterParams);
+        when(imageFilterParamsFactory.create(image, lockComponents, stack, new InternalUpgradeSettings())).thenReturn(imageFilterParams);
         when(clusterUpgradeImageFilter.filter(accountId, WORKSPACE_ID, CATALOG_NAME, CLOUD_PLATFORM, imageFilterParams)).thenReturn(filteredImages);
         when(upgradeOptionsResponseFactory.createV4Response(image, filteredImages, CLOUD_PLATFORM, REGION, CATALOG_NAME)).thenReturn(upgradeResponse);
         when(upgradeResponse.getReason()).thenReturn("done");
 
-        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, Boolean.TRUE);
+        UpgradeV4Response actual = underTest.checkForUpgradesByName(stack, lockComponents, true, new InternalUpgradeSettings());
 
         assertEquals(upgradeResponse, actual);
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ImageFilterParamsFactoryTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cluster.service.ClouderaManagerProductsProvider;
@@ -83,10 +84,11 @@ public class ImageFilterParamsFactoryTest {
         when(parcelService.getParcelComponentsByBlueprint(stack)).thenReturn(cdhClusterComponent);
         when(clouderaManagerProductsProvider.getProducts(cdhClusterComponent)).thenReturn(Set.of(spark, nifi));
 
-        ImageFilterParams actual = underTest.create(image, true, stack);
+        ImageFilterParams actual = underTest.create(image, true, stack, new InternalUpgradeSettings(true));
 
         assertEquals(image, actual.getCurrentImage());
         assertTrue(actual.isLockComponents());
+        assertTrue(actual.isSkipValidations());
         assertEquals(sparkVersion, actual.getStackRelatedParcels().get(sparkName));
         assertEquals(nifiVersion, actual.getStackRelatedParcels().get(nifiName));
         assertEquals(StackType.WORKLOAD, actual.getStackType());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/BlueprintUpgradeOptionValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/BlueprintUpgradeOptionValidatorTest.java
@@ -30,7 +30,7 @@ public class BlueprintUpgradeOptionValidatorTest {
     @Test
     public void testIsValidBlueprintShouldReturnTrueWhenTheUpgradeOptionIsEnabledOnDefaultBlueprintAndTheUpgradeIsRuntimeUpgrade() {
         Blueprint blueprint = createBlueprint(ResourceStatus.DEFAULT, BlueprintUpgradeOption.ENABLED);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, false);
         assertTrue(actual.isValid());
         assertNull(actual.getReason());
         verifyNoInteractions(customTemplateUpgradeValidator);
@@ -39,9 +39,17 @@ public class BlueprintUpgradeOptionValidatorTest {
     @Test
     public void testIsValidBlueprintShouldReturnFalseWhenTheUpgradeOptionIsDisabledOnDefaultBlueprintAndTheUpgradeIsRuntimeUpgrade() {
         Blueprint blueprint = createBlueprint(ResourceStatus.DEFAULT, BlueprintUpgradeOption.DISABLED);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, false);
         assertFalse(actual.isValid());
         assertEquals("The cluster template is not eligible for upgrade because the upgrade option is: DISABLED", actual.getReason());
+        verifyNoInteractions(customTemplateUpgradeValidator);
+    }
+
+    @Test
+    public void testIsValidBlueprintShouldReturnTrueWhenTheUpgradeOptionIsDisabledOnDefaultBlueprintAndTheUpgradeIsRuntimeUpgradeWithInternal() {
+        Blueprint blueprint = createBlueprint(ResourceStatus.DEFAULT, BlueprintUpgradeOption.DISABLED);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, true);
+        assertTrue(actual.isValid());
         verifyNoInteractions(customTemplateUpgradeValidator);
     }
 
@@ -49,27 +57,36 @@ public class BlueprintUpgradeOptionValidatorTest {
     public void testIsValidBlueprintShouldReturnTrueWhenTheTemplateIsAValidCustomTemplate() {
         Blueprint blueprint = createBlueprint(ResourceStatus.USER_MANAGED, BlueprintUpgradeOption.ENABLED);
         when(customTemplateUpgradeValidator.isValid(blueprint)).thenReturn(new BlueprintValidationResult(true));
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, false);
         assertTrue(actual.isValid());
         assertNull(actual.getReason());
         verify(customTemplateUpgradeValidator).isValid(blueprint);
     }
 
     @Test
-    public void testIsValidBlueprintShouldReturnTrueWhenTheTemplateIsANotValidCustomTemplate() {
+    public void testIsValidBlueprintShouldReturnFalseWhenTheTemplateIsANotValidCustomTemplate() {
         Blueprint blueprint = createBlueprint(ResourceStatus.USER_MANAGED, BlueprintUpgradeOption.ENABLED);
         BlueprintValidationResult result = new BlueprintValidationResult(false, "Custom template not eligible.");
         when(customTemplateUpgradeValidator.isValid(blueprint)).thenReturn(result);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, false);
         assertFalse(actual.isValid());
         assertEquals(result.getReason(), actual.getReason());
         verify(customTemplateUpgradeValidator).isValid(blueprint);
     }
 
     @Test
+    public void testIsValidBlueprintShouldReturnTrueWhenTheTemplateIsANotValidCustomTemplateButInternalApiUsed() {
+        Blueprint blueprint = createBlueprint(ResourceStatus.USER_MANAGED, BlueprintUpgradeOption.DISABLED);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, true);
+        assertTrue(actual.isValid());
+        assertNull(actual.getReason());
+        verifyNoInteractions(customTemplateUpgradeValidator);
+    }
+
+    @Test
     public void testIsValidBlueprintShouldReturnTrueWhenTheUpgradeOptionIsEnabledOnDefaultBlueprintAndTheUpgradeIsOsUpgrade() {
         Blueprint blueprint = createBlueprint(ResourceStatus.DEFAULT, BlueprintUpgradeOption.ENABLED);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, true);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, true, false);
         assertTrue(actual.isValid());
         verifyNoInteractions(customTemplateUpgradeValidator);
     }
@@ -77,7 +94,7 @@ public class BlueprintUpgradeOptionValidatorTest {
     @Test
     public void testIsValidBlueprintShouldReturnTrueWhenTheUpgradeOptionIsOsEnabledOnDefaultBlueprintAndTheUpgradeIsOsUpgrade() {
         Blueprint blueprint = createBlueprint(ResourceStatus.DEFAULT, BlueprintUpgradeOption.OS_UPGRADE_ENABLED);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, true);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, true, false);
         assertTrue(actual.isValid());
         verifyNoInteractions(customTemplateUpgradeValidator);
     }
@@ -85,7 +102,7 @@ public class BlueprintUpgradeOptionValidatorTest {
     @Test
     public void testIsValidBlueprintShouldReturnTrueWhenTheUpgradeOptionIsOsEnabledOnDefaultBlueprintAndTheUpgradeIsRuntimeUpgrade() {
         Blueprint blueprint = createBlueprint(ResourceStatus.DEFAULT, BlueprintUpgradeOption.OS_UPGRADE_ENABLED);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, false);
         assertTrue(actual.isValid());
         verifyNoInteractions(customTemplateUpgradeValidator);
     }
@@ -93,7 +110,7 @@ public class BlueprintUpgradeOptionValidatorTest {
     @Test
     public void testIsValidBlueprintShouldReturnTrueWhenTheUpgradeOptionIsOsDisabledOnDefaultBlueprintAndTheUpgradeIsRuntimeUpgrade() {
         Blueprint blueprint = createBlueprint(ResourceStatus.DEFAULT, BlueprintUpgradeOption.OS_UPGRADE_DISABLED);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, false);
         assertTrue(actual.isValid());
         verifyNoInteractions(customTemplateUpgradeValidator);
     }
@@ -101,7 +118,7 @@ public class BlueprintUpgradeOptionValidatorTest {
     @Test
     public void testIsValidBlueprintShouldReturnTrueWhenTheUpgradeOptionNullOnDefaultBlueprintAndTheUpgradeIsOsUpgrade() {
         Blueprint blueprint = createBlueprint(ResourceStatus.DEFAULT, null);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, true);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, true, false);
         assertTrue(actual.isValid());
         verifyNoInteractions(customTemplateUpgradeValidator);
     }
@@ -109,7 +126,7 @@ public class BlueprintUpgradeOptionValidatorTest {
     @Test
     public void testIsValidBlueprintShouldReturnFalseWhenTheUpgradeOptionIsOsDisabledOnDefaultBlueprintAndTheUpgradeIsOsUpgrade() {
         Blueprint blueprint = createBlueprint(ResourceStatus.DEFAULT, BlueprintUpgradeOption.OS_UPGRADE_DISABLED);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, true);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, true, false);
         assertFalse(actual.isValid());
         assertEquals("The cluster template is not eligible for upgrade because the upgrade option is: OS_UPGRADE_DISABLED", actual.getReason());
         verifyNoInteractions(customTemplateUpgradeValidator);
@@ -118,7 +135,7 @@ public class BlueprintUpgradeOptionValidatorTest {
     @Test
     public void testIsValidBlueprintShouldReturnFalseWhenTheUpgradeOptionIsDisabledOnDefaultBlueprintAndTheUpgradeIsOsUpgrade() {
         Blueprint blueprint = createBlueprint(ResourceStatus.DEFAULT, BlueprintUpgradeOption.DISABLED);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, true);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, true, false);
         assertFalse(actual.isValid());
         assertEquals("The cluster template is not eligible for upgrade because the upgrade option is: DISABLED", actual.getReason());
         verifyNoInteractions(customTemplateUpgradeValidator);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/ClusterUpgradeImageFilterTest.java
@@ -155,26 +155,27 @@ public class ClusterUpgradeImageFilterTest {
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, lockComponents, activatedParcels, StackType.WORKLOAD, blueprint, STACK_ID);
         ImageFilterResult imageFilterResult = new ImageFilterResult(new Images(null, properImages, null, null), "");
         when(imageCatalogServiceProxy.getImageFilterResult(cloudbreakImageCatalogV3)).thenReturn(imageFilterResult);
-        when(blueprintUpgradeOptionValidator.isValidBlueprint(blueprint, imageFilterParams.isLockComponents())).thenReturn(new BlueprintValidationResult(true));
+        when(blueprintUpgradeOptionValidator.isValidBlueprint(blueprint, imageFilterParams.isLockComponents(), false))
+                .thenReturn(new BlueprintValidationResult(true));
 
         ImageFilterResult actual = underTest.filter(ACCOUNT_ID, cloudbreakImageCatalogV3, CLOUD_PLATFORM, imageFilterParams);
 
         assertTrue(actual.getReason(), actual.getAvailableImages().getCdhImages().contains(this.properImage));
         assertEquals(1, actual.getAvailableImages().getCdhImages().size());
-        verify(blueprintUpgradeOptionValidator).isValidBlueprint(blueprint, imageFilterParams.isLockComponents());
+        verify(blueprintUpgradeOptionValidator).isValidBlueprint(blueprint, imageFilterParams.isLockComponents(), false);
     }
 
     @Test
     public void testFilterShouldNotReturnTheAvailableImageWhenTheBlueprintIsNotEligibleForUpgradeAndTheStackTypeIsWorkload() {
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, lockComponents, activatedParcels, StackType.WORKLOAD, blueprint, STACK_ID);
         BlueprintValidationResult blueprintValidationResult = new BlueprintValidationResult(false, "The upgrade is not allowed for this template.");
-        when(blueprintUpgradeOptionValidator.isValidBlueprint(blueprint, imageFilterParams.isLockComponents())).thenReturn(blueprintValidationResult);
+        when(blueprintUpgradeOptionValidator.isValidBlueprint(blueprint, imageFilterParams.isLockComponents(), false)).thenReturn(blueprintValidationResult);
 
         ImageFilterResult actual = underTest.filter(ACCOUNT_ID, cloudbreakImageCatalogV3, CLOUD_PLATFORM, imageFilterParams);
 
         assertEquals(blueprintValidationResult.getReason(), actual.getReason());
         assertTrue(actual.getAvailableImages().getCdhImages().isEmpty());
-        verify(blueprintUpgradeOptionValidator).isValidBlueprint(blueprint, imageFilterParams.isLockComponents());
+        verify(blueprintUpgradeOptionValidator).isValidBlueprint(blueprint, imageFilterParams.isLockComponents(), false);
         verifyNoInteractions(imageCatalogServiceProxy);
     }
 
@@ -418,13 +419,13 @@ public class ClusterUpgradeImageFilterTest {
     public void testFilterShouldNotReturnTheAvailableImageByImageCatalogNameWhenTheBlueprintIsNotEligibleForUpgrade() {
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, lockComponents, activatedParcels, StackType.WORKLOAD, blueprint, STACK_ID);
         BlueprintValidationResult blueprintValidationResult = new BlueprintValidationResult(false, "The upgrade is not allowed for this template.");
-        when(blueprintUpgradeOptionValidator.isValidBlueprint(blueprint, imageFilterParams.isLockComponents())).thenReturn(blueprintValidationResult);
+        when(blueprintUpgradeOptionValidator.isValidBlueprint(blueprint, imageFilterParams.isLockComponents(), false)).thenReturn(blueprintValidationResult);
 
         ImageFilterResult actual = underTest.filter(ACCOUNT_ID, WORKSPACE_ID, CATALOG_NAME, CLOUD_PLATFORM, imageFilterParams);
 
         assertEquals(blueprintValidationResult.getReason(), actual.getReason());
         assertTrue(actual.getAvailableImages().getCdhImages().isEmpty());
-        verify(blueprintUpgradeOptionValidator).isValidBlueprint(blueprint, imageFilterParams.isLockComponents());
+        verify(blueprintUpgradeOptionValidator).isValidBlueprint(blueprint, imageFilterParams.isLockComponents(), false);
         verifyNoInteractions(imageCatalogService);
     }
 
@@ -434,13 +435,14 @@ public class ClusterUpgradeImageFilterTest {
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImage, lockComponents, activatedParcels, StackType.WORKLOAD, blueprint, STACK_ID);
         when(imageCatalogService.getImages(WORKSPACE_ID, CATALOG_NAME, CLOUD_PLATFORM))
                 .thenReturn(StatedImages.statedImages(new Images(null, imageForUpgrade, null, null), null, null));
-        when(blueprintUpgradeOptionValidator.isValidBlueprint(blueprint, imageFilterParams.isLockComponents())).thenReturn(new BlueprintValidationResult(true));
+        when(blueprintUpgradeOptionValidator.isValidBlueprint(blueprint, imageFilterParams.isLockComponents(), false))
+                .thenReturn(new BlueprintValidationResult(true));
 
         ImageFilterResult actual = underTest.filter(ACCOUNT_ID, WORKSPACE_ID, CATALOG_NAME, CLOUD_PLATFORM, imageFilterParams);
 
         assertTrue(actual.getReason(), actual.getAvailableImages().getCdhImages().contains(this.properImage));
         assertEquals(1, actual.getAvailableImages().getCdhImages().size());
-        verify(blueprintUpgradeOptionValidator).isValidBlueprint(blueprint, imageFilterParams.isLockComponents());
+        verify(blueprintUpgradeOptionValidator).isValidBlueprint(blueprint, imageFilterParams.isLockComponents(), false);
     }
 
     private Image createCurrentImage() {

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/controller/DistroxUpgradeV1ControllerTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/controller/DistroxUpgradeV1ControllerTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
@@ -59,10 +60,10 @@ class DistroxUpgradeV1ControllerTest {
     @Test
     public void testDryRun() {
         DistroXUpgradeV1Request distroxUpgradeRequest = new DistroXUpgradeV1Request();
-        when(componentLocker.lockComponentsIfRuntimeUpgradeIsDisabled(distroxUpgradeRequest, USER_CRN,  CLUSTER_NAME)).thenReturn(distroxUpgradeRequest);
+        when(componentLocker.lockComponentsIfRuntimeUpgradeIsDisabled(distroxUpgradeRequest, USER_CRN, CLUSTER_NAME)).thenReturn(distroxUpgradeRequest);
         UpgradeV4Request upgradeV4Request = new UpgradeV4Request();
         upgradeV4Request.setDryRun(Boolean.TRUE);
-        when(upgradeConverter.convert(distroxUpgradeRequest)).thenReturn(upgradeV4Request);
+        when(upgradeConverter.convert(distroxUpgradeRequest, new InternalUpgradeSettings())).thenReturn(upgradeV4Request);
         UpgradeV4Response upgradeV4Response = new UpgradeV4Response();
         when(upgradeAvailabilityService.checkForUpgrade(NameOrCrn.ofName(CLUSTER_NAME), WORKSPACE_ID, upgradeV4Request, USER_CRN)).thenReturn(upgradeV4Response);
         when(upgradeConverter.convert(upgradeV4Response)).thenReturn(new DistroXUpgradeV1Response());
@@ -76,10 +77,10 @@ class DistroxUpgradeV1ControllerTest {
     @Test
     public void testShowAvailableImages() {
         DistroXUpgradeV1Request distroxUpgradeRequest = new DistroXUpgradeV1Request();
-        when(componentLocker.lockComponentsIfRuntimeUpgradeIsDisabled(distroxUpgradeRequest, USER_CRN,  CLUSTER_NAME)).thenReturn(distroxUpgradeRequest);
+        when(componentLocker.lockComponentsIfRuntimeUpgradeIsDisabled(distroxUpgradeRequest, USER_CRN, CLUSTER_NAME)).thenReturn(distroxUpgradeRequest);
         UpgradeV4Request upgradeV4Request = new UpgradeV4Request();
         upgradeV4Request.setShowAvailableImages(UpgradeShowAvailableImages.SHOW);
-        when(upgradeConverter.convert(distroxUpgradeRequest)).thenReturn(upgradeV4Request);
+        when(upgradeConverter.convert(distroxUpgradeRequest, new InternalUpgradeSettings())).thenReturn(upgradeV4Request);
         UpgradeV4Response upgradeV4Response = new UpgradeV4Response();
         when(upgradeAvailabilityService.checkForUpgrade(NameOrCrn.ofName(CLUSTER_NAME), WORKSPACE_ID, upgradeV4Request, USER_CRN)).thenReturn(upgradeV4Response);
         when(upgradeConverter.convert(upgradeV4Response)).thenReturn(new DistroXUpgradeV1Response());
@@ -93,10 +94,10 @@ class DistroxUpgradeV1ControllerTest {
     @Test
     public void testUpgradeCalled() {
         DistroXUpgradeV1Request distroxUpgradeRequest = new DistroXUpgradeV1Request();
-        when(componentLocker.lockComponentsIfRuntimeUpgradeIsDisabled(distroxUpgradeRequest, USER_CRN,  CLUSTER_NAME)).thenReturn(distroxUpgradeRequest);
+        when(componentLocker.lockComponentsIfRuntimeUpgradeIsDisabled(distroxUpgradeRequest, USER_CRN, CLUSTER_NAME)).thenReturn(distroxUpgradeRequest);
         UpgradeV4Request upgradeV4Request = new UpgradeV4Request();
         upgradeV4Request.setDryRun(Boolean.FALSE);
-        when(upgradeConverter.convert(distroxUpgradeRequest)).thenReturn(upgradeV4Request);
+        when(upgradeConverter.convert(distroxUpgradeRequest, new InternalUpgradeSettings())).thenReturn(upgradeV4Request);
         UpgradeV4Response upgradeV4Response = new UpgradeV4Response();
         when(upgradeService.triggerUpgrade(NameOrCrn.ofName(CLUSTER_NAME), WORKSPACE_ID, USER_CRN, upgradeV4Request)).thenReturn(upgradeV4Response);
         when(upgradeConverter.convert(upgradeV4Response)).thenReturn(new DistroXUpgradeV1Response());
@@ -110,10 +111,10 @@ class DistroxUpgradeV1ControllerTest {
     @Test
     public void testUpgradeCalledWithCrn() {
         DistroXUpgradeV1Request distroxUpgradeRequest = new DistroXUpgradeV1Request();
-        when(componentLocker.lockComponentsIfRuntimeUpgradeIsDisabled(distroxUpgradeRequest, USER_CRN,  CLUSTER_NAME)).thenReturn(distroxUpgradeRequest);
+        when(componentLocker.lockComponentsIfRuntimeUpgradeIsDisabled(distroxUpgradeRequest, USER_CRN, CLUSTER_NAME)).thenReturn(distroxUpgradeRequest);
         UpgradeV4Request upgradeV4Request = new UpgradeV4Request();
         upgradeV4Request.setDryRun(Boolean.FALSE);
-        when(upgradeConverter.convert(distroxUpgradeRequest)).thenReturn(upgradeV4Request);
+        when(upgradeConverter.convert(distroxUpgradeRequest, new InternalUpgradeSettings())).thenReturn(upgradeV4Request);
         UpgradeV4Response upgradeV4Response = new UpgradeV4Response();
         when(upgradeService.triggerUpgrade(NameOrCrn.ofCrn(CLUSTER_NAME), WORKSPACE_ID, USER_CRN, upgradeV4Request)).thenReturn(upgradeV4Response);
         when(upgradeConverter.convert(upgradeV4Response)).thenReturn(new DistroXUpgradeV1Response());

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/UpgradeConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/UpgradeConverterTest.java
@@ -1,7 +1,9 @@
 package com.sequenceiq.distrox.v1.distrox.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.InternalUpgradeSettings;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.ImageInfoV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.upgrade.UpgradeV4Response;
@@ -46,7 +49,7 @@ class UpgradeConverterTest {
         source.setReplaceVms(DistroXUpgradeReplaceVms.DISABLED);
         source.setRuntime("runtime");
 
-        UpgradeV4Request result = underTest.convert(source);
+        UpgradeV4Request result = underTest.convert(source, new InternalUpgradeSettings());
 
         assertEquals(source.getDryRun(), result.getDryRun());
         assertEquals(source.getImageId(), result.getImageId());
@@ -54,6 +57,17 @@ class UpgradeConverterTest {
         assertEquals(source.getLockComponents(), result.getLockComponents());
         assertEquals(Boolean.FALSE, result.getReplaceVms());
         assertEquals(source.getRuntime(), result.getRuntime());
+        assertFalse(result.getInternalUpgradeSettings().isSkipValidations());
+    }
+
+    @Test
+    public void testConvertRequestWhenInternal() {
+        // GIVEN
+        DistroXUpgradeV1Request source = new DistroXUpgradeV1Request();
+        // WHEN
+        UpgradeV4Request result = underTest.convert(source, new InternalUpgradeSettings(true));
+        // THEN
+        assertTrue(result.getInternalUpgradeSettings().isSkipValidations());
     }
 
     @Test
@@ -61,7 +75,7 @@ class UpgradeConverterTest {
         // GIVEN
         DistroXUpgradeV1Request source = new DistroXUpgradeV1Request();
         // WHEN
-        UpgradeV4Request result = underTest.convert(source);
+        UpgradeV4Request result = underTest.convert(source, new InternalUpgradeSettings());
         // THEN
         assertNull(result.getReplaceVms());
     }


### PR DESCRIPTION
…llow internal API requests

A new hidden field is introduced on the `UpgradeV4Request` so we can build features around it
or simply bypass some of the validations. This flag can't be set on the API, but an internal API
call is needed to set it. As part of this PR I've introduced the internal counterparts of the
upgrade APIs for Data Hub. This can be called from the experiences with the internal actor crn.
The current purpose of this field is to bypass the blueprint validation even if it's `DISABLED`.
The scenario is that the COD clusters are disabled for upgrade on the Data Hub page, but the `ODX`
experience would like to drive the upgrade for these clusters so they can call the internal API.
This is to prevent customers to directly upgrade the COD clusters without the `ODX` app knowing
about it.

Tested with curl:
```
curl -X POST \
-H "Content-Type: application/json" \
-H "x-cdp-actor-crn: crn:cdp:iam:us-west-1:altus:user:__internal__actor__" \
-d '{"runtime":"7.2.10"}' \
http://localhost:9091/cb/api/v1/distrox/internal/krisz-wl-1/upgrade\?initiatorUserCrn\=crn:cdp:iam:us-west-1:pepsi:user:khorvath
```
