### PR TITLE
CB-13434 fix "Can't find cloud instance by private ID" exception if n…

### DIFF
--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationStackUtil.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationStackUtil.java
@@ -124,7 +124,10 @@ public class CloudFormationStackUtil {
                 .flatMap(entry -> {
                     Group group = entry.getKey();
                     List<CloudResource> cloudResources = new ArrayList<>();
-                    Iterator<CloudInstance> groupInstancesIterator = group.getInstances().iterator();
+                    Iterator<CloudInstance> groupInstancesIterator = group.getInstances().stream()
+                            .filter(cloudInstance -> cloudInstance.getInstanceId() == null)
+                            .collect(Collectors.toList())
+                            .iterator();
                     for (String instanceId : entry.getValue()) {
                         CloudResource cloudResource = CloudResource.builder()
                                 .type(ResourceType.AWS_INSTANCE)


### PR DESCRIPTION
…ot every instances are repaired in a hostgroup for AWS

It is a fix for this PR: https://github.com/hortonworks/cloudbreak/pull/11116