### PR TITLE
CB-8692 Cloud storage link on the test result page like Kibana link

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/AbstractCloudProvider.java
@@ -17,6 +17,7 @@ import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
 import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
 import com.sequenceiq.environment.api.v1.environment.model.request.AttachedFreeIpaRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.TestParameter;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
@@ -152,6 +153,11 @@ public abstract class AbstractCloudProvider implements CloudProvider {
 
     @Override
     public LoggingRequest loggingRequest(TelemetryTestDto dto) {
+        return null;
+    }
+
+    @Override
+    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
         return null;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProvider.java
@@ -10,6 +10,7 @@ import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
@@ -80,6 +81,8 @@ public interface CloudProvider {
     LoggingRequest loggingRequest(TelemetryTestDto dto);
 
     DistroXRootVolumeTestDto distroXRootVolume(DistroXRootVolumeTestDto distroXRootVolume);
+
+    NetworkRequest networkRequest(FreeIpaTestDto dto);
 
     NetworkV4TestDto network(NetworkV4TestDto network);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/CloudProviderProxy.java
@@ -17,6 +17,7 @@ import com.sequenceiq.common.api.type.ServiceEndpointCreation;
 import com.sequenceiq.common.model.FileSystemType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
@@ -370,6 +371,11 @@ public class CloudProviderProxy implements CloudProvider {
     @Override
     public LoggingRequest loggingRequest(TelemetryTestDto dto) {
         return getDelegate(dto).loggingRequest(dto);
+    }
+
+    @Override
+    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
+        return getDelegate(dto).networkRequest(dto);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/aws/AwsCloudProvider.java
@@ -41,6 +41,8 @@ import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnviro
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaSpotParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.S3GuardRequestParameters;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.AwsNetworkParameters;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProvider;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -61,6 +63,7 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXRootVolumeT
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXVolumeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDtoBase;
@@ -183,6 +186,16 @@ public class AwsCloudProvider extends AbstractCloudProvider {
     public DistroXRootVolumeTestDto distroXRootVolume(DistroXRootVolumeTestDto distroXRootVolume) {
         int rootVolumeSize = awsProperties.getInstance().getRootVolumeSize();
         return distroXRootVolume.withSize(rootVolumeSize);
+    }
+
+    @Override
+    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
+        NetworkRequest networkRequest = new NetworkRequest();
+        AwsNetworkParameters networkParameters = new AwsNetworkParameters();
+        networkParameters.setSubnetId(getSubnetId());
+        networkParameters.setVpcId(getVpcId());
+        networkRequest.setAws(networkParameters);
+        return networkRequest;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/azure/AzureCloudProvider.java
@@ -34,6 +34,8 @@ import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzu
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.ResourceGroupUsage;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.AzureNetworkParameters;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.ResourceGroupTest;
 import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProvider;
@@ -54,6 +56,7 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXRootVolumeT
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXVolumeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDtoBase;
@@ -204,6 +207,18 @@ public class AzureCloudProvider extends AbstractCloudProvider {
     }
 
     @Override
+    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
+        NetworkRequest networkRequest = new NetworkRequest();
+        AzureNetworkParameters networkParameters = new AzureNetworkParameters();
+        networkParameters.setSubnetId(getSubnetId());
+        networkParameters.setNetworkId(getNetworkId());
+        networkParameters.setNoPublicIp(getNoPublicIp());
+        networkParameters.setResourceGroupName(getResourceGroupName());
+        networkRequest.setAzure(networkParameters);
+        return networkRequest;
+    }
+
+    @Override
     public NetworkV4TestDto network(NetworkV4TestDto network) {
         AzureNetworkV4Parameters parameters = new AzureNetworkV4Parameters();
         parameters.setNoPublicIp(false);
@@ -232,7 +247,7 @@ public class AzureCloudProvider extends AbstractCloudProvider {
 
     @Override
     public EnvironmentNetworkTestDto network(EnvironmentNetworkTestDto network) {
-        return network.withSubnetIDs(getSubnetIDs())
+        return network.withSubnetIDs(getSubnetIds())
                 .withAzure(environmentNetworkParameters());
     }
 
@@ -264,8 +279,13 @@ public class AzureCloudProvider extends AbstractCloudProvider {
         return azureProperties.getNetwork().getNetworkId();
     }
 
-    public Set<String> getSubnetIDs() {
+    public Set<String> getSubnetIds() {
         return azureProperties.getNetwork().getSubnetIds();
+    }
+
+    public String getSubnetId() {
+        Set<String> subnetIDs = getSubnetIds();
+        return subnetIDs.iterator().next();
     }
 
     public Boolean getNoPublicIp() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/gcp/GcpCloudProvider.java
@@ -30,6 +30,8 @@ import com.sequenceiq.environment.api.v1.credential.model.parameters.gcp.JsonPar
 import com.sequenceiq.environment.api.v1.credential.model.parameters.gcp.P12Parameters;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkGcpParams;
 import com.sequenceiq.environment.api.v1.environment.model.request.SecurityAccessRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.GcpNetworkParameters;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProvider;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -51,6 +53,7 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXVolumeTestD
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentSecurityAccessTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
@@ -175,6 +178,39 @@ public class GcpCloudProvider extends AbstractCloudProvider {
     public DistroXRootVolumeTestDto distroXRootVolume(DistroXRootVolumeTestDto distroXRootVolume) {
         int rootVolumeSize = gcpProperties.getInstance().getRootVolumeSize();
         return distroXRootVolume.withSize(rootVolumeSize);
+    }
+
+    @Override
+    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
+        NetworkRequest networkRequest = new NetworkRequest();
+        GcpNetworkParameters networkParameters = new GcpNetworkParameters();
+        networkParameters.setSubnetId(getSubnetId());
+        networkParameters.setNetworkId(getNetworkId());
+        networkParameters.setNoPublicIp(getNoPublicIp());
+        networkParameters.setNoFirewallRules(getNoFirewallRules());
+        networkParameters.setSharedProjectId(getSharedProjectId());
+        networkRequest.setGcp(networkParameters);
+        return networkRequest;
+    }
+
+    public String getNetworkId() {
+        return gcpProperties.getNetwork().getNetworkId();
+    }
+
+    public String getSubnetId() {
+        return gcpProperties.getNetwork().getSubnetId();
+    }
+
+    public Boolean getNoPublicIp() {
+        return gcpProperties.getNetwork().getNoPublicIp();
+    }
+
+    public Boolean getNoFirewallRules() {
+        return gcpProperties.getNetwork().getNoFirewallRules();
+    }
+
+    public String getSharedProjectId() {
+        return gcpProperties.getNetwork().getSharedProjectId();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/cloud/v4/mock/MockCloudProvider.java
@@ -24,6 +24,8 @@ import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.Instan
 import com.sequenceiq.distrox.api.v1.distrox.model.network.mock.MockNetworkV1Parameters;
 import com.sequenceiq.environment.api.v1.credential.model.parameters.mock.MockParameters;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.MockNetworkParameters;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
 import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.ResourcePropertyProvider;
 import com.sequenceiq.it.cloudbreak.cloud.v4.AbstractCloudProvider;
@@ -46,6 +48,7 @@ import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXNetworkTest
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXRootVolumeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.instancegroup.DistroXVolumeTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCloudStorageTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDtoBase;
@@ -305,6 +308,17 @@ public class MockCloudProvider extends AbstractCloudProvider {
     @Override
     public DistroXRootVolumeTestDto distroXRootVolume(DistroXRootVolumeTestDto distroXRootVolume) {
         return distroXRootVolume.withSize(100);
+    }
+
+    @Override
+    public NetworkRequest networkRequest(FreeIpaTestDto dto) {
+        NetworkRequest networkRequest = new NetworkRequest();
+        MockNetworkParameters networkParameters = new MockNetworkParameters();
+        networkParameters.setSubnetId(getSubnetId());
+        networkParameters.setVpcId(getVpcId());
+        networkParameters.setInternetGatewayId(getInternetGatewayId());
+        networkRequest.setMock(networkParameters);
+        return networkRequest;
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/E2ETestContext.java
@@ -31,6 +31,6 @@ public class E2ETestContext extends TestContext {
     @Override
     public void cleanupTestContext() {
         super.cleanupTestContext();
-        getResources().values().forEach(value -> tagsUtil.verifyTags(value, this));
+        getResourceNames().values().forEach(value -> tagsUtil.verifyTags(value, this));
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/MeasuredTestContext.java
@@ -57,8 +57,13 @@ public class MeasuredTestContext extends MockedTestContext {
     }
 
     @Override
-    public Map<String, CloudbreakTestDto> getResources() {
-        return wrappedTestContext.getResources();
+    public Map<String, CloudbreakTestDto> getResourceNames() {
+        return wrappedTestContext.getResourceNames();
+    }
+
+    @Override
+    public Map<String, CloudbreakTestDto> getResourceCrns() {
+        return wrappedTestContext.getResourceCrns();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/freeipa/FreeIpaTestDto.java
@@ -15,6 +15,8 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.testng.util.Strings;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4SpotParameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.authentication.StackAuthenticationV4Request;
@@ -227,6 +229,11 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
         return template;
     }
 
+    public FreeIpaTestDto withNetwork() {
+        getRequest().setNetwork(getCloudProvider().networkRequest(this));
+        return this;
+    }
+
     private FreeIpaTestDto withNetwork(NetworkV4TestDto network) {
         NetworkV4Request request = network.getRequest();
         NetworkRequest networkRequest = new NetworkRequest();
@@ -275,6 +282,17 @@ public class FreeIpaTestDto extends AbstractFreeIpaTestDto<CreateFreeIpaRequest,
         ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
         imageSettingsRequest.setCatalog(catalog);
         getRequest().setImage(imageSettingsRequest);
+        return this;
+    }
+
+    public FreeIpaTestDto withCatalog(String imageCatalog, String imageUuid) {
+        if (!Strings.isNullOrEmpty(imageCatalog) && !Strings.isNullOrEmpty(imageUuid)) {
+            ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
+            imageSettingsRequest.setCatalog(imageCatalog);
+            imageSettingsRequest.setId(imageUuid);
+
+            getRequest().setImage(imageSettingsRequest);
+        }
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/telemetry/TelemetryTestDto.java
@@ -35,7 +35,6 @@ public class TelemetryTestDto extends AbstractCloudbreakTestDto<TelemetryRequest
 
     public TelemetryTestDto withLogging() {
         getRequest().setLogging(getCloudProvider().loggingRequest(this));
-
         return this;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/ReportListener.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/ReportListener.java
@@ -4,24 +4,52 @@ import static com.sequenceiq.it.cloudbreak.log.Log.log;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.ITestResult;
 import org.testng.Reporter;
 import org.testng.TestListenerAdapter;
 
 import com.google.common.collect.Iterables;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CloudProviderProxy;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CommonCloudProperties;
 import com.sequenceiq.it.cloudbreak.context.MeasuredTestContext;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.search.ClusterLogsStorageUrl;
 import com.sequenceiq.it.cloudbreak.search.KibanaSearchUrl;
 import com.sequenceiq.it.cloudbreak.search.SearchUrl;
 import com.sequenceiq.it.cloudbreak.search.Searchable;
+import com.sequenceiq.it.cloudbreak.search.StorageUrl;
 
 public class ReportListener extends TestListenerAdapter {
+
     public static final String SEARCH_URL = "searchUrl";
 
+    public static final String FI_STORAGE_URL = "freeipaStorageUrl";
+
+    public static final String DL_STORAGE_URL = "datalakeStorageUrl";
+
+    public static final String DH_STORAGE_URL = "datahubStorageUrl";
+
     public static final String MEASUREMENTS = "measurements";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReportListener.class);
+
+    @Inject
+    private CommonCloudProperties commonCloudProperties;
 
     @Override
     public void onTestFailure(ITestResult tr) {
@@ -59,7 +87,7 @@ public class ReportListener extends TestListenerAdapter {
         } catch (ClassCastException e) {
             return;
         }
-        Iterable<Searchable> searchables = Iterables.filter(testContext.getResources().values(), Searchable.class);
+        Iterable<Searchable> searchables = Iterables.filter(testContext.getResourceNames().values(), Searchable.class);
         List<Searchable> listOfSearchables = StreamSupport.stream(searchables.spliterator(), false).collect(Collectors.toList());
         if (listOfSearchables.size() == 0) {
             return;
@@ -67,6 +95,13 @@ public class ReportListener extends TestListenerAdapter {
         SearchUrl searchUrl = new KibanaSearchUrl();
         tr.getTestContext().setAttribute(tr.getName() + SEARCH_URL,
                 searchUrl.getSearchUrl(listOfSearchables, new Date(tr.getStartMillis()), new Date(tr.getEndMillis())));
+
+        String baseLocation = getCloudStorageBaseLocation(testContext);
+        CloudProviderProxy cloudProvider = testContext.getCloudProvider();
+        generateClusterLogsUrl(FreeIpaTestDto.class, tr, testContext.getResourceNames(), testContext.getResourceCrns(), baseLocation, cloudProvider);
+        generateClusterLogsUrl(SdxTestDto.class, tr, testContext.getResourceNames(), testContext.getResourceCrns(), baseLocation, cloudProvider);
+        generateClusterLogsUrl(SdxInternalTestDto.class, tr, testContext.getResourceNames(), testContext.getResourceCrns(), baseLocation, cloudProvider);
+        generateClusterLogsUrl(DistroXTestDto.class, tr, testContext.getResourceNames(), testContext.getResourceCrns(), baseLocation, cloudProvider);
     }
 
     private void logMeasurements(ITestResult tr) {
@@ -80,6 +115,90 @@ public class ReportListener extends TestListenerAdapter {
             return;
         }
         tr.setAttribute(tr.getName() + MEASUREMENTS, measuredTestContext.getMeasure());
+    }
+
+    private <T extends CloudbreakTestDto> void generateClusterLogsUrl(Class<T> dtoClass, ITestResult tr, Map<String, CloudbreakTestDto> resourceNames,
+            Map<String, CloudbreakTestDto> resourceCrns, String baseLocation, CloudProviderProxy cloudProvider) {
+        try {
+            String resourceName = getResourceName(dtoClass, resourceNames);
+            String resourceCrn = getResourceCrn(dtoClass, resourceCrns);
+            if (StringUtils.isEmpty(resourceCrn)) {
+                LOGGER.info("{} resource is not present in Cluster Logs", dtoClass.getSimpleName());
+            } else {
+                switch (dtoClass.getSimpleName()) {
+                    case "FreeIpaTestDto":
+                        getFreeIpaCloudStorageUrl(tr, resourceName, resourceCrn, baseLocation, cloudProvider);
+                        break;
+                    case "DistroXTestDto":
+                        getDistroxCloudStorageUrl(tr, resourceName, resourceCrn, baseLocation, cloudProvider);
+                        break;
+                    case "SdxInternalTestDto":
+                    case "SdxTestDto":
+                        getSdxCloudStorageUrl(tr, resourceName, resourceCrn, baseLocation, cloudProvider);
+                        break;
+                    default:
+                        LOGGER.warn("The given {} TestDTO is not in the list of Cluster Logs related testDTOs (freeIPA, Data Lake, Data Hub)!",
+                                dtoClass.getSimpleName());
+                        break;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.info("{} resource is not present in Test Context.", dtoClass.getSimpleName(), e);
+        }
+    }
+
+    private String getFreeIpaCloudStorageUrl(ITestResult tr, String resourceName, String resourceCrn, String baseLocation, CloudProviderProxy cloudProvider) {
+        StorageUrl storageUrl = new ClusterLogsStorageUrl();
+
+        String freeIpaCloudStorageUrl = storageUrl.getFreeIpaStorageUrl(resourceName, resourceCrn, baseLocation, cloudProvider);
+        tr.getTestContext().setAttribute(tr.getName() + FI_STORAGE_URL, freeIpaCloudStorageUrl);
+        LOGGER.info("FreeIpa cloud storage: {}:{}", tr.getName() + FI_STORAGE_URL, freeIpaCloudStorageUrl);
+        return freeIpaCloudStorageUrl;
+    }
+
+    private String getSdxCloudStorageUrl(ITestResult tr, String resourceName, String resourceCrn, String baseLocation, CloudProviderProxy cloudProvider) {
+        StorageUrl storageUrl = new ClusterLogsStorageUrl();
+
+        String datalakeCloudStorageUrl = storageUrl.getDatalakeStorageUrl(resourceName, resourceCrn, baseLocation, cloudProvider);
+        tr.getTestContext().setAttribute(tr.getName() + DL_STORAGE_URL, datalakeCloudStorageUrl);
+        LOGGER.info("Data lake cloud storage: {}:{}", tr.getName() + DL_STORAGE_URL, datalakeCloudStorageUrl);
+        return datalakeCloudStorageUrl;
+    }
+
+    private String getDistroxCloudStorageUrl(ITestResult tr, String resourceName, String resourceCrn, String baseLocation, CloudProviderProxy cloudProvider) {
+        StorageUrl storageUrl = new ClusterLogsStorageUrl();
+
+        String datahubCloudStorageUrl = storageUrl.getDataHubStorageUrl(resourceName, resourceCrn, baseLocation, cloudProvider);
+        tr.getTestContext().setAttribute(tr.getName() + DH_STORAGE_URL, datahubCloudStorageUrl);
+        LOGGER.info("Data hub cloud storage: {}:{}", tr.getName() + DH_STORAGE_URL, datahubCloudStorageUrl);
+        return datahubCloudStorageUrl;
+    }
+
+    private String getCloudStorageBaseLocation(TestContext testContext) {
+        try {
+            String storageBaseLocation = testContext.get(EnvironmentTestDto.class).getResponse().getTelemetry().getLogging().getStorageLocation();
+            LOGGER.info("Cloud Storage base location: {}", storageBaseLocation);
+            return storageBaseLocation;
+        } catch (Exception e) {
+            LOGGER.info("Cannot get Cloud Storage base location, because of {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private <T extends CloudbreakTestDto> String getResourceName(Class<T> dtoClass, Map<String, CloudbreakTestDto> resourceNames) {
+        return resourceNames.values().stream()
+                .filter(cloudbreakTestDto -> dtoClass.getSimpleName().equalsIgnoreCase(cloudbreakTestDto.getClass().getSimpleName()))
+                .map(CloudbreakTestDto::getName)
+                .findAny()
+                .orElse(null);
+    }
+
+    private <T extends CloudbreakTestDto> String getResourceCrn(Class<T> dtoClass, Map<String, CloudbreakTestDto> resourceCrns) {
+        return resourceCrns.entrySet().stream()
+                .filter(resourceMap -> dtoClass.getSimpleName().equalsIgnoreCase(resourceMap.getValue().getClass().getSimpleName()))
+                .map(Map.Entry::getKey)
+                .findAny()
+                .orElse(null);
     }
 }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestInvocationListener.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/listener/TestInvocationListener.java
@@ -55,7 +55,7 @@ public class TestInvocationListener implements IInvokedMethodListener {
             return;
         }
 
-        List<CloudbreakTestDto> testDtos = new ArrayList<>(testContext.getResources().values());
+        List<CloudbreakTestDto> testDtos = new ArrayList<>(testContext.getResourceNames().values());
         List<CloudbreakTestDto> orderedTestDtos = testDtos.stream().sorted(new CompareByOrder()).collect(Collectors.toList());
         for (CloudbreakTestDto testDto : orderedTestDtos) {
             try {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/ClusterLogsStorageUrl.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/ClusterLogsStorageUrl.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.it.cloudbreak.search;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.it.cloudbreak.cloud.v4.CloudProviderProxy;
+
+@Component
+public class ClusterLogsStorageUrl implements StorageUrl {
+
+    @Override
+    public String getFreeIpaStorageUrl(String resourceName, String resourceCrn, String baseLocation, CloudProviderProxy cloudProvider) {
+        return cloudProvider.getCloudFunctionality().getFreeIpaLogsUrl(resourceName, resourceCrn, baseLocation);
+    }
+
+    @Override
+    public String getDatalakeStorageUrl(String resourceName, String resourceCrn, String baseLocation, CloudProviderProxy cloudProvider) {
+        return cloudProvider.getCloudFunctionality().getDataLakeLogsUrl(resourceName, resourceCrn, baseLocation);
+    }
+
+    @Override
+    public String getDataHubStorageUrl(String resourceName, String resourceCrn, String baseLocation, CloudProviderProxy cloudProvider) {
+        return cloudProvider.getCloudFunctionality().getDataHubLogsUrl(resourceName, resourceCrn, baseLocation);
+    }
+}
+

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/KibanaSearchUrl.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/KibanaSearchUrl.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.time.DateUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -33,9 +34,10 @@ public class KibanaSearchUrl implements SearchUrl {
         if (testStartDate == null || testStopDate == null) {
             throw new IllegalArgumentException("Dates must be filled");
         }
+
         this.searchables = searchables;
-        this.testStartDate = testStartDate;
-        this.testStopDate = testStopDate;
+        this.testStartDate = DateUtils.addHours(testStartDate, -2);
+        this.testStopDate = DateUtils.addHours(testStopDate, -2);
     }
 
     @Override
@@ -54,15 +56,15 @@ public class KibanaSearchUrl implements SearchUrl {
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.S'Z'");
         String end = formatter.format(testStopDate);
         String start = formatter.format(testStartDate);
-        return String.format("(refreshInterval:(display:Off,pause:!f,value:0),time:(from:'%s',mode:absolute,to:'%s'))", start, end);
+        return String.format("(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'%s',to:'%s'))", start, end);
     }
 
     private String getAppState() {
-        return String.format("(columns:!('@message','@app'," + KEY + "),filters:!(%s('$state':(store:appState),"
-                        + "meta:(alias:!n,disabled:!f,index:'logstash-*',key:" + KEY + ",negate:!f,params:!(%s),"
+        return String.format("(columns:!('@message','@app'," + KEY + "),filters:!(('$state':(store:appState),"
+                        + "meta:(alias:!n,disabled:!f,index:'0ec45520-98e6-11eb-85ad-c5cb99d34f92',key:" + KEY + ",negate:!f,params:!(%s),"
                         + "type:phrases,value:'%s'),query:(bool:(minimum_should_match:1,should:!(%s"
-                        + "))))),index:'logstash-*',interval:auto,query:(match_all:()),sort:!('@timestamp',desc))",
-                getEnvironmentQuery(), getResourceList(), getResourceList(), getResourceQueries());
+                        + "))))),index:'0ec45520-98e6-11eb-85ad-c5cb99d34f92',interval:auto,query:(language:kuery,query:''),sort:!('@timestamp',desc))",
+                getResourceList(), getResourceList(), getResourceQueries());
 
     }
 
@@ -70,19 +72,6 @@ public class KibanaSearchUrl implements SearchUrl {
         List<String> list = searchables.stream().map(Searchable::getSearchId).collect(Collectors.toList());
 
         return String.join(",", list);
-    }
-
-    private String getEnvironmentQuery() {
-        String envQuery = "";
-        String env = kibanaProps.getApp();
-
-        if (env == null || !"".equals(env)) {
-            envQuery = String.format("('$state':(store:appState),meta:"
-                    + "(alias:!n,disabled:!f,index:'logstash-*',key:'@app',negate:!f,type:phrase,value:%s),"
-                    + "query:(match:('@app':(query:%s,type:phrase)))),", env, env);
-        }
-
-        return envQuery;
     }
 
     private String getResourceQueries() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/StorageUrl.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/StorageUrl.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.it.cloudbreak.search;
+
+import com.sequenceiq.it.cloudbreak.cloud.v4.CloudProviderProxy;
+
+public interface StorageUrl {
+    String getFreeIpaStorageUrl(String resourceName, String resourceCrn, String baseLocation, CloudProviderProxy cloudProvider);
+
+    String getDatalakeStorageUrl(String resourceName, String resourceCrn, String baseLocation, CloudProviderProxy cloudProvider);
+
+    String getDataHubStorageUrl(String resourceName, String resourceCrn, String baseLocation, CloudProviderProxy cloudProvider);
+}
+

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/CloudFunctionality.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+
 public interface CloudFunctionality {
 
     int MAX_DELAY = 5000;
@@ -84,5 +86,29 @@ public interface CloudFunctionality {
 
     default String transformTagKeyOrValue(String originalValue) {
         return originalValue;
+    }
+
+    @Retryable(
+            maxAttempts = ATTEMPTS,
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
+    )
+    default String getFreeIpaLogsUrl(String clusterName, String crn, String baseLocation) {
+        return "/cluster-logs/freeipa/" + clusterName + "_" + Crn.fromString(crn).getResource();
+    }
+
+    @Retryable(
+            maxAttempts = ATTEMPTS,
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
+    )
+    default String getDataLakeLogsUrl(String clusterName, String crn, String baseLocation) {
+        return "/cluster-logs/datalake/" + clusterName + "_" + Crn.fromString(crn).getResource();
+    }
+
+    @Retryable(
+            maxAttempts = ATTEMPTS,
+            backoff = @Backoff(delay = DELAY, multiplier = MULTIPLIER, maxDelay = MAX_DELAY)
+    )
+    default String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
+        return "/cluster-logs/datahub/" + clusterName + "_" + Crn.fromString(crn).getResource();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/AwsCloudFunctionality.java
@@ -78,4 +78,19 @@ public class AwsCloudFunctionality implements CloudFunctionality {
     public Map<String, String> getInstanceSubnetMap(List<String> instanceIds) {
         return amazonEC2Util.instanceSubnet(instanceIds);
     }
+
+    @Override
+    public String getFreeIpaLogsUrl(String clusterName, String crn, String baseLocation) {
+        return amazonS3Util.getFreeIpaLogsUrl(clusterName, crn, baseLocation);
+    }
+
+    @Override
+    public String getDataLakeLogsUrl(String clusterName, String crn, String baseLocation) {
+        return amazonS3Util.getDataLakeLogsUrl(clusterName, crn, baseLocation);
+    }
+
+    @Override
+    public String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
+        return amazonS3Util.getDataHubLogsUrl(clusterName, crn, baseLocation);
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/AmazonS3Util.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/AmazonS3Util.java
@@ -4,6 +4,7 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.it.cloudbreak.util.aws.amazons3.action.S3ClientActions;
 
 @Component
@@ -28,6 +29,19 @@ public class AmazonS3Util {
     }
 
     public void listDataLakeObject(String baseLocation) {
-        s3ClientActions.listBucketSelectedObject(baseLocation, "cluster-logs/datalake", false);
+        s3ClientActions.listBucketSelectedObject(baseLocation, "cluster-logs/datalake",
+                false);
+    }
+
+    public String getFreeIpaLogsUrl(String clusterName, String crn, String baseLocation) {
+        return s3ClientActions.getLoggingUrl(baseLocation, "/cluster-logs/freeipa/" + clusterName + "_" + Crn.fromString(crn).getResource());
+    }
+
+    public String getDataLakeLogsUrl(String clusterName, String crn, String baseLocation) {
+        return s3ClientActions.getLoggingUrl(baseLocation, "/cluster-logs/datalake/" + clusterName + "_" + Crn.fromString(crn).getResource());
+    }
+
+    public String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
+        return s3ClientActions.getLoggingUrl(baseLocation, "/cluster-logs/datahub/" + clusterName + "_" + Crn.fromString(crn).getResource());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/client/S3Client.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/aws/amazons3/client/S3Client.java
@@ -16,6 +16,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.sequenceiq.common.model.FileSystemType;
+import com.sequenceiq.it.cloudbreak.cloud.v4.aws.AwsCloudProvider;
 import com.sequenceiq.it.cloudbreak.cloud.v4.aws.AwsProperties;
 
 @Service
@@ -24,6 +25,9 @@ public class S3Client {
 
     @Inject
     private AwsProperties awsProperties;
+
+    @Inject
+    private AwsCloudProvider awsCloudProvider;
 
     public S3Client() {
     }
@@ -67,7 +71,7 @@ public class S3Client {
         }
     }
 
-    public String getEUWestS3Uri() {
+    public String getBaseLocationUri() {
         return String.join(".", "http://" + getBucketName(), "s3", awsProperties.getRegion(), "amazonaws.com");
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/AzureCloudFunctionality.java
@@ -76,4 +76,19 @@ public class AzureCloudFunctionality implements CloudFunctionality {
         //TODO
         return null;
     }
+
+    @Override
+    public String getFreeIpaLogsUrl(String clusterName, String crn, String baseLocation) {
+        return azureCloudBlobUtil.getFreeIpaLogsUrl(clusterName, crn, baseLocation);
+    }
+
+    @Override
+    public String getDataLakeLogsUrl(String clusterName, String crn, String baseLocation) {
+        return azureCloudBlobUtil.getDataLakeLogsUrl(clusterName, crn, baseLocation);
+    }
+
+    @Override
+    public String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
+        return azureCloudBlobUtil.getDataHubLogsUrl(clusterName, crn, baseLocation);
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/AzureCloudBlobUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/AzureCloudBlobUtil.java
@@ -54,4 +54,17 @@ public class AzureCloudBlobUtil {
         azureCloudBlobClientActions.listSelectedDirectory(baseLocation,
                 "cluster-logs/freeipa/" + clusterName + "_" + Crn.fromString(crn).getResource(), false);
     }
+
+    public String getFreeIpaLogsUrl(String clusterName, String crn, String baseLocation) {
+        return azureCloudBlobClientActions.getLoggingUrl(baseLocation, "/cluster-logs/freeipa/" + clusterName + "_" + Crn.fromString(crn).getResource());
+    }
+
+    public String getDataLakeLogsUrl(String clusterName, String crn, String baseLocation) {
+        return azureCloudBlobClientActions.getLoggingUrl(baseLocation, "/cluster-logs/datalake/" + clusterName + "_" + Crn.fromString(crn).getResource());
+    }
+
+    public String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
+        return azureCloudBlobClientActions.getLoggingUrl(baseLocation, "/cluster-logs/datahub/" + clusterName + "_" + Crn.fromString(crn).getResource());
+    }
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurecloudblob/action/AzureCloudBlobClientActions.java
@@ -358,4 +358,28 @@ public class AzureCloudBlobClientActions extends AzureCloudBlobClient {
             throw new TestFailException("Azure Adls Gen 2 Blob couldn't process the call.", e);
         }
     }
+
+    public String getLoggingUrl(String baseLocation, String clusterLogPath) {
+        String containerName = getContainerName(baseLocation);
+        CloudBlobContainer cloudBlobContainer = getCloudBlobContainer(containerName);
+
+        Log.log(LOGGER, format(" Azure Blob Storage URI: %s", cloudBlobContainer.getStorageUri()));
+        Log.log(LOGGER, format(" Azure Blob Container: %s", cloudBlobContainer.getName()));
+        Log.log(LOGGER, format(" Azure Blob Cluster Logs: %s", clusterLogPath));
+
+        try {
+            CloudBlobDirectory logsDirectory = cloudBlobContainer.getDirectoryReference(clusterLogPath);
+            if (logsDirectory.listBlobs().iterator().hasNext()) {
+                return String.format("https://autotestingapi.blob.core.windows.net/%s%s",
+                        containerName, clusterLogPath);
+            } else {
+                LOGGER.error("Azure Adls Gen 2 Blob is NOT present with name: {}", containerName);
+                throw new TestFailException("Azure Adls Gen 2 Blob is NOT present with name: " + containerName);
+            }
+        } catch (StorageException | URISyntaxException e) {
+            LOGGER.error("Azure Adls Gen 2 Blob couldn't process the call. So it has been returned with error!", e);
+            throw new TestFailException("Azure Adls Gen 2 Blob couldn't process the call.", e);
+        }
+    }
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpCloudFunctionality.java
@@ -86,4 +86,19 @@ public class GcpCloudFunctionality implements CloudFunctionality {
     public String transformTagKeyOrValue(String originalValue) {
         return gcpLabelUtil.transformLabelKeyOrValue(originalValue);
     }
+
+    @Override
+    public String getFreeIpaLogsUrl(String clusterName, String crn, String baseLocation) {
+        return gcpUtil.getFreeIpaLogsUrl(clusterName, crn, baseLocation);
+    }
+
+    @Override
+    public String getDataLakeLogsUrl(String clusterName, String crn, String baseLocation) {
+        return gcpUtil.getDataLakeLogsUrl(clusterName, crn, baseLocation);
+    }
+
+    @Override
+    public String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
+        return gcpUtil.getDataHubLogsUrl(clusterName, crn, baseLocation);
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/gcp/GcpUtil.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.it.cloudbreak.util.gcp;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 
@@ -11,8 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
-import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.util.gcp.action.GcpClientActions;
 
 @Component
@@ -67,12 +65,18 @@ public class GcpUtil {
     }
 
     private void listSelectedObject(String baseLocation, boolean zeroContent) {
-        try {
-            URI baseLocationUri = new URI(baseLocation);
-            gcpClientActions.listBucketSelectedObject(baseLocationUri, zeroContent);
-        } catch (URISyntaxException e) {
-            LOGGER.error("Google GCS base location path: '{}' is not a valid URI!", baseLocation);
-            throw new TestFailException(String.format(" Google GCS base location path: '%s' is not a valid URI! ", baseLocation));
-        }
+        gcpClientActions.listBucketSelectedObject(baseLocation, zeroContent);
+    }
+
+    public String getFreeIpaLogsUrl(String clusterName, String crn, String baseLocation) {
+        return gcpClientActions.getLoggingUrl(baseLocation, "/cluster-logs/freeipa/" + clusterName + "_" + Crn.fromString(crn).getResource());
+    }
+
+    public String getDataLakeLogsUrl(String clusterName, String crn, String baseLocation) {
+        return gcpClientActions.getLoggingUrl(baseLocation, "/cluster-logs/datalake/" + clusterName + "_" + Crn.fromString(crn).getResource());
+    }
+
+    public String getDataHubLogsUrl(String clusterName, String crn, String baseLocation) {
+        return gcpClientActions.getLoggingUrl(baseLocation, "/cluster-logs/datahub/" + clusterName + "_" + Crn.fromString(crn).getResource());
     }
 }

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -280,7 +280,7 @@ integrationtest:
   defaultBlueprintName:
 
   kibana:
-    url: https://logs-dev.sre.cloudera.com/app/kibana#/discover
+    url: https://logs-dev-7x.sre.cloudera.com/_plugin/kibana/app/discover#/
     cluster:
     app:
 

--- a/integration-test/src/main/resources/org/uncommons/reportng/templates/html/custom.class-results.html.vm
+++ b/integration-test/src/main/resources/org/uncommons/reportng/templates/html/custom.class-results.html.vm
@@ -8,17 +8,45 @@
   <td class="method">
     #set ($testInstanceName = "")
     #if ($testResult.testName)
-      #set ($testInstanceName = " ($testResult.testName)")
+        #set ($testName = $testResult.testName)
+        #if ($testName.matches("^.*(_test).*"))
+            #set ($testName = $testResult.testName.split("_").get(1))
+        #end
+        #set ($testInstanceName = " ($testName)")
+    #end
+    #set ($name = $testResult.name)
+    #if ($name.matches("^.*(_test).*"))
+        #set ($name = $testResult.name.split("_").get(1))
     #end
     #if ($testResult.method.description && $testResult.method.description.length() > 0)
-      <span class="description" title="$testResult.method.description">$testResult.name$testInstanceName</span>
+      <span class="description" title="$testResult.method.description">$name$testInstanceName</span>
     #else
-      $testResult.name$testInstanceName
+      $name$testInstanceName
     #end
     #set ($searchUrlIndexPostFix = "searchUrl")
-    #set ($searchUrl = $testResult.testContext.getAttribute("$testResult.name$testInstanceName$searchUrlIndexPostFix"))
+    #set ($searchUrl = $testResult.testContext.getAttribute("$name$testInstanceName$searchUrlIndexPostFix"))
     #if ( $searchUrl )
-    &#183; <a href=$searchUrl target="_blank">Search in logs</a>
+        <br />
+        &#183; <a href=$searchUrl target="_blank">Search in logs</a>
+        <br />
+    #end
+    #set ($freeipaStorageUrlIndexPostFix = "freeipaStorageUrl")
+    #set ($freeipaStorageUrl = $testResult.testContext.getAttribute("$name$testInstanceName$freeipaStorageUrlIndexPostFix"))
+    #if ( $freeipaStorageUrl )
+        &#183; <a href=$freeipaStorageUrl target="_blank">FreeIpa Cluster Logs</a>
+        <br />
+    #end
+    #set ($datalakeStorageUrlIndexPostFix = "datalakeStorageUrl")
+    #set ($datalakeStorageUrl = $testResult.testContext.getAttribute("$name$testInstanceName$datalakeStorageUrlIndexPostFix"))
+    #if ( $datalakeStorageUrl )
+        &#183; <a href=$datalakeStorageUrl target="_blank">Datalake Cluster Logs</a>
+        <br />
+    #end
+    #set ($datahubStorageUrlIndexPostFix = "datahubStorageUrl")
+    #set ($datahubStorageUrl = $testResult.testContext.getAttribute("$name$testInstanceName$datahubStorageUrlIndexPostFix"))
+    #if ( $datahubStorageUrl )
+        &#183; <a href=$datahubStorageUrl target="_blank">Datahub Cluster Logs</a>
+        <br />
     #end
   </td>
   <td class="duration">

--- a/integration-test/src/main/resources/org/uncommons/reportng/templates/html/integration-test.class-results.html.vm
+++ b/integration-test/src/main/resources/org/uncommons/reportng/templates/html/integration-test.class-results.html.vm
@@ -8,17 +8,45 @@
   <td class="method">
     #set ($testInstanceName = "")
     #if ($testResult.testName)
-      #set ($testInstanceName = " ($testResult.testName)")
+        #set ($testName = $testResult.testName)
+        #if ($testName.matches("^.*(_test).*"))
+            #set ($testName = $testResult.testName.split("_").get(1))
+        #end
+        #set ($testInstanceName = " ($testName)")
+    #end
+    #set ($name = $testResult.name)
+    #if ($name.matches("^.*(_test).*"))
+        #set ($name = $testResult.name.split("_").get(1))
     #end
     #if ($testResult.method.description && $testResult.method.description.length() > 0)
-      <span class="description" title="$testResult.method.description">$testResult.name$testInstanceName</span>
+      <span class="description" title="$testResult.method.description">$name$testInstanceName</span>
     #else
-      $testResult.name$testInstanceName
+      $name$testInstanceName
     #end
     #set ($logSearchUrlIndexPostFix = "logSearchUrl")
-    #set ($logSearchUrl = $testResult.testContext.getAttribute("$testResult.name$testInstanceName$logSearchUrlIndexPostFix"))
+    #set ($logSearchUrl = $testResult.testContext.getAttribute("$name$testInstanceName$logSearchUrlIndexPostFix"))
     #if ( $logSearchUrl )
-    &#183; <a href=$logSearchUrl target="_blank">LogSearch</a>
+        <br />
+        &#183; <a href=$logSearchUrl target="_blank">LogSearch</a>
+        <br />
+    #end
+    #set ($freeipaStorageUrlIndexPostFix = "freeipaStorageUrl")
+    #set ($freeipaStorageUrl = $testResult.testContext.getAttribute("$name$testInstanceName$freeipaStorageUrlIndexPostFix"))
+    #if ( $freeipaStorageUrl )
+        &#183; <a href=$freeipaStorageUrl target="_blank">FreeIpaClusterLogs</a>
+        <br />
+    #end
+    #set ($datalakeStorageUrlIndexPostFix = "datalakeStorageUrl")
+    #set ($datalakeStorageUrl = $testResult.testContext.getAttribute("$name$testInstanceName$datalakeStorageUrlIndexPostFix"))
+    #if ( $datalakeStorageUrl )
+        &#183; <a href=$datalakeStorageUrl target="_blank">DatalakeClusterLogs</a>
+        <br />
+    #end
+    #set ($datahubStorageUrlIndexPostFix = "datahubStorageUrl")
+    #set ($datahubStorageUrl = $testResult.testContext.getAttribute("$name$testInstanceName$datahubStorageUrlIndexPostFix"))
+    #if ( $datahubStorageUrl )
+        &#183; <a href=$datahubStorageUrl target="_blank">DatahubClusterLogs</a>
+        <br />
     #end
   </td>
   <td class="duration">


### PR DESCRIPTION
For easier navigation (find the related cluster logs) we need to introduce direct links to the cluster logs (freeipa, datalake, datahub) on the ReportNG Report test case result index page similarly as we have for Kibana logs.

Beyond this I've upgraded Kibana logs URL generation to the new SRE Kibana.