### PR TITLE
CB-13322 Workaround for datalake backup L0 tests

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupAction.java
@@ -3,6 +3,7 @@ package com.sequenceiq.it.cloudbreak.action.sdx;
 import static java.lang.String.format;
 
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,12 +11,12 @@ import org.slf4j.LoggerFactory;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.sdx.api.model.SdxBackupResponse;
 import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 
-public class SdxBackupAction implements Action<SdxInternalTestDto, SdxClient> {
+public class SdxBackupAction implements Action<SdxTestDto, SdxClient> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SdxBackupAction.class);
 
@@ -29,22 +30,31 @@ public class SdxBackupAction implements Action<SdxInternalTestDto, SdxClient> {
     }
 
     @Override
-    public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
+    public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
-        Log.when(LOGGER, format(" SDX '%s' backup has been started to '%s' as '%s' ", sdxName, backupLocation, backupName));
+        sleep(2, sdxName);
+
+        Log.when(LOGGER, format(" SDX '%s' backup has been started to '%s' by name '%s'... ", sdxName, backupLocation, backupName));
         Log.whenJson(LOGGER, " SDX backup request: ", testDto.getRequest());
-        LOGGER.info(format(" SDX '%s' backup has been started to '%s' as '%s'... ", sdxName, backupLocation, backupName));
+        LOGGER.info(format(" SDX '%s' backup has been started to '%s' by name '%s'... ", sdxName, backupLocation, backupName));
         SdxBackupResponse sdxBackupResponse = client.getDefaultClient()
                 .sdxBackupEndpoint()
                 .backupDatalakeByName(sdxName, backupLocation, backupName);
         testDto.setFlow("SDX backup", sdxBackupResponse.getFlowIdentifier());
-
         SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetail(sdxName, Collections.emptySet());
         testDto.setResponse(detailedResponse);
-        Log.whenJson(LOGGER, " SDX backup response: ", client.getDefaultClient().sdxEndpoint().get(sdxName));
+        Log.whenJson(LOGGER, " SDX response after backup: ", client.getDefaultClient().sdxEndpoint().get(sdxName));
         return testDto;
