### PR TITLE
CB-13134: Set encryption key for an existing env that does not yet have encryption enabled 

### DIFF
--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/info/model/RightV4.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/info/model/RightV4.java
@@ -25,6 +25,7 @@ public enum RightV4 {
     ENV_DESCRIBE(AuthorizationResourceAction.DESCRIBE_ENVIRONMENT),
     CHANGE_CRED(AuthorizationResourceAction.CHANGE_CREDENTIAL),
     DH_CREATE(AuthorizationResourceAction.ENVIRONMENT_CREATE_DATAHUB),
+    UPDATE_AZURE_ENCRYPTION_RESOURCES(AuthorizationResourceAction.UPDATE_AZURE_ENCRYPTION_RESOURCES),
     // dh level
     DH_START(AuthorizationResourceAction.START_DATAHUB),
     DH_STOP(AuthorizationResourceAction.STOP_DATAHUB),

--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
@@ -88,6 +88,7 @@ public enum AuthorizationResourceAction {
     POWERUSER_ONLY("cloudbreak/allowPowerUserOnly", null),
     LIST_ASSIGNED_ROLES("iam/listAssignedResourceRoles", null),
     STRUCTURED_EVENTS_READ("structured_events/read", AuthorizationResourceType.STRUCTURED_EVENT),
+    UPDATE_AZURE_ENCRYPTION_RESOURCES("environments/updateAzureEncryptionResources", AuthorizationResourceType.ENVIRONMENT),
     // deprecated actions, please do not use them
     ENVIRONMENT_READ("environments/read", AuthorizationResourceType.ENVIRONMENT),
     ENVIRONMENT_WRITE("environments/write", AuthorizationResourceType.ENVIRONMENT),

--- a/authorization-common/src/main/resources/legacyRights.json
+++ b/authorization-common/src/main/resources/legacyRights.json
@@ -85,5 +85,6 @@
   "datahub/read": "datahub/read",
   "datahub/write": "datahub/write",
   "structured_events/read": "structured_events/read",
-  "iam/listAssignedResourceRoles": "iam/listAssignedResourceRoles"
+  "iam/listAssignedResourceRoles": "iam/listAssignedResourceRoles",
+  "environments/updateAzureEncryptionResources": "environments/write"
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
@@ -33,6 +33,8 @@ public class EnvironmentOpDescription {
     public static final String GET_LAST_FLOW_PROGRESS = "Get last flow operation progress details for resource by resource crn";
     public static final String LIST_FLOW_PROGRESS = "List recent flow operations progress details for resource by resource crn";
     public static final String GET_OPERATION = "Get flow operation progress details for resource by resource crn";
+    public static final String UPDATE_AZURE_ENCRYPTION_RESOURCES_BY_NAME = "Updates the Customer managed key of the Azure environment of a given name.";
+    public static final String UPDATE_AZURE_ENCRYPTION_RESOURCES_BY_CRN = "Updates the Customer managed key of the Azure environment of a given CRN.";
 
     private EnvironmentOpDescription() {
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
@@ -33,6 +33,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentCl
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentEditRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLoadBalancerUpdateRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.azure.UpdateAzureResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
@@ -114,6 +115,14 @@ public interface EnvironmentEndpoint {
     DetailedEnvironmentResponse changeCredentialByEnvironmentName(@PathParam("name") String environmentName, @Valid EnvironmentChangeCredentialRequest request);
 
     @PUT
+    @Path("/name/{name}/update_azure_encryption_resources")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.UPDATE_AZURE_ENCRYPTION_RESOURCES_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+            nickname = "UpdateAzureResourceEncryptionParametersV1")
+    DetailedEnvironmentResponse updateAzureResourceEncryptionParametersByEnvironmentName(@PathParam("name") String environmentName,
+            @Valid UpdateAzureResourceEncryptionParametersRequest request);
+
+    @PUT
     @Path("/name/{name}/change_telemetry_features")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = EnvironmentOpDescription.CHANGE_TELEMETRY_FEATURES_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
@@ -167,6 +176,14 @@ public interface EnvironmentEndpoint {
             nickname = "changeCredentialInEnvironmentV1ByCrn")
     DetailedEnvironmentResponse changeCredentialByEnvironmentCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @PathParam("crn") String crn,
             @Valid EnvironmentChangeCredentialRequest request);
+
+    @PUT
+    @Path("/crn/{crn}/update_azure_encryption_resources")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.UPDATE_AZURE_ENCRYPTION_RESOURCES_BY_CRN, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+            nickname = "UpdateAzureResourceEncryptionParametersV1ByCrn")
+    DetailedEnvironmentResponse updateAzureResourceEncryptionParametersByEnvironmentCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+    @PathParam("crn") String crn, @Valid UpdateAzureResourceEncryptionParametersRequest request);
 
     @PUT
     @Path("/crn/{crn}/change_telemetry_features")

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/UpdateAzureResourceEncryptionParametersRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/UpdateAzureResourceEncryptionParametersRequest.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.environment.api.v1.environment.model.request.azure;
+
+import java.io.Serializable;
+
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(value = "UpdateAzureEncryptionParametersV1Request")
+public class UpdateAzureResourceEncryptionParametersRequest implements Serializable {
+
+    @ApiModelProperty(EnvironmentModelDescription.RESOURCE_ENCRYPTION_PARAMETERS)
+    private AzureResourceEncryptionParameters azureResourceEncryptionParameters;
+
+    public AzureResourceEncryptionParameters getAzureResourceEncryptionParameters() {
+        return azureResourceEncryptionParameters;
+    }
+
+    public void setAzureResourceEncryptionParameters(AzureResourceEncryptionParameters azureResourceEncryptionParameters) {
+        this.azureResourceEncryptionParameters = azureResourceEncryptionParameters;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateAzureResourceEncryptionParametersRequest{" +
+                "AzureResourceEncryptionParameters='" + azureResourceEncryptionParameters + '\'' +
+                '}';
+    }
+
+    public static class Builder {
+        private AzureResourceEncryptionParameters azureResourceEncryptionParameters;
+
+        private Builder() {
+        }
+
+        public Builder withAzureResourceEncryptionParameters(AzureResourceEncryptionParameters azureResourceEncryptionParameters) {
+            this.azureResourceEncryptionParameters = azureResourceEncryptionParameters;
+            return this;
+        }
+
+        public UpdateAzureResourceEncryptionParametersRequest build() {
+            UpdateAzureResourceEncryptionParametersRequest updateAzureResourceEncryptionParametersRequest = new UpdateAzureResourceEncryptionParametersRequest();
+            updateAzureResourceEncryptionParametersRequest.setAzureResourceEncryptionParameters(azureResourceEncryptionParameters);
+            return updateAzureResourceEncryptionParametersRequest;
+        }
+    }
+}

--- a/environment-api/src/test/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/UpdateAzureResourceEncryptionParametersRequestTest.java
+++ b/environment-api/src/test/java/com/sequenceiq/environment/api/v1/environment/model/request/azure/UpdateAzureResourceEncryptionParametersRequestTest.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.environment.api.v1.environment.model.request.azure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UpdateAzureResourceEncryptionParametersRequestTest {
+
+    private static final String ENCRYPTION_KEY_URL = "encryptionKeyUrl";
+
+    private static final String ENCRYPTION_KEY_RESOURCE_GROUP_NAME = "encryptionKeyResourceGroupName";
+
+    @Test
+    void builderTest() {
+        UpdateAzureResourceEncryptionParametersRequest underTest = new UpdateAzureResourceEncryptionParametersRequest();
+        underTest.setAzureResourceEncryptionParameters(AzureResourceEncryptionParameters.builder()
+                .withEncryptionKeyUrl(ENCRYPTION_KEY_URL)
+                .withEncryptionKeyResourceGroupName(ENCRYPTION_KEY_RESOURCE_GROUP_NAME)
+                .build()
+        );
+
+        assertThat(underTest.getAzureResourceEncryptionParameters().getEncryptionKeyUrl()).isEqualTo(ENCRYPTION_KEY_URL);
+        assertThat(underTest.getAzureResourceEncryptionParameters().getEncryptionKeyResourceGroupName()).isEqualTo(ENCRYPTION_KEY_RESOURCE_GROUP_NAME);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/UpdateAzureResourceEncryptionDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/UpdateAzureResourceEncryptionDto.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.environment.environment.dto;
+
+import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
+
+public class UpdateAzureResourceEncryptionDto {
+
+    private AzureResourceEncryptionParametersDto azureResourceEncryptionParametersDto;
+
+    public AzureResourceEncryptionParametersDto getAzureResourceEncryptionParametersDto() {
+        return azureResourceEncryptionParametersDto;
+    }
+
+    public void setAzureResourceEncryptionParametersDto(AzureResourceEncryptionParametersDto azureResourceEncryptionParametersDto) {
+        this.azureResourceEncryptionParametersDto = azureResourceEncryptionParametersDto;
+    }
+
+    public static UpdateAzureResourceEncryptionDto.Builder builder() {
+        return new UpdateAzureResourceEncryptionDto.Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateAzureResourceEncryptionDto{" +
+                "AzureResourceEncryptionParametersDto='" + azureResourceEncryptionParametersDto + '\'' +
+                '}';
+    }
+
+    public static final class Builder {
+
+        private AzureResourceEncryptionParametersDto azureResourceEncryptionParametersDto;
+
+        public Builder withAzureResourceEncryptionParametersDto(AzureResourceEncryptionParametersDto azureResourceEncryptionParametersDto) {
+            this.azureResourceEncryptionParametersDto = azureResourceEncryptionParametersDto;
+            return this;
+        }
+
+        public UpdateAzureResourceEncryptionDto build() {
+            UpdateAzureResourceEncryptionDto updateAzureResourceEncryptionDto = new UpdateAzureResourceEncryptionDto();
+            updateAzureResourceEncryptionDto.setAzureResourceEncryptionParametersDto(azureResourceEncryptionParametersDto);
+            return updateAzureResourceEncryptionDto;
+        }
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/ResourceEncryptionDeleteHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/ResourceEncryptionDeleteHandler.java
@@ -60,12 +60,12 @@ public class ResourceEncryptionDeleteHandler extends EventSenderAwareHandler<Env
         try {
             environmentService.findEnvironmentById(environmentDto.getId()).ifPresent(environment -> {
                 if (AZURE.name().equalsIgnoreCase(environmentDto.getCloudPlatform())) {
-                    String encryptionKeyUrl = Optional.ofNullable(environmentDto.getParameters())
+                    String diskEncryptionSetId = Optional.ofNullable(environmentDto.getParameters())
                             .map(ParametersDto::getAzureParametersDto)
                             .map(AzureParametersDto::getAzureResourceEncryptionParametersDto)
-                            .map(AzureResourceEncryptionParametersDto::getEncryptionKeyUrl)
+                            .map(AzureResourceEncryptionParametersDto::getDiskEncryptionSetId)
                             .orElse(null);
-                    if (StringUtils.isNotEmpty(encryptionKeyUrl) &&
+                    if (StringUtils.isNotEmpty(diskEncryptionSetId) &&
                             (environment.getStatus() != EnvironmentStatus.ENVIRONMENT_ENCRYPTION_RESOURCES_DELETED)) {
                         deleteEncryptionResources(environmentDto, environment);
                     } else {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
@@ -34,8 +34,8 @@ import com.sequenceiq.authorization.annotation.ResourceName;
 import com.sequenceiq.authorization.annotation.ResourceNameList;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
 import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
@@ -50,9 +50,9 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentCl
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentEditRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLoadBalancerUpdateRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.azure.UpdateAzureResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
-import com.sequenceiq.environment.environment.service.EnvironmentProgressService;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.SimpleEnvironmentResponses;
 import com.sequenceiq.environment.authorization.EnvironmentFiltering;
@@ -65,11 +65,13 @@ import com.sequenceiq.environment.environment.dto.EnvironmentCreationDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentEditDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
+import com.sequenceiq.environment.environment.dto.UpdateAzureResourceEncryptionDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.environment.service.EnvironmentCreationService;
 import com.sequenceiq.environment.environment.service.EnvironmentDeletionService;
 import com.sequenceiq.environment.environment.service.EnvironmentLoadBalancerService;
 import com.sequenceiq.environment.environment.service.EnvironmentModificationService;
+import com.sequenceiq.environment.environment.service.EnvironmentProgressService;
 import com.sequenceiq.environment.environment.service.EnvironmentService;
 import com.sequenceiq.environment.environment.service.EnvironmentStackConfigUpdateService;
 import com.sequenceiq.environment.environment.service.EnvironmentStartService;
@@ -301,6 +303,26 @@ public class EnvironmentController implements EnvironmentEndpoint {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         EnvironmentDto result = environmentModificationService.changeCredentialByEnvironmentCrn(accountId, crn,
                 environmentApiConverter.convertEnvironmentChangeCredentialDto(request));
+        return environmentResponseConverter.dtoToDetailedResponse(result);
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.UPDATE_AZURE_ENCRYPTION_RESOURCES)
+    public DetailedEnvironmentResponse updateAzureResourceEncryptionParametersByEnvironmentCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+    @ResourceCrn String crn, @RequestObject @Valid UpdateAzureResourceEncryptionParametersRequest request) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        EnvironmentDto result = environmentModificationService.updateAzureResourceEncryptionParametersByEnvironmentCrn(accountId, crn,
+                environmentApiConverter.convertUpdateAzureResourceEncryptionDto(request));
+        return environmentResponseConverter.dtoToDetailedResponse(result);
+    }
+
+    @Override
+    @CheckPermissionByResourceName(action = AuthorizationResourceAction.UPDATE_AZURE_ENCRYPTION_RESOURCES)
+    public DetailedEnvironmentResponse updateAzureResourceEncryptionParametersByEnvironmentName(@ResourceName String environmentName,
+            @RequestObject @Valid UpdateAzureResourceEncryptionParametersRequest request) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        UpdateAzureResourceEncryptionDto dto = environmentApiConverter.convertUpdateAzureResourceEncryptionDto(request);
+        EnvironmentDto result = environmentModificationService.updateAzureResourceEncryptionParametersByEnvironmentName(accountId, environmentName, dto);
         return environmentResponseConverter.dtoToDetailedResponse(result);
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
@@ -18,9 +18,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-import com.sequenceiq.cloudbreak.auth.crn.RegionAwareCrnGenerator;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareCrnGenerator;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.util.NullUtil;
 import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
@@ -41,6 +41,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEn
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.ResourceGroupUsage;
+import com.sequenceiq.environment.api.v1.environment.model.request.azure.UpdateAzureResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
@@ -55,6 +56,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentEditDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
 import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
+import com.sequenceiq.environment.environment.dto.UpdateAzureResourceEncryptionDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
@@ -383,6 +385,13 @@ public class EnvironmentApiConverter {
     public EnvironmentChangeCredentialDto convertEnvironmentChangeCredentialDto(EnvironmentChangeCredentialRequest request) {
         return anEnvironmentChangeCredentialDto()
                 .withCredentialName(request.getCredential() != null ? request.getCredential().getName() : request.getCredentialName())
+                .build();
+    }
+
+    public UpdateAzureResourceEncryptionDto convertUpdateAzureResourceEncryptionDto(UpdateAzureResourceEncryptionParametersRequest request) {
+        return UpdateAzureResourceEncryptionDto.builder()
+                .withAzureResourceEncryptionParametersDto(
+                        azureResourceEncryptionParametersToAzureEncryptionParametersDto(request.getAzureResourceEncryptionParameters()))
                 .build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.environment.environment.validation;
 
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
-import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
 import static com.sequenceiq.cloudbreak.util.SecurityGroupSeparator.getSecurityGroupIds;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.GCP;
 import static com.sequenceiq.common.model.CredentialType.ENVIRONMENT;
@@ -279,23 +278,15 @@ public class EnvironmentValidatorService {
         return resultBuilder.build();
     }
 
-    public ValidationResult validateEncryptionKeyUrl(EnvironmentCreationDto creationDto) {
+    public ValidationResult validateEncryptionKeyUrl(String encryptionKeyUrl, String accountId) {
         ValidationResultBuilder resultBuilder = ValidationResult.builder();
-        if (AZURE.name().equalsIgnoreCase(creationDto.getCloudPlatform())) {
-            String encryptionKeyUrl = Optional.ofNullable(creationDto.getParameters())
-                    .map(paramsDto -> paramsDto.getAzureParametersDto())
-                    .map(azureParamsDto -> azureParamsDto.getAzureResourceEncryptionParametersDto())
-                    .map(azureREParamsDto -> azureREParamsDto.getEncryptionKeyUrl()).orElse(null);
-            if (StringUtils.isNotEmpty(encryptionKeyUrl)) {
-                if (!entitlementService.isAzureDiskSSEWithCMKEnabled(creationDto.getAccountId())) {
-                    resultBuilder.error(String.format("You have specified encryption-key-url to enable Server Side Encryption for Azure Managed disks with CMK"
-                            + "but that feature is currently not enabled for this account."
-                            + " Please get 'CDP_CB_AZURE_DISK_SSE_WITH_CMK' enabled for this account to use SSE with CMK."));
-                } else {
-                    ValidationResult validationResult = encryptionKeyUrlValidator.validateEncryptionKeyUrl(encryptionKeyUrl);
-                    resultBuilder.merge(validationResult);
-                }
-            }
+        if (!entitlementService.isAzureDiskSSEWithCMKEnabled(accountId)) {
+            resultBuilder.error(String.format("You have specified encryption-key-url to enable Server Side Encryption for Azure Managed disks with CMK"
+                    + " but that feature is currently not enabled for this account."
+                    + " Please get 'CDP_CB_AZURE_DISK_SSE_WITH_CMK' enabled for this account to use SSE with CMK."));
+        } else {
+            ValidationResult validationResult = encryptionKeyUrlValidator.validateEncryptionKeyUrl(encryptionKeyUrl);
+            resultBuilder.merge(validationResult);
         }
         return resultBuilder.build();
     }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/dto/UpdateAzureResourceEncryptionDtoTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/dto/UpdateAzureResourceEncryptionDtoTest.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.environment.environment.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
+
+class UpdateAzureResourceEncryptionDtoTest {
+
+    @Test
+    void builderTest() {
+        UpdateAzureResourceEncryptionDto underTest = new UpdateAzureResourceEncryptionDto();
+        underTest.setAzureResourceEncryptionParametersDto(AzureResourceEncryptionParametersDto.builder().build());
+
+        assertThat(underTest.getAzureResourceEncryptionParametersDto()).isNotNull();
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
@@ -56,6 +56,8 @@ import com.sequenceiq.environment.network.CloudNetworkService;
 import com.sequenceiq.environment.network.NetworkService;
 import com.sequenceiq.environment.network.service.LoadBalancerEntitlementService;
 import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
+import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
+import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameters.service.ParametersService;
 
@@ -480,7 +482,7 @@ class EnvironmentCreationServiceTest {
 
         ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
         validationResultBuilder.error("error");
-        when(validatorService.validateEncryptionKeyUrl(any())).thenReturn(validationResultBuilder.build());
+        when(validatorService.validateEncryptionKeyUrl(any(), any())).thenReturn(validationResultBuilder.build());
 
         when(environmentService.isNameOccupied(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(false);
         when(environmentDtoConverter.creationDtoToEnvironment(eq(environmentCreationDto))).thenReturn(environment);
@@ -535,6 +537,13 @@ class EnvironmentCreationServiceTest {
                 .withCreator(CRN)
                 .withAccountId(ACCOUNT_ID)
                 .withAuthentication(AuthenticationDto.builder().build())
+                .withParameters(ParametersDto.builder()
+                        .withAzureParameters(AzureParametersDto.builder()
+                                .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
+                                        .withEncryptionKeyUrl("dummy-key-url")
+                                        .build())
+                                .build())
+                        .build())
                 .build();
         final Environment environment = new Environment();
         environment.setName(ENVIRONMENT_NAME);
@@ -545,7 +554,7 @@ class EnvironmentCreationServiceTest {
 
         ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
         validationResultBuilder.error("error");
-        when(validatorService.validateEncryptionKeyUrl(any())).thenReturn(validationResultBuilder.build());
+        when(validatorService.validateEncryptionKeyUrl(any(), any())).thenReturn(validationResultBuilder.build());
 
         when(environmentService.isNameOccupied(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(false);
         when(environmentDtoConverter.creationDtoToEnvironment(eq(environmentCreationDto))).thenReturn(environment);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
@@ -25,9 +25,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.sequenceiq.cloudbreak.auth.crn.RegionAwareCrnGenerator;
-import com.sequenceiq.cloudbreak.auth.crn.CrnTestUtil;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.crn.CrnTestUtil;
+import com.sequenceiq.cloudbreak.auth.crn.RegionAwareCrnGenerator;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.type.CloudConstants;
 import com.sequenceiq.common.api.telemetry.model.Features;
@@ -54,6 +54,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEn
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.ResourceGroupUsage;
+import com.sequenceiq.environment.api.v1.environment.model.request.azure.UpdateAzureResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
 import com.sequenceiq.environment.credential.service.CredentialService;
@@ -67,6 +68,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
 import com.sequenceiq.environment.environment.dto.FreeIpaCreationDto;
 import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
+import com.sequenceiq.environment.environment.dto.UpdateAzureResourceEncryptionDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
@@ -82,6 +84,10 @@ public class EnvironmentApiConverterTest {
     private static final String REGION_DISPLAY_NAME = "US WEST";
 
     private static final String USER_CRN = "crn:altus:iam:us-west-1:test-aws:user:cloudbreak@hortonworks.com";
+
+    private static final String KEY_URL = "dummy-key-url";
+
+    private static final String KEY_URL_RESOURCE_GROUP = "dummy-key-url";
 
     @InjectMocks
     private EnvironmentApiConverter underTest;
@@ -325,8 +331,8 @@ public class EnvironmentApiConverterTest {
         request.setAzure(AzureEnvironmentParameters.builder()
                 .withResourceEncryptionParameters(
                         AzureResourceEncryptionParameters.builder()
-                                .withEncryptionKeyUrl("dummy-key-url")
-                                .withEncryptionKeyResourceGroupName("dummyResourceGroupName")
+                                .withEncryptionKeyUrl(KEY_URL)
+                                .withEncryptionKeyResourceGroupName(KEY_URL_RESOURCE_GROUP)
                                 .build())
                 .build());
         FreeIpaCreationDto freeIpaCreationDto = mock(FreeIpaCreationDto.class);
@@ -346,9 +352,9 @@ public class EnvironmentApiConverterTest {
 
         EnvironmentCreationDto actual = underTest.initCreationDto(request);
 
-        assertEquals("dummy-key-url",
+        assertEquals(KEY_URL,
                 actual.getParameters().getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl());
-        assertEquals("dummyResourceGroupName",
+        assertEquals(KEY_URL_RESOURCE_GROUP,
                 actual.getParameters().getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
     }
 
@@ -380,6 +386,21 @@ public class EnvironmentApiConverterTest {
 
         assertEquals("dummy-encryption-key",
                 actual.getParameters().getGcpParametersDto().getGcpResourceEncryptionParametersDto().getEncryptionKey());
+    }
+
+    @Test
+    void testConvertUpdateAzureResourceEncryptionDto() {
+        UpdateAzureResourceEncryptionParametersRequest request = UpdateAzureResourceEncryptionParametersRequest.builder()
+                .withAzureResourceEncryptionParameters(AzureResourceEncryptionParameters.builder()
+                        .withEncryptionKeyUrl(KEY_URL)
+                        .withEncryptionKeyResourceGroupName(KEY_URL_RESOURCE_GROUP)
+                        .build())
+                .build();
+
+        UpdateAzureResourceEncryptionDto actual = underTest.convertUpdateAzureResourceEncryptionDto(request);
+
+        assertEquals(KEY_URL, actual.getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl());
+        assertEquals(KEY_URL_RESOURCE_GROUP, actual.getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
     }
 
     private void assertLocation(LocationRequest request, LocationDto actual) {
@@ -512,8 +533,8 @@ public class EnvironmentApiConverterTest {
         );
         azureEnvironmentParameters.setResourceEncryptionParameters(
                 AzureResourceEncryptionParameters.builder()
-                        .withEncryptionKeyUrl("dummy-key-url")
-                        .withEncryptionKeyResourceGroupName("dummyResourceGroupName")
+                        .withEncryptionKeyUrl(KEY_URL)
+                        .withEncryptionKeyResourceGroupName(KEY_URL_RESOURCE_GROUP)
                         .build()
         );
         return azureEnvironmentParameters;
@@ -524,8 +545,8 @@ public class EnvironmentApiConverterTest {
 
         gcpEnvironmentParameters.setGcpResourceEncryptionParameters(
                 GcpResourceEncryptionParameters.builder()
-                    .withEncryptionKey("dummy-encryption-key")
-                    .build()
+                        .withEncryptionKey("dummy-encryption-key")
+                        .build()
         );
         return gcpEnvironmentParameters;
     }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
@@ -49,8 +49,6 @@ import com.sequenceiq.environment.environment.validation.validators.PublicKeyVal
 import com.sequenceiq.environment.environment.validation.validators.TagValidator;
 import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
-import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
-import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
 import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
@@ -375,23 +373,12 @@ class EnvironmentValidatorServiceTest {
 
     @Test
     void shouldFailIfEncryptionKeyUrlSpecifiedAndEntitlementAndWrongFormat() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("AZURE")
-                .withParameters(ParametersDto.builder()
-                        .withAzureParameters(AzureParametersDto.builder()
-                                .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
-                                        .withEncryptionKeyUrl("Dummy-key-url")
-                                        .build())
-                                .build())
-                        .build())
-                .build();
-
+        String encryptionKeyUrl = "Dummy-key-url";
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
         validationResultBuilder.error("error");
         when(encryptionKeyUrlValidator.validateEncryptionKeyUrl(any())).thenReturn(validationResultBuilder.build());
         when(entitlementService.isAzureDiskSSEWithCMKEnabled(any())).thenReturn(true);
-        ValidationResult validationResult = underTest.validateEncryptionKeyUrl(creationDto);
+        ValidationResult validationResult = underTest.validateEncryptionKeyUrl(encryptionKeyUrl, ACCOUNT_ID);
         assertTrue(validationResult.hasError());
     }
 
@@ -446,49 +433,19 @@ class EnvironmentValidatorServiceTest {
 
     @Test
     void shouldFailIfEncryptionKeyUrlSpecifiedAndNotEntitlement() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("AZURE")
-                .withParameters(ParametersDto.builder()
-                        .withAzureParameters(AzureParametersDto.builder()
-                                .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
-                                        .withEncryptionKeyUrl("Dummy-key-url")
-                                        .build())
-                                .build())
-                        .build())
-                .build();
+        String encryptionKeyUrl = "Dummy-key-url";
         when(entitlementService.isAzureDiskSSEWithCMKEnabled(any())).thenReturn(false);
-        ValidationResult validationResult = underTest.validateEncryptionKeyUrl(creationDto);
+        ValidationResult validationResult = underTest.validateEncryptionKeyUrl(encryptionKeyUrl, ACCOUNT_ID);
         assertTrue(validationResult.hasError());
     }
 
     @Test
-    void testValidateEncryptionKeyUrlNotSpecified() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("AZURE")
-                .build();
-        ValidationResult validationResult = underTest.validateEncryptionKeyUrl(creationDto);
-        assertFalse(validationResult.hasError());
-    }
-
-    @Test
     void testValidateEncryptionKeyUrlSpecifiedAndEntitlement() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("AZURE")
-                .withParameters(ParametersDto.builder()
-                        .withAzureParameters(AzureParametersDto.builder()
-                                .withEncryptionParameters(AzureResourceEncryptionParametersDto.builder()
-                                        .withEncryptionKeyUrl("https://someVault.vault.azure.net/keys/someKey/someKeyVersion")
-                                        .build())
-                                .build())
-                        .build())
-                .build();
+        String encryptionKeyUrl = "https://someVault.vault.azure.net/keys/someKey/someKeyVersion";
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
         when(encryptionKeyUrlValidator.validateEncryptionKeyUrl(any())).thenReturn(validationResultBuilder.build());
         when(entitlementService.isAzureDiskSSEWithCMKEnabled(any())).thenReturn(true);
-        ValidationResult validationResult = underTest.validateEncryptionKeyUrl(creationDto);
+        ValidationResult validationResult = underTest.validateEncryptionKeyUrl(encryptionKeyUrl, ACCOUNT_ID);
         assertFalse(validationResult.hasError());
     }
 


### PR DESCRIPTION
CB-13134: Set encryption key for an existing env that does not yet have encryption enabled.

CB-9920 introduced the encryption of Azure Managed disks using Customer Managed Key. This feature is behind an entitlement "CDP_CB_AZURE_DISK_SSE_WITH_CMK" and can be used for new environments.
This PR allows to set the encryption key for existing environments such that the new disks launched as part of new Datahubs will be encrypted with Customer Managed Key. All the previously launched disks/resources would remain encrypted by Azure's platform managed key.

Thunderhead PR - https://github.com/hortonworks/cloudbreak/pull/11225 , Once CB changes are merged, will update the parent/pom.xml in thunderhead PR and open it for reviews.


Validated these changes with :
-  Existing environment
    - Using wrong key url
    - Using disabled key
    - With keyVault not having read/write permissions
    - Using enabled key valid url
- Non - Existing environement