### PR TITLE
CB-13391. Fix circular dep for freeipa between flow and operation ser…

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/OperationV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/OperationV1Controller.java
@@ -19,6 +19,7 @@ import com.sequenceiq.flow.api.model.operation.OperationView;
 import com.sequenceiq.freeipa.api.v1.operation.OperationV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 import com.sequenceiq.freeipa.converter.operation.OperationToOperationStatusConverter;
+import com.sequenceiq.freeipa.service.operation.FlowOperationService;
 import com.sequenceiq.freeipa.service.operation.OperationService;
 
 @Controller
@@ -26,6 +27,9 @@ public class OperationV1Controller implements OperationV1Endpoint {
 
     @Inject
     private OperationService operationService;
+
+    @Inject
+    private FlowOperationService flowOperationService;
 
     @Inject
     private OperationToOperationStatusConverter operationToOperationStatusConverter;
@@ -40,6 +44,6 @@ public class OperationV1Controller implements OperationV1Endpoint {
     @Override
     @CheckPermissionByResourceCrn(action = DESCRIBE_ENVIRONMENT)
     public OperationView getOperationProgressByEnvironmentCrn(@ResourceCrn String resourceCrn, boolean detailed) {
-        return operationService.getOperationProgressByEnvironmentCrn(resourceCrn, detailed);
+        return flowOperationService.getOperationProgressByEnvironmentCrn(resourceCrn, detailed);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/FlowOperationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/FlowOperationService.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.freeipa.service.operation;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
+import com.sequenceiq.flow.api.model.operation.OperationResource;
+import com.sequenceiq.flow.api.model.operation.OperationView;
+import com.sequenceiq.flow.converter.OperationDetailsPopulator;
+import com.sequenceiq.flow.service.FlowService;
+import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionFlowConfig;
+import com.sequenceiq.freeipa.flow.stack.provision.StackProvisionFlowConfig;
+
+@Service
+public class FlowOperationService {
+
+    @Inject
+    private FlowService flowService;
+
+    @Inject
+    private OperationDetailsPopulator operationDetailsPopulator;
+
+    public OperationView getOperationProgressByEnvironmentCrn(String environmentCrn, boolean detailed) {
+        OperationView operationView = new OperationView();
+        Optional<OperationFlowsView> operationFlowsViewOpt = flowService.getLastFlowOperationByResourceCrn(environmentCrn);
+        if (operationFlowsViewOpt.isPresent()) {
+            OperationFlowsView operationFlowsView = operationFlowsViewOpt.get();
+            OperationResource operationResource = OperationResource.FREEIPA;
+            com.sequenceiq.flow.api.model.operation.OperationType operationType = operationFlowsView.getOperationType();
+            if (com.sequenceiq.flow.api.model.operation.OperationType.PROVISION.equals(operationType)) {
+                operationView = operationDetailsPopulator.createOperationView(operationFlowsView, operationResource,
+                        List.of(StackProvisionFlowConfig.class, FreeIpaProvisionFlowConfig.class));
+            } else {
+                operationView = operationDetailsPopulator.createOperationView(operationFlowsView, operationResource);
+            }
+        }
+        return operationView;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/operation/OperationService.java
@@ -16,18 +16,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
-import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
-import com.sequenceiq.flow.api.model.operation.OperationResource;
-import com.sequenceiq.flow.api.model.operation.OperationView;
-import com.sequenceiq.flow.converter.OperationDetailsPopulator;
-import com.sequenceiq.flow.service.FlowService;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.FailureDetails;
 import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
 import com.sequenceiq.freeipa.entity.Operation;
-import com.sequenceiq.freeipa.flow.freeipa.provision.FreeIpaProvisionFlowConfig;
-import com.sequenceiq.freeipa.flow.stack.provision.StackProvisionFlowConfig;
 import com.sequenceiq.freeipa.repository.OperationRepository;
 import com.sequenceiq.freeipa.service.freeipa.user.AcceptResult;
 
@@ -40,12 +33,6 @@ public class OperationService {
 
     @Inject
     private List<OperationAcceptor> operationAcceptorList;
-
-    @Inject
-    private FlowService flowService;
-
-    @Inject
-    private OperationDetailsPopulator operationDetailsPopulator;
 
     private Map<OperationType, OperationAcceptor> operationAcceptorMap = new HashMap<>();
 
@@ -137,22 +124,5 @@ public class OperationService {
         operation.setError(reason);
         LOGGER.warn("Operation rejected: {}. Operation duration was {} ms.", operation, operation.getEndTime() - operation.getStartTime());
         return operationRepository.save(operation);
-    }
-
-    public OperationView getOperationProgressByEnvironmentCrn(String resourceCrn, boolean detailed) {
-        OperationView operationView = new OperationView();
-        Optional<OperationFlowsView> operationFlowsViewOpt = flowService.getLastFlowOperationByResourceCrn(resourceCrn);
-        if (operationFlowsViewOpt.isPresent()) {
-            OperationFlowsView operationFlowsView = operationFlowsViewOpt.get();
-            OperationResource operationResource = OperationResource.FREEIPA;
-            com.sequenceiq.flow.api.model.operation.OperationType operationType = operationFlowsView.getOperationType();
-            if (com.sequenceiq.flow.api.model.operation.OperationType.PROVISION.equals(operationType)) {
-                operationView = operationDetailsPopulator.createOperationView(operationFlowsView, operationResource,
-                        List.of(StackProvisionFlowConfig.class, FreeIpaProvisionFlowConfig.class));
-            } else {
-                operationView = operationDetailsPopulator.createOperationView(operationFlowsView, operationResource);
-            }
-        }
-        return operationView;
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/operation/FlowOperationServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/operation/FlowOperationServiceTest.java
@@ -9,12 +9,10 @@ import static org.mockito.Mockito.verify;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.sequenceiq.flow.api.model.operation.OperationFlowsView;
@@ -30,14 +28,14 @@ import com.sequenceiq.freeipa.flow.stack.StackEvent;
 import com.sequenceiq.freeipa.flow.stack.provision.StackProvisionFlowConfig;
 
 @ExtendWith(MockitoExtension.class)
-public class OperationServiceTest {
+public class FlowOperationServiceTest {
 
     private static final String TEST_ENV_CRN = "crn:cdp:environments:us-west-1:autoscale:cluster:ffff";
 
     private static final List<Class<?>> EXPECTED_TYPE_LIST = List.of(StackProvisionFlowConfig.class, FreeIpaProvisionFlowConfig.class);
 
     @InjectMocks
-    private OperationService underTest;
+    private FlowOperationService underTest;
 
     @Mock
     private FlowService flowService;
@@ -47,12 +45,6 @@ public class OperationServiceTest {
 
     @Mock
     private OperationFlowsView operationFlowsView;
-
-    @BeforeEach
-    public void setUp() {
-        underTest = new OperationService();
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Test
     public void testGetOperationProgressByResourceCrn() {


### PR DESCRIPTION
…vice beans.

details:
- there is already an OperationService that was used inseide flows
- new OperationApi was added notso long - this operationService was re-used, and overlap with curreent operations (by using different objects)
- From that point operationService has the flowService which has dependencies for FlowConfigs, but in many freeipa flow configs, operationService is referenced
- this issue can be solved by separate the OperationApi related code from the original operation usage.

See detailed description in the commit message.