+    }
+
+    private void sleep(long sleepMinutes, String sdxName) {
+        try {
+            TimeUnit.MINUTES.sleep(sleepMinutes);
+        } catch (InterruptedException ignored) {
+            LOGGER.warn("Waiting for CM services to be synchronized has been interrupted, cause:", ignored);
+        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRestoreAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRestoreAction.java
@@ -10,12 +10,12 @@ import org.slf4j.LoggerFactory;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
-import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 import com.sequenceiq.sdx.api.model.SdxRestoreResponse;
 
-public class SdxRestoreAction implements Action<SdxInternalTestDto, SdxClient> {
+public class SdxRestoreAction implements Action<SdxTestDto, SdxClient> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SdxRestoreAction.class);
 
@@ -29,7 +29,7 @@ public class SdxRestoreAction implements Action<SdxInternalTestDto, SdxClient> {
     }
 
     @Override
-    public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
+    public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
         Log.when(LOGGER, format(" SDX '%s' restore has been started to '%s' ", sdxName, backupLocation));
@@ -44,7 +44,7 @@ public class SdxRestoreAction implements Action<SdxInternalTestDto, SdxClient> {
                 .sdxEndpoint()
                 .getDetail(sdxName, Collections.emptySet());
         testDto.setResponse(detailedResponse);
-        Log.whenJson(LOGGER, " SDX restore response: ", client.getDefaultClient().sdxEndpoint().get(sdxName));
+        Log.whenJson(LOGGER, " SDX response after restore: ", client.getDefaultClient().sdxEndpoint().get(sdxName));
         return testDto;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -161,11 +161,11 @@ public class SdxTestClient {
         return new SdxRetryAction();
     }
 
-    public Action<SdxInternalTestDto, SdxClient> backup(String backupLocation, String backupName) {
+    public Action<SdxTestDto, SdxClient> backup(String backupLocation, String backupName) {
         return new SdxBackupAction(backupLocation, backupName);
     }
 
-    public Action<SdxInternalTestDto, SdxClient> restore(String backupId, String backupLocation) {
+    public Action<SdxTestDto, SdxClient> restore(String backupId, String backupLocation) {
         return new SdxRestoreAction(backupId, backupLocation);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
@@ -99,4 +99,13 @@ public class TelemetryTestDto extends AbstractCloudbreakTestDto<TelemetryRequest
         getRequest().setFluentAttributes(fluentAttributes);
         return this;
     }
+
+    public TelemetryTestDto withOnlyCloudStorageLogging() {
+        FeaturesRequest featuresRequest = new FeaturesRequest();
+        featuresRequest.addClusterLogsCollection(false);
+        featuresRequest.addWorkloadAnalytics(false);
+        featuresRequest.addCloudStorageLogging(true);
+        getRequest().setFeatures(featuresRequest);
+        return this;
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
@@ -13,9 +13,11 @@ import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class PreconditionSdxE2ETest extends AbstractE2ETest {
 
@@ -60,5 +62,27 @@ public class PreconditionSdxE2ETest extends AbstractE2ETest {
                 .sdxEndpoint()
                 .getDetailByCrn(testDto.getCrn(), Collections.emptySet())
                 .getStackV4Response().getInstanceGroups();
+    }
+
+    protected void createSdx(TestContext testContext) {
+        testContext
+                .given(SdxTestDto.class)
+                    .withCloudStorage(getCloudStorageRequest(testContext))
+                .when(sdxTestClient.create())
+                .await(SdxClusterStatusResponse.RUNNING)
+                .awaitForHealthyInstances()
+                .when(sdxTestClient.describe())
+                .validate();
+    }
+
+    protected void createInternalSdx(TestContext testContext) {
+        testContext
+                .given(SdxInternalTestDto.class)
+                    .withCloudStorage(getCloudStorageRequest(testContext))
+                .when(sdxTestClient.createInternal())
+                .await(SdxClusterStatusResponse.RUNNING)
+                .awaitForHealthyInstances()
+                .when(sdxTestClient.describeInternal())
+                .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/action/S3ClientActions.java
@@ -103,14 +103,19 @@ public class S3ClientActions extends S3Client {
                     }
                 } while (filteredObjectSummaries.isEmpty() && objectListing.isTruncated());
 
-                Log.log(LOGGER, format(" Amazon S3 object: %s contains %d sub-objects.",
-                        selectedObject, filteredObjectSummaries.size()));
+                if (filteredObjectSummaries.size() == 0) {
+                    LOGGER.error("Amazon S3 object: {} has 0 sub-objects!", selectedObject);
+                    throw new TestFailException(String.format("Amazon S3 object: %s has 0 sub-objects!", selectedObject));
+                } else {
+                    Log.log(LOGGER, format(" Amazon S3 object: %s contains %d sub-objects.",
+                            selectedObject, filteredObjectSummaries.size()));
+                }
 
                 for (S3ObjectSummary objectSummary : filteredObjectSummaries.stream().limit(10).collect(Collectors.toList())) {
                     S3Object object = s3Client.getObject(bucketName, objectSummary.getKey());
                     S3ObjectInputStream inputStream = object.getObjectContent();
 
-                    if (object.getObjectMetadata().getContentLength() == 0 && !zeroContent) {
+                    if (!zeroContent && object.getObjectMetadata().getContentLength() == 0) {
                         LOGGER.error("Amazon S3 path: {} has 0 bytes of content!", object.getKey());
                         throw new TestFailException(String.format("Amazon S3 path: %s has 0 bytes of content!", object.getKey()));
                     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/FlowUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/FlowUtil.java
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,7 @@ public class FlowUtil {
     }
 
     public boolean getFlowFailed() {
-        return flowFailed;
+        return BooleanUtils.toBooleanDefaultIfNull(flowFailed, false);
     }
 
     public <T extends CloudbreakTestDto> T waitBasedOnLastKnownFlow(T testDto, MicroserviceClient msClient) {
@@ -63,7 +64,6 @@ public class FlowUtil {
                     LOGGER.info("Waiting for flow chain: '{}' at resource: '{}', retry count: '{}'", flowChainId, crn, retryCount);
                     FlowCheckResponse flowCheckResponse = flowEndpoint.hasFlowRunningByChainId(flowChainId, crn);
                     flowRunning = flowCheckResponse.getHasActiveFlow();
-                    flowFailed = flowCheckResponse.getLatestFlowFinalizedAndFailed();
                 } else if (StringUtils.isNoneBlank(flowId)) {
                     LOGGER.info("Waiting for flow: '{}' at resource: '{}', retry count: '{}'", flowId, crn, retryCount);
                     FlowCheckResponse flowCheckResponse = flowEndpoint.hasFlowRunningByFlowId(flowId, crn);


### PR DESCRIPTION
[CB-13322](https://jira.cloudera.com/browse/CB-13322) Datalake backup is failing, because of `409, Could not connect to Solr` and `ATLAS_JANUS_TABLE: HBase failure: Failed to take snapshot`
This is a workaround for `L0 SdxBackupRestoreTest`: few minutes wait before backup seems solved above API backup issues.

