### PR TITLE
CB-11919. Support multi region CP for databus clients

### DIFF
--- a/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/testcontext/TestApplicationContext.java
+++ b/cloud-reactor/src/test/java/com/sequenceiq/cloudbreak/cloud/handler/testcontext/TestApplicationContext.java
@@ -148,7 +148,7 @@ public class TestApplicationContext {
 
     @Bean
     public AltusDatabusConfiguration altusDatabusConfiguration() {
-        return new AltusDatabusConfiguration("", false, "", "");
+        return new AltusDatabusConfiguration("", "", false, "", "");
     }
 
     @Bean

--- a/common/src/main/java/com/sequenceiq/cloudbreak/altus/AltusDatabusConfiguration.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/altus/AltusDatabusConfiguration.java
@@ -9,6 +9,8 @@ public class AltusDatabusConfiguration {
 
     private final String altusDatabusEndpoint;
 
+    private final String altusDatabusS3BucketName;
+
     private final boolean useSharedAltusCredential;
 
     private final String sharedAccessKey;
@@ -17,10 +19,12 @@ public class AltusDatabusConfiguration {
 
     public AltusDatabusConfiguration(
             @Value("${altus.databus.endpoint:}") String altusDatabusEndpoint,
+            @Value("${altus.databus.s3.bucket:}") String altusDatabusS3BucketName,
             @Value("${altus.databus.shared.credential.enabled:false}") boolean useSharedAltusCredential,
             @Value("${altus.databus.shared.accessKey:}") String sharedAccessKey,
             @Value("${altus.databus.shared.secretKey:}") String sharedSecretKey) {
         this.altusDatabusEndpoint = altusDatabusEndpoint;
+        this.altusDatabusS3BucketName = altusDatabusS3BucketName;
         this.useSharedAltusCredential = useSharedAltusCredential;
         this.sharedAccessKey = sharedAccessKey;
         this.sharedSecretKey = StringUtils.isBlank(sharedSecretKey) ? null : sharedSecretKey.toCharArray();
@@ -28,6 +32,10 @@ public class AltusDatabusConfiguration {
 
     public String getAltusDatabusEndpoint() {
         return altusDatabusEndpoint;
+    }
+
+    public String getAltusDatabusS3BucketName() {
+        return altusDatabusS3BucketName;
     }
 
     public boolean isUseSharedAltusCredential() {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/DataBusEndpointProvider.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/DataBusEndpointProvider.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.config.DataBusS3EndpointPattern;
 import com.sequenceiq.cloudbreak.config.DataBusS3EndpointPatternsConfig;
 
@@ -14,12 +15,17 @@ public class DataBusEndpointProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DataBusEndpointProvider.class);
 
+    private static final String DATABUS_S3_HTTP_ENDPOINT = "https://%s.s3.amazonaws.com";
+
+    private final AltusDatabusConfiguration altusDatabusConfiguration;
+
     private final DataBusS3EndpointPatternsConfig dataBusS3EndpointPatternsConfig;
 
     private final String databusCnameEndpoint;
 
-    public DataBusEndpointProvider(DataBusS3EndpointPatternsConfig dataBusS3EndpointPatternsConfig,
-            @Value("${altus.databus.cname}") String databusCnameEndpoint) {
+    public DataBusEndpointProvider(AltusDatabusConfiguration altusDatabusConfiguration,
+            DataBusS3EndpointPatternsConfig dataBusS3EndpointPatternsConfig, @Value("${altus.databus.cname}") String databusCnameEndpoint) {
+        this.altusDatabusConfiguration = altusDatabusConfiguration;
         this.dataBusS3EndpointPatternsConfig = dataBusS3EndpointPatternsConfig;
         this.databusCnameEndpoint = databusCnameEndpoint;
     }
@@ -33,7 +39,19 @@ public class DataBusEndpointProvider {
         return databusUrl;
     }
 
+    public String getDatabusS3Endpoint(String endpoint, boolean forceToUsePatterns) {
+        if (StringUtils.isNotBlank(altusDatabusConfiguration.getAltusDatabusS3BucketName()) && !forceToUsePatterns) {
+            return String.format(DATABUS_S3_HTTP_ENDPOINT, altusDatabusConfiguration.getAltusDatabusS3BucketName());
+        } else {
+            return getDatabusS3EndpointFromPatterns(endpoint);
+        }
+    }
+
     public String getDatabusS3Endpoint(String endpoint) {
+        return getDatabusS3Endpoint(endpoint, false);
+    }
+
+    private String getDatabusS3EndpointFromPatterns(String endpoint) {
         String dbusS3Endpoint = null;
         for (DataBusS3EndpointPattern s3EndpointPatternObj : dataBusS3EndpointPatternsConfig.getPatterns()) {
             if (StringUtils.isNotBlank(endpoint) && endpoint.contains(s3EndpointPatternObj.getPattern())) {

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryClusterDetails.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/TelemetryClusterDetails.java
@@ -29,6 +29,8 @@ public class TelemetryClusterDetails {
 
     private final boolean databusEndpointValidation;
 
+    private final String databusS3Endpoint;
+
     private TelemetryClusterDetails(Builder builder) {
         this.name = builder.name;
         this.type = builder.type;
@@ -38,6 +40,7 @@ public class TelemetryClusterDetails {
         this.version = builder.version;
         this.databusEndpoint = builder.databusEndpoint;
         this.databusEndpointValidation = builder.databusEndpointValidation;
+        this.databusS3Endpoint = builder.databusS3Endpoint;
     }
 
     public String getName() {
@@ -82,6 +85,7 @@ public class TelemetryClusterDetails {
         map.put("clusterVersion", this.version);
         map.put("databusEndpoint", this.databusEndpoint);
         map.put("databusEndpointValidation", this.databusEndpointValidation);
+        map.put("databusS3Endpoint", this.databusS3Endpoint);
         return map;
     }
 
@@ -102,6 +106,8 @@ public class TelemetryClusterDetails {
         private String databusEndpoint;
 
         private boolean databusEndpointValidation;
+
+        private String databusS3Endpoint;
 
         private Builder() {
         }
@@ -151,6 +157,11 @@ public class TelemetryClusterDetails {
 
         public Builder withDatabusEndpointValidation(boolean databusEndpointValidation) {
             this.databusEndpointValidation = databusEndpointValidation;
+            return this;
+        }
+
+        public Builder withDatabusS3Endpoint(String databusS3Endpoint) {
+            this.databusS3Endpoint = databusS3Endpoint;
             return this;
         }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigService.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/common/TelemetryCommonConfigService.java
@@ -42,7 +42,7 @@ public class TelemetryCommonConfigService {
     // TODO: refactor parameters to 1 object
     public TelemetryCommonConfigView createTelemetryCommonConfigs(Telemetry telemetry, List<VmLog> logs,
             String clusterType, String clusterCrn, String clusterName, String clusterOwner, String platform,
-            String databusEndpoint) {
+            String databusEndpoint, String databusS3Endpoint) {
         final TelemetryClusterDetails clusterDetails = TelemetryClusterDetails.Builder.builder()
                 .withOwner(clusterOwner)
                 .withName(clusterName)
@@ -51,6 +51,7 @@ public class TelemetryCommonConfigService {
                 .withPlatform(platform)
                 .withVersion(version)
                 .withDatabusEndpoint(databusEndpoint)
+                .withDatabusS3Endpoint(databusS3Endpoint)
                 .withDatabusEndpointValidation(databusEndpointValidation)
                 .build();
         resolveLogPathReferences(telemetry, logs);

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigView.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ObjectUtils;
 
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfigView;
 import com.sequenceiq.cloudbreak.telemetry.logcollection.ClusterLogsCollectionConfiguration;
@@ -68,6 +69,8 @@ public class FluentConfigView implements TelemetryConfigView {
 
     private final String providerPrefix;
 
+    private final String environmentRegion;
+
     private final Integer partitionIntervalMin;
 
     private final String azureStorageAccount;
@@ -112,6 +115,7 @@ public class FluentConfigView implements TelemetryConfigView {
         this.serviceLogFolderPrefix = builder.serviceLogFolderPrefix;
         this.region = builder.region;
         this.providerPrefix = builder.providerPrefix;
+        this.environmentRegion = builder.environmentRegion;
         this.partitionIntervalMin = builder.partitionIntervalMin;
         this.logFolderName = builder.logFolderName;
         this.s3LogArchiveBucketName = builder.s3LogArchiveBucketName;
@@ -157,6 +161,10 @@ public class FluentConfigView implements TelemetryConfigView {
 
     public String getProviderPrefix() {
         return providerPrefix;
+    }
+
+    public String getEnvironmentRegion() {
+        return environmentRegion;
     }
 
     public Integer getPartitionIntervalMin() {
@@ -244,6 +252,7 @@ public class FluentConfigView implements TelemetryConfigView {
         map.put("dbusIncludeSaltLogs", DBUS_INCLUDE_SALT_LOGS_DEFAULT);
         map.put("user", ObjectUtils.defaultIfNull(this.user, TD_AGENT_USER_DEFAULT));
         map.put("group", ObjectUtils.defaultIfNull(this.group, TD_AGENT_GROUP_DEFAULT));
+        map.put("environmentRegion", ObjectUtils.defaultIfNull(this.environmentRegion, Crn.Region.US_WEST_1.getName()));
         map.put("providerPrefix", ObjectUtils.defaultIfNull(this.providerPrefix, PROVIDER_PREFIX_DEFAULT));
         map.put("region", ObjectUtils.defaultIfNull(this.region, EMPTY_CONFIG_DEFAULT));
         map.put("serverLogFolderPrefix", ObjectUtils.defaultIfNull(this.serverLogFolderPrefix, LOG_FOLDER_DEFAULT));
@@ -327,6 +336,8 @@ public class FluentConfigView implements TelemetryConfigView {
 
         private String providerPrefix;
 
+        private String environmentRegion;
+
         private Integer partitionIntervalMin;
 
         private String logFolderName;
@@ -394,6 +405,11 @@ public class FluentConfigView implements TelemetryConfigView {
 
         public Builder withProviderPrefix(String providerPrefix) {
             this.providerPrefix = providerPrefix;
+            return this;
+        }
+
+        public Builder withEnvironmentRegion(String environmentRegion) {
+            this.environmentRegion = environmentRegion;
             return this;
         }
 

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/DataBusEndpointProviderTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/DataBusEndpointProviderTest.java
@@ -2,25 +2,36 @@ package com.sequenceiq.cloudbreak.telemetry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.BDDMockito.given;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.altus.AltusDatabusConfiguration;
 import com.sequenceiq.cloudbreak.config.DataBusS3EndpointPattern;
 import com.sequenceiq.cloudbreak.config.DataBusS3EndpointPatternsConfig;
 
+@ExtendWith(MockitoExtension.class)
 public class DataBusEndpointProviderTest {
 
     private static final String DATABUS_ENDPOINT_CNAME = "https://dbusapi.us-west-1.altus.cloudera.com";
 
+    @InjectMocks
     private DataBusEndpointProvider underTest;
+
+    @Mock
+    private AltusDatabusConfiguration altusDatabusConfiguration;
 
     @BeforeEach
     public void setUp() {
-        underTest = new DataBusEndpointProvider(createDatabusS3EndpointPatterns(), DATABUS_ENDPOINT_CNAME);
+        underTest = new DataBusEndpointProvider(altusDatabusConfiguration, createDatabusS3EndpointPatterns(), DATABUS_ENDPOINT_CNAME);
     }
 
     @Test
@@ -30,6 +41,16 @@ public class DataBusEndpointProviderTest {
         String result = underTest.getDatabusS3Endpoint("https://dbusapi.us-west-1.sigma.altus.cloudera.com");
         // THEN
         assertEquals("https://cloudera-dbus-prod.s3.amazonaws.com", result);
+    }
+
+    @Test
+    public void testGetDatabusS3EndpointWithProvidedS3Bucket() {
+        // GIVEN
+        given(altusDatabusConfiguration.getAltusDatabusS3BucketName()).willReturn("mybucket");
+        // WHEN
+        String result = underTest.getDatabusS3Endpoint("https://dbusapi.us-west-1.sigma.altus.cloudera.com");
+        // THEN
+        assertEquals("https://mybucket.s3.amazonaws.com", result);
     }
 
     @Test

--- a/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/telemetry/fluent/FluentConfigServiceTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryClusterDetails;
 import com.sequenceiq.cloudbreak.telemetry.TelemetryConfiguration;
@@ -31,8 +32,10 @@ public class FluentConfigServiceTest {
 
     private static final String REGION_SAMPLE = "eu-central-1";
 
+    private static final String DATAHUB_CRN = "crn:cdp:datahub:eu-1:1234:user:91011";
+
     private static final TelemetryClusterDetails DEFAULT_FLUENT_CLUSTER_DETAILS =
-            TelemetryClusterDetails.Builder.builder().withType(CLUSTER_TYPE_DEFAULT).withPlatform(PLATFORM_DEFAULT).build();
+            TelemetryClusterDetails.Builder.builder().withType(CLUSTER_TYPE_DEFAULT).withPlatform(PLATFORM_DEFAULT).withCrn(DATAHUB_CRN).build();
 
     private FluentConfigService underTest;
 
@@ -64,6 +67,7 @@ public class FluentConfigServiceTest {
         assertTrue(result.isCloudStorageLoggingEnabled());
         assertEquals("cluster-logs/datahub/cl1", result.getLogFolderName());
         assertEquals("mybucket", result.getS3LogArchiveBucketName());
+        assertEquals(Crn.Region.EU_1.getName(), result.toMap().get("environmentRegion"));
     }
 
     @Test

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecorator.java
@@ -143,6 +143,7 @@ public class TelemetryDecorator {
         String accountId = Crn.safeFromString(stack.getResourceCrn()).getAccountId();
         boolean useDbusCnameEndpoint = entitlementService.useDataBusCNameEndpointEnabled(accountId);
         String databusEndpoint = dataBusEndpointProvider.getDataBusEndpoint(telemetry.getDatabusEndpoint(), useDbusCnameEndpoint);
+        String databusS3Endpoint = dataBusEndpointProvider.getDatabusS3Endpoint(databusEndpoint);
 
         DatabusConfigView databusConfigView = databusConfigService.createDatabusConfigs(
                 dbusCredential.getAccessKey(), dbusCredential.getPrivateKey(), null, databusEndpoint);
@@ -167,7 +168,7 @@ public class TelemetryDecorator {
                 .build();
         final TelemetryCommonConfigView telemetryCommonConfigs = telemetryCommonConfigService.createTelemetryCommonConfigs(
                 telemetry, vmLogsService.getVmLogs(), clusterType, clusterCrn, stack.getName(), stack.getCreator().getUserCrn(), stack.getCloudPlatform(),
-                databusEndpoint);
+                databusEndpoint, databusS3Endpoint);
         servicePillar.put("telemetry",
                 new SaltPillarProperties("/telemetry/init.sls", Collections.singletonMap("telemetry", telemetryCommonConfigs.toMap())));
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/diagnostics/DiagnosticsFlowService.java
@@ -56,6 +56,8 @@ public class DiagnosticsFlowService {
 
     private static final String AWS_METADATA_SERVER_V2_SUPPORT_VERSION = "0.4.9";
 
+    private static final String MULTI_CP_REGION_SUPPORT_VERSION = "0.4.12";
+
     private static final String AWS_EC2_METADATA_SERVICE_WARNING = "Could be related with unavailable instance metadata service response " +
             "from ec2 node. (region, domain)";
 
@@ -99,6 +101,7 @@ public class DiagnosticsFlowService {
                     String cdpTelemetryVersion = nodeStatusReport.getCdpTelemetryVersion();
                     boolean stableNetworkCheckSupported = isVersionGreaterOrEqual(cdpTelemetryVersion, STABLE_NETWORK_CHECK_VERSION);
                     boolean awsMetadataServerV2Supported = isVersionGreaterOrEqual(cdpTelemetryVersion, AWS_METADATA_SERVER_V2_SUPPORT_VERSION);
+                    boolean multiCpRegionSupported = isVersionGreaterOrEqual(cdpTelemetryVersion, MULTI_CP_REGION_SUPPORT_VERSION);
                     List<NodeStatusProto.NetworkDetails> networkNodes = nodeStatusReport.getNodesList().stream()
                             .map(NodeStatusProto.NodeStatus::getNetworkDetails)
                             .collect(Collectors.toList());
@@ -109,7 +112,7 @@ public class DiagnosticsFlowService {
                         firePreFlightCheckEvents(stackId, String.format("DataBus API ('%s') accessibility", databusEndpoint),
                                 networkNodes, NodeStatusProto.NetworkDetails::getDatabusAccessible);
                     }
-                    String databusS3Endpoint = dataBusEndpointProvider.getDatabusS3Endpoint(databusEndpoint);
+                    String databusS3Endpoint = dataBusEndpointProvider.getDatabusS3Endpoint(databusEndpoint, !multiCpRegionSupported);
                     if (StringUtils.isNotBlank(databusS3Endpoint)) {
                         firePreFlightCheckEvents(stackId, String.format("DataBus S3 API ('%s') accessibility", databusS3Endpoint),
                                 networkNodes, NodeStatusProto.NetworkDetails::getDatabusS3Accessible, stableNetworkCheckSupported);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/TelemetryConverterTest.java
@@ -40,11 +40,13 @@ public class TelemetryConverterTest {
 
     private static final String DATABUS_ENDPOINT = "myCustomEndpoint";
 
+    private static final String DATABUS_S3_BUCKET = "myCustomS3Bucket";
+
     private TelemetryConverter underTest;
 
     @Before
     public void setUp() {
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, true, "****", "****");
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, DATABUS_S3_BUCKET, true, "****", "****");
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, "app", "stream");
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, "app", "stream");
         MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(true, null, null);
@@ -222,7 +224,7 @@ public class TelemetryConverterTest {
     public void testConvertFromEnvAndSdxResponseWithDefaultDisabled() {
         // GIVEN
         SdxClusterResponse sdxClusterResponse = null;
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, DATABUS_S3_BUCKET, false, "", null);
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, null, null);
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
         MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(false, null, null);
@@ -298,7 +300,7 @@ public class TelemetryConverterTest {
         SdxClusterResponse sdxClusterResponse = new SdxClusterResponse();
         sdxClusterResponse.setCrn("crn:cdp:cloudbreak:us-west-1:someone:sdxcluster:sdxId");
         sdxClusterResponse.setName("sdxName");
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, DATABUS_S3_BUCKET, false, "", null);
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(true, null, null);
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
         MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(false, null, null);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/decorator/TelemetryDecoratorTest.java
@@ -307,7 +307,7 @@ public class TelemetryDecoratorTest {
                 .willReturn(monitoringConfigView);
         given(nodeStatusConfigService.createNodeStatusConfig(isNull(), isNull(), anyBoolean())).willReturn(nodeStatusConfigView);
         given(telemetryCommonConfigService.createTelemetryCommonConfigs(any(), anyList(), anyString(), anyString(),
-                anyString(), anyString(), anyString(), anyString()))
+                anyString(), anyString(), anyString(), anyString(), isNull()))
                 .willReturn(telemetryCommonConfigView);
         given(entitlementService.useDataBusCNameEndpointEnabled(anyString())).willReturn(false);
     }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/TelemetryApiConverterTest.java
@@ -36,7 +36,7 @@ public class TelemetryApiConverterTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", true, "****", "****");
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration("", "", true, "****", "****");
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(false, null, null);
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
         MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(true, null, null);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/telemetry/TelemetryConfigService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/telemetry/TelemetryConfigService.java
@@ -109,7 +109,7 @@ public class TelemetryConfigService {
     private Map<String, SaltPillarProperties> getTelemetryCommonPillarConfig(Stack stack, Telemetry telemetry, String databusEndpoint) {
         TelemetryCommonConfigView telemetryCommonConfigs = telemetryCommonConfigService.createTelemetryCommonConfigs(
                 telemetry, vmLogsService.getVmLogs(), FluentClusterType.FREEIPA.value(), stack.getResourceCrn(),
-                stack.getName(), stack.getOwner(), stack.getCloudPlatform(), databusEndpoint);
+                stack.getName(), stack.getOwner(), stack.getCloudPlatform(), databusEndpoint, dataBusEndpointProvider.getDatabusS3Endpoint(databusEndpoint));
         return Map.of("telemetry",
                 new SaltPillarProperties("/telemetry/init.sls", Collections.singletonMap("telemetry", telemetryCommonConfigs.toMap())));
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/telemetry/TelemetryConverterTest.java
@@ -28,13 +28,15 @@ public class TelemetryConverterTest {
 
     private static final String DATABUS_ENDPOINT = "myCustomEndpoint";
 
+    private static final String DATABUS_S3_BUCKET = "myCustomS3Bucket";
+
     private static final String EMAIL = "blah@blah.blah";
 
     private TelemetryConverter underTest;
 
     @BeforeEach
     public void setUp() {
-        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, false, "", null);
+        AltusDatabusConfiguration altusDatabusConfiguration = new AltusDatabusConfiguration(DATABUS_ENDPOINT, DATABUS_S3_BUCKET, false, "", null);
         MeteringConfiguration meteringConfiguration = new MeteringConfiguration(false, null, null);
         ClusterLogsCollectionConfiguration logCollectionConfig = new ClusterLogsCollectionConfiguration(true, null, null);
         MonitoringConfiguration monitoringConfig = new MonitoringConfiguration(true, null, null);

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/settings.sls
@@ -89,6 +89,7 @@
 {% set cluster_crn = salt['pillar.get']('fluent:clusterCrn')%}
 {% set cluster_owner = salt['pillar.get']('fluent:clusterOwner')%}
 {% set cluster_version = salt['pillar.get']('fluent:clusterVersion')%}
+{% set environment_region = salt['pillar.get']('fluent:environmentRegion')%}
 
 {% set partition_interval = salt['pillar.get']('fluent:partitionIntervalMin') %}
 {% set cloudera_public_gem_repo = 'https://repository.cloudera.com/cloudera/api/gems/cloudera-gems/' %}
@@ -282,6 +283,7 @@
     "dbusIncludeSaltLogs": dbus_include_salt_logs,
     "forwardPort" : 24224,
     "region": region,
+    "environmentRegion" : environment_region,
     "platform": platform,
     "proxyUrl": proxy_url,
     "proxyAuth": proxy_auth,

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_metering.conf.j2
@@ -27,7 +27,8 @@
     proxy_url                        "{{ fluent.proxyUrl }}"{%- if fluent.proxyAuth %}
     proxy_username                   "{{ fluent.proxyUser }}"
     proxy_password                   "{{ fluent.proxyPassword }}"{% endif %}{% if fluent.noProxyHosts and fluent.fluentVersion > 3 %}
-    no_proxy                         "{{ fluent.noProxyHosts }}"{% endif %}{% endif %}
+    no_proxy                         "{{ fluent.noProxyHosts }}"{% endif %}{% endif %}{% if fluent.environmentRegion %}
+    region                           "{{ fluent.environmentRegion }}"{% endif %}
     <buffer tag,time>
       @type file
       path /var/log/{{ fluent.binary }}/metering_databus

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_monitoring.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/databus_monitoring.conf.j2
@@ -27,7 +27,8 @@
     proxy_url                        "{{ fluent.proxyUrl }}"{%- if fluent.proxyAuth %}
     proxy_username                   "{{ fluent.proxyUser }}"
     proxy_password                   "{{ fluent.proxyPassword }}"{% endif %}{% if fluent.noProxyHosts and fluent.fluentVersion > 3 %}
-    no_proxy                         "{{ fluent.noProxyHosts }}"{% endif %}{% endif %}
+    no_proxy                         "{{ fluent.noProxyHosts }}"{% endif %}{% endif %}{% if fluent.environmentRegion %}
+    region                           "{{ fluent.environmentRegion }}"{% endif %}
     <buffer tag,time>
       @type file
       path /var/log/{{ fluent.binary }}/monitoring_databus

--- a/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/fluent/template/output_databus.conf.j2
@@ -19,7 +19,8 @@
     proxy_url                        "{{ fluent.proxyUrl }}"{%- if fluent.proxyAuth %}
     proxy_username                   "{{ fluent.proxyUser }}"
     proxy_password                   "{{ fluent.proxyPassword }}"{% endif %}{% if fluent.noProxyHosts and fluent.fluentVersion > 3 %}
-    no_proxy                         "{{ fluent.noProxyHosts }}"{% endif %}{% endif %}
+    no_proxy                         "{{ fluent.noProxyHosts }}"{% endif %}{% endif %}{% if fluent.environmentRegion %}
+    region                           "{{ fluent.environmentRegion }}"{% endif %}
     <buffer tag,time>
       @type file
       path /var/log/{{ fluent.binary }}/databus_service_logs

--- a/orchestrator-salt/src/main/resources/salt-common/salt/nodestatus/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/nodestatus/settings.sls
@@ -15,7 +15,13 @@
     {% set additional_collect_params = "" %}
 {% endif %}
 
-{% set collect_params = databus_params + " " + additional_collect_params %}
+{% if telemetry.cdpTelemetryPackageVersion and salt['pkg.version_cmp'](telemetry.cdpTelemetryPackageVersion,'0.4.12-1') >= 0 and telemetry.databusS3Endpoint %}
+  {% set databus_s3_endpoint_params = "--databus-s3-url " + telemetry.databusS3Endpoint + " " %}
+{% else %}
+  {% set databus_s3_endpoint_params = "" %}
+{% endif %}
+
+{% set collect_params = databus_s3_endpoint_params + databus_params + " " + additional_collect_params %}
 
 {% if telemetry.cdpTelemetryVersion > 2 %}
   {% set collect_available = True %}

--- a/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/telemetry/settings.sls
@@ -8,6 +8,7 @@
 {% set cluster_type = salt['pillar.get']('telemetry:clusterType') %}
 {% set cluster_owner = salt['pillar.get']('telemetry:clusterOwner') %}
 {% set databus_endpoint = salt['pillar.get']('telemetry:databusEndpoint') %}
+{% set databus_s3_endpoint = salt['pillar.get']('telemetry:databusS3Endpoint') %}
 
 {% if salt['pillar.get']('telemetry:databusEndpointValidation') %}
     {% set databus_endpoint_validation = True %}
@@ -94,6 +95,7 @@
     "anonymizationRules": anonymization_rules,
     "databusEndpoint": databus_endpoint,
     "databusEndpointValidation": databus_endpoint_validation,
+    "databusS3Endpoint": databus_s3_endpoint,
     "cdpTelemetryVersion": cdp_telemetry_version,
     "cdpTelemetryPackageVersion": cdp_telemetry_package_version,
     "proxyUrl": proxy_full_url,


### PR DESCRIPTION
details:
- add new configuration (that should be passed in cloud-services-infra + dps-k8s) -> as thunderhad-sigmadbus is part of CSI, pass the s3 bucket name for dbus.
- use env region option for fluentd dbus plugin, if region is not used (or us-west-1 is passed), it will use the old dbus api, otherwise it will use the new /api/v1/dbus one
- update Uts