### PR TITLE
CB-13491. Include rotated CM server logs in diagnostics by default.

### DIFF
--- a/core/src/main/resources/defaults/vm-logs.json
+++ b/core/src/main/resources/defaults/vm-logs.json
@@ -47,7 +47,7 @@
     "label": "waagent"
   },
   {
-    "path": "${serverLogFolderPrefix}/cloudera-scm-server/cloudera-scm-server.log",
+    "path": "${serverLogFolderPrefix}/cloudera-scm-server/cloudera-scm-server.log*",
     "label": "cloudera_server_log"
   },
   {


### PR DESCRIPTION
See detailed description in the commit message.