### PR TITLE
CB-13357. Remove 'all' param from IPA group find command

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClient.java
@@ -273,12 +273,17 @@ public class FreeIpaClient {
         List<Object> flags = List.of();
         Map<String, Object> params = Map.of(
                 "sizelimit", 0,
-                "timelimit", 0,
-                "all", true
+                "timelimit", 0
         );
         ParameterizedType type = TypeUtils
                 .parameterize(Set.class, Group.class);
         return (Set<Group>) invoke("group_find", flags, params, type).getResult();
+    }
+
+    public Group groupShow(String groupName) throws FreeIpaClientException {
+        List<Object> flags = List.of(groupName);
+        Map<String, Object> params = Map.of();
+        return (Group) invoke("group_show", flags, params, Group.class).getResult();
     }
 
     public String getRootCertificate() throws FreeIpaClientException {


### PR DESCRIPTION
Group-find with the 'all' parameter is very slow. Anecdotally, for ~7000
groups, it takes > 5 minutes while running without the 'all' parameter
only takes ~10 seconds. The 'all' parameter was removed from FreeIpaClient.groupFindAll
to improve user sync performance.

A search of the codebase revealed only two usages of the FreeIpaClient.groupFindAll
command: user sync and the freeipa client test service.

The freeipa client test service only needs to retrieve a single group at a time. This
code was updated to use group-show instead of group-find.

User sync only requires the group names when finding all the groups and does not need
the other infromation returned with the 'all' parameter.