### PR TITLE
CB-7415: Added list of stopped instanced to repair error message.

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairServiceTest.java
@@ -425,7 +425,9 @@ public class ClusterRepairServiceTest {
         });
 
         String expectedErrorMessage =
-                "Action cannot be performed because there are stopped nodes in the cluster. Please select them for repair or start the stopped nodes.";
+                "Action cannot be performed because there are stopped nodes in the cluster. " +
+                        "Stopped nodes: [host2]. " +
+                        "Please select them for repair or start the stopped nodes.";
         assertEquals(expectedErrorMessage,
                 exception.getMessage());
         verifyEventArguments(CLUSTER_MANUALRECOVERY_COULD_NOT_START,


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-7415

This change simply serves to modify the error message resulting when you try to repair a cluster when some instances are in a stopped state. Specifically, this adds the IDs of those stopped instances so the user knows which to restart.

Let me know if any of my logic is incorrect as I have assumed that these IDs are always available in this case.