### PR TITLE
CB-13597 gcp can't create instances on default subnet

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
@@ -469,12 +469,12 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
 
     private void prepareNetworkAndSubnet(String projectId, Region region, Network network, NetworkInterface networkInterface,
         CloudInstance instance) {
+        String subnetId = Strings.isNullOrEmpty(instance.getSubnetId()) ? gcpStackUtil.getSubnetId(network) : instance.getSubnetId();
         if (StringUtils.isNotEmpty(gcpStackUtil.getSharedProjectId(network))) {
             networkInterface.setNetwork(getNetworkUrl(gcpStackUtil.getSharedProjectId(network), gcpStackUtil.getCustomNetworkId(network)));
-            String subnetId = Strings.isNullOrEmpty(instance.getSubnetId()) ? gcpStackUtil.getSubnetId(network) : instance.getSubnetId();
             networkInterface.setSubnetwork(getSubnetUrl(gcpStackUtil.getSharedProjectId(network), region.value(), subnetId));
         } else {
-            networkInterface.setSubnetwork(getSubnetUrl(projectId, region.value(), instance.getSubnetId()));
+            networkInterface.setSubnetwork(getSubnetUrl(projectId, region.value(), subnetId));
         }
     }
 

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilderTest.java
@@ -386,7 +386,7 @@ public class GcpInstanceResourceBuilderTest {
         when(insert.setPrettyPrint(anyBoolean())).thenReturn(insert);
         when(insert.execute()).thenReturn(operation);
 
-        Operation addOperation  = new Operation();
+        Operation addOperation = new Operation();
         addOperation.setName("operation");
         addOperation.setHttpErrorStatusCode(401);
         addOperation.setHttpErrorMessage("Not Authorized");
@@ -435,6 +435,33 @@ public class GcpInstanceResourceBuilderTest {
         verify(instances).insert(anyString(), anyString(), instanceArg.capture());
         assertNull(instanceArg.getValue().getHostname());
         verifyNoInteractions(addInstances);
+    }
+
+    @Test
+    public void noSubnetInformationOnInstance() throws Exception {
+
+        // GIVEN
+        Group group = newGroupWithParams(ImmutableMap.of());
+        List<CloudResource> buildableResources = builder.create(context, group.getInstances().get(0), privateId, authenticatedContext, group, image);
+        context.addComputeResources(0L, buildableResources);
+        group.getInstances().get(0).setSubnetId(null);
+        when(gcpStackUtil.getSubnetId(any())).thenReturn("default");
+
+        // WHEN
+        when(compute.instances()).thenReturn(instances);
+        when(instances.insert(anyString(), anyString(), any(Instance.class))).thenReturn(insert);
+        when(insert.setPrettyPrint(anyBoolean())).thenReturn(insert);
+        when(insert.execute()).thenReturn(operation);
+        mockInstanceGroupAdd(group);
+
+        builder.build(context, group.getInstances().get(0), privateId, authenticatedContext, group, buildableResources, cloudStack);
+
+        // THEN
+        verify(compute).instances();
+        verify(instances).insert(anyString(), anyString(), instanceArg.capture());
+        assertEquals("https://www.googleapis.com/compute/v1/projects/projectId/regions/region/subnetworks/default",
+                instanceArg.getValue().getNetworkInterfaces().get(0).getSubnetwork());
+        assertNull(instanceArg.getValue().getHostname());
     }
 
     public Group newGroupWithParams(Map<String, Object> params) {


### PR DESCRIPTION
small change to fallback to network parameters when the instance doesn't have a subnet defined yet.