### PR TITLE
Revert defaulting Tunneling to CCMv2_JUMPGATE

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
@@ -146,11 +146,11 @@ public class EnvironmentCreationService {
         if (!overrideTunnel) {
             if ((Tunnel.CCMV2 == tunnel || Tunnel.CCMV2_JUMPGATE == tunnel) && !ccmV2Enabled) {
                 throw new BadRequestException("CCMV2 not enabled for account.");
-            } else if ((Tunnel.CCM == tunnel || Tunnel.CCMV2 == tunnel) && ccmV2Enabled) {
+            } else if (Tunnel.CCM == tunnel && ccmV2Enabled) {
                 ExperimentalFeatures experimentalFeaturesJson = environment.getExperimentalFeaturesJson();
-                experimentalFeaturesJson.setTunnel(Tunnel.CCMV2_JUMPGATE);
+                experimentalFeaturesJson.setTunnel(Tunnel.CCMV2);
                 environment.setExperimentalFeaturesJson(experimentalFeaturesJson);
-                LOGGER.info("Environment is initialized with CCMV2_JUMPGATE tunnel.");
+                LOGGER.info("Environment is initialized with CCMV2 tunnel.");
             }
         }
         LOGGER.info("Environment is initialized with [{}] tunnel.", tunnel);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
@@ -125,7 +125,7 @@ class EnvironmentCreationServiceTest {
     }
 
     @Test
-    void testCreateForCcmV2JumpgateTunnelInitialization() {
+    void testCreateForCcmV2TunnelInitialization() {
         EnvironmentCreationDto environmentCreationDto = EnvironmentCreationDto.builder()
                 .withName(ENVIRONMENT_NAME).withAccountId(ACCOUNT_ID).withAuthentication(AuthenticationDto.builder().build())
                 .build();
@@ -152,7 +152,7 @@ class EnvironmentCreationServiceTest {
         ArgumentCaptor<Environment> captor = ArgumentCaptor.forClass(Environment.class);
         verify(environmentService).save(captor.capture());
         Environment capturedEnvironment = captor.getValue();
-        assertEquals(Tunnel.CCMV2_JUMPGATE, capturedEnvironment.getExperimentalFeaturesJson().getTunnel(), "Tunnel should be CCMV2_JUMPGATE");
+        assertEquals(Tunnel.CCMV2, capturedEnvironment.getExperimentalFeaturesJson().getTunnel(), "Tunnel should be CCMV2");
     }
 
     @Test


### PR DESCRIPTION
As it might cause problems as of now.

See detailed description in the commit message.