### PR TITLE
CB-13488 handle the case when the image is null in the instance metad…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageProvider.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
@@ -44,14 +45,16 @@ public class ImageProvider {
     private Set<Image> getImagesFromInstanceMetadata(Long stackId) {
         return instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(stackId)
                 .stream()
+                .map(InstanceMetaData::getImage)
+                .filter(json -> !json.getMap().isEmpty())
                 .map(convertJsonToImage())
                 .collect(Collectors.toSet());
     }
 
-    private Function<InstanceMetaData, Image> convertJsonToImage() {
-        return image -> {
+    private Function<Json, Image> convertJsonToImage() {
+        return imageJson -> {
             try {
-                return image.getImage().get(Image.class);
+                return imageJson.get(Image.class);
             } catch (IOException e) {
                 String message = "Failed to convert Json to Image";
                 LOGGER.error(message, e);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageProviderTest.java
@@ -52,6 +52,44 @@ public class ImageProviderTest {
         verify(instanceMetaDataService).getNotDeletedInstanceMetadataByStackId(STACK_ID);
     }
 
+    @Test
+    public void testFilterCurrentImageShouldReturnFalseWhenOneOfTheImageJsonIsNull() {
+        InstanceMetaData nullImageInstanceMetadata = new InstanceMetaData();
+        nullImageInstanceMetadata.setImage(new Json(null));
+        Set<InstanceMetaData> instanceMetaData = Set.of(createInstanceMetaData(NEW_IMAGE), nullImageInstanceMetadata);
+        when(instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
+
+        assertFalse(underTest.filterCurrentImage(STACK_ID, NEW_IMAGE));
+
+        verify(instanceMetaDataService).getNotDeletedInstanceMetadataByStackId(STACK_ID);
+    }
+
+    @Test
+    public void testFilterCurrentImageShouldReturnTrueWhenOneOfTheImageJsonIsNullButTheOtherIsOnOldImage() {
+        InstanceMetaData nullImageInstanceMetadata = new InstanceMetaData();
+        nullImageInstanceMetadata.setImage(new Json(null));
+        Set<InstanceMetaData> instanceMetaData = Set.of(createInstanceMetaData(OLD_IMAGE), nullImageInstanceMetadata);
+        when(instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
+
+        assertTrue(underTest.filterCurrentImage(STACK_ID, NEW_IMAGE));
+
+        verify(instanceMetaDataService).getNotDeletedInstanceMetadataByStackId(STACK_ID);
+    }
+
+    @Test
+    public void testFilterCurrentImageShouldReturnFalseWhenBothOfTheImageJsonIsNull() {
+        InstanceMetaData nullImageInstanceMetadata = new InstanceMetaData();
+        nullImageInstanceMetadata.setImage(new Json(null));
+        InstanceMetaData nullImageInstanceMetadata2 = new InstanceMetaData();
+        nullImageInstanceMetadata2.setImage(new Json(null));
+        Set<InstanceMetaData> instanceMetaData = Set.of(nullImageInstanceMetadata, nullImageInstanceMetadata2);
+        when(instanceMetaDataService.getNotDeletedInstanceMetadataByStackId(STACK_ID)).thenReturn(instanceMetaData);
+
+        assertFalse(underTest.filterCurrentImage(STACK_ID, NEW_IMAGE));
+
+        verify(instanceMetaDataService).getNotDeletedInstanceMetadataByStackId(STACK_ID);
+    }
+
     private com.sequenceiq.cloudbreak.cloud.model.Image createImage(String imageId) {
         return new com.sequenceiq.cloudbreak.cloud.model.Image(null, null, null, null, null, null, imageId, null);
     }


### PR DESCRIPTION
…ata object

Recently, we introduced an image filter for upgrade to see if we need to offer
images for OS upgrade or not. However, during provisioning while the instance
metadata is not saved fully the image field is also null. This case was not
handled and the upgrade check failed. Later when the instance metadata is filled
it works correctly, but until then the user sees an error popup saying
"argument "content" is null ". As part of the PR this case is also handled.

See detailed description in the commit message.