### PR TITLE
CB-13495 Make Oozie HA work with Azure basic load-balancer

### DIFF
--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -212,14 +212,8 @@
                         </#list>
                      </#if>
                      },
-                   <#if loadBalancers?? && (loadBalancers?filter(loadBalancer -> loadBalancer.instanceGroupNames?size > 1)?size > 0)>
-                     "sku": {
-                         "name": "Standard",
-                         "tier": "Regional"
-                     },
-                   </#if>
                    "properties": {
-                       <#if instanceGroup == "GATEWAY" || (instance.availabilitySetName?? && instance.availabilitySetName?has_content)>
+                       <#if instanceGroup == "GATEWAY">
                        "publicIPAllocationMethod": "Static"
                        <#else>
                        "publicIPAllocationMethod": "Dynamic"
@@ -530,11 +524,7 @@
                     ]
                   },
                   "sku": {
-                      <#if (loadBalancers?filter(loadBalancer -> loadBalancer.instanceGroupNames?size > 1)?size > 0)>
-                          "name": "Standard"
-                      <#else>
-                          "name": "Basic"
-                      </#if>
+                      "name": "Basic"
                   }
                 }
                 <#if loadBalancer.type == "PUBLIC">
@@ -544,11 +534,7 @@
                     "name": "${loadBalancer.name}-publicIp",
                     "location": "[parameters('region')]",
                     "sku": {
-                        <#if (loadBalancers?filter(loadBalancer -> loadBalancer.instanceGroupNames?size > 1)?size > 0)>
-                            "name": "Standard"
-                        <#else>
-                            "name": "Basic"
-                        </#if>
+                        "name": "Basic"
                     },
                     "properties": {
                         "publicIPAddressVersion": "IPv4",

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureTemplateBuilderTest.java
@@ -530,7 +530,6 @@ public class AzureTemplateBuilderTest {
         assertTrue(templateString.contains("\"name\": \"port-8443-probe\","));
         assertTrue(templateString.contains("\"type\": \"Microsoft.Network/publicIPAddresses\","));
         assertTrue(templateString.contains("\"name\": \"Basic\""));
-        assertFalse(templateString.contains("\"name\": \"Standard\""));
     }
 
     @ParameterizedTest(name = "buildWithGatewayInstanceGroupTypeAndMultipleLoadBalancers {0}")
@@ -578,7 +577,6 @@ public class AzureTemplateBuilderTest {
         assertTrue(templateString.contains("\"name\": \"port-8443-probe\","));
         assertTrue(templateString.contains("\"type\": \"Microsoft.Network/publicIPAddresses\","));
         assertTrue(templateString.contains("\"name\": \"Basic\""));
-        assertFalse(templateString.contains("\"name\": \"Standard\""));
         assertEquals(2, StringUtils.countMatches(templateString,
             "\"[resourceId('Microsoft.Network/loadBalancers'"));
         assertEquals(2, StringUtils.countMatches(templateString,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
@@ -210,11 +210,6 @@ public class LoadBalancerConfigService {
      * Adds availability sets to instance groups associated with Knox and Oozie target groups.
      * This method updates the JSON parameters associated with certain instance groups.
      *
-     * It's only necessary to add availability sets to the Azure deployment while we
-     * use the {@code basic} Azure Load Balancer SKU. We use {@code standard} Load Balancer
-     * we still use availability set to indicate that we need a {@code standard} IP addresses
-     * for the instances in those availability sets.
-     *
      * @param availabilitySetPrefix A string prefix. Should be a stack name normally.
      * @param loadBalancers the list of load balancers to look up target groups from.
      */
@@ -450,11 +445,11 @@ public class LoadBalancerConfigService {
     }
 
     private Optional<InstanceGroup> getOozieHAInstanceGroup(Stack stack) {
-        if (stack.getStackVersion() != null &&
-            isVersionNewerOrEqualThanLimited(stack.getStackVersion(), CLOUDERA_STACK_VERSION_7_2_11)) {
-            Cluster cluster = stack.getCluster();
-            if (cluster != null) {
-                CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(cluster.getBlueprint().getBlueprintText());
+        Cluster cluster = stack.getCluster();
+        if (cluster != null) {
+            CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(cluster.getBlueprint().getBlueprintText());
+            String cdhVersion = cmTemplateProcessor.getStackVersion();
+            if (cdhVersion != null && isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_11)) {
                 Set<String> oozieGroupNames = getOozieGroups(cmTemplateProcessor);
                 return stack.getInstanceGroups().stream()
                     .filter(ig -> oozieGroupNames.contains(ig.getGroupName()))

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
@@ -494,7 +494,6 @@
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",
           "hms-HIVEMETASTORE-BASE",
-          "oozie-OOZIE_SERVER-BASE",
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
@@ -502,7 +501,9 @@
           "hdfs-JOURNALNODE-BASE",
           "zookeeper-SERVER-BASE",
           "yarn-GATEWAY-BASE",
-          "sqoop-SQOOP_CLIENT-GATEWAY-BASE"
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE"
         ]
       },
       {
@@ -527,9 +528,7 @@
           "zookeeper-SERVER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
           "yarn-QUEUEMANAGER_STORE-BASE",
-          "yarn-GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "hue-HUE_SERVER-BASE"
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -552,8 +551,8 @@
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "knox-KNOX_GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "hue-HUE_SERVER-BASE"
+          "oozie-OOZIE_SERVER-BASE",
+          "spark_on_yarn-GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-ha.bp
@@ -494,7 +494,6 @@
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",
           "hms-HIVEMETASTORE-BASE",
-          "oozie-OOZIE_SERVER-BASE",
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
@@ -502,7 +501,9 @@
           "hdfs-JOURNALNODE-BASE",
           "zookeeper-SERVER-BASE",
           "yarn-GATEWAY-BASE",
-          "sqoop-SQOOP_CLIENT-GATEWAY-BASE"
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE"
         ]
       },
       {
@@ -527,9 +528,7 @@
           "zookeeper-SERVER-BASE",
           "yarn-QUEUEMANAGER_WEBAPP-BASE",
           "yarn-QUEUEMANAGER_STORE-BASE",
-          "yarn-GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "hue-HUE_SERVER-BASE"
+          "yarn-GATEWAY-BASE"
         ]
       },
       {
@@ -552,8 +551,8 @@
         "cardinality": 1,
         "roleConfigGroupsRefNames": [
           "knox-KNOX_GATEWAY-BASE",
-          "hue-HUE_LOAD_BALANCER-BASE",
-          "hue-HUE_SERVER-BASE"
+          "oozie-OOZIE_SERVER-BASE",
+          "spark_on_yarn-GATEWAY-BASE"
         ]
       }
     ]

--- a/core/src/test/resources/input/de-ha.bp
+++ b/core/src/test/resources/input/de-ha.bp
@@ -385,20 +385,21 @@
           "hdfs-FAILOVERCONTROLLER-BASE",
           "hdfs-NAMENODE-BASE",
           "hdfs-GATEWAY-BASE",
+          "hdfs-HTTPFS-BASE",
           "hive-GATEWAY-BASE",
           "hive-HIVESERVER2-BASE",
           "hms-GATEWAY-BASE",
           "hms-HIVEMETASTORE-BASE",
-          "hue-HUE_SERVER-BASE",
-          "oozie-OOZIE_SERVER-BASE",
-          "knox-KNOX_GATEWAY-BASE",
           "livy-GATEWAY-BASE",
           "spark_on_yarn-GATEWAY-BASE",
           "tez-GATEWAY-BASE",
           "yarn-RESOURCEMANAGER-BASE",
           "hdfs-JOURNALNODE-BASE",
           "zookeeper-SERVER-BASE",
-          "yarn-GATEWAY-BASE"
+          "yarn-GATEWAY-BASE",
+          "sqoop-SQOOP_CLIENT-GATEWAY-BASE",
+          "hue-HUE_LOAD_BALANCER-BASE",
+          "hue-HUE_SERVER-BASE"
         ]
       },
       {
@@ -421,7 +422,9 @@
           "das-DAS_WEBAPP",
           "hdfs-JOURNALNODE-BASE",
           "zookeeper-SERVER-BASE",
-          "yarn-GATEWAY-BASE"
+          "yarn-GATEWAY-BASE",
+          "oozie-OOZIE_SERVER-BASE",
+          "knox-KNOX_GATEWAY-BASE"
         ]
       },
       {

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology.xml.j2
@@ -256,11 +256,11 @@
              {% if 'OOZIE' in exposed and 'OOZIE_SERVER' in salt['pillar.get']('gateway:location') -%}
              <param>
                  <name>OOZIEUI</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
              </param>
              <param>
                  <name>OOZIE</name>
-                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
              </param>
              {%- endif %}
              {% if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -189,7 +189,7 @@
             {% if 'OOZIE' in exposed and 'OOZIE_SERVER' in salt['pillar.get']('gateway:location') -%}
             <param>
                 <name>OOZIE</name>
-                <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+                <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000;enableStickySession=false;noFallback=false;enableLoadBalancing=true</value>
             </param>
             {%- endif %}
             {% if 'RANGER' in exposed and 'RANGER_ADMIN' in salt['pillar.get']('gateway:location') -%}


### PR DESCRIPTION
1. Azure internal standard load-balancer is hard to work with.
2. To get internet connectivity we have to attach a NAT gateway to the customer provided subnet.
3. Instead of getting deep into the bowels of Azure network connectivity this approach simply falls back on the previous workaround.
4. This change re-arrages services in such a way that we will not need standard load-balancer or any of the complex network setup to make the services talk to each other when they are in same group.
5. Added ability for knox to load-balance between Oozie instances.

See detailed description in the commit message.