### PR TITLE
CB-13382 Fix CloudStorage Object validation

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupTest.java
@@ -3,9 +3,11 @@ package com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion;
 import static java.lang.String.format;
 
 import java.util.Collections;
+import java.util.List;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -65,16 +67,16 @@ public class SdxBackupTest extends PreconditionSdxE2ETest {
 
         SdxInternalTestDto sdxInternalTestDto = testContext.given(SdxInternalTestDto.class);
         String cloudStorageBaseLocation = sdxInternalTestDto.getResponse().getCloudStorageBaseLocation();
-        String backupLocation = cloudStorageBaseLocation + "/backups";
+        String backupObject = "backups";
         testContext
                 .given(SdxInternalTestDto.class)
-                .when(sdxTestClient.backup(backupLocation, null))
+                .when(sdxTestClient.backup(StringUtils.join(List.of(cloudStorageBaseLocation, backupObject), "/"), null))
                 .await(SdxClusterStatusResponse.RUNNING)
                 .awaitForHealthyInstances()
                 .then(this::validateDatalakeBackupStatus)
                 .then(this::validateDatalakeStatus)
                 .then((tc, testDto, client) -> {
-                    getCloudFunctionality(tc).cloudStorageListContainer(cloudStorageBaseLocation, backupLocation, false);
+                    getCloudFunctionality(tc).cloudStorageListContainer(cloudStorageBaseLocation, backupObject, false);
                     return testDto;
                 })
                 .validate();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
@@ -99,7 +99,8 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                 .getResponse();
 
         SdxTestDto sdxTestDto = testContext
-                .given(sdx, SdxTestDto.class).withCloudStorage()
+                .given(sdx, SdxTestDto.class)
+                    .withCloudStorage(getCloudStorageRequest(testContext))
                 .when(sdxTestClient.create(), key(sdx))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
@@ -50,7 +50,7 @@ public interface CloudFunctionality {
             maxAttempts = ATTEMPTS,
             backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
     )
-    void cloudStorageListContainer(String baseLocation, String pathToTargetObject, boolean zeroContent);
+    void cloudStorageListContainer(String baseLocation, String selectedObject, boolean zeroContent);
 
     @Retryable(
             maxAttempts = ATTEMPTS,

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
@@ -50,8 +50,8 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public void cloudStorageListContainer(String baseLocation, String pathToTargetObject, boolean zeroContent) {
-        amazonS3Util.listBucketSelectedObject(baseLocation, pathToTargetObject, zeroContent);
+    public void cloudStorageListContainer(String baseLocation, String selectedObject, boolean zeroContent) {
+        amazonS3Util.listBucketSelectedObject(baseLocation, selectedObject, zeroContent);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/AmazonS3Util.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/AmazonS3Util.java
@@ -18,15 +18,16 @@ public class AmazonS3Util {
         s3ClientActions.deleteNonVersionedBucket(baseLocation);
     }
 
-    public void listBucketSelectedObject(String baseLocation, String pathToTargetObject, boolean zeroContent) {
-        s3ClientActions.listBucketSelectedObject(baseLocation, pathToTargetObject, zeroContent);
+    public void listBucketSelectedObject(String baseLocation, String selectedObject, boolean zeroContent) {
+        s3ClientActions.listBucketSelectedObject(baseLocation, selectedObject, zeroContent);
     }
 
     public void listFreeIpaObject(String baseLocation) {
-        s3ClientActions.listBucketSelectedObject(baseLocation, "freeipa", false);
+        s3ClientActions.listBucketSelectedObject(baseLocation, "cluster-logs/freeipa",
+                false);
     }
 
     public void listDataLakeObject(String baseLocation) {
-        s3ClientActions.listBucketSelectedObject(baseLocation, "datalake", false);
+        s3ClientActions.listBucketSelectedObject(baseLocation, "cluster-logs/datalake", false);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
@@ -78,8 +78,6 @@ public class S3ClientActions extends S3Client {
 
         if (StringUtils.isEmpty(selectedObject)) {
             selectedObject = "ranger";
-        } else {
-            selectedObject = getPath(selectedObject).replace(bucketName + "/", "") + "/";
         }
 
         Log.log(LOGGER, format(" Amazon S3 URI: %s", amazonS3URI));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
@@ -47,8 +47,8 @@ public class AzureCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public void cloudStorageListContainer(String baseLocation, String pathToTargetObject, boolean zeroContent) {
-        azureCloudBlobUtil.listSelectedFoldersInAContaier(baseLocation, pathToTargetObject, zeroContent);
+    public void cloudStorageListContainer(String baseLocation, String selectedDirectory, boolean zeroContent) {
+        azureCloudBlobUtil.listSelectedFoldersInAContaier(baseLocation, selectedDirectory, zeroContent);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/AzureCloudBlobUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/AzureCloudBlobUtil.java
@@ -41,17 +41,17 @@ public class AzureCloudBlobUtil {
         azureCloudBlobClientActions.listAllFolders(baseLocation);
     }
 
-    public void listSelectedFoldersInAContaier(String baseLocation, String pathToTargetObject, boolean zeroContent) {
-        azureCloudBlobClientActions.listSelectedDirectory(baseLocation, pathToTargetObject, zeroContent);
+    public void listSelectedFoldersInAContaier(String baseLocation, String selectedDirectory, boolean zeroContent) {
+        azureCloudBlobClientActions.listSelectedDirectory(baseLocation, selectedDirectory, zeroContent);
     }
 
     public void listDataLakeFoldersInAContaier(String baseLocation, String clusterName, String crn) {
         azureCloudBlobClientActions.listSelectedDirectory(baseLocation,
-                "datalake/" + clusterName + "_" + Crn.fromString(crn).getResource(), false);
+                "cluster-logs/datalake/" + clusterName + "_" + Crn.fromString(crn).getResource(), false);
     }
 
     public void listFreeIpaFoldersInAContaier(String baseLocation, String clusterName, String crn) {
         azureCloudBlobClientActions.listSelectedDirectory(baseLocation,
-                "freeipa/" + clusterName + "_" + Crn.fromString(crn).getResource(), false);
+                "cluster-logs/freeipa/" + clusterName + "_" + Crn.fromString(crn).getResource(), false);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
@@ -323,11 +323,10 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
         Log.log(LOGGER, format(" Azure Blob Directory: %s", selectedDirectory));
 
         try {
-            CloudBlobDirectory logsDirectory = cloudBlobContainer.getDirectoryReference("cluster-logs");
-            CloudBlobDirectory selectedLogsDirectory = logsDirectory.getDirectoryReference(selectedDirectory);
+            CloudBlobDirectory selectedLogsDirectory = cloudBlobContainer.getDirectoryReference(selectedDirectory);
             Set<String> blobsWithZeroLength = new HashSet<>();
 
-            Iterable<ListBlobItem> blobListing = cloudBlobContainer.listBlobs("cluster-logs/" + selectedDirectory, true);
+            Iterable<ListBlobItem> blobListing = cloudBlobContainer.listBlobs(selectedDirectory, true);
             List<ListBlobItem> listBlobItems = StreamSupport
                     .stream(blobListing.spliterator(), false)
                     .collect(Collectors.toList());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
@@ -52,8 +52,8 @@ public class GcpCloudFunctionality implements CloudFunctionality {
     }
 
     @Override
-    public void cloudStorageListContainer(String baseLocation, String pathToTargetObject, boolean zeroContent) {
-        gcpUtil.cloudStorageListContainer(baseLocation, pathToTargetObject, zeroContent);
+    public void cloudStorageListContainer(String baseLocation, String selectedObject, boolean zeroContent) {
+        gcpUtil.cloudStorageListContainer(baseLocation, selectedObject, zeroContent);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
@@ -38,16 +38,16 @@ public class GcpUtil {
         gcpClientActions.stopHostGroupInstances(instanceIds);
     }
 
-    public void cloudStorageListContainer(String baseLocation, String pathToTargetObject, boolean zeroContent) {
-        gcpClientActions.listBucketSelectedObject(gcpStackUtil.getBucketName(baseLocation), "/" + pathToTargetObject, zeroContent);
+    public void cloudStorageListContainer(String baseLocation, String selectedObject, boolean zeroContent) {
+        listSelectedObject(baseLocation + selectedObject, zeroContent);
     }
 
     public void cloudStorageListContainerFreeIpa(String baseLocation, String clusterName, String crn) {
-        listSelectedObject(baseLocation);
+        listSelectedObject(baseLocation + "/cluster-logs/freeipa");
     }
 
     public void cloudStorageListContainerDataLake(String baseLocation, String clusterName, String crn) {
-        listSelectedObject(baseLocation);
+        listSelectedObject(baseLocation + "/cluster-logs/datalake");
     }
 
     public void cloudStorageDeleteContainer(String baseLocation) {
@@ -56,11 +56,15 @@ public class GcpUtil {
     }
 
     private void listSelectedObject(String baseLocation) {
+        listSelectedObject(baseLocation, false);
+    }
+
+    private void listSelectedObject(String baseLocation, boolean zeroContent) {
         String bucketName = gcpStackUtil.getBucketName(baseLocation);
         String objectPath = gcpStackUtil
                 .getPath(baseLocation)
                 .replace(bucketName + "/", "")
                 + "/";
-        gcpClientActions.listBucketSelectedObject(bucketName, objectPath, false);
+        gcpClientActions.listBucketSelectedObject(bucketName, objectPath, zeroContent);
     }
 }


### PR DESCRIPTION
Last few API AWS and GCP E2E builds are failing, because of `SdxRepairTests.testSDXRepairMasterAndIDBRokerWithStoppedEC2Instance` test is failing with `cloud storage object has 0 bytes of content`.

So the related AWS and GCP Cloud Storage listing methods have been upgraded.

