### PR TITLE
CB-13508 Early populate subnet, AZ & rackId in `InstanceMetaData` (core)

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -150,7 +150,7 @@ dependencyManagement {
     dependency group: 'com.thoughtworks.xstream',           name: 'xstream',                     version: xStream
     dependency group: 'com.github.fommil',                  name: 'openssh',                     version: '1.0'
 
-    dependency (group: 'io.swagger',                         name: 'swagger-jersey2-jaxrs',       version: swaggerVersion) {
+    dependency (group: 'io.swagger',                        name: 'swagger-jersey2-jaxrs',       version: swaggerVersion) {
       exclude 'org.yaml:snakeyaml'
     }
     dependency group: 'javax.mail',                         name: 'mail',                        version: '1.5.0-b01'
@@ -176,7 +176,7 @@ dependencyManagement {
 dependencies {
   compile group: 'com.squareup.okhttp3',               name: 'okhttp',                     version: okhttpVersion
   compile group: 'com.google.code.gson',               name: 'gson'
-  compile group: 'com.fasterxml.jackson.core',    name: 'jackson-databind'
+  compile group: 'com.fasterxml.jackson.core',         name: 'jackson-databind'
 
   compile group: 'org.springframework.boot',           name: 'spring-boot-starter'
   compile group: 'org.springframework.boot',           name: 'spring-boot-starter-web'
@@ -273,16 +273,17 @@ dependencies {
   runtime project(':cluster-cm')
   runtime project(':auth-connector')
   runtime project(':audit-connector')
-  runtime group: 'activation',                    name: 'activation'
+  runtime group: 'activation',                   name: 'activation'
 
   testCompile project(path: ':core-model', configuration: 'tests')
   testCompile project(path: ':cloud-common', configuration: 'tests')
   testCompile project(path: ':common', configuration: 'tests')
   testCompile project(path: ':authorization-common', configuration: 'tests')
+  testCompile project(path: ':flow', configuration: 'tests')
 
   testCompile group: 'org.powermock',            name: 'powermock-module-junit4'
   testCompile group: 'org.powermock',            name: 'powermock-api-mockito2'
-  testCompile (group: 'org.mockito',              name: 'mockito-core') {
+  testCompile (group: 'org.mockito',             name: 'mockito-core') {
     exclude group: 'org.hamcrest'
   }
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/StackCreatorService.java
@@ -30,6 +30,8 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.sequenceiq.authorization.service.OwnerAssignmentService;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
@@ -46,6 +48,7 @@ import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.hue.HueRoles;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
+import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
@@ -60,6 +63,7 @@ import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.IdBroker;
@@ -350,7 +354,7 @@ public class StackCreatorService {
     private void throwBadRequestIfHaveMissingRecipe(final Set<String> missingRecipes, final String instanceGroupName) {
         if (!missingRecipes.isEmpty()) {
             if (missingRecipes.size() > 1) {
-                throw new BadRequestException(String.format("The given recipes does not exists for the instance group \"%s\": %s",
+                throw new BadRequestException(String.format("The given recipes do not exist for the instance group \"%s\": %s",
                         instanceGroupName, String.join(", ", missingRecipes)));
             } else {
                 throw new BadRequestException(String.format("The given recipe does not exist for the instance group \"%s\": %s",
@@ -367,16 +371,38 @@ public class StackCreatorService {
         }
     }
 
+    @VisibleForTesting
     void fillInstanceMetadata(DetailedEnvironmentResponse environment, Stack stack) {
         long privateIdNumber = 0;
+        Map<String, String> subnetAzPairs = multiAzCalculatorService.prepareSubnetAzMap(environment);
+        String stackSubnetId = getStackSubnetIdIfExists(stack);
+        String stackAz = stackSubnetId == null ? null : subnetAzPairs.get(stackSubnetId);
         for (InstanceGroup instanceGroup : sortInstanceGroups(stack)) {
             for (InstanceMetaData instanceMetaData : instanceGroup.getAllInstanceMetaData()) {
                 instanceMetaData.setPrivateId(privateIdNumber++);
                 instanceMetaData.setInstanceStatus(InstanceStatus.REQUESTED);
             }
-            multiAzCalculatorService.calculateByRoundRobin(
-                    multiAzCalculatorService.prepareSubnetAzMap(environment),
-                    instanceGroup);
+            multiAzCalculatorService.calculateByRoundRobin(subnetAzPairs, instanceGroup);
+            prepareInstanceMetaDataSubnetAndAvailabilityZoneAndRackId(stackSubnetId, stackAz, instanceGroup);
+        }
+    }
+
+    private String getStackSubnetIdIfExists(Stack stack) {
+        return Optional.ofNullable(stack.getNetwork())
+                .map(Network::getAttributes)
+                .map(Json::getMap)
+                .map(attr -> attr.get("subnetId"))
+                .map(Object::toString)
+                .orElse(null);
+    }
+
+    private void prepareInstanceMetaDataSubnetAndAvailabilityZoneAndRackId(String stackSubnetId, String stackAz, InstanceGroup instanceGroup) {
+        for (InstanceMetaData instanceMetaData : instanceGroup.getAllInstanceMetaData()) {
+            if (Strings.isNullOrEmpty(instanceMetaData.getSubnetId()) && Strings.isNullOrEmpty(instanceMetaData.getAvailabilityZone())) {
+                instanceMetaData.setSubnetId(stackSubnetId);
+                instanceMetaData.setAvailabilityZone(stackAz);
+            }
+            instanceMetaData.setRackId(multiAzCalculatorService.determineRackId(instanceMetaData.getSubnetId(), instanceMetaData.getAvailabilityZone()));
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackScaleV4RequestToUpdateStackV4RequestConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackScaleV4RequestToUpdateStackV4RequestConverter.java
@@ -15,7 +15,7 @@ import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
 
 @Component
-public class UpdateStackRequestV2ToUpdateStackRequestConverter extends AbstractConversionServiceAwareConverter<StackScaleV4Request, UpdateStackV4Request> {
+public class StackScaleV4RequestToUpdateStackV4RequestConverter extends AbstractConversionServiceAwareConverter<StackScaleV4Request, UpdateStackV4Request> {
 
     @Inject
     private InstanceGroupService instanceGroupService;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/ClusterRepairFlowEventChainFactory.java
@@ -129,14 +129,14 @@ public class ClusterRepairFlowEventChainFactory implements FlowEventChainFactory
     }
 
     private StackDownscaleTriggerEvent stackDownscaleEvent(ClusterRepairTriggerEvent event, String groupName, List<String> hostNames) {
-        Set<InstanceMetaData> instanceMetaData = instanceMetaDataService.getAllInstanceMetadataWithoutInstaceGroupByStackId(event.getStackId());
+        Set<InstanceMetaData> instanceMetaData = instanceMetaDataService.getAllInstanceMetadataWithoutInstanceGroupByStackId(event.getStackId());
         Set<Long> privateIdsForHostNames = stackService.getPrivateIdsForHostNames(instanceMetaData, new HashSet<>(hostNames));
         return new StackDownscaleTriggerEvent(STACK_DOWNSCALE_EVENT.event(), event.getResourceId(), groupName, privateIdsForHostNames, event.accepted())
                 .setRepair();
     }
 
     private ClusterAndStackDownscaleTriggerEvent fullDownscaleEvent(ClusterRepairTriggerEvent event, String hostGroupName, List<String> hostNames) {
-        Set<InstanceMetaData> instanceMetaData = instanceMetaDataService.getAllInstanceMetadataWithoutInstaceGroupByStackId(event.getStackId());
+        Set<InstanceMetaData> instanceMetaData = instanceMetaDataService.getAllInstanceMetadataWithoutInstanceGroupByStackId(event.getStackId());
         Set<Long> privateIdsForHostNames = stackService.getPrivateIdsForHostNames(instanceMetaData, hostNames);
         return new ClusterAndStackDownscaleTriggerEvent(FlowChainTriggers.FULL_DOWNSCALE_TRIGGER_EVENT, event.getResourceId(),
                 hostGroupName, Sets.newHashSet(privateIdsForHostNames), ScalingType.DOWNSCALE_TOGETHER, event.accepted(),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/DownscaleFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/DownscaleFlowEventChainFactory.java
@@ -43,8 +43,7 @@ public class DownscaleFlowEventChainFactory implements FlowEventChainFactory<Clu
     @Override
     public FlowTriggerEventQueue createFlowTriggerEventQueue(ClusterAndStackDownscaleTriggerEvent event) {
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
-        ClusterScaleTriggerEvent cste;
-        cste = event.getPrivateIds() == null
+        ClusterScaleTriggerEvent cste = event.getPrivateIds() == null
                 ? new ClusterDownscaleTriggerEvent(DECOMMISSION_EVENT.event(), event.getResourceId(), event.getHostGroupName(), event.getAdjustment(),
                 event.accepted(), event.getDetails())
                 : new ClusterDownscaleTriggerEvent(DECOMMISSION_EVENT.event(), event.getResourceId(), event.getHostGroupName(), event.getPrivateIds(),
@@ -55,8 +54,7 @@ public class DownscaleFlowEventChainFactory implements FlowEventChainFactory<Clu
             HostGroup hostGroup = hostGroupService.findHostGroupInClusterByName(stackView.getClusterView().getId(), event.getHostGroupName())
                     .orElseThrow(NotFoundException.notFound("hostgroup", event.getHostGroupName()));
             String instanceGroupName = Optional.ofNullable(hostGroup.getInstanceGroup()).map(InstanceGroup::getGroupName).orElse(null);
-            StackScaleTriggerEvent sste;
-            sste = event.getPrivateIds() == null
+            StackScaleTriggerEvent sste = event.getPrivateIds() == null
                     ? new StackDownscaleTriggerEvent(STACK_DOWNSCALE_EVENT.event(), event.getResourceId(), instanceGroupName, event.getAdjustment())
                     : new StackDownscaleTriggerEvent(STACK_DOWNSCALE_EVENT.event(), event.getResourceId(), instanceGroupName, event.getPrivateIds());
             if (event.getDetails() != null && event.getDetails().isRepair()) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
@@ -208,9 +208,10 @@ public class StackUpscaleService {
         Optional<InstanceGroup> extendedInstanceGroup = stack.getInstanceGroups().stream()
                 .filter(instanceGroup -> extendedInstanceGroupName.equals(instanceGroup.getGroupName()))
                 .findAny();
-        long privateId = getFirstValidPrivateId(stack.getInstanceGroupsAsList());
         List<CloudInstance> newInstances = new ArrayList<>();
         if (extendedInstanceGroup.isPresent()) {
+            long privateId = getFirstValidPrivateId(stack.getInstanceGroupsAsList());
+            DetailedEnvironmentResponse environment = getEnvironmentByEnvironmentCrn(stack.getEnvironmentCrn());
             for (long i = 0; i < count; i++) {
                 newInstances.add(cloudStackConverter.buildInstance(
                         null,
@@ -218,7 +219,7 @@ public class StackUpscaleService {
                         stack.getStackAuthentication(),
                         privateId++,
                         InstanceStatus.CREATE_REQUESTED,
-                        getEnvironmentByEnvironmentCrn(stack.getEnvironmentCrn())));
+                        environment));
             }
         }
         LOGGER.debug("New instances have been built: {}", newInstances.stream().map(CloudInstance::getInstanceId).collect(Collectors.toList()));
@@ -237,7 +238,7 @@ public class StackUpscaleService {
         return environment;
     }
 
-    private Long getFirstValidPrivateId(List<InstanceGroup> instanceGroups) {
+    private long getFirstValidPrivateId(List<InstanceGroup> instanceGroups) {
         LOGGER.debug("Get first valid PrivateId of instanceGroups");
         long id = instanceGroups.stream()
                 .flatMap(ig -> ig.getAllInstanceMetaData().stream())
@@ -249,4 +250,5 @@ public class StackUpscaleService {
         LOGGER.debug("First valid privateId: {}", id);
         return id;
     }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
@@ -2,7 +2,7 @@ package com.sequenceiq.cloudbreak.converter.v4.stacks;
 
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.MOCK;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,9 +26,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -82,6 +85,8 @@ import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvi
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.TagResponse;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<StackV4Request> {
 
     private static final String TEST_USER_CRN = "crn:cdp:iam:us-west-1:accid:user:mockuser@cloudera.com";
@@ -172,7 +177,6 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.initMocks(this);
         when(restRequestThreadLocalService.getCloudbreakUser()).thenReturn(cloudbreakUser);
         when(cloudbreakUser.getUsername()).thenReturn("username");
         when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(1L);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActionsTest.java
@@ -1,0 +1,226 @@
+package com.sequenceiq.cloudbreak.core.flow2.stack.upscale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.isNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.statemachine.action.Action;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.model.EventStatus;
+import com.sequenceiq.cloudbreak.cloud.event.resource.UpscaleStackResult;
+import com.sequenceiq.cloudbreak.cloud.event.resource.UpscaleStackValidationRequest;
+import com.sequenceiq.cloudbreak.cloud.event.resource.UpscaleStackValidationResult;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
+import com.sequenceiq.cloudbreak.converter.spi.StackToCloudStackConverter;
+import com.sequenceiq.cloudbreak.core.flow2.event.StackScaleTriggerEvent;
+import com.sequenceiq.cloudbreak.core.flow2.stack.downscale.StackScalingFlowContext;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.resource.ResourceService;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+import com.sequenceiq.flow.core.AbstractActionTestSupport;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.flow.core.FlowRegister;
+import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
+
+import reactor.bus.Event;
+import reactor.bus.EventBus;
+
+@ExtendWith(MockitoExtension.class)
+class StackUpscaleActionsTest {
+
+    private static final String INSTANCE_GROUP_NAME = "worker";
+
+    private static final int ADJUSTMENT = 3;
+
+    private static final int ADJUSTMENT_ZERO = 0;
+
+    private static final String SELECTOR = "selector";
+
+    private static final Long STACK_ID = 123L;
+
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @Mock
+    private StackScalabilityCondition stackScalabilityCondition;
+
+    @Mock
+    private StackUpscaleService stackUpscaleService;
+
+    @Mock
+    private StackToCloudStackConverter cloudStackConverter;
+
+    @Mock
+    private ResourceService resourceService;
+
+    @InjectMocks
+    private StackUpscaleActions underTest;
+
+    private StackScalingFlowContext context;
+
+    @Mock
+    private FlowParameters flowParameters;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private CloudContext cloudContext;
+
+    @Mock
+    private CloudCredential cloudCredential;
+
+    @Mock
+    private CloudStack cloudStack;
+
+    @Mock
+    private FlowRegister runningFlows;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private ErrorHandlerAwareReactorEventFactory reactorEventFactory;
+
+    @Mock
+    private Event<Object> event;
+
+    @Captor
+    private ArgumentCaptor<Object> payloadArgumentCaptor;
+
+    @Mock
+    private CloudResourceStatus cloudResourceStatus;
+
+    @Mock
+    private CloudInstance cloudInstance;
+
+    @BeforeEach
+    void setUp() {
+        context = new StackScalingFlowContext(flowParameters, stack, cloudContext, cloudCredential, cloudStack, INSTANCE_GROUP_NAME, Set.of(), ADJUSTMENT,
+                false);
+    }
+
+    private AbstractStackUpscaleAction<StackScaleTriggerEvent> getPrevalidateAction() {
+        AbstractStackUpscaleAction<StackScaleTriggerEvent> action = (AbstractStackUpscaleAction<StackScaleTriggerEvent>) underTest.prevalidate();
+        initActionPrivateFields(action);
+        return action;
+    }
+
+    private void initActionPrivateFields(Action<?, ?> action) {
+        ReflectionTestUtils.setField(action, null, runningFlows, FlowRegister.class);
+        ReflectionTestUtils.setField(action, null, eventBus, EventBus.class);
+        ReflectionTestUtils.setField(action, null, reactorEventFactory, ErrorHandlerAwareReactorEventFactory.class);
+    }
+
+    // Note: this implicitly tests getPrevalidateAction().createRequest() as well.
+    @Test
+    void prevalidateTestDoExecuteWhenScalingNeededAndAllowed() throws Exception {
+        when(cloudContext.getId()).thenReturn(STACK_ID);
+        StackScaleTriggerEvent payload = new StackScaleTriggerEvent(SELECTOR, STACK_ID, INSTANCE_GROUP_NAME, ADJUSTMENT);
+
+        when(stackScalabilityCondition.isScalable(stack, INSTANCE_GROUP_NAME)).thenReturn(true);
+
+        List<CloudInstance> newInstances = List.of(cloudInstance);
+        when(stackUpscaleService.buildNewInstances(stack, INSTANCE_GROUP_NAME, ADJUSTMENT)).thenReturn(newInstances);
+
+        Stack updatedStack = mock(Stack.class);
+        when(instanceMetaDataService.saveInstanceAndGetUpdatedStack(stack, newInstances, false, context.getHostNames())).thenReturn(updatedStack);
+
+        CloudStack convertedCloudStack = mock(CloudStack.class);
+        when(cloudStackConverter.convert(updatedStack)).thenReturn(convertedCloudStack);
+
+        when(reactorEventFactory.createEvent(anyMap(), isNotNull())).thenReturn(event);
+
+        new AbstractActionTestSupport<>(getPrevalidateAction()).doExecute(context, payload, Map.of());
+
+        verify(stackUpscaleService).addInstanceFireEventAndLog(stack, ADJUSTMENT, INSTANCE_GROUP_NAME);
+        verify(stackUpscaleService).startAddInstances(stack, ADJUSTMENT, INSTANCE_GROUP_NAME);
+
+        verify(reactorEventFactory).createEvent(anyMap(), payloadArgumentCaptor.capture());
+        verify(eventBus).notify("UPSCALESTACKVALIDATIONREQUEST", event);
+
+        Object responsePayload = payloadArgumentCaptor.getValue();
+        assertThat(responsePayload).isInstanceOf(UpscaleStackValidationRequest.class);
+
+        UpscaleStackValidationRequest<UpscaleStackValidationResult> upscaleStackValidationRequest =
+                (UpscaleStackValidationRequest<UpscaleStackValidationResult>) responsePayload;
+        assertThat(upscaleStackValidationRequest.getResourceId()).isEqualTo(STACK_ID);
+        assertThat(upscaleStackValidationRequest.getCloudContext()).isSameAs(cloudContext);
+        assertThat(upscaleStackValidationRequest.getCloudStack()).isSameAs(convertedCloudStack);
+        assertThat(upscaleStackValidationRequest.getCloudCredential()).isSameAs(cloudCredential);
+    }
+
+    @Test
+    void prevalidateTestDoExecuteWhenScalingNeededAndNotAllowed() throws Exception {
+        StackScaleTriggerEvent payload = new StackScaleTriggerEvent(SELECTOR, STACK_ID, INSTANCE_GROUP_NAME, ADJUSTMENT);
+
+        when(stackScalabilityCondition.isScalable(stack, INSTANCE_GROUP_NAME)).thenReturn(false);
+
+        List<CloudResourceStatus> resourceStatuses = List.of(cloudResourceStatus);
+        when(resourceService.getAllAsCloudResourceStatus(STACK_ID)).thenReturn(resourceStatuses);
+
+        when(reactorEventFactory.createEvent(anyMap(), isNotNull())).thenReturn(event);
+
+        new AbstractActionTestSupport<>(getPrevalidateAction()).doExecute(context, payload, Map.of());
+
+        verify(stackUpscaleService).addInstanceFireEventAndLog(stack, ADJUSTMENT, INSTANCE_GROUP_NAME);
+        verifyEventForUpscaleStackResult(resourceStatuses);
+    }
+
+    private void verifyEventForUpscaleStackResult(List<CloudResourceStatus> resourceStatuses) {
+        verify(reactorEventFactory).createEvent(anyMap(), payloadArgumentCaptor.capture());
+        verify(eventBus).notify("UPSCALESTACKRESULT", event);
+
+        Object responsePayload = payloadArgumentCaptor.getValue();
+        assertThat(responsePayload).isInstanceOf(UpscaleStackResult.class);
+
+        UpscaleStackResult upscaleStackResult = (UpscaleStackResult) responsePayload;
+        assertThat(upscaleStackResult.getResourceId()).isEqualTo(STACK_ID);
+        assertThat(upscaleStackResult.getResourceStatus()).isEqualTo(ResourceStatus.CREATED);
+        assertThat(upscaleStackResult.getResults()).isEqualTo(resourceStatuses);
+        assertThat(upscaleStackResult.getStatus()).isEqualTo(EventStatus.OK);
+        assertThat(upscaleStackResult.getStatusReason()).isNull();
+        assertThat(upscaleStackResult.getErrorDetails()).isNull();
+    }
+
+    @Test
+    void prevalidateTestDoExecuteWhenScalingNotNeeded() throws Exception {
+        context = new StackScalingFlowContext(flowParameters, stack, cloudContext, cloudCredential, cloudStack, INSTANCE_GROUP_NAME, Set.of(), ADJUSTMENT_ZERO,
+                false);
+        StackScaleTriggerEvent payload = new StackScaleTriggerEvent(SELECTOR, STACK_ID, INSTANCE_GROUP_NAME, ADJUSTMENT_ZERO);
+
+        when(stackScalabilityCondition.isScalable(stack, INSTANCE_GROUP_NAME)).thenReturn(true);
+
+        List<CloudResourceStatus> resourceStatuses = List.of(cloudResourceStatus);
+        when(resourceService.getAllAsCloudResourceStatus(STACK_ID)).thenReturn(resourceStatuses);
+
+        when(reactorEventFactory.createEvent(anyMap(), isNotNull())).thenReturn(event);
+
+        new AbstractActionTestSupport<>(getPrevalidateAction()).doExecute(context, payload, Map.of());
+
+        verify(stackUpscaleService).addInstanceFireEventAndLog(stack, ADJUSTMENT_ZERO, INSTANCE_GROUP_NAME);
+        verifyEventForUpscaleStackResult(resourceStatuses);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/multiaz/MultiAzCalculatorServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/multiaz/MultiAzCalculatorServiceTest.java
@@ -1,14 +1,20 @@
 package com.sequenceiq.cloudbreak.service.multiaz;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,7 +24,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.util.CollectionUtils;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -32,6 +41,18 @@ import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentN
 
 @ExtendWith(MockitoExtension.class)
 public class MultiAzCalculatorServiceTest {
+
+    private static final String SUBNET_ID = "SUBNET_ID";
+
+    private static final String AVAILABILITY_ZONE = "AVAILABILITY_ZONE";
+
+    private static final int SINGLE_INSTANCE = 1;
+
+    private static final int NO_SUBNETS = 0;
+
+    private static final int SINGLE_SUBNET = 1;
+
+    private static final String INSTANCE_ID = "i-123";
 
     @Mock
     private MultiAzValidator multiAzValidator;
@@ -50,12 +71,32 @@ public class MultiAzCalculatorServiceTest {
         detailedEnvironmentResponse.setNetwork(environmentNetworkResponse);
 
         Map<String, String> result = underTest.prepareSubnetAzMap(detailedEnvironmentResponse);
+
         Assertions.assertEquals(result.size(), 4);
         Assertions.assertEquals(result.get(cloudSubnetName(1)), cloudSubnetAz(1));
         Assertions.assertEquals(result.get(cloudSubnetName(2)), cloudSubnetAz(2));
     }
 
-    static Object[][] testSubnetDistributionData() {
+    static Object[][] prepareSubnetAzMapTestWhenEmptyResultDataProvider() {
+        return new Object[][]{
+                // testCaseName environment
+                {"environment=null", null},
+                {"network=null", DetailedEnvironmentResponse.builder().withNetwork(null).build()},
+                {"subnetMetas=null",
+                        DetailedEnvironmentResponse.builder().withNetwork(EnvironmentNetworkResponse.builder().withSubnetMetas(null).build()).build()},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("prepareSubnetAzMapTestWhenEmptyResultDataProvider")
+    void prepareSubnetAzMapTestWhenEmptyResult(String testCaseName, DetailedEnvironmentResponse environment) {
+        Map<String, String> result = underTest.prepareSubnetAzMap(environment);
+
+        assertThat(result).isNotNull();
+        assertThat(result).isEmpty();
+    }
+
+    static Object[][] testSubnetDistributionForWholeInstanceGroupData() {
         return new Object[][]{
                 // cloudPlatform, subnetCount, instanceCount, expectedCounts, supported
                 { CloudPlatform.AWS,    1,  99,  Arrays.asList(99L),                  true   },
@@ -70,14 +111,15 @@ public class MultiAzCalculatorServiceTest {
                 { CloudPlatform.AWS,    4,  58,  Arrays.asList(15L, 15L, 14L, 14L),   true   },
                 { CloudPlatform.AWS,    4,  57,  Arrays.asList(15L, 14L, 14L, 14L),   true   },
                 { CloudPlatform.AWS,    4,  56,  Arrays.asList(14L, 14L, 14L, 14L),   true   },
-                { CloudPlatform.YARN,   0,  99,  Arrays.asList(),                     false  },
+                { CloudPlatform.YARN,   0,  0,   Arrays.asList(),                     false  },
         };
     }
 
-    @ParameterizedTest(name = "testSubnetDistribution with {0} platform when {1} should result as {2}")
-    @MethodSource("testSubnetDistributionData")
-    public void testSubnetDistribution(CloudPlatform cloudPlatform, int subnetCount, int instanceCount,
-        List<Long> expectedCounts, boolean supported) {
+    @ParameterizedTest(name = "testSubnetDistributionForWholeInstanceGroup " +
+            "with {0} platform when {1} subnets and {2} instances should result in {3} subnet counts")
+    @MethodSource("testSubnetDistributionForWholeInstanceGroupData")
+    public void testSubnetDistributionForWholeInstanceGroup(CloudPlatform cloudPlatform, int subnetCount, int instanceCount, List<Long> expectedCounts,
+            boolean supported) {
         if (supported) {
             when(multiAzValidator.supportedForInstanceMetadataGeneration(any(InstanceGroup.class))).thenReturn(true);
         }
@@ -92,13 +134,474 @@ public class MultiAzCalculatorServiceTest {
             int finalI = i;
             actualCounts.add(instanceGroup.getAllInstanceMetaData()
                     .stream()
-                    .filter(e -> e.getSubnetId().equals(cloudSubnetName(finalI)))
+                    .filter(instance -> instance.getSubnetId().equals(cloudSubnetName(finalI)))
                     .count());
         }
         Collections.sort(expectedCounts);
         Collections.sort(actualCounts);
 
         Assertions.assertEquals(expectedCounts, actualCounts);
+    }
+
+    @ParameterizedTest(name = "testSubnetDistributionForWholeInstanceGroupWhenPrepopulatedForeignSubnetId " +
+            "with {0} platform when {1} subnets and {2} instances should result in {3} subnet counts")
+    @MethodSource("testSubnetDistributionForWholeInstanceGroupData")
+    public void testSubnetDistributionForWholeInstanceGroupWhenPrepopulatedForeignSubnetId(CloudPlatform cloudPlatform, int subnetCount, int instanceCount,
+            List<Long> expectedCounts, boolean supported) {
+        if (supported) {
+            when(multiAzValidator.supportedForInstanceMetadataGeneration(any(InstanceGroup.class))).thenReturn(true);
+        }
+
+        InstanceGroup instanceGroup = instanceGroup(cloudPlatform, instanceCount, subnetCount);
+        InstanceMetaData instanceWithPrepopulatedForeignSubnetId = instanceMetaData(instanceCount, SUBNET_ID, AVAILABILITY_ZONE, InstanceStatus.REQUESTED);
+        instanceGroup.getAllInstanceMetaData().add(instanceWithPrepopulatedForeignSubnetId);
+
+        underTest.calculateByRoundRobin(
+                subnetAzPairs(subnetCount),
+                instanceGroup);
+
+        List<Long> actualCounts = new ArrayList<>();
+        for (int i = 0; i < subnetCount; i++) {
+            int finalI = i;
+            actualCounts.add(instanceGroup.getAllInstanceMetaData()
+                    .stream()
+                    .filter(instance -> instance.getSubnetId().equals(cloudSubnetName(finalI)))
+                    .count());
+        }
+        Collections.sort(expectedCounts);
+        Collections.sort(actualCounts);
+
+        Assertions.assertEquals(expectedCounts, actualCounts);
+
+        assertThat(instanceWithPrepopulatedForeignSubnetId.getSubnetId()).isEqualTo(SUBNET_ID);
+        assertThat(instanceWithPrepopulatedForeignSubnetId.getAvailabilityZone()).isEqualTo(AVAILABILITY_ZONE);
+    }
+
+    static Object[][] testSubnetDistributionForWholeInstanceGroupWhen5InstancesWithPrepopulatedKnownSubnetIdData() {
+        return new Object[][]{
+                // cloudPlatform, subnetCount, instanceCount, expectedCounts, supported
+                { CloudPlatform.AWS,    1,  99,  Arrays.asList(104L),                 true   },
+                { CloudPlatform.AWS,    3,  99,  Arrays.asList(35L, 35L, 34L),        true   },
+                { CloudPlatform.AWS,    3,  60,  Arrays.asList(22L, 22L, 21L),        true   },
+                { CloudPlatform.AWS,    3,  59,  Arrays.asList(22L, 21L, 21L),        true   },
+                { CloudPlatform.AWS,    3,  58,  Arrays.asList(21L, 21L, 21L),        true   },
+                { CloudPlatform.AWS,    3,  57,  Arrays.asList(21L, 21L, 20L),        true   },
+                { CloudPlatform.AWS,    3,  56,  Arrays.asList(21L, 20L, 20L),        true   },
+                { CloudPlatform.AWS,    4,  60,  Arrays.asList(17L, 16L, 16L, 16L),   true   },
+                { CloudPlatform.AWS,    4,  59,  Arrays.asList(16L, 16L, 16L, 16L),   true   },
+                { CloudPlatform.AWS,    4,  58,  Arrays.asList(16L, 16L, 16L, 15L),   true   },
+                { CloudPlatform.AWS,    4,  57,  Arrays.asList(16L, 16L, 15L, 15L),   true   },
+                { CloudPlatform.AWS,    4,  56,  Arrays.asList(16L, 15L, 15L, 15L),   true   },
+                { CloudPlatform.YARN,   0,  0,   Arrays.asList(),                     false  },
+        };
+    }
+
+    @ParameterizedTest(name = "testSubnetDistributionForWholeInstanceGroupWhen5InstancesWithPrepopulatedKnownSubnetId " +
+            "with {0} platform when {1} subnets and {2} instances should result in {3} subnet counts")
+    @MethodSource("testSubnetDistributionForWholeInstanceGroupWhen5InstancesWithPrepopulatedKnownSubnetIdData")
+    public void testSubnetDistributionForWholeInstanceGroupWhen5InstancesWithPrepopulatedKnownSubnetId(CloudPlatform cloudPlatform, int subnetCount,
+            int instanceCount, List<Long> expectedCounts, boolean supported) {
+        if (supported) {
+            when(multiAzValidator.supportedForInstanceMetadataGeneration(any(InstanceGroup.class))).thenReturn(true);
+        }
+
+        InstanceGroup instanceGroup = instanceGroup(cloudPlatform, instanceCount, subnetCount);
+        Set<InstanceMetaData> extraInstancesWithPrepopulatedSubnetId = new HashSet<>();
+        String subnetIdForExtraInstances = cloudSubnetName(0);
+        String availabilityZoneForExtraInstances = cloudSubnetAz(0);
+        if (subnetCount > 0) {
+            for (int i = 0; i < 5; i++) {
+                extraInstancesWithPrepopulatedSubnetId.add(instanceMetaData(instanceCount + i, subnetIdForExtraInstances, availabilityZoneForExtraInstances,
+                        null));
+            }
+        }
+        instanceGroup.getAllInstanceMetaData().addAll(extraInstancesWithPrepopulatedSubnetId);
+
+        underTest.calculateByRoundRobin(
+                subnetAzPairs(subnetCount),
+                instanceGroup);
+
+        List<Long> actualCounts = new ArrayList<>();
+        for (int i = 0; i < subnetCount; i++) {
+            int finalI = i;
+            actualCounts.add(instanceGroup.getAllInstanceMetaData()
+                    .stream()
+                    .filter(instance -> instance.getSubnetId().equals(cloudSubnetName(finalI)))
+                    .count());
+        }
+        Collections.sort(expectedCounts);
+        Collections.sort(actualCounts);
+
+        Assertions.assertEquals(expectedCounts, actualCounts);
+
+        extraInstancesWithPrepopulatedSubnetId.forEach(instance -> {
+            assertThat(instance.getSubnetId()).isEqualTo(subnetIdForExtraInstances);
+            assertThat(instance.getAvailabilityZone()).isEqualTo(availabilityZoneForExtraInstances);
+        });
+    }
+
+    @ParameterizedTest(name = "testSubnetDistributionForWholeInstanceGroupWhenDeletedInstances " +
+            "with {0} platform when {1} subnets and {2} instances should result in {3} subnet counts")
+    @MethodSource("testSubnetDistributionForWholeInstanceGroupData")
+    public void testSubnetDistributionForWholeInstanceGroupWhenDeletedInstances(CloudPlatform cloudPlatform, int subnetCount, int instanceCount,
+            List<Long> expectedCounts, boolean supported) {
+        if (supported) {
+            when(multiAzValidator.supportedForInstanceMetadataGeneration(any(InstanceGroup.class))).thenReturn(true);
+        }
+
+        InstanceGroup instanceGroup = instanceGroup(cloudPlatform, instanceCount, subnetCount);
+        Set<InstanceMetaData> deletedInstancesWithPrepopulatedSubnetId = new HashSet<>();
+        String subnetIdForDeletedInstances = cloudSubnetName(0);
+        String availabilityZoneForDeletedInstances = cloudSubnetAz(0);
+        if (subnetCount > 0) {
+            InstanceMetaData instanceWithTerminationDate = instanceMetaData(instanceCount, subnetIdForDeletedInstances, availabilityZoneForDeletedInstances,
+                    null);
+            instanceWithTerminationDate.setTerminationDate(1234L);
+            deletedInstancesWithPrepopulatedSubnetId.add(instanceWithTerminationDate);
+            deletedInstancesWithPrepopulatedSubnetId.add(instanceMetaData(instanceCount + 1, subnetIdForDeletedInstances, availabilityZoneForDeletedInstances,
+                    InstanceStatus.TERMINATED));
+            deletedInstancesWithPrepopulatedSubnetId.add(instanceMetaData(instanceCount + 2, subnetIdForDeletedInstances, availabilityZoneForDeletedInstances,
+                    InstanceStatus.DELETED_BY_PROVIDER));
+            deletedInstancesWithPrepopulatedSubnetId.add(instanceMetaData(instanceCount + 3, subnetIdForDeletedInstances, availabilityZoneForDeletedInstances,
+                    InstanceStatus.DELETED_ON_PROVIDER_SIDE));
+        }
+        instanceGroup.getAllInstanceMetaData().addAll(deletedInstancesWithPrepopulatedSubnetId);
+
+        underTest.calculateByRoundRobin(
+                subnetAzPairs(subnetCount),
+                instanceGroup);
+
+        List<Long> actualCounts = new ArrayList<>();
+        for (int i = 0; i < subnetCount; i++) {
+            int finalI = i;
+            actualCounts.add(instanceGroup.getAllInstanceMetaData()
+                    .stream()
+                    .filter(instance -> instance.getSubnetId().equals(cloudSubnetName(finalI)))
+                    .filter(instance -> !deletedInstancesWithPrepopulatedSubnetId.contains(instance))
+                    .count());
+        }
+        Collections.sort(expectedCounts);
+        Collections.sort(actualCounts);
+
+        Assertions.assertEquals(expectedCounts, actualCounts);
+
+        deletedInstancesWithPrepopulatedSubnetId.forEach(instance -> {
+            assertThat(instance.getSubnetId()).isEqualTo(subnetIdForDeletedInstances);
+            assertThat(instance.getAvailabilityZone()).isEqualTo(availabilityZoneForDeletedInstances);
+        });
+    }
+
+    static Object[][] calculateByRoundRobinTestWhenWholeInstanceGroupAndNoSubnetIdsDataProvider() {
+        return new Object[][]{
+                // testCaseName disableNetwork disableAttributes disableSubnetIdsAttribute
+                {"instanceGroupNetwork=null", true, false, false},
+                {"attributes=null", false, true, false},
+                {"subnetIdsAttribute=null", false, false, true},
+                {"subnetIds=empty", false, false, false},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("calculateByRoundRobinTestWhenWholeInstanceGroupAndNoSubnetIdsDataProvider")
+    void calculateByRoundRobinTestWhenWholeInstanceGroupAndNoSubnetIds(String testCaseName, boolean disableNetwork, boolean disableAttributes,
+            boolean disableSubnetIdsAttribute) {
+        InstanceGroup instanceGroup = instanceGroup(CloudPlatform.AWS, SINGLE_INSTANCE, NO_SUBNETS);
+        if (disableNetwork) {
+            instanceGroup.setInstanceGroupNetwork(null);
+        } else if (disableAttributes) {
+            instanceGroup.getInstanceGroupNetwork().setAttributes(null);
+        } else if (disableSubnetIdsAttribute) {
+            instanceGroup.getInstanceGroupNetwork().setAttributes(new Json(Map.of()));
+        }
+
+        underTest.calculateByRoundRobin(
+                subnetAzPairs(NO_SUBNETS),
+                instanceGroup);
+
+        instanceGroup.getAllInstanceMetaData().forEach(instance -> {
+            assertThat(instance.getSubnetId()).isNull();
+            assertThat(instance.getAvailabilityZone()).isNull();
+        });
+    }
+
+    static Object[][] calculateByRoundRobinTestWhenCloudInstanceData() {
+        return new Object[][]{
+                // cloudPlatform, subnetCount, instanceCount, existingCounts, supported, expectedPermissibleSubnetIdIndexes
+                {CloudPlatform.YARN, 0, 0, List.of(), false, Set.of()},
+                {CloudPlatform.AWS, 1, 0, List.of(), true, Set.of(0)},
+                {CloudPlatform.AWS, 1, 1, List.of(1), true, Set.of(0)},
+                {CloudPlatform.AWS, 1, 2, List.of(2), true, Set.of(0)},
+                {CloudPlatform.AWS, 2, 0, List.of(), true, Set.of(0, 1)},
+                {CloudPlatform.AWS, 2, 1, List.of(1, 0), true, Set.of(1)},
+                {CloudPlatform.AWS, 2, 1, List.of(0, 1), true, Set.of(0)},
+                {CloudPlatform.AWS, 2, 2, List.of(2, 0), true, Set.of(1)},
+                {CloudPlatform.AWS, 2, 2, List.of(1, 1), true, Set.of(0, 1)},
+                {CloudPlatform.AWS, 2, 2, List.of(0, 2), true, Set.of(0)},
+                {CloudPlatform.AWS, 2, 3, List.of(3, 0), true, Set.of(1)},
+                {CloudPlatform.AWS, 2, 3, List.of(0, 3), true, Set.of(0)},
+                {CloudPlatform.AWS, 2, 3, List.of(2, 1), true, Set.of(1)},
+                {CloudPlatform.AWS, 2, 3, List.of(1, 2), true, Set.of(0)},
+                {CloudPlatform.AWS, 3, 0, List.of(), true, Set.of(0, 1, 2)},
+                {CloudPlatform.AWS, 3, 1, List.of(1, 0, 0), true, Set.of(1, 2)},
+                {CloudPlatform.AWS, 3, 1, List.of(0, 1, 0), true, Set.of(0, 2)},
+                {CloudPlatform.AWS, 3, 1, List.of(0, 0, 1), true, Set.of(0, 1)},
+                {CloudPlatform.AWS, 3, 2, List.of(2, 0, 0), true, Set.of(1, 2)},
+                {CloudPlatform.AWS, 3, 2, List.of(0, 2, 0), true, Set.of(0, 2)},
+                {CloudPlatform.AWS, 3, 2, List.of(0, 0, 2), true, Set.of(0, 1)},
+                {CloudPlatform.AWS, 3, 2, List.of(1, 1, 0), true, Set.of(2)},
+                {CloudPlatform.AWS, 3, 2, List.of(0, 1, 1), true, Set.of(0)},
+                {CloudPlatform.AWS, 3, 2, List.of(1, 0, 1), true, Set.of(1)},
+                {CloudPlatform.AWS, 3, 3, List.of(3, 0, 0), true, Set.of(1, 2)},
+                {CloudPlatform.AWS, 3, 3, List.of(0, 3, 0), true, Set.of(0, 2)},
+                {CloudPlatform.AWS, 3, 3, List.of(0, 0, 3), true, Set.of(0, 1)},
+                {CloudPlatform.AWS, 3, 3, List.of(2, 1, 0), true, Set.of(2)},
+                {CloudPlatform.AWS, 3, 3, List.of(0, 1, 2), true, Set.of(0)},
+                {CloudPlatform.AWS, 3, 3, List.of(2, 0, 1), true, Set.of(1)},
+                {CloudPlatform.AWS, 3, 3, List.of(1, 1, 1), true, Set.of(0, 1, 2)},
+                {CloudPlatform.AWS, 3, 4, List.of(4, 0, 0), true, Set.of(1, 2)},
+                {CloudPlatform.AWS, 3, 4, List.of(0, 4, 0), true, Set.of(0, 2)},
+                {CloudPlatform.AWS, 3, 4, List.of(0, 0, 4), true, Set.of(0, 1)},
+                {CloudPlatform.AWS, 3, 4, List.of(3, 1, 0), true, Set.of(2)},
+                {CloudPlatform.AWS, 3, 4, List.of(1, 3, 0), true, Set.of(2)},
+                {CloudPlatform.AWS, 3, 4, List.of(3, 0, 1), true, Set.of(1)},
+                {CloudPlatform.AWS, 3, 4, List.of(1, 0, 3), true, Set.of(1)},
+                {CloudPlatform.AWS, 3, 4, List.of(0, 3, 1), true, Set.of(0)},
+                {CloudPlatform.AWS, 3, 4, List.of(0, 1, 3), true, Set.of(0)},
+                {CloudPlatform.AWS, 3, 4, List.of(2, 2, 0), true, Set.of(2)},
+                {CloudPlatform.AWS, 3, 4, List.of(2, 0, 2), true, Set.of(1)},
+                {CloudPlatform.AWS, 3, 4, List.of(0, 2, 2), true, Set.of(0)},
+                {CloudPlatform.AWS, 3, 4, List.of(2, 1, 1), true, Set.of(1, 2)},
+                {CloudPlatform.AWS, 3, 4, List.of(1, 2, 1), true, Set.of(0, 2)},
+                {CloudPlatform.AWS, 3, 4, List.of(1, 1, 2), true, Set.of(0, 1)},
+        };
+    }
+
+    @ParameterizedTest(name = "calculateByRoundRobinTestWhenCloudInstance " +
+            "with {0} platform when {1} subnets and {2} instances and {3} subnet counts should result in {5} subnet / AZ")
+    @MethodSource("calculateByRoundRobinTestWhenCloudInstanceData")
+    public void calculateByRoundRobinTestWhenCloudInstance(CloudPlatform cloudPlatform, int subnetCount, int instanceCount, List<Integer> existingCounts,
+            boolean supported, Set<Integer> expectedPermissibleSubnetIdIndexes) {
+        if (supported) {
+            when(multiAzValidator.supportedForInstanceMetadataGeneration(any(InstanceGroup.class))).thenReturn(true);
+        }
+
+        InstanceGroup instanceGroup = instanceGroup(cloudPlatform, instanceCount, subnetCount);
+        initSubnetIdAndAvailabilityZoneForInstances(existingCounts, instanceGroup);
+
+        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, null, null);
+
+        underTest.calculateByRoundRobin(
+                subnetAzPairs(subnetCount),
+                instanceGroup,
+                cloudInstance);
+
+        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, cloudInstance);
+        verifySubnetIdAndAvailabilityZoneForInstancesAreUnchanged(existingCounts, instanceGroup, Set.of());
+    }
+
+    @ParameterizedTest(name = "calculateByRoundRobinTestWhenCloudInstanceAndForeignSubnetId " +
+            "with {0} platform when {1} subnets and {2} instances and {3} subnet counts should result in {5} subnet / AZ")
+    @MethodSource("calculateByRoundRobinTestWhenCloudInstanceData")
+    public void calculateByRoundRobinTestWhenCloudInstanceAndForeignSubnetId(CloudPlatform cloudPlatform, int subnetCount, int instanceCount,
+            List<Integer> existingCounts, boolean supported, Set<Integer> expectedPermissibleSubnetIdIndexes) {
+        if (supported) {
+            when(multiAzValidator.supportedForInstanceMetadataGeneration(any(InstanceGroup.class))).thenReturn(true);
+        }
+
+        InstanceGroup instanceGroup = instanceGroup(cloudPlatform, instanceCount, subnetCount);
+        initSubnetIdAndAvailabilityZoneForInstances(existingCounts, instanceGroup);
+        InstanceMetaData instanceWithPrepopulatedForeignSubnetId = instanceMetaData(instanceCount, SUBNET_ID, AVAILABILITY_ZONE, InstanceStatus.REQUESTED);
+        instanceGroup.getAllInstanceMetaData().add(instanceWithPrepopulatedForeignSubnetId);
+
+        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, null, null);
+
+        underTest.calculateByRoundRobin(
+                subnetAzPairs(subnetCount),
+                instanceGroup,
+                cloudInstance);
+
+        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, cloudInstance);
+        verifySubnetIdAndAvailabilityZoneForInstancesAreUnchanged(existingCounts, instanceGroup, Set.of(instanceWithPrepopulatedForeignSubnetId));
+
+        assertThat(instanceWithPrepopulatedForeignSubnetId.getSubnetId()).isEqualTo(SUBNET_ID);
+        assertThat(instanceWithPrepopulatedForeignSubnetId.getAvailabilityZone()).isEqualTo(AVAILABILITY_ZONE);
+    }
+
+    @ParameterizedTest(name = "calculateByRoundRobinTestWhenCloudInstanceAndDeletedInstances " +
+            "with {0} platform when {1} subnets and {2} instances and {3} subnet counts should result in {5} subnet / AZ")
+    @MethodSource("calculateByRoundRobinTestWhenCloudInstanceData")
+    public void calculateByRoundRobinTestWhenCloudInstanceAndDeletedInstances(CloudPlatform cloudPlatform, int subnetCount, int instanceCount,
+            List<Integer> existingCounts, boolean supported, Set<Integer> expectedPermissibleSubnetIdIndexes) {
+        if (supported) {
+            when(multiAzValidator.supportedForInstanceMetadataGeneration(any(InstanceGroup.class))).thenReturn(true);
+        }
+
+        InstanceGroup instanceGroup = instanceGroup(cloudPlatform, instanceCount, subnetCount);
+        initSubnetIdAndAvailabilityZoneForInstances(existingCounts, instanceGroup);
+        Set<InstanceMetaData> deletedInstancesWithPrepopulatedSubnetId = new HashSet<>();
+        String subnetIdForDeletedInstances = cloudSubnetName(0);
+        String availabilityZoneForDeletedInstances = cloudSubnetAz(0);
+        if (subnetCount > 0) {
+            InstanceMetaData instanceWithTerminationDate = instanceMetaData(instanceCount, subnetIdForDeletedInstances, availabilityZoneForDeletedInstances,
+                    null);
+            instanceWithTerminationDate.setTerminationDate(1234L);
+            deletedInstancesWithPrepopulatedSubnetId.add(instanceWithTerminationDate);
+            deletedInstancesWithPrepopulatedSubnetId.add(instanceMetaData(instanceCount + 1, subnetIdForDeletedInstances, availabilityZoneForDeletedInstances,
+                    InstanceStatus.TERMINATED));
+            deletedInstancesWithPrepopulatedSubnetId.add(instanceMetaData(instanceCount + 2, subnetIdForDeletedInstances, availabilityZoneForDeletedInstances,
+                    InstanceStatus.DELETED_BY_PROVIDER));
+            deletedInstancesWithPrepopulatedSubnetId.add(instanceMetaData(instanceCount + 3, subnetIdForDeletedInstances, availabilityZoneForDeletedInstances,
+                    InstanceStatus.DELETED_ON_PROVIDER_SIDE));
+        }
+        instanceGroup.getAllInstanceMetaData().addAll(deletedInstancesWithPrepopulatedSubnetId);
+
+        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, null, null);
+
+        underTest.calculateByRoundRobin(
+                subnetAzPairs(subnetCount),
+                instanceGroup,
+                cloudInstance);
+
+        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, cloudInstance);
+        verifySubnetIdAndAvailabilityZoneForInstancesAreUnchanged(existingCounts, instanceGroup, deletedInstancesWithPrepopulatedSubnetId);
+
+        deletedInstancesWithPrepopulatedSubnetId.forEach(instance -> {
+            assertThat(instance.getSubnetId()).isEqualTo(subnetIdForDeletedInstances);
+            assertThat(instance.getAvailabilityZone()).isEqualTo(availabilityZoneForDeletedInstances);
+        });
+    }
+
+    static Object[][] calculateByRoundRobinTestWhenCloudInstanceAndNoSubnetIdsDataProvider() {
+        return new Object[][]{
+                // testCaseName disableNetwork disableAttributes disableSubnetIdsAttribute prepopulateCloudInstanceSubnet
+                {"instanceGroupNetwork=null, prepopulateCloudInstanceSubnet=false", true, false, false, false},
+                {"instanceGroupNetwork=null, prepopulateCloudInstanceSubnet=true", true, false, false, true},
+                {"attributes=null, prepopulateCloudInstanceSubnet=false", false, true, false, false},
+                {"attributes=null, prepopulateCloudInstanceSubnet=true", false, true, false, true},
+                {"subnetIdsAttribute=null, prepopulateCloudInstanceSubnet=false", false, false, true, false},
+                {"subnetIdsAttribute=null, prepopulateCloudInstanceSubnet=true", false, false, true, true},
+                {"subnetIds=empty, prepopulateCloudInstanceSubnet=false", false, false, false, false},
+                {"subnetIds=empty, prepopulateCloudInstanceSubnet=true", false, false, false, true},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("calculateByRoundRobinTestWhenCloudInstanceAndNoSubnetIdsDataProvider")
+    void calculateByRoundRobinTestWhenCloudInstanceAndNoSubnetIds(String testCaseName, boolean disableNetwork, boolean disableAttributes,
+            boolean disableSubnetIdsAttribute, boolean prepopulateCloudInstanceSubnet) {
+        InstanceGroup instanceGroup = instanceGroup(CloudPlatform.AWS, SINGLE_INSTANCE, NO_SUBNETS);
+        if (disableNetwork) {
+            instanceGroup.setInstanceGroupNetwork(null);
+        } else if (disableAttributes) {
+            instanceGroup.getInstanceGroupNetwork().setAttributes(null);
+        } else if (disableSubnetIdsAttribute) {
+            instanceGroup.getInstanceGroupNetwork().setAttributes(new Json(Map.of()));
+        }
+
+        String cloudInstanceSubnetId = prepopulateCloudInstanceSubnet ? SUBNET_ID : null;
+        String cloudInstanceAvailabilityZone = prepopulateCloudInstanceSubnet ? AVAILABILITY_ZONE : null;
+        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, cloudInstanceSubnetId, cloudInstanceAvailabilityZone);
+
+        underTest.calculateByRoundRobin(
+                subnetAzPairs(NO_SUBNETS),
+                instanceGroup,
+                cloudInstance);
+
+        verifyCloudInstance(cloudInstanceSubnetId == null ? Set.of() : Set.of(cloudInstanceSubnetId),
+                cloudInstanceAvailabilityZone == null ? Set.of() : Set.of(cloudInstanceAvailabilityZone),
+                cloudInstance);
+
+        instanceGroup.getAllInstanceMetaData().forEach(instance -> {
+            assertThat(instance.getSubnetId()).isNull();
+            assertThat(instance.getAvailabilityZone()).isNull();
+        });
+    }
+
+    @Test
+    public void calculateByRoundRobinTestWhenCloudInstanceAndPrepopulatedCloudInstanceSubnet() {
+        when(multiAzValidator.supportedForInstanceMetadataGeneration(any(InstanceGroup.class))).thenReturn(true);
+
+        List<Integer> existingCounts = List.of(SINGLE_SUBNET);
+        InstanceGroup instanceGroup = instanceGroup(CloudPlatform.AWS, SINGLE_INSTANCE, SINGLE_SUBNET);
+        initSubnetIdAndAvailabilityZoneForInstances(existingCounts, instanceGroup);
+
+        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, SUBNET_ID, AVAILABILITY_ZONE);
+
+        underTest.calculateByRoundRobin(
+                subnetAzPairs(SINGLE_SUBNET),
+                instanceGroup,
+                cloudInstance);
+
+        verifyCloudInstance(Set.of(SUBNET_ID), Set.of(AVAILABILITY_ZONE), cloudInstance);
+        verifySubnetIdAndAvailabilityZoneForInstancesAreUnchanged(existingCounts, instanceGroup, Set.of());
+    }
+
+    static Object[][] calculateByRoundRobinTestWhenCloudInstanceAndInstancesWithoutSubnetData() {
+        return new Object[][]{
+                // cloudPlatform, subnetCount, instanceCount, supported, expectedPermissibleSubnetIdIndexes
+                {CloudPlatform.YARN, 0, 0, false, Set.of()},
+                {CloudPlatform.AWS, 1, 0, true, Set.of(0)},
+                {CloudPlatform.AWS, 1, 1, true, Set.of(0)},
+                {CloudPlatform.AWS, 1, 2, true, Set.of(0)},
+                {CloudPlatform.AWS, 2, 0, true, Set.of(0, 1)},
+                {CloudPlatform.AWS, 2, 1, true, Set.of(0, 1)},
+                {CloudPlatform.AWS, 2, 2, true, Set.of(0, 1)},
+                {CloudPlatform.AWS, 2, 3, true, Set.of(0, 1)},
+                {CloudPlatform.AWS, 3, 0, true, Set.of(0, 1, 2)},
+                {CloudPlatform.AWS, 3, 1, true, Set.of(0, 1, 2)},
+                {CloudPlatform.AWS, 3, 2, true, Set.of(0, 1, 2)},
+                {CloudPlatform.AWS, 3, 3, true, Set.of(0, 1, 2)},
+                {CloudPlatform.AWS, 3, 4, true, Set.of(0, 1, 2)},
+        };
+    }
+
+    @ParameterizedTest(name = "calculateByRoundRobinTestWhenCloudInstanceAndInstancesWithoutSubnet " +
+            "with {0} platform when {1} subnets and {2} instances and {3} subnet counts should result in {5} subnet / AZ")
+    @MethodSource("calculateByRoundRobinTestWhenCloudInstanceAndInstancesWithoutSubnetData")
+    public void calculateByRoundRobinTestWhenCloudInstanceAndInstancesWithoutSubnet(CloudPlatform cloudPlatform, int subnetCount, int instanceCount,
+            boolean supported, Set<Integer> expectedPermissibleSubnetIdIndexes) {
+        if (supported) {
+            when(multiAzValidator.supportedForInstanceMetadataGeneration(any(InstanceGroup.class))).thenReturn(true);
+        }
+
+        InstanceGroup instanceGroup = instanceGroup(cloudPlatform, instanceCount, subnetCount);
+
+        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, null, null);
+
+        underTest.calculateByRoundRobin(
+                subnetAzPairs(subnetCount),
+                instanceGroup,
+                cloudInstance);
+
+        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, cloudInstance);
+
+        instanceGroup.getAllInstanceMetaData().forEach(instance -> {
+            assertThat(instance.getSubnetId()).isNull();
+            assertThat(instance.getAvailabilityZone()).isNull();
+        });
+    }
+
+    static Object[][] determineRackIdTestDataProvider() {
+        return new Object[][]{
+                // testCaseName subnetId availabilityZone rackIdExpected
+                {"subnetId=null, availabilityZone=null", null, null, "/default-rack"},
+                {"subnetId=\"\", availabilityZone=null", "", null, "/default-rack"},
+                {"subnetId=null, availabilityZone=\"\"", null, "", "/default-rack"},
+                {"subnetId=\"\", availabilityZone=\"\"", "", "", "/default-rack"},
+                {"subnetId=SUBNET_ID, availabilityZone=null", SUBNET_ID, null, "/SUBNET_ID"},
+                {"subnetId=SUBNET_ID, availabilityZone=\"\"", SUBNET_ID, "", "/SUBNET_ID"},
+                {"subnetId=null, availabilityZone=AVAILABILITY_ZONE", null, AVAILABILITY_ZONE, "/AVAILABILITY_ZONE"},
+                {"subnetId=\"\", availabilityZone=AVAILABILITY_ZONE", "", AVAILABILITY_ZONE, "/AVAILABILITY_ZONE"},
+                {"subnetId=SUBNET_ID, availabilityZone=AVAILABILITY_ZONE", SUBNET_ID, AVAILABILITY_ZONE, "/AVAILABILITY_ZONE"},
+        };
+    }
+
+    @ParameterizedTest(name = "saveInstanceMetaDataTestDataProvider {0}")
+    @MethodSource("determineRackIdTestDataProvider")
+    void determineRackIdTest(String testCaseName, String subnetId, String availabilityZone, String rackIdExpected) {
+        String rackId = underTest.determineRackId(subnetId, availabilityZone);
+
+        assertThat(rackId).isEqualTo(rackIdExpected);
     }
 
     private InstanceGroup instanceGroup(CloudPlatform cloudPlatform, int instanceNumber, int subnetCount) {
@@ -118,15 +621,23 @@ public class MultiAzCalculatorServiceTest {
         return instanceGroup;
     }
 
+    private InstanceMetaData instanceMetaData(int i, String subnetId, String availabilityZone, InstanceStatus instanceStatus) {
+        InstanceMetaData instance = instanceMetaData(i);
+        instance.setSubnetId(subnetId);
+        instance.setAvailabilityZone(availabilityZone);
+        instance.setInstanceStatus(instanceStatus);
+        return instance;
+    }
+
     private InstanceMetaData instanceMetaData(int i) {
         InstanceMetaData instanceMetaData = new InstanceMetaData();
-        instanceMetaData.setId(Long.valueOf(i));
+        instanceMetaData.setId((long) i);
         return instanceMetaData;
     }
 
-    private Map<String, String> subnetAzPairs(int maxNumber) {
+    private Map<String, String> subnetAzPairs(int subnetCount) {
         Map<String, String> subnetAzPairs = new HashMap<>();
-        for (int i = 0; i < maxNumber; i++) {
+        for (int i = 0; i < subnetCount; i++) {
             subnetAzPairs.put(cloudSubnetName(i), cloudSubnetAz(i));
         }
         return subnetAzPairs;
@@ -147,4 +658,85 @@ public class MultiAzCalculatorServiceTest {
     private String cloudSubnetAz(int i) {
         return "az-" + i;
     }
+
+    private void initSubnetIdAndAvailabilityZoneForInstances(List<Integer> existingCounts, InstanceGroup instanceGroup) {
+        int totalExistingCount = existingCounts.stream()
+                .mapToInt(Integer::intValue)
+                .sum();
+        Queue<Integer> existingSubnetIdIndexes = new ArrayDeque<>(totalExistingCount);
+        int existingSubnetIdIndex = 0;
+        for (int count : existingCounts) {
+            for (int i = 0; i < count; i++) {
+                existingSubnetIdIndexes.add(existingSubnetIdIndex);
+            }
+            existingSubnetIdIndex++;
+        }
+        instanceGroup.getAllInstanceMetaData().forEach(instance -> {
+            Integer subnetIdIndex = existingSubnetIdIndexes.poll();
+            if (subnetIdIndex != null) {
+                instance.setSubnetId(cloudSubnetName(subnetIdIndex));
+                instance.setAvailabilityZone(cloudSubnetAz(subnetIdIndex));
+            }
+        });
+    }
+
+    private void verifyCloudInstance(Set<Integer> expectedPermissibleSubnetIdIndexes, CloudInstance cloudInstance) {
+        Set<String> expectedPermissibleSubnetIds = null;
+        Set<String> expectedPermissibleAvailabilityZones = null;
+        if (!CollectionUtils.isEmpty(expectedPermissibleSubnetIdIndexes)) {
+            expectedPermissibleSubnetIds = expectedPermissibleSubnetIdIndexes.stream()
+                    .map(this::cloudSubnetName)
+                    .collect(Collectors.toSet());
+            expectedPermissibleAvailabilityZones = expectedPermissibleSubnetIdIndexes.stream()
+                    .map(this::cloudSubnetAz)
+                    .collect(Collectors.toSet());
+        }
+
+        verifyCloudInstance(expectedPermissibleSubnetIds, expectedPermissibleAvailabilityZones, cloudInstance);
+    }
+
+    private void verifyCloudInstance(Set<String> expectedPermissibleSubnetIds, Set<String> expectedPermissibleAvailabilityZones, CloudInstance cloudInstance) {
+        if (CollectionUtils.isEmpty(expectedPermissibleSubnetIds)) {
+            assertThat(cloudInstance.getSubnetId()).isNull();
+        } else {
+            assertThat(cloudInstance.getSubnetId()).isIn(expectedPermissibleSubnetIds);
+        }
+
+        if (CollectionUtils.isEmpty(expectedPermissibleAvailabilityZones)) {
+            assertThat(cloudInstance.getAvailabilityZone()).isNull();
+        } else {
+            assertThat(cloudInstance.getAvailabilityZone()).isIn(expectedPermissibleAvailabilityZones);
+        }
+
+        assertThat(cloudInstance.getInstanceId()).isEqualTo(INSTANCE_ID);
+        assertThat(cloudInstance.getAuthentication()).isNull();
+        assertThat(cloudInstance.getTemplate()).isNull();
+        assertThat(cloudInstance.getParameters()).isNotNull();
+        assertThat(cloudInstance.getParameters()).isEmpty();
+    }
+
+    private void verifySubnetIdAndAvailabilityZoneForInstancesAreUnchanged(List<Integer> existingCounts, InstanceGroup instanceGroup,
+            Set<InstanceMetaData> instancesToIgnore) {
+        int countNum = existingCounts.size();
+        Map<String, Integer> subnetIdToIndexMap = new HashMap<>(countNum);
+        Map<String, Integer> availabilityZoneToIndexMap = new HashMap<>(countNum);
+        for (int i = 0; i < countNum; i++) {
+            subnetIdToIndexMap.put(cloudSubnetName(i), i);
+            availabilityZoneToIndexMap.put(cloudSubnetAz(i), i);
+        }
+
+        Integer[] actualCountsArray = new Integer[countNum];
+        Arrays.fill(actualCountsArray, 0);
+        instanceGroup.getAllInstanceMetaData().forEach(instance -> {
+            if (!instancesToIgnore.contains(instance)) {
+                Integer subnetIdIndex = subnetIdToIndexMap.get(instance.getSubnetId());
+                Integer availabilityZoneIndex = availabilityZoneToIndexMap.get(instance.getAvailabilityZone());
+                assertThat(subnetIdIndex).isNotNull();
+                assertThat(subnetIdIndex).isEqualTo(availabilityZoneIndex);
+                actualCountsArray[subnetIdIndex]++;
+            }
+        });
+        assertThat(Arrays.asList(actualCountsArray)).isEqualTo(existingCounts);
+    }
+
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataServiceTest.java
@@ -1,0 +1,363 @@
+package com.sequenceiq.cloudbreak.service.stack;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceAuthentication;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.domain.Network;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.repository.InstanceMetaDataRepository;
+import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.service.multiaz.MultiAzCalculatorService;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+
+@ExtendWith(MockitoExtension.class)
+class InstanceMetaDataServiceTest {
+
+    private static final int INSTANCE_GROUP_COUNT = 2;
+
+    private static final String ENVIRONMENT_CRN = "ENVIRONMENT_CRN";
+
+    private static final String SUBNET_ID = "SUBNET_ID";
+
+    private static final String AVAILABILITY_ZONE = "AVAILABILITY_ZONE";
+
+    private static final String RACK_ID = "/RACK_ID";
+
+    private static final String HOSTNAME_1 = "host-1.foo.org";
+
+    private static final String HOSTNAME_2 = "host-2.foo.org";
+
+    private static final String HOSTNAME_3 = "host-3.foo.org";
+
+    @Mock
+    private InstanceMetaDataRepository repository;
+
+    @Mock
+    private EnvironmentClientService environmentClientService;
+
+    @Mock
+    private MultiAzCalculatorService multiAzCalculatorService;
+
+    @InjectMocks
+    private InstanceMetaDataService underTest;
+
+    @Mock
+    private DetailedEnvironmentResponse environment;
+
+    @Captor
+    private ArgumentCaptor<InstanceMetaData> instanceMetaDataCaptor;
+
+    static Object[][] saveInstanceAndGetUpdatedStackTestWhenSubnetAndAvailabilityZoneAndRackIdAndRoundRobinDataProvider() {
+        return new Object[][]{
+                // testCaseName save hostnames subnetId availabilityZone rackId
+                {"save=false, hostnames=[], subnetId=SUBNET_ID, availabilityZone=null, rackId=null,", false, List.of(), SUBNET_ID, null, null},
+                {"save=false, hostnames=[], subnetId=SUBNET_ID, availabilityZone=null, rackId=RACK_ID,", false, List.of(), SUBNET_ID, null, RACK_ID},
+                {"save=false, hostnames=[], subnetId=SUBNET_ID, availabilityZone=AVAILABILITY_ZONE, rackId=RACK_ID,", false, List.of(), SUBNET_ID,
+                        AVAILABILITY_ZONE, RACK_ID},
+                {"save=true, hostnames=[], subnetId=SUBNET_ID, availabilityZone=AVAILABILITY_ZONE, rackId=RACK_ID,", true, List.of(), SUBNET_ID,
+                        AVAILABILITY_ZONE, RACK_ID},
+                {"save=false, hostnames=[HOSTNAME_1], subnetId=SUBNET_ID, availabilityZone=AVAILABILITY_ZONE, rackId=RACK_ID,", false, List.of(HOSTNAME_1),
+                        SUBNET_ID, AVAILABILITY_ZONE, RACK_ID},
+                {"save=false, hostnames=[HOSTNAME_1, HOSTNAME_2], subnetId=SUBNET_ID, availabilityZone=AVAILABILITY_ZONE, rackId=RACK_ID,", false,
+                        List.of(HOSTNAME_1, HOSTNAME_2), SUBNET_ID, AVAILABILITY_ZONE, RACK_ID},
+                {"save=false, hostnames=[HOSTNAME_1, HOSTNAME_2, HOSTNAME_3], subnetId=SUBNET_ID, availabilityZone=AVAILABILITY_ZONE, rackId=RACK_ID,", false,
+                        List.of(HOSTNAME_1, HOSTNAME_2, HOSTNAME_3), SUBNET_ID, AVAILABILITY_ZONE, RACK_ID},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("saveInstanceAndGetUpdatedStackTestWhenSubnetAndAvailabilityZoneAndRackIdAndRoundRobinDataProvider")
+    void saveInstanceAndGetUpdatedStackTestWhenSubnetAndAvailabilityZoneAndRackIdAndRoundRobin(String testCaseName, boolean save, List<String> hostnames,
+            String subnetId, String availabilityZone, String rackId) {
+        Stack stack = stack(INSTANCE_GROUP_COUNT);
+
+        when(environmentClientService.getByCrn(ENVIRONMENT_CRN)).thenReturn(environment);
+        Map<String, String> subnetAzPairs = Map.of();
+        when(multiAzCalculatorService.prepareSubnetAzMap(environment)).thenReturn(subnetAzPairs);
+        doAnswer(invocation -> {
+            CloudInstance cloudInstance = invocation.getArgument(2, CloudInstance.class);
+            cloudInstance.setSubnetId(subnetId);
+            cloudInstance.setAvailabilityZone(availabilityZone);
+            return null;
+        }).when(multiAzCalculatorService).calculateByRoundRobin(eq(subnetAzPairs), any(InstanceGroup.class), any(CloudInstance.class));
+        when(multiAzCalculatorService.determineRackId(subnetId, availabilityZone)).thenReturn(rackId);
+
+        Stack result = underTest.saveInstanceAndGetUpdatedStack(stack, cloudInstances(INSTANCE_GROUP_COUNT), save, new LinkedHashSet<>(hostnames));
+
+        assertThat(result).isSameAs(stack);
+
+        Set<InstanceGroup> resultInstanceGroups = result.getInstanceGroups();
+        assertThat(resultInstanceGroups).isNotNull();
+        assertThat(resultInstanceGroups).hasSize(INSTANCE_GROUP_COUNT);
+        verifyInstances(resultInstanceGroups, hostnames, subnetId, availabilityZone, rackId, null, INSTANCE_GROUP_COUNT);
+        verifyRepositorySave(resultInstanceGroups, save);
+    }
+
+    private void verifyInstances(Set<InstanceGroup> resultInstanceGroups, List<String> hostnames, String expectedSubnetId, String expectedAvailabilityZone,
+            String expectedRackId, InstanceMetaData instanceToIgnore, int expectedInstanceCount) {
+        AtomicInteger instanceCount = new AtomicInteger();
+        resultInstanceGroups.forEach(instanceGroup -> {
+            assertThat(instanceGroup.getAllInstanceMetaData()).isNotNull();
+            String groupName = instanceGroup.getGroupName();
+            int idx = indexFromGroupName(groupName);
+            assertThat(idx).overridingErrorMessage("Could not determine index from invalid group name '%s'", groupName).isGreaterThanOrEqualTo(0);
+            instanceGroup.getAllInstanceMetaData().forEach(instance -> {
+                if (instance != instanceToIgnore) {
+                    instanceCount.incrementAndGet();
+                    assertThat(instance.getPrivateId()).isEqualTo(idx);
+                    assertThat(instance.getInstanceStatus()).isEqualTo(com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.REQUESTED);
+                    assertThat(instance.getInstanceGroup()).isEqualTo(instanceGroup);
+                    assertThat(instance.getDiscoveryFQDN()).isEqualTo(idx < hostnames.size() ? hostnames.get(idx) : null);
+                    assertThat(instance.getSubnetId()).isEqualTo(expectedSubnetId);
+                    assertThat(instance.getAvailabilityZone()).isEqualTo(expectedAvailabilityZone);
+                    assertThat(instance.getRackId()).isEqualTo(expectedRackId);
+                }
+            });
+        });
+        assertThat(instanceCount.get()).isEqualTo(expectedInstanceCount);
+    }
+
+    private void verifyRepositorySave(Set<InstanceGroup> resultInstanceGroups, boolean save) {
+        if (save) {
+            verify(repository, times(INSTANCE_GROUP_COUNT)).save(instanceMetaDataCaptor.capture());
+            List<InstanceMetaData> instancesCaptured = instanceMetaDataCaptor.getAllValues();
+            assertThat(instancesCaptured).hasSize(INSTANCE_GROUP_COUNT);
+            for (int i = 0; i < INSTANCE_GROUP_COUNT; i++) {
+                InstanceMetaData instanceCaptured = instancesCaptured.get(i);
+                InstanceGroup instanceGroup = findInstanceGroupByIndex(resultInstanceGroups, i);
+                boolean found = instanceGroup.getAllInstanceMetaData().stream()
+                        .anyMatch(instance -> instance == instanceCaptured);
+                assertThat(found).overridingErrorMessage("Captured instance '%s' could not be found in group of index %d", instanceCaptured, i).isTrue();
+            }
+        } else {
+            verify(repository, never()).save(any(InstanceMetaData.class));
+        }
+    }
+
+    private InstanceGroup findInstanceGroupByIndex(Set<InstanceGroup> instanceGroups, int idx) {
+        String groupName = groupName(idx);
+        InstanceGroup result = instanceGroups.stream()
+                .filter(instanceGroup -> groupName.equals(instanceGroup.getGroupName()))
+                .findFirst().orElse(null);
+        assertThat(result).overridingErrorMessage("Group '%s' not found in stack", groupName).isNotNull();
+        return result;
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("saveInstanceAndGetUpdatedStackTestWhenSubnetAndAvailabilityZoneAndRackIdAndRoundRobinDataProvider")
+    void saveInstanceAndGetUpdatedStackTestWhenSubnetAndAvailabilityZoneAndRackIdAndRoundRobinAndExistingInstance(String testCaseName, boolean save,
+            List<String> hostnames, String subnetId, String availabilityZone, String rackId) {
+        Stack stack = stack(INSTANCE_GROUP_COUNT);
+
+        InstanceMetaData existingInstance = new InstanceMetaData();
+        existingInstance.setPrivateId(1234L);
+        existingInstance.setInstanceStatus(com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.SERVICES_RUNNING);
+        existingInstance.setInstanceGroup(stack.getInstanceGroups().iterator().next());
+        existingInstance.setDiscoveryFQDN("existing.foo.org");
+        existingInstance.setSubnetId("subnetId-existing");
+        existingInstance.setAvailabilityZone("availabilityZone-existing");
+        existingInstance.setRackId("/rackId-existing");
+        stack.getInstanceGroups().iterator().next().getAllInstanceMetaData().add(existingInstance);
+
+        when(environmentClientService.getByCrn(ENVIRONMENT_CRN)).thenReturn(environment);
+        Map<String, String> subnetAzPairs = Map.of();
+        when(multiAzCalculatorService.prepareSubnetAzMap(environment)).thenReturn(subnetAzPairs);
+        doAnswer(invocation -> {
+            CloudInstance cloudInstance = invocation.getArgument(2, CloudInstance.class);
+            cloudInstance.setSubnetId(subnetId);
+            cloudInstance.setAvailabilityZone(availabilityZone);
+            return null;
+        }).when(multiAzCalculatorService).calculateByRoundRobin(eq(subnetAzPairs), any(InstanceGroup.class), any(CloudInstance.class));
+        when(multiAzCalculatorService.determineRackId(subnetId, availabilityZone)).thenReturn(rackId);
+
+        Stack result = underTest.saveInstanceAndGetUpdatedStack(stack, cloudInstances(INSTANCE_GROUP_COUNT), save, new LinkedHashSet<>(hostnames));
+
+        assertThat(result).isSameAs(stack);
+
+        Set<InstanceGroup> resultInstanceGroups = result.getInstanceGroups();
+        assertThat(resultInstanceGroups).isNotNull();
+        assertThat(resultInstanceGroups).hasSize(INSTANCE_GROUP_COUNT);
+        verifyInstances(resultInstanceGroups, hostnames, subnetId, availabilityZone, rackId, existingInstance, INSTANCE_GROUP_COUNT);
+        verifyRepositorySave(resultInstanceGroups, save);
+
+        boolean foundExistingInstance = stack.getInstanceGroups().iterator().next().getAllInstanceMetaData().stream()
+                .anyMatch(instance -> instance == existingInstance);
+        assertThat(foundExistingInstance).overridingErrorMessage("Could not find existingInstance").isTrue();
+        assertThat(existingInstance.getPrivateId()).isEqualTo(1234L);
+        assertThat(existingInstance.getInstanceStatus()).isEqualTo(com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.SERVICES_RUNNING);
+        assertThat(existingInstance.getInstanceGroup()).isEqualTo(stack.getInstanceGroups().iterator().next());
+        assertThat(existingInstance.getDiscoveryFQDN()).isEqualTo("existing.foo.org");
+        assertThat(existingInstance.getSubnetId()).isEqualTo("subnetId-existing");
+        assertThat(existingInstance.getAvailabilityZone()).isEqualTo("availabilityZone-existing");
+        assertThat(existingInstance.getRackId()).isEqualTo("/rackId-existing");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("saveInstanceAndGetUpdatedStackTestWhenSubnetAndAvailabilityZoneAndRackIdAndRoundRobinDataProvider")
+    void saveInstanceAndGetUpdatedStackTestWhenSubnetAndAvailabilityZoneAndRackIdAndRoundRobinAndCloudInstanceWithBadGroupName(String testCaseName,
+            boolean save, List<String> hostnames, String subnetId, String availabilityZone, String rackId) {
+        Stack stack = stack(INSTANCE_GROUP_COUNT);
+
+        when(environmentClientService.getByCrn(ENVIRONMENT_CRN)).thenReturn(environment);
+        Map<String, String> subnetAzPairs = Map.of();
+        when(multiAzCalculatorService.prepareSubnetAzMap(environment)).thenReturn(subnetAzPairs);
+        doAnswer(invocation -> {
+            CloudInstance cloudInstance = invocation.getArgument(2, CloudInstance.class);
+            cloudInstance.setSubnetId(subnetId);
+            cloudInstance.setAvailabilityZone(availabilityZone);
+            return null;
+        }).when(multiAzCalculatorService).calculateByRoundRobin(eq(subnetAzPairs), any(InstanceGroup.class), any(CloudInstance.class));
+        when(multiAzCalculatorService.determineRackId(subnetId, availabilityZone)).thenReturn(rackId);
+
+        List<CloudInstance> cloudInstances = new ArrayList<>(cloudInstances(INSTANCE_GROUP_COUNT));
+        cloudInstances.add(cloudInstance(INSTANCE_GROUP_COUNT + 1));
+        Stack result = underTest.saveInstanceAndGetUpdatedStack(stack, cloudInstances, save, new LinkedHashSet<>(hostnames));
+
+        assertThat(result).isSameAs(stack);
+
+        Set<InstanceGroup> resultInstanceGroups = result.getInstanceGroups();
+        assertThat(resultInstanceGroups).isNotNull();
+        assertThat(resultInstanceGroups).hasSize(INSTANCE_GROUP_COUNT);
+        verifyInstances(resultInstanceGroups, hostnames, subnetId, availabilityZone, rackId, null, INSTANCE_GROUP_COUNT);
+        verifyRepositorySave(resultInstanceGroups, save);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("saveInstanceAndGetUpdatedStackTestWhenSubnetAndAvailabilityZoneAndRackIdAndRoundRobinDataProvider")
+    void saveInstanceAndGetUpdatedStackTestWhenSubnetAndAvailabilityZoneAndRackIdAndStackFallback(String testCaseName, boolean save, List<String> hostnames,
+            String subnetId, String availabilityZone, String rackId) {
+        Stack stack = stack(INSTANCE_GROUP_COUNT);
+        Network network = new Network();
+        network.setAttributes(Json.silent(subnetId == null ? Map.of() : Map.of("subnetId", subnetId)));
+        stack.setNetwork(network);
+
+        when(environmentClientService.getByCrn(ENVIRONMENT_CRN)).thenReturn(environment);
+        Map<String, String> subnetAzPairs = subnetId == null || availabilityZone == null ? Map.of() : Map.of(subnetId, availabilityZone);
+        when(multiAzCalculatorService.prepareSubnetAzMap(environment)).thenReturn(subnetAzPairs);
+        doNothing().when(multiAzCalculatorService).calculateByRoundRobin(eq(subnetAzPairs), any(InstanceGroup.class), any(CloudInstance.class));
+        when(multiAzCalculatorService.determineRackId(subnetId, availabilityZone)).thenReturn(rackId);
+
+        Stack result = underTest.saveInstanceAndGetUpdatedStack(stack, cloudInstances(INSTANCE_GROUP_COUNT), save, new LinkedHashSet<>(hostnames));
+
+        assertThat(result).isSameAs(stack);
+
+        Set<InstanceGroup> resultInstanceGroups = result.getInstanceGroups();
+        assertThat(resultInstanceGroups).isNotNull();
+        assertThat(resultInstanceGroups).hasSize(INSTANCE_GROUP_COUNT);
+        verifyInstances(resultInstanceGroups, hostnames, subnetId, availabilityZone, rackId, null, INSTANCE_GROUP_COUNT);
+        verifyRepositorySave(resultInstanceGroups, save);
+    }
+
+    @Test
+    void saveInstanceAndGetUpdatedStackTestWhenNoCloudInstances() {
+        Stack stack = stack(1);
+
+        when(environmentClientService.getByCrn(ENVIRONMENT_CRN)).thenReturn(environment);
+        when(multiAzCalculatorService.prepareSubnetAzMap(environment)).thenReturn(Map.of());
+
+        Stack result = underTest.saveInstanceAndGetUpdatedStack(stack, List.of(), true, Set.of());
+
+        assertThat(result).isSameAs(stack);
+
+        Set<InstanceGroup> resultInstanceGroups = result.getInstanceGroups();
+        assertThat(resultInstanceGroups).isNotNull();
+        assertThat(resultInstanceGroups).hasSize(1);
+        verifyInstances(resultInstanceGroups, List.of(), null, null, null, null, 0);
+        verifyRepositorySave(resultInstanceGroups, false);
+
+        verify(multiAzCalculatorService, never()).calculateByRoundRobin(anyMap(), any(InstanceGroup.class), any(CloudInstance.class));
+        verify(multiAzCalculatorService, never()).determineRackId(anyString(), anyString());
+    }
+
+    private Stack stack(int instanceGroupCount) {
+        Stack stack = new Stack();
+        stack.setEnvironmentCrn(ENVIRONMENT_CRN);
+        Set<InstanceGroup> instanceGroups = new HashSet<>(instanceGroupCount);
+        for (int i = 0; i < instanceGroupCount; i++) {
+            instanceGroups.add(instanceGroup(i));
+        }
+        stack.setInstanceGroups(instanceGroups);
+        return stack;
+    }
+
+    private InstanceGroup instanceGroup(int idx) {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setGroupName(groupName(idx));
+        return instanceGroup;
+    }
+
+    private String groupName(int idx) {
+        return "group-" + idx;
+    }
+
+    private int indexFromGroupName(String groupName) {
+        int idx = -1;
+        if (groupName.startsWith("group-")) {
+            try {
+                idx = Integer.parseInt(groupName.substring("group-".length()));
+            } catch (NumberFormatException e) {
+                // Ignore
+            }
+        }
+        return idx;
+    }
+
+    private CloudInstance cloudInstance(int idx) {
+        return new CloudInstance(instanceId(idx), instanceTemplate(idx), instanceAuthentication(), "dummySubnetId", "dummyAvailabilityZone");
+    }
+
+    private String instanceId(int idx) {
+        return "instanceId-" + idx;
+    }
+
+    private InstanceTemplate instanceTemplate(int idx) {
+        return new InstanceTemplate(null, groupName(idx), (long) idx, List.of(), com.sequenceiq.cloudbreak.cloud.model.InstanceStatus.CREATED, Map.of(),
+                (long) idx, null, null);
+    }
+
+    private InstanceAuthentication instanceAuthentication() {
+        return new InstanceAuthentication(null, null, null);
+    }
+
+    private List<CloudInstance> cloudInstances(int instanceGroupCount) {
+        return IntStream.range(0, instanceGroupCount)
+                .mapToObj(this::cloudInstance)
+                .collect(Collectors.toList());
+    }
+
+}

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentNetworkResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentNetworkResponse.java
@@ -162,7 +162,11 @@ public class EnvironmentNetworkResponse extends EnvironmentNetworkBase {
                 '}';
     }
 
-    public static final class EnvironmentNetworkResponseBuilder {
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
         private String crn;
 
         private String name;
@@ -209,124 +213,120 @@ public class EnvironmentNetworkResponse extends EnvironmentNetworkBase {
 
         private Set<String> endpointGatewaySubnetIds;
 
-        private EnvironmentNetworkResponseBuilder() {
+        private Builder() {
         }
 
-        public static EnvironmentNetworkResponseBuilder anEnvironmentNetworkResponse() {
-            return new EnvironmentNetworkResponseBuilder();
-        }
-
-        public EnvironmentNetworkResponseBuilder withCrn(String id) {
+        public Builder withCrn(String id) {
             this.crn = id;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withName(String name) {
+        public Builder withName(String name) {
             this.name = name;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withSubnetIds(Set<String> subnetIds) {
+        public Builder withSubnetIds(Set<String> subnetIds) {
             this.subnetIds = subnetIds;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withSubnetMetas(Map<String, CloudSubnet> subnetMetas) {
+        public Builder withSubnetMetas(Map<String, CloudSubnet> subnetMetas) {
             this.subnetMetas = subnetMetas;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withCbSubnets(Map<String, CloudSubnet> cbSubnets) {
+        public Builder withCbSubnets(Map<String, CloudSubnet> cbSubnets) {
             this.cbSubnets = cbSubnets;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withDwxSubnets(Map<String, CloudSubnet> dwxSubnets) {
+        public Builder withDwxSubnets(Map<String, CloudSubnet> dwxSubnets) {
             this.dwxSubnets = dwxSubnets;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withMlxSubnets(Map<String, CloudSubnet> mlxSubnets) {
+        public Builder withMlxSubnets(Map<String, CloudSubnet> mlxSubnets) {
             this.mlxSubnets = mlxSubnets;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withLiftieSubnets(Map<String, CloudSubnet> liftieSubnets) {
+        public Builder withLiftieSubnets(Map<String, CloudSubnet> liftieSubnets) {
             this.liftieSubnets = liftieSubnets;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withExistingNetwork(boolean existingNetwork) {
+        public Builder withExistingNetwork(boolean existingNetwork) {
             this.existingNetwork = existingNetwork;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withPreferedSubnetId(String preferedSubnetId) {
+        public Builder withPreferedSubnetId(String preferedSubnetId) {
             this.preferedSubnetId = preferedSubnetId;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withPrivateSubnetCreation(PrivateSubnetCreation privateSubnetCreation) {
+        public Builder withPrivateSubnetCreation(PrivateSubnetCreation privateSubnetCreation) {
             this.privateSubnetCreation = privateSubnetCreation;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withServiceEndpointCreation(ServiceEndpointCreation serviceEndpointCreation) {
+        public Builder withServiceEndpointCreation(ServiceEndpointCreation serviceEndpointCreation) {
             this.serviceEndpointCreation = serviceEndpointCreation;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withOutboundInternetTraffic(OutboundInternetTraffic outboundInternetTraffic) {
+        public Builder withOutboundInternetTraffic(OutboundInternetTraffic outboundInternetTraffic) {
             this.outboundInternetTraffic = outboundInternetTraffic;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withAws(EnvironmentNetworkAwsParams aws) {
+        public Builder withAws(EnvironmentNetworkAwsParams aws) {
             this.aws = aws;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withAzure(EnvironmentNetworkAzureParams azure) {
+        public Builder withAzure(EnvironmentNetworkAzureParams azure) {
             this.azure = azure;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withYarn(EnvironmentNetworkYarnParams yarn) {
+        public Builder withYarn(EnvironmentNetworkYarnParams yarn) {
             this.yarn = yarn;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withGcp(EnvironmentNetworkGcpParams gcp) {
+        public Builder withGcp(EnvironmentNetworkGcpParams gcp) {
             this.gcp = gcp;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withNetworkCidr(String networkCidr) {
+        public Builder withNetworkCidr(String networkCidr) {
             this.networkCidr = networkCidr;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withNetworkCidrs(Set<String> networkCidrs) {
+        public Builder withNetworkCidrs(Set<String> networkCidrs) {
             this.networkCidrs = networkCidrs;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withMock(EnvironmentNetworkMockParams mock) {
+        public Builder withMock(EnvironmentNetworkMockParams mock) {
             this.mock = mock;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withUsePublicEndpointAccessGateway(PublicEndpointAccessGateway publicEndpointAccessGateway) {
+        public Builder withUsePublicEndpointAccessGateway(PublicEndpointAccessGateway publicEndpointAccessGateway) {
             this.publicEndpointAccessGateway = publicEndpointAccessGateway;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withEndpointGatewaySubnetMetas(Map<String, CloudSubnet> endpointGatewaySubnetMetas) {
+        public Builder withEndpointGatewaySubnetMetas(Map<String, CloudSubnet> endpointGatewaySubnetMetas) {
             this.endpointGatewaySubnetMetas = endpointGatewaySubnetMetas;
             return this;
         }
 
-        public EnvironmentNetworkResponseBuilder withEndpointGatewaySubnetIds(Set<String> endpointGatewaySubnetIds) {
+        public Builder withEndpointGatewaySubnetIds(Set<String> endpointGatewaySubnetIds) {
             this.endpointGatewaySubnetIds = endpointGatewaySubnetIds;
             return this;
         }
@@ -359,4 +359,5 @@ public class EnvironmentNetworkResponse extends EnvironmentNetworkBase {
             return environmentNetworkResponse;
         }
     }
+
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/NetworkDtoToResponseConverter.java
@@ -25,7 +25,7 @@ public class NetworkDtoToResponseConverter {
     }
 
     public EnvironmentNetworkResponse convert(NetworkDto network, Tunnel tunnel, boolean detailedResponse) {
-        return EnvironmentNetworkResponse.EnvironmentNetworkResponseBuilder.anEnvironmentNetworkResponse()
+        return EnvironmentNetworkResponse.builder()
                 .withCrn(network.getResourceCrn())
                 .withSubnetIds(network.getSubnetIds())
                 .withNetworkCidr(network.getNetworkCidr())

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/converter/stack/AllocateDatabaseServerV4RequestToDBStackConverterTest.java
@@ -338,7 +338,7 @@ class AllocateDatabaseServerV4RequestToDBStackConverterTest {
                 .withTag(new TagResponse())
                 .withLocation(LocationResponse.LocationResponseBuilder.aLocationResponse().withName(REGION).build())
                 .withSecurityAccess(SecurityAccessResponse.builder().withDefaultSecurityGroupId(DEFAULT_SECURITY_GROUP_ID).build())
-                .withNetwork(EnvironmentNetworkResponse.EnvironmentNetworkResponseBuilder.anEnvironmentNetworkResponse()
+                .withNetwork(EnvironmentNetworkResponse.builder()
                         .withSubnetMetas(
                                 Map.of(
                                         "subnet-1", cloudSubnets.get(0),

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdderTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/service/network/NetworkParameterAdderTest.java
@@ -24,7 +24,7 @@ import com.sequenceiq.common.model.PrivateEndpointType;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAwsParams.EnvironmentNetworkAwsParamsBuilder;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkAzureParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
-import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse.EnvironmentNetworkResponseBuilder;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
 
 public class NetworkParameterAdderTest {
@@ -66,7 +66,7 @@ public class NetworkParameterAdderTest {
         DBStack dbStack = new DBStack();
         DetailedEnvironmentResponse environment = DetailedEnvironmentResponse.builder()
                 .withCloudPlatform(CloudPlatform.AWS.name())
-                .withNetwork(EnvironmentNetworkResponseBuilder.anEnvironmentNetworkResponse()
+                .withNetwork(EnvironmentNetworkResponse.builder()
                         .withAws(EnvironmentNetworkAwsParamsBuilder.anEnvironmentNetworkAwsParams().withVpcId(TEST_VPC_ID).build())
                         .withNetworkCidr(TEST_VPC_CIDR)
                         .build())
@@ -84,7 +84,7 @@ public class NetworkParameterAdderTest {
         DBStack dbStack = new DBStack();
         DetailedEnvironmentResponse environment = DetailedEnvironmentResponse.builder()
                 .withCloudPlatform(CloudPlatform.AZURE.name())
-                .withNetwork(EnvironmentNetworkResponseBuilder.anEnvironmentNetworkResponse()
+                .withNetwork(EnvironmentNetworkResponse.builder()
                         .withSubnetMetas(Map.of())
                         .withAzure(
                                 EnvironmentNetworkAzureParams.EnvironmentNetworkAzureParamsBuilder.anEnvironmentNetworkAzureParams()


### PR DESCRIPTION
* Set subnet, AZ & rackId in `InstanceMetaData` (core) as early as possible.
  * Applies to stack launch and stack upscale. (Repair is also implicitly covered since it involves an upscale as well.)
  * Removes the former related logic in `MetadataSetupService`.
* `MultiAzCalculatorService`:
  * Extract rackId generation into `determineRackId()`.
  * Fix `InstanceMetaData` subnet usage statistics calculation in `collectCurrentSubnetUsage()`.
  * Only consider not deleted instances. This affects instance updates (`calculateByRoundRobin()`) and subnet usage statistics calculation (`collectCurrentSubnetUsage()`).
* Code enhancements:
  * Minor refactors, removal of unused methods & args, renaming improper identifiers.
  * NPE elimination in several places.
* Testing:
  * Manual verification in local CB: AWS CF (DL+DH), AWS native single-AZ (DL+DH), AWS native multi-AZ (DL single-AZ, DH multi-AZ), Azure (DL), YCloud (DL).
  * Added new UT and updated existing ones.