### PR TITLE
CB-10914 Extend Config Provider for Cruise Control and Kafka

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -52,6 +52,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_11 = () -> "7.2.11";
 
+    public static final Versioned CLOUDERA_STACK_VERSION_7_2_12 = () -> "7.2.12";
+
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
     public static final Versioned CDPD_VERSION_7_2_11 = () -> "7.2.11";

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProvider.java
@@ -50,6 +50,12 @@ public class CruiseControlRoleConfigProvider implements CmHostGroupRoleConfigPro
 
     private static final String LEADER_REPLICA_COUNT_BALANCE_THRESHOLD = "leader.replica.count.balance.threshold";
 
+    private static final String AUTHENTICATION_METHOD = "auth_method";
+
+    private static final String ADMIN_LEVEL_USERS = "auth_admins";
+
+    private static final String TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED = "trusted.proxy.spnego.fallback.enabled";
+
     @Override
     public String getServiceType() {
         return CruiseControlRoles.CRUISECONTROL;
@@ -92,13 +98,21 @@ public class CruiseControlRoleConfigProvider implements CmHostGroupRoleConfigPro
                             "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
                             "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
                             "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
-                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal"),
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal," +
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal"),
                     config(HARD_GOALS, "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
                             "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
                             "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
                             "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
                             "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
-                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal")
+                            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal"),
+                    config(AUTHENTICATION_METHOD, "Trusted Proxy"),
+                    config(ADMIN_LEVEL_USERS, "kafka"),
+                    config(TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED, "true")
             );
         }
         return List.of();

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaDatahubConfigProvider.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_2_0;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_12;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 
@@ -25,6 +26,8 @@ public class KafkaDatahubConfigProvider implements CmTemplateComponentConfigProv
 
     static final String PRODUCER_METRICS_ENABLE = "producer.metrics.enable";
 
+    static final String KAFKA_DECOMMISSION_HOOK_ENABLED = "kafka.decommission.hook.enabled";
+
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject source) {
         ArrayList<ApiClusterTemplateConfig> configs = Lists.newArrayList();
@@ -35,6 +38,9 @@ public class KafkaDatahubConfigProvider implements CmTemplateComponentConfigProv
         }
         if (KafkaConfigProviderUtils.getCdhVersionForStreaming(source).supportsRangerServiceCreation()) {
             configs.add(config(RANGER_PLUGIN_KAFKA_SERVICE_NAME, GENERATED_RANGER_SERVICE_NAME));
+        }
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_12)) {
+            configs.add(config(KAFKA_DECOMMISSION_HOOK_ENABLED, "true"));
         }
         return configs;
     }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProviderTest.java
@@ -30,8 +30,16 @@ public class CruiseControlRoleConfigProviderTest {
     private CmTemplateProcessor processor;
 
     @Test
-    void testRoleConfigWithCdpVersionIsAtLeast7211() {
+    void testRoleConfigWithCdpVersionIs7211() {
         cdpMainVersionIs("7.2.11");
+        HostgroupView hostGroup = new HostgroupView("test group");
+        assertEquals(createExpectedConfigWithStackVersionAtLeast7211(),
+                provider.getRoleConfigs(CruiseControlRoles.CRUISE_CONTROL_SERVER, hostGroup, getTemplatePreparationObject(hostGroup)));
+    }
+
+    @Test
+    void testRoleConfigWithCdpVersionIsHigherThan7211() {
+        cdpMainVersionIs("7.2.12");
         HostgroupView hostGroup = new HostgroupView("test group");
         assertEquals(createExpectedConfigWithStackVersionAtLeast7211(),
                 provider.getRoleConfigs(CruiseControlRoles.CRUISE_CONTROL_SERVER, hostGroup, getTemplatePreparationObject(hostGroup)));
@@ -79,13 +87,21 @@ public class CruiseControlRoleConfigProviderTest {
                         "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
                         "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
                         "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal"),
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal," +
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal"),
                 config("hard.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
                         "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
                         "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
                         "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
                         "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal")
+                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal"),
+                config("auth_method", "Trusted Proxy"),
+                config("auth_admins", "kafka"),
+                config("trusted.proxy.spnego.fallback.enabled", "true")
         );
     }
 


### PR DESCRIPTION
This commit adds new custom configuration properties to both the Cruise Control and Kafka configuration providers.
These new entries are specific in DataHub and cannot go as default into the CSD.

See detailed description in the commit message.

Tested:

- Unit tests
- Manual on cluster