### PR TITLE
CB-13226 Making root disk to be of type SSD for FreeIPA in GCP

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverter.java
@@ -26,6 +26,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.VolumeR
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.aws.AwsInstanceTemplateParameters;
 import com.sequenceiq.freeipa.entity.Template;
 import com.sequenceiq.freeipa.service.DefaultRootVolumeSizeProvider;
+import com.sequenceiq.freeipa.service.DefaultRootVolumeTypeProvider;
 import com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceTypeProvider;
 
 @Component
@@ -36,6 +37,9 @@ public class InstanceTemplateRequestToTemplateConverter {
 
     @Inject
     private DefaultRootVolumeSizeProvider defaultRootVolumeSizeProvider;
+
+    @Inject
+    private DefaultRootVolumeTypeProvider defaultRootVolumeTypeProvider;
 
     @Inject
     private DefaultInstanceTypeProvider defaultInstanceTypeProvider;
@@ -73,10 +77,11 @@ public class InstanceTemplateRequestToTemplateConverter {
     }
 
     private void setVolumesProperty(Set<VolumeRequest> attachedVolumes, Template template, CloudPlatform cloudPlatform) {
+        String diskType = defaultRootVolumeTypeProvider.getForPlatform(cloudPlatform.name());
         if (!CollectionUtils.isEmpty(attachedVolumes)) {
             attachedVolumes.stream().findFirst().ifPresent(v -> {
                 String volumeType = v.getType();
-                template.setVolumeType(volumeType == null ? "HDD" : volumeType);
+                template.setVolumeType(volumeType == null ? diskType : volumeType);
                 Integer volumeCount = v.getCount();
                 template.setVolumeCount(volumeCount == null ? Integer.valueOf(0) : volumeCount);
                 Integer volumeSize = v.getSize();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/DefaultRootVolumeTypeProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/DefaultRootVolumeTypeProvider.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.freeipa.service;
+
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.PlatformVariants;
+import com.sequenceiq.cloudbreak.cloud.model.generic.StringType;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+
+/**
+ * This class reads the environment properties of default root volume type configurations for each cloud provider platform.
+ * In order to configure a root volume type for a platform, eg. GCP, one must specify a property like this:
+ * -Dcb.platform.default.rootVolumeType.GCP=SSD
+ */
+@Service
+public class DefaultRootVolumeTypeProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRootVolumeTypeProvider.class);
+
+    private static final String DEFAULT_ROOT_VOLUME_TYPE = "HDD";
+
+    private static final String ROOT_VOLUME_TYPE_PROPERTY_PREFIX = "cb.platform.default.rootVolumeType.";
+
+    private final Map<String, String> platformVolumeTypeMap;
+
+    public DefaultRootVolumeTypeProvider(CloudPlatformConnectors cloudPlatformConnectors, Environment environment) {
+        PlatformVariants platformVariants = cloudPlatformConnectors.getPlatformVariants();
+        platformVolumeTypeMap = Collections.unmodifiableMap(
+                platformVariants.getDefaultVariants().keySet()
+                .stream()
+                .collect(Collectors.toMap(StringType::value, p -> initPlatform(environment, p)))
+        );
+    }
+
+    public String getForPlatform(String platform) {
+        if (!platformVolumeTypeMap.containsKey(platform.toUpperCase())) {
+            LOGGER.debug("No default root volume type found for platform: {}. Falling back to default value of {}. "
+                            + "Set '{}' property if '{}' is a valid cloud provider.",
+                    platform, DEFAULT_ROOT_VOLUME_TYPE, ROOT_VOLUME_TYPE_PROPERTY_PREFIX + platform, platform);
+        }
+        return platformVolumeTypeMap.getOrDefault(platform.toUpperCase(), DEFAULT_ROOT_VOLUME_TYPE);
+    }
+
+    private String initPlatform(Environment environment, Platform platform) {
+        String propetyKey = ROOT_VOLUME_TYPE_PROPERTY_PREFIX + platform.value();
+        if (!environment.containsProperty(propetyKey)) {
+            LOGGER.debug("{} property is not set. Defaulting its value to {}.", propetyKey, DEFAULT_ROOT_VOLUME_TYPE);
+        }
+        return environment.getProperty(propetyKey, DEFAULT_ROOT_VOLUME_TYPE);
+    }
+}

--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -178,6 +178,8 @@ cb:
     AWS: 100
     AZURE: 100
     GCP: 100
+  platform.default.rootVolumeType:
+    GCP: SSD
   enabled.linux.types: redhat6,redhat7,centos6,centos7,amazonlinux,amazonlinux2
   publicip:
   etc.config.dir: /etc/freeipa

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
@@ -22,6 +22,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.aws.Aws
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.aws.AwsInstanceTemplateSpotParameters;
 import com.sequenceiq.freeipa.entity.Template;
 import com.sequenceiq.freeipa.service.DefaultRootVolumeSizeProvider;
+import com.sequenceiq.freeipa.service.DefaultRootVolumeTypeProvider;
 import com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceTypeProvider;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,6 +43,9 @@ class InstanceTemplateRequestToTemplateConverterTest {
 
     @Mock
     private DefaultRootVolumeSizeProvider defaultRootVolumeSizeProvider;
+
+    @Mock
+    private DefaultRootVolumeTypeProvider defaultRootVolumeTypeProvider;
 
     @Mock
     private DefaultInstanceTypeProvider defaultInstanceTypeProvider;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/DefaultRootVolumeTypeProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/DefaultRootVolumeTypeProviderTest.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.freeipa.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.PlatformVariants;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
+
+class DefaultRootVolumeTypeProviderTest {
+
+    private DefaultRootVolumeTypeProvider underTest;
+
+    @BeforeEach
+    void setUp() {
+        CloudPlatformConnectors cloudPlatformConnectors = mock(CloudPlatformConnectors.class);
+        PlatformVariants platformVariants = mock(PlatformVariants.class);
+        Map<Platform, Variant> variantMap = new HashMap<>();
+        variantMap.put(Platform.platform("GCP"), Variant.variant("GCP"));
+        when(platformVariants.getDefaultVariants()).thenReturn(variantMap);
+        when(cloudPlatformConnectors.getPlatformVariants()).thenReturn(platformVariants);
+        Environment environment = mock(Environment.class);
+        when(environment.containsProperty(anyString())).thenReturn(true);
+        when(environment.getProperty(anyString(), anyString())).thenReturn("SSD");
+        underTest = new DefaultRootVolumeTypeProvider(cloudPlatformConnectors, environment);
+    }
+
+    @Test
+    void getForPlatform() {
+        assertThat(underTest.getForPlatform("GCP")).isEqualTo("SSD");
+        assertThat(underTest.getForPlatform("YARN")).isEqualTo("HDD");
+    }
+}


### PR DESCRIPTION
1. The previous PR #11076 changed the root disk of datalake and datahub.
2. There is a separate code path for FreeIPA which still sets the root disk type to HDD.
3. Found during end-to-end testing.
4. Will perform the tests in parallel.