### PR TITLE
CB-13354 FreeIPA add backup to upgrade flowchain

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/UpgradeFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/UpgradeFlowEventChainFactory.java
@@ -1,23 +1,29 @@
 package com.sequenceiq.freeipa.flow.chain;
 
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupEvent.FULL_BACKUP_EVENT;
 import static com.sequenceiq.freeipa.flow.stack.image.change.event.ImageChangeEvents.IMAGE_CHANGE_EVENT;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.core.chain.FlowEventChainFactory;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
+import com.sequenceiq.freeipa.flow.freeipa.backup.full.event.TriggerFullBackupEvent;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.event.DownscaleEvent;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.event.ChangePrimaryGatewayEvent;
 import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent;
 import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateTriggerEvent;
+import com.sequenceiq.freeipa.flow.freeipa.salt.update.action.SaltUpdateActions;
 import com.sequenceiq.freeipa.flow.freeipa.upgrade.UpgradeEvent;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.event.UpscaleEvent;
@@ -25,6 +31,13 @@ import com.sequenceiq.freeipa.flow.stack.image.change.event.ImageChangeEvent;
 
 @Component
 public class UpgradeFlowEventChainFactory implements FlowEventChainFactory<UpgradeEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SaltUpdateActions.class);
+
+    private static final int PRIMARY_GW_EVENT_COUNT = 3;
+
+    private static final int PRIMARY_GW_INSTANCE_COUNT = 1;
+
     @Override
     public String initEvent() {
         return FlowChainTriggers.UPGRADE_TRIGGER_EVENT;
@@ -35,36 +48,55 @@ public class UpgradeFlowEventChainFactory implements FlowEventChainFactory<Upgra
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new SaltUpdateTriggerEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted(), true, false)
                 .withOperationId(event.getOperationId()));
+        createBackupTriggerEvent(event).ifPresent(flowEventChain::add);
         flowEventChain.add(new ImageChangeEvent(IMAGE_CHANGE_EVENT.event(), event.getResourceId(), event.getImageSettingsRequest())
                 .withOperationId(event.getOperationId()));
 
-        int instanceCountForUpscale = event.getInstanceIds().size() + 2;
-        int instanceCountForDownscale = event.getInstanceIds().size() + 1;
-        addScaleEventsForNonPgwInstances(event, flowEventChain, instanceCountForUpscale, instanceCountForDownscale);
-        addScaleEventsAndChangePgw(event, flowEventChain, instanceCountForUpscale, instanceCountForDownscale);
+        int nonPrimaryGwInstanceCount = event.getInstanceIds().size();
+        int instanceCountForUpscale = nonPrimaryGwInstanceCount + PRIMARY_GW_INSTANCE_COUNT + 1;
+        int instanceCountForDownscale = nonPrimaryGwInstanceCount + PRIMARY_GW_INSTANCE_COUNT;
+        flowEventChain.addAll(createScaleEventsForNonPgwInstances(event, instanceCountForUpscale, instanceCountForDownscale));
+        flowEventChain.addAll(createScaleEventsAndChangePgw(event, instanceCountForUpscale, instanceCountForDownscale));
         flowEventChain.add(new SaltUpdateTriggerEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted(), true, true)
                 .withOperationId(event.getOperationId()));
         return new FlowTriggerEventQueue(getName(), flowEventChain);
     }
 
