### PR TITLE
CB-13252 Create new L0 test for Datalake Backup

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
@@ -31,6 +31,8 @@ import com.sequenceiq.cloudbreak.validation.ValidStackNameLength;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.sdx.api.model.AdvertisedRuntime;
 import com.sequenceiq.sdx.api.model.RangerCloudIdentitySyncStatus;
+import com.sequenceiq.sdx.api.model.SdxBackupResponse;
+import com.sequenceiq.sdx.api.model.SdxBackupStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterResponse;
@@ -40,15 +42,14 @@ import com.sequenceiq.sdx.api.model.SdxDatabaseBackupStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRestoreResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRestoreStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
-import com.sequenceiq.sdx.api.model.SdxValidateCloudStorageRequest;
-import com.sequenceiq.sdx.api.model.SetRangerCloudIdentityMappingRequest;
-import com.sequenceiq.sdx.api.model.SdxBackupResponse;
-import com.sequenceiq.sdx.api.model.SdxBackupStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxRestoreResponse;
 import com.sequenceiq.sdx.api.model.SdxRestoreStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxValidateCloudStorageRequest;
+import com.sequenceiq.sdx.api.model.SetRangerCloudIdentityMappingRequest;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 @Validated
 @Path("/sdx")
@@ -205,6 +206,15 @@ public interface SdxEndpoint {
     SdxBackupStatusResponse backupDatalakeStatusByName(@PathParam("name") String name,
             @QueryParam("backupId") String backupId,
             @QueryParam("backupName") String backupName);
+
+    @GET
+    @Path("{name}/getBackupDatalakeStatus")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "backup status of the datalake by datalake name ", produces = MediaType.APPLICATION_JSON,
+            nickname = "getBackupDatalakeStatus")
+    SdxBackupStatusResponse getBackupDatalakeStatus(@ApiParam(value = "required: datalake name", required = true) @PathParam("name") String name,
+            @ApiParam(value = "optional: datalake backup id", required = false) @QueryParam("backupId") String backupId,
+            @ApiParam(value = "optional: datalake backup name", required = false) @QueryParam("backupName") String backupName);
 
     @POST
     @Path("{name}/restoreDatalake")

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupResponse.java
@@ -30,7 +30,7 @@ public class SdxBackupResponse {
 
     @Override
     public String toString() {
-        return "SdxDatabaseBackupResponse{" +
+        return "SdxBackupResponse{" +
                 "FlowIdentifier= " + flowIdentifier.toString() +
                 "OperationId=" + operationId +
                 '}';

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupStatusResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxBackupStatusResponse.java
@@ -35,7 +35,7 @@ public class SdxBackupStatusResponse {
 
     @Override
     public String toString() {
-        return "SdxDatabaseBackupResponse{" +
+        return "SdxBackupStatusResponse{" +
                 "OperationId=" + operationId +
                 "Status=" + status +
                 "Reason=" + reason +

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupStatusResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupStatusResponse.java
@@ -12,7 +12,6 @@ public class SdxDatabaseBackupStatusResponse {
     public SdxDatabaseBackupStatusResponse(DatalakeDatabaseDrStatus status, String statusReason) {
         this.status = status;
         this.statusReason = statusReason;
-
     }
 
     public DatalakeDatabaseDrStatus getStatus() {

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -334,6 +334,15 @@ public class SdxController implements SdxEndpoint {
     }
 
     @Override
+    @CheckPermissionByResourceName(action = AuthorizationResourceAction.BACKUP_DATALAKE)
+    public SdxBackupStatusResponse getBackupDatalakeStatus(@ResourceName String name,
+            String backupId,
+            String backupName) {
+        return sdxBackupRestoreService.getDatalakeBackupStatus(name, backupId, backupName,
+                ThreadBasedUserCrnProvider.getUserCrn());
+    }
+
+    @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.RESTORE_DATALAKE)
     public SdxDatabaseRestoreResponse restoreDatabaseByName(@ResourceName String name, String backupId,
             String restoreId, String backupLocation) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/dr/SdxBackupRestoreService.java
@@ -8,6 +8,15 @@ import static com.sequenceiq.datalake.flow.dr.restore.DatalakeRestoreEvent.DATAL
 import static com.sequenceiq.datalake.service.sdx.CloudbreakFlowService.FlowState.FINISHED;
 import static com.sequenceiq.datalake.service.sdx.CloudbreakFlowService.FlowState.RUNNING;
 
+import java.util.Collections;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
 import com.cloudera.thunderhead.service.datalakedr.datalakeDRProto;
 import com.dyngr.Polling;
 import com.dyngr.core.AttemptResult;
@@ -47,23 +56,14 @@ import com.sequenceiq.datalake.service.sdx.CloudbreakFlowService;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.sdx.api.model.DatalakeDatabaseDrStatus;
+import com.sequenceiq.sdx.api.model.SdxBackupResponse;
+import com.sequenceiq.sdx.api.model.SdxBackupStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseBackupResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseBackupStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRestoreResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRestoreStatusResponse;
-import com.sequenceiq.sdx.api.model.SdxBackupResponse;
-import com.sequenceiq.sdx.api.model.SdxBackupStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxRestoreResponse;
 import com.sequenceiq.sdx.api.model.SdxRestoreStatusResponse;
-
-import java.util.Collections;
-
-import javax.inject.Inject;
-import javax.ws.rs.WebApplicationException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
 /**
  * Service to perform backup/restore of the database backing SDX.
@@ -404,11 +404,11 @@ public class SdxBackupRestoreService {
     public SdxBackupStatusResponse getDatalakeBackupStatus(String datalakeName, String backupId, String backupName,
             String userCrn) {
         LOGGER.info("Requesting datalake backup status for datalake: '{}'", datalakeName);
-        DatalakeDrStatusResponse datalakeDrStatusResponse = datalakeDrClient.getBackupStatusByBackupId(
+        DatalakeDrStatusResponse datalakeDrStatusResponse = datalakeDrClient.getBackupStatus(
                 datalakeName, backupId, backupName, userCrn);
         return new SdxBackupStatusResponse(datalakeDrStatusResponse.getDrOperationId(),
-                                            datalakeDrStatusResponse.getState().name(),
-                                            datalakeDrStatusResponse.getFailureReason());
+                datalakeDrStatusResponse.getState().name(),
+                datalakeDrStatusResponse.getFailureReason());
     }
 
     public DatalakeDrStatusResponse triggerDatalakeRestore(Long id, String backupId, String backupLocationOverride, String userCrn) {

--- a/flow-api/src/main/java/com/sequenceiq/flow/api/model/FlowCheckResponse.java
+++ b/flow-api/src/main/java/com/sequenceiq/flow/api/model/FlowCheckResponse.java
@@ -11,6 +11,8 @@ public class FlowCheckResponse {
 
     private Boolean hasActiveFlow;
 
+    private Boolean latestFlowFinalizedAndFailed;
+
     public String getFlowId() {
         return flowId;
     }
@@ -33,5 +35,13 @@ public class FlowCheckResponse {
 
     public void setHasActiveFlow(Boolean hasActiveFlow) {
         this.hasActiveFlow = hasActiveFlow;
+    }
+
+    public Boolean getLatestFlowFinalizedAndFailed() {
+        return latestFlowFinalizedAndFailed;
+    }
+
+    public void setLatestFlowFinalizedAndFailed(Boolean latestFlowFinalizedAndFailed) {
+        this.latestFlowFinalizedAndFailed = latestFlowFinalizedAndFailed;
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/service/FlowService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/FlowService.java
@@ -123,6 +123,7 @@ public class FlowService {
             Set<String> relatedFlowIds = flowLogDBService.getFlowIdsByChainIds(relatedChainIds);
             List<FlowLog> relatedFlowLogs = flowLogDBService.getFlowLogsByFlowIdsCreatedDesc(relatedFlowIds);
             flowCheckResponse.setHasActiveFlow(!completed("Flow chain", chainId, relatedChains, relatedFlowLogs));
+            flowCheckResponse.setLatestFlowFinalizedAndFailed(firstIsFinalizedAndFailed(relatedFlowLogs));
             return flowCheckResponse;
         } else {
             flowCheckResponse.setHasActiveFlow(Boolean.FALSE);
@@ -142,6 +143,7 @@ public class FlowService {
             List<FlowLog> relatedFlowLogs = flowLogDBService.getFlowLogsByFlowIdsCreatedDesc(relatedFlowIds);
             validateResourceId(relatedFlowLogs, resourceId);
             flowCheckResponse.setHasActiveFlow(!completed("Flow chain", chainId, relatedChains, relatedFlowLogs));
+            flowCheckResponse.setLatestFlowFinalizedAndFailed(firstIsFinalizedAndFailed(relatedFlowLogs));
             return flowCheckResponse;
         } else {
             flowCheckResponse.setHasActiveFlow(Boolean.FALSE);
@@ -160,6 +162,7 @@ public class FlowService {
         FlowCheckResponse flowCheckResponse = new FlowCheckResponse();
         flowCheckResponse.setFlowId(flowId);
         flowCheckResponse.setHasActiveFlow(!completed("Flow", flowId, List.of(), allByFlowIdOrderByCreatedDesc));
+        flowCheckResponse.setLatestFlowFinalizedAndFailed(firstIsFinalizedAndFailed(allByFlowIdOrderByCreatedDesc));
         return flowCheckResponse;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupAction.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import static java.lang.String.format;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxBackupResponse;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+
+public class SdxBackupAction implements Action<SdxInternalTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxBackupAction.class);
+
+    private final String backupLocation;
+
+    private final String backupName;
+
+    public SdxBackupAction(String backupLocation, String backupName) {
+        this.backupLocation = backupLocation;
+        this.backupName = backupName;
+    }
+
+    @Override
+    public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
+        String sdxName = testDto.getName();
+
+        Log.when(LOGGER, format(" SDX '%s' backup has been started to '%s' as '%s' ", sdxName, backupLocation, backupName));
+        Log.whenJson(LOGGER, " SDX backup request: ", testDto.getRequest());
+        LOGGER.info(format(" SDX '%s' backup has been started to '%s' as '%s'... ", sdxName, backupLocation, backupName));
+        SdxBackupResponse sdxBackupResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .backupDatalakeByName(sdxName, backupLocation, backupName);
+        testDto.setFlow("SDX backup", sdxBackupResponse.getFlowIdentifier());
+
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(sdxName, Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX backup response: ", client.getDefaultClient().sdxEndpoint().get(sdxName));
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -32,6 +32,7 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxSyncAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxSyncInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxUpgradeAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.RenewDatalakeCertificateAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxBackupAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.SdxRetryAction;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCMDiagnosticsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
@@ -158,4 +159,9 @@ public class SdxTestClient {
     public Action<SdxInternalTestDto, SdxClient> retry() {
         return new SdxRetryAction();
     }
+
+    public Action<SdxInternalTestDto, SdxClient> backup(String backupLocation, String backupName) {
+        return new SdxBackupAction(backupLocation, backupName);
+    }
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -995,7 +995,16 @@ public abstract class TestContext implements ApplicationContextAware {
                     Log.await(LOGGER, String.format(" Cloudbreak await for flow '%s' is failed for '%s', because of %s",
                             awaitEntity, awaitEntity.getName(), e.getMessage()));
                 }
-                getExceptionMap().put("Cloudbreak await for flow " + awaitEntity, e);
+                getExceptionMap().put(String.format("Cloudbreak await for flow %s", awaitEntity), e);
+            }
+            if (flowUtilSingleStatus.getFlowFailed()) {
+                if (runningParameter.isLogError()) {
+                    LOGGER.error("Cloudbreak await for flow '{}' is failed for: '{}', because of latest flow status is FAILED", awaitEntity,
+                            awaitEntity.getName());
+                    Log.await(LOGGER, String.format(" Cloudbreak await for flow '%s' is failed for '%s', because of latest flow status is FAILED ",
+                            awaitEntity, awaitEntity.getName()));
+                }
+                getExceptionMap().put(String.format("Cloudbreak await for flow %s", awaitEntity), new TestFailException("Latest flow status is FAILED!"));
             }
         }
         entity.setLastKnownFlowId(null);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractSdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/AbstractSdxTestDto.java
@@ -5,6 +5,7 @@ import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunning
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
 
 import org.apache.commons.lang3.NotImplementedException;
@@ -14,8 +15,12 @@ import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.assertion.Assertion;
 import com.sequenceiq.it.cloudbreak.context.RunningParameter;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.util.wait.FlowUtil;
 
 public abstract class AbstractSdxTestDto<R, S, T extends CloudbreakTestDto> extends AbstractTestDto<R, S, T, SdxClient> {
+
+    @Inject
+    private FlowUtil flowUtil;
 
     protected AbstractSdxTestDto(String newId) {
         super(newId);
@@ -108,5 +113,9 @@ public abstract class AbstractSdxTestDto<R, S, T extends CloudbreakTestDto> exte
         }
         return getTestContext().then((T) this, SdxClient.class, assertions.get(assertions.size() - 1),
                 runningParameters.get(runningParameters.size() - 1));
+    }
+
+    public FlowUtil getFlowUtil() {
+        return flowUtil;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -18,6 +18,7 @@ import com.sequenceiq.it.cloudbreak.action.v4.imagecatalog.ImageCatalogCreateRet
 import com.sequenceiq.it.cloudbreak.actor.CloudbreakActor;
 import com.sequenceiq.it.cloudbreak.client.BlueprintTestClient;
 import com.sequenceiq.it.cloudbreak.client.CredentialTestClient;
+import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.client.EnvironmentTestClient;
 import com.sequenceiq.it.cloudbreak.client.ImageCatalogTestClient;
 import com.sequenceiq.it.cloudbreak.client.KerberosTestClient;
@@ -29,6 +30,7 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.blueprint.BlueprintTestDto;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
 import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
@@ -73,6 +75,9 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
 
     @Inject
     private SdxTestClient sdxTestClient;
+
+    @Inject
+    private DistroXTestClient distroXTestClient;
 
     @Inject
     private AzureCloudBlobUtil azureCloudBlobUtil;
@@ -160,6 +165,16 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
                 .await(SdxClusterStatusResponse.RUNNING)
                 .awaitForHealthyInstances()
                 .when(sdxTestClient.describeInternal())
+                .validate();
+    }
+
+    protected void createDatahub(TestContext testContext) {
+        testContext
+                .given(DistroXTestDto.class)
+                .when(distroXTestClient.create())
+                .await(STACK_AVAILABLE)
+                .awaitForHealthyInstances()
+                .when(distroXTestClient.get())
                 .validate();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupTest.java
@@ -1,0 +1,115 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion;
+
+import static java.lang.String.format;
+
+import java.util.Collections;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.client.StackTestClient;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.PreconditionSdxE2ETest;
+import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
+import com.sequenceiq.sdx.api.model.SdxBackupStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
+import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
+
+public class SdxBackupTest extends PreconditionSdxE2ETest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxBackupTest.class);
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private StackTestClient stackTestClient;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
+        createDefaultUser(testContext);
+        initializeDefaultBlueprints(testContext);
+        createDefaultCredential(testContext);
+        createEnvironmentWithNetworkAndFreeIpa(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(
+            given = "there is a running Manowar SDX cluster in available state",
+            when = "a basic SDX create request with FreeIPA and DataLake Cloud Storage has been sent",
+            then = "SDX should be available along with the created Cloud storage objects"
+    )
+    public void testSDXBackupCanBeCreatedSuccessfully(TestContext testContext) {
+        SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
+        sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NON_HA);
+        testContext
+                .given(SdxInternalTestDto.class)
+                    .withDatabase(sdxDatabaseRequest)
+                    .withCloudStorage(getCloudStorageRequest(testContext))
+                .when(sdxTestClient.createInternal())
+                .await(SdxClusterStatusResponse.RUNNING)
+                .awaitForHealthyInstances()
+                .validate();
+
+        SdxInternalTestDto sdxInternalTestDto = testContext.given(SdxInternalTestDto.class);
+        String cloudStorageBaseLocation = sdxInternalTestDto.getResponse().getCloudStorageBaseLocation();
+        String backupLocation = cloudStorageBaseLocation + "/backups";
+        testContext
+                .given(SdxInternalTestDto.class)
+                .when(sdxTestClient.backup(backupLocation, null))
+                .await(SdxClusterStatusResponse.RUNNING)
+                .awaitForHealthyInstances()
+                .then(this::validateDatalakeBackupStatus)
+                .then(this::validateDatalakeStatus)
+                .then((tc, testDto, client) -> {
+                    getCloudFunctionality(tc).cloudStorageListContainer(cloudStorageBaseLocation, backupLocation, false);
+                    return testDto;
+                })
+                .validate();
+    }
+
+    private SdxInternalTestDto validateDatalakeStatus(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) {
+        String statuReason = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetailByCrn(testDto.getCrn(), Collections.emptySet())
+                .getStatusReason();
+        if (statuReason.contains("Datalake backup failed")) {
+            LOGGER.error(String.format(" Sdx '%s' backup has been failed: '%s' ", testDto.getName(), statuReason));
+            throw new TestFailException(String.format(" Sdx '%s' backup has been failed: '%s' ", testDto.getName(), statuReason));
+        } else {
+            LOGGER.info(String.format(" Sdx '%s' backup has been done with '%s'. ", testDto.getName(), statuReason));
+            Log.then(LOGGER, format(" Sdx '%s' backup has been done with '%s'. ", testDto.getName(), statuReason));
+        }
+        return testDto;
+    }
+
+    private SdxInternalTestDto validateDatalakeBackupStatus(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) {
+        String sdxName = testDto.getName();
+        SdxBackupStatusResponse sdxBackupStatusResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getBackupDatalakeStatus(sdxName, null, null);
+        String status = sdxBackupStatusResponse.getStatus();
+        String statuReason = sdxBackupStatusResponse.getReason();
+        LOGGER.info(format(" SDX '%s' backup status '%s', because of %s ", sdxName, status, statuReason));
+        if (status.contains("FAILED")) {
+            LOGGER.error(String.format(" Sdx '%s' backup has been failed: '%s' ", testDto.getName(), statuReason));
+            throw new TestFailException(String.format(" Sdx '%s' backup has been failed: '%s' ", testDto.getName(), statuReason));
+        } else {
+            LOGGER.info(String.format(" Sdx '%s' backup has been done with '%s'. ", testDto.getName(), statuReason));
+            Log.then(LOGGER, format(" Sdx '%s' backup has been done with '%s'. ", testDto.getName(), statuReason));
+        }
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
@@ -50,7 +50,7 @@ public interface CloudFunctionality {
             maxAttempts = ATTEMPTS,
             backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
     )
-    void cloudStorageListContainer(String baseLocation);
+    void cloudStorageListContainer(String baseLocation, String pathToTargetObject, boolean zeroContent);
 
     @Retryable(
             maxAttempts = ATTEMPTS,

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
@@ -50,8 +50,8 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public void cloudStorageListContainer(String baseLocation) {
-        amazonS3Util.listBucket(baseLocation);
+    public void cloudStorageListContainer(String baseLocation, String pathToTargetObject, boolean zeroContent) {
+        amazonS3Util.listBucketSelectedObject(baseLocation, pathToTargetObject, zeroContent);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/AmazonS3Util.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/AmazonS3Util.java
@@ -18,8 +18,8 @@ public class AmazonS3Util {
         s3ClientActions.deleteNonVersionedBucket(baseLocation);
     }
 
-    public void listBucket(String baseLocation) {
-        s3ClientActions.listBucketSelectedObject(baseLocation, "ranger", true);
+    public void listBucketSelectedObject(String baseLocation, String pathToTargetObject, boolean zeroContent) {
+        s3ClientActions.listBucketSelectedObject(baseLocation, pathToTargetObject, zeroContent);
     }
 
     public void listFreeIpaObject(String baseLocation) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
@@ -69,12 +69,18 @@ public class S3ClientActions extends S3Client {
         }
     }
 
-    public void listBucketSelectedObject(String baseLocation, String selectedObject, Boolean zeroContent) {
+    public void listBucketSelectedObject(String baseLocation, String selectedObject, boolean zeroContent) {
         AmazonS3 s3Client = buildS3Client();
         String bucketName = getBucketName();
         AmazonS3URI amazonS3URI = new AmazonS3URI(getEUWestS3Uri());
         List<S3ObjectSummary> filteredObjectSummaries;
         String keyPrefix = StringUtils.substringAfterLast(baseLocation, "/");
+
+        if (StringUtils.isEmpty(selectedObject)) {
+            selectedObject = "ranger";
+        } else {
+            selectedObject = getPath(selectedObject).replace(bucketName + "/", "") + "/";
+        }
 
         Log.log(LOGGER, format(" Amazon S3 URI: %s", amazonS3URI));
         Log.log(LOGGER, format(" Amazon S3 Bucket: %s", bucketName));
@@ -89,8 +95,9 @@ public class S3ClientActions extends S3Client {
                 ObjectListing objectListing = s3Client.listObjects(listObjectsRequest);
 
                 do {
+                    String finalSelectedObject = selectedObject;
                     filteredObjectSummaries = objectListing.getObjectSummaries().stream()
-                            .filter(objectSummary -> objectSummary.getKey().contains(selectedObject))
+                            .filter(objectSummary -> objectSummary.getKey().contains(finalSelectedObject))
                             .collect(Collectors.toList());
 
                     if (objectListing.isTruncated()) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
@@ -47,8 +47,8 @@ public class AzureCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public void cloudStorageListContainer(String baseLocation) {
-        azureCloudBlobUtil.listAllFoldersInAContaier(baseLocation);
+    public void cloudStorageListContainer(String baseLocation, String pathToTargetObject, boolean zeroContent) {
+        azureCloudBlobUtil.listSelectedFoldersInAContaier(baseLocation, pathToTargetObject, zeroContent);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/AzureCloudBlobUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/AzureCloudBlobUtil.java
@@ -41,6 +41,10 @@ public class AzureCloudBlobUtil {
         azureCloudBlobClientActions.listAllFolders(baseLocation);
     }
 
+    public void listSelectedFoldersInAContaier(String baseLocation, String pathToTargetObject, boolean zeroContent) {
+        azureCloudBlobClientActions.listSelectedDirectory(baseLocation, pathToTargetObject, zeroContent);
+    }
+
     public void listDataLakeFoldersInAContaier(String baseLocation, String clusterName, String crn) {
         azureCloudBlobClientActions.listSelectedDirectory(baseLocation,
                 "datalake/" + clusterName + "_" + Crn.fromString(crn).getResource(), false);

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
@@ -314,7 +314,7 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
         }
     }
 
-    public void listSelectedDirectory(String baseLocation, String selectedDirectory, Boolean zeroContent) {
+    public void listSelectedDirectory(String baseLocation, String selectedDirectory, boolean zeroContent) {
         String containerName = getContainerName(baseLocation);
         CloudBlobContainer cloudBlobContainer = getCloudBlobContainer(containerName);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
@@ -52,8 +52,8 @@ public class GcpCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public void cloudStorageListContainer(String baseLocation) {
-        gcpUtil.cloudStorageListContainer(baseLocation);
+    public void cloudStorageListContainer(String baseLocation, String pathToTargetObject, boolean zeroContent) {
+        gcpUtil.cloudStorageListContainer(baseLocation, pathToTargetObject, zeroContent);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
@@ -38,8 +38,8 @@ public class GcpUtil {
         gcpClientActions.stopHostGroupInstances(instanceIds);
     }
 
-    public void cloudStorageListContainer(String baseLocation) {
-        listSelectedObject(baseLocation);
+    public void cloudStorageListContainer(String baseLocation, String pathToTargetObject, boolean zeroContent) {
+        gcpClientActions.listBucketSelectedObject(gcpStackUtil.getBucketName(baseLocation), "/" + pathToTargetObject, zeroContent);
     }
 
     public void cloudStorageListContainerFreeIpa(String baseLocation, String clusterName, String crn) {

--- a/integration-test/src/main/resources/testsuites/e2e/l0promotion/aws-sdx-backup-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/l0promotion/aws-sdx-backup-tests.yaml
@@ -1,0 +1,5 @@
+name: "aws-sdx-backup-tests"
+tests:
+  - name: "aws_sdx_backup_e2e_tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion.SdxBackupTest


### PR DESCRIPTION
A new SDX Backup test case for L0 tests.

Beyond the new test case I've introduced:
- new operations at SDX API Endpoint:
   - `getBackupDatalakeStatusByName`: is needed for the `validateDatalakeBackupStatus` of `SdxBackupTest` 
   - `getBackupDatalakeStatusById`: this is for clarify, because of the `backupDatalakeStatusByName` operation is actually points to the `getBackupStatusByBackupId` at the `datalakeDrClient`.
- fixed some typos
- new request at Datalake DR Client:
   - `getBackupStatusByDatalakeName`: is needed for the `getBackupDatalakeStatusByName` new SDX API operation
- updated the SDX Controller and SDX Backup/Restore Service as well based on the above changes
- updated the Flow Util and Service with `getLatestFlowFinalizedAndFailed`: to stabilise the IT module wait for flow feature 
