### PR TITLE
CB-7668 Data Lake should not set a default admin password

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -182,10 +182,8 @@ public class StackRequestManifester {
         if (cluster != null && cluster.getBlueprintName() == null) {
             throw new BadRequestException("BlueprintName not defined, should only happen on private API");
         }
-        if (cluster != null && cluster.getUserName() == null) {
-            cluster.setUserName("admin");
-        }
         if (cluster != null && cluster.getPassword() == null) {
+            // default password needed for ranger
             cluster.setPassword(PasswordUtil.generatePassword());
         }
     }


### PR DESCRIPTION
Datalake service will not set `admin` for user field in stackV4Request, although password is still needed for Ranger as default password.
https://github.com/hortonworks/cloudbreak/blob/master/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx.bp#L104-L121
With this, cluster installation succeeds and Cloudbreak removes default admin user from CM:
<img width="1675" alt="Screenshot 2021-07-22 at 13 23 41" src="https://user-images.githubusercontent.com/26329499/126631984-56929657-7dfe-4c4b-ae66-0ad0ef51f2b6.png">