-    private void addScaleEventsAndChangePgw(UpgradeEvent event, Queue<Selectable> flowEventChain, int instanceCountForUpscale, int instanceCountForDownscale) {
-        flowEventChain.add(new UpscaleEvent(UpscaleFlowEvent.UPSCALE_EVENT.event(),
+    private List<Selectable> createScaleEventsAndChangePgw(UpgradeEvent event, int instanceCountForUpscale, int instanceCountForDownscale) {
+        LOGGER.debug("Add events for primary gateway with id: [{}]", event.getPrimareGwInstanceId());
+        List<Selectable> events = new ArrayList<>(PRIMARY_GW_EVENT_COUNT);
+        events.add(new UpscaleEvent(UpscaleFlowEvent.UPSCALE_EVENT.event(),
                 event.getResourceId(), instanceCountForUpscale, Boolean.FALSE, true, false, event.getOperationId()));
         List<String> oldInstances = new ArrayList<>(event.getInstanceIds());
         oldInstances.add(event.getPrimareGwInstanceId());
-        flowEventChain.add(new ChangePrimaryGatewayEvent(ChangePrimaryGatewayFlowEvent.CHANGE_PRIMARY_GATEWAY_EVENT.event(), event.getResourceId(),
+        events.add(new ChangePrimaryGatewayEvent(ChangePrimaryGatewayFlowEvent.CHANGE_PRIMARY_GATEWAY_EVENT.event(), event.getResourceId(),
                 oldInstances, Boolean.FALSE, event.getOperationId()));
-        flowEventChain.add(new DownscaleEvent(DownscaleFlowEvent.DOWNSCALE_EVENT.event(),
+        events.add(new DownscaleEvent(DownscaleFlowEvent.DOWNSCALE_EVENT.event(),
                 event.getResourceId(), List.of(event.getPrimareGwInstanceId()), instanceCountForDownscale, false, true, false, event.getOperationId()));
+        return events;
     }
 
-    private void addScaleEventsForNonPgwInstances(UpgradeEvent event, Queue<Selectable> flowEventChain, int instanceCountForUpscale,
-            int instanceCountForDownscale) {
+    private List<Selectable> createScaleEventsForNonPgwInstances(UpgradeEvent event, int instanceCountForUpscale, int instanceCountForDownscale) {
+        LOGGER.debug("Add scale events for non primary gateway instances. upscale count: [{}] downscale count: [{}]",
+                instanceCountForUpscale, instanceCountForDownscale);
+        List<Selectable> events = new ArrayList<>(event.getInstanceIds().size() * 2);
         for (String instanceId : event.getInstanceIds()) {
-            flowEventChain.add(new UpscaleEvent(UpscaleFlowEvent.UPSCALE_EVENT.event(),
+            LOGGER.debug("Add upscale and downscale event for [{}]", instanceId);
+            events.add(new UpscaleEvent(UpscaleFlowEvent.UPSCALE_EVENT.event(),
                     event.getResourceId(), instanceCountForUpscale, Boolean.FALSE, true, false, event.getOperationId()));
-            flowEventChain.add(new DownscaleEvent(DownscaleFlowEvent.DOWNSCALE_EVENT.event(),
+            events.add(new DownscaleEvent(DownscaleFlowEvent.DOWNSCALE_EVENT.event(),
                     event.getResourceId(), List.of(instanceId), instanceCountForDownscale, false, true, false, event.getOperationId()));
+        }
+        return events;
+    }
+
+    private Optional<TriggerFullBackupEvent> createBackupTriggerEvent(UpgradeEvent event) {
+        if (event.isBackupSet()) {
+            LOGGER.info("Backup is set, adding full backup to upgrade flow chain");
+            return Optional.of(new TriggerFullBackupEvent(FULL_BACKUP_EVENT.event(), event.getResourceId(), event.getOperationId(), true, false));
+        } else {
+            LOGGER.info("Backup is not set for FreeIPA. No backup will be performed before upgrade.");
+            return Optional.empty();
         }
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/BackupContext.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/BackupContext.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.freeipa.flow.freeipa.backup.full;
+
+import com.sequenceiq.flow.core.CommonContext;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.freeipa.entity.Stack;
+
+public class BackupContext extends CommonContext {
+
+    private final Stack stack;
+
+    public BackupContext(FlowParameters flowParameters, Stack stack) {
+        super(flowParameters);
+        this.stack = stack;
+    }
+
+    public Stack getStack() {
+        return stack;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/CreateFullBackupHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/CreateFullBackupHandler.java
@@ -1,0 +1,93 @@
+package com.sequenceiq.freeipa.flow.freeipa.backup.full;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.freeipa.backup.full.event.CreateFullBackupEvent;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.service.GatewayConfigService;
+import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaNodeUtilService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+import reactor.bus.Event;
+
+@Component
+public class CreateFullBackupHandler extends ExceptionCatcherEventHandler<CreateFullBackupEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreateFullBackupHandler.class);
+
+    @Inject
+    private HostOrchestrator orchestrator;
+
+    @Inject
+    private GatewayConfigService gatewayConfigService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private FreeIpaNodeUtilService nodeService;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(CreateFullBackupEvent.class);
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<CreateFullBackupEvent> event) {
+        LOGGER.error("Unexpected error happened during backup creation", e);
+        return new StackFailureEvent(FullBackupEvent.FULL_BACKUP_FAILED_EVENT.event(), resourceId, e);
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent<CreateFullBackupEvent> event) {
+        Stack stack = stackService.getByIdWithListsInTransaction(event.getData().getResourceId());
+        MDCBuilder.buildMdcContext(stack);
+        Set<Node> nodes = nodeService.mapInstancesToNodes(stack.getNotDeletedInstanceMetaDataSet());
+        OrchestratorStateParams stateParameters = createOrchestratorStateParams(stack, nodes);
+        try {
+            runBackupForNodesSequentially(nodes, stateParameters);
+            return new StackEvent(FullBackupEvent.FULL_BACKUP_SUCCESSFUL_EVENT.event(), event.getData().getResourceId());
+        } catch (CloudbreakOrchestratorFailedException | CloneNotSupportedException e) {
+            LOGGER.error("Full backup failed for node: {}", stateParameters.getTargetHostNames(), e);
+            return new StackFailureEvent(FullBackupEvent.FULL_BACKUP_FAILED_EVENT.event(), event.getData().getResourceId(), e);
+        }
+    }
+
+    private void runBackupForNodesSequentially(Set<Node> nodes, OrchestratorStateParams stateParameters)
+            throws CloudbreakOrchestratorFailedException, CloneNotSupportedException {
+        for (Node node : nodes) {
+            OrchestratorStateParams orchestratorStateParams = stateParameters.clone();
+            LOGGER.info("Run full backup for {}", node);
+            orchestratorStateParams.setTargetHostNames(Set.of(node.getHostname()));
+            orchestrator.runOrchestratorState(orchestratorStateParams);
+        }
+    }
+
+    private OrchestratorStateParams createOrchestratorStateParams(Stack stack, Set<Node> nodes) {
+        GatewayConfig primaryGatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
+        OrchestratorStateParams stateParameters = new OrchestratorStateParams();
+        stateParameters.setPrimaryGatewayConfig(primaryGatewayConfig);
+        stateParameters.setState("freeipa.backup-full");
+        stateParameters.setAllNodes(nodes);
+        LOGGER.debug("Created OrchestratorStateParams for running full backup: {}", stateParameters);
+        return stateParameters;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/FullBackupEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/FullBackupEvent.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.freeipa.flow.freeipa.backup.full;
+
+import com.sequenceiq.flow.core.FlowEvent;
+
+public enum FullBackupEvent implements FlowEvent {
+    FULL_BACKUP_EVENT,
+    FULL_BACKUP_SUCCESSFUL_EVENT,
+    FULL_BACKUP_FINISHED_EVENT,
+    FULL_BACKUP_FAILED_EVENT,
+    FULL_BACKUP_FAILURE_HANDLED_EVENT;
+
+    private final String event;
+
+    FullBackupEvent() {
+        event = name();
+    }
+
+    @Override
+    public String event() {
+        return event;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/FullBackupFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/FullBackupFlowConfig.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.freeipa.flow.freeipa.backup.full;
+
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupEvent.FULL_BACKUP_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupEvent.FULL_BACKUP_FAILED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupEvent.FULL_BACKUP_FAILURE_HANDLED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupEvent.FULL_BACKUP_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupEvent.FULL_BACKUP_SUCCESSFUL_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupState.BACKUP_FAILED_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupState.BACKUP_FINISHED_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupState.BACKUP_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupState.FINAL_STATE;
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupState.INIT_SATE;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration.Transition.Builder;
+
+@Component
+public class FullBackupFlowConfig extends AbstractFlowConfiguration<FullBackupState, FullBackupEvent> {
+
+    private static final List<Transition<FullBackupState, FullBackupEvent>> TRANSITIONS =
+            new Builder<FullBackupState, FullBackupEvent>().defaultFailureEvent(FULL_BACKUP_FAILED_EVENT)
+            .from(INIT_SATE)
+            .to(BACKUP_STATE)
+            .event(FULL_BACKUP_EVENT)
+            .defaultFailureEvent()
+
+            .from(BACKUP_STATE)
+            .to(BACKUP_FINISHED_STATE)
+            .event(FULL_BACKUP_SUCCESSFUL_EVENT)
+            .defaultFailureEvent()
+
+            .from(BACKUP_FINISHED_STATE)
+            .to(FINAL_STATE)
+            .event(FULL_BACKUP_FINISHED_EVENT)
+            .defaultFailureEvent()
+
+            .build();
+
+    protected FullBackupFlowConfig() {
+        super(FullBackupState.class, FullBackupEvent.class);
+    }
+
+    @Override
+    protected List<Transition<FullBackupState, FullBackupEvent>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<FullBackupState, FullBackupEvent> getEdgeConfig() {
+        return new FlowEdgeConfig<>(INIT_SATE, FINAL_STATE, BACKUP_FAILED_STATE, FULL_BACKUP_FAILURE_HANDLED_EVENT);
+    }
+
+    @Override
+    public FullBackupEvent[] getEvents() {
+        return FullBackupEvent.values();
+    }
+
+    @Override
+    public FullBackupEvent[] getInitEvents() {
+        return new FullBackupEvent[]{FULL_BACKUP_EVENT};
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "FreeIPA full backup";
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/FullBackupState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/FullBackupState.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.freeipa.flow.freeipa.backup.full;
+
+import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.FillInMemoryStateStoreRestartAction;
+
+public enum FullBackupState implements FlowState {
+    INIT_SATE,
+    BACKUP_STATE,
+    BACKUP_FINISHED_STATE,
+    BACKUP_FAILED_STATE,
+    FINAL_STATE;
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return FillInMemoryStateStoreRestartAction.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/action/AbstractBackupAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/action/AbstractBackupAction.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.freeipa.flow.freeipa.backup.full.action;
+
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupEvent.FULL_BACKUP_FAILED_EVENT;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.statemachine.StateContext;
+
+import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.OperationAwareAction;
+import com.sequenceiq.freeipa.flow.chain.FlowChainAwareAction;
+import com.sequenceiq.freeipa.flow.freeipa.backup.full.BackupContext;
+import com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupEvent;
+import com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupState;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+public abstract class AbstractBackupAction<P extends Payload> extends AbstractAction<FullBackupState, FullBackupEvent, BackupContext, P>
+        implements OperationAwareAction, FlowChainAwareAction {
+
+    @Inject
+    private StackService stackService;
+
+    protected AbstractBackupAction(Class<P> payloadClass) {
+        super(payloadClass);
+    }
+
+    @Override
+    protected BackupContext createFlowContext(FlowParameters flowParameters, StateContext<FullBackupState, FullBackupEvent> stateContext, P payload) {
+        Stack stack = stackService.getStackById(payload.getResourceId());
+        MDCBuilder.buildMdcContext(stack);
+        return new BackupContext(flowParameters, stack);
+    }
+
+    @Override
+    protected Object getFailurePayload(P payload, Optional<BackupContext> flowContext, Exception ex) {
+        return new StackFailureEvent(FULL_BACKUP_FAILED_EVENT.event(), payload.getResourceId(), ex);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/action/FullBackupActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/action/FullBackupActions.java
@@ -1,0 +1,92 @@
+package com.sequenceiq.freeipa.flow.freeipa.backup.full.action;
+
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupEvent.FULL_BACKUP_FAILURE_HANDLED_EVENT;
+import static com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupEvent.FULL_BACKUP_FINISHED_EVENT;
+
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+
+import com.sequenceiq.flow.core.Flow;
+import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.freeipa.backup.full.BackupContext;
+import com.sequenceiq.freeipa.flow.freeipa.backup.full.event.CreateFullBackupEvent;
+import com.sequenceiq.freeipa.flow.freeipa.backup.full.event.TriggerFullBackupEvent;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+
+@Configuration
+public class FullBackupActions {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FullBackupActions.class);
+
+    @Bean(name = "BACKUP_STATE")
+    public Action<?, ?> backupAction() {
+        return new AbstractBackupAction<>(TriggerFullBackupEvent.class) {
+
+            @Override
+            protected void doExecute(BackupContext context, TriggerFullBackupEvent payload, Map<Object, Object> variables) {
+                LOGGER.info("Full backup flow started with: {}", payload);
+                setChainedAction(variables, payload.isChained());
+                setFinalChain(variables, payload.isFinalChain());
+                setOperationId(variables, payload.getOperationId());
+                sendEvent(context, new CreateFullBackupEvent(payload.getResourceId()));
+            }
+        };
+    }
+
+    @Bean(name = "BACKUP_FINISHED_STATE")
+    public Action<?, ?> backupFinishedAction() {
+        return new AbstractBackupAction<>(StackEvent.class) {
+
+            @Inject
+            private OperationService operationService;
+
+            @Override
+            protected void doExecute(BackupContext context, StackEvent payload, Map<Object, Object> variables) {
+                LOGGER.info("Full backup flow finished");
+                if (isOperationIdSet(variables) && (!isChainedAction(variables) || isFinalChain(variables))) {
+                    LOGGER.debug("Complete operation with id: [{}]", getOperationId(variables));
+                    Stack stack = context.getStack();
+                    SuccessDetails successDetails = new SuccessDetails(stack.getEnvironmentCrn());
+                    operationService.completeOperation(stack.getAccountId(), getOperationId(variables), Set.of(successDetails), Set.of());
+                }
+                sendEvent(context, new StackEvent(FULL_BACKUP_FINISHED_EVENT.event(), payload.getResourceId()));
+            }
+        };
+    }
+
+    @Bean(name = "BACKUP_FAILED_STATE")
+    public Action<?, ?> backupFailedAction() {
+        return new AbstractBackupAction<>(StackFailureEvent.class) {
+
+            @Inject
+            private OperationService operationService;
+
+            @Override
+            protected void doExecute(BackupContext context, StackFailureEvent payload, Map<Object, Object> variables) {
+                LOGGER.error("Full backup failed", payload.getException());
+                failFlow(context, payload);
+                if (isOperationIdSet(variables)) {
+                    LOGGER.debug("Fail operation with id: [{}]", getOperationId(variables));
+                    operationService.failOperation(context.getStack().getAccountId(), getOperationId(variables), payload.getException().getMessage());
+                }
+                sendEvent(context, new StackEvent(FULL_BACKUP_FAILURE_HANDLED_EVENT.event(), payload.getResourceId()));
+            }
+
+            private void failFlow(BackupContext context, StackFailureEvent payload) {
+                Flow flow = getFlow(context.getFlowParameters().getFlowId());
+                flow.setFlowFailed(payload.getException());
+            }
+        };
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/event/CreateFullBackupEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/event/CreateFullBackupEvent.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.freeipa.flow.freeipa.backup.full.event;
+
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+
+public class CreateFullBackupEvent extends StackEvent {
+    public CreateFullBackupEvent(Long stackId) {
+        super(stackId);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/event/TriggerFullBackupEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/event/TriggerFullBackupEvent.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.freeipa.flow.freeipa.backup.full.event;
+
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+
+public class TriggerFullBackupEvent extends StackEvent {
+    private final String operationId;
+
+    private final boolean chained;
+
+    private final boolean finalChain;
+
+    public TriggerFullBackupEvent(String selector, Long stackId, String operationId, boolean chained, boolean finalChain) {
+        super(selector, stackId);
+        this.operationId = operationId;
+        this.chained = chained;
+        this.finalChain = finalChain;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    public boolean isChained() {
+        return chained;
+    }
+
+    public boolean isFinalChain() {
+        return finalChain;
+    }
+
+    @Override
+    public String toString() {
+        return "TriggerFullBackupEvent{" +
+                "operationId='" + operationId + '\'' +
+                ", chained=" + chained +
+                ", finalChain=" + finalChain +
+                "} " + super.toString();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/action/SaltUpdateActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/action/SaltUpdateActions.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.flow.freeipa.salt.update;
+package com.sequenceiq.freeipa.flow.freeipa.salt.update.action;
 
 import java.util.Map;
 
@@ -13,6 +13,7 @@ import com.sequenceiq.freeipa.flow.freeipa.provision.event.bootstrap.BootstrapMa
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.orchestrator.OrchestratorConfigRequest;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.orchestrator.OrchestratorConfigSuccess;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.services.InstallFreeIpaServicesRequest;
+import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateTriggerEvent;
 import com.sequenceiq.freeipa.flow.stack.StackContext;
 import com.sequenceiq.freeipa.flow.stack.provision.action.AbstractStackProvisionAction;
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/action/SaltUpdateFailureAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/action/SaltUpdateFailureAction.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.flow.freeipa.salt.update;
+package com.sequenceiq.freeipa.flow.freeipa.salt.update.action;
 
 import java.util.Map;
 
@@ -10,6 +10,8 @@ import org.slf4j.LoggerFactory;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
 import com.sequenceiq.freeipa.flow.OperationAwareAction;
+import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent;
+import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateState;
 import com.sequenceiq.freeipa.flow.stack.AbstractStackFailureAction;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 import com.sequenceiq.freeipa.flow.stack.StackFailureContext;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/action/SaltUpdateFinishedAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/action/SaltUpdateFinishedAction.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.flow.freeipa.salt.update;
+package com.sequenceiq.freeipa.flow.freeipa.salt.update.action;
 
 import java.util.Map;
 import java.util.Set;
@@ -14,6 +14,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.user.model.SuccessDetails;
 import com.sequenceiq.freeipa.flow.OperationAwareAction;
 import com.sequenceiq.freeipa.flow.chain.FlowChainAwareAction;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.services.InstallFreeIpaServicesSuccess;
+import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateEvent;
 import com.sequenceiq.freeipa.flow.stack.StackContext;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
 import com.sequenceiq.freeipa.flow.stack.provision.action.AbstractStackProvisionAction;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/action/UpdateSaltFilesAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/salt/update/action/UpdateSaltFilesAction.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.flow.freeipa.salt.update;
+package com.sequenceiq.freeipa.flow.freeipa.salt.update.action;
 
 import java.util.Map;
 
@@ -12,6 +12,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackSta
 import com.sequenceiq.freeipa.flow.OperationAwareAction;
 import com.sequenceiq.freeipa.flow.chain.FlowChainAwareAction;
 import com.sequenceiq.freeipa.flow.freeipa.provision.event.bootstrap.BootstrapMachinesRequest;
+import com.sequenceiq.freeipa.flow.freeipa.salt.update.SaltUpdateTriggerEvent;
 import com.sequenceiq.freeipa.flow.stack.StackContext;
 import com.sequenceiq.freeipa.flow.stack.provision.action.AbstractStackProvisionAction;
 import com.sequenceiq.freeipa.service.stack.StackUpdater;

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upgrade/UpgradeEvent.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/freeipa/upgrade/UpgradeEvent.java
@@ -2,11 +2,8 @@ package com.sequenceiq.freeipa.flow.freeipa.upgrade;
 
 import java.util.Set;
 
-import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
 import com.sequenceiq.freeipa.flow.stack.StackEvent;
-
-import reactor.rx.Promise;
 
 public class UpgradeEvent extends StackEvent {
 
@@ -18,30 +15,16 @@ public class UpgradeEvent extends StackEvent {
 
     private final ImageSettingsRequest imageSettingsRequest;
 
-    public UpgradeEvent(Long stackId, Set<String> instanceIds, String primareGwInstanceId, String operationId, ImageSettingsRequest imageSettingsRequest) {
-        super(stackId);
-        this.instanceIds = instanceIds;
-        this.primareGwInstanceId = primareGwInstanceId;
-        this.operationId = operationId;
-        this.imageSettingsRequest = imageSettingsRequest;
-    }
+    private final boolean backupSet;
 
     public UpgradeEvent(String selector, Long stackId, Set<String> instanceIds, String primareGwInstanceId, String operationId,
-            ImageSettingsRequest imageSettingsRequest) {
+            ImageSettingsRequest imageSettingsRequest, boolean backupSet) {
         super(selector, stackId);
         this.instanceIds = instanceIds;
         this.primareGwInstanceId = primareGwInstanceId;
         this.operationId = operationId;
         this.imageSettingsRequest = imageSettingsRequest;
-    }
-
-    public UpgradeEvent(String selector, Long stackId, Promise<AcceptResult> accepted, Set<String> instanceIds, String primareGwInstanceId, String operationId,
-            ImageSettingsRequest imageSettingsRequest) {
-        super(selector, stackId, accepted);
-        this.instanceIds = instanceIds;
-        this.primareGwInstanceId = primareGwInstanceId;
-        this.operationId = operationId;
-        this.imageSettingsRequest = imageSettingsRequest;
+        this.backupSet = backupSet;
     }
 
     public Set<String> getInstanceIds() {
@@ -58,5 +41,9 @@ public class UpgradeEvent extends StackEvent {
 
     public ImageSettingsRequest getImageSettingsRequest() {
         return imageSettingsRequest;
+    }
+
+    public boolean isBackupSet() {
+        return backupSet;
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/UpgradeService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/UpgradeService.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.freeipa.api.v1.operation.model.OperationState.RUNNI
 import static java.util.function.Predicate.not;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -70,7 +71,7 @@ public class UpgradeService {
             Set<String> nonPgwInstanceIds, ImageSettingsRequest imageSettingsRequest, ImageInfoResponse selectedImage, ImageInfoResponse currentImage) {
         Operation operation = startUpgradeOperation(stack.getAccountId(), request);
         UpgradeEvent upgradeEvent = new UpgradeEvent(FlowChainTriggers.UPGRADE_TRIGGER_EVENT, stack.getId(), nonPgwInstanceIds, pgwInstanceId,
-                operation.getOperationId(), imageSettingsRequest);
+                operation.getOperationId(), imageSettingsRequest, Objects.nonNull(stack.getBackup()));
         LOGGER.info("Trigger upgrade flow with event: {}", upgradeEvent);
         FlowIdentifier flowIdentifier = flowManager.notify(FlowChainTriggers.UPGRADE_TRIGGER_EVENT, upgradeEvent);
         return new FreeIpaUpgradeResponse(flowIdentifier, selectedImage, currentImage, operation.getOperationId());

--- a/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backup-full.sls
+++ b/freeipa/src/main/resources/freeipa-salt/salt/freeipa/backup-full.sls
@@ -1,0 +1,13 @@
+include:
+  - freeipa.backup-common
+
+{% if salt['pillar.get']('freeipa:backup:enabled') %}
+freeipa_full_backup:
+  cmd.run:
+    - name: /usr/local/bin/freeipa_backup -t FULL -f "{{salt['grains.get']('fqdn')}}/full" && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/freeipa_full_backup-executed
+    - failhard: True
+    - require:
+        - file: /usr/local/bin/freeipa_backup
+        - file: /usr/local/bin/backup-log-filter.sh
+        - file: /etc/freeipa_backup.conf
+{% endif %}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeFlowEventChainFactoryTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeFlowEventChainFactoryTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.Test;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.flow.core.chain.config.FlowTriggerEventQueue;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
+import com.sequenceiq.freeipa.flow.freeipa.backup.full.FullBackupEvent;
+import com.sequenceiq.freeipa.flow.freeipa.backup.full.event.TriggerFullBackupEvent;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.DownscaleFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.downscale.event.DownscaleEvent;
 import com.sequenceiq.freeipa.flow.freeipa.repair.changeprimarygw.ChangePrimaryGatewayFlowEvent;
@@ -37,7 +39,7 @@ class UpgradeFlowEventChainFactoryTest {
     @Test
     public void testFlowChainCreation() {
         ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
-        UpgradeEvent event = new UpgradeEvent(STACK_ID, Set.of("repl1", "repl2"), "pgw", OPERATION_ID, imageSettingsRequest);
+        UpgradeEvent event = new UpgradeEvent("selector", STACK_ID, Set.of("repl1", "repl2"), "pgw", OPERATION_ID, imageSettingsRequest, false);
 
         FlowTriggerEventQueue eventQueue = underTest.createFlowTriggerEventQueue(event);
 
@@ -50,6 +52,115 @@ class UpgradeFlowEventChainFactoryTest {
         assertEquals(STACK_ID, saltUpdateTriggerEvent.getResourceId());
         assertEquals(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), saltUpdateTriggerEvent.selector());
         assertFalse(saltUpdateTriggerEvent.isFinalChain());
+
+        ImageChangeEvent imageChangeEvent = (ImageChangeEvent) queue.poll();
+        assertEquals(OPERATION_ID, imageChangeEvent.getOperationId());
+        assertEquals(STACK_ID, imageChangeEvent.getResourceId());
+        assertEquals(IMAGE_CHANGE_EVENT.event(), imageChangeEvent.selector());
+        assertEquals(imageSettingsRequest, imageChangeEvent.getRequest());
+
+        UpscaleEvent upscaleEvent1 = (UpscaleEvent) queue.poll();
+        assertEquals(OPERATION_ID, upscaleEvent1.getOperationId());
+        assertEquals(STACK_ID, upscaleEvent1.getResourceId());
+        assertTrue(upscaleEvent1.isChained());
+        assertFalse(upscaleEvent1.isFinalChain());
+        assertFalse(upscaleEvent1.isRepair());
+        assertEquals(UpscaleFlowEvent.UPSCALE_EVENT.event(), upscaleEvent1.selector());
+        assertEquals(4, upscaleEvent1.getInstanceCountByGroup());
+
+        DownscaleEvent downscaleEvent1 = (DownscaleEvent) queue.poll();
+        assertEquals(OPERATION_ID, downscaleEvent1.getOperationId());
+        assertEquals(STACK_ID, downscaleEvent1.getResourceId());
+        assertTrue(downscaleEvent1.isChained());
+        assertFalse(downscaleEvent1.isFinalChain());
+        assertFalse(downscaleEvent1.isRepair());
+        assertEquals(DownscaleFlowEvent.DOWNSCALE_EVENT.event(), downscaleEvent1.selector());
+        assertEquals(3, downscaleEvent1.getInstanceCountByGroup());
+        assertEquals(1, downscaleEvent1.getInstanceIds().size());
+        String firstInstanceToDownscale = downscaleEvent1.getInstanceIds().get(0);
+        assertTrue(firstInstanceToDownscale.startsWith("repl"));
+
+        UpscaleEvent upscaleEvent2 = (UpscaleEvent) queue.poll();
+        assertEquals(OPERATION_ID, upscaleEvent2.getOperationId());
+        assertEquals(STACK_ID, upscaleEvent2.getResourceId());
+        assertTrue(upscaleEvent2.isChained());
+        assertFalse(upscaleEvent2.isFinalChain());
+        assertFalse(upscaleEvent2.isRepair());
+        assertEquals(UpscaleFlowEvent.UPSCALE_EVENT.event(), upscaleEvent2.selector());
+        assertEquals(4, upscaleEvent2.getInstanceCountByGroup());
+
+        DownscaleEvent downscaleEvent2 = (DownscaleEvent) queue.poll();
+        assertEquals(OPERATION_ID, downscaleEvent2.getOperationId());
+        assertEquals(STACK_ID, downscaleEvent2.getResourceId());
+        assertTrue(downscaleEvent2.isChained());
+        assertFalse(downscaleEvent2.isFinalChain());
+        assertFalse(downscaleEvent2.isRepair());
+        assertEquals(DownscaleFlowEvent.DOWNSCALE_EVENT.event(), downscaleEvent2.selector());
+        assertEquals(3, downscaleEvent2.getInstanceCountByGroup());
+        assertEquals(1, downscaleEvent2.getInstanceIds().size());
+        String secondInstanceToDownscale = downscaleEvent2.getInstanceIds().get(0);
+        assertTrue(secondInstanceToDownscale.startsWith("repl"));
+
+        assertNotEquals(firstInstanceToDownscale, secondInstanceToDownscale);
+
+        UpscaleEvent upscaleEvent3 = (UpscaleEvent) queue.poll();
+        assertEquals(OPERATION_ID, upscaleEvent3.getOperationId());
+        assertEquals(STACK_ID, upscaleEvent3.getResourceId());
+        assertTrue(upscaleEvent3.isChained());
+        assertFalse(upscaleEvent3.isFinalChain());
+        assertFalse(upscaleEvent3.isRepair());
+        assertEquals(UpscaleFlowEvent.UPSCALE_EVENT.event(), upscaleEvent3.selector());
+        assertEquals(4, upscaleEvent3.getInstanceCountByGroup());
+
+        ChangePrimaryGatewayEvent changePrimaryGatewayEvent = (ChangePrimaryGatewayEvent) queue.poll();
+        assertEquals(OPERATION_ID, changePrimaryGatewayEvent.getOperationId());
+        assertEquals(STACK_ID, changePrimaryGatewayEvent.getResourceId());
+        assertFalse(changePrimaryGatewayEvent.isFinalChain());
+        assertEquals(ChangePrimaryGatewayFlowEvent.CHANGE_PRIMARY_GATEWAY_EVENT.event(), changePrimaryGatewayEvent.selector());
+        assertEquals(3, changePrimaryGatewayEvent.getRepairInstaceIds().size());
+        assertTrue(List.of("repl1", "repl2", "pgw").containsAll(changePrimaryGatewayEvent.getRepairInstaceIds()));
+
+        DownscaleEvent downscaleEvent3 = (DownscaleEvent) queue.poll();
+        assertEquals(OPERATION_ID, downscaleEvent3.getOperationId());
+        assertEquals(STACK_ID, downscaleEvent3.getResourceId());
+        assertTrue(downscaleEvent3.isChained());
+        assertFalse(downscaleEvent3.isFinalChain());
+        assertFalse(downscaleEvent3.isRepair());
+        assertEquals(DownscaleFlowEvent.DOWNSCALE_EVENT.event(), downscaleEvent3.selector());
+        assertEquals(3, downscaleEvent3.getInstanceCountByGroup());
+        assertEquals(1, downscaleEvent3.getInstanceIds().size());
+        assertEquals("pgw", downscaleEvent3.getInstanceIds().get(0));
+
+        SaltUpdateTriggerEvent saltUpdateTriggerEvent2 = (SaltUpdateTriggerEvent) queue.poll();
+        assertEquals(OPERATION_ID, saltUpdateTriggerEvent2.getOperationId());
+        assertEquals(STACK_ID, saltUpdateTriggerEvent2.getResourceId());
+        assertEquals(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), saltUpdateTriggerEvent2.selector());
+        assertTrue(saltUpdateTriggerEvent2.isChained());
+        assertTrue(saltUpdateTriggerEvent2.isFinalChain());
+    }
+
+    @Test
+    public void testFlowChainCreationWithBackup() {
+        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
+        UpgradeEvent event = new UpgradeEvent("selector", STACK_ID, Set.of("repl1", "repl2"), "pgw", OPERATION_ID, imageSettingsRequest, true);
+
+        FlowTriggerEventQueue eventQueue = underTest.createFlowTriggerEventQueue(event);
+
+        assertEquals("FreeIPA upgrade flow", eventQueue.getFlowChainName());
+        Queue<Selectable> queue = eventQueue.getQueue();
+        assertEquals(11, queue.size());
+
+        SaltUpdateTriggerEvent saltUpdateTriggerEvent = (SaltUpdateTriggerEvent) queue.poll();
+        assertEquals(OPERATION_ID, saltUpdateTriggerEvent.getOperationId());
+        assertEquals(STACK_ID, saltUpdateTriggerEvent.getResourceId());
+        assertEquals(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), saltUpdateTriggerEvent.selector());
+        assertFalse(saltUpdateTriggerEvent.isFinalChain());
+
+        TriggerFullBackupEvent fullBackupEvent = (TriggerFullBackupEvent) queue.poll();
+        assertEquals(OPERATION_ID, fullBackupEvent.getOperationId());
+        assertEquals(STACK_ID, fullBackupEvent.getResourceId());
+        assertEquals(FullBackupEvent.FULL_BACKUP_EVENT.event(), fullBackupEvent.selector());
+        assertFalse(fullBackupEvent.isFinalChain());
 
         ImageChangeEvent imageChangeEvent = (ImageChangeEvent) queue.poll();
         assertEquals(OPERATION_ID, imageChangeEvent.getOperationId());

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/CreateFullBackupHandlerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/freeipa/backup/full/CreateFullBackupHandlerTest.java
@@ -1,0 +1,141 @@
+package com.sequenceiq.freeipa.flow.freeipa.backup.full;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.orchestrator.host.OrchestratorStateParams;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.orchestrator.model.Node;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.freeipa.backup.full.event.CreateFullBackupEvent;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.service.GatewayConfigService;
+import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaNodeUtilService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+import reactor.bus.Event;
+
+@ExtendWith(MockitoExtension.class)
+class CreateFullBackupHandlerTest {
+
+    @Mock
+    private HostOrchestrator orchestrator;
+
+    @Mock
+    private GatewayConfigService gatewayConfigService;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private FreeIpaNodeUtilService nodeService;
+
+    @InjectMocks
+    private CreateFullBackupHandler underTest;
+
+    @Test
+    public void testSelector() {
+        assertEquals(EventSelectorUtil.selector(CreateFullBackupEvent.class), underTest.selector());
+    }
+
+    @Test
+    public void testDefaultFailureEvent() {
+        Exception e = new Exception();
+
+        StackFailureEvent result = (StackFailureEvent) underTest.defaultFailureEvent(2L, e, new Event<>(new CreateFullBackupEvent(3L)));
+
+        assertEquals(2L, result.getResourceId());
+        assertEquals(e, result.getException());
+        assertEquals(FullBackupEvent.FULL_BACKUP_FAILED_EVENT.event(), result.selector());
+    }
+
+    @Test
+    public void testBackupSuccessful() throws CloudbreakOrchestratorFailedException {
+        Stack stack = mock(Stack.class);
+        when(stackService.getByIdWithListsInTransaction(2L)).thenReturn(stack);
+        Set<InstanceMetaData> metaDataSet = Set.of();
+        when(stack.getNotDeletedInstanceMetaDataSet()).thenReturn(metaDataSet);
+        Node node1 = createNode("node1");
+        Node node2 = createNode("node2");
+        Set<Node> nodes = Set.of(node1, node2);
+        when(nodeService.mapInstancesToNodes(metaDataSet)).thenReturn(nodes);
+        GatewayConfig gatewayConfig = mock(GatewayConfig.class);
+        when(gatewayConfigService.getPrimaryGatewayConfig(stack)).thenReturn(gatewayConfig);
+
+        StackEvent result = (StackEvent) underTest.doAccept(new HandlerEvent<>(new Event<>(new CreateFullBackupEvent(2L))));
+
+        ArgumentCaptor<OrchestratorStateParams> captor = ArgumentCaptor.forClass(OrchestratorStateParams.class);
+        verify(orchestrator, times(2)).runOrchestratorState(captor.capture());
+        List<OrchestratorStateParams> stateParams = captor.getAllValues();
+        assertThat(stateParams, everyItem(allOf(
+                hasProperty("primaryGatewayConfig", is(gatewayConfig)),
+                hasProperty("state", is("freeipa.backup-full")),
+                hasProperty("allNodes", is(nodes))
+                )));
+        assertThat(stateParams, hasItem(hasProperty("targetHostNames", allOf(
+                hasItem("node1"),
+                iterableWithSize(1)
+        ))));
+        assertThat(stateParams, hasItem(hasProperty("targetHostNames", allOf(
+                hasItem("node2"),
+                iterableWithSize(1)
+        ))));
+
+        assertEquals(2L, result.getResourceId());
+        assertEquals(FullBackupEvent.FULL_BACKUP_SUCCESSFUL_EVENT.event(), result.selector());
+    }
+
+    private Node createNode(String hostname) {
+        Node node = mock(Node.class);
+        when(node.getHostname()).thenReturn(hostname);
+        return node;
+    }
+
+    @Test
+    public void testOrchestratorThrowException() throws CloudbreakOrchestratorFailedException {
+        Stack stack = mock(Stack.class);
+        when(stackService.getByIdWithListsInTransaction(2L)).thenReturn(stack);
+        Set<InstanceMetaData> metaDataSet = Set.of();
+        when(stack.getNotDeletedInstanceMetaDataSet()).thenReturn(metaDataSet);
+        Node node1 = createNode("node1");
+        Set<Node> nodes = Set.of(node1);
+        when(nodeService.mapInstancesToNodes(metaDataSet)).thenReturn(nodes);
+        GatewayConfig gatewayConfig = mock(GatewayConfig.class);
+        when(gatewayConfigService.getPrimaryGatewayConfig(stack)).thenReturn(gatewayConfig);
+        doThrow(new CloudbreakOrchestratorFailedException("tada")).when(orchestrator).runOrchestratorState(any(OrchestratorStateParams.class));
+
+        StackFailureEvent result = (StackFailureEvent) underTest.doAccept(new HandlerEvent<>(new Event<>(new CreateFullBackupEvent(2L))));
+
+        assertEquals(2L, result.getResourceId());
+        assertEquals(FullBackupEvent.FULL_BACKUP_FAILED_EVENT.event(), result.selector());
+        assertEquals("tada", result.getException().getMessage());
+    }
+}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/OrchestratorStateParams.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/OrchestratorStateParams.java
@@ -10,7 +10,7 @@ import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
 
-public class OrchestratorStateParams {
+public class OrchestratorStateParams implements Cloneable {
     private String state;
 
     private GatewayConfig primaryGatewayConfig;
@@ -103,5 +103,25 @@ public class OrchestratorStateParams {
 
     public void setErrorMessage(String errorMessage) {
         this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public OrchestratorStateParams clone() throws CloneNotSupportedException {
+        return (OrchestratorStateParams) super.clone();
+    }
+
+    @Override
+    public String toString() {
+        return "OrchestratorStateParams{" +
+                "state='" + state + '\'' +
+                ", primaryGatewayConfig=" + primaryGatewayConfig +
+                ", targetHostNames=" + targetHostNames +
+                ", allNodes=" + allNodes +
+                ", exitCriteriaModel=" + exitCriteriaModel +
+                ", stateRetryParams=" + stateRetryParams +
+                ", stateParams=" + stateParams +
+                ", concurrent=" + concurrent +
+                ", errorMessage='" + errorMessage + '\'' +
+                '}';
     }
 }


### PR DESCRIPTION
- a new flow is implemented to create full backups
- it's available only in upgrade flow chain now, no separate endpoint
- backup is added after salt update to ensure the new state is present
- backup is initiated on one node at a time, as full backup stops FreeIPA related services
- backup is only added to the flowchain if the `Stack` is configured for backup

See detailed description in the commit message.