### PR TITLE
CB-13484 SdxRepair mocktest refactors

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxCustomTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxCustomTestDto.java
@@ -78,7 +78,7 @@ public class SdxCustomTestDto extends AbstractSdxTestDto<SdxCustomClusterRequest
         ImageCatalogTestDto imageCatalogTestDto = getTestContext().get(ImageCatalogTestDto.class);
 
         withName(getResourcePropertyProvider().getName(getCloudPlatform()))
-                .withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getResponse().getName())
+                .withEnvironmentName(getTestContext().get(EnvironmentTestDto.class).getRequest().getName())
                 .withClusterShape(getCloudProvider().getClusterShape())
                 .withTags(getCloudProvider().getTags())
                 .withImageCatalogNameAndImageId(imageCatalogTestDto.getName(), imageSettingsV4Request.getId());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxInternalTestDto.java
@@ -301,6 +301,10 @@ public class SdxInternalTestDto extends AbstractSdxTestDto<SdxInternalClusterReq
         return await(status, emptyRunningParameter());
     }
 
+    public SdxInternalTestDto await(SdxClusterStatusResponse status, Duration duration) {
+        return getTestContext().await(this, Map.of("status", status), emptyRunningParameter(), duration);
+    }
+
     public SdxInternalTestDto await(SdxClusterStatusResponse status, RunningParameter runningParameter) {
         return getTestContext().await(this, Map.of("status", status), runningParameter);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRepairTests.java
@@ -1,0 +1,126 @@
+package com.sequenceiq.it.cloudbreak.testcase.mock;
+
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.IDBROKER;
+import static com.sequenceiq.it.cloudbreak.cloud.HostGroupType.MASTER;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
+
+import org.testng.annotations.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.customdomain.CustomDomainSettingsV4Request;
+import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.util.SdxUtil;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxDatabaseAvailabilityType;
+import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
+
+public class MockSdxRepairTests extends AbstractMockTest {
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private SdxUtil sdxUtil;
+
+    protected void setupTest(TestContext testContext) {
+        createDefaultUser(testContext);
+        createDefaultCredential(testContext);
+        createDefaultImageCatalog(testContext);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Description(
+            given = "there is a running Cloudbreak",
+            when = "terminate instances and repair an sdx cluster",
+            then = "SDX should be available"
+    )
+    public void repairTerminatedMasterAndIdbroker(MockedTestContext testContext) {
+        testRepair(testContext,
+                List.of(MASTER, IDBROKER),
+                instanceBasePath -> getExecuteQueryToMockInfrastructure().call(instanceBasePath + "/terminate", w -> w),
+                SdxClusterStatusResponse.DELETED_ON_PROVIDER_SIDE);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Description(
+            given = "there is a running Cloudbreak",
+            when = "terminate instances and repair an sdx cluster",
+            then = "SDX should be available"
+    )
+    public void repairTerminatedMaster(MockedTestContext testContext) {
+        testRepair(testContext,
+                List.of(MASTER),
+                instanceBasePath -> getExecuteQueryToMockInfrastructure().call(instanceBasePath + "/terminate", w -> w),
+                SdxClusterStatusResponse.CLUSTER_AMBIGUOUS);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, invocationCount = 1)
+    @Description(
+            given = "there is a running Cloudbreak",
+            when = "stop and repair an sdx cluster",
+            then = "SDX should be available"
+    )
+    public void repairStoppedMasterAndIdbroker(MockedTestContext testContext) {
+        testRepair(testContext,
+                List.of(MASTER, IDBROKER),
+                instanceBasePath -> getExecuteQueryToMockInfrastructure().call(instanceBasePath + "/stop", w -> w),
+                SdxClusterStatusResponse.STOPPED);
+    }
+
+    public void testRepair(MockedTestContext testContext,
+            List<HostGroupType> hostGroups,
+            Consumer<String> actionOnNode,
+            SdxClusterStatusResponse stateBeforeRepair
+    ) {
+        String sdxInternal = resourcePropertyProvider().getName();
+        String networkKey = "someOtherNetwork";
+
+        SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
+        sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NON_HA);
+        CustomDomainSettingsV4Request customDomain = new CustomDomainSettingsV4Request();
+        customDomain.setDomainName("dummydomainname");
+        customDomain.setHostname("dummyhostname");
+        customDomain.setClusterNameAsSubdomain(true);
+        customDomain.setHostgroupNameAsHostname(true);
+        testContext
+                .given(networkKey, EnvironmentNetworkTestDto.class)
+                .withMock(new EnvironmentNetworkMockParams())
+                .given(EnvironmentTestDto.class)
+                .withNetwork(networkKey)
+                .withCreateFreeIpa(Boolean.FALSE)
+                .withName(resourcePropertyProvider().getEnvironmentName())
+                .when(getEnvironmentTestClient().create())
+                .await(EnvironmentStatus.AVAILABLE)
+                .given(sdxInternal, SdxInternalTestDto.class)
+                .withDatabase(sdxDatabaseRequest)
+                .withCustomDomain(customDomain)
+                .when(sdxTestClient.createInternal(), key(sdxInternal))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
+                .then((tc, testDto, client) -> {
+                    List<String> instancesToDelete = new ArrayList<>();
+                    for (HostGroupType hostGroupType : hostGroups) {
+                        instancesToDelete.addAll(sdxUtil.getInstanceIds(testDto, client, hostGroupType.getName()));
+                    }
+                    instancesToDelete.forEach(instanceId -> actionOnNode.accept("/" + testDto.getCrn() + "/spi/" + instanceId));
+                    return testDto;
+                })
+                .await(stateBeforeRepair)
+                .when(sdxTestClient.repairInternal(hostGroups.stream().map(HostGroupType::getName).toArray(String[]::new)), key(sdxInternal))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
+                .validate();
+    }
+}


### PR DESCRIPTION
SdxRepair mocktest refactors. Splitting basic SDX test from repair use cases. Removed unnecessary env creation from testcases. Increased repair timeout to 370 seconds since its possible that we hit an unlucky sync timing.