### PR TITLE
CB-13483 Differentiate init.ftl for ccmv2 agent installation

### DIFF
--- a/core/src/main/resources/init/init.ftl
+++ b/core/src/main/resources/init/init.ftl
@@ -67,6 +67,7 @@ export IS_CCM_V2_JUMPGATE_ENABLED=true
 <#else>
 export IS_CCM_V2_JUMPGATE_ENABLED=false
 </#if>
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 ${customUserData}
 

--- a/core/src/test/resources/azure-core-ccm-init.sh
+++ b/core/src/test/resources/azure-core-ccm-init.sh
@@ -19,6 +19,7 @@ export IS_PROXY_ENABLED=false
 export IS_CCM_ENABLED=false
 export IS_CCM_V2_ENABLED=false
 export IS_CCM_V2_JUMPGATE_ENABLED=false
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 date >> /tmp/time.txt
 

--- a/core/src/test/resources/azure-core-init.sh
+++ b/core/src/test/resources/azure-core-init.sh
@@ -19,6 +19,7 @@ export IS_PROXY_ENABLED=false
 export IS_CCM_ENABLED=false
 export IS_CCM_V2_ENABLED=false
 export IS_CCM_V2_JUMPGATE_ENABLED=false
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 date >> /tmp/time.txt
 

--- a/core/src/test/resources/azure-gateway-ccm-init.sh
+++ b/core/src/test/resources/azure-gateway-ccm-init.sh
@@ -27,6 +27,7 @@ export CCM_GATEWAY_PORT=9443
 export CCM_KNOX_PORT=8443
 export IS_CCM_V2_ENABLED=false
 export IS_CCM_V2_JUMPGATE_ENABLED=false
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 date >> /tmp/time.txt
 

--- a/core/src/test/resources/azure-gateway-ccm-v2-init.sh
+++ b/core/src/test/resources/azure-gateway-ccm-v2-init.sh
@@ -26,6 +26,7 @@ export CCM_V2_AGENT_KEY_ID="agentKeyId"
 export CCM_V2_AGENT_CRN="agentCrn"
 export CCM_V2_AGENT_BACKEND_ID_PREFIX="agentCrn-"
 export IS_CCM_V2_JUMPGATE_ENABLED=false
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 date >> /tmp/time.txt
 

--- a/core/src/test/resources/azure-gateway-ccm-v2-jumpgate-init.sh
+++ b/core/src/test/resources/azure-gateway-ccm-v2-jumpgate-init.sh
@@ -26,6 +26,7 @@ export CCM_V2_AGENT_KEY_ID="agentKeyId"
 export CCM_V2_AGENT_CRN="agentCrn"
 export CCM_V2_AGENT_BACKEND_ID_PREFIX="agentCrn-"
 export IS_CCM_V2_JUMPGATE_ENABLED=true
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 date >> /tmp/time.txt
 

--- a/core/src/test/resources/azure-gateway-init-authproxy.sh
+++ b/core/src/test/resources/azure-gateway-init-authproxy.sh
@@ -24,6 +24,7 @@ export PROXY_NO_PROXY_HOSTS="noproxy.com"
 export IS_CCM_ENABLED=false
 export IS_CCM_V2_ENABLED=false
 export IS_CCM_V2_JUMPGATE_ENABLED=false
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 date >> /tmp/time.txt
 

--- a/core/src/test/resources/azure-gateway-init-noauthproxy.sh
+++ b/core/src/test/resources/azure-gateway-init-noauthproxy.sh
@@ -22,6 +22,7 @@ export PROXY_NO_PROXY_HOSTS="noproxy.com"
 export IS_CCM_ENABLED=false
 export IS_CCM_V2_ENABLED=false
 export IS_CCM_V2_JUMPGATE_ENABLED=false
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 date >> /tmp/time.txt
 

--- a/core/src/test/resources/azure-gateway-init.sh
+++ b/core/src/test/resources/azure-gateway-init.sh
@@ -19,6 +19,7 @@ export IS_PROXY_ENABLED=false
 export IS_CCM_ENABLED=false
 export IS_CCM_V2_ENABLED=false
 export IS_CCM_V2_JUMPGATE_ENABLED=false
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 date >> /tmp/time.txt
 

--- a/freeipa/src/main/resources/init/init.ftl
+++ b/freeipa/src/main/resources/init/init.ftl
@@ -64,8 +64,10 @@ export IS_CCM_V2_ENABLED=false
 </#if>
 <#if ccmV2JumpgateEnabled!false>
 export IS_CCM_V2_JUMPGATE_ENABLED=true
+export START_CCM_V2_JUMPGATE_AGENT=true
 <#else>
 export IS_CCM_V2_JUMPGATE_ENABLED=false
+export START_CCM_V2_JUMPGATE_AGENT=false
 </#if>
 
 ${customUserData}

--- a/freeipa/src/test/resources/azure-ccm-init.sh
+++ b/freeipa/src/test/resources/azure-ccm-init.sh
@@ -26,6 +26,7 @@ export CCM_ENCIPHERED_PRIVATE_KEY="cHJpdmF0ZS1rZXk="
 export CCM_GATEWAY_PORT=9443
 export IS_CCM_V2_ENABLED=false
 export IS_CCM_V2_JUMPGATE_ENABLED=false
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 date >> /tmp/time.txt
 

--- a/freeipa/src/test/resources/azure-ccm-v2-init.sh
+++ b/freeipa/src/test/resources/azure-ccm-v2-init.sh
@@ -26,6 +26,7 @@ export CCM_V2_AGENT_KEY_ID="agentKeyId"
 export CCM_V2_AGENT_CRN="agentCrn"
 export CCM_V2_AGENT_BACKEND_ID_PREFIX="agentCrn-"
 export IS_CCM_V2_JUMPGATE_ENABLED=false
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 date >> /tmp/time.txt
 

--- a/freeipa/src/test/resources/azure-ccm-v2-jumpgate-init.sh
+++ b/freeipa/src/test/resources/azure-ccm-v2-jumpgate-init.sh
@@ -26,6 +26,7 @@ export CCM_V2_AGENT_KEY_ID="agentKeyId"
 export CCM_V2_AGENT_CRN="agentCrn"
 export CCM_V2_AGENT_BACKEND_ID_PREFIX="agentCrn-"
 export IS_CCM_V2_JUMPGATE_ENABLED=true
+export START_CCM_V2_JUMPGATE_AGENT=true
 
 date >> /tmp/time.txt
 

--- a/freeipa/src/test/resources/azure-init.sh
+++ b/freeipa/src/test/resources/azure-init.sh
@@ -19,6 +19,7 @@ export IS_PROXY_ENABLED=false
 export IS_CCM_ENABLED=false
 export IS_CCM_V2_ENABLED=false
 export IS_CCM_V2_JUMPGATE_ENABLED=false
+export START_CCM_V2_JUMPGATE_AGENT=false
 
 date >> /tmp/time.txt
 


### PR DESCRIPTION
CCMv2 jumpgate agent needs to be installed on FreeIPA host only, and will not be installed on datalake/datahub gateway node.

See detailed description in the commit message.