### PR TITLE
CB-13672 Fix hybrid cloud test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/InstanceGroupTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/InstanceGroupTestDto.java
@@ -43,13 +43,15 @@ public class InstanceGroupTestDto extends AbstractCloudbreakTestDto<InstanceGrou
     }
 
     public InstanceGroupTestDto withHostGroup(HostGroupType hostGroupType) {
+        final String instanceTemplateName = String.format("%s-%s-%s",
+                InstanceTemplateV4TestDto.class.getSimpleName(), getCloudPlatform(), hostGroupType.getName());
         return withRecoveryMode(getRecoveryModeParam(hostGroupType))
                 .withNodeCount(hostGroupType.determineInstanceCount(getTestParameter()))
                 .withGroup(hostGroupType.getName())
                 .withSecurityGroup(getTestContext().init(SecurityGroupTestDto.class))
                 .withType(hostGroupType.getInstanceGroupType())
                 .withName(hostGroupType.getName())
-                .withTemplate(getTestContext().given("InstanceGroupTestDto" + hostGroupType.getName(), InstanceTemplateV4TestDto.class, getCloudPlatform()));
+                .withTemplate(getTestContext().given(instanceTemplateName, InstanceTemplateV4TestDto.class, getCloudPlatform()));
     }
 
     public InstanceGroupTestDto withNetwork() {
@@ -100,7 +102,7 @@ public class InstanceGroupTestDto extends AbstractCloudbreakTestDto<InstanceGrou
                 .withRecoveryMode(entity.getRecoveryModeParam(hostGroupType))
                 .withNodeCount(nodeCount)
                 .withGroup(hostGroupType.getName())
-                .withSecurityGroup(testContext.init(SecurityGroupTestDto.class))
+                .withSecurityGroup(testContext.given(SecurityGroupTestDto.class))
                 .withType(hostGroupType.getInstanceGroupType())
                 .withName(hostGroupType.getName())
                 .withTemplate(testContext.given(InstanceTemplateV4TestDto.class));

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/hybrid/AwsYcloudHybridCloudTest.java
@@ -42,11 +42,11 @@ import com.sequenceiq.it.cloudbreak.dto.ClouderaManagerProductTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ClouderaManagerTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
 import com.sequenceiq.it.cloudbreak.dto.InstanceGroupTestDto;
+import com.sequenceiq.it.cloudbreak.dto.SecurityGroupTestDto;
 import com.sequenceiq.it.cloudbreak.dto.StackAuthenticationTestDto;
 import com.sequenceiq.it.cloudbreak.dto.blueprint.BlueprintTestDto;
 import com.sequenceiq.it.cloudbreak.dto.credential.CredentialTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
-import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentSecurityAccessTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
@@ -125,11 +125,8 @@ public class AwsYcloudHybridCloudTest extends AbstractE2ETest {
         createDefaultCredential(testContext);
         //Use a pre-prepared security group what allows inbound connections from ycloud
         testContext
-                .given(EnvironmentSecurityAccessTestDto.class)
-                .withDefaultSecurityGroupId(hybridCloudSecurityGroupID)
-                .withSecurityGroupIdForKnox(hybridCloudSecurityGroupID)
-                .given(EnvironmentTestDto.class)
-                .withSecurityAccess();
+                .given(SecurityGroupTestDto.class)
+                .withSecurityGroupIds(hybridCloudSecurityGroupID);
         createEnvironmentWithNetworkAndFreeIpa(testContext);
 
         testContext


### PR DESCRIPTION
Issue 1: AWS Freeipa, and YARN Datalake master instance groups receive the same name, so instead of creating a new instance group for YARN, the test framework used the one that was created for AWS.
The fix was to include the cloud platform in the test dto's name, so AWS and YARN receive different names.

Issue 2: Freeipa is no longer created by environment service, so the security groups set for the environment are not automatically applied to Freeipa instances.
The fix was to set the security group directly to the Freeipa request.