### PR TITLE
[CB-13049] collect metadata for GCP loadbalancers

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilder.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -44,6 +46,9 @@ public class GcpBackendServiceResourceBuilder extends AbstractGcpLoadBalancerBui
     private static final int ORDER = 2;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GcpBackendServiceResourceBuilder.class);
+
+    @Inject
+    private GcpLoadBalancerTypeConverter gcpLoadBalancerTypeConverter;
 
     @Override
     public List<CloudResource> create(GcpContext context, AuthenticatedContext auth, CloudLoadBalancer loadBalancer) {
@@ -98,7 +103,7 @@ public class GcpBackendServiceResourceBuilder extends AbstractGcpLoadBalancerBui
 
             backendService.setBackends(backends);
             backendService.setName(buildableResource.getName());
-            backendService.setLoadBalancingScheme(GcpLoadBalancerScheme.getScheme(loadBalancer).getGcpType());
+            backendService.setLoadBalancingScheme(gcpLoadBalancerTypeConverter.getScheme(loadBalancer).getGcpType());
             backendService.setProtocol("TCP");
             String regionName = context.getLocation().getRegion().getRegionName();
             Insert insert = context.getCompute().regionBackendServices().insert(projectId, regionName, backendService);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpForwardingRuleResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpForwardingRuleResourceBuilder.java
@@ -56,6 +56,9 @@ public class GcpForwardingRuleResourceBuilder extends AbstractGcpLoadBalancerBui
     @Inject
     private GcpStackUtil gcpStackUtil;
 
+    @Inject
+    private GcpLoadBalancerTypeConverter gcpLoadBalancerTypeConverter;
+
     @Override
     public List<CloudResource> create(GcpContext context, AuthenticatedContext auth, CloudLoadBalancer loadBalancer) {
         List<CloudResource> resources = new ArrayList<>();
@@ -79,7 +82,7 @@ public class GcpForwardingRuleResourceBuilder extends AbstractGcpLoadBalancerBui
         String regionName = context.getLocation().getRegion().getRegionName();
         Network network = cloudStack.getNetwork();
         List<CloudResource> results = new ArrayList<>();
-        GcpLoadBalancerScheme scheme = GcpLoadBalancerScheme.getScheme(loadBalancer);
+        GcpLoadBalancerScheme scheme = gcpLoadBalancerTypeConverter.getScheme(loadBalancer);
 
         List<CloudResource> backendResources = filterResourcesByType(context.getLoadBalancerResources(loadBalancer.getType()), ResourceType.GCP_BACKEND_SERVICE);
         List<CloudResource> ipResources = filterResourcesByType(context.getLoadBalancerResources(loadBalancer.getType()), ResourceType.GCP_RESERVED_IP);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancerScheme.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancerScheme.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer;
 
-import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 
 public enum GcpLoadBalancerScheme {
@@ -23,13 +22,4 @@ public enum GcpLoadBalancerScheme {
         return cbType;
     }
 
-    public static GcpLoadBalancerScheme getScheme(CloudLoadBalancer cloudLoadBalancer) {
-        switch (cloudLoadBalancer.getType()) {
-            case PUBLIC:
-                return EXTERNAL;
-            case PRIVATE:
-            default:
-                return INTERNAL;
-        }
-    }
 }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancerTypeConverter.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancerTypeConverter.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer;
+
+import static com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer.GcpLoadBalancerScheme.EXTERNAL;
+import static com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer.GcpLoadBalancerScheme.INTERNAL;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
+
+@Component
+public class GcpLoadBalancerTypeConverter {
+
+    public GcpLoadBalancerScheme getScheme(CloudLoadBalancer cloudLoadBalancer) {
+        switch (cloudLoadBalancer.getType()) {
+            case PUBLIC:
+                return EXTERNAL;
+            case PRIVATE:
+            default:
+                return INTERNAL;
+        }
+    }
+
+    public GcpLoadBalancerScheme getScheme(String gcpType) {
+        if (EXTERNAL.getGcpType().equals(gcpType)) {
+            return EXTERNAL;
+        }
+        return INTERNAL;
+    }
+}

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancingIpResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancingIpResourceBuilder.java
@@ -33,6 +33,9 @@ public class GcpLoadBalancingIpResourceBuilder extends AbstractGcpLoadBalancerBu
     @Inject
     private GcpReservedIpResourceBuilder reservedIpResourceBuilder;
 
+    @Inject
+    private GcpLoadBalancerTypeConverter gcpLoadBalancerTypeConverter;
+
     @Override
     public List<CloudResource> create(GcpContext context, AuthenticatedContext auth, CloudLoadBalancer loadBalancer) {
         String groupName = loadBalancer.getPortToTargetGroupMapping().values().stream()
@@ -50,7 +53,7 @@ public class GcpLoadBalancingIpResourceBuilder extends AbstractGcpLoadBalancerBu
     public List<CloudResource> build(GcpContext context, AuthenticatedContext auth, List<CloudResource> buildableResources,
             CloudLoadBalancer loadBalancer, CloudStack cloudStack) throws Exception {
         return reservedIpResourceBuilder.buildReservedIp(context, buildableResources, cloudStack,
-                GcpLoadBalancerScheme.getScheme(loadBalancer));
+                gcpLoadBalancerTypeConverter.getScheme(loadBalancer));
     }
 
     @Override

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GCPLoadBalancerMetadataCollectorTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/GCPLoadBalancerMetadataCollectorTest.java
@@ -1,0 +1,241 @@
+package com.sequenceiq.cloudbreak.cloud.gcp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.ForwardingRule;
+import com.google.api.services.compute.model.ForwardingRuleList;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.gcp.client.GcpComputeFactory;
+import com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer.GcpLoadBalancerTypeConverter;
+import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
+import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.LoadBalancerType;
+import com.sequenceiq.common.api.type.ResourceType;
+
+@ExtendWith(MockitoExtension.class)
+public class GCPLoadBalancerMetadataCollectorTest {
+
+    private static final String FORWARDING_RULE_NAME_1 = "stack-public-80";
+
+    private static final String FORWARDING_RULE_NAME_2 = "stack-private-80";
+
+    private static final String PUBLIC_IP = "192.168.1.1";
+
+    private static final String PRIVATE_IP = "10.10.1.1";
+
+    private static final String PUBLIC_IP2 = "192.168.1.2";
+
+    @Mock
+    private GcpComputeFactory gcpComputeFactory;
+
+    @Mock
+    private Compute compute;
+
+    @Mock
+    private Compute.ForwardingRules forwardingRules;
+
+    @Mock
+    private Compute.ForwardingRules.List forwardingRulesList;
+
+    @Mock
+    private ForwardingRuleList forwardingRuleListResponse;
+
+    @InjectMocks
+    private GcpMetadataCollector underTest;
+
+    @Mock
+    private GcpStackUtil gcpStackUtil;
+
+    @Mock
+    private GcpLoadBalancerTypeConverter gcpLoadBalancerTypeConverter;
+
+    private AuthenticatedContext authenticatedContext;
+
+    @BeforeEach
+    public void before() throws IOException {
+
+        Location location = Location.location(Region.region("us-west2"), AvailabilityZone.availabilityZone("us-west2-a"));
+        CloudContext cloudContext = CloudContext.Builder.builder()
+                .withName("test-cluster")
+                .withLocation(location)
+                .withUserName("")
+                .build();
+
+        CloudCredential cloudCredential =
+                new CloudCredential("1", "gcp-cred", Collections.singletonMap("projectId", "gcp-cred"), false);
+        authenticatedContext = new AuthenticatedContext(cloudContext, cloudCredential);
+
+        when(gcpStackUtil.getProjectId(any())).thenReturn("gcp-cred");
+        when(gcpComputeFactory.buildCompute(any())).thenReturn(compute);
+        when(compute.forwardingRules()).thenReturn(forwardingRules);
+        when(forwardingRules.list(anyString(), anyString())).thenReturn(forwardingRulesList);
+        when(forwardingRulesList.execute()).thenReturn(forwardingRuleListResponse);
+        lenient().when(gcpLoadBalancerTypeConverter.getScheme(anyString())).thenCallRealMethod();
+    }
+
+    @Test
+    public void testCollectSinglePublicLoadBalancer() {
+        List<CloudResource> resources = new ArrayList<>();
+        resources.add(createCloudResource(FORWARDING_RULE_NAME_1, ResourceType.GCP_FORWARDING_RULE));
+        ForwardingRule publicFowardingRule = createPublicFowardingRule();
+        when(forwardingRuleListResponse.getItems()).thenReturn(List.of(publicFowardingRule));
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PUBLIC), resources);
+
+        assertEquals(1, result.size());
+        assertEquals(PUBLIC_IP, result.get(0).getIp());
+        assertEquals(LoadBalancerType.PUBLIC, result.get(0).getType());
+    }
+
+    @Test
+    public void testCollectSinglePublicLoadBalancerWithMultipleForwardingRules() {
+
+        List<CloudResource> resources = new ArrayList<>();
+        resources.add(createCloudResource(FORWARDING_RULE_NAME_1, ResourceType.GCP_FORWARDING_RULE));
+        resources.add(createCloudResource(FORWARDING_RULE_NAME_2, ResourceType.GCP_FORWARDING_RULE));
+        ForwardingRule publicFowardingRule = createPublicFowardingRule();
+        ForwardingRule publicFowardingRule2 = createPublicFowardingRule();
+        publicFowardingRule2.setIPAddress(PUBLIC_IP2);
+        publicFowardingRule2.setName(FORWARDING_RULE_NAME_2);
+        when(forwardingRuleListResponse.getItems()).thenReturn(List.of(publicFowardingRule, publicFowardingRule2));
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PUBLIC), resources);
+
+        assertEquals(2, result.size());
+        assertEquals(PUBLIC_IP, result.get(0).getIp());
+        assertEquals(PUBLIC_IP2, result.get(1).getIp());
+        assertEquals(LoadBalancerType.PUBLIC, result.get(0).getType());
+    }
+
+    @Test
+    public void testCollectPublicAndPrivateLoadBalancer() {
+
+        List<CloudResource> resources = new ArrayList<>();
+        resources.add(createCloudResource(FORWARDING_RULE_NAME_1, ResourceType.GCP_FORWARDING_RULE));
+        resources.add(createCloudResource(FORWARDING_RULE_NAME_2, ResourceType.GCP_FORWARDING_RULE));
+        ForwardingRule publicFowardingRule = createPublicFowardingRule();
+        ForwardingRule publicFowardingRule2 = createPrivateFowardingRule();
+        when(forwardingRuleListResponse.getItems()).thenReturn(List.of(publicFowardingRule, publicFowardingRule2));
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext,
+                List.of(LoadBalancerType.PUBLIC, LoadBalancerType.PRIVATE), resources);
+
+        assertEquals(2, result.size());
+
+        Optional<CloudLoadBalancerMetadata> publicResult = result.stream().filter(p -> p.getType().equals(LoadBalancerType.PUBLIC)).findFirst();
+        assertTrue(publicResult.isPresent());
+        assertEquals(PUBLIC_IP, publicResult.get().getIp());
+
+        Optional<CloudLoadBalancerMetadata> privateResult = result.stream().filter(p -> p.getType().equals(LoadBalancerType.PRIVATE)).findFirst();
+        assertTrue(privateResult.isPresent());
+        assertEquals(PRIVATE_IP, privateResult.get().getIp());
+
+    }
+
+    @Test
+    public void testCollectPrivateLoadBalancer() {
+        List<CloudResource> resources = new ArrayList<>();
+        resources.add(createCloudResource(FORWARDING_RULE_NAME_2, ResourceType.GCP_FORWARDING_RULE));
+        ForwardingRule privateForwardingRule = createPrivateFowardingRule();
+        when(forwardingRuleListResponse.getItems()).thenReturn(List.of(privateForwardingRule));
+
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PRIVATE), resources);
+
+        assertEquals(1, result.size());
+        assertEquals(PRIVATE_IP, result.get(0).getIp());
+        assertEquals(LoadBalancerType.PRIVATE, result.get(0).getType());
+    }
+
+    @Test
+    public void testCollectOtherType() {
+        List<CloudResource> resources = new ArrayList<>();
+        resources.add(createCloudResource(FORWARDING_RULE_NAME_2, ResourceType.GCP_FORWARDING_RULE));
+        ForwardingRule privateForwardingRule = createPrivateFowardingRule();
+        when(forwardingRuleListResponse.getItems()).thenReturn(List.of(privateForwardingRule));
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PUBLIC), resources);
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testCollectLoadBalancerWithNoIps() {
+        List<CloudResource> resources = new ArrayList<>();
+        resources.add(createCloudResource(FORWARDING_RULE_NAME_1, ResourceType.GCP_FORWARDING_RULE));
+        ForwardingRule forwardingRule = new ForwardingRule();
+        forwardingRule.setLoadBalancingScheme("EXTERNAL");
+        forwardingRule.setName(FORWARDING_RULE_NAME_1);
+        when(forwardingRuleListResponse.getItems()).thenReturn(List.of(forwardingRule));
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PUBLIC), resources);
+
+        assertEquals(1, result.size());
+        assertEquals(null, result.get(0).getIp());
+        assertEquals(LoadBalancerType.PUBLIC, result.get(0).getType());
+    }
+
+    @Test
+    public void testCollectLoadBalancerSkipsMetadataWhenRuntimeExceptionIsThrown() throws IOException {
+        List<CloudResource> resources = new ArrayList<>();
+        resources.add(createCloudResource(FORWARDING_RULE_NAME_1, ResourceType.GCP_FORWARDING_RULE));
+        when(forwardingRulesList.execute()).thenThrow(new RuntimeException());
+
+
+        List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PUBLIC), resources);
+
+        assertEquals(0, result.size());
+    }
+
+    private ForwardingRule createPublicFowardingRule() {
+        ForwardingRule forwardingRule = new ForwardingRule();
+        forwardingRule.setLoadBalancingScheme("EXTERNAL");
+        forwardingRule.setName(FORWARDING_RULE_NAME_1);
+        forwardingRule.setIPAddress(PUBLIC_IP);
+        return forwardingRule;
+    }
+
+    private ForwardingRule createPrivateFowardingRule() {
+        ForwardingRule forwardingRule = new ForwardingRule();
+        forwardingRule.setLoadBalancingScheme("INTERNAL");
+        forwardingRule.setName(FORWARDING_RULE_NAME_2);
+        forwardingRule.setIPAddress(PRIVATE_IP);
+        return forwardingRule;
+    }
+
+    static CloudResource createCloudResource(String name, ResourceType type) {
+        return CloudResource.builder()
+                .name(name)
+                .type(type)
+                .status(CommonStatus.CREATED)
+                .params(Collections.emptyMap())
+                .build();
+    }
+
+}

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpBackendServiceResourceBuilderTest.java
@@ -80,6 +80,9 @@ public class GcpBackendServiceResourceBuilderTest {
     @Mock
     private Operation operation;
 
+    @Mock
+    private GcpLoadBalancerTypeConverter gcpLoadBalancerTypeConverter;
+
     private Image image;
 
     private CloudStack cloudStack;
@@ -161,6 +164,7 @@ public class GcpBackendServiceResourceBuilderTest {
         when(insert.execute()).thenReturn(operation);
         when(operation.getName()).thenReturn("name");
         when(operation.getHttpErrorStatusCode()).thenReturn(null);
+        when(gcpLoadBalancerTypeConverter.getScheme(any(CloudLoadBalancer.class))).thenCallRealMethod();
 
         List<CloudResource> cloudResources = underTest.build(gcpContext, authenticatedContext,
                 Collections.singletonList(resource), cloudLoadBalancer, cloudStack);

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpForwardingRuleResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpForwardingRuleResourceBuilderTest.java
@@ -94,6 +94,9 @@ public class GcpForwardingRuleResourceBuilderTest {
     @Captor
     private ArgumentCaptor<ForwardingRule> forwardingRuleArg;
 
+    @Mock
+    private GcpLoadBalancerTypeConverter gcpLoadBalancerTypeConverter;
+
     private Image image;
 
     private CloudStack cloudStack;
@@ -247,5 +250,7 @@ public class GcpForwardingRuleResourceBuilderTest {
         lenient().when(gcpStackUtil.getSubnetId(any())).thenReturn("default-subnet");
         lenient().when(gcpStackUtil.getNetworkUrl(anyString(), anyString())).thenCallRealMethod();
         lenient().when(gcpStackUtil.getSubnetUrl(anyString(), anyString(), anyString())).thenCallRealMethod();
+        lenient().when(gcpLoadBalancerTypeConverter.getScheme(any(CloudLoadBalancer.class))).thenCallRealMethod();
+
     }
 }


### PR DESCRIPTION
requires other changes from CB-13426 to establish GCP loadbalancing scheme, and Forwarding Rules type.

Gathers the just IP address that has been assigned to a loadbalancer. Other details around backing instances will be a part of the CLI required changes. 

test coverage similar to AWS, Azure loadbalancer metadata collectors