### PR TITLE
CB-12913: Add backup and restore policies for S3.

### DIFF
--- a/cloud-aws-cloudformation/src/main/resources/definitions/aws-datalake-backup-policy.json
+++ b/cloud-aws-cloudformation/src/main/resources/definitions/aws-datalake-backup-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DatalakeBackupPermissions",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::<BACKUP_BUCKET>/*"
+      ]
+    }
+  ]
+}

--- a/cloud-aws-cloudformation/src/main/resources/definitions/aws-datalake-restore-policy.json
+++ b/cloud-aws-cloudformation/src/main/resources/definitions/aws-datalake-restore-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DatalakeRestorePolicy",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::<your-backup-bucket>/*",
+        "arn:aws:s3:::<your-backup-bucket>"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes [CB-12913](https://jira.cloudera.com/browse/CB-12913).

Check the AWS policy for Datalake backup + restore into cloudbreak so that we can refer to the policies from the public facing documentation.

I arrived at these values by creating a bucket outside of the normal permissions, and running backup restore while whittling the permissions down.

These policies are more permissive than they absolutely have to be, but they're also simpler for it.

The most restrictive/specific policies would include separate policies for Admin, Logger, and Ranger roles when restoring.

This issue is related to updating the public facing docs in [CB-12981](https://jira.cloudera.com/browse/CB-12981).