### PR TITLE
CB-13457 Show Cruise Control icon on cluster creation page

### DIFF
--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.2.12.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/cdh/7.2.12.json
@@ -143,6 +143,10 @@
     {
       "name": "STREAMS_REPLICATION_MANAGER",
       "version": "1.0.0"
+    },
+    {
+      "name": "CRUISE_CONTROL",
+      "version": "2.0.100"
     }
   ],
   "version": "7.2.12",

--- a/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/service-definitions-minimal.json
+++ b/template-manager-cmtemplate/src/main/resources/cloudera-manager-template/service-definitions-minimal.json
@@ -456,7 +456,7 @@
           "base": true
         }
       ],
-      "dependencies": ["ZOOKEEPER"]
+      "dependencies": ["HDFS", "RANGER"]
     },
     {
       "name": "STREAMS_MESSAGING_MANAGER",
@@ -474,7 +474,7 @@
           "base": true
         }
       ],
-      "dependencies": ["ZOOKEEPER"]
+      "dependencies": ["ZOOKEEPER","KAFKA", "RANGER", "SCHEMAREGISTRY", "STREAMS_REPLICATION_MANAGER"]
     },
     {
       "name": "DAS",
@@ -594,7 +594,20 @@
           "base" : true
         }
       ],
-      "dependencies": ["ZOOKEEPER", "HDFS", "HBASE"]
+      "dependencies": ["KAFKA"]
+    },
+    {
+      "name": "CRUISE_CONTROL",
+      "displayName": "Cruise Control",
+      "componentNameInParcel": "cruise_control",
+      "components": [
+        {
+          "name": "CRUISE_CONTROL_SERVER",
+          "groups": ["cruise_control"],
+          "base" : true
+        }
+      ],
+      "dependencies": ["KAFKA", "ZOOKEEPER"]
     }
   ]
 }


### PR DESCRIPTION
Added Cruise Control to version files show that it appears on cluster creation page. Also fixed streaming component dependencies in _service-definitions-minimal.json_.

Testing: manual