### PR TITLE
CB-13514 - Add updated load balancer metadata collection to AwsNative classes

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/service/AwsResourceNameService.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/service/AwsResourceNameService.java
@@ -14,6 +14,9 @@ import com.sequenceiq.common.api.type.ResourceType;
 
 @Service("AwsResourceNameServiceV2")
 public class AwsResourceNameService extends CloudbreakResourceNameService {
+
+    public static final String TG_PART_NAME = "TG";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(AwsResourceNameService.class);
 
     private static final String FIREWALL_INTERNAL_NAME_SUFFIX = "internal";
@@ -151,7 +154,7 @@ public class AwsResourceNameService extends CloudbreakResourceNameService {
         String stackName = String.valueOf(parts[0]);
         String scheme = String.valueOf(parts[1]);
         String port = String.valueOf(parts[2]);
-        String resourceNameWithScheme = "TG" + port + scheme;
+        String resourceNameWithScheme = TG_PART_NAME + port + scheme;
         int numberOfAppends = 2;
         int maxLengthOfStackName = maxLoadBalancerResourceNameLength - getDefaultHashLength() - resourceNameWithScheme.length() - numberOfAppends;
         String reducedStackName = stackName.substring(0, maxLengthOfStackName);

--- a/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/metadata/AwsNativeLbMetadataCollector.java
+++ b/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/metadata/AwsNativeLbMetadataCollector.java
@@ -1,0 +1,73 @@
+package com.sequenceiq.cloudbreak.cloud.aws.metadata;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.aws.common.service.AwsResourceNameService;
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsLoadBalancerMetadataView;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.common.api.type.ResourceType;
+
+@Service
+public class AwsNativeLbMetadataCollector {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AwsNativeLbMetadataCollector.class);
+
+    private static final Pattern TG_NAME_PATTERN = Pattern.compile("(" + AwsResourceNameService.TG_PART_NAME + "\\d+)");
+
+    public Map<String, Object> getParameters(String loadBalancerArn, List<CloudResource> resources) {
+        LOGGER.info("Gathering AWS load balancer ARN information");
+        Map<String, Object> parameters = parseTargetGroupCloudParams(loadBalancerArn, resources);
+        parameters.put(AwsLoadBalancerMetadataView.LOADBALANCER_ARN, loadBalancerArn);
+        return parameters;
+    }
+
+    private Map<String, Object> parseTargetGroupCloudParams(String loadBalancerArn, List<CloudResource> resources) {
+        Set<CloudResource> targetGroups = resources.stream()
+            .filter(resource -> loadBalancerArn.equals(resource.getInstanceId()))
+            .filter(resource -> ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP.equals(resource.getType()))
+            .collect(Collectors.toSet());
+
+        Map<String, Object> targetGroupParameters = new HashMap<>();
+        targetGroups.forEach(targetGroup -> {
+            Optional<Integer> port = getPortFromTargetGroupName(targetGroup.getName());
+            if (port.isPresent()) {
+                String targetGroupArn = targetGroup.getReference();
+                String listenerArn = resources.stream()
+                    .filter(resource -> targetGroup.getName().equals(resource.getName()))
+                    .filter(resource -> ResourceType.ELASTIC_LOAD_BALANCER_LISTENER.equals(resource.getType()))
+                    .map(CloudResource::getReference)
+                    .findFirst().orElse(null);
+
+                LOGGER.debug("Found target group ARN {} and listern ARN {} associated with load balancer {}, port {}",
+                    targetGroupArn, listenerArn, loadBalancerArn, port);
+                targetGroupParameters.put(AwsLoadBalancerMetadataView.getTargetGroupParam(port.get()), targetGroupArn);
+                targetGroupParameters.put(AwsLoadBalancerMetadataView.getListenerParam(port.get()), listenerArn);
+            } else {
+                LOGGER.warn("Unable to parse target group and listener port from target group name [{}]. Setup will continue, " +
+                    "but load balancer metadata will be missing target group and listener information.", targetGroup.getName());
+            }
+        });
+        return targetGroupParameters;
+    }
+
+    private Optional<Integer> getPortFromTargetGroupName(String targetGroupName) {
+        Matcher matcher = TG_NAME_PATTERN.matcher(targetGroupName);
+        if (matcher.find()) {
+            String matchedGroup = matcher.group();
+            Integer port = Integer.valueOf(matchedGroup.replace(AwsResourceNameService.TG_PART_NAME, ""));
+            return Optional.of(port);
+        }
+        return Optional.empty();
+    }
+}

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorApiIntegrationTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorApiIntegrationTest.java
@@ -38,6 +38,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetFilterStr
 import com.sequenceiq.cloudbreak.cloud.aws.common.subnetselector.SubnetSelectorService;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsEncodedAuthorizationFailureMessageDecoder;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsLifeCycleMapper;
+import com.sequenceiq.cloudbreak.cloud.aws.metadata.AwsNativeLbMetadataCollector;
 import com.sequenceiq.cloudbreak.cloud.aws.metadata.AwsNativeMetadataCollector;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
@@ -82,6 +83,9 @@ class AwsNativeMetadataCollectorApiIntegrationTest {
 
     @MockBean
     private AwsPlatformResources awsPlatformResources;
+
+    @MockBean
+    private AwsNativeLbMetadataCollector awsNativeLbMetadataCollector;
 
     @Inject
     private AwsAuthenticator awsAuthenticator;

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeMetadataCollectorTest.java
@@ -46,6 +46,7 @@ import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonEc2Client;
 import com.sequenceiq.cloudbreak.cloud.aws.common.client.AmazonElasticLoadBalancingClient;
 import com.sequenceiq.cloudbreak.cloud.aws.common.loadbalancer.LoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.cloud.aws.common.util.AwsLifeCycleMapper;
+import com.sequenceiq.cloudbreak.cloud.aws.metadata.AwsNativeLbMetadataCollector;
 import com.sequenceiq.cloudbreak.cloud.aws.metadata.AwsNativeMetadataCollector;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
@@ -83,6 +84,9 @@ class AwsNativeMetadataCollectorTest {
 
     @Mock
     private AuthenticatedContext authenticatedContext;
+
+    @Mock
+    private AwsNativeLbMetadataCollector awsNativeLbMetadataCollector;
 
     @InjectMocks
     private AwsNativeMetadataCollector underTest;

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/metadata/AwsNativeLbMetadataCollectorTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/metadata/AwsNativeLbMetadataCollectorTest.java
@@ -1,0 +1,98 @@
+package com.sequenceiq.cloudbreak.cloud.aws.metadata;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.aws.common.view.AwsLoadBalancerMetadataView;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.common.api.type.ResourceType;
+
+@ExtendWith(MockitoExtension.class)
+public class AwsNativeLbMetadataCollectorTest {
+
+    private static final String TARGET_GROUP_NAME = "stackTG%dInternal2021";
+
+    private static final String TARGET_GROUP_ARN = "arn:targetgroup";
+
+    private static final String LOAD_BALANCER_ARN = "arn:loadbalancer";
+
+    private static final String LISTENER_ARN = "arn:listener";
+
+    private final AwsNativeLbMetadataCollector underTest = new AwsNativeLbMetadataCollector();
+
+    @Test
+    public void testCollectInternalLoadBalancer() {
+        List<CloudResource> resources = createCloudResources(1, true);
+
+        Map<String, Object> expectedParameters = Map.of(
+            AwsLoadBalancerMetadataView.LOADBALANCER_ARN, LOAD_BALANCER_ARN,
+            AwsLoadBalancerMetadataView.LISTENER_ARN_PREFIX + 0, LISTENER_ARN + "0Internal",
+            AwsLoadBalancerMetadataView.TARGET_GROUP_ARN_PREFIX + 0, TARGET_GROUP_ARN + "0Internal"
+        );
+
+        Map<String, Object> parameters = underTest.getParameters(LOAD_BALANCER_ARN, resources);
+        assertEquals(expectedParameters, parameters);
+    }
+
+    @Test
+    public void testCollectLoadBalancerMultiplePorts() {
+        List<CloudResource> resources = createCloudResources(3, true);
+
+        Map<String, Object> expectedParameters = Map.of(
+            AwsLoadBalancerMetadataView.LOADBALANCER_ARN, LOAD_BALANCER_ARN,
+            AwsLoadBalancerMetadataView.LISTENER_ARN_PREFIX + 0, LISTENER_ARN + "0Internal",
+            AwsLoadBalancerMetadataView.TARGET_GROUP_ARN_PREFIX + 0, TARGET_GROUP_ARN + "0Internal",
+            AwsLoadBalancerMetadataView.LISTENER_ARN_PREFIX + 1, LISTENER_ARN + "1Internal",
+            AwsLoadBalancerMetadataView.TARGET_GROUP_ARN_PREFIX + 1, TARGET_GROUP_ARN + "1Internal",
+            AwsLoadBalancerMetadataView.LISTENER_ARN_PREFIX + 2, LISTENER_ARN + "2Internal",
+            AwsLoadBalancerMetadataView.TARGET_GROUP_ARN_PREFIX + 2, TARGET_GROUP_ARN + "2Internal"
+        );
+
+        Map<String, Object> parameters = underTest.getParameters(LOAD_BALANCER_ARN, resources);
+        assertEquals(expectedParameters, parameters);
+    }
+
+    @Test
+    public void testCollectLoadBalancerMissingListener() {
+        List<CloudResource> resources = createCloudResources(1, false);
+
+        Map<String, Object> expectedParameters = new HashMap<>();
+        expectedParameters.put(AwsLoadBalancerMetadataView.LOADBALANCER_ARN, LOAD_BALANCER_ARN);
+        expectedParameters.put(AwsLoadBalancerMetadataView.LISTENER_ARN_PREFIX + 0, null);
+        expectedParameters.put(AwsLoadBalancerMetadataView.TARGET_GROUP_ARN_PREFIX + 0, TARGET_GROUP_ARN + "0Internal");
+
+        Map<String, Object> parameters = underTest.getParameters(LOAD_BALANCER_ARN, resources);
+        assertEquals(expectedParameters, parameters);
+    }
+
+    private List<CloudResource> createCloudResources(int numPorts, boolean includeListener) {
+        List<CloudResource> resources = new ArrayList<>();
+        for (int i = 0; i < numPorts; i++) {
+            CloudResource targetGroup = CloudResource.builder()
+                .type(ResourceType.ELASTIC_LOAD_BALANCER_TARGET_GROUP)
+                .instanceId(LOAD_BALANCER_ARN)
+                .reference(TARGET_GROUP_ARN + i + "Internal")
+                .name(String.format(TARGET_GROUP_NAME, i))
+                .build();
+            resources.add(targetGroup);
+            if (includeListener) {
+                CloudResource listener = CloudResource.builder()
+                    .type(ResourceType.ELASTIC_LOAD_BALANCER_LISTENER)
+                    .instanceId(LOAD_BALANCER_ARN)
+                    .reference(LISTENER_ARN + i + "Internal")
+                    .name(String.format(TARGET_GROUP_NAME, i))
+                    .build();
+                resources.add(listener);
+            }
+        }
+        return resources;
+    }
+}


### PR DESCRIPTION
Adds a new AwsNativeLbMetadataCollector to collect the AWS LB specific metadata to later
be persisted to the database.

Tested with unit tests.