### PR TITLE
CB-13493 Fix Datahub HA repair, remove primary gateway change

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -582,18 +582,22 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource {
         this.parameters = parameters;
     }
 
-    public List<InstanceMetaData> getGatewayInstanceMetadata() {
-        List<InstanceMetaData> metadataList = new ArrayList<>();
-        for (InstanceGroup instanceGroup : instanceGroups) {
-            if (InstanceGroupType.GATEWAY.equals(instanceGroup.getInstanceGroupType())) {
-                metadataList.addAll(instanceGroup.getNotTerminatedInstanceMetaDataSet());
-            }
-        }
-        return metadataList;
+    public List<InstanceMetaData> getNotTerminatedGatewayInstanceMetadata() {
+        return instanceGroups.stream()
+                .filter(ig -> InstanceGroupType.GATEWAY.equals(ig.getInstanceGroupType()))
+                .flatMap(ig -> ig.getNotTerminatedInstanceMetaDataSet().stream())
+                .collect(Collectors.toList());
+    }
+
+    public List<InstanceMetaData> getReachableGatewayInstanceMetadata() {
+        return instanceGroups.stream()
+                .filter(ig -> InstanceGroupType.GATEWAY.equals(ig.getInstanceGroupType()))
+                .flatMap(ig -> ig.getReachableInstanceMetaDataSet().stream())
+                .collect(Collectors.toList());
     }
 
     public InstanceMetaData getPrimaryGatewayInstance() {
-        Optional<InstanceMetaData> metaData = getGatewayInstanceMetadata().stream()
+        Optional<InstanceMetaData> metaData = getNotTerminatedGatewayInstanceMetadata().stream()
                 .filter(im -> InstanceMetadataType.GATEWAY_PRIMARY.equals(im.getInstanceMetadataType())).findFirst();
         return metaData.orElse(null);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
@@ -279,7 +279,7 @@ public class ClusterBootstrapper {
     private List<GatewayConfig> collectAndCheckGateways(Stack stack) {
         LOGGER.info("Collect and check gateways for {}", stack.getName());
         List<GatewayConfig> allGatewayConfig = new ArrayList<>();
-        for (InstanceMetaData gateway : stack.getGatewayInstanceMetadata()) {
+        for (InstanceMetaData gateway : stack.getNotTerminatedGatewayInstanceMetadata()) {
             GatewayConfig gatewayConfig = gatewayConfigService.getGatewayConfig(stack, gateway, isKnoxEnabled(stack));
             LOGGER.info("Add gateway config: {}", gatewayConfig);
             allGatewayConfig.add(gatewayConfig);
@@ -384,7 +384,7 @@ public class ClusterBootstrapper {
             throws CloudbreakOrchestratorException {
         Cluster cluster = stack.getCluster();
         Boolean enableKnox = cluster.getGateway() != null;
-        for (InstanceMetaData gateway : stack.getGatewayInstanceMetadata()) {
+        for (InstanceMetaData gateway : stack.getNotTerminatedGatewayInstanceMetadata()) {
             GatewayConfig gatewayConfig = gatewayConfigService.getGatewayConfig(stack, gateway, enableKnox);
             PollingResult bootstrapApiPolling = hostBootstrapApiPollingService.pollWithAbsoluteTimeoutSingleFailure(
                     hostBootstrapApiCheckerTask, new HostBootstrapApiContext(stack, gatewayConfig, hostOrchestrator), POLL_INTERVAL, MAX_POLLING_ATTEMPTS);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -593,8 +593,9 @@ public class ClusterHostServiceRunner {
         Optional<Stack> datalakeStackOptional = datalakeService.getDatalakeStackByDatahubStack(stack);
         if (datalakeStackOptional.isPresent()) {
             Stack dataLakeStack = datalakeStackOptional.get();
-            String datalakeDomain = dataLakeStack.getGatewayInstanceMetadata().get(0).getDomain();
-            List<String> ipList = dataLakeStack.getGatewayInstanceMetadata().stream().map(InstanceMetaData::getPrivateIp).collect(Collectors.toList());
+            String datalakeDomain = dataLakeStack.getNotTerminatedGatewayInstanceMetadata().get(0).getDomain();
+            List<String> ipList = dataLakeStack.getNotTerminatedGatewayInstanceMetadata().stream().map(InstanceMetaData::getPrivateIp)
+                    .collect(Collectors.toList());
             servicePillar.put("forwarder-zones", new SaltPillarProperties("/unbound/forwarders.sls",
                     singletonMap("forwarder-zones", singletonMap(datalakeDomain, singletonMap("nameservers", ipList)))));
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
@@ -17,7 +17,6 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Component;
 
 import com.google.common.collect.Sets;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.common.type.ClusterManagerType;
 import com.sequenceiq.cloudbreak.common.type.ScalingType;
@@ -92,11 +91,9 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
                 Optional<String> primaryGatewayHostName = instanceMetaDataService.getPrimaryGatewayDiscoveryFQDNByInstanceGroup(event.getStackId(),
                         instanceGroup.getId());
                 boolean primaryGatewayRepairable = primaryGatewayHostName.isPresent() && hostNames.contains(primaryGatewayHostName.get());
-                boolean singlePrimaryGatewayRepairable = primaryGatewayRepairable && !isMultipleGateway(event.getStackId());
-                if (singlePrimaryGatewayRepairable || StackType.DATALAKE.equals(stack.getType())) {
+                if (primaryGatewayRepairable) {
                     repairConfig.setSinglePrimaryGateway(new Repair(instanceGroup.getGroupName(), hostGroup.getName(), hostNames));
-                } else if (primaryGatewayRepairable) {
-                    repairConfig.setChangePGW(true);
+                } else {
                     repairConfig.addRepairs(new Repair(instanceGroup.getGroupName(), hostGroup.getName(), hostNames));
                 }
             } else {
@@ -104,17 +101,6 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
             }
         }
         return repairConfig;
-    }
-
-    private boolean isMultipleGateway(Long stackId) {
-        Set<InstanceGroupView> instanceGroupViews = instanceGroupService.findViewByStackId(stackId);
-        int gatewayCount = 0;
-        for (InstanceGroupView ig : instanceGroupViews) {
-            if (ig.getInstanceGroupType() == InstanceGroupType.GATEWAY) {
-                gatewayCount += ig.getNodeCount();
-            }
-        }
-        return gatewayCount > 1;
     }
 
     private Queue<Selectable> createFlowTriggers(ClusterRepairTriggerEvent event, RepairConfig repairConfig) {
@@ -125,8 +111,6 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
             flowTriggers.add(stackDownscaleEvent(event, repair.getHostGroupName(), repair.getHostNames()));
             flowTriggers.add(fullUpscaleEvent(event, repair.getHostGroupName(), repair.getHostNames(), true,
                     event.isRestartServices(), isKerberosSecured(event.getStackId())));
-        } else if (repairConfig.isChangePGW()) {
-            flowTriggers.add(changePrimaryGatewayEvent(event));
         }
         for (Repair repair : repairConfig.getRepairs()) {
             flowTriggers.add(fullDownscaleEvent(event, repair.getHostGroupName(), repair.getHostNames()));
@@ -135,7 +119,7 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
                         event.isRestartServices(), false));
             }
         }
-        if (!event.isRemoveOnly() && (repairConfig.getSinglePrimaryGateway().isPresent() || repairConfig.isChangePGW())
+        if (!event.isRemoveOnly() && (repairConfig.getSinglePrimaryGateway().isPresent())
                 && !stackService.findClustersConnectedToDatalakeByDatalakeStackId(event.getResourceId()).isEmpty()) {
             flowTriggers.add(upgradeEphemeralClustersEvent(event));
         }
@@ -197,9 +181,6 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
     }
 
     private static class RepairConfig {
-
-        private boolean changePGW;
-
         private Optional<Repair> singlePrimaryGateway;
 
         private List<Repair> repairs;
@@ -207,14 +188,6 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
         RepairConfig() {
             singlePrimaryGateway = Optional.empty();
             repairs = new ArrayList<>();
-        }
-
-        public boolean isChangePGW() {
-            return changePGW;
-        }
-
-        public void setChangePGW(boolean changePGW) {
-            this.changePGW = changePGW;
         }
 
         public Optional<Repair> getSinglePrimaryGateway() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/service/ClusterProxyService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/service/ClusterProxyService.java
@@ -147,7 +147,7 @@ public class ClusterProxyService {
     }
 
     private List<ClusterServiceConfig> getClusterServiceConfigsForGWs(Stack stack) {
-        List<InstanceMetaData> gatewayInstanceMetadatas = stack.getGatewayInstanceMetadata();
+        List<InstanceMetaData> gatewayInstanceMetadatas = stack.getNotTerminatedGatewayInstanceMetadata();
         return gatewayInstanceMetadatas.stream()
                 .map(gatewayInstanceMetadata -> createClusterServiceConfigFromGWMetadata(stack, gatewayInstanceMetadata))
                 .collect(Collectors.toList());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/service/StackCreationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/service/StackCreationService.java
@@ -246,7 +246,7 @@ public class StackCreationService {
 
     public void setupTls(StackContext context) throws CloudbreakException {
         Stack stack = context.getStack();
-        for (InstanceMetaData gwInstance : stack.getGatewayInstanceMetadata()) {
+        for (InstanceMetaData gwInstance : stack.getNotTerminatedGatewayInstanceMetadata()) {
             tlsSetupService.setupTls(stack, gwInstance);
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
@@ -128,7 +128,7 @@ public class StackUpscaleService {
 
     public void setupTls(StackContext context) throws CloudbreakException {
         Stack stack = context.getStack();
-        for (InstanceMetaData gwInstance : stack.getGatewayInstanceMetadata()) {
+        for (InstanceMetaData gwInstance : stack.getNotTerminatedGatewayInstanceMetadata()) {
             if (!stack.getTunnel().useCcm() && CREATED.equals(gwInstance.getInstanceStatus())) {
                 tlsSetupService.setupTls(stack, gwInstance);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
@@ -101,7 +101,7 @@ public class InstanceMetadataUpdater {
 
     private GatewayConfig getGatewayConfig(Stack stack, Boolean enableKnox) {
         GatewayConfig gatewayConfig = null;
-        for (InstanceMetaData gateway : stack.getGatewayInstanceMetadata()) {
+        for (InstanceMetaData gateway : stack.getNotTerminatedGatewayInstanceMetadata()) {
             if (InstanceMetadataType.GATEWAY_PRIMARY.equals(gateway.getInstanceMetadataType())) {
                 gatewayConfig = gatewayConfigService.getGatewayConfig(stack, gateway, enableKnox);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/sharedservice/DatalakeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/sharedservice/DatalakeService.java
@@ -161,8 +161,8 @@ public class DatalakeService {
     private String getDatalakeClusterManagerFqdn(Stack datalakeStack) {
         String fqdn;
         try {
-            fqdn = transactionService.required(() -> datalakeStack.getGatewayInstanceMetadata().isEmpty()
-                    ? datalakeStack.getClusterManagerIp() : datalakeStack.getGatewayInstanceMetadata().iterator().next().getDiscoveryFQDN());
+            fqdn = transactionService.required(() -> datalakeStack.getNotTerminatedGatewayInstanceMetadata().isEmpty()
+                    ? datalakeStack.getClusterManagerIp() : datalakeStack.getNotTerminatedGatewayInstanceMetadata().iterator().next().getDiscoveryFQDN());
         } catch (Exception ignored) {
             LOGGER.debug("Get instance metadata transaction failed, giving back IP as FQDN");
             fqdn = datalakeStack.getClusterManagerIp();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/DiskSpaceValidationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/DiskSpaceValidationService.java
@@ -56,7 +56,7 @@ public class DiskSpaceValidationService {
         long parcelSize = parcelSizeService.getAllParcelSize(imageCatalogUrl, imageCatalogName, imageId, stack);
         Map<String, String> freeDiskSpaceByNodes = getFreeDiskSpaceByNodes(stack);
         LOGGER.debug("Required free space for parcels {} KB. Free space by nodes in KB: {}", parcelSize, freeDiskSpaceByNodes);
-        Map<String, String> notEligibleNodes = getNotEligibleNodes(freeDiskSpaceByNodes, parcelSize, stack.getGatewayInstanceMetadata());
+        Map<String, String> notEligibleNodes = getNotEligibleNodes(freeDiskSpaceByNodes, parcelSize, stack.getNotTerminatedGatewayInstanceMetadata());
         if (!notEligibleNodes.isEmpty()) {
             throw new UpgradeValidationFailedException(String.format(
                     "There is not enough free space on the nodes to perform upgrade operation. The required free space by nodes: %s",

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactoryTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactoryTest.java
@@ -167,8 +167,7 @@ public class ClusterRepairFlowEventChainFactoryTest {
         List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of(
                 "FLOWCHAIN_INIT_TRIGGER_EVENT",
-                "CHANGE_PRIMARY_GATEWAY_TRIGGER_EVENT",
-                "FULL_DOWNSCALE_TRIGGER_EVENT",
+                "STACK_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
                 "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT",
                 "FLOWCHAIN_FINALIZE_TRIGGER_EVENT"), triggeredOperations);
@@ -190,8 +189,7 @@ public class ClusterRepairFlowEventChainFactoryTest {
         List<String> triggeredOperations = eventQueues.getQueue().stream().map(Selectable::selector).collect(Collectors.toList());
         assertEquals(List.of(
                 "FLOWCHAIN_INIT_TRIGGER_EVENT",
-                "CHANGE_PRIMARY_GATEWAY_TRIGGER_EVENT",
-                "FULL_DOWNSCALE_TRIGGER_EVENT",
+                "STACK_DOWNSCALE_TRIGGER_EVENT",
                 "FULL_UPSCALE_TRIGGER_EVENT",
                 "EPHEMERAL_CLUSTERS_UPDATE_TRIGGER_EVENT",
                 "RESCHEDULE_STATUS_CHECK_TRIGGER_EVENT",

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/AbstractRdsConfigProviderTest.java
@@ -66,9 +66,9 @@ public class AbstractRdsConfigProviderTest {
     public void createServicePillarForLocalRdsConfig() {
         when(rdsConfigService.createIfNotExists(any(), any(), any())).thenAnswer(i -> i.getArguments()[1]);
         Stack testStack = TestUtil.stack();
-        InstanceMetaData metaData = testStack.getGatewayInstanceMetadata().iterator().next();
+        InstanceMetaData metaData = testStack.getNotTerminatedGatewayInstanceMetadata().iterator().next();
         metaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
-        testStack.getGatewayInstanceMetadata().add(metaData);
+        testStack.getNotTerminatedGatewayInstanceMetadata().add(metaData);
         Cluster testCluster = TestUtil.cluster();
 
         Map<String, Object> result = underTest.createServicePillarConfigMapIfNeeded(testStack, testCluster);
@@ -96,9 +96,9 @@ public class AbstractRdsConfigProviderTest {
         when(secretService.getByResponse(username)).thenReturn(REMOTE_ADMIN);
         when(secretService.getByResponse(password)).thenReturn(REMOTE_ADMIN_PASSWORD);
         Stack testStack = TestUtil.stack();
-        InstanceMetaData metaData = testStack.getGatewayInstanceMetadata().iterator().next();
+        InstanceMetaData metaData = testStack.getNotTerminatedGatewayInstanceMetadata().iterator().next();
         metaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
-        testStack.getGatewayInstanceMetadata().add(metaData);
+        testStack.getNotTerminatedGatewayInstanceMetadata().add(metaData);
         Cluster testCluster = TestUtil.cluster();
         testStack.setCluster(testCluster);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbServerConfigurerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/rdsconfig/RedbeamsDbServerConfigurerTest.java
@@ -157,9 +157,9 @@ public class RedbeamsDbServerConfigurerTest {
 
     private Stack createStack(Cluster testCluster) {
         Stack testStack = TestUtil.stack();
-        InstanceMetaData metaData = testStack.getGatewayInstanceMetadata().iterator().next();
+        InstanceMetaData metaData = testStack.getNotTerminatedGatewayInstanceMetadata().iterator().next();
         metaData.setInstanceMetadataType(InstanceMetadataType.GATEWAY_PRIMARY);
-        testStack.getGatewayInstanceMetadata().add(metaData);
+        testStack.getNotTerminatedGatewayInstanceMetadata().add(metaData);
         testStack.setCluster(testCluster);
         return testStack;
     }

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/general/GeneralClusterConfigsProvider.java
@@ -27,7 +27,7 @@ public class GeneralClusterConfigsProvider {
         boolean gatewayInstanceMetadataPresented = false;
         boolean instanceMetadataPresented = false;
         if (stack.getInstanceGroups() != null && !stack.getInstanceGroups().isEmpty()) {
-            List<InstanceMetaData> gatewayInstanceMetadata = stack.getGatewayInstanceMetadata();
+            List<InstanceMetaData> gatewayInstanceMetadata = stack.getNotTerminatedGatewayInstanceMetadata();
             gatewayInstanceMetadataPresented = !gatewayInstanceMetadata.isEmpty()
                     && stack.getCluster().getGateway() != null;
             instanceMetadataPresented = true;


### PR DESCRIPTION
- Primary gateway change messes up the salt roles and PGW on CB side. As CM is non HA, PGW doesn't make any sense, similarly to DL.
- Fixed downscale when the instance is not returned by AWS as it's deleted long time ago. In this case no termination request is sent for the instance.
- When fetching all `GatewayConfig` only the reachables are returned to avoid connection issues. If there is no gateway instance reachable an error is raised.

See detailed description in the commit message.