### PR TITLE
CB-13176 Gather AWS medium duty datalake load balancer configs and re…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancerMetadata.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancerMetadata.java
@@ -1,8 +1,10 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
+import com.sequenceiq.cloudbreak.cloud.model.generic.DynamicModel;
 import com.sequenceiq.common.api.type.LoadBalancerType;
+import java.util.Map;
 
-public class CloudLoadBalancerMetadata {
+public class CloudLoadBalancerMetadata extends DynamicModel {
 
     private final LoadBalancerType type;
 
@@ -14,7 +16,9 @@ public class CloudLoadBalancerMetadata {
 
     private final String name;
 
-    private CloudLoadBalancerMetadata(LoadBalancerType type, String cloudDns, String hostedZoneId, String ip, String name) {
+    private CloudLoadBalancerMetadata(LoadBalancerType type, String cloudDns, String hostedZoneId, String ip, String name,
+            Map<String, Object> parameters) {
+        super(parameters);
         this.type = type;
         this.cloudDns = cloudDns;
         this.hostedZoneId = hostedZoneId;
@@ -65,6 +69,8 @@ public class CloudLoadBalancerMetadata {
 
         private String name;
 
+        private Map<String, Object> parameters;
+
         public Builder withType(LoadBalancerType type) {
             this.type = type;
             return this;
@@ -90,8 +96,13 @@ public class CloudLoadBalancerMetadata {
             return this;
         }
 
+        public Builder withParameters(Map<String, Object> parameters) {
+            this.parameters = parameters;
+            return this;
+        }
+
         public CloudLoadBalancerMetadata build() {
-            return new CloudLoadBalancerMetadata(type, cloudDns, hostedZoneId, ip, name);
+            return new CloudLoadBalancerMetadata(type, cloudDns, hostedZoneId, ip, name, parameters);
         }
     }
 }

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsLoadBalancerMetadataCollector.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsLoadBalancerMetadataCollector.java
@@ -1,0 +1,90 @@
+package com.sequenceiq.cloudbreak.cloud.aws;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.amazonaws.services.cloudformation.model.ListStackResourcesResult;
+import com.amazonaws.services.cloudformation.model.StackResourceSummary;
+import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancer;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsListener;
+import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsLoadBalancerScheme;
+import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsTargetGroup;
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsCredentialView;
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsLoadBalancerMetadataView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+
+@Service
+public class AwsLoadBalancerMetadataCollector {
+
+    @Inject
+    private AwsCloudFormationClient awsClient;
+
+    @Inject
+    private CloudFormationStackUtil cloudFormationStackUtil;
+
+    @Inject
+    private AwsStackRequestHelper awsStackRequestHelper;
+
+    public Map<String, Object> getParameters(AuthenticatedContext ac, LoadBalancer loadBalancer, AwsLoadBalancerScheme scheme) {
+        String region = ac.getCloudContext().getLocation().getRegion().value();
+        String cFStackName = cloudFormationStackUtil.getCfStackName(ac);
+        AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
+        AmazonCloudFormationClient cfRetryClient = awsClient.createCloudFormationClient(credentialView, region);
+        ListStackResourcesResult result = cfRetryClient.listStackResources(awsStackRequestHelper.createListStackResourcesRequest(cFStackName));
+
+        Map<String, Object> parameters = parseTargetGroupCloudParams(scheme, result.getStackResourceSummaries());
+        parameters.put(AwsLoadBalancerMetadataView.LOADBALANCER_ARN, loadBalancer.getLoadBalancerArn());
+        return parameters;
+    }
+
+    /**
+     * Parses the stack resource summary for the cloudformation stack and pulls out all listener and target group ARNs
+     * associated with a particular load balancer, and creates AwsTargetGroupMetadata objects using the provided
+     * resources summaries.
+     * @param scheme The scheme of the load balancer being processed, either INTERNAL or INTERNET-FACING
+     * @param summaries The list of resource summaries from cloud formation that contain both the logical resource id
+     *                  (the name), and the physical resource id (ARN).
+     * @return A list of metadata pulled from the resource summaries.
+     */
+    private Map<String, Object> parseTargetGroupCloudParams(AwsLoadBalancerScheme scheme, List<StackResourceSummary> summaries) {
+        // Listeners and target groups have a naming convention of 'prefix + port + LB scheme'. Here we're pulling out
+        // port information for the load balancer via its associated listeners, and will use that list to construct the
+        // names of all listeners and target groups associated with the LB.
+        List<Integer> ports = summaries.stream()
+            .filter(summary -> summary.getLogicalResourceId().startsWith(AwsListener.LISTENER_NAME_PREFIX))
+            .filter(summary -> summary.getLogicalResourceId().endsWith(scheme.resourceName()))
+            .map(summary -> getPortFromListenerName(summary.getLogicalResourceId(), scheme))
+            .collect(Collectors.toList());
+
+        Map<String, Object> targetGroupParameters = new HashMap<>();
+        // Each configured port should have a single listener and a single target group associated with it.
+        // Build the appropriate names for each resource, and use that to pull out the physical resource id,
+        // which in this case is the resource ARN.
+        ports.forEach(port -> {
+            String listenerArn = summaries.stream()
+                .filter(summary -> AwsListener.getListenerName(port, scheme).equals(summary.getLogicalResourceId()))
+                .map(StackResourceSummary::getPhysicalResourceId)
+                .findFirst().orElse(null);
+            String targetGroupArn = summaries.stream()
+                .filter(summary -> AwsTargetGroup.getTargetGroupName(port, scheme).equals(summary.getLogicalResourceId()))
+                .map(StackResourceSummary::getPhysicalResourceId)
+                .findFirst().orElse(null);
+
+            targetGroupParameters.put(AwsLoadBalancerMetadataView.getTargetGroupParam(port), targetGroupArn);
+            targetGroupParameters.put(AwsLoadBalancerMetadataView.getListenerParam(port), listenerArn);
+        });
+        return targetGroupParameters;
+    }
+
+    private Integer getPortFromListenerName(String name, AwsLoadBalancerScheme scheme) {
+        return Integer.valueOf(name.replace(AwsListener.LISTENER_NAME_PREFIX, "")
+            .replace(scheme.resourceName(), ""));
+    }
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsLoadBalancerMetadataCollectorTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsLoadBalancerMetadataCollectorTest.java
@@ -1,0 +1,189 @@
+package com.sequenceiq.cloudbreak.cloud.aws;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.amazonaws.services.cloudformation.model.ListStackResourcesRequest;
+import com.amazonaws.services.cloudformation.model.ListStackResourcesResult;
+import com.amazonaws.services.cloudformation.model.StackResourceSummary;
+import com.amazonaws.services.elasticloadbalancingv2.model.LoadBalancer;
+import com.sequenceiq.cloudbreak.cloud.aws.client.AmazonCloudFormationClient;
+import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
+import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsListener;
+import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsLoadBalancer;
+import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsLoadBalancerScheme;
+import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.AwsTargetGroup;
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsLoadBalancerMetadataView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsLoadBalancerMetadataCollectorTest {
+
+    private static final Long WORKSPACE_ID = 1L;
+
+    private static final String TARGET_GROUP_ARN = "arn:targetgroup";
+
+    private static final String LOAD_BALANCER_ARN = "arn:loadbalancer";
+
+    private static final String LISTENER_ARN = "arn:listener";
+
+    @Mock
+    private AmazonEc2Client amazonEC2Client;
+
+    @Mock
+    private AwsCloudFormationClient awsClient;
+
+    @Mock
+    private CloudFormationStackUtil cloudFormationStackUtil;
+
+    @Mock
+    private AwsStackRequestHelper awsStackRequestHelper;
+
+    @Mock
+    private AmazonCloudFormationClient cfRetryClient;
+
+    @InjectMocks
+    private AwsLoadBalancerMetadataCollector underTest;
+
+    @Test
+    public void testCollectInternalLoadBalancer() {
+        int numPorts = 1;
+        AuthenticatedContext ac = authenticatedContext();
+        LoadBalancer loadBalancer = createLoadBalancer();
+        List<StackResourceSummary> summaries = createSummaries(numPorts, true);
+        ListStackResourcesResult result = new ListStackResourcesResult();
+        result.setStackResourceSummaries(summaries);
+
+        Map<String, Object> expectedParameters = Map.of(
+            AwsLoadBalancerMetadataView.LOADBALANCER_ARN, LOAD_BALANCER_ARN,
+            AwsLoadBalancerMetadataView.LISTENER_ARN_PREFIX + 0, LISTENER_ARN + "0Internal",
+            AwsLoadBalancerMetadataView.TARGET_GROUP_ARN_PREFIX + 0, TARGET_GROUP_ARN + "0Internal"
+        );
+
+        when(awsClient.createCloudFormationClient(any(), any())).thenReturn(cfRetryClient);
+        when(cloudFormationStackUtil.getCfStackName(ac)).thenReturn("stackName");
+        when(awsStackRequestHelper.createListStackResourcesRequest(eq("stackName"))).thenReturn(new ListStackResourcesRequest());
+        when(cfRetryClient.listStackResources(any())).thenReturn(result);
+
+        Map<String, Object> parameters = underTest.getParameters(ac, loadBalancer, AwsLoadBalancerScheme.INTERNAL);
+
+        assertEquals(expectedParameters, parameters);
+    }
+
+    @Test
+    public void testCollectLoadBalancerMultiplePorts() {
+        int numPorts = 3;
+        AuthenticatedContext ac = authenticatedContext();
+        LoadBalancer loadBalancer = createLoadBalancer();
+        List<StackResourceSummary> summaries = createSummaries(numPorts, true);
+        ListStackResourcesResult result = new ListStackResourcesResult();
+        result.setStackResourceSummaries(summaries);
+
+        Map<String, Object> expectedParameters = Map.of(
+            AwsLoadBalancerMetadataView.LOADBALANCER_ARN, LOAD_BALANCER_ARN,
+            AwsLoadBalancerMetadataView.LISTENER_ARN_PREFIX + 0, LISTENER_ARN + "0Internal",
+            AwsLoadBalancerMetadataView.TARGET_GROUP_ARN_PREFIX + 0, TARGET_GROUP_ARN + "0Internal",
+            AwsLoadBalancerMetadataView.LISTENER_ARN_PREFIX + 1, LISTENER_ARN + "1Internal",
+            AwsLoadBalancerMetadataView.TARGET_GROUP_ARN_PREFIX + 1, TARGET_GROUP_ARN + "1Internal",
+            AwsLoadBalancerMetadataView.LISTENER_ARN_PREFIX + 2, LISTENER_ARN + "2Internal",
+            AwsLoadBalancerMetadataView.TARGET_GROUP_ARN_PREFIX + 2, TARGET_GROUP_ARN + "2Internal"
+        );
+
+        when(awsClient.createCloudFormationClient(any(), any())).thenReturn(cfRetryClient);
+        when(cloudFormationStackUtil.getCfStackName(ac)).thenReturn("stackName");
+        when(awsStackRequestHelper.createListStackResourcesRequest(eq("stackName"))).thenReturn(new ListStackResourcesRequest());
+        when(cfRetryClient.listStackResources(any())).thenReturn(result);
+
+        Map<String, Object> parameters = underTest.getParameters(ac, loadBalancer, AwsLoadBalancerScheme.INTERNAL);
+
+        assertEquals(expectedParameters, parameters);
+    }
+
+    @Test
+    public void testCollectLoadBalancerMissingTargetGroup() {
+        int numPorts = 1;
+        AuthenticatedContext ac = authenticatedContext();
+        LoadBalancer loadBalancer = createLoadBalancer();
+        List<StackResourceSummary> summaries = createSummaries(numPorts, false);
+        ListStackResourcesResult result = new ListStackResourcesResult();
+        result.setStackResourceSummaries(summaries);
+
+        Map<String, Object> expectedParameters = new HashMap<>();
+        expectedParameters.put(AwsLoadBalancerMetadataView.LOADBALANCER_ARN, LOAD_BALANCER_ARN);
+        expectedParameters.put(AwsLoadBalancerMetadataView.LISTENER_ARN_PREFIX + 0, LISTENER_ARN + "0Internal");
+        expectedParameters.put(AwsLoadBalancerMetadataView.TARGET_GROUP_ARN_PREFIX + 0, null);
+
+        when(awsClient.createCloudFormationClient(any(), any())).thenReturn(cfRetryClient);
+        when(cloudFormationStackUtil.getCfStackName(ac)).thenReturn("stackName");
+        when(awsStackRequestHelper.createListStackResourcesRequest(eq("stackName"))).thenReturn(new ListStackResourcesRequest());
+        when(cfRetryClient.listStackResources(any())).thenReturn(result);
+
+        Map<String, Object> parameters = underTest.getParameters(ac, loadBalancer, AwsLoadBalancerScheme.INTERNAL);
+
+        assertEquals(expectedParameters, parameters);
+    }
+
+    private AuthenticatedContext authenticatedContext() {
+        Location location = Location.location(Region.region("region"), AvailabilityZone.availabilityZone("az"));
+        CloudContext context = CloudContext.Builder.builder()
+            .withId(5L)
+            .withName("name")
+            .withCrn("crn")
+            .withPlatform("platform")
+            .withVariant("variant")
+            .withLocation(location)
+            .withWorkspaceId(WORKSPACE_ID)
+            .build();
+        CloudCredential credential = new CloudCredential("crn", null, null, false);
+        AuthenticatedContext authenticatedContext = new AuthenticatedContext(context, credential);
+        authenticatedContext.putParameter(AmazonEc2Client.class, amazonEC2Client);
+        return authenticatedContext;
+    }
+
+    private LoadBalancer createLoadBalancer() {
+        LoadBalancer loadBalancer = new LoadBalancer();
+        loadBalancer.setLoadBalancerArn(LOAD_BALANCER_ARN);
+        return loadBalancer;
+    }
+
+    private List<StackResourceSummary> createSummaries(int numPorts, boolean includeTargetGroup) {
+        List<StackResourceSummary> summaries = new ArrayList<>();
+        for (AwsLoadBalancerScheme scheme : AwsLoadBalancerScheme.class.getEnumConstants()) {
+            StackResourceSummary lbSummary = new StackResourceSummary();
+            lbSummary.setLogicalResourceId(AwsLoadBalancer.getLoadBalancerName(scheme));
+            lbSummary.setPhysicalResourceId(LOAD_BALANCER_ARN + scheme.resourceName());
+            summaries.add(lbSummary);
+            for (int i = 0; i < numPorts; i++) {
+                if (includeTargetGroup) {
+                    StackResourceSummary tgSummary = new StackResourceSummary();
+                    tgSummary.setLogicalResourceId(AwsTargetGroup.getTargetGroupName(i, scheme));
+                    tgSummary.setPhysicalResourceId(TARGET_GROUP_ARN + i + scheme.resourceName());
+                    summaries.add(tgSummary);
+                }
+                StackResourceSummary lSummary = new StackResourceSummary();
+                lSummary.setLogicalResourceId(AwsListener.getListenerName(i, scheme));
+                lSummary.setPhysicalResourceId(LISTENER_ARN + i + scheme.resourceName());
+                summaries.add(lSummary);
+            }
+        }
+        return summaries;
+    }
+}

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetaDataCollectorTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsMetaDataCollectorTest.java
@@ -117,6 +117,9 @@ public class AwsMetaDataCollectorTest {
     @Mock
     private LoadBalancerTypeConverter loadBalancerTypeConverter;
 
+    @Mock
+    private AwsLoadBalancerMetadataCollector awsLoadBalancerMetadataCollector;
+
     @InjectMocks
     private AwsMetadataCollector awsMetadataCollector;
 
@@ -427,7 +430,6 @@ public class AwsMetaDataCollectorTest {
     @Test
     public void testCollectLoadBalancers() {
         setupMethodsForLoadBalancer(true);
-
         AuthenticatedContext ac = authenticatedContext();
         List<CloudLoadBalancerMetadata> metadata = awsMetadataCollector.collectLoadBalancer(ac,
                 List.of(LoadBalancerType.PRIVATE, LoadBalancerType.PUBLIC), null);
@@ -451,7 +453,7 @@ public class AwsMetaDataCollectorTest {
     @Test
     public void testCollectLoadBalancerOnlyDefaultGateway() {
         setupMethodsForLoadBalancer(true);
-
+        when(awsLoadBalancerMetadataCollector.getParameters(any(), any(), any())).thenReturn(Map.of());
         AuthenticatedContext ac = authenticatedContext();
         List<CloudLoadBalancerMetadata> metadata = awsMetadataCollector.collectLoadBalancer(ac,
                 List.of(LoadBalancerType.PRIVATE), null);
@@ -469,7 +471,7 @@ public class AwsMetaDataCollectorTest {
     @Test
     public void testCollectLoadBalancerOnlyEndpointAccessGateway() {
         setupMethodsForLoadBalancer(true);
-
+        when(awsLoadBalancerMetadataCollector.getParameters(any(), any(), any())).thenReturn(Map.of());
         AuthenticatedContext ac = authenticatedContext();
         List<CloudLoadBalancerMetadata> metadata = awsMetadataCollector.collectLoadBalancer(ac,
                 List.of(LoadBalancerType.PUBLIC), null);
@@ -486,7 +488,7 @@ public class AwsMetaDataCollectorTest {
     @Test
     public void testCollectLoadBalancerMissingMetadata() {
         setupMethodsForLoadBalancer(false);
-
+        when(awsLoadBalancerMetadataCollector.getParameters(any(), any(), any())).thenReturn(Map.of());
         AuthenticatedContext ac = authenticatedContext();
         List<CloudLoadBalancerMetadata> metadata = awsMetadataCollector.collectLoadBalancer(ac,
                 List.of(LoadBalancerType.PRIVATE, LoadBalancerType.PUBLIC), null);
@@ -564,5 +566,4 @@ public class AwsMetaDataCollectorTest {
         assertThat(result).hasMessage("Serious problem");
         assertThat(result).hasCause(exception);
     }
-
 }

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/loadbalancer/AwsListener.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/loadbalancer/AwsListener.java
@@ -4,7 +4,7 @@ import java.util.Set;
 
 public class AwsListener {
 
-    private static final String LISTENER_NAME_PREFIX = "ListenerPort";
+    public static final String LISTENER_NAME_PREFIX = "ListenerPort";
 
     private final int port;
 

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/view/AwsLoadBalancerMetadataView.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/view/AwsLoadBalancerMetadataView.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.view;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
+
+public class AwsLoadBalancerMetadataView {
+
+    public static final String LOADBALANCER_ARN = "loadBalancerArn";
+
+    public static final String LISTENER_ARN_PREFIX = "listenerArn";
+
+    public static final String TARGET_GROUP_ARN_PREFIX = "targetGroupArn";
+
+    private final CloudLoadBalancerMetadata cloudLoadBalancerMetadata;
+
+    public AwsLoadBalancerMetadataView(CloudLoadBalancerMetadata cloudLoadBalancerMetadata) {
+        this.cloudLoadBalancerMetadata = cloudLoadBalancerMetadata;
+    }
+
+    public String getLoadbalancerArn() {
+        return cloudLoadBalancerMetadata.getStringParameter(LOADBALANCER_ARN);
+    }
+
+    public String getListenerArnByPort(int port) {
+        return cloudLoadBalancerMetadata.getStringParameter(getListenerParam(port));
+    }
+
+    public String getTargetGroupArnByPort(int port) {
+        return cloudLoadBalancerMetadata.getStringParameter(getTargetGroupParam(port));
+    }
+
+    public static String getListenerParam(int port) {
+        return LISTENER_ARN_PREFIX + port;
+    }
+
+    public static String getTargetGroupParam(int port) {
+        return TARGET_GROUP_ARN_PREFIX + port;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/StackV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/StackV4Response.java
@@ -25,6 +25,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.database.Databa
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.hardware.HardwareInfoGroupV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.StackImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer.LoadBalancerResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.network.NetworkV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.tags.TagsV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.workspace.responses.WorkspaceResourceV4Response;
@@ -134,6 +135,9 @@ public class StackV4Response extends StackV4Base implements TaggedResponse {
 
     @ApiModelProperty(StackModelDescription.EXTERNAL_DATABASE)
     private DatabaseResponse externalDatabase;
+
+    @ApiModelProperty(StackModelDescription.LOAD_BALANCER)
+    private List<LoadBalancerResponse> loadBalancers;
 
     public Long getId() {
         return id;
@@ -388,6 +392,14 @@ public class StackV4Response extends StackV4Base implements TaggedResponse {
 
     public void setVariant(String variant) {
         this.variant = variant;
+    }
+
+    public List<LoadBalancerResponse> getLoadBalancers() {
+        return loadBalancers;
+    }
+
+    public void setLoadBalancers(List<LoadBalancerResponse> loadBalancers) {
+        this.loadBalancers = loadBalancers;
     }
 
     @Override

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/AwsLoadBalancerResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/AwsLoadBalancerResponse.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions.StackModelDescription;
+
+public class AwsLoadBalancerResponse implements Serializable {
+
+    @ApiModelProperty(StackModelDescription.AWS_LB_ARN)
+    @NotNull
+    private String arn;
+
+    public String getArn() {
+        return arn;
+    }
+
+    public void setArn(String arn) {
+        this.arn = arn;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/AwsTargetGroupResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/AwsTargetGroupResponse.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions.StackModelDescription;
+
+public class AwsTargetGroupResponse implements Serializable {
+
+    @ApiModelProperty(StackModelDescription.AWS_LISTENER_ARN)
+    @NotNull
+    private String listenerArn;
+
+    @ApiModelProperty(StackModelDescription.AWS_TARGETGROUP_ARN)
+    @NotNull
+    private String targetGroupArn;
+
+    public String getListenerArn() {
+        return listenerArn;
+    }
+
+    public void setListenerArn(String listenerArn) {
+        this.listenerArn = listenerArn;
+    }
+
+    public String getTargetGroupArn() {
+        return targetGroupArn;
+    }
+
+    public void setTargetGroupArn(String targetGroupArn) {
+        this.targetGroupArn = targetGroupArn;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/LoadBalancerResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/LoadBalancerResponse.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer;
+
+import java.io.Serializable;
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions.StackModelDescription;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.common.api.type.LoadBalancerType;
+
+@JsonInclude(Include.NON_NULL)
+public class LoadBalancerResponse implements Serializable {
+
+    @ApiModelProperty(StackModelDescription.LOAD_BALANCER_FQDN)
+    private String fqdn;
+
+    @ApiModelProperty(StackModelDescription.LOAD_BALANCER_CLOUD_DNS)
+    private String cloudDns;
+
+    @ApiModelProperty(StackModelDescription.LOAD_BALANCER_IP)
+    private String ip;
+
+    @ApiModelProperty(StackModelDescription.LOAD_BALANCER_TARGETS)
+    @NotNull
+    private List<TargetGroupResponse> targets;
+
+    @ApiModelProperty(StackModelDescription.LOAD_BALANCER_TYPE)
+    @NotNull
+    private LoadBalancerType type;
+
+    @ApiModelProperty(StackModelDescription.LOAD_BALANCER_AWS)
+    private AwsLoadBalancerResponse awsResourceId;
+
+    public String getFqdn() {
+        return fqdn;
+    }
+
+    public void setFqdn(String fqdn) {
+        this.fqdn = fqdn;
+    }
+
+    public String getCloudDns() {
+        return cloudDns;
+    }
+
+    public void setCloudDns(String cloudDns) {
+        this.cloudDns = cloudDns;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+
+    public List<TargetGroupResponse> getTargets() {
+        return targets;
+    }
+
+    public void setTargets(List<TargetGroupResponse> targets) {
+        this.targets = targets;
+    }
+
+    public LoadBalancerType getType() {
+        return type;
+    }
+
+    public void setType(LoadBalancerType type) {
+        this.type = type;
+    }
+
+    public AwsLoadBalancerResponse getAwsResourceId() {
+        return awsResourceId;
+    }
+
+    public void setAwsResourceId(AwsLoadBalancerResponse awsResourceId) {
+        this.awsResourceId = awsResourceId;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/TargetGroupResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/TargetGroupResponse.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer;
+
+import java.io.Serializable;
+import java.util.Set;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions.StackModelDescription;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+public class TargetGroupResponse implements Serializable {
+
+    @ApiModelProperty(StackModelDescription.TARGET_GROUP_PORT)
+    @NotNull
+    private long port;
+
+    @ApiModelProperty(StackModelDescription.TARGET_GROUP_INSTANCES)
+    @NotNull
+    private Set<String> targetInstances;
+
+    @ApiModelProperty(StackModelDescription.TARGET_GROUP_AWS)
+    private AwsTargetGroupResponse awsResourceIds;
+
+    public long getPort() {
+        return port;
+    }
+
+    public void setPort(long port) {
+        this.port = port;
+    }
+
+    public Set<String> getTargetInstances() {
+        return targetInstances;
+    }
+
+    public void setTargetInstances(Set<String> targetInstances) {
+        this.targetInstances = targetInstances;
+    }
+
+    public AwsTargetGroupResponse getAwsResourceIds() {
+        return awsResourceIds;
+    }
+
+    public void setAwsResourceIds(AwsTargetGroupResponse awsResourceIds) {
+        this.awsResourceIds = awsResourceIds;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -256,6 +256,19 @@ public class ModelDescriptions {
         public static final String EXTERNAL_DATABASE = "External database parameters for the stack.";
         public static final String ENDPOINT_GATEWAY_FLOWS = "A list of stack and the flow id for the add endpoint gateway flow";
         public static final String ENABLE_LOAD_BALANCER = "Enable load balancer.";
+        public static final String LOAD_BALANCER = "Any load balancers routing traffic both to and inside of the cluster.";
+        public static final String LOAD_BALANCER_FQDN = "The registered FQDN of the load balancer.";
+        public static final String LOAD_BALANCER_CLOUD_DNS = "The AWS generated DNS name for the load balancer.";
+        public static final String LOAD_BALANCER_IP = "The frontend ip address for the load balancer.";
+        public static final String LOAD_BALANCER_TARGETS = "The list of target instances the load balancer routes traffic to.";
+        public static final String LOAD_BALANCER_TYPE = "Whether the load balancer is internet-facing (public), or only accessible over private endpoints.";
+        public static final String LOAD_BALANCER_AWS = "The AWS resource id for the load balancer.";
+        public static final String TARGET_GROUP_PORT = "The port where the load balancer receives traffic and forward it to the associated targets.";
+        public static final String TARGET_GROUP_INSTANCES = "Ids for the target instances receiving traffic from the load balancer on the defined port.";
+        public static final String TARGET_GROUP_AWS = "The AWS listener and target group resource ids.";
+        public static final String AWS_LB_ARN = "The ARN of the AWS load balancer.";
+        public static final String AWS_LISTENER_ARN = "The ARN of the AWS listener for the specified port.";
+        public static final String AWS_TARGETGROUP_ARN = "The ARN of the AWS target group for the specified port.";
     }
 
     public static class ClusterModelDescription {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancer.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancer.java
@@ -1,10 +1,10 @@
 package com.sequenceiq.cloudbreak.domain.stack.loadbalancer;
 
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import java.util.HashSet;
 import java.util.Set;
 
 import java.util.stream.Collectors;
+import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -15,9 +15,13 @@ import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.SequenceGenerator;
 
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.json.JsonToString;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
 import com.sequenceiq.cloudbreak.domain.converter.LoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 
 @Entity
@@ -45,6 +49,10 @@ public class LoadBalancer implements ProvisionEntity  {
     private Set<TargetGroup> targetGroupSet = new HashSet<>();
 
     private String fqdn;
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json providerConfig;
 
     public Long getId() {
         return id;
@@ -122,6 +130,19 @@ public class LoadBalancer implements ProvisionEntity  {
 
     public void setFqdn(String fqdn) {
         this.fqdn = fqdn;
+    }
+
+    public LoadBalancerConfigDbWrapper getProviderConfig() {
+        if (providerConfig != null && providerConfig.getValue() != null) {
+            return JsonUtil.readValueOpt(providerConfig.getValue(), LoadBalancerConfigDbWrapper.class).orElse(null);
+        }
+        return null;
+    }
+
+    public void setProviderConfig(LoadBalancerConfigDbWrapper cloudConfig) {
+        if (cloudConfig != null) {
+            this.providerConfig = new Json(cloudConfig);
+        }
     }
 
     @Override

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancerConfigDbWrapper.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancerConfigDbWrapper.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.domain.stack.loadbalancer;
+
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsLoadBalancerConfigDb;
+
+/**
+ * A wrapper for the cloud provider specific load balancer metadata stored in the database. Only one
+ * type of config should be set, depending on what the cloud platform for the stack is. This class
+ * is intended to be serialized into a JSON string and stored in the database, and deserialized
+ * when fetched.
+ */
+public class LoadBalancerConfigDbWrapper {
+
+    private AwsLoadBalancerConfigDb awsConfig;
+
+    public AwsLoadBalancerConfigDb getAwsConfig() {
+        return awsConfig;
+    }
+
+    public void setAwsConfig(AwsLoadBalancerConfigDb awsConfig) {
+        this.awsConfig = awsConfig;
+    }
+
+    @Override
+    public String toString() {
+        return "CloudLoadBalancerConfig{" +
+            "awsConfig=" + awsConfig +
+            '}';
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/TargetGroup.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/TargetGroup.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -13,6 +14,9 @@ import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.SequenceGenerator;
 
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.json.JsonToString;
+import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
 import com.sequenceiq.cloudbreak.domain.converter.TargetGroupTypeConverter;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
@@ -33,6 +37,10 @@ public class TargetGroup implements ProvisionEntity {
 
     @ManyToMany(fetch = FetchType.EAGER)
     private Set<InstanceGroup> instanceGroups = new HashSet<>();
+
+    @Convert(converter = JsonToString.class)
+    @Column(columnDefinition = "TEXT")
+    private Json providerConfig;
 
     public Long getId() {
         return id;
@@ -64,6 +72,19 @@ public class TargetGroup implements ProvisionEntity {
 
     public void setInstanceGroups(Set<InstanceGroup> instanceGroups) {
         this.instanceGroups = instanceGroups;
+    }
+
+    public TargetGroupConfigDbWrapper getProviderConfig() {
+        if (providerConfig != null && providerConfig.getValue() != null) {
+            return JsonUtil.readValueOpt(providerConfig.getValue(), TargetGroupConfigDbWrapper.class).orElse(null);
+        }
+        return null;
+    }
+
+    public void setProviderConfig(TargetGroupConfigDbWrapper cloudConfig) {
+        if (cloudConfig != null) {
+            this.providerConfig = new Json(cloudConfig);
+        }
     }
 
     @Override

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/TargetGroupConfigDbWrapper.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/TargetGroupConfigDbWrapper.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.domain.stack.loadbalancer;
+
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsTargetGroupConfigDb;
+
+/**
+ * A wrapper for the cloud provider specific target group metadata stored in the database. Only one
+ * type of config should be set, depending on what the cloud platform for the stack is. This class
+ * is intended to be serialized into a JSON string and stored in the database, and deserialized
+ * when fetched.
+ */
+public class TargetGroupConfigDbWrapper {
+
+    private AwsTargetGroupConfigDb awsConfig;
+
+    public AwsTargetGroupConfigDb getAwsConfig() {
+        return awsConfig;
+    }
+
+    public void setAwsConfig(AwsTargetGroupConfigDb awsConfig) {
+        this.awsConfig = awsConfig;
+    }
+
+    @Override
+    public String toString() {
+        return "TargetGroupConfigDbWrapper{" +
+            "awsConfig=" + awsConfig +
+            '}';
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/aws/AwsLoadBalancerConfigDb.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/aws/AwsLoadBalancerConfigDb.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws;
+
+/**
+ * The top level AWS specific load balancer metadata database object. For AWS, the only metadata needed at
+ * the load balancer level is the load balancer ARN.
+ */
+public class AwsLoadBalancerConfigDb {
+
+    private String arn;
+
+    public void setArn(String arn) {
+        this.arn = arn;
+    }
+
+    public String getArn() {
+        return arn;
+    }
+
+    @Override
+    public String toString() {
+        return "AwsLoadBalancerConfig{" +
+            "arn='" + arn + '\'' +
+            '}';
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/aws/AwsTargetGroupArnsDb.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/aws/AwsTargetGroupArnsDb.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws;
+
+/**
+ * Contains the ARNs for both a listener and the target group that listener forwards traffic to.
+ */
+public class AwsTargetGroupArnsDb {
+
+    private String listenerArn;
+
+    private String targetGroupArn;
+
+    public String getListenerArn() {
+        return listenerArn;
+    }
+
+    public void setListenerArn(String listenerArn) {
+        this.listenerArn = listenerArn;
+    }
+
+    public String getTargetGroupArn() {
+        return targetGroupArn;
+    }
+
+    public void setTargetGroupArn(String targetGroupArn) {
+        this.targetGroupArn = targetGroupArn;
+    }
+
+    @Override
+    public String toString() {
+        return "AwsTargetGroupArnsDb{" +
+            "listenerArn='" + listenerArn + '\'' +
+            ", targetGroupArn='" + targetGroupArn + '\'' +
+            '}';
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/aws/AwsTargetGroupConfigDb.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/aws/AwsTargetGroupConfigDb.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The top level AWS specific target group metadata database object. For AWS, there is a listener and target group
+ * resources associated with each port the load balander is listening on. This class stores a map object that
+ * maps ports to the listener listening on that port, and the target group that listener forwards traffic to.
+ */
+public class AwsTargetGroupConfigDb {
+
+    private Map<Integer, AwsTargetGroupArnsDb> portArnMapping = new HashMap<>();
+
+    public Map<Integer, AwsTargetGroupArnsDb> getPortArnMapping() {
+        return portArnMapping;
+    }
+
+    public void setPortArnMapping(Map<Integer, AwsTargetGroupArnsDb> portArnMapping) {
+        this.portArnMapping = portArnMapping;
+    }
+
+    public void addPortArnMapping(Integer port, AwsTargetGroupArnsDb arns) {
+        portArnMapping.put(port, arns);
+    }
+
+    @Override
+    public String toString() {
+        return "AwsTargetGroupConfigDb{" +
+            "portArnMapping=" + portArnMapping +
+            '}';
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/loadbalancer/LoadBalancerToLoadBalancerResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/loadbalancer/LoadBalancerToLoadBalancerResponseConverter.java
@@ -1,0 +1,125 @@
+package com.sequenceiq.cloudbreak.converter.v4.stacks.loadbalancer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer.AwsLoadBalancerResponse;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer.AwsTargetGroupResponse;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer.LoadBalancerResponse;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer.TargetGroupResponse;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
+import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsLoadBalancerConfigDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsTargetGroupArnsDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsTargetGroupConfigDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroupConfigDbWrapper;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
+import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+import com.sequenceiq.cloudbreak.service.stack.TargetGroupPersistenceService;
+
+@Component
+public class LoadBalancerToLoadBalancerResponseConverter extends AbstractConversionServiceAwareConverter<LoadBalancer, LoadBalancerResponse> {
+
+    @Inject
+    private TargetGroupPersistenceService targetGroupService;
+
+    @Inject
+    private InstanceGroupService instanceGroupService;
+
+    @Inject
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Inject
+    private LoadBalancerConfigService loadBalancerConfigService;
+
+    @Override
+    public LoadBalancerResponse convert(LoadBalancer source) {
+        LoadBalancerResponse response = new LoadBalancerResponse();
+        response.setIp(source.getIp());
+        response.setCloudDns(source.getDns());
+        response.setFqdn(source.getFqdn());
+        response.setType(source.getType());
+        response.setTargets(convertTargetGroups(targetGroupService.findByLoadBalancerId(source.getId())));
+        if (source.getProviderConfig() != null) {
+            response.setAwsResourceId(convertAwsLoadBalancer(source.getProviderConfig().getAwsConfig()));
+        }
+
+        return response;
+    }
+
+    private AwsLoadBalancerResponse convertAwsLoadBalancer(AwsLoadBalancerConfigDb awsMetadata) {
+        if (awsMetadata != null) {
+            AwsLoadBalancerResponse awsSettings = new AwsLoadBalancerResponse();
+            awsSettings.setArn(awsMetadata.getArn());
+            return awsSettings;
+        }
+        return null;
+    }
+
+    public List<TargetGroupResponse> convertTargetGroups(Set<TargetGroup> targetGroups) {
+        List<TargetGroupResponse> allResponses = new ArrayList<>();
+        for (TargetGroup targetGroup : targetGroups) {
+            allResponses.addAll(convertTargetGroup(targetGroup));
+        }
+        return allResponses;
+    }
+
+    public List<TargetGroupResponse> convertTargetGroup(TargetGroup targetGroup) {
+        Set<InstanceGroup> instanceGroups = instanceGroupService.findByTargetGroupId(targetGroup.getId());
+        Set<String> instanceIds = getInstanceMetadataForGroups(instanceGroups).stream()
+            .map(InstanceMetaData::getInstanceId)
+            .collect(Collectors.toSet());
+        TargetGroupConfigDbWrapper targetGroupConfig = targetGroup.getProviderConfig();
+        Set<TargetGroupPortPair> portPairs = loadBalancerConfigService.getTargetGroupPortPairs(targetGroup);
+
+        return portPairs.stream()
+            .map(portPair -> mapPortPairToTargetGroup(instanceIds, targetGroupConfig, portPair))
+            .collect(Collectors.toList());
+    }
+
+    private TargetGroupResponse mapPortPairToTargetGroup(Set<String> instanceIds, TargetGroupConfigDbWrapper targetGroupConfig, TargetGroupPortPair portPair) {
+        TargetGroupResponse response = new TargetGroupResponse();
+        response.setPort(portPair.getTrafficPort());
+        response.setTargetInstances(instanceIds);
+        if (targetGroupConfig != null) {
+            response.setAwsResourceIds(convertAwsTargetGroup(targetGroupConfig.getAwsConfig(), portPair.getTrafficPort()));
+        }
+        return response;
+    }
+
+    private AwsTargetGroupResponse convertAwsTargetGroup(AwsTargetGroupConfigDb awsConfig, Integer port) {
+        if (awsConfig != null) {
+            Optional<AwsTargetGroupArnsDb> arns = awsConfig.getPortArnMapping().entrySet().stream()
+                .filter(entry -> entry.getKey().equals(port))
+                .map(Map.Entry::getValue)
+                .findFirst();
+            if (arns.isPresent()) {
+                AwsTargetGroupResponse awsSettings = new AwsTargetGroupResponse();
+                awsSettings.setListenerArn(arns.get().getListenerArn());
+                awsSettings.setTargetGroupArn(arns.get().getTargetGroupArn());
+                return awsSettings;
+            }
+        }
+        return null;
+    }
+
+    private List<InstanceMetaData> getInstanceMetadataForGroups(Set<InstanceGroup> instanceGroups) {
+        return instanceGroups.stream()
+            .map(ig -> instanceMetaDataService.findAliveInstancesInInstanceGroup(ig.getId()))
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigConverter.java
@@ -1,0 +1,80 @@
+package com.sequenceiq.cloudbreak.service;
+
+import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AWS;
+import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AZURE;
+import static com.sequenceiq.cloudbreak.common.type.CloudConstants.GCP;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsLoadBalancerMetadataView;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsLoadBalancerConfigDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsTargetGroupArnsDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsTargetGroupConfigDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancerConfigDbWrapper;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroupConfigDbWrapper;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
+
+@Service
+public class LoadBalancerConfigConverter {
+
+    static final String MISSING_CLOUD_RESOURCE = "Could not find cloud resource corresponding to this traffic port.";
+
+    @Inject
+    private LoadBalancerConfigService loadBalancerConfigService;
+
+    public LoadBalancerConfigDbWrapper convertLoadBalancer(String cloudPlatform, CloudLoadBalancerMetadata cloudLoadBalancerMetadata) {
+        switch (cloudPlatform) {
+            case AWS:
+                return buildAwsConfig(new AwsLoadBalancerMetadataView(cloudLoadBalancerMetadata));
+            // TODO: AZURE, GCP
+            default:
+                return new LoadBalancerConfigDbWrapper();
+        }
+    }
+
+    private LoadBalancerConfigDbWrapper buildAwsConfig(AwsLoadBalancerMetadataView awsMetadata) {
+        LoadBalancerConfigDbWrapper cloudLoadBalancerConfigDbWrapper = new LoadBalancerConfigDbWrapper();
+        AwsLoadBalancerConfigDb awsLoadBalancerConfigDb = new AwsLoadBalancerConfigDb();
+        awsLoadBalancerConfigDb.setArn(awsMetadata.getLoadbalancerArn());
+        cloudLoadBalancerConfigDbWrapper.setAwsConfig(awsLoadBalancerConfigDb);
+        return cloudLoadBalancerConfigDbWrapper;
+    }
+
+    public TargetGroupConfigDbWrapper convertTargetGroup(String cloudPlatform, CloudLoadBalancerMetadata cloudLoadBalancerMetadata, TargetGroup targetGroup) {
+        switch (cloudPlatform) {
+            case AWS:
+                return buildAwsConfig(new AwsLoadBalancerMetadataView(cloudLoadBalancerMetadata), targetGroup);
+            case AZURE:
+            case GCP:
+            default:
+                return new TargetGroupConfigDbWrapper();
+        }
+    }
+
+    private TargetGroupConfigDbWrapper buildAwsConfig(AwsLoadBalancerMetadataView awsMetadata, TargetGroup targetGroup) {
+        Set<Integer> trafficPorts = loadBalancerConfigService.getTargetGroupPortPairs(targetGroup).stream()
+            .map(TargetGroupPortPair::getTrafficPort)
+            .collect(Collectors.toSet());
+
+        TargetGroupConfigDbWrapper targetGroupConfigDbWrapper = new TargetGroupConfigDbWrapper();
+        AwsTargetGroupConfigDb awsTargetGroupConfigDb = new AwsTargetGroupConfigDb();
+        for (Integer port : trafficPorts) {
+            AwsTargetGroupArnsDb targetGroupArns = new AwsTargetGroupArnsDb();
+            String listenerArn = awsMetadata.getListenerArnByPort(port);
+            String targetGroupArn = awsMetadata.getTargetGroupArnByPort(port);
+            targetGroupArns.setListenerArn(StringUtils.isEmpty(listenerArn) ? MISSING_CLOUD_RESOURCE : listenerArn);
+            targetGroupArns.setTargetGroupArn(StringUtils.isEmpty(targetGroupArn) ? MISSING_CLOUD_RESOURCE : targetGroupArn);
+            awsTargetGroupConfigDb.addPortArnMapping(port, targetGroupArns);
+        }
+        targetGroupConfigDbWrapper.setAwsConfig(awsTargetGroupConfigDb);
+        return targetGroupConfigDbWrapper;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
@@ -133,7 +133,7 @@ public class LoadBalancerConfigService {
             case OOZIE:
                 return Set.of(new TargetGroupPortPair(Integer.parseInt(OOZIE_HTTPS_PORT), Integer.parseInt(OOZIE_HTTPS_PORT)));
             default:
-                return null;
+                return Set.of();
         }
     }
 

--- a/core/src/main/resources/schema/app/20210629154850_CB-13176_Gather_AWS_load_balancer_configs.sql
+++ b/core/src/main/resources/schema/app/20210629154850_CB-13176_Gather_AWS_load_balancer_configs.sql
@@ -1,0 +1,11 @@
+-- // CB-13176 Gather AWS load balancer configs
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE loadbalancer ADD COLUMN IF NOT EXISTS providerconfig TEXT;
+ALTER TABLE targetgroup ADD COLUMN IF NOT EXISTS providerconfig TEXT;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE loadbalancer DROP COLUMN IF EXISTS providerconfig;
+ALTER TABLE targetgroup DROP COLUMN IF EXISTS providerconfig;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/loadbalancer/LoadBalancerToLoadBalancerResponseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/stack/loadbalancer/LoadBalancerToLoadBalancerResponseConverterTest.java
@@ -1,0 +1,151 @@
+package com.sequenceiq.cloudbreak.converter.stack.loadbalancer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer.AwsTargetGroupResponse;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer.LoadBalancerResponse;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer.TargetGroupResponse;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
+import com.sequenceiq.cloudbreak.converter.AbstractEntityConverterTest;
+import com.sequenceiq.cloudbreak.converter.v4.stacks.loadbalancer.LoadBalancerToLoadBalancerResponseConverter;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancerConfigDbWrapper;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroupConfigDbWrapper;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsLoadBalancerConfigDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsTargetGroupArnsDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsTargetGroupConfigDb;
+import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+import com.sequenceiq.cloudbreak.service.stack.TargetGroupPersistenceService;
+import com.sequenceiq.common.api.type.LoadBalancerType;
+
+public class LoadBalancerToLoadBalancerResponseConverterTest extends AbstractEntityConverterTest<LoadBalancer> {
+
+    private static final String LB_FQDN = "loadbalancer.domain.name";
+
+    private static final String LB_IP = "0.0.0.0";
+
+    private static final String LB_DNS = "loadbalancer.dns";
+
+    private static final int PORT = 443;
+
+    private static final String INSTANCE_ID = "instanceId";
+
+    private static final String LB_ARN = "arn:loadbalancer";
+
+    private static final String TG_ARN = "arn:targetGroup";
+
+    private static final String LISTENER_ARN = "arn:listener";
+
+    @Mock
+    private TargetGroupPersistenceService targetGroupService;
+
+    @Mock
+    private InstanceGroupService instanceGroupService;
+
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Mock
+    private LoadBalancerConfigService loadBalancerConfigService;
+
+    @InjectMocks
+    private LoadBalancerToLoadBalancerResponseConverter underTest;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        when(instanceGroupService.findByTargetGroupId(any())).thenReturn(Set.of(new InstanceGroup()));
+        when(instanceMetaDataService.findAliveInstancesInInstanceGroup(any())).thenReturn(ceateInstanceMetadata());
+        when(loadBalancerConfigService.getTargetGroupPortPairs(any())).thenReturn(Set.of(new TargetGroupPortPair(PORT, PORT)));
+    }
+
+    @Test
+    public void testNoSavedCloudConfig() {
+        LoadBalancer source = getSource();
+        // GIVEN
+        given(targetGroupService.findByLoadBalancerId(any())).willReturn(createAwsTargetGroups());
+        // WHEN
+        LoadBalancerResponse response = underTest.convert(source);
+        // THEN
+        assertAllFieldsNotNull(response, List.of("awsResourceId"));
+        assertNull(response.getAwsResourceId());
+    }
+
+    @Test
+    public void testConvertAws() {
+        LoadBalancer source = getSource();
+        // GIVEN
+        getSource().setProviderConfig(createAwsLoadBalancerConfig());
+        given(targetGroupService.findByLoadBalancerId(any())).willReturn(createAwsTargetGroups());
+        // WHEN
+        LoadBalancerResponse response = underTest.convert(source);
+        // THEN
+        assertAllFieldsNotNull(response, List.of());
+        assertEquals(LB_ARN, response.getAwsResourceId().getArn());
+        assertEquals(1, response.getTargets().size());
+        TargetGroupResponse targetGroupResponse = response.getTargets().get(0);
+        assertEquals(PORT, targetGroupResponse.getPort());
+        assertEquals(Set.of(INSTANCE_ID), targetGroupResponse.getTargetInstances());
+        AwsTargetGroupResponse awsTargetGroupResponse = targetGroupResponse.getAwsResourceIds();
+        assertNotNull(awsTargetGroupResponse);
+        assertEquals(LISTENER_ARN, awsTargetGroupResponse.getListenerArn());
+        assertEquals(TG_ARN, awsTargetGroupResponse.getTargetGroupArn());
+    }
+
+    @Override
+    public LoadBalancer createSource() {
+        LoadBalancer loadBalancer = new LoadBalancer();
+        loadBalancer.setType(LoadBalancerType.PRIVATE);
+        loadBalancer.setFqdn(LB_FQDN);
+        loadBalancer.setIp(LB_IP);
+        loadBalancer.setDns(LB_DNS);
+        return loadBalancer;
+    }
+
+    private LoadBalancerConfigDbWrapper createAwsLoadBalancerConfig() {
+        AwsLoadBalancerConfigDb awsLoadBalancerConfigDb = new AwsLoadBalancerConfigDb();
+        awsLoadBalancerConfigDb.setArn(LB_ARN);
+        LoadBalancerConfigDbWrapper cloudLoadBalancerConfigDbWrapper = new LoadBalancerConfigDbWrapper();
+        cloudLoadBalancerConfigDbWrapper.setAwsConfig(awsLoadBalancerConfigDb);
+        return cloudLoadBalancerConfigDbWrapper;
+    }
+
+    private Set<TargetGroup> createAwsTargetGroups() {
+        AwsTargetGroupArnsDb awsTargetGroupArnsDb = new AwsTargetGroupArnsDb();
+        awsTargetGroupArnsDb.setListenerArn(LISTENER_ARN);
+        awsTargetGroupArnsDb.setTargetGroupArn(TG_ARN);
+        AwsTargetGroupConfigDb awsTargetGroupConfigDb = new AwsTargetGroupConfigDb();
+        awsTargetGroupConfigDb.setPortArnMapping(Map.of(PORT, awsTargetGroupArnsDb));
+        TargetGroupConfigDbWrapper targetGroupConfigDbWrapper = new TargetGroupConfigDbWrapper();
+        targetGroupConfigDbWrapper.setAwsConfig(awsTargetGroupConfigDb);
+        TargetGroup targetGroup = new TargetGroup();
+        targetGroup.setProviderConfig(targetGroupConfigDbWrapper);
+        return Set.of(targetGroup);
+    }
+
+    private List<InstanceMetaData> ceateInstanceMetadata() {
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceId(INSTANCE_ID);
+        return List.of(instanceMetaData);
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigConverterTest.java
@@ -1,0 +1,143 @@
+package com.sequenceiq.cloudbreak.service;
+
+import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AWS;
+import static com.sequenceiq.cloudbreak.service.LoadBalancerConfigConverter.MISSING_CLOUD_RESOURCE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsLoadBalancerMetadataView;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsLoadBalancerConfigDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsTargetGroupArnsDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsTargetGroupConfigDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancerConfigDbWrapper;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroupConfigDbWrapper;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.TargetGroup;
+import com.sequenceiq.common.api.type.TargetGroupType;
+
+public class LoadBalancerConfigConverterTest {
+
+    private static final String LB_ARN = "arn://loadbalancer";
+
+    private static final String TARGET_ARN = "arn://targetgroup";
+
+    private static final String LISTENER_ARN = "arn://listener";
+
+    private static final Integer PORT1 = 443;
+
+    private static final Integer PORT2 = 444;
+
+    private static final Integer PORT3 = 445;
+
+    @Mock
+    private LoadBalancerConfigService loadBalancerConfigService;
+
+    @InjectMocks
+    private LoadBalancerConfigConverter underTest;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testConvertAwsLoadBalancer() {
+        CloudLoadBalancerMetadata cloudLoadBalancerMetadata = new CloudLoadBalancerMetadata.Builder()
+            .withParameters(createParams(0))
+            .build();
+
+        LoadBalancerConfigDbWrapper cloudLoadBalancerConfigDbWrapper = underTest.convertLoadBalancer(AWS, cloudLoadBalancerMetadata);
+        assertNotNull(cloudLoadBalancerConfigDbWrapper.getAwsConfig());
+        AwsLoadBalancerConfigDb awsLoadBalancerConfigDb = cloudLoadBalancerConfigDbWrapper.getAwsConfig();
+        assertEquals(LB_ARN, awsLoadBalancerConfigDb.getArn());
+    }
+
+    @Test
+    public void testConvertAwsTargetGroup() {
+        CloudLoadBalancerMetadata cloudLoadBalancerMetadata = new CloudLoadBalancerMetadata.Builder()
+            .withParameters(createParams(1))
+            .build();
+        TargetGroup targetGroup = new TargetGroup();
+        targetGroup.setType(TargetGroupType.KNOX);
+        TargetGroupPortPair portPair = new TargetGroupPortPair(PORT1, PORT2);
+
+        when(loadBalancerConfigService.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair));
+
+        TargetGroupConfigDbWrapper targetGroupConfigDbWrapper = underTest.convertTargetGroup(AWS, cloudLoadBalancerMetadata, targetGroup);
+        assertNotNull(targetGroupConfigDbWrapper.getAwsConfig());
+        AwsTargetGroupConfigDb awsTargetGroupConfigDb = targetGroupConfigDbWrapper.getAwsConfig();
+        assertEquals(1, awsTargetGroupConfigDb.getPortArnMapping().size());
+        assertEquals(PORT1, awsTargetGroupConfigDb.getPortArnMapping().keySet().iterator().next());
+        AwsTargetGroupArnsDb targetGroupArns = awsTargetGroupConfigDb.getPortArnMapping().get(PORT1);
+        assertEquals(LISTENER_ARN, targetGroupArns.getListenerArn());
+        assertEquals(TARGET_ARN, targetGroupArns.getTargetGroupArn());
+    }
+
+    @Test
+    public void testConvertAwsTargetGroupExtraPortsInMetadata() {
+        CloudLoadBalancerMetadata cloudLoadBalancerMetadata = new CloudLoadBalancerMetadata.Builder()
+            .withParameters(createParams(3))
+            .build();
+        TargetGroup targetGroup = new TargetGroup();
+        targetGroup.setType(TargetGroupType.KNOX);
+        TargetGroupPortPair portPair1 = new TargetGroupPortPair(PORT1, PORT1);
+        TargetGroupPortPair portPair2 = new TargetGroupPortPair(PORT2, PORT2);
+
+        when(loadBalancerConfigService.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair1, portPair2));
+
+        TargetGroupConfigDbWrapper targetGroupConfigDbWrapper = underTest.convertTargetGroup(AWS, cloudLoadBalancerMetadata, targetGroup);
+        assertNotNull(targetGroupConfigDbWrapper.getAwsConfig());
+        AwsTargetGroupConfigDb awsTargetGroupConfigDb = targetGroupConfigDbWrapper.getAwsConfig();
+        assertEquals(2, awsTargetGroupConfigDb.getPortArnMapping().size());
+        assertEquals(Set.of(PORT1, PORT2), awsTargetGroupConfigDb.getPortArnMapping().keySet());
+    }
+
+    @Test
+    public void testConvertAwsTargetGroupMissingPortInMetadata() {
+        CloudLoadBalancerMetadata cloudLoadBalancerMetadata = new CloudLoadBalancerMetadata.Builder()
+            .withParameters(createParams(1))
+            .build();
+        TargetGroup targetGroup = new TargetGroup();
+        targetGroup.setType(TargetGroupType.KNOX);
+        TargetGroupPortPair portPair1 = new TargetGroupPortPair(PORT1, PORT1);
+        TargetGroupPortPair portPair2 = new TargetGroupPortPair(PORT2, PORT2);
+
+        when(loadBalancerConfigService.getTargetGroupPortPairs(eq(targetGroup))).thenReturn(Set.of(portPair1, portPair2));
+
+        TargetGroupConfigDbWrapper targetGroupConfigDbWrapper = underTest.convertTargetGroup(AWS, cloudLoadBalancerMetadata, targetGroup);
+        assertNotNull(targetGroupConfigDbWrapper.getAwsConfig());
+        AwsTargetGroupConfigDb awsTargetGroupConfigDb = targetGroupConfigDbWrapper.getAwsConfig();
+        assertEquals(2, awsTargetGroupConfigDb.getPortArnMapping().size());
+        assertEquals(Set.of(PORT1, PORT2), awsTargetGroupConfigDb.getPortArnMapping().keySet());
+        AwsTargetGroupArnsDb targetGroupArns = awsTargetGroupConfigDb.getPortArnMapping().get(PORT1);
+        assertEquals(LISTENER_ARN, targetGroupArns.getListenerArn());
+        assertEquals(TARGET_ARN, targetGroupArns.getTargetGroupArn());
+        targetGroupArns = awsTargetGroupConfigDb.getPortArnMapping().get(PORT2);
+        assertEquals(MISSING_CLOUD_RESOURCE, targetGroupArns.getListenerArn());
+        assertEquals(MISSING_CLOUD_RESOURCE, targetGroupArns.getTargetGroupArn());
+    }
+
+    private Map<String, Object> createParams(int numPorts) {
+        Map<String, Object> params = new HashMap<>();
+        params.put(AwsLoadBalancerMetadataView.LOADBALANCER_ARN, LB_ARN);
+        for (int i = 0; i < numPorts; i++) {
+            int port = PORT1 + i;
+            params.put(AwsLoadBalancerMetadataView.getListenerParam(port), LISTENER_ARN);
+            params.put(AwsLoadBalancerMetadataView.getTargetGroupParam(port), TARGET_ARN);
+        }
+        return params;
+    }
+}


### PR DESCRIPTION
…turn via cdp cli

The goal of this change is to provide load balancer details that can be used to find and query the
load balancer configuration on the cloud provider side. This change includes:
  1. New columns in the loadbalancer and targetgroup tables where cloud provider specific metadata
     can be stored, via a serialized JSON class.
  2. LoadBalancerConfigDbWrapper and TargetGroupConfigDbWrapper, the wrapper classes that will be
     serialized and stored in the database, and contain the cloud provider metadata.
  3. A new converter, LoadBalancerToLoadBalanacerResponseConverter, that will convert the database
     objects into a LoadBalancerResponse, included as part of the StackV4Response.
  4. The AWS implementation of the metadata collection, storage, and conversion.

See detailed description in the commit message.