### PR TITLE
CB-13551 fix the permission of 2 Auto-TLS related files

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/start.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/agent/start.sls
@@ -6,6 +6,15 @@ check_token:
     - name: /etc/cloudera-scm-agent/cmagent.token
     - retry:
         attempts: 10
+
+/etc/cloudera-scm-agent/cmagent.token:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 600
+    - replace: False
+    - require:
+      - file: check_token
 {% endif %}
 
 start_agent:

--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/setup-autotls.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/setup-autotls.sh.j2
@@ -43,6 +43,7 @@ fi
 /opt/cloudera/cm-agent/bin/certmanager --location $CERTMANAGER_DIR setup --configure-services $CERTMANAGER_ARGS --override ca_dn="CN=${HOSTNAME}" --stop-at-csr ${ALTNAME} --trusted-ca-certs ${CACERTS_DIR}/cacerts.pem
 /opt/cloudera/cm/bin/generate_intermediate_ca_ipa.sh $CM_PRINCIPAL ${CERTMANAGER_DIR}/CMCA/private/ca_csr.pem $OUT_FILE
 /opt/cloudera/cm-agent/bin/certmanager --location $CERTMANAGER_DIR setup --configure-services $CERTMANAGER_ARGS --override ca_dn="CN=${HOSTNAME}" --signed-ca-cert=$OUT_FILE --skip-cm-init ${ALTNAME} --trusted-ca-certs ${CACERTS_DIR}/cacerts.pem > $CERTMANAGER_DIR/auto-tls.init.txt
+chmod 600 $CERTMANAGER_DIR/auto-tls.init.txt
 
 rm -rf $OUT_FILE
 


### PR DESCRIPTION
Cloudbreak generates 2 files to set up Auto-TLS:
- /etc/cloudera-scm-server/certs/auto-tls.init.txt
- /etc/cloudera-scm-agent/cmagent.token
Both of these files have the world-readable permission and as
part of this PR it is changed to 600. The auto-tls.init.txt can be used
by the cloudera-scm user and the cmagent.token can be used by the root user.

See detailed description in the commit message.