### PR TITLE
CB-12898 AWS native metadata collector fix and group resource connectors by cloud platform vairant

### DIFF
--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/ComponentTestUtil.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/component/ComponentTestUtil.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.google.common.collect.ImmutableMap;
+import com.sequenceiq.cloudbreak.cloud.aws.common.AwsConstants;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
@@ -84,8 +85,8 @@ public class ComponentTestUtil {
                 .withId(1L)
                 .withName("cloudContext")
                 .withCrn("crn")
-                .withPlatform("AWS")
-                .withVariant("variant")
+                .withPlatform(AwsConstants.AWS_PLATFORM.value())
+                .withVariant(AwsConstants.AWS_DEFAULT_VARIANT.value())
                 .withLocation(location)
                 .withUserId("owner@company.com")
                 .withAccountId("5")

--- a/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
+++ b/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilder.java
@@ -79,6 +79,7 @@ public class AwsNativeInstanceResourceBuilder extends AbstractAwsNativeComputeBu
                 .status(CommonStatus.CREATED)
                 .name(resourceName)
                 .persistent(true)
+                .reference(String.valueOf(privateId))
                 .build());
     }
 

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorTest.java
@@ -147,9 +147,9 @@ class AwsNativeMetadataCollectorTest {
         List<CloudResource> resources = List.of(cloudResource, secondCloudResource);
         InstanceTemplate instanceTemplate =
                 new InstanceTemplate("flavor", "alma", 1L, Set.of(), CREATED, Map.of(), 1L, "imageid", TemporaryStorage.ATTACHED_VOLUMES);
+        CloudInstance cloudInstance = new CloudInstance(anInstanceId, instanceTemplate, null, "subnet-123", "az1");
         InstanceTemplate secondInstanceTemplate =
                 new InstanceTemplate("flavor", "alma", 2L, Set.of(), CREATED, Map.of(), 1L, "imageid", TemporaryStorage.ATTACHED_VOLUMES);
-        CloudInstance cloudInstance = new CloudInstance(anInstanceId, instanceTemplate, null, "subnet-123", "az1");
         CloudInstance secondCloudInstance = new CloudInstance(secondInstanceId, secondInstanceTemplate, null, "subnet-123", "az1");
         List<CloudInstance> cloudInstances = List.of(cloudInstance, secondCloudInstance);
         when(awsClient.createEc2Client(any(), anyString())).thenReturn(ec2Client);
@@ -178,9 +178,9 @@ class AwsNativeMetadataCollectorTest {
         List<CloudResource> resources = List.of(cloudResource, secondCloudResource);
         InstanceTemplate instanceTemplate =
                 new InstanceTemplate("flavor", "alma", 1L, Set.of(), CREATED, Map.of(), 1L, "imageid", TemporaryStorage.ATTACHED_VOLUMES);
+        CloudInstance cloudInstance = new CloudInstance(anInstanceId, instanceTemplate, null, "subnet-123", "az1");
         InstanceTemplate secondInstanceTemplate =
                 new InstanceTemplate("flavor", "alma", 2L, Set.of(), CREATED, Map.of(), 1L, "imageid", TemporaryStorage.ATTACHED_VOLUMES);
-        CloudInstance cloudInstance = new CloudInstance(anInstanceId, instanceTemplate, null, "subnet-123", "az1");
         CloudInstance secondCloudInstance = new CloudInstance(secondInstanceId, secondInstanceTemplate, null, "subnet-123", "az1");
         List<CloudInstance> cloudInstances = List.of(cloudInstance, secondCloudInstance);
         when(awsClient.createEc2Client(any(), anyString())).thenReturn(ec2Client);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.TlsInfo;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.service.CloudbreakResourceNameService;
 import com.sequenceiq.cloudbreak.cloud.template.AbstractResourceConnector;
@@ -75,17 +76,18 @@ public class GcpResourceConnector extends AbstractResourceConnector {
     public List<CloudResourceStatus> upscale(AuthenticatedContext auth, CloudStack stack, List<CloudResource> resources) {
         CloudContext cloudContext = auth.getCloudContext();
         Platform platform = cloudContext.getPlatform();
+        Variant variant = cloudContext.getVariant();
 
         //context
         ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), resources, true);
 
         //network
-        context.addNetworkResources(networkResourceService.getNetworkResources(platform, resources));
+        context.addNetworkResources(networkResourceService.getNetworkResources(variant, resources));
 
         Group scalingGroup = getScalingGroup(getGroup(stack.getGroups(), getGroupName(stack)));
 
         //group
-        context.addGroupResources(scalingGroup.getName(), groupResourceService.getGroupResources(platform, resources));
+        context.addGroupResources(scalingGroup.getName(), groupResourceService.getGroupResources(variant, resources));
 
         //compute
         List<CloudResource> diskSets = resources.stream()

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnectorTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnectorTest.java
@@ -45,6 +45,7 @@ import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Security;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.template.ResourceContextBuilder;
 import com.sequenceiq.cloudbreak.cloud.template.compute.ComputeResourceService;
@@ -167,6 +168,7 @@ public class GcpResourceConnectorTest {
         when(authenticatedContext.getCloudContext()).thenReturn(cloudContext);
         when(cloudStack.getNetwork()).thenReturn(network);
         when(cloudContext.getPlatform()).thenReturn(platform("GCP"));
+        when(cloudContext.getVariant()).thenReturn(GcpConstants.GCP_VARIANT);
         when(contextBuilders.get(any(Platform.class))).thenReturn(resourceContextBuilder);
         when(resourceContextBuilder.contextInit(
                 any(CloudContext.class),
@@ -174,9 +176,9 @@ public class GcpResourceConnectorTest {
                 any(Network.class),
                 anyList(),
                 anyBoolean())).thenReturn(resourceBuilderContext);
-        when(networkResourceService.getNetworkResources(any(Platform.class), anyList())).thenReturn(new ArrayList<>());
+        when(networkResourceService.getNetworkResources(any(Variant.class), anyList())).thenReturn(new ArrayList<>());
         doNothing().when(resourceBuilderContext).addNetworkResources(anyCollection());
-        when(groupResourceService.getGroupResources(any(Platform.class), anyCollection()))
+        when(groupResourceService.getGroupResources(any(Variant.class), anyCollection()))
                 .thenReturn(List.of(cloudResource("test-1", GCP_INSTANCE)));
         when(cloudStack.getGroups()).thenReturn(List.of(group("master")));
         doNothing().when(resourceBuilderContext).addComputeResources(anyLong(), anyList());
@@ -190,8 +192,8 @@ public class GcpResourceConnectorTest {
         underTest.upscale(authenticatedContext, cloudStack, cloudResourceList);
 
         verify(contextBuilders, times(1)).get(any(Platform.class));
-        verify(networkResourceService, times(1)).getNetworkResources(any(Platform.class), anyList());
-        verify(groupResourceService, times(1)).getGroupResources(any(Platform.class), anyList());
+        verify(networkResourceService, times(1)).getNetworkResources(any(Variant.class), anyList());
+        verify(groupResourceService, times(1)).getGroupResources(any(Variant.class), anyList());
         verify(resourceBuilderContext, times(1)).addComputeResources(anyLong(), anyList());
         verify(computeResourceService, times(1)).buildResourcesForUpscale(
                 any(ResourceBuilderContext.class),

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/CloudFailureHandler.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/CloudFailureHandler.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.template.ComputeResourceBuilder;
 import com.sequenceiq.cloudbreak.cloud.template.context.ResourceBuilderContext;
 import com.sequenceiq.cloudbreak.cloud.template.init.ResourceBuilders;
@@ -124,7 +125,8 @@ public class CloudFailureHandler {
 
     private void doRollbackAndDecreaseNodeCount(AuthenticatedContext auth, List<CloudResourceStatus> statuses, Collection<Long> ids, Group group,
             ResourceBuilderContext ctx, ResourceBuilders resourceBuilders, Boolean upscale) {
-        List<ComputeResourceBuilder<ResourceBuilderContext>> compute = resourceBuilders.compute(auth.getCloudContext().getPlatform());
+        Variant variant = auth.getCloudContext().getVariant();
+        List<ComputeResourceBuilder<ResourceBuilderContext>> compute = resourceBuilders.compute(variant);
         Collection<Future<ResourceRequestResult<List<CloudResourceStatus>>>> futures = new ArrayList<>();
         LOGGER.info("InstanceGroup {} node count decreased with one so the new node size is: {}", group.getName(), group.getInstancesSize());
 

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/ComputeResourceService.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/ComputeResourceService.java
@@ -34,8 +34,8 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
-import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
@@ -100,8 +100,8 @@ public class ComputeResourceService {
         LOGGER.debug("Deleting the following resources: {}", resources);
         List<CloudResourceStatus> results = new ArrayList<>();
         Collection<Future<ResourceRequestResult<List<CloudResourceStatus>>>> futures = new ArrayList<>();
-        Platform platform = auth.getCloudContext().getPlatform();
-        List<ComputeResourceBuilder<ResourceBuilderContext>> builders = resourceBuilders.compute(platform);
+        Variant variant = auth.getCloudContext().getVariant();
+        List<ComputeResourceBuilder<ResourceBuilderContext>> builders = resourceBuilders.compute(variant);
         int numberOfBuilders = builders.size();
         for (int i = numberOfBuilders - 1; i >= 0; i--) {
             ComputeResourceBuilder<ResourceBuilderContext> builder = builders.get(i);
@@ -135,8 +135,8 @@ public class ComputeResourceService {
     private List<CloudVmInstanceStatus> stopStart(ResourceBuilderContext context,
             AuthenticatedContext auth, List<CloudResource> resources, List<CloudInstance> instances) {
         List<CloudVmInstanceStatus> results = new ArrayList<>();
-        Platform platform = auth.getCloudContext().getPlatform();
-        List<ComputeResourceBuilder<ResourceBuilderContext>> builders = resourceBuilders.compute(platform);
+        Variant variant = auth.getCloudContext().getVariant();
+        List<ComputeResourceBuilder<ResourceBuilderContext>> builders = resourceBuilders.compute(variant);
         if (!context.isBuild()) {
             Collections.reverse(builders);
         }
@@ -348,7 +348,8 @@ public class ComputeResourceService {
         }
 
         private Optional<ComputeResourceBuilder<ResourceBuilderContext>> determineComputeResourceBuilder(CloudResource resource) {
-            return resourceBuilders.compute(auth.getCloudContext().getPlatform())
+            Variant variant = auth.getCloudContext().getVariant();
+            return resourceBuilders.compute(variant)
                     .stream().filter(rb -> rb.resourceType().equals(resource.getType())).findFirst();
         }
 

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/ResourceCreationCallable.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/compute/ResourceCreationCallable.java
@@ -19,6 +19,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
@@ -81,7 +82,8 @@ public class ResourceCreationCallable implements Callable<ResourceRequestResult<
             Collection<CloudResource> buildableResources = new ArrayList<>();
             Long privateId = instance.getTemplate().getPrivateId();
             try {
-                List<ComputeResourceBuilder<ResourceBuilderContext>> compute = resourceBuilders.compute(auth.getCloudContext().getPlatform());
+                Variant variant = auth.getCloudContext().getVariant();
+                List<ComputeResourceBuilder<ResourceBuilderContext>> compute = resourceBuilders.compute(variant);
                 for (ComputeResourceBuilder<ResourceBuilderContext> builder : compute) {
                     LOGGER.info("Start building '{} ({})' resources of '{}' instance group of '{}' stack", builder.resourceType(),
                             builder.getClass().getSimpleName(), group.getName(), stackName);

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/group/GroupResourceService.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/group/GroupResourceService.java
@@ -21,8 +21,8 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
-import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Security;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
@@ -57,7 +57,7 @@ public class GroupResourceService {
             AuthenticatedContext auth, Iterable<Group> groups, Network network, Security security) throws Exception {
         CloudContext cloudContext = auth.getCloudContext();
         List<CloudResourceStatus> results = new ArrayList<>();
-        for (GroupResourceBuilder<ResourceBuilderContext> builder : resourceBuilders.group(cloudContext.getPlatform())) {
+        for (GroupResourceBuilder<ResourceBuilderContext> builder : resourceBuilders.group(cloudContext.getVariant())) {
             PollGroup pollGroup = InMemoryStateStore.getStack(auth.getCloudContext().getId());
             if (CANCELLED.equals(pollGroup)) {
                 break;
@@ -85,7 +85,7 @@ public class GroupResourceService {
             AuthenticatedContext auth, Collection<CloudResource> resources, Network network, boolean cancellable) throws Exception {
         CloudContext cloudContext = auth.getCloudContext();
         List<CloudResourceStatus> results = new ArrayList<>();
-        List<GroupResourceBuilder<ResourceBuilderContext>> builderChain = resourceBuilders.group(cloudContext.getPlatform());
+        List<GroupResourceBuilder<ResourceBuilderContext>> builderChain = resourceBuilders.group(cloudContext.getVariant());
         for (int i = builderChain.size() - 1; i >= 0; i--) {
             GroupResourceBuilder<ResourceBuilderContext> builder = builderChain.get(i);
             List<CloudResource> specificResources = getResources(resources, builder.resourceType());
@@ -109,7 +109,7 @@ public class GroupResourceService {
             Network network, Security security, Collection<CloudResource> groupResources) throws Exception {
         List<CloudResourceStatus> results = new ArrayList<>();
         CloudContext cloudContext = auth.getCloudContext();
-        for (NetworkResourceBuilder<ResourceBuilderContext> builder : resourceBuilders.network(cloudContext.getPlatform())) {
+        for (NetworkResourceBuilder<ResourceBuilderContext> builder : resourceBuilders.network(cloudContext.getVariant())) {
             List<CloudResource> resources = getResources(groupResources, builder.resourceType());
             for (CloudResource resource : resources) {
                 CloudResourceStatus status = builder.update(context, auth, network, security, resource);
@@ -124,9 +124,9 @@ public class GroupResourceService {
         return results;
     }
 
-    public List<CloudResource> getGroupResources(Platform platform, Collection<CloudResource> resources) {
+    public List<CloudResource> getGroupResources(Variant variant, Collection<CloudResource> resources) {
         Collection<ResourceType> types = new ArrayList<>();
-        for (GroupResourceBuilder<?> builder : resourceBuilders.group(platform)) {
+        for (GroupResourceBuilder<?> builder : resourceBuilders.group(variant)) {
             types.add(builder.resourceType());
         }
         return getResources(resources, types);

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/init/ResourceBuilders.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/init/ResourceBuilders.java
@@ -17,7 +17,7 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.template.ComputeResourceBuilder;
 import com.sequenceiq.cloudbreak.cloud.template.GroupResourceBuilder;
 import com.sequenceiq.cloudbreak.cloud.template.NetworkResourceBuilder;
@@ -38,11 +38,11 @@ public class ResourceBuilders {
     @Autowired(required = false)
     private List<GroupResourceBuilder> group = new ArrayList<>();
 
-    private final Map<Platform, List<NetworkResourceBuilder<ResourceBuilderContext>>> networkChain = new HashMap<>();
+    private final Map<Variant, List<NetworkResourceBuilder<ResourceBuilderContext>>> networkChain = new HashMap<>();
 
-    private final Map<Platform, List<GroupResourceBuilder<ResourceBuilderContext>>> groupChain = new HashMap<>();
+    private final Map<Variant, List<GroupResourceBuilder<ResourceBuilderContext>>> groupChain = new HashMap<>();
 
-    private final Map<Platform, List<ComputeResourceBuilder<ResourceBuilderContext>>> computeChain = new HashMap<>();
+    private final Map<Variant, List<ComputeResourceBuilder<ResourceBuilderContext>>> computeChain = new HashMap<>();
 
     @PostConstruct
     public void init() {
@@ -52,28 +52,28 @@ public class ResourceBuilders {
         initCompute(comparator);
     }
 
-    public List<NetworkResourceBuilder<ResourceBuilderContext>> network(Platform platform) {
-        List<NetworkResourceBuilder<ResourceBuilderContext>> networkResourceBuilders = networkChain.get(platform);
+    public List<NetworkResourceBuilder<ResourceBuilderContext>> network(Variant platformVariant) {
+        List<NetworkResourceBuilder<ResourceBuilderContext>> networkResourceBuilders = networkChain.get(platformVariant);
         if (networkResourceBuilders == null) {
-            LOGGER.info("Cannot find NetworkResourceBuilder for {}", platform);
+            LOGGER.info("Cannot find NetworkResourceBuilder for platform variant: '{}'", platformVariant);
             return Collections.emptyList();
         }
         return new ArrayList<>(networkResourceBuilders);
     }
 
-    public List<ComputeResourceBuilder<ResourceBuilderContext>> compute(Platform platform) {
-        List<ComputeResourceBuilder<ResourceBuilderContext>> computeResourceBuilders = computeChain.get(platform);
+    public List<ComputeResourceBuilder<ResourceBuilderContext>> compute(Variant platformVariant) {
+        List<ComputeResourceBuilder<ResourceBuilderContext>> computeResourceBuilders = computeChain.get(platformVariant);
         if (computeResourceBuilders == null) {
-            LOGGER.info("Cannot find ComputeResourceBuilder for {}", platform);
+            LOGGER.info("Cannot find ComputeResourceBuilder for platform variant: '{}'", platformVariant);
             return Collections.emptyList();
         }
         return new ArrayList<>(computeResourceBuilders);
     }
 
-    public List<GroupResourceBuilder<ResourceBuilderContext>> group(Platform platform) {
-        List<GroupResourceBuilder<ResourceBuilderContext>> groupResourceBuilders = groupChain.get(platform);
+    public List<GroupResourceBuilder<ResourceBuilderContext>> group(Variant platformVariant) {
+        List<GroupResourceBuilder<ResourceBuilderContext>> groupResourceBuilders = groupChain.get(platformVariant);
         if (groupResourceBuilders == null) {
-            LOGGER.info("Cannot find GroupResourceBuilder for {}", platform);
+            LOGGER.info("Cannot find GroupResourceBuilder for platform variant: '{}'", platformVariant);
             return Collections.emptyList();
         }
         return new ArrayList<>(groupResourceBuilders);
@@ -81,7 +81,7 @@ public class ResourceBuilders {
 
     private void initNetwork(Comparator<OrderedBuilder> comparator) {
         for (NetworkResourceBuilder<ResourceBuilderContext> builder : network) {
-            List<NetworkResourceBuilder<ResourceBuilderContext>> chain = networkChain.computeIfAbsent(builder.platform(), k -> new LinkedList<>());
+            List<NetworkResourceBuilder<ResourceBuilderContext>> chain = networkChain.computeIfAbsent(builder.variant(), k -> new LinkedList<>());
             chain.add(builder);
             chain.sort(comparator);
         }
@@ -89,7 +89,7 @@ public class ResourceBuilders {
 
     private void initCompute(Comparator<OrderedBuilder> comparator) {
         for (ComputeResourceBuilder<ResourceBuilderContext> builder : compute) {
-            List<ComputeResourceBuilder<ResourceBuilderContext>> chain = computeChain.computeIfAbsent(builder.platform(), k -> new LinkedList<>());
+            List<ComputeResourceBuilder<ResourceBuilderContext>> chain = computeChain.computeIfAbsent(builder.variant(), k -> new LinkedList<>());
             chain.add(builder);
             chain.sort(comparator);
         }
@@ -97,7 +97,7 @@ public class ResourceBuilders {
 
     private void initGroup(Comparator<OrderedBuilder> comparator) {
         for (GroupResourceBuilder<ResourceBuilderContext> builder : group) {
-            List<GroupResourceBuilder<ResourceBuilderContext>> chain = groupChain.computeIfAbsent(builder.platform(), k -> new LinkedList<>());
+            List<GroupResourceBuilder<ResourceBuilderContext>> chain = groupChain.computeIfAbsent(builder.variant(), k -> new LinkedList<>());
             chain.add(builder);
             chain.sort(comparator);
         }

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/network/NetworkResourceService.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/network/NetworkResourceService.java
@@ -18,8 +18,8 @@ import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
-import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Security;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.scheduler.SyncPollingScheduler;
@@ -53,7 +53,8 @@ public class NetworkResourceService {
             AuthenticatedContext auth, Network network, Security security) throws Exception {
         CloudContext cloudContext = auth.getCloudContext();
         List<CloudResourceStatus> results = new ArrayList<>();
-        for (NetworkResourceBuilder<ResourceBuilderContext> builder : resourceBuilders.network(cloudContext.getPlatform())) {
+        Variant variant = cloudContext.getVariant();
+        for (NetworkResourceBuilder<ResourceBuilderContext> builder : resourceBuilders.network(variant)) {
             PollGroup pollGroup = InMemoryStateStore.getStack(auth.getCloudContext().getId());
             if (CANCELLED.equals(pollGroup)) {
                 break;
@@ -78,7 +79,8 @@ public class NetworkResourceService {
             AuthenticatedContext auth, Iterable<CloudResource> resources, Network network, boolean cancellable) throws Exception {
         CloudContext cloudContext = auth.getCloudContext();
         List<CloudResourceStatus> results = new ArrayList<>();
-        List<NetworkResourceBuilder<ResourceBuilderContext>> builderChain = resourceBuilders.network(cloudContext.getPlatform());
+        Variant variant = cloudContext.getVariant();
+        List<NetworkResourceBuilder<ResourceBuilderContext>> builderChain = resourceBuilders.network(variant);
         for (int i = builderChain.size() - 1; i >= 0; i--) {
             NetworkResourceBuilder<ResourceBuilderContext> builder = builderChain.get(i);
             List<CloudResource> specificResources = getResources(resources, builder.resourceType());
@@ -102,7 +104,8 @@ public class NetworkResourceService {
             Network network, Security security, Iterable<CloudResource> networkResources) throws Exception {
         List<CloudResourceStatus> results = new ArrayList<>();
         CloudContext cloudContext = auth.getCloudContext();
-        for (NetworkResourceBuilder<ResourceBuilderContext> builder : resourceBuilders.network(cloudContext.getPlatform())) {
+        Variant variant = cloudContext.getVariant();
+        for (NetworkResourceBuilder<ResourceBuilderContext> builder : resourceBuilders.network(variant)) {
             List<CloudResource> resources = getResources(networkResources, builder.resourceType());
             if (!resources.isEmpty()) {
                 CloudResource resource = resources.get(0);
@@ -118,9 +121,9 @@ public class NetworkResourceService {
         return results;
     }
 
-    public List<CloudResource> getNetworkResources(Platform platform, Iterable<CloudResource> resources) {
+    public List<CloudResource> getNetworkResources(Variant variant, Iterable<CloudResource> resources) {
         Collection<ResourceType> types = new ArrayList<>();
-        for (NetworkResourceBuilder<?> builder : resourceBuilders.network(platform)) {
+        for (NetworkResourceBuilder<?> builder : resourceBuilders.network(variant)) {
             types.add(builder.resourceType());
         }
         return getResources(resources, types);

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -266,6 +266,7 @@ dependencies {
   runtime project(':cloud-openstack')
   runtime project(':cloud-gcp')
   implementation project(':cloud-aws-cloudformation')
+  implementation project(':cloud-aws-native')
   runtime project(':cloud-mock')
   runtime project(':cloud-azure')
   runtime project(':cloud-yarn')


### PR DESCRIPTION
**Changes**
 - map CloudInstance to CloudResource with private id if necessary in AwsNativeMetadataCollector
 - group resource connectors by Variant instead of Platform
 - include `cloud-aws-native` module in `core` modul