### PR TITLE
CB-13700 Add ACI_ERROR(2100) error to the FreeIPA retriable list

### DIFF
--- a/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
+++ b/freeipa-client/src/main/java/com/sequenceiq/freeipa/client/FreeIpaClientExceptionUtil.java
@@ -46,7 +46,8 @@ public class FreeIpaClientExceptionUtil {
             FreeIpaErrorCodes.SIZE_LIMIT_EXCEEDED,
             FreeIpaErrorCodes.ADMIN_LIMIT_EXCEEDED,
             FreeIpaErrorCodes.NON_FATAL_ERROR,
-            FreeIpaErrorCodes.GENERIC_ERROR
+            FreeIpaErrorCodes.GENERIC_ERROR,
+            FreeIpaErrorCodes.ACI_ERROR
     );
 
     private static final Set<FreeIpaErrorCodes> CLIENT_UNUSABLE_ERROR_CODES = Set.of(


### PR DESCRIPTION
ACI_ERROR is returned when the FreeIPA says that we don't have permission
to make some changes.
```
Insufficient 'write' privilege to the 'userPassword' attribute of entry 'uid=ldapbind-cb246-ntp-gcp-spk3de,cn=users,cn=accounts,dc=cb246-nt,dc=s8bs-i2ta,dc=stg,dc=cldr,dc=work'.]. Failure details: [empty]
```
However, we're using a super user that has all the priviliges to make any
changes. We've only seen this error when we tried to set the password for
service users. To mitigate the problem I'm adding it to the retry list so
hopefully the `user_mod` method will succeed eventually.

See detailed description in the commit message.