### PR TITLE
CB-12911 Set rackId mapping in CM

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ClusterHostAttributes.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ClusterHostAttributes.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.cloudbreak.cluster.model;
+
+public final class ClusterHostAttributes {
+
+    public static final String FQDN = "fqdn";
+
+    public static final String RACK_ID = "rackId";
+
+    private ClusterHostAttributes() {
+    }
+
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaHostGroupAssociationBuilder.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaHostGroupAssociationBuilder.java
@@ -10,13 +10,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.cluster.model.ClusterHostAttributes;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.util.NullUtil;
 
 @Service
 class ClouderaHostGroupAssociationBuilder {
-
-    private static final String FQDN = "fqdn";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaHostGroupAssociationBuilder.class);
 
@@ -35,7 +35,8 @@ class ClouderaHostGroupAssociationBuilder {
         List<Map<String, String>> hostInfoForHostGroup = new ArrayList<>();
         for (InstanceMetaData metaData : instanceMetadataList) {
             Map<String, String> hostInfo = new HashMap<>();
-            hostInfo.put(FQDN, metaData.getDiscoveryFQDN());
+            hostInfo.put(ClusterHostAttributes.FQDN, metaData.getDiscoveryFQDN());
+            NullUtil.putIfPresent(hostInfo, ClusterHostAttributes.RACK_ID, metaData.getRackId());
             hostInfoForHostGroup.add(hostInfo);
         }
         return hostInfoForHostGroup;

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaHostGroupAssociationBuilderTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaHostGroupAssociationBuilderTest.java
@@ -1,20 +1,22 @@
 package com.sequenceiq.cloudbreak.cm;
 
-import static org.junit.Assert.assertEquals;
+import static com.sequenceiq.cloudbreak.cluster.model.ClusterHostAttributes.FQDN;
+import static com.sequenceiq.cloudbreak.cluster.model.ClusterHostAttributes.RACK_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 
 public class ClouderaHostGroupAssociationBuilderTest {
-
-    private static final String FQDN = "fqdn";
 
     private static final String HOSTGROUP_NAME_1 = "hostgroup-1";
 
@@ -28,7 +30,16 @@ public class ClouderaHostGroupAssociationBuilderTest {
 
     private static final String FQDN_4 = "fqdn-4";
 
-    private ClouderaHostGroupAssociationBuilder underTest = new ClouderaHostGroupAssociationBuilder();
+    private static final String RACK_ID_1 = "/dc-1/rack-2";
+
+    private static final String RACK_ID_2 = "";
+
+    private ClouderaHostGroupAssociationBuilder underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new ClouderaHostGroupAssociationBuilder();
+    }
 
     @Test
     public void testBuildHostGroupAssociationsShouldReturnsHostGroupAssociationsWhenTheParametersArePresent() {
@@ -40,6 +51,10 @@ public class ClouderaHostGroupAssociationBuilderTest {
         assertEquals(FQDN_2, actual.get(HOSTGROUP_NAME_1).get(1).get(FQDN));
         assertEquals(FQDN_3, actual.get(HOSTGROUP_NAME_2).get(0).get(FQDN));
         assertEquals(FQDN_4, actual.get(HOSTGROUP_NAME_2).get(1).get(FQDN));
+        assertThat(actual.get(HOSTGROUP_NAME_1).get(0).get(RACK_ID)).isEqualTo(RACK_ID_1);
+        assertThat(actual.get(HOSTGROUP_NAME_1).get(1).get(RACK_ID)).isEqualTo(RACK_ID_1);
+        assertThat(actual.get(HOSTGROUP_NAME_2).get(0).get(RACK_ID)).isEqualTo(RACK_ID_2);
+        assertThat(actual.get(HOSTGROUP_NAME_2).get(1)).doesNotContainKey(RACK_ID);
     }
 
     @Test
@@ -51,8 +66,8 @@ public class ClouderaHostGroupAssociationBuilderTest {
 
     private Map<HostGroup, List<InstanceMetaData>> createInstanceMetaDataByHostGroup() {
         Map<HostGroup, List<InstanceMetaData>> map = new HashMap<>();
-        map.put(createHostGroup(HOSTGROUP_NAME_1), List.of(createInstanceMetaData(FQDN_1), createInstanceMetaData(FQDN_2)));
-        map.put(createHostGroup(HOSTGROUP_NAME_2), List.of(createInstanceMetaData(FQDN_3), createInstanceMetaData(FQDN_4)));
+        map.put(createHostGroup(HOSTGROUP_NAME_1), List.of(createInstanceMetaData(FQDN_1, RACK_ID_1), createInstanceMetaData(FQDN_2, RACK_ID_1)));
+        map.put(createHostGroup(HOSTGROUP_NAME_2), List.of(createInstanceMetaData(FQDN_3, RACK_ID_2), createInstanceMetaData(FQDN_4, null)));
         return map;
     }
 
@@ -62,9 +77,10 @@ public class ClouderaHostGroupAssociationBuilderTest {
         return hostGroup;
     }
 
-    private InstanceMetaData createInstanceMetaData(String discoveryFQDN) {
+    private InstanceMetaData createInstanceMetaData(String discoveryFQDN, String rackId) {
         InstanceMetaData instanceMetaData = new InstanceMetaData();
         instanceMetaData.setDiscoveryFQDN(discoveryFQDN);
+        instanceMetaData.setRackId(rackId);
         return instanceMetaData;
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/util/URLUtils.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/util/URLUtils.java
@@ -1,7 +1,9 @@
-package com.sequenceiq.cloudbreak.converter.util;
+package com.sequenceiq.cloudbreak.util;
 
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
@@ -16,4 +18,9 @@ public class URLUtils {
         }
         return IOUtils.toString(new URL(url));
     }
+
+    public static String encodeString(String text) {
+        return URLEncoder.encode(text, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+    }
+
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/util/URLUtilsTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/util/URLUtilsTest.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.cloudbreak.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class URLUtilsTest {
+
+    static Object[][] encodeStringDataProvider() {
+        return new Object[][]{
+                // testCaseName text expectedResult
+                {"text=<empty string>", "", ""},
+                {"text=abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz", "abcdefghijklmnopqrstuvwxyz"},
+                {"text=ABCDEFGHIJKLMNOPQRSTUVWXYZ", "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "ABCDEFGHIJKLMNOPQRSTUVWXYZ"},
+                {"text=1234567890", "1234567890", "1234567890"},
+                {"text=.-*_", ".-*_", ".-*_"},
+                {"text=foo bar", "foo @bar", "foo%20%40bar"},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("encodeStringDataProvider")
+    void encodeStringTestWhenSuccess(String testCaseName, String text, String expectedResult) {
+        String result = URLUtils.encodeString(text);
+
+        assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @Test
+    void encodeStringTestWhenNPE() {
+        assertThrows(NullPointerException.class, () -> URLUtils.encodeString(null));
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/blueprint/BlueprintV4RequestToBlueprintConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/blueprint/BlueprintV4RequestToBlueprintConverter.java
@@ -25,7 +25,7 @@ import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.common.type.APIResourceType;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
-import com.sequenceiq.cloudbreak.converter.util.URLUtils;
+import com.sequenceiq.cloudbreak.util.URLUtils;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.json.CloudbreakApiException;
 import com.sequenceiq.cloudbreak.json.JsonHelper;

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/base/BatchResourceOperation.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/base/BatchResourceOperation.java
@@ -1,0 +1,107 @@
+package com.sequenceiq.mock.clouderamanager.base;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+import javax.validation.Valid;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.mock.clouderamanager.ResponseCreatorComponent;
+import com.sequenceiq.mock.clouderamanager.base.batchapi.BatchApiHandler;
+import com.sequenceiq.mock.swagger.model.ApiBatchRequest;
+import com.sequenceiq.mock.swagger.model.ApiBatchRequestElement;
+import com.sequenceiq.mock.swagger.model.ApiBatchResponse;
+import com.sequenceiq.mock.swagger.model.ApiBatchResponseElement;
+
+@Service
+public class BatchResourceOperation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(BatchResourceOperation.class);
+
+    private final ResponseCreatorComponent responseCreatorComponent;
+
+    private final List<BatchApiHandler> batchApiHandlers;
+
+    public BatchResourceOperation(ResponseCreatorComponent responseCreatorComponent, List<BatchApiHandler> batchApiHandlers) {
+        this.responseCreatorComponent = responseCreatorComponent;
+        this.batchApiHandlers = batchApiHandlers;
+    }
+
+    @PostConstruct
+    void init() {
+        String handlers = batchApiHandlers.stream()
+                .map(batchApiHandler -> String.format("%s: %s", batchApiHandler.getClass().getName(), batchApiHandler.getDescription()))
+                .collect(Collectors.joining(",\n"));
+        LOGGER.debug("Registered handlers:\n" + handlers);
+    }
+
+    public ResponseEntity<ApiBatchResponse> execute(String mockUuid, @Valid ApiBatchRequest body) {
+        LOGGER.debug("Processing request. MockUuid: [{}]. Request: {}", mockUuid, body);
+        ApiBatchResponse apiBatchResponse = new ApiBatchResponse();
+        if (body == null || body.getItems() == null) {
+            apiBatchResponse.success(false);
+        } else {
+            AtomicBoolean success = new AtomicBoolean(true);
+            List<ApiBatchResponseElement> apiBatchResponseElements = body.getItems().stream()
+                    .map(apiBatchRequestElement -> {
+                        ApiBatchResponseElement apiBatchResponseElement = processApiBatchRequestElement(mockUuid, apiBatchRequestElement);
+                        success.set(isSuccessResponse(apiBatchResponseElement) && success.get());
+                        return apiBatchResponseElement;
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+            apiBatchResponse.success(success.get());
+            apiBatchResponse.items(apiBatchResponseElements);
+        }
+        LOGGER.debug("Processing request completed. MockUuid: [{}]. Response: {}", mockUuid, apiBatchResponse);
+        return responseCreatorComponent.exec(apiBatchResponse);
+    }
+
+    private ApiBatchResponseElement processApiBatchRequestElement(String mockUuid, ApiBatchRequestElement apiBatchRequestElement) {
+        for (BatchApiHandler batchApiHandler : batchApiHandlers) {
+            if (batchApiHandler.canProcess(apiBatchRequestElement)) {
+                try {
+                    return batchApiHandler.process(mockUuid, apiBatchRequestElement);
+                } catch (RuntimeException e) {
+                    LOGGER.error(String.format("Error while processing request, returning failed response. MockUuid: [%s]. Request: %s", mockUuid,
+                            apiBatchRequestElement), e);
+                    return getFailureApiBatchResponseElement();
+                }
+            }
+        }
+        LOGGER.warn("No handler found to process request, returning failed response. MockUuid: [{}]. Request: {}", mockUuid, apiBatchRequestElement);
+        return getFailureApiBatchResponseElement();
+    }
+
+    private ApiBatchResponseElement getFailureApiBatchResponseElement() {
+        return new ApiBatchResponseElement()
+                .statusCode(BigDecimal.valueOf(HttpStatus.BAD_REQUEST.value()));
+    }
+
+    private boolean isSuccessResponse(ApiBatchResponseElement apiBatchResponseElement) {
+        HttpStatus httpStatus = Optional.ofNullable(apiBatchResponseElement)
+                .map(ApiBatchResponseElement::getStatusCode)
+                .map(BigDecimal::intValue)
+                .map(HttpStatus::resolve)
+                .orElse(null);
+        if (httpStatus != null) {
+            boolean success = httpStatus.is2xxSuccessful() || httpStatus.is3xxRedirection();
+            LOGGER.debug("Mapping response status: [{}]. Success: {}", httpStatus, success);
+            return success;
+        } else {
+            LOGGER.warn("Invalid status code for response, assuming failure. Response: " + apiBatchResponseElement);
+            return false;
+        }
+    }
+
+}

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/base/batchapi/AbstractBatchApiHandler.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/base/batchapi/AbstractBatchApiHandler.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.mock.clouderamanager.base.batchapi;
+
+import java.math.BigDecimal;
+
+import org.springframework.http.HttpStatus;
+
+import com.sequenceiq.mock.swagger.model.ApiBatchResponseElement;
+
+public abstract class AbstractBatchApiHandler implements BatchApiHandler {
+
+    protected ApiBatchResponseElement getSuccessApiBatchResponseElement(String response) {
+        return new ApiBatchResponseElement()
+                .statusCode(BigDecimal.valueOf(HttpStatus.OK.value()))
+                .response(response);
+    }
+
+}

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/base/batchapi/BatchApiHandler.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/base/batchapi/BatchApiHandler.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.mock.clouderamanager.base.batchapi;
+
+import com.sequenceiq.mock.swagger.model.ApiBatchRequestElement;
+import com.sequenceiq.mock.swagger.model.ApiBatchResponseElement;
+
+public interface BatchApiHandler {
+
+    default String getDescription() {
+        return "<Description missing>";
+    }
+
+    boolean canProcess(ApiBatchRequestElement apiBatchRequestElement);
+
+    ApiBatchResponseElement process(String mockUuid, ApiBatchRequestElement apiBatchRequestElement);
+
+}

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/base/batchapi/HostsResourceApiUpdateHostBatchApiHandler.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/base/batchapi/HostsResourceApiUpdateHostBatchApiHandler.java
@@ -1,0 +1,65 @@
+package com.sequenceiq.mock.clouderamanager.base.batchapi;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.mock.clouderamanager.DataProviderService;
+import com.sequenceiq.mock.swagger.model.ApiBatchRequestElement;
+import com.sequenceiq.mock.swagger.model.ApiBatchResponseElement;
+import com.sequenceiq.mock.swagger.model.ApiHost;
+import com.sequenceiq.mock.swagger.model.HTTPMethod;
+
+@Component
+public class HostsResourceApiUpdateHostBatchApiHandler extends AbstractBatchApiHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HostsResourceApiUpdateHostBatchApiHandler.class);
+
+    private static final Pattern HOSTS_RESOURCE_API_UPDATE_HOST_PATTERN = Pattern.compile("^/api/v31/hosts/(.+)$");
+
+    private static final int GROUP_HOST_ID = 1;
+
+    private final DataProviderService dataProviderService;
+
+    public HostsResourceApiUpdateHostBatchApiHandler(DataProviderService dataProviderService) {
+        this.dataProviderService = dataProviderService;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Handler for the batch API request representing " +
+                "com.cloudera.api.swagger.HostsResourceApi.updateHost(String hostId, com.cloudera.api.swagger.model.ApiHost).";
+    }
+
+    @Override
+    public boolean canProcess(ApiBatchRequestElement apiBatchRequestElement) {
+        Matcher matcher = HOSTS_RESOURCE_API_UPDATE_HOST_PATTERN.matcher(apiBatchRequestElement.getUrl());
+        return matcher.matches() && apiBatchRequestElement.getMethod() == HTTPMethod.PUT;
+    }
+
+    @Override
+    public ApiBatchResponseElement process(String mockUuid, ApiBatchRequestElement apiBatchRequestElement) {
+        Matcher matcher = HOSTS_RESOURCE_API_UPDATE_HOST_PATTERN.matcher(apiBatchRequestElement.getUrl());
+        if (matcher.matches()) {
+            LOGGER.debug("Processing request. MockUuid: [{}]. Request: {}", mockUuid, apiBatchRequestElement);
+            String hostId = matcher.group(GROUP_HOST_ID);
+            Json jsonFromRequestBody = new Json(apiBatchRequestElement.getBody());
+            ApiHost apiHostFromRequestBody = jsonFromRequestBody.getSilent(ApiHost.class);
+            String rackId = apiHostFromRequestBody.getRackId();
+            ApiHost apiHostFound = dataProviderService.getApiHost(mockUuid, hostId);
+            apiHostFound.rackId(rackId);
+            // Host updates could be persisted here, but now this is not necessary as ApiHost details are directly populated from SPI VM metadata.
+            ApiBatchResponseElement apiBatchResponseElement = getSuccessApiBatchResponseElement(jsonFromRequestBody.getValue());
+            LOGGER.debug("Processing request completed. MockUuid: [{}]. Response: {}", mockUuid, apiBatchResponseElement);
+            return apiBatchResponseElement;
+        } else {
+            // Should not happen as this method ought to be only invoked if "canProcess()" previously returned true.
+            throw new UnsupportedOperationException("This handler does not support processing the request " + apiBatchRequestElement);
+        }
+    }
+
+}

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/v31/controller/BatchResourceV31Controller.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/clouderamanager/v31/controller/BatchResourceV31Controller.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.mock.clouderamanager.v31.controller;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+import com.sequenceiq.mock.clouderamanager.base.BatchResourceOperation;
+import com.sequenceiq.mock.swagger.model.ApiBatchRequest;
+import com.sequenceiq.mock.swagger.model.ApiBatchResponse;
+import com.sequenceiq.mock.swagger.v31.api.BatchResourceApi;
+
+@Controller
+public class BatchResourceV31Controller implements BatchResourceApi {
+
+    @Inject
+    private BatchResourceOperation batchResourceOperation;
+
+    @Override
+    public ResponseEntity<ApiBatchResponse> execute(String mockUuid, @Valid ApiBatchRequest body) {
+        return batchResourceOperation.execute(mockUuid, body);
+    }
+
+}

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CmTemplateProcessor.java
@@ -50,6 +50,7 @@ import com.cloudera.api.swagger.model.ApiEntityTag;
 import com.cloudera.api.swagger.model.ApiProductVersion;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Enums;
+import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.altus.model.Entitlement;
 import com.sequenceiq.cloudbreak.cloud.model.AutoscaleRecommendation;
@@ -57,6 +58,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cloud.model.GatewayRecommendation;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceCount;
 import com.sequenceiq.cloudbreak.cloud.model.ResizeRecommendation;
+import com.sequenceiq.cloudbreak.cluster.model.ClusterHostAttributes;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.yarn.YarnConstants;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.yarn.YarnRoles;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
@@ -355,7 +357,7 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
                 .filter(e -> isYarnNodemanager(e.getValue()))
                 .collect(toMap(Entry::getKey, Entry::getValue));
         return hgToNonGwServiceComponentsWithYarnNMs.entrySet()
-                .stream().collect(toMap(e -> e.getKey(), e -> collectComponents(e.getValue())));
+                .stream().collect(toMap(Entry::getKey, e -> collectComponents(e.getValue())));
     }
 
     private boolean isYarnNodemanager(Set<ServiceComponent> serviceComponents) {
@@ -575,7 +577,11 @@ public class CmTemplateProcessor implements BlueprintTextProcessor {
 
     public void addHosts(Map<String, List<Map<String, String>>> hostGroupMappings) {
         hostGroupMappings.forEach((hostGroup, hostAttributes) -> hostAttributes.forEach(
-                attr -> cmTemplate.getInstantiator().addHostsItem(new ApiClusterTemplateHostInfo().hostName(attr.get("fqdn")).hostTemplateRefName(hostGroup))
+                attr -> cmTemplate.getInstantiator().addHostsItem(new ApiClusterTemplateHostInfo()
+                        .hostName(attr.get(ClusterHostAttributes.FQDN))
+                        .hostTemplateRefName(hostGroup)
+                        .rackId(Strings.isNullOrEmpty(attr.get(ClusterHostAttributes.RACK_ID)) ? null : attr.get(ClusterHostAttributes.RACK_ID))
+                )
         ));
     }
 


### PR DESCRIPTION
* Set rack ID for every host in the CM cluster template when launching the cluster. Works irrespective of the stack type (DL or DH).
* `ClouderaManagerModificationService.upscaleCluster()` has been heavily refactored:
  * Performance improvements: Replace linear searches in lists with set lookups. Replace nested linear searches (O(n^2)) with map lookups.
  * Set rack ID for every newly added (upscaled) host during a cluster upscaling.
  * Update rack ID for every outdated host of the hostgroup during a hostgroup repair (node replacement scenario).
  * The former two points are realized using CM API batch operations.
* `ClouderaManagerSecurityService.createHostCertsBatchRequest()`: Add URL percent encoding around the host ID path variable. The former logic only worked because host IDs are currently URL-safe UUIDs.
* Extract host attribute magic constant `"fqdn"` as a public constant into the new utility class `ClusterHostAttributes` (`cluster-api`).
* `URLUtils`:
  * Move class from `core` over to `common`.
  * Add `encodeString()` for percent encoding to be used when manually constructing URLs with dynamic path variables made of unsafe text. The implementation is adapted from `com.cloudera.api.swagger.client.ApiClient.escapeString()` that is used in all CM Swagger Java client endpoints having path variables.
* `mock-infrastructure` has been extended with an additional endpoint (`BatchResourceV31Controller`) to implement the CM `BatchResourceApi`. It delegates to `BatchResourceOperation`, which in turn depends on `BatchApiHandler` IF implementations that evaluate the actual CM API operation described by the current `ApiBatchRequestElement` and produce a corresponding `ApiBatchResponseElement`. At the moment, `BatchApiHandler` has two implementations, `AbstractBatchApiHandler` and `HostsResourceApiUpdateHostBatchApiHandler` (required for `ClouderaManagerModificationService.upscaleCluster()`). The CM `BatchResourceApi` would also be needed for `ClouderaManagerSecurityService.rotateHostCertificates()`, but IT do not yet check for certificate rotation scenarios. Another `BatchApiHandler` implementation can be added later for that as needed.
* Testing:
  * Manual verification in local CB.
  * Added new unit tests and extended existing ones. All affected files have been migrated to JUnit 5.