### PR TITLE
CB-13226 Fixing the incorrect Disk class method call in GCP SDK.

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpDiskResourceBuilder.java
@@ -62,7 +62,7 @@ public class GcpDiskResourceBuilder extends AbstractGcpComputeBuilder {
         disk.setDescription(description());
         disk.setSizeGb((long) group.getRootVolumeSize());
         disk.setName(buildableResources.get(0).getName());
-        disk.setKind(GcpDiskType.SSD.getUrl(projectId, location));
+        disk.setType(GcpDiskType.SSD.getUrl(projectId, location));
 
         InstanceTemplate template = group.getReferenceInstanceTemplate();
         customGcpDiskEncryptionService.addEncryptionKeyToDisk(template, disk);


### PR DESCRIPTION
1. We need a SSD root volume. This is how AWS and Azure are setup.
2. The Disk#setKind method accepts a dummy value like compute#disks.
3. The SDK or the backend does not have any input checks. So it proceeds to create root volume with magnetic disks which are the default.
4. The right method for this setting is setType.
5. FreeIPA will perform poorly in a setup with magnetic disks.
6. Will perform a series of tests to see if the FreeIPA performs better in terms of repair resiliency and sync performance.

Tested in a seperate main class with the SDK integration.