### PR TITLE
CB-13303 -  Failed to create kerberos bind user during recovery testing

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/deserializer/BooleanDeserializationProblemHandler.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/deserializer/BooleanDeserializationProblemHandler.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.freeipa.client.deserializer;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler;
+
+public class BooleanDeserializationProblemHandler extends DeserializationProblemHandler {
+
+    @Override
+    public Object handleWeirdStringValue(DeserializationContext ctxt, Class<?> targetType, String valueToConvert, String failureMsg) throws IOException {
+        if (targetType == Boolean.class) {
+            return Boolean.valueOf(StringUtils.lowerCase(valueToConvert));
+        }
+        return super.handleWeirdStringValue(ctxt, targetType, valueToConvert, failureMsg);
+    }
+}

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/deserializer/ListFlatteningDeserializer.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/deserializer/ListFlatteningDeserializer.java
@@ -22,6 +22,7 @@ public class ListFlatteningDeserializer<T> extends JsonDeserializer<T> implement
         JsonNode node = oc.readTree(p);
 
         ObjectMapper mapper = (ObjectMapper) p.getCodec();
+        mapper.addHandler(new BooleanDeserializationProblemHandler());
 
         if (node.iterator().hasNext()) {
             JsonNode actual = node;

--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/User.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/model/User.java
@@ -29,6 +29,7 @@ public class User {
     @JsonDeserialize(using = ListFlatteningDeserializer.class)
     private String title;
 
+    @JsonDeserialize(using = ListFlatteningDeserializer.class)
     private Boolean nsAccountLock;
 
     public String getDn() {


### PR DESCRIPTION
Corrects the following error, discovered during manual testing of recovery:

Failed to create kerberos bind user: [kerberosbind-dp-re-17]com.sequenceiq.freeipa.client.RetryableFreeIpaClientException: Invoke FreeIPA failed: Cannot deserialize instance of `java.lang.Boolean` out of START_ARRAY token at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: com.sequenceiq.cloudbreak.client.RPCResponse["result"]->com.sequenceiq.freeipa.client.model.User["nsaccountlock"]

