### PR TITLE
CB-13443: Enabled Load balancing using Knox for Profiler Manager Service.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -338,19 +338,19 @@
              {% if 'DATA-DISCOVERY-SERVICE-API' in exposed and 'DATA_DISCOVERY_SERVICE_AGENT' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>DATA-DISCOVERY-SERVICE-API</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
              </param>
              {%- endif %}
              {% if 'PROFILER-ADMIN-API' in exposed and 'PROFILER_ADMIN_AGENT' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>PROFILER-ADMIN-API</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
              </param>
              {%- endif %}
              {% if 'PROFILER-METRICS-API' in exposed and 'PROFILER_METRICS_AGENT' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>PROFILER-METRICS-API</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
              </param>
              {%- endif %}
              {% if 'PROFILER-SCHEDULER-API' in exposed and 'PROFILER_SCHEDULER_AGENT' in salt['pillar.get']('gateway:location') -%}


### PR DESCRIPTION
Profiler Manager Services has 3 main services i.e. profiler_manager_service, profiler_metrics_service and data_discovery_service. They all supports active-active HA now. 
Added enableLoadBalancing explicitly for all the services which would help in scaling. 

Tested these configs on my local cluster.