### PR TITLE
CB-13038 `AwsNativeMetadataCollector` bugfixes & code quality enhancements

### DIFF
--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorApiIntegrationTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorApiIntegrationTest.java
@@ -1,12 +1,13 @@
 package com.sequenceiq.cloudbreak.cloud.aws;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,7 +60,7 @@ import io.opentracing.Tracer;
 
 /*
     This is an integration test to check our API integration in case of missing resources during metadata collection.
-    The `cb.aws.native.test.accesskey` and `cb.aws.native.test.secretkey` are required for operation.
+    The properties `cb.aws.native.test.accesskey` and `cb.aws.native.test.secretkey` are required for operation.
  */
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(properties = {
@@ -124,7 +125,7 @@ class AwsNativeMetadataCollectorApiIntegrationTest {
 
         List<CloudVmMetaDataStatus> collect = underTest.collect(authenticatedContext, List.of(), vms, vms);
 
-        Assertions.assertTrue(collect.isEmpty());
+        assertTrue(collect.isEmpty());
     }
 
     @Test
@@ -144,7 +145,7 @@ class AwsNativeMetadataCollectorApiIntegrationTest {
 
         List<CloudLoadBalancerMetadata> cloudLoadBalancerMetadata = underTest.collectLoadBalancer(authenticatedContext, loadbalancerTypes, resources);
 
-        Assertions.assertTrue(cloudLoadBalancerMetadata.isEmpty());
+        assertTrue(cloudLoadBalancerMetadata.isEmpty());
     }
 
     @Configuration


### PR DESCRIPTION
* `AwsNativeMetadataCollector`:
  * `describeLoadBalancer()`: Fix broken logic.
  * Some code refactor & log fixes.
  * Make `CloudInstance` processing order deterministic (keeping the input iteration order). This may have a minor performance impact due to the usage of `LinkedHashMap` & `LinkedHashSet` vs the usual `HashMap` & `HashSet`.
* Testing:
    * Manual verification in local CB (environment & DL: AWS CF, DH: AWS native).
    * Updated existing UT.
    * Fixed `AwsNativeMetadataCollectorTest.collectInstanceMetadataWhenOneOrMoreOfSpecifiedInstanceIdsDoNotExistAndMultipleBatchRequestsAreNecessary()`. The expectation regarding the result list size was incorrect. The right answer did not match previously due to the presence of the non-deterministic `CloudInstance` processing order mentioned above.