### PR TITLE
CB-12701 Add support for registering CCMV2 Jumpgate type clusters

### DIFF
--- a/ccm-connector/src/generated/main/java/com/cloudera/thunderhead/service/clusterconnectivitymanagementv2/ClusterConnectivityManagementV2Proto.java
+++ b/ccm-connector/src/generated/main/java/com/cloudera/thunderhead/service/clusterconnectivitymanagementv2/ClusterConnectivityManagementV2Proto.java
@@ -9201,18 +9201,18 @@ public final class ClusterConnectivityManagementV2Proto {
      * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
      * </pre>
      *
-     * <code>string envirinmentCrn = 4;</code>
+     * <code>string environmentCrn = 4;</code>
      */
-    java.lang.String getEnvirinmentCrn();
+    java.lang.String getEnvironmentCrn();
     /**
      * <pre>
      * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
      * </pre>
      *
-     * <code>string envirinmentCrn = 4;</code>
+     * <code>string environmentCrn = 4;</code>
      */
     com.google.protobuf.ByteString
-        getEnvirinmentCrnBytes();
+        getEnvironmentCrnBytes();
 
     public com.cloudera.thunderhead.service.clusterconnectivitymanagementv2.ClusterConnectivityManagementV2Proto.ListAgentsRequest.FilterOneofCase getFilterOneofCase();
   }
@@ -9323,7 +9323,7 @@ public final class ClusterConnectivityManagementV2Proto {
     public enum FilterOneofCase
         implements com.google.protobuf.Internal.EnumLite {
       ACCOUNTID(3),
-      ENVIRINMENTCRN(4),
+      ENVIRONMENTCRN(4),
       FILTERONEOF_NOT_SET(0);
       private final int value;
       private FilterOneofCase(int value) {
@@ -9340,7 +9340,7 @@ public final class ClusterConnectivityManagementV2Proto {
       public static FilterOneofCase forNumber(int value) {
         switch (value) {
           case 3: return ACCOUNTID;
-          case 4: return ENVIRINMENTCRN;
+          case 4: return ENVIRONMENTCRN;
           case 0: return FILTERONEOF_NOT_SET;
           default: return null;
         }
@@ -9437,15 +9437,15 @@ public final class ClusterConnectivityManagementV2Proto {
       }
     }
 
-    public static final int ENVIRINMENTCRN_FIELD_NUMBER = 4;
+    public static final int ENVIRONMENTCRN_FIELD_NUMBER = 4;
     /**
      * <pre>
      * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
      * </pre>
      *
-     * <code>string envirinmentCrn = 4;</code>
+     * <code>string environmentCrn = 4;</code>
      */
-    public java.lang.String getEnvirinmentCrn() {
+    public java.lang.String getEnvironmentCrn() {
       java.lang.Object ref = "";
       if (filterOneofCase_ == 4) {
         ref = filterOneof_;
@@ -9467,10 +9467,10 @@ public final class ClusterConnectivityManagementV2Proto {
      * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
      * </pre>
      *
-     * <code>string envirinmentCrn = 4;</code>
+     * <code>string environmentCrn = 4;</code>
      */
     public com.google.protobuf.ByteString
-        getEnvirinmentCrnBytes() {
+        getEnvironmentCrnBytes() {
       java.lang.Object ref = "";
       if (filterOneofCase_ == 4) {
         ref = filterOneof_;
@@ -9569,8 +9569,8 @@ public final class ClusterConnectivityManagementV2Proto {
               .equals(other.getAccountId());
           break;
         case 4:
-          result = result && getEnvirinmentCrn()
-              .equals(other.getEnvirinmentCrn());
+          result = result && getEnvironmentCrn()
+              .equals(other.getEnvironmentCrn());
           break;
         case 0:
         default:
@@ -9598,8 +9598,8 @@ public final class ClusterConnectivityManagementV2Proto {
           hash = (53 * hash) + getAccountId().hashCode();
           break;
         case 4:
-          hash = (37 * hash) + ENVIRINMENTCRN_FIELD_NUMBER;
-          hash = (53 * hash) + getEnvirinmentCrn().hashCode();
+          hash = (37 * hash) + ENVIRONMENTCRN_FIELD_NUMBER;
+          hash = (53 * hash) + getEnvironmentCrn().hashCode();
           break;
         case 0:
         default:
@@ -9847,7 +9847,7 @@ public final class ClusterConnectivityManagementV2Proto {
             onChanged();
             break;
           }
-          case ENVIRINMENTCRN: {
+          case ENVIRONMENTCRN: {
             filterOneofCase_ = 4;
             filterOneof_ = other.filterOneof_;
             onChanged();
@@ -10149,9 +10149,9 @@ public final class ClusterConnectivityManagementV2Proto {
        * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
        * </pre>
        *
-       * <code>string envirinmentCrn = 4;</code>
+       * <code>string environmentCrn = 4;</code>
        */
-      public java.lang.String getEnvirinmentCrn() {
+      public java.lang.String getEnvironmentCrn() {
         java.lang.Object ref = "";
         if (filterOneofCase_ == 4) {
           ref = filterOneof_;
@@ -10173,10 +10173,10 @@ public final class ClusterConnectivityManagementV2Proto {
        * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
        * </pre>
        *
-       * <code>string envirinmentCrn = 4;</code>
+       * <code>string environmentCrn = 4;</code>
        */
       public com.google.protobuf.ByteString
-          getEnvirinmentCrnBytes() {
+          getEnvironmentCrnBytes() {
         java.lang.Object ref = "";
         if (filterOneofCase_ == 4) {
           ref = filterOneof_;
@@ -10198,9 +10198,9 @@ public final class ClusterConnectivityManagementV2Proto {
        * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
        * </pre>
        *
-       * <code>string envirinmentCrn = 4;</code>
+       * <code>string environmentCrn = 4;</code>
        */
-      public Builder setEnvirinmentCrn(
+      public Builder setEnvironmentCrn(
           java.lang.String value) {
         if (value == null) {
     throw new NullPointerException();
@@ -10215,9 +10215,9 @@ public final class ClusterConnectivityManagementV2Proto {
        * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
        * </pre>
        *
-       * <code>string envirinmentCrn = 4;</code>
+       * <code>string environmentCrn = 4;</code>
        */
-      public Builder clearEnvirinmentCrn() {
+      public Builder clearEnvironmentCrn() {
         if (filterOneofCase_ == 4) {
           filterOneofCase_ = 0;
           filterOneof_ = null;
@@ -10230,9 +10230,9 @@ public final class ClusterConnectivityManagementV2Proto {
        * If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
        * </pre>
        *
-       * <code>string envirinmentCrn = 4;</code>
+       * <code>string environmentCrn = 4;</code>
        */
-      public Builder setEnvirinmentCrnBytes(
+      public Builder setEnvironmentCrnBytes(
           com.google.protobuf.ByteString value) {
         if (value == null) {
     throw new NullPointerException();
@@ -11497,7 +11497,7 @@ public final class ClusterConnectivityManagementV2Proto {
       "onmentCrn\030\004 \001(\t\022\032\n\014certificates\030\005 \003(\tB\004\210" +
       "\265\030\001\"\212\001\n\021ListAgentsRequest\022\020\n\010pageSize\030\001 " +
       "\001(\005\022$\n\tpageToken\030\002 \001(\0132\021.paging.PageToke" +
-      "n\022\023\n\taccountId\030\003 \001(\tH\000\022\030\n\016envirinmentCrn" +
+      "n\022\023\n\taccountId\030\003 \001(\tH\000\022\030\n\016environmentCrn" +
       "\030\004 \001(\tH\000B\016\n\014filter_oneof\"\204\001\n\022ListAgentsR" +
       "esponse\022(\n\rnextPageToken\030\001 \001(\0132\021.paging." +
       "PageToken\022D\n\006agents\030\002 \003(\01324.clusterconne" +
@@ -11623,7 +11623,7 @@ public final class ClusterConnectivityManagementV2Proto {
     internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_clusterconnectivitymanagementv2_ListAgentsRequest_descriptor,
-        new java.lang.String[] { "PageSize", "PageToken", "AccountId", "EnvirinmentCrn", "FilterOneof", });
+        new java.lang.String[] { "PageSize", "PageToken", "AccountId", "EnvironmentCrn", "FilterOneof", });
     internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_descriptor =
       getDescriptor().getMessageTypes().get(13);
     internal_static_clusterconnectivitymanagementv2_ListAgentsResponse_fieldAccessorTable = new

--- a/ccm-connector/src/main/proto/clusterconnectivitymanagementv2.proto
+++ b/ccm-connector/src/main/proto/clusterconnectivitymanagementv2.proto
@@ -152,7 +152,7 @@ message ListAgentsRequest {
     // If an accountId is passed-in, all agents belonging to this accountId would be returned.
     string accountId = 3;
     // If an environmentCrn is passed-in, all agents belonging to this environmnent would be returned.
-    string envirinmentCrn = 4;
+    string environmentCrn = 4;
   }
 }
 

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/AuthenticationType.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/AuthenticationType.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.cloudbreak.clusterproxy;
+
+public enum AuthenticationType {
+    UNAVAILABLE, NONE, BASIC_SECRET
+}

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/CcmV2Config.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/CcmV2Config.java
@@ -1,38 +1,39 @@
 package com.sequenceiq.cloudbreak.clusterproxy;
 
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CcmV2Config {
 
-    @JsonProperty("agentCrn")
-    private String agentCrn;
-
     @JsonProperty("backendId")
-    private String backendId;
+    private final String backendId;
 
     @JsonProperty("host")
-    private String gatewayHost;
+    private final String gatewayHost;
 
     @JsonProperty("port")
-    private int gatewayPort;
+    private final int gatewayPort;
 
-    public CcmV2Config(String agentCrn, String backendId, String gatewayHost, int gatewayPort) {
-        this.agentCrn = agentCrn;
-        this.backendId = backendId;
+    @JsonProperty("serviceName")
+    private final String serviceName;
+
+    public CcmV2Config(String gatewayHost, int gatewayPort, String backendId, String serviceName) {
         this.gatewayHost = gatewayHost;
         this.gatewayPort = gatewayPort;
+        this.backendId = backendId;
+        this.serviceName = serviceName;
     }
 
     @Override
     public String toString() {
-        return "CcmV2Config{" +
-                "agentCrn='" + agentCrn + '\'' +
-                ", backendId='" + backendId + '\'' +
-                ", gatewayHost='" + gatewayHost + '\'' +
-                ", gatewayPort=" + gatewayPort +
-                '}';
+        return new StringJoiner(", ", CcmV2Config.class.getSimpleName() + "[", "]")
+                .add("backendId='" + backendId + "'")
+                .add("gatewayHost='" + gatewayHost + "'")
+                .add("gatewayPort=" + gatewayPort)
+                .add("serviceName='" + serviceName + "'")
+                .toString();
     }
 
     @Override
@@ -45,13 +46,13 @@ public class CcmV2Config {
         }
         CcmV2Config that = (CcmV2Config) o;
         return gatewayPort == that.gatewayPort &&
-                Objects.equals(agentCrn, that.agentCrn) &&
                 Objects.equals(backendId, that.backendId) &&
-                Objects.equals(gatewayHost, that.gatewayHost);
+                Objects.equals(gatewayHost, that.gatewayHost) &&
+                Objects.equals(serviceName, that.serviceName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(agentCrn, backendId, gatewayHost, gatewayPort);
+        return Objects.hash(backendId, gatewayHost, gatewayPort, serviceName);
     }
 }

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClientCertificate.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClientCertificate.java
@@ -6,11 +6,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ClientCertificate {
-    @JsonProperty
-    private String keyRef;
 
     @JsonProperty
-    private String certificateRef;
+    private final String keyRef;
+
+    @JsonProperty
+    private final String certificateRef;
 
     @JsonCreator
     public ClientCertificate(String keyRef, String certificateRef) {

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceConfig.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceConfig.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.clusterproxy;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.StringJoiner;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -9,32 +10,40 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ClusterServiceConfig {
 
     @JsonProperty
-    private String name;
+    private final String name;
 
     @JsonProperty
-    private List<String> endpoints;
+    private final List<String> endpoints;
 
     @JsonProperty
-    private List<ClusterServiceCredential> credentials;
+    private final AuthenticationType authenticationType;
 
     @JsonProperty
-    private ClientCertificate clientCertificate;
+    private final boolean removeProxyContentType;
 
     @JsonProperty
-    private ClusterServiceHealthCheck healthCheck;
+    private final List<ClusterServiceCredential> credentials;
+
+    @JsonProperty
+    private final ClientCertificate clientCertificate;
+
+    @JsonProperty
+    private final ClusterServiceHealthCheck healthCheck;
 
     @JsonCreator
-    public ClusterServiceConfig(String serviceName, List<String> endpoints, List<ClusterServiceCredential> credentials, ClientCertificate clientCertificate,
-                                ClusterServiceHealthCheck healthCheck) {
+    public ClusterServiceConfig(String serviceName, List<String> endpoints, AuthenticationType authenticationType, boolean removeProxyContentType,
+            List<ClusterServiceCredential> credentials, ClientCertificate clientCertificate, ClusterServiceHealthCheck healthCheck) {
         this.name = serviceName;
         this.endpoints = endpoints;
+        this.authenticationType = authenticationType;
+        this.removeProxyContentType = removeProxyContentType;
         this.credentials = credentials;
         this.clientCertificate = clientCertificate;
         this.healthCheck = healthCheck;
     }
 
     public ClusterServiceConfig(String serviceName, List<String> endpoints, List<ClusterServiceCredential> credentials, ClientCertificate clientCertificate) {
-        this(serviceName, endpoints, credentials, clientCertificate, null);
+        this(serviceName, endpoints, null, false, credentials, clientCertificate, null);
     }
 
     //CHECKSTYLE:OFF: CyclomaticComplexity
@@ -46,11 +55,11 @@ public class ClusterServiceConfig {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         ClusterServiceConfig that = (ClusterServiceConfig) o;
-
-        return Objects.equals(name, that.name) &&
+        return removeProxyContentType == that.removeProxyContentType &&
+                Objects.equals(name, that.name) &&
                 Objects.equals(endpoints, that.endpoints) &&
+                Objects.equals(authenticationType, that.authenticationType) &&
                 Objects.equals(credentials, that.credentials) &&
                 Objects.equals(clientCertificate, that.clientCertificate) &&
                 Objects.equals(healthCheck, that.healthCheck);
@@ -59,16 +68,19 @@ public class ClusterServiceConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, endpoints, credentials, clientCertificate, healthCheck);
+        return Objects.hash(name, endpoints, authenticationType, removeProxyContentType, credentials, clientCertificate, healthCheck);
     }
 
     @Override
     public String toString() {
-        return "ClusterServiceConfig{serviceName='" + name + '\''
-                + ", endpoints=" + endpoints
-                + ", credentials=" + credentials
-                + ", clientCertificate=" + clientCertificate
-                + ", healthCheck=" + healthCheck
-                + '}';
+        return new StringJoiner(", ", ClusterServiceConfig.class.getSimpleName() + "[", "]")
+                .add("name='" + name + "'")
+                .add("endpoints=" + endpoints)
+                .add("authenticationType='" + authenticationType + "'")
+                .add("removeProxyContentType=" + removeProxyContentType)
+                .add("credentials=" + credentials)
+                .add("clientCertificate=" + clientCertificate)
+                .add("healthCheck=" + healthCheck)
+                .toString();
     }
 }

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceCredential.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceCredential.java
@@ -6,14 +6,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ClusterServiceCredential {
-    @JsonProperty
-    private String username;
 
     @JsonProperty
-    private String credentialRef;
+    private final String username;
 
     @JsonProperty
-    private boolean isDefault;
+    private final String credentialRef;
+
+    @JsonProperty
+    private final boolean isDefault;
 
     @JsonCreator
     public ClusterServiceCredential(String username, String credentialRef) {

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceHealthCheck.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterServiceHealthCheck.java
@@ -6,17 +6,18 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ClusterServiceHealthCheck {
-    @JsonProperty
-    private int intervalInSec;
 
     @JsonProperty
-    private String endpointSuffix;
+    private final int intervalInSec;
 
     @JsonProperty
-    private int timeoutInSec;
+    private final String endpointSuffix;
 
     @JsonProperty
-    private int healthyStatusCode;
+    private final int timeoutInSec;
+
+    @JsonProperty
+    private final int healthyStatusCode;
 
     @JsonCreator
     public ClusterServiceHealthCheck(int intervalInSec, String endpointSuffix, int timeoutInSec, int healthyStatusCode) {

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ConfigDeleteRequest.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ConfigDeleteRequest.java
@@ -6,8 +6,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ConfigDeleteRequest {
+
     @JsonProperty
-    private String clusterCrn;
+    private final String clusterCrn;
 
     @JsonCreator
     public ConfigDeleteRequest(String clusterCrn) {

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ConfigRegistrationRequest.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ConfigRegistrationRequest.java
@@ -9,42 +9,50 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public class ConfigRegistrationRequest {
+
     @SuppressFBWarnings("URF_UNREAD_FIELD")
     @JsonProperty
-    private String accountId;
+    private final String accountId;
 
     @JsonProperty
-    private String clusterCrn;
+    private final String clusterCrn;
 
     @JsonProperty
-    private String uriOfKnox;
+    private final String environmentCrn;
 
     @JsonProperty
-    private List<String> aliases;
+    private final String uriOfKnox;
 
     @JsonProperty
-    private List<ClusterServiceConfig> services;
+    private final List<String> aliases;
 
     @JsonProperty
-    private List<String> certificates;
+    private final List<ClusterServiceConfig> services;
 
     @JsonProperty
-    private boolean useTunnel;
+    private final List<String> certificates;
 
     @JsonProperty
-    private List<TunnelEntry> tunnels;
+    private final boolean useTunnel;
+
+    @JsonProperty
+    private final List<TunnelEntry> tunnels;
 
     @JsonProperty("useCCMv2")
-    private boolean useCcmV2;
+    private final boolean useCcmV2;
 
     @JsonProperty
-    private List<CcmV2Config> ccmV2Configs;
+    private final List<CcmV2Config> ccmV2Configs;
+
+    @JsonProperty
+    private final boolean tlsStrictCheck;
 
     @JsonCreator
-    public ConfigRegistrationRequest(String clusterCrn, String knoxUrl, String accountId, boolean useTunnel, List<TunnelEntry> tunnelEntries,
-            List<String> aliases, List<ClusterServiceConfig> services, List<String> certificates, boolean useCcmV2,
-            List<CcmV2Config> ccmV2Configs) {
+    public ConfigRegistrationRequest(String clusterCrn, String environmentCrn, String knoxUrl, String accountId, boolean useTunnel,
+            List<TunnelEntry> tunnelEntries, List<String> aliases, List<ClusterServiceConfig> services, List<String> certificates, boolean useCcmV2,
+            List<CcmV2Config> ccmV2Configs, boolean tlsStrictCheck) {
         this.clusterCrn = clusterCrn;
+        this.environmentCrn = environmentCrn;
         this.uriOfKnox = knoxUrl;
         this.accountId = accountId;
         this.useTunnel = useTunnel;
@@ -54,10 +62,15 @@ public class ConfigRegistrationRequest {
         this.certificates = certificates;
         this.useCcmV2 = useCcmV2;
         this.ccmV2Configs = ccmV2Configs;
+        this.tlsStrictCheck = tlsStrictCheck;
     }
 
     public String getClusterCrn() {
         return clusterCrn;
+    }
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
     }
 
     public List<ClusterServiceConfig> getServices() {
@@ -96,6 +109,10 @@ public class ConfigRegistrationRequest {
         return tunnels;
     }
 
+    public boolean isTlsStrictCheck() {
+        return tlsStrictCheck;
+    }
+
     //CHECKSTYLE:OFF: CyclomaticComplexity
     @Override
     public boolean equals(Object o) {
@@ -107,21 +124,24 @@ public class ConfigRegistrationRequest {
         }
         ConfigRegistrationRequest that = (ConfigRegistrationRequest) o;
         return useTunnel == that.useTunnel &&
+                useCcmV2 == that.useCcmV2 &&
+                tlsStrictCheck == that.tlsStrictCheck &&
                 Objects.equals(accountId, that.accountId) &&
                 Objects.equals(clusterCrn, that.clusterCrn) &&
+                Objects.equals(environmentCrn, that.environmentCrn) &&
                 Objects.equals(uriOfKnox, that.uriOfKnox) &&
                 Objects.equals(aliases, that.aliases) &&
                 Objects.equals(services, that.services) &&
                 Objects.equals(certificates, that.certificates) &&
                 Objects.equals(tunnels, that.tunnels) &&
-                Objects.equals(useCcmV2, that.useCcmV2) &&
                 Objects.equals(ccmV2Configs, that.ccmV2Configs);
     }
     //CHECKSTYLE:ON
 
     @Override
     public int hashCode() {
-        return Objects.hash(accountId, clusterCrn, uriOfKnox, aliases, services, certificates, useTunnel, tunnels, useCcmV2, ccmV2Configs);
+        return Objects.hash(accountId, clusterCrn, environmentCrn, uriOfKnox, aliases,
+                services, certificates, useTunnel, tunnels, useCcmV2, ccmV2Configs, tlsStrictCheck);
     }
 
     @Override
@@ -129,6 +149,7 @@ public class ConfigRegistrationRequest {
         return "ConfigRegistrationRequest{" +
                 "accountId='" + accountId + '\'' +
                 ", clusterCrn='" + clusterCrn + '\'' +
+                ", environmentCrn='" + environmentCrn + '\'' +
                 ", uriOfKnox='" + uriOfKnox + '\'' +
                 ", aliases=" + aliases +
                 ", services=" + services +
@@ -137,6 +158,7 @@ public class ConfigRegistrationRequest {
                 ", tunnels=" + tunnels +
                 ", useCcmV2=" + useCcmV2 +
                 ", ccmV2Configs=" + ccmV2Configs +
+                ", tlsStrictCheck=" + tlsStrictCheck +
                 '}';
     }
 }

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ConfigRegistrationRequestBuilder.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ConfigRegistrationRequestBuilder.java
@@ -3,9 +3,12 @@ package com.sequenceiq.cloudbreak.clusterproxy;
 import java.util.List;
 
 public class ConfigRegistrationRequestBuilder {
+
     private String accountId;
 
-    private String clusterCrn;
+    private final String clusterCrn;
+
+    private String environmentCrn;
 
     private String uriOfKnox;
 
@@ -23,8 +26,17 @@ public class ConfigRegistrationRequestBuilder {
 
     private List<CcmV2Config> ccmV2Configs;
 
+    // TODO: cluster-proxy documentation suggests this should be set to "true" in production services. We have not set it ever and the default at
+    // cluster-proxy level is "false"
+    private boolean tlsStrictCheck;
+
     public ConfigRegistrationRequestBuilder(String clusterCrn) {
         this.clusterCrn = clusterCrn;
+    }
+
+    public ConfigRegistrationRequestBuilder withEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+        return this;
     }
 
     public ConfigRegistrationRequestBuilder withAliases(List<String> aliases) {
@@ -44,6 +56,11 @@ public class ConfigRegistrationRequestBuilder {
 
     public ConfigRegistrationRequestBuilder withAccountId(String accountId) {
         this.accountId = accountId;
+        return this;
+    }
+
+    public ConfigRegistrationRequestBuilder withUseCcmV2(boolean useCcmV2) {
+        this.useCcmV2 = useCcmV2;
         return this;
     }
 
@@ -68,7 +85,13 @@ public class ConfigRegistrationRequestBuilder {
         return this;
     }
 
+    public ConfigRegistrationRequestBuilder withTlsStrictCheck(boolean tlsStrictCheck) {
+        this.tlsStrictCheck = tlsStrictCheck;
+        return this;
+    }
+
     public ConfigRegistrationRequest build() {
-        return new ConfigRegistrationRequest(clusterCrn, uriOfKnox, accountId, useTunnel, tunnels, aliases, services, certificates, useCcmV2, ccmV2Configs);
+        return new ConfigRegistrationRequest(clusterCrn, environmentCrn, uriOfKnox, accountId,
+                useTunnel, tunnels, aliases, services, certificates, useCcmV2, ccmV2Configs, tlsStrictCheck);
     }
 }

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ConfigRegistrationResponse.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ConfigRegistrationResponse.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.clusterproxy;
 import java.util.Objects;
 
 public class ConfigRegistrationResponse {
+
     private String result;
 
     private String x509Unwrapped;

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ConfigUpdateRequest.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ConfigUpdateRequest.java
@@ -6,11 +6,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ConfigUpdateRequest {
-    @JsonProperty
-    private String clusterCrn;
 
     @JsonProperty
-    private String uriOfKnox;
+    private final String clusterCrn;
+
+    @JsonProperty
+    private final String uriOfKnox;
 
     @JsonCreator
     public ConfigUpdateRequest(String clusterCrn, String uriOfKnox) {

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigEndpoint.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigEndpoint.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.clusterproxy;
 import java.util.Objects;
 
 public class ReadConfigEndpoint {
+
     private String endpointId;
 
     private String status;
@@ -75,6 +76,6 @@ public class ReadConfigEndpoint {
     }
 
     public String toHumanReadableString() {
-        return "[endpointId = [" + endpointId + "], endpoint: [" + endpoint + "], status: [" + status + "]]";
+        return "[endpointId = [" + endpointId + "], endpoint: [" + endpoint + "], status: [" + status + "], updatedTime: [" + updatedTime + " ]]";
     }
 }

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigRequest.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigRequest.java
@@ -6,8 +6,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ReadConfigRequest {
+
     @JsonProperty
-    private String clusterCrn;
+    private final String clusterCrn;
 
     @JsonCreator
     public ReadConfigRequest(String clusterCrn) {

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigResponse.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigResponse.java
@@ -5,7 +5,12 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ReadConfigResponse {
+
     private String crn;
+
+    private List<String> aliases;
+
+    private String uriOfKnox;
 
     private List<ReadConfigService> services;
 
@@ -25,6 +30,22 @@ public class ReadConfigResponse {
         this.services = services;
     }
 
+    public List<String> getAliases() {
+        return aliases;
+    }
+
+    public void setAliases(List<String> aliases) {
+        this.aliases = aliases;
+    }
+
+    public String getUriOfKnox() {
+        return uriOfKnox;
+    }
+
+    public void setUriOfKnox(String uriOfKnox) {
+        this.uriOfKnox = uriOfKnox;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -33,25 +54,32 @@ public class ReadConfigResponse {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         ReadConfigResponse that = (ReadConfigResponse) o;
-
         return Objects.equals(crn, that.crn) &&
+                Objects.equals(aliases, that.aliases) &&
+                Objects.equals(uriOfKnox, that.uriOfKnox) &&
                 Objects.equals(services, that.services);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(crn, services);
+        return Objects.hash(crn, aliases, uriOfKnox, services);
     }
 
     @Override
     public String toString() {
-        return "ReadConfigResponse{crn='" + crn + '\'' + ", services=" + services + '}';
+        return "ReadConfigResponse{" +
+                "crn='" + crn + '\'' +
+                ", aliases=" + aliases +
+                ", uriOfKnox='" + uriOfKnox + '\'' +
+                ", services=" + services +
+                '}';
     }
 
     public String toHumanReadableString() {
         return "ClusterProxy for crn: [" + crn + "], " +
-                "services: [" + services.stream().map(ReadConfigService::toHumanReadableString).collect(Collectors.joining(", ")) + "]]";
+                "services: [" + services.stream().map(ReadConfigService::toHumanReadableString).collect(Collectors.joining(", ")) + "], " +
+                "aliases: [" + aliases + "], " +
+                "Knox URI: [" + uriOfKnox +  "]";
     }
 }

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigService.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/ReadConfigService.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ReadConfigService {
+
     private String name;
 
     private List<ReadConfigEndpoint> endpoints;

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/Tunnel.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/Tunnel.java
@@ -1,23 +1,23 @@
 package com.sequenceiq.cloudbreak.clusterproxy;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.Objects;
 
 public class Tunnel {
 
     @JsonProperty
-    private String key;
+    private final String key;
 
     @JsonProperty
-    private String serviceType;
+    private final String serviceType;
 
     @JsonProperty
-    private String host;
+    private final String host;
 
     @JsonProperty
-    private int port;
+    private final int port;
 
     @JsonCreator
     public Tunnel(String key, String serviceType, String host, int port) {

--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/TunnelEntry.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/TunnelEntry.java
@@ -5,20 +5,21 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class TunnelEntry {
-    @JsonProperty
-    private String key;
 
     @JsonProperty
-    private String serviceType;
+    private final String key;
 
     @JsonProperty
-    private String host;
+    private final String serviceType;
 
     @JsonProperty
-    private int port;
+    private final String host;
 
     @JsonProperty
-    private String minaSshdServiceId;
+    private final int port;
+
+    @JsonProperty
+    private final String minaSshdServiceId;
 
     public TunnelEntry(String key, String serviceType, String host, int port, String minaSshdServiceId) {
         this.key = key;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyRegistrationClientTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/clusterproxy/ClusterProxyRegistrationClientTest.java
@@ -32,6 +32,8 @@ import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 public class ClusterProxyRegistrationClientTest {
     private static final String STACK_CRN = "stack-crn";
 
+    private static final String ENVIORONMENT_CRN = "environment-crn";
+
     private static final String CLUSTER_ID = "cluster-id";
 
     private static final String KNOX_URI = "https://10.10.10.10:8443/test-cluster";
@@ -68,7 +70,7 @@ public class ClusterProxyRegistrationClientTest {
     @Test
     public void shouldRegisterProxyConfigurationWithClusterProxy() throws URISyntaxException, JsonProcessingException {
         ClusterServiceConfig clusterServiceConfig = clusterServiceConfig();
-        ConfigRegistrationRequest request = configRegistrationRequest(STACK_CRN, CLUSTER_ID, clusterServiceConfig, CERTIFICATES);
+        ConfigRegistrationRequest request = configRegistrationRequest(STACK_CRN, ENVIORONMENT_CRN, CLUSTER_ID, clusterServiceConfig, CERTIFICATES);
 
         ConfigRegistrationResponse response = new ConfigRegistrationResponse();
         response.setX509Unwrapped("X509PublicKey");
@@ -109,12 +111,13 @@ public class ClusterProxyRegistrationClientTest {
         ClusterServiceCredential cloudbreakUser = new ClusterServiceCredential("cloudbreak", "/cb/test-data/secret/cbpassword:secret");
         ClusterServiceCredential dpUser = new ClusterServiceCredential("cmmgmt", "/cb/test-data/secret/dppassword:secret", true);
         return new ClusterServiceConfig("cloudera-manager",
-                List.of("https://10.10.10.10/clouderamanager"), asList(cloudbreakUser, dpUser), null, null);
+                List.of("https://10.10.10.10/clouderamanager"), null, false, asList(cloudbreakUser, dpUser), null, null);
     }
 
-    private ConfigRegistrationRequest configRegistrationRequest(String stackCrn, String clusterId,
+    private ConfigRegistrationRequest configRegistrationRequest(String stackCrn, String environmentCrn, String clusterId,
                                                                 ClusterServiceConfig serviceConfig, List<String> certificates) {
-        return new ConfigRegistrationRequestBuilder(stackCrn).withAliases(List.of(clusterId)).withServices(List.of(serviceConfig))
+        return new ConfigRegistrationRequestBuilder(stackCrn).withEnvironmentCrn(environmentCrn)
+                .withAliases(List.of(clusterId)).withServices(List.of(serviceConfig))
                 .withCertificates(certificates).build();
     }
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ClusterProxyService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ClusterProxyService.java
@@ -255,10 +255,10 @@ public class ClusterProxyService {
                 .collect(Collectors.toList());
         serviceConfigs.add(new ClusterServiceConfig(generateFreeIpaFqdn(stack),
                 endpoints,
+                null,
+                false,
                 List.of(),
-                clientCertificate,
-                getHealthCheck(stack)
-        ));
+                clientCertificate, getHealthCheck(stack)));
         return serviceConfigs;
     }
 
@@ -288,10 +288,11 @@ public class ClusterProxyService {
     private List<CcmV2Config> createCcmV2Configs(Stack stack, List<GatewayConfig> gatewayConfigs) {
         return gatewayConfigs.stream()
                 .map(gatewayConfig -> new CcmV2Config(
-                        stack.getCcmV2AgentCrn(),
-                        String.format(CCMV2_BACKEND_ID_FORMAT, stack.getCcmV2AgentCrn(), gatewayConfig.getInstanceId()),
                         gatewayConfig.getPrivateAddress(),
-                        getNginxPort(stack)))
+                        getNginxPort(stack),
+                        String.format(CCMV2_BACKEND_ID_FORMAT, stack.getCcmV2AgentCrn(), gatewayConfig.getInstanceId()),
+                        FREEIPA_SERVICE_NAME
+                ))
                 .collect(Collectors.toList());
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/ClusterProxyServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/ClusterProxyServiceTest.java
@@ -50,6 +50,8 @@ public class ClusterProxyServiceTest {
 
     private static final String TEST_ACCOUNT_ID = "9d74eee4-1cad-45d7-b645-7ccf9edbb73d";
 
+    private static final String FREEIPA_SERVICE = "freeipa";
+
     @InjectMocks
     private ClusterProxyService underTest;
 
@@ -116,8 +118,9 @@ public class ClusterProxyServiceTest {
 
         assertEquals(false, proxyRegisterationReq.isUseTunnel(), "CCMV1 tunnel should not be enabled");
         assertEquals(true, proxyRegisterationReq.isUseCcmV2(), ccmv2Mode.toString() + " should be enabled.");
-        assertEquals(List.of(new CcmV2Config("testAgentCrn", "testAgentCrn-testInstanceId", "privateIpAddress",
-                ServiceFamilies.GATEWAY.getDefaultPort())), proxyRegisterationReq.getCcmV2Configs(), ccmv2Mode.toString() + " config should match");
+        assertEquals(List.of(new CcmV2Config("privateIpAddress", ServiceFamilies.GATEWAY.getDefaultPort(),
+                        "testAgentCrn-testInstanceId", FREEIPA_SERVICE)),
+                proxyRegisterationReq.getCcmV2Configs(), ccmv2Mode.toString() + " config should match");
     }
 
     @ParameterizedTest
@@ -163,10 +166,10 @@ public class ClusterProxyServiceTest {
         assertEquals(false, proxyRegisterationReq.isUseTunnel(), "CCMV1 tunnel should not be enabled");
         assertEquals(true, proxyRegisterationReq.isUseCcmV2(), ccmv2Mode.toString() + " should be enabled.");
         assertEquals(List.of(
-                new CcmV2Config("testAgentCrn", "testAgentCrn-testInstanceId1", "privateIpAddress1",
-                        ServiceFamilies.GATEWAY.getDefaultPort()),
-                new CcmV2Config("testAgentCrn", "testAgentCrn-testInstanceId2", "privateIpAddress2",
-                        ServiceFamilies.GATEWAY.getDefaultPort())), proxyRegisterationReq.getCcmV2Configs(), ccmv2Mode.toString() + " config should match");
+                new CcmV2Config("privateIpAddress1", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-testInstanceId1", FREEIPA_SERVICE
+                ),
+                new CcmV2Config("privateIpAddress2", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-testInstanceId2", FREEIPA_SERVICE
+                )), proxyRegisterationReq.getCcmV2Configs(), ccmv2Mode.toString() + " config should match");
     }
 
     @Test


### PR DESCRIPTION
Updated cluster-proxy request and response objects according to the latest
image available.
Fixed typo in CCMV2 proto file.
Added fallback for CCM tunnel type.
Changed cluster proxy registration mode depending on CCMv2 or Jumpgate:
for Jumpgate, the Environment CRN must be passed but the CCMv2 config
should not, only the CCMv2 boolean flag must be set.
Old CCMv2 registration should remain the same.

Merge only after proper images are ready for FreeIPA AND base/prewarm