### PR TITLE
CB-13157: Remove dummy DB column environment_parameters.encryption_keyurl

### DIFF
--- a/environment/src/main/resources/schema/app/20210722081943_CB-13157_Remove_dummy_DB_column_environment_parameters.encryption_keyurl.sql
+++ b/environment/src/main/resources/schema/app/20210722081943_CB-13157_Remove_dummy_DB_column_environment_parameters.encryption_keyurl.sql
@@ -1,0 +1,9 @@
+-- // CB-13157: Remove dummy DB column environment_parameters.encryption_keyurl
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_parameters DROP COLUMN IF EXISTS encryption_keyUrl;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE environment_parameters ADD COLUMN IF NOT EXISTS encryption_keyUrl text;
+


### PR DESCRIPTION
CB-13157: Remove dummy DB column environment_parameters.encryption_keyurl
The associated entity field got removed in CB 2.45, the unused DB column environment_parameters.encryption_keyurl (environmentdb) is removed as part of this PR.
