### PR TITLE
CB-13676 Move Kibana timestamp with one hour in HTML reports

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/KibanaSearchUrl.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/KibanaSearchUrl.java
@@ -36,8 +36,8 @@ public class KibanaSearchUrl implements SearchUrl {
         }
 
         this.searchables = searchables;
-        this.testStartDate = DateUtils.addHours(testStartDate, -2);
-        this.testStopDate = DateUtils.addHours(testStopDate, -2);
+        this.testStartDate = DateUtils.addHours(testStartDate, -1);
+        this.testStopDate = DateUtils.addHours(testStopDate, -1);
     }
 
     @Override


### PR DESCRIPTION
Actually Kibana links are behind one hour as the Jenkins. So we need to reduce the 2 hours offset to just 1 hour.

It is related to the [CB-8692 Cloud storage link on the test result page like Kibana link](https://jira.cloudera.com/browse/CB-8692) change.