### PR TITLE
CB-13110:Add the encryption Arn parameter passed from CLI to AWS env creation in Cloudbreak

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
@@ -32,6 +32,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentNe
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.LocationRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.SecurityAccessRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsDiskEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.S3GuardRequestParameters;
@@ -53,6 +54,7 @@ import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.network.dto.NetworkDto;
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
@@ -191,6 +193,11 @@ public class EnvironmentApiConverter {
                 .withDynamoDbTableName(Optional.ofNullable(aws)
                         .map(AwsEnvironmentParameters::getS3guard)
                         .map(S3GuardRequestParameters::getDynamoDbTableName)
+                        .orElse(null))
+                .withAwsDiskEncryptionParameters(Optional.ofNullable(aws)
+                        .map(AwsEnvironmentParameters::getAwsDiskEncryptionParameters)
+                        .filter(awsDiskEncryptionParameters ->  Objects.nonNull(awsDiskEncryptionParameters.getEncryptionKeyArn()))
+                        .map(this::awsDiskEncryptionParametersToAwsDiskEncryptionParametersDto)
                         .orElse(null));
         Optional.ofNullable(awsFreeIpa)
                 .map(AwsFreeIpaParameters::getSpot)
@@ -198,7 +205,15 @@ public class EnvironmentApiConverter {
                     builder.withFreeIpaSpotPercentage(awsFreeIpaSpotParameters.getPercentage())
                             .withFreeIpaSpotMaxPrice(awsFreeIpaSpotParameters.getMaxPrice());
                 });
+
         return builder.build();
+    }
+
+    private AwsDiskEncryptionParametersDto awsDiskEncryptionParametersToAwsDiskEncryptionParametersDto(
+            AwsDiskEncryptionParameters awsDiskEncryptionParameters) {
+        AwsDiskEncryptionParametersDto.Builder awsDiskEncryptionParametersDto = AwsDiskEncryptionParametersDto.builder()
+                .withEncryptionKeyArn(awsDiskEncryptionParameters.getEncryptionKeyArn());
+        return awsDiskEncryptionParametersDto.build();
     }
 
     private AzureParametersDto azureParamsToAzureParametersDto(AzureEnvironmentParameters azureEnvironmentParameters) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -13,6 +13,7 @@ import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.S3GuardRequestParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsDiskEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
@@ -34,6 +35,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
 import com.sequenceiq.environment.network.dto.NetworkDto;
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
@@ -172,9 +174,13 @@ public class EnvironmentResponseConverter {
     }
 
     private AwsEnvironmentParameters awsEnvParamsToAwsEnvironmentParams(ParametersDto parameters) {
+        AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto = Optional.ofNullable(parameters.getAwsParametersDto())
+                .map(AwsParametersDto::getAwsDiskEncryptionParametersDto)
+                .orElse(null);
         return Optional.ofNullable(parameters.getAwsParametersDto())
                 .map(aws -> AwsEnvironmentParameters.builder()
                         .withS3guard(getIfNotNull(aws, this::awsParametersToS3guardParam))
+                        .withAwsDiskEncryptionParameters(getIfNotNull(awsDiskEncryptionParametersDto, this::awsParametersToAwsDiskEncryptionParameters))
                         .build())
                 .orElse(null);
     }
@@ -211,6 +217,12 @@ public class EnvironmentResponseConverter {
     private S3GuardRequestParameters awsParametersToS3guardParam(AwsParametersDto awsParametersDto) {
         return S3GuardRequestParameters.builder()
                 .withDynamoDbTableName(awsParametersDto.getS3GuardTableName())
+                .build();
+    }
+
+    private AwsDiskEncryptionParameters awsParametersToAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto) {
+        return AwsDiskEncryptionParameters.builder()
+                .withEncryptionKeyArn(awsDiskEncryptionParametersDto.getEncryptionKeyArn())
                 .build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/AwsParameters.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/AwsParameters.java
@@ -1,5 +1,11 @@
 package com.sequenceiq.environment.parameters.dao.domain;
 
+import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
+
+import com.sequenceiq.cloudbreak.service.secret.SecretValue;
+import com.sequenceiq.cloudbreak.service.secret.domain.AccountIdAwareResource;
+import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
+import com.sequenceiq.cloudbreak.service.secret.domain.SecretToString;
 import com.sequenceiq.environment.parameter.dto.s3guard.S3GuardTableCreation;
 import com.sequenceiq.environment.parameters.dao.converter.S3GuardTableCreationConverter;
 
@@ -12,7 +18,7 @@ import javax.persistence.Entity;
 
 @Entity
 @DiscriminatorValue("AWS")
-public class AwsParameters extends BaseParameters {
+public class AwsParameters extends BaseParameters implements AccountIdAwareResource {
 
     @Column(name = "s3guard_dynamo_table_name")
     private String s3guardTableName;
@@ -26,6 +32,11 @@ public class AwsParameters extends BaseParameters {
 
     @Column(name = "freeipa_spot_max_price")
     private Double freeIpaSpotMaxPrice;
+
+    @Column(name = "encryption_key_arn")
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret encryptionKeyArn = Secret.EMPTY;
 
     public String getS3guardTableName() {
         return s3guardTableName;
@@ -57,5 +68,17 @@ public class AwsParameters extends BaseParameters {
 
     public void setFreeIpaSpotMaxPrice(Double freeIpaSpotMaxPrice) {
         this.freeIpaSpotMaxPrice = freeIpaSpotMaxPrice;
+    }
+
+    public String getEncryptionKeyArn() {
+        return getIfNotNull(encryptionKeyArn, Secret::getRaw);
+    }
+
+    public String getEncryptionKeyArnSecret() {
+        return getIfNotNull(encryptionKeyArn, Secret::getSecret);
+    }
+
+    public void setEncryptionKeyArn(String encryptionKeyArn) {
+        this.encryptionKeyArn = new Secret(encryptionKeyArn);
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/AwsEnvironmentParametersConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/AwsEnvironmentParametersConverter.java
@@ -8,6 +8,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.parameters.dao.domain.AwsParameters;
 import com.sequenceiq.environment.parameters.dao.domain.BaseParameters;
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto.Builder;
@@ -43,6 +44,10 @@ public class AwsEnvironmentParametersConverter extends BaseEnvironmentParameters
         awsParameters.setFreeIpaSpotMaxPrice(awsParametersDto
                 .map(AwsParametersDto::getFreeIpaSpotMaxPrice)
                 .orElse(null));
+        awsParameters.setEncryptionKeyArn(awsParametersDto
+                .map(AwsParametersDto::getAwsDiskEncryptionParametersDto)
+                .map(AwsDiskEncryptionParametersDto::getEncryptionKeyArn)
+                .orElse(null));
     }
 
     @Override
@@ -54,6 +59,9 @@ public class AwsEnvironmentParametersConverter extends BaseEnvironmentParameters
                 .withDynamoDbTableCreation(awsParameters.getS3guardTableCreation())
                 .withFreeIpaSpotPercentage(awsParameters.getFreeIpaSpotPercentage())
                 .withFreeIpaSpotMaxPrice(awsParameters.getFreeIpaSpotMaxPrice())
+                .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
+                        .withEncryptionKeyArn(awsParameters.getEncryptionKeyArn())
+                        .build())
                 .build());
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AwsParameterValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AwsParameterValidator.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.util.DocumentationLinkProvider;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
@@ -15,6 +16,7 @@ import com.sequenceiq.environment.environment.domain.LocationAwareCredential;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentValidationDto;
 import com.sequenceiq.environment.environment.service.NoSqlTableCreationModeDeterminerService;
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameter.dto.s3guard.S3GuardTableCreation;
@@ -33,10 +35,13 @@ public class AwsParameterValidator implements ParameterValidator {
 
     private final ParametersService parametersService;
 
+    private final EntitlementService entitlementService;
+
     public AwsParameterValidator(NoSqlTableCreationModeDeterminerService noSqlTableCreationModeDeterminerService,
-            ParametersService parametersService) {
+            ParametersService parametersService, EntitlementService entitlementService) {
         this.noSqlTableCreationModeDeterminerService = noSqlTableCreationModeDeterminerService;
         this.parametersService = parametersService;
+        this.entitlementService = entitlementService;
     }
 
     @Override
@@ -62,6 +67,16 @@ public class AwsParameterValidator implements ParameterValidator {
                 determineAwsParameters(environmentDto, parametersDto);
             }
         }
+        AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto = awsParametersDto.getAwsDiskEncryptionParametersDto();
+
+        if (awsDiskEncryptionParametersDto != null) {
+            ValidationResult validationResult = validateEntitlement(validationResultBuilder,
+                    awsDiskEncryptionParametersDto, environmentDto.getAccountId());
+            if (validationResult.hasError()) {
+                return validationResult;
+            }
+        }
+
         if (awsParametersDto.getFreeIpaSpotPercentage() < PERCENTAGE_MIN || awsParametersDto.getFreeIpaSpotPercentage() > PERCENTAGE_MAX) {
             validationResultBuilder.error(String.format("FreeIpa spot percentage must be between %d and %d.", PERCENTAGE_MIN, PERCENTAGE_MAX));
         }
@@ -93,4 +108,21 @@ public class AwsParameterValidator implements ParameterValidator {
                 .withLocation(environment.getLocation().getName())
                 .build();
     }
+
+    private ValidationResult validateEntitlement(ValidationResultBuilder validationResultBuilder,
+            AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto, String accountId) {
+        String encryptionKeyArn = awsDiskEncryptionParametersDto.getEncryptionKeyArn();
+        if (Objects.nonNull(encryptionKeyArn)) {
+            if (!entitlementService.isAWSDiskEncryptionWithCMKEnabled(accountId)) {
+                LOGGER.info("Invalid request, CDP_CB_AWS_DISK_ENCRYPTION_WITH_CMK entitlement turned off for account {}", accountId);
+                return validationResultBuilder.error(
+                        "You specified encryptionKeyArn to use Server Side Encryption for AWS Managed disks with CMK, "
+                                + "but that feature is currently disabled. Get 'CDP_CB_AWS_DISK_ENCRYPTION_WITH_CMK' " +
+                                "enabled for your account to use SSE with CMK.").
+                        build();
+            }
+        }
+        return validationResultBuilder.build();
+    }
+
 }

--- a/environment/src/main/resources/schema/app/20210722121419_CB-13110_Add_the_encryption_Arn_parameter_passed_from_CLI_to_AWS_env_creation_in_Cloudbreak.sql
+++ b/environment/src/main/resources/schema/app/20210722121419_CB-13110_Add_the_encryption_Arn_parameter_passed_from_CLI_to_AWS_env_creation_in_Cloudbreak.sql
@@ -1,0 +1,8 @@
+-- // CB-13110:Add the encryption Arn parameter passed from CLI to AWS env creation in Cloudbreak
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_parameters ADD COLUMN IF NOT EXISTS encryption_key_arn VARCHAR(255);
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE environment_parameters DROP COLUMN IF EXISTS encryption_key_arn;

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
@@ -43,6 +43,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentNe
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.LocationRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.SecurityAccessRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsDiskEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaSpotParameters;
@@ -293,6 +294,29 @@ public class EnvironmentApiConverterTest {
     }
 
     @Test
+    void testAwsDiskEncryptionParametersAndAwsRequest() {
+        EnvironmentRequest request = createEnvironmentRequest(AWS);
+        FreeIpaCreationDto freeIpaCreationDto = mock(FreeIpaCreationDto.class);
+        EnvironmentTelemetry environmentTelemetry = mock(EnvironmentTelemetry.class);
+        EnvironmentBackup environmentBackup = mock(EnvironmentBackup.class);
+        AccountTelemetry accountTelemetry = mock(AccountTelemetry.class);
+        Features features = mock(Features.class);
+        NetworkDto networkDto = mock(NetworkDto.class);
+        when(credentialService.getCloudPlatformByCredential(anyString(), anyString(), any())).thenReturn(AWS.name());
+        when(freeIpaConverter.convert(request.getFreeIpa())).thenReturn(freeIpaCreationDto);
+        when(accountTelemetry.getFeatures()).thenReturn(features);
+        when(accountTelemetryService.getOrDefault(any())).thenReturn(accountTelemetry);
+        when(telemetryApiConverter.convert(eq(request.getTelemetry()), any())).thenReturn(environmentTelemetry);
+        when(backupConverter.convert(eq(request.getBackup()))).thenReturn(environmentBackup);
+        when(tunnelConverter.convert(request.getTunnel())).thenReturn(request.getTunnel());
+        when(networkRequestToDtoConverter.convert(request.getNetwork())).thenReturn(networkDto);
+
+        EnvironmentCreationDto actual = underTest.initCreationDto(request);
+        assertEquals("dummy-key-arn",
+                actual.getParameters().getAwsParametersDto().getAwsDiskEncryptionParametersDto().getEncryptionKeyArn());
+    }
+
+    @Test
     void testAzureResourceEncryptionParametersAndAzureRequest() {
         EnvironmentRequest request = createEnvironmentRequest(AZURE);
         request.setAzure(AzureEnvironmentParameters.builder()
@@ -365,6 +389,8 @@ public class EnvironmentApiConverterTest {
         assertEquals(request.getAws().getS3guard().getDynamoDbTableName(), actual.getAwsParametersDto().getS3GuardTableName());
         assertEquals(request.getFreeIpa().getAws().getSpot().getPercentage(), actual.getAwsParametersDto().getFreeIpaSpotPercentage());
         assertEquals(request.getFreeIpa().getAws().getSpot().getMaxPrice(), actual.getAwsParametersDto().getFreeIpaSpotMaxPrice());
+        assertEquals(request.getAws().getAwsDiskEncryptionParameters().getEncryptionKeyArn(),
+                actual.getAwsParametersDto().getAwsDiskEncryptionParametersDto().getEncryptionKeyArn());
     }
 
     private void assertSecurityAccess(SecurityAccessRequest request, SecurityAccessDto actual) {
@@ -426,6 +452,11 @@ public class EnvironmentApiConverterTest {
         s3GuardRequestParameters.setDynamoDbTableName("my-table");
         AwsEnvironmentParameters awsEnvironmentParameters = new AwsEnvironmentParameters();
         awsEnvironmentParameters.setS3guard(s3GuardRequestParameters);
+        awsEnvironmentParameters.setAwsDiskEncryptionParameters(
+                AwsDiskEncryptionParameters.builder()
+                        .withEncryptionKeyArn("dummy-key-arn")
+                        .build()
+        );
         return awsEnvironmentParameters;
     }
 

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
@@ -53,6 +53,7 @@ import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 import com.sequenceiq.environment.network.dto.NetworkDto;
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
@@ -210,6 +211,8 @@ public class EnvironmentResponseConverterTest {
     private void assertParameters(EnvironmentDto environment, EnvironmentBaseResponse actual, CloudPlatform cloudPlatform) {
         if (AWS.equals(cloudPlatform)) {
             assertEquals(environment.getParameters().getAwsParametersDto().getS3GuardTableName(), actual.getAws().getS3guard().getDynamoDbTableName());
+            assertEquals(environment.getParameters().getAwsParametersDto().getAwsDiskEncryptionParametersDto().getEncryptionKeyArn(),
+                    actual.getAws().getAwsDiskEncryptionParameters().getEncryptionKeyArn());
         } else {
             assertAzureParameters(environment.getParameters().getAzureParametersDto(), actual.getAzure());
         }
@@ -316,6 +319,11 @@ public class EnvironmentResponseConverterTest {
         return ParametersDto.builder()
                 .withAwsParameters(AwsParametersDto.builder()
                         .withDynamoDbTableName("my-table")
+                        .build())
+                .withAwsParameters(AwsParametersDto.builder()
+                        .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
+                                .withEncryptionKeyArn("dummy-key-arn")
+                        .build())
                         .build())
                 .build();
     }

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/AwsEnvironmentParametersConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/AwsEnvironmentParametersConverterTest.java
@@ -17,6 +17,7 @@ import com.sequenceiq.environment.environment.domain.EnvironmentViewConverter;
 import com.sequenceiq.environment.parameters.dao.domain.AwsParameters;
 import com.sequenceiq.environment.parameters.dao.domain.BaseParameters;
 import com.sequenceiq.environment.parameter.dto.s3guard.S3GuardTableCreation;
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 
@@ -32,6 +33,8 @@ class AwsEnvironmentParametersConverterTest {
     private static final EnvironmentView ENVIRONMENT_VIEW = new EnvironmentView();
 
     private static final long ID = 10L;
+
+    private static final String ENCRYPTION_KEY_ARN = "dummy-key-arn";
 
     @Mock
     private EnvironmentViewConverter environmentViewConverter;
@@ -53,12 +56,18 @@ class AwsEnvironmentParametersConverterTest {
     void convertTest() {
         when(environmentViewConverter.convert(any(Environment.class))).thenReturn(ENVIRONMENT_VIEW);
         ParametersDto parameters = ParametersDto.builder()
-                .withId(ID)
-                .withAwsParameters(AwsParametersDto.builder()
-                        .withDynamoDbTableName(TABLE_NAME)
-                        .withDynamoDbTableCreation(S3GuardTableCreation.CREATE_NEW)
-                        .build())
-                .build();
+                                .withId(ID)
+                                .withAwsParameters(AwsParametersDto.builder()
+                                    .withDynamoDbTableName(TABLE_NAME)
+                                    .withDynamoDbTableCreation(S3GuardTableCreation.CREATE_NEW)
+                                    .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
+                                            .withEncryptionKeyArn(ENCRYPTION_KEY_ARN)
+                                    .build())
+                                .build())
+                            .build();
+
+
+
         Environment environment = new Environment();
         environment.setName(ENV_NAME);
         environment.setAccountId(ACCOUNT_ID);
@@ -87,6 +96,7 @@ class AwsEnvironmentParametersConverterTest {
         parameters.setS3guardTableCreation(S3GuardTableCreation.CREATE_NEW);
         parameters.setFreeIpaSpotPercentage(null);
         parameters.setFreeIpaSpotMaxPrice(0.9);
+        parameters.setEncryptionKeyArn(ENCRYPTION_KEY_ARN);
 
         ParametersDto result = underTest.convertToDto(parameters);
 
@@ -97,5 +107,6 @@ class AwsEnvironmentParametersConverterTest {
         assertEquals(S3GuardTableCreation.CREATE_NEW, result.getAwsParametersDto().getDynamoDbTableCreation());
         assertEquals(0, result.getAwsParametersDto().getFreeIpaSpotPercentage());
         assertEquals(0.9, result.getAwsParametersDto().getFreeIpaSpotMaxPrice());
+        assertEquals(ENCRYPTION_KEY_ARN, result.getAwsParametersDto().getAwsDiskEncryptionParametersDto().getEncryptionKeyArn());
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AwsParameterValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AwsParameterValidatorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -22,6 +23,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
@@ -30,6 +32,7 @@ import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.service.NoSqlTableCreationModeDeterminerService;
 import com.sequenceiq.environment.environment.validation.ValidationType;
 import com.sequenceiq.environment.parameter.dto.s3guard.S3GuardTableCreation;
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameters.service.ParametersService;
@@ -45,6 +48,9 @@ class AwsParameterValidatorTest {
 
     @Mock
     private ParametersService parametersService;
+
+    @Mock
+    private EntitlementService entitlementService;
 
     @InjectMocks
     private AwsParameterValidator underTest;
@@ -69,6 +75,7 @@ class AwsParameterValidatorTest {
         AwsParametersDto awsParameters = AwsParametersDto.builder()
                 .withDynamoDbTableName("tablename")
                 .build();
+
         ParametersDto parametersDto = ParametersDto.builder()
                 .withAwsParameters(awsParameters)
                 .build();
@@ -105,6 +112,54 @@ class AwsParameterValidatorTest {
         verify(parametersService, times(1)).saveParameters(ENV_ID, parametersDto);
     }
 
+    @Test
+    public void testNoEncryptionKeyArnAndEntitlementEnabledThenNoError() {
+        EnvironmentDto environmentDto = new AwsParameterValidatorTest.EnvironmentDtoBuilder()
+                                        .withAwsParameters(AwsParametersDto.builder().build())
+                                        .build();
+        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
+
+        ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
+
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    public void testWhenEncryptionKeyArnPresentAndEntitlementDisabledThenError() {
+        EnvironmentDto environmentDto = new AwsParameterValidatorTest.EnvironmentDtoBuilder()
+                                        .withAwsParameters(AwsParametersDto.builder()
+                                        .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
+                                            .withEncryptionKeyArn("dummy-key-arn")
+                                            .build())
+                                            .build())
+                                        .build();
+
+        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
+        when(entitlementService.isAWSDiskEncryptionWithCMKEnabled(anyString())).thenReturn(false);
+        ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
+        assertTrue(validationResult.hasError());
+        assertEquals(String.format("You specified encryptionKeyArn to use Server Side Encryption for AWS Managed disks with CMK, "
+                        + "but that feature is currently disabled. Get 'CDP_CB_AWS_DISK_ENCRYPTION_WITH_CMK' " +
+                        "enabled for your account to use SSE with CMK."),
+                validationResult.getFormattedErrors());
+    }
+
+    @Test
+    public void testWhenEncryptionKeyArnPresentAndEntitlementEnabledThenNoError() {
+        EnvironmentDto environmentDto = new AwsParameterValidatorTest.EnvironmentDtoBuilder()
+                                            .withAwsParameters(AwsParametersDto.builder()
+                                            .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
+                                                    .withEncryptionKeyArn("dummy-key-arn")
+                                                    .build())
+                                                    .build())
+                                        .build();
+
+        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
+        when(entitlementService.isAWSDiskEncryptionWithCMKEnabled(anyString())).thenReturn(true);
+        ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
+        assertFalse(validationResult.hasError());
+    }
+
     @ParameterizedTest(name = "FreeIpa Spot percentage {0} is validated as {1}")
     @MethodSource("freeIpaSpotPercentageParameters")
     void validateFreeIpaSpotPercentage(int percentage, boolean hasError) {
@@ -131,5 +186,26 @@ class AwsParameterValidatorTest {
                 Arguments.of(100, false),
                 Arguments.of(101, true)
         );
+    }
+
+    private static class EnvironmentDtoBuilder {
+
+        private static final String ACCOUNT_ID = "accountId";
+
+        private final EnvironmentDto environmentDto = new EnvironmentDto();
+
+        private final ParametersDto.Builder parametersDtoBuilder = ParametersDto.builder();
+
+        public AwsParameterValidatorTest.EnvironmentDtoBuilder withAwsParameters(AwsParametersDto awsParametersDto) {
+            parametersDtoBuilder.withAwsParameters(awsParametersDto);
+            return this;
+        }
+
+        public EnvironmentDto build() {
+            ParametersDto parametersDto = parametersDtoBuilder.build();
+            environmentDto.setParameters(parametersDto);
+            environmentDto.setAccountId(ACCOUNT_ID);
+            return environmentDto;
+        }
     }
 }

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AwsDiskEncryptionParametersDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AwsDiskEncryptionParametersDto.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.environment.parameter.dto;
+
+public class AwsDiskEncryptionParametersDto {
+
+    private final String encryptionKeyArn;
+
+    private AwsDiskEncryptionParametersDto(AwsDiskEncryptionParametersDto.Builder builder) {
+        encryptionKeyArn = builder.encryptionKeyArn;
+    }
+
+    public String getEncryptionKeyArn() {
+        return encryptionKeyArn;
+    }
+
+    public static AwsDiskEncryptionParametersDto.Builder builder() {
+        return new AwsDiskEncryptionParametersDto.Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "AzureResourceEncryptionParametersDto{" +
+                "encryptionKeyArn=" + encryptionKeyArn +
+                '}';
+    }
+
+    public static final class Builder {
+        private String encryptionKeyArn;
+
+        public AwsDiskEncryptionParametersDto.Builder withEncryptionKeyArn(String encryptionKeyArn) {
+            this.encryptionKeyArn = encryptionKeyArn;
+            return this;
+        }
+
+        public AwsDiskEncryptionParametersDto build() {
+            return new AwsDiskEncryptionParametersDto(this);
+        }
+    }
+}

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AwsParametersDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AwsParametersDto.java
@@ -13,11 +13,14 @@ public class AwsParametersDto implements S3GuardParameters {
 
     private Double freeIpaSpotMaxPrice;
 
+    private AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto;
+
     private AwsParametersDto(Builder builder) {
         dynamoDbTableName = builder.dynamoDbTableName;
         dynamoDbTableCreation = builder.dynamoDbTableCreation;
         freeIpaSpotPercentage = builder.freeIpaSpotPercentage;
         freeIpaSpotMaxPrice = builder.freeIpaSpotMaxPrice;
+        awsDiskEncryptionParametersDto = builder.awsDiskEncryptionParametersDto;
     }
 
     @Override
@@ -50,6 +53,10 @@ public class AwsParametersDto implements S3GuardParameters {
         this.freeIpaSpotMaxPrice = freeIpaSpotMaxPrice;
     }
 
+    public AwsDiskEncryptionParametersDto getAwsDiskEncryptionParametersDto() {
+        return awsDiskEncryptionParametersDto;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -61,6 +68,7 @@ public class AwsParametersDto implements S3GuardParameters {
                 + ", dynamoDbTableCreation=" + dynamoDbTableCreation
                 + ", freeIpaSpotPercentage=" + freeIpaSpotPercentage
                 + ", freeIpaSpotMaxPrice=" + freeIpaSpotMaxPrice
+                + ", awsDiskEncryptionParametersDto" + awsDiskEncryptionParametersDto
                 + '}';
     }
 
@@ -73,6 +81,8 @@ public class AwsParametersDto implements S3GuardParameters {
         private int freeIpaSpotPercentage;
 
         private Double freeIpaSpotMaxPrice;
+
+        private AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto;
 
         private Builder() {
         }
@@ -94,6 +104,11 @@ public class AwsParametersDto implements S3GuardParameters {
 
         public Builder withFreeIpaSpotMaxPrice(Double freeIpaSpotMaxPrice) {
             this.freeIpaSpotMaxPrice = freeIpaSpotMaxPrice;
+            return this;
+        }
+
+        public Builder withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto) {
+            this.awsDiskEncryptionParametersDto = awsDiskEncryptionParametersDto;
             return this;
         }
 

--- a/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/AwsDiskEncryptionParametersDtoTest.java
+++ b/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/AwsDiskEncryptionParametersDtoTest.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.environment.parameter.dto;
+
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class AwsDiskEncryptionParametersDtoTest {
+
+    @Test
+    void testAwsDiskEncryptionParametersDtowithEncryptionKeyArn() {
+        AwsDiskEncryptionParametersDto dummyAwsDiskEncryptionParametersDto = createAwsDiskEncryptionParametersDto();
+        assertEquals(dummyAwsDiskEncryptionParametersDto.getEncryptionKeyArn(), "dummy-key-arn");
+    }
+
+    private AwsDiskEncryptionParametersDto createAwsDiskEncryptionParametersDto() {
+        return AwsDiskEncryptionParametersDto.builder().withEncryptionKeyArn("dummy-key-arn").build();
+    }
+}
+
+
+
+

--- a/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/AwsParametersDtoTest.java
+++ b/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/AwsParametersDtoTest.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.environment.parameter.dto;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AwsParametersDtoTest {
+    @Test
+    void testAwsParametersDtoWithEncryptionParameters() {
+        AwsParametersDto dummyAwsParametersDto = AwsParametersDto.builder()
+                .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
+                        .withEncryptionKeyArn("dummy-key-arn")
+                        .build())
+                .build();
+        Assertions.assertNotNull(dummyAwsParametersDto.getAwsDiskEncryptionParametersDto());
+    }
+
+}
+


### PR DESCRIPTION
Created a Environment with the encryption Key Arn from CLI and verified that the parameter encryption-key-arn is added to the DB:<img width="833" alt="Screenshot 2021-07-29 at 5 21 34 PM" src="https://user-images.githubusercontent.com/7271603/127487186-01bf109d-5b9d-4dd3-a7bc-9e53ebf102a8.png">
