### PR TITLE
CB-13539 CollectDownscaleCandidatesHandler transaction is too long

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterDecomissionService.java
@@ -14,7 +14,7 @@ import com.sequenceiq.cloudbreak.service.CloudbreakException;
 public interface ClusterDecomissionService {
     void verifyNodesAreRemovable(Stack stack, Collection<InstanceMetaData> removableInstances);
 
-    Set<InstanceMetaData> collectDownscaleCandidates(@Nonnull HostGroup hostGroup, Integer scalingAdjustment, int defaultRootVolumeSize,
+    Set<InstanceMetaData> collectDownscaleCandidates(@Nonnull HostGroup hostGroup, Integer scalingAdjustment,
             Set<InstanceMetaData> instanceMetaDatasInStack) throws CloudbreakException;
 
     Map<String, InstanceMetaData> collectHostsToRemove(@Nonnull HostGroup hostGroup, Set<String> hostNames);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionService.java
@@ -75,10 +75,9 @@ public class ClouderaManagerClusterDecomissionService implements ClusterDecomiss
     }
 
     @Override
-    public Set<InstanceMetaData> collectDownscaleCandidates(@Nonnull HostGroup hostGroup, Integer scalingAdjustment, int defaultRootVolumeSize,
+    public Set<InstanceMetaData> collectDownscaleCandidates(@Nonnull HostGroup hostGroup, Integer scalingAdjustment,
             Set<InstanceMetaData> instanceMetaDatasInStack) {
-        return clouderaManagerDecomissioner.collectDownscaleCandidates(client, stack, hostGroup, scalingAdjustment, defaultRootVolumeSize,
-                instanceMetaDatasInStack);
+        return clouderaManagerDecomissioner.collectDownscaleCandidates(client, stack, hostGroup, scalingAdjustment, instanceMetaDatasInStack);
     }
 
     @Override

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterDecomissionServiceTest.java
@@ -99,7 +99,6 @@ public class ClouderaManagerClusterDecomissionServiceTest {
     public void testCollectDownscaleCandidates() {
         HostGroup hostGroup = new HostGroup();
         Integer scalingAdjustment = 1;
-        int defaultRootVolumeSize = 2;
         Set<InstanceMetaData> instanceMetadatas = new HashSet<>();
         InstanceMetaData instanceMetaData1 = new InstanceMetaData();
         instanceMetaData1.setDiscoveryFQDN("host1");
@@ -110,14 +109,13 @@ public class ClouderaManagerClusterDecomissionServiceTest {
         instanceMetaData2.setPrivateId(2L);
         instanceMetadatas.add(instanceMetaData2);
 
-        when(clouderaManagerDecomissioner.collectDownscaleCandidates(apiClient, stack, hostGroup, scalingAdjustment, defaultRootVolumeSize,
-                instanceMetadatas)).thenReturn(instanceMetadatas);
+        when(clouderaManagerDecomissioner.collectDownscaleCandidates(apiClient, stack, hostGroup, scalingAdjustment, instanceMetadatas))
+                .thenReturn(instanceMetadatas);
 
-        Set<InstanceMetaData> actual = underTest.collectDownscaleCandidates(hostGroup, scalingAdjustment, defaultRootVolumeSize, instanceMetadatas);
+        Set<InstanceMetaData> actual = underTest.collectDownscaleCandidates(hostGroup, scalingAdjustment, instanceMetadatas);
 
         assertEquals(instanceMetadatas, actual);
-        verify(clouderaManagerDecomissioner).collectDownscaleCandidates(apiClient, stack, hostGroup, scalingAdjustment, defaultRootVolumeSize,
-                instanceMetadatas);
+        verify(clouderaManagerDecomissioner).collectDownscaleCandidates(apiClient, stack, hostGroup, scalingAdjustment, instanceMetadatas);
     }
 
     @Test

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecommisionerTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerDecommisionerTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -22,7 +21,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import com.cloudera.api.swagger.ClustersResourceApi;
 import com.cloudera.api.swagger.HostTemplatesResourceApi;
 import com.cloudera.api.swagger.HostsResourceApi;
 import com.cloudera.api.swagger.ServicesResourceApi;
@@ -208,16 +206,7 @@ public class ClouderaManagerDecommisionerTest {
         Set<HostGroup> hostGroups = createTestHostGroups(1, 6);
         cluster.setHostGroups(hostGroups);
         HostGroup downscaledHostGroup = hostGroups.iterator().next();
-        ClustersResourceApi clustersResourceApi = mock(ClustersResourceApi.class);
-        when(clouderaManagerApiFactory.getClustersResourceApi(any(ApiClient.class))).thenReturn(clustersResourceApi);
         HostsResourceApi hostsResourceApi = mock(HostsResourceApi.class);
-        when(hostsResourceApi.readHost(anyString(), anyString())).thenAnswer(invocation -> {
-            ApiHost apiHost = new ApiHost();
-            apiHost.setHealthSummary(ApiHealthSummary.GOOD);
-            apiHost.setHostname(invocation.getArgument(0));
-            apiHost.setHostId(invocation.getArgument(0));
-            return apiHost;
-        });
         when(clouderaManagerApiFactory.getHostsResourceApi(any(ApiClient.class))).thenReturn(hostsResourceApi);
         HostTemplatesResourceApi hostTemplatesResourceApi = mock(HostTemplatesResourceApi.class);
         when(clouderaManagerApiFactory.getHostTemplatesResourceApi(any(ApiClient.class))).thenReturn(hostTemplatesResourceApi);
@@ -232,11 +221,12 @@ public class ClouderaManagerDecommisionerTest {
                     ApiHost apiHostRef = new ApiHost();
                     apiHostRef.setHostname(hostName);
                     apiHostRef.setHostId(hostName);
+                    apiHostRef.setHealthSummary(ApiHealthSummary.GOOD);
                     apiHosts.add(apiHostRef);
                 });
         apiHostRefList.setItems(apiHosts);
-        when(clustersResourceApi.listHosts(stack.getName(), null, null, null)).thenReturn(apiHostRefList);
-        Set<InstanceMetaData> downscaleCandidates = underTest.collectDownscaleCandidates(mock(ApiClient.class), stack, downscaledHostGroup, -2, 0,
+        when(hostsResourceApi.readHosts(any(), any(), any())).thenReturn(apiHostRefList);
+        Set<InstanceMetaData> downscaleCandidates = underTest.collectDownscaleCandidates(mock(ApiClient.class), stack, downscaledHostGroup, -2,
                 downscaledHostGroup.getInstanceGroup().getAllInstanceMetaData());
         assertEquals(2, downscaleCandidates.size());
         assertTrue("Assert if downscaleCandidates contains hg0-instanceid-4",
@@ -255,15 +245,13 @@ public class ClouderaManagerDecommisionerTest {
         Set<HostGroup> hostGroups = createTestHostGroups(1, 6);
         cluster.setHostGroups(hostGroups);
         HostGroup downscaledHostGroup = hostGroups.iterator().next();
-        ClustersResourceApi clustersResourceApi = mock(ClustersResourceApi.class);
-        when(clouderaManagerApiFactory.getClustersResourceApi(any(ApiClient.class))).thenReturn(clustersResourceApi);
         HostsResourceApi hostsResourceApi = mock(HostsResourceApi.class);
         when(clouderaManagerApiFactory.getHostsResourceApi(any(ApiClient.class))).thenReturn(hostsResourceApi);
         HostTemplatesResourceApi hostTemplatesResourceApi = mock(HostTemplatesResourceApi.class);
         when(clouderaManagerApiFactory.getHostTemplatesResourceApi(any(ApiClient.class))).thenReturn(hostTemplatesResourceApi);
         ApiHostTemplateList hostTemplates = createEmptyHostTemplates();
         Mockito.when(hostTemplatesResourceApi.readHostTemplates(stack.getName())).thenReturn(hostTemplates);
-        assertThrows(NotEnoughNodeException.class, () -> underTest.collectDownscaleCandidates(mock(ApiClient.class), stack, downscaledHostGroup, -8, 0,
+        assertThrows(NotEnoughNodeException.class, () -> underTest.collectDownscaleCandidates(mock(ApiClient.class), stack, downscaledHostGroup, -8,
                 downscaledHostGroup.getInstanceGroup().getAllInstanceMetaData()));
     }
 
@@ -281,16 +269,7 @@ public class ClouderaManagerDecommisionerTest {
                 .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN().equals("hg0-host-2"))
                 .findFirst();
         hgHost2.ifPresent(instanceMetaData -> instanceMetaData.setDiscoveryFQDN(null));
-        ClustersResourceApi clustersResourceApi = mock(ClustersResourceApi.class);
-        when(clouderaManagerApiFactory.getClustersResourceApi(any(ApiClient.class))).thenReturn(clustersResourceApi);
         HostsResourceApi hostsResourceApi = mock(HostsResourceApi.class);
-        when(hostsResourceApi.readHost(anyString(), anyString())).thenAnswer(invocation -> {
-            ApiHost apiHost = new ApiHost();
-            apiHost.setHealthSummary(ApiHealthSummary.GOOD);
-            apiHost.setHostname(invocation.getArgument(0));
-            apiHost.setHostId(invocation.getArgument(0));
-            return apiHost;
-        });
         when(clouderaManagerApiFactory.getHostsResourceApi(any(ApiClient.class))).thenReturn(hostsResourceApi);
         HostTemplatesResourceApi hostTemplatesResourceApi = mock(HostTemplatesResourceApi.class);
         when(clouderaManagerApiFactory.getHostTemplatesResourceApi(any(ApiClient.class))).thenReturn(hostTemplatesResourceApi);
@@ -305,11 +284,12 @@ public class ClouderaManagerDecommisionerTest {
                     ApiHost apiHostRef = new ApiHost();
                     apiHostRef.setHostname(hostName);
                     apiHostRef.setHostId(hostName);
+                    apiHostRef.setHealthSummary(ApiHealthSummary.GOOD);
                     apiHosts.add(apiHostRef);
                 });
         apiHostRefList.setItems(apiHosts);
-        when(clustersResourceApi.listHosts(stack.getName(), null, null, null)).thenReturn(apiHostRefList);
-        Set<InstanceMetaData> downscaleCandidates = underTest.collectDownscaleCandidates(mock(ApiClient.class), stack, downscaledHostGroup, -2, 0,
+        when(hostsResourceApi.readHosts(any(), any(), any())).thenReturn(apiHostRefList);
+        Set<InstanceMetaData> downscaleCandidates = underTest.collectDownscaleCandidates(mock(ApiClient.class), stack, downscaledHostGroup, -2,
                 downscaledHostGroup.getInstanceGroup().getAllInstanceMetaData());
         assertEquals(2, downscaleCandidates.size());
         assertTrue("Assert if downscaleCandidates contains hg0-host-2, because FQDN is missing",


### PR DESCRIPTION
- old behaviour: during collection of downscale candidates we called listHosts in CM then we called readHost in CM for every known instance with summary view
- new behaviour: during collection of downscale candidates we call readHosts in CM with summary view