### PR TITLE
CB-13532: Modified backup-restore scripts to work on a given database.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/pillar/postgresql/disaster_recovery.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/postgresql/disaster_recovery.sls
@@ -1,2 +1,4 @@
 disaster_recovery:
   object_storage_url:
+  ranger_admin_group:
+  database_name:

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -6,7 +6,7 @@ include:
 {% if 'None' != configure_remote_db %}
 backup_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}}
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
     - require:
       - sls: postgresql.disaster_recovery
 
@@ -23,7 +23,7 @@ add_root_role_to_database:
 
 backup_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} "/var/lib/pgsql"
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}} "/var/lib/pgsql"
     - require:
       - cmd: add_root_role_to_database
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
@@ -6,7 +6,7 @@ include:
 {% if 'None' != configure_remote_db %}
 restore_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}}
+    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
     - require:
         - sls: postgresql.disaster_recovery
 
@@ -23,7 +23,7 @@ add_root_role_to_database:
 
 restore_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} "/var/lib/pgsql"
+    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}} "/var/lib/pgsql"
     - require:
         - cmd: add_root_role_to_database
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -8,15 +8,16 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-if [[ $# -ne 5 && $# -ne 6 ]]; then
+if [[ $# -lt 5 || $# -gt 7 ]]; then
   echo "Invalid inputs provided"
-  echo "Script accepts 5 inputs:"
+  echo "Script accepts at least 5 and at most 7 inputs:"
   echo "  1. Object Storage Service url to place backups."
   echo "  2. PostgreSQL host name."
   echo "  3. PostgreSQL port."
   echo "  4. PostgreSQL user name."
   echo "  5. Ranger admin group."
-  echo "  6. (optional) Log file location."
+  echo "  6. (optional) Name of the database to backup. If not given, will backup ranger and hive databases."
+  echo "  7. (optional) Log file location. Must be provided along with a database name."
   exit 1
 fi
 
@@ -25,7 +26,8 @@ HOST="$2"
 PORT="$3"
 USERNAME="$4"
 RANGERGROUP="$5"
-LOGFILE=${6:-/var/log/}/dl_postgres_backup.log
+DATABASENAME="${6-}"
+LOGFILE=${7:-/var/log}/dl_postgres_backup.log
 echo "Logs at ${LOGFILE}"
 
 {%- from 'postgresql/settings.sls' import postgresql with context %}
@@ -142,8 +144,14 @@ run_backup() {
   DATE_DIR=${BACKUPS_DIR}/$(date '+%Y-%m-%dT%H:%M:%SZ')
   mkdir -p "$DATE_DIR" || error_exit "Could not create local directory for backups."
 
-  backup_database_for_service "hive"
-  backup_database_for_service "ranger"
+  if [[ -z "$DATABASENAME" ]]; then
+    echo "No database name provided. Will backup hive and ranger databases."
+    backup_database_for_service "hive"
+    backup_database_for_service "ranger"
+  else
+    echo "Backing up ${DATABASENAME}."
+    backup_database_for_service "${DATABASENAME}"
+  fi
 
   rmdir -v "$DATE_DIR" > >(tee -a $LOGFILE) 2> >(tee -a $LOGFILE >&2)
 }


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-13532

This change is primarily focused on extending the existing backup/restore scripts to be usable with a given database. Specifically, I have made it so the scripts take in an optional database name argument and, when the argument is _not_ provided, the default action is to backup the hive and ranger databases (the existing behavior).

Part of this change includes changes to the existing salt files in order to work correctly with the new optional argument. A side effect of this change is that the other optional argument, the log file location, can now only be used when the database name argument is given as well. We believe that this is okay as this argument is not used much in practice.

I have performed general testing of these changes, but not any rigorous QE tests, so I hope that they can be done once this is merged in.