### PR TITLE
CB-7554 Disallow 5 Part Cron Expression

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/DateService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/DateService.java
@@ -21,12 +21,6 @@ import com.sequenceiq.periscope.utils.TimeUtil;
 @Service
 public final class DateService {
 
-    public static final int DAY_OF_WEEK_FIELD = 5;
-
-    public static final int MINIMAL_CRON_SEGMENT_LENGTH = 6;
-
-    public static final int MINIMAL_USER_DEFINED_CRON_SEGMENT_LENGTH = 3;
-
     private static final Logger LOGGER = LoggerFactory.getLogger(DateService.class);
 
     @Inject
@@ -60,12 +54,6 @@ public final class DateService {
     }
 
     public CronSequenceGenerator getCronExpression(String cron) throws ParseException {
-        String[] splits = cron.split("\\s+");
-        if (splits.length < MINIMAL_CRON_SEGMENT_LENGTH && splits.length > MINIMAL_USER_DEFINED_CRON_SEGMENT_LENGTH) {
-            for (int i = splits.length; i < MINIMAL_CRON_SEGMENT_LENGTH; i++) {
-                cron = i == DAY_OF_WEEK_FIELD ? String.format("%s ?", cron) : String.format("%s *", cron);
-            }
-        }
         try {
             return new CronSequenceGenerator(cron);
         } catch (Exception ex) {

--- a/autoscale/src/test/java/com/sequenceiq/periscope/controller/validation/AlertValidatorTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/controller/validation/AlertValidatorTest.java
@@ -136,7 +136,7 @@ public class AlertValidatorTest {
         request.setCron("2 22 22243 333");
 
         expectedException.expect(BadRequestException.class);
-        expectedException.expectMessage("Range exceeds maximum");
+        expectedException.expectMessage("Cron expression must consist of 6 fields (found 4 in \"2 22 22243 333\")");
 
         underTest.validateSchedule(request);
     }

--- a/autoscale/src/test/java/com/sequenceiq/periscope/utils/CronTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/utils/CronTest.java
@@ -45,13 +45,13 @@ public class CronTest {
     @Parameters(name = "{index}: cronExpressionTest({0})={1}")
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][] {
-                { "* * * * *",              "* * * * * ?",              null },
+                { "* * * * * ?",              "* * * * * ?",            null },
                 { "00 59 23 31 DEC Fri",    "00 59 23 31 DEC Fri",      null },
                 { "00 45 17 7 6 *",         "00 45 17 7 6 *",           null },
                 { "* * * 1,3,5,7,9,11 * *", "* * * 1,3,5,7,9,11 * *",   null },
                 { "0 9 1-7 * 1 *",          "0 9 1-7 * 1 *",            null },
                 { "0 0 1 * * *",            "0 0 1 * * *",              null },
-                { "* 0-11 * * *",           "* 0-11 * * * ?",           null },
+                { "* 0-11 * * * ?",           "* 0-11 * * * ?",         null },
                 { "* * * 1,2,3 * *",        "* * * 1,2,3 * *",          null },
                 { "0 0 * * * *",            "0 0 * * * *",              null },
                 { "0 0 * * 3 *",            "0 0 * * 3 *",              null },
@@ -65,8 +65,8 @@ public class CronTest {
                 { "* * * 1,2,3 * *",        "* * * 1,2,3 * *",          null },
                 { "0 0 * * * *",            "0 0 * * * *",              null },
                 { "0 0 * * 3 *",            "0 0 * * 3 *",              null },
-                { "0 8 * * 5",              "0 8 * * 5 ?",              null },
-                { "0 8 * *",                "0 8 * * * ?",                null },
+                { "0 8 * * 5 ?",            "0 8 * * 5 ?",              null },
+                { "0 8 * * * ?",            "0 8 * * * ?",              null },
                 { "* * * Jan,Feb,Mar * *",                  null, ParseException.class },
                 { "0,15,30,45 0,6,12,18 1,15,31 * * *",     null, ParseException.class },
                 { "1,2,3,5,20-25,30-35,59 23 31 12 * *",    null, ParseException.class },


### PR DESCRIPTION
Cron Expression accepted for schedule based autoscaling should be of minimum 6 parts.
Current mechanism of autogenerating  certain parts results in user confusion and also deviates from UI input for the same which mandatorily requires minimum 6 parts.

See detailed description in the commit message.