### PR TITLE
CB-13610 Optimize time monitor

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/MonitorUpdateRate.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/MonitorUpdateRate.java
@@ -20,7 +20,7 @@ public final class MonitorUpdateRate {
     /**
      * Time update rate in ms, aligned to the cron expression.
      */
-    public static final long CRON_UPDATE_RATE_IN_MILLIS = 10_000L;
+    public static final long CRON_UPDATE_RATE_IN_MILLIS = 30_000L;
 
     /**
      * Every 10 seconds.


### PR DESCRIPTION
Currently Time-monitor is scheduled to run every 10 seconds which causes considerable load on the autoscaling service. The time precision of 10 seconds is very low considering the distributed nature of CDP  where in scale-up/scale-down takes place in minutes.

Also  this low value results in high probability of fire-ready trigger missing the trigger window (which will also be only 10 seconds) in case of server slowness and would cause missed schedules and customer escalations.

Hence Time-monitor rate is increased to 30 seconds.

See detailed description in the commit message.