### PR TITLE
CB-13676 Remove time offset from Kibana search URL

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/KibanaSearchUrl.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/KibanaSearchUrl.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.time.DateUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -36,8 +35,8 @@ public class KibanaSearchUrl implements SearchUrl {
         }
 
         this.searchables = searchables;
-        this.testStartDate = DateUtils.addHours(testStartDate, -1);
-        this.testStopDate = DateUtils.addHours(testStopDate, -1);
+        this.testStartDate = testStartDate;
+        this.testStopDate = testStopDate;
     }
 
     @Override


### PR DESCRIPTION
Remove time offset from Kibana search URL start and end time, because of Jenkins has already the 2 hours offset; for example:
[api-e2e-newway-aws](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-newway-aws/) `Build #3538--2.47.0-b114-AWS (05-Aug-2021 02:50:09)` and the [DistroXEncryptedVolumeTest.testCreateDistroXWithEncryptedVolume-20210805.log](http://ci-cloudbreak.eng.hortonworks.com/job/api-e2e-newway-aws/3538/artifact/suites_log/DistroXEncryptedVolumeTest.testCreateDistroXWithEncryptedVolume-20210805.log) shows `2021-08-05 00:51:25,028` start and `2021-08-05 02:01:58,285` end time.

It is related to the [CB-8692 Cloud storage link on the test result page like Kibana link](https://jira.cloudera.com/browse/CB-8692) change.