### PR TITLE
DISTX-678 - Set hive.metastore.try.direct.sql.ddl=true explicitly in Hive templates

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-ha.bp
@@ -130,7 +130,13 @@
           {
             "refName": "hms-HIVEMETASTORE-BASE",
             "roleType": "HIVEMETASTORE",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_metastore_config_safety_valve",
+                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering-spark3.bp
@@ -259,7 +259,13 @@
           {
             "refName": "hms-HIVEMETASTORE-BASE",
             "roleType": "HIVEMETASTORE",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_metastore_config_safety_valve",
+                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-data-engineering.bp
@@ -249,7 +249,13 @@
           {
             "refName": "hms-HIVEMETASTORE-BASE",
             "roleType": "HIVEMETASTORE",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_metastore_config_safety_valve",
+                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-ha.bp
@@ -130,7 +130,13 @@
           {
             "refName": "hms-HIVEMETASTORE-BASE",
             "roleType": "HIVEMETASTORE",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_metastore_config_safety_valve",
+                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-spark3.bp
@@ -259,7 +259,13 @@
           {
             "refName": "hms-HIVEMETASTORE-BASE",
             "roleType": "HIVEMETASTORE",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_metastore_config_safety_valve",
+                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering.bp
@@ -249,7 +249,13 @@
           {
             "refName": "hms-HIVEMETASTORE-BASE",
             "roleType": "HIVEMETASTORE",
-            "base": true
+            "base": true,
+            "configs": [
+              {
+                "name": "hive_metastore_config_safety_valve",
+                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+              }
+            ]
           }
         ]
       },


### PR DESCRIPTION
 DISTX-678 - Set hive.metastore.try.direct.sql.ddl=true explicitly in Hive templates
    As part of CDPD-25578, "hive.metastore.try.direct.sql.ddl" was explicitly set to true for "hive_service_config_safety_valve" - used by hive
    This PR sets "hive.metastore.try.direct.sql.ddl" as true for "hive_metastore_config_safety_valve" to be used by hive metastore.

**Property set for "hive_metastore_config_safety_valve"**
<img width="1373" alt="Screenshot 2021-08-09 at 5 56 07 PM" src="https://user-images.githubusercontent.com/32215750/128706347-4839f3de-fa51-4e04-a158-159c58f7cb92.png">


**Property set for "hive_service_config_safety_valve" - already as part of CDPD-25578**
<img width="1526" alt="Screenshot 2021-08-09 at 5 56 59 PM" src="https://user-images.githubusercontent.com/32215750/128706505-f72a44f3-d703-4af7-9992-77acb6a67449.png">

