### PR TITLE
CB-13733 Cluster stays in UPDATE_IN_PROGRESS state after validation e…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeContext.java
@@ -13,11 +13,6 @@ public class ClusterUpgradeContext extends CommonContext {
         stackId = event.getResourceId();
     }
 
-    public ClusterUpgradeContext(FlowParameters flowParameters, Long stackId) {
-        super(flowParameters);
-        this.stackId = stackId;
-    }
-
     public static ClusterUpgradeContext from(FlowParameters flowParameters, StackEvent event) {
         return new ClusterUpgradeContext(flowParameters, event);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/ClusterUpgradeImageValidationEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/ClusterUpgradeImageValidationEvent.java
@@ -35,4 +35,12 @@ public class ClusterUpgradeImageValidationEvent extends ClusterUpgradeValidation
         return cloudContext;
     }
 
+    @Override
+    public String toString() {
+        return "ClusterUpgradeImageValidationEvent{" +
+                "cloudCredential=" + cloudCredential +
+                ", cloudStack=" + cloudStack +
+                ", cloudContext=" + cloudContext +
+                "} " + super.toString();
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeServiceValidationEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeServiceValidationEvent.java
@@ -14,4 +14,11 @@ public class ClusterUpgradeServiceValidationEvent extends StackEvent {
     public boolean isLockComponents() {
         return lockComponents;
     }
+
+    @Override
+    public String toString() {
+        return "ClusterUpgradeServiceValidationEvent{" +
+                "lockComponents=" + lockComponents +
+                "} " + super.toString();
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/event/ClusterUpgradeValidationEvent.java
@@ -1,9 +1,6 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event;
 
-import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
-
-import reactor.rx.Promise;
 
 public class ClusterUpgradeValidationEvent extends StackEvent {
 
@@ -14,12 +11,14 @@ public class ClusterUpgradeValidationEvent extends StackEvent {
         this.imageId = imageId;
     }
 
-    public ClusterUpgradeValidationEvent(String selector, Long resourceId, Promise<AcceptResult> accepted, String imageId) {
-        super(selector, resourceId, accepted);
-        this.imageId = imageId;
-    }
-
     public String getImageId() {
         return imageId;
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterUpgradeValidationEvent{" +
+                "imageId='" + imageId + '\'' +
+                "} " + super.toString();
     }
 }


### PR DESCRIPTION
…rror

- set stack and cluster status to `AVAILABLE` after validation failure
- add logs
- smaller refactors

See detailed description in the commit message.