### PR TITLE
CB-13523 CM agent token copy sporadically fails for base images.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/generate_agent_tokens.sh.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/cloudera/manager/scripts/generate_agent_tokens.sh.j2
@@ -35,7 +35,7 @@ do
   if [[ ! -e ${tokendir}/agent_token_copied_to_client ]]; then
     set +e
     # This can be fairly slow, for large clusters
-    COPY_RESULT=$(salt ${fqdn} cp.get_file salt://agent-tls-tokens/${AGENT_FQDN_TOKENDIR_MAP[${fqdn}]}/cmagent.token /etc/cloudera-scm-agent/cmagent.token)
+    COPY_RESULT=$(salt ${fqdn} cp.get_file salt://agent-tls-tokens/${AGENT_FQDN_TOKENDIR_MAP[${fqdn}]}/cmagent.token /etc/cloudera-scm-agent/cmagent.token makedirs=True)
     SALT_CP_RET=$?
     set -e
     if [[ "$COPY_RESULT" != *"False"* ]] && [[ "$SALT_CP_RET" -eq 0 ]] ; then


### PR DESCRIPTION
In case of base images it's possible that the scm agent is not yet installed and the directory is not present. This causes the salt cp.get_file command to fail. Since the downscale fix introduced previously ignores whether the copy is successful or not this can lead to scaleing/provision failures.