### PR TITLE
CB-13259 FreeIPA replica DNA ID range initialization

### DIFF
--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/init.sls
@@ -66,3 +66,11 @@ disable_old_tls_for_ldap_server:
   file.append:
     - name: /usr/share/ipa/updates/20-sslciphers.update
     - text: 'only:sslVersionMin: TLS1.2'
+
+/opt/salt/scripts/initdnarange.py:
+  file.managed:
+    - makedirs: True
+    - user: root
+    - group: root
+    - mode: 700
+    - source: salt://freeipa/scripts/initdnarange.py

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/replica-install.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/replica-install.sls
@@ -22,3 +22,4 @@ install-freeipa-replica:
     - require:
         - file: /opt/salt/scripts/freeipa_replica_install.sh
         - file: /etc/resolv.conf.install
+        - file: /opt/salt/scripts/initdnarange.py

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_promote_replica_to_master.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_promote_replica_to_master.sh
@@ -15,7 +15,7 @@ CURRENT_CA_MASTER=`ipa config-show | grep "CA renewal master" | cut -d":" -f2 | 
 echo "The current CA renewal master is $CURRENT_CA_MASTER"
 if [[ "$CURRENT_CA_MASTER" != "$FQDN" ]]; then
   ipa config-mod --ca-renewal-master-server $FQDN
-  ccho "The current CA renewal master was changed to $FQDN"
+  echo "The current CA renewal master was changed to $FQDN"
 fi
 ipa-crlgen-manage enable
 

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/freeipa_replica_install.sh
@@ -123,3 +123,8 @@ ipa-replica-install \
           --no-ntp
 
 set +e
+
+# Id range initialization is after 'set +e' to not fail the state. FreeIPA installation/repair shouldn't fail because of this.
+echo "Try to initialize DNA ID range on replica"
+ipa -e in_server=True console /opt/salt/scripts/initdnarange.py
+echo "Finished initializing DNA ID range on replica"

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/initdnarange.py
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/scripts/initdnarange.py
@@ -1,0 +1,156 @@
+from ipalib import api
+from ipaserver.install import replication
+import logging
+from random import randint
+from time import sleep
+
+
+class RangeSet:
+    def __init__(self, elements):
+        self.ranges = list(elements)
+
+    def __iter__(self):
+        return iter(self.ranges)
+
+    def __repr__(self):
+        return 'RangeSet: %r' % self.ranges
+
+    def has(self, tup):
+        for pos, i in enumerate(self.ranges):
+            if i[0] <= tup[0] and i[1] >= tup[1]:
+                return pos, i
+        raise ValueError('Invalid range or overlapping range')
+
+    def minus(self, tup):
+        pos, (x, y) = self.has(tup)
+        out = []
+        if x < tup[0]:
+            out.append((x, tup[0] - 1))
+        if y > tup[1]:
+            out.append((tup[1] + 1, y))
+        self.ranges[pos:pos + 1] = out
+
+    def __sub__(self, r):
+        r1 = RangeSet(self)
+        for i in r: r1.minus(i)
+        return r1
+
+    def sub(self, r):  # inplace subtraction
+        for i in r:
+            self.minus(i)
+
+    def subWithResult(self, result, r):  # unfortunately ipa console won't work with the __sub__ solution, couldn't initialize RangeSet
+        result.ranges = self.ranges
+        for i in r:
+            result.minus(i)
+        return result
+
+
+class DnaRangeIniter:
+    """Needed a class as FreeIPA console couldn't resolved method to method calls"""
+
+    MIN_RANGE_SIZE = 1000
+
+    def __init__(self, repl):
+        """Console couldn't resolve the import otherwise in class methods"""
+        self.replication = repl
+        self.localReplManager = self.replication.ReplicationManager(api.env.realm, api.env.host, starttls=True, port=389)
+
+    def validate_dna_range_missing(self):
+        dna_range_start, dna_range_end = self.localReplManager.get_DNA_range(api.env.host)
+        print ("DNA range on this server: {} - {}".format(dna_range_start, dna_range_end))
+        if dna_range_start is not None:
+            print ("DNA range is already set on this server, exiting")
+            exit(0)
+
+        dna_next_range_start, dna_next_range_end = self.localReplManager.get_DNA_next_range(api.env.host)
+        print ("DNA next range on this server: {} - {}".format(dna_next_range_start, dna_next_range_end))
+        if dna_next_range_start is not None:
+            print ("DNA next range is already set on this server, exiting")
+            exit(0)
+
+    def get_all_servers_fqdn(self):
+        servers_resp = api.Command.server_find(None, pkey_only=True)['result']
+        servers = []
+        for server in servers_resp:
+            servers.append(server['cn'][0])
+        print("Found servers: {}".format(servers))
+        return servers
+
+    def get_ranges_from_server(self, fqdn):
+        repl_manager = self.replication.ReplicationManager(api.env.realm, fqdn, starttls=True, port=389)
+        dna_range_start, dna_range_end = repl_manager.get_DNA_range(fqdn)
+        print ("DNA range on {} server: {} - {}".format(fqdn, dna_range_start, dna_range_end))
+        dna_next_range_start, dna_next_range_end = repl_manager.get_DNA_next_range(fqdn)
+        print ("DNA next range on {} server: {} - {}".format(fqdn, dna_next_range_start, dna_next_range_end))
+        result = []
+        if dna_range_start is not None:
+            result.append((dna_range_start, dna_range_end))
+        if dna_next_range_start is not None:
+            result.append((dna_next_range_start, dna_next_range_end))
+        return result
+
+    def grab_all_assigned_ranges(self):
+        servers = self.get_all_servers_fqdn()
+        ranges = []
+        for server in servers:
+            ranges_from_server = self.get_ranges_from_server(server)
+            ranges.extend(ranges_from_server)
+        print ("All ranges from servers: {}".format(ranges))
+        return ranges
+
+    def grab_original_range(self):
+        idrange_result = api.Command.idrange_show(api.env.realm + "_id_range")['result']
+        print ("Id range response: ", idrange_result)
+        ipabaseid = int(idrange_result['ipabaseid'][0])
+        ipaidrangesize = int(idrange_result['ipaidrangesize'][0])
+        print ("ipabaseid: {} ipaidrangesize: {}".format(ipabaseid, ipaidrangesize))
+        return ipabaseid, ipabaseid + ipaidrangesize
+
+    def setRanges(self, freeRanges):
+        if len(freeRanges) == 0:
+            print ("There  no free ranges to set")
+        else:
+            print ("Available free ranges: ", freeRanges)
+            for freeRange in freeRanges:
+                if freeRange[1] - freeRange[0] < self.MIN_RANGE_SIZE:
+                    print ("Range {} is smaller than the minimal size [{}]".format(freeRange, self.MIN_RANGE_SIZE))
+                else:
+                    try:
+                        print ("Try to set next range to ", freeRange)
+                        ret = self.localReplManager.save_DNA_next_range(freeRange[0], freeRange[1])
+                        if ret:
+                            print ("Successfully set next range")
+                            return
+                        else:
+                            print ("Next range was not set as it has been set already")
+                            return
+                    except Exception:
+                        logging.exception("Couldn't set the range. Most probably another instance got it first. Trying another one if there is. Ex: ")
+
+
+def create_and_delete_user():
+    user_for_test = api.env.host.split('.')[0] + "rangeinit"
+    print ("Add user [{}] to ensure dna range is assigned".format(user_for_test))
+    api.Command.user_add(user_for_test, givenname=u'idrange', sn=u'allocation')
+    print ("Delete user [{}]".format(user_for_test))
+    api.Command.user_del(user_for_test)
+    print ("User [{}] deleted".format(user_for_test))
+
+
+rangeIniter = DnaRangeIniter(replication)
+
+rangeIniter.validate_dna_range_missing()
+originalRangeSet = RangeSet([(rangeIniter.grab_original_range())])
+try:
+    assignedRanges = RangeSet(rangeIniter.grab_all_assigned_ranges())
+    freeRanges = originalRangeSet.subWithResult(RangeSet([]), assignedRanges).ranges
+except ValueError:
+    logging.exception("Calculating failed, most probably the ranges returned are out of sync. Retry... Ex: ")
+    sleep(randint(3,10))
+    assignedRanges = RangeSet(rangeIniter.grab_all_assigned_ranges())
+    freeRanges = originalRangeSet.subWithResult(RangeSet([]), assignedRanges).ranges
+
+print ("Free ranges: ", freeRanges)
+rangeIniter.setRanges(freeRanges)
+create_and_delete_user()


### PR DESCRIPTION
When a FreeIPA first instance is installed it allocates an id range with a size of 200000. The FreeIPA allocates ids from the beginning of this range when creating a user or a group.
After a replica is added to the existing FreeIPA domain it will ask for an id range when first time it needs an id, like the first time a user is added on that instance. In this case another FreeIPA master which already has an id range set, will give the upper half of it range to the one without a range. This behavior has 2 consequences:
- a FreeIPA instance/replica can exist without an id range for indefinitely long time
- with every new replica another instance can "loose" half of its range available

With this commit after replica install every replica will run a script to try to allocate ID range for itself.
Logic implemented:
- validate the new replica doesn't have a range assigned. If it has, then the script exists as it has nothing to do
- fetch the original whole ID range
- fetch the occupied ID ranges, both used and next ranges
- check if there is any free range with at least a 1000 ID
- if there is, try to assign one as next range. If one fails (maybe another replica was faster) then try the next one until there is no more
- create and delete a user to ensure the replica has an active range, either assigned by the script or by getting half range of another instance

It's possible when querying the already asigned ranges, instances return overlapping ranges. If this happens there is a retry after 3 to 10 seconds.

The script is prepared to run using `ipa console` command. This enforces some changes to the script which won't be necessary in case of a normal python script.

Developed on a separate repo for easier development and testing: lacikaaa/ipadnarange