### PR TITLE
CB 12913: Update DL backup/restore permissions to be less permissive to Log role.

### DIFF
--- a/cloud-aws-cloudformation/src/main/resources/definitions/aws-datalake-ranger-audit-backup-policy.json
+++ b/cloud-aws-cloudformation/src/main/resources/definitions/aws-datalake-ranger-audit-backup-policy.json
@@ -2,13 +2,9 @@
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "DatalakeAdminBackupPermissions",
+      "Sid": "RangerAuditBackupPermission",
       "Effect": "Allow",
-      "Action": [
-        "s3:PutObject",
-        "s3:GetObject",
-        "s3:DeleteObject"
-      ],
+      "Action": "s3:PutObject",
       "Resource": [
         "arn:aws:s3:::<BACKUP_BUCKET>/*"
       ]

--- a/cloud-aws-cloudformation/src/main/resources/definitions/aws-datalake-restore-policy.json
+++ b/cloud-aws-cloudformation/src/main/resources/definitions/aws-datalake-restore-policy.json
@@ -2,15 +2,15 @@
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "DatalakeRestorePolicy",
+      "Sid": "DatalakeRestorePermissions",
       "Effect": "Allow",
       "Action": [
         "s3:GetObject",
         "s3:ListBucket"
       ],
       "Resource": [
-        "arn:aws:s3:::<your-backup-bucket>/*",
-        "arn:aws:s3:::<your-backup-bucket>"
+        "arn:aws:s3:::<BACKUP_BUCKET>/*",
+        "arn:aws:s3:::<BACKUP_BUCKET>"
       ]
     }
   ]


### PR DESCRIPTION
This is an updated PR based on the discussion in [CB-12913](https://jira.cloudera.com/browse/CB-12913).

Broke the backup permissions into two parts so we don't give broad read access to the log role, since every node in the cluster gets access to that role. We don't want arbitrary users to be able to read the backup of the data lake, it's a security issue.

I changed some of the wording for `Sid`s and backup location names, so that they're consistent through out the related policies.