### PR TITLE
CB-13419 Revert back to Basic load-balancer in Azure for datalake and…

### DIFF
--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -530,7 +530,11 @@
                     ]
                   },
                   "sku": {
-                    "name": "Standard"
+                      <#if (loadBalancer.instanceGroupNames?size > 1)>
+                          "name": "Standard"
+                      <#else>
+                          "name": "Basic"
+                      </#if>
                   }
                 }
                 <#if loadBalancer.type == "PUBLIC">
@@ -540,7 +544,11 @@
                     "name": "${loadBalancer.name}-publicIp",
                     "location": "[parameters('region')]",
                     "sku": {
-                        "name": "Standard"
+                        <#if (loadBalancer.instanceGroupNames?size > 1)>
+                            "name": "Standard"
+                        <#else>
+                            "name": "Basic"
+                        </#if>
                     },
                     "properties": {
                         "publicIPAddressVersion": "IPv4",

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -529,6 +529,7 @@ public class AzureTemplateBuilderTest {
         assertTrue(templateString.contains("\"name\": \"port-443-rule\","));
         assertTrue(templateString.contains("\"name\": \"port-8443-probe\","));
         assertTrue(templateString.contains("\"type\": \"Microsoft.Network/publicIPAddresses\","));
+        assertTrue(templateString.contains("\"name\": \"Basic\""));
     }
 
     @ParameterizedTest(name = "buildWithGatewayInstanceGroupTypeAndMultipleLoadBalancers {0}")
@@ -575,6 +576,7 @@ public class AzureTemplateBuilderTest {
         assertTrue(templateString.contains("\"name\": \"port-443-rule\","));
         assertTrue(templateString.contains("\"name\": \"port-8443-probe\","));
         assertTrue(templateString.contains("\"type\": \"Microsoft.Network/publicIPAddresses\","));
+        assertTrue(templateString.contains("\"name\": \"Basic\""));
         assertEquals(2, StringUtils.countMatches(templateString,
             "\"[resourceId('Microsoft.Network/loadBalancers'"));
         assertEquals(2, StringUtils.countMatches(templateString,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigServiceTest.java
@@ -675,6 +675,7 @@ public class LoadBalancerConfigServiceTest extends SubnetTest {
     @Test
     public void testCreateAzurePrivateLoadBalancerWithOozieHA() {
         Stack stack = createAzureStack(StackType.DATALAKE, PRIVATE_ID_1, true);
+        stack.setStackVersion("7.2.11");
         CloudSubnet subnet = getPrivateCloudSubnet(PRIVATE_ID_1, AZ_1);
         DetailedEnvironmentResponse environment = createEnvironment(subnet, false);
 
@@ -834,6 +835,7 @@ public class LoadBalancerConfigServiceTest extends SubnetTest {
         }
         network.setAttributes(new Json(attributes));
         stack.setNetwork(network);
+        stack.setStackVersion("7.2.10");
         return stack;
     }
 


### PR DESCRIPTION
… DE HA for 7.2.10.

1. Basic load-balancer allows the VMs behind it talk to internet, Standard doesn't.
2. This does not entirely fix CB-13419, instead a stop gap till 7.2.11 DE HA is released.
3. To fix DE HA, we need to find a way for the nodes to communicate with internet using one of the options given in https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-connections