### PR TITLE
CB-13456 Fix Datalake upgrade to 7.4.3

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/init.sls
@@ -55,7 +55,7 @@ setup_autotls_san:
     - name: /etc/cloudera-scm-agent/config.ini
     - mode: ensure
     - content: "subject_alt_names={{ internal_loadbalancer_san }}"
-    - after: "# subject_alt_names.*"
+    - after: "# client_cert_file.*"
     - backup: False
     - quiet: True
 


### PR DESCRIPTION
1. subject_alt_names was a new feature in config.ini from 7.4.3
2. When prior versions are upgraded to 7.4.3 the non CM nodes does not get the updated config.ini when auto-tls provisions their tokens.
3. To fix it choosing a line that existed for the entirety of Cloudera (almost) in config.ini

See detailed description in the commit message.