### PR TITLE
CB-13741 Change streaming config providers to fix a couple of recent issues

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.12/aws/streaming.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.12/aws/streaming.json
@@ -86,6 +86,7 @@
           ]
         },
         "nodeCount": 3,
+        "minimumNodeCount": 3,
         "type": "CORE",
         "recoveryMode": "MANUAL",
         "recipeNames": []

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProvider.java
@@ -52,8 +52,6 @@ public class CruiseControlRoleConfigProvider implements CmHostGroupRoleConfigPro
 
     private static final String AUTHENTICATION_METHOD = "auth_method";
 
-    private static final String ADMIN_LEVEL_USERS = "auth_admins";
-
     private static final String TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED = "trusted.proxy.spnego.fallback.enabled";
 
     @Override
@@ -111,7 +109,6 @@ public class CruiseControlRoleConfigProvider implements CmHostGroupRoleConfigPro
                             "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
                             "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal"),
                     config(AUTHENTICATION_METHOD, "Trusted Proxy"),
-                    config(ADMIN_LEVEL_USERS, "kafka"),
                     config(TRUSTED_PROXY_SPNEGO_FALLBACK_ENABLED, "true")
             );
         }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProviderTest.java
@@ -100,7 +100,6 @@ public class CruiseControlRoleConfigProviderTest {
                         "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
                         "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal"),
                 config("auth_method", "Trusted Proxy"),
-                config("auth_admins", "kafka"),
                 config("trusted.proxy.spnego.fallback.enabled", "true")
         );
     }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaVolumeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/kafka/KafkaVolumeConfigProviderTest.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaRoles.KAFKA_BROKER;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaRoles.KAFKA_SERVICE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.VolumeConfigProviderTestHelper;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaVolumeConfigProviderTest {
+
+    private final KafkaVolumeConfigProvider provider = new KafkaVolumeConfigProvider();
+
+    @Test
+    void getKafkaVolumeConfigMinimum() {
+        assertEquals(List.of(config("log.dirs", "/hadoopfs/fs1/kafka")),
+                provider.getRoleConfigs(KAFKA_BROKER, null, source(4, 1, StackType.WORKLOAD))
+        );
+    }
+
+    @Test
+    void getKafkaVolumeConfigWithEqualVolume() {
+        HostgroupView hostgroupView = new HostgroupView("test", 2, InstanceGroupType.CORE, 2);
+        assertEquals(List.of(config("log.dirs", "/hadoopfs/fs1/kafka,/hadoopfs/fs2/kafka,/hadoopfs/fs3/kafka")),
+                provider.getRoleConfigs(KAFKA_BROKER, hostgroupView, source(3, 3, StackType.WORKLOAD))
+        );
+    }
+
+    @Test
+    void getKafkaVolumeConfigWithZeroVolume() {
+        assertEquals(List.of(config("log.dirs", "/hadoopfs/root1/kafka")),
+                provider.getRoleConfigs(KAFKA_BROKER, null, source(0, 0, StackType.WORKLOAD))
+        );
+    }
+
+    @Test
+    void getKafkaVolumeConfigWithIncorrectRoleType() {
+        assertEquals(List.of(),
+                provider.getRoleConfigs(KAFKA_SERVICE, null, source(5, 2, StackType.WORKLOAD))
+        );
+    }
+
+    @Test
+    void getKafkaVolumeConfigWithDatalakeStackType() {
+        HostgroupView hostgroupView = new HostgroupView("test", 3, InstanceGroupType.CORE, 2);
+        assertEquals(List.of(config("log.dirs", "/hadoopfs/fs1/kafka,/hadoopfs/fs2/kafka,/hadoopfs/fs3/kafka")),
+                provider.getRoleConfigs(KAFKA_BROKER, hostgroupView, source(5, 2, StackType.DATALAKE))
+        );
+    }
+
+    @Test
+    void getKafkaVolumeConfigWithNullStackType() {
+        HostgroupView hostgroupView = new HostgroupView("test", 2, InstanceGroupType.CORE, 2);
+        assertEquals(List.of(config("log.dirs", "/hadoopfs/fs1/kafka,/hadoopfs/fs2/kafka")),
+                provider.getRoleConfigs(KAFKA_BROKER, hostgroupView, source(0, 0, null))
+        );
+    }
+
+    private TemplatePreparationObject source(int brokerVolumeCount, int coreBrokerVolumeCount, StackType stackType) {
+        HostgroupView broker = VolumeConfigProviderTestHelper.hostGroupWithVolumeCount(brokerVolumeCount);
+        HostgroupView coreBroker = VolumeConfigProviderTestHelper.hostGroupWithVolumeCount(coreBrokerVolumeCount);
+        TemplatePreparationObject source = mock(TemplatePreparationObject.class);
+        when(source.getHostGroupsWithComponent(KAFKA_BROKER)).thenReturn(Stream.of(broker, coreBroker));
+        Mockito.lenient().when(source.getStackType()).thenReturn(stackType);
+
+        return source;
+    }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/srm/StreamsReplicationManagerConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/srm/StreamsReplicationManagerConfigProviderTest.java
@@ -1,10 +1,16 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.srm;
 
 import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.model.GeneralClusterConfigs;
+import com.sequenceiq.cloudbreak.template.views.BlueprintView;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.List;
@@ -16,9 +22,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class StreamsReplicationManagerConfigProviderTest {
 
     private StreamsReplicationManagerConfigProvider underTest = new StreamsReplicationManagerConfigProvider();
+
+    @Mock
+    private BlueprintView blueprintView;
+
+    @Mock
+    private CmTemplateProcessor cmTemplateProcessor;
 
     @Test
     void getServiceConfigsPlain() {
@@ -52,18 +65,70 @@ class StreamsReplicationManagerConfigProviderTest {
                 List.of(config("streams.replication.manager.service.target.cluster", "primary")));
     }
 
+    @Test
+    void getServiceConfigsWithCoreBroker7212() {
+        var source = sourceForCoreBroker(true);
+        cdhMainVersionIs("7.2.12");
+        var expected = List.of(
+                config("streams.replication.manager.config", "bootstrap.servers=corebroker-1:9093,corebroker-2:9093"),
+                config("clusters", "primary,secondary")
+        );
+        assertThat(underTest.getServiceConfigs(null, source)).hasSameElementsAs(expected);
+    }
+
+    @Test
+    void getServiceConfigsWithCoreBroker7211() {
+        var source = sourceForCoreBroker(true);
+        cdhMainVersionIs("7.2.11");
+        var expected = List.of(
+                config("streams.replication.manager.config", "bootstrap.servers=broker-1:9093,broker-2:9093,corebroker-1:9093,corebroker-2:9093"),
+                config("clusters", "primary,secondary")
+        );
+        assertThat(underTest.getServiceConfigs(null, source)).hasSameElementsAs(expected);
+    }
+
     private TemplatePreparationObject source(boolean sslEnabled, String... brokerHosts) {
         var generalClusterConfig = mock(GeneralClusterConfigs.class);
         when(generalClusterConfig.getAutoTlsEnabled()).thenReturn(sslEnabled);
 
         var hostGroup = mock(HostgroupView.class);
         when(hostGroup.getHosts()).thenReturn(Sets.newTreeSet(Arrays.asList(brokerHosts)));
+        when(hostGroup.getName()).thenReturn("broker");
 
         var source = mock(TemplatePreparationObject.class);
         when(source.getGeneralClusterConfigs()).thenReturn(generalClusterConfig);
         when(source.getHostGroupsWithComponent(KAFKA_BROKER)).thenReturn(Stream.of(hostGroup));
+        when(source.getBlueprintView()).thenReturn(blueprintView);
+
+        // Correct versioning is not relevant for this source, but need to set a version
+        cdhMainVersionIs("7.2.12");
 
         return source;
+    }
+
+    private TemplatePreparationObject sourceForCoreBroker(boolean sslEnabled) {
+        var generalClusterConfig = mock(GeneralClusterConfigs.class);
+        when(generalClusterConfig.getAutoTlsEnabled()).thenReturn(sslEnabled);
+
+        var hostGroupBroker = mock(HostgroupView.class);
+        Mockito.lenient().when(hostGroupBroker.getHosts()).thenReturn(Sets.newTreeSet(Arrays.asList("broker-1", "broker-2")));
+        when(hostGroupBroker.getName()).thenReturn("broker");
+
+        var hostGroupCoreBroker = mock(HostgroupView.class);
+        when(hostGroupCoreBroker.getHosts()).thenReturn(Sets.newTreeSet(Arrays.asList("corebroker-1", "corebroker-2")));
+        when(hostGroupCoreBroker.getName()).thenReturn("core_broker");
+
+        var source = mock(TemplatePreparationObject.class);
+        when(source.getGeneralClusterConfigs()).thenReturn(generalClusterConfig);
+        when(source.getHostGroupsWithComponent(KAFKA_BROKER)).thenReturn(Stream.of(hostGroupBroker, hostGroupCoreBroker));
+        when(source.getBlueprintView()).thenReturn(blueprintView);
+
+        return source;
+    }
+
+    private void cdhMainVersionIs(String version) {
+        when(cmTemplateProcessor.getStackVersion()).thenReturn(version);
+        when(blueprintView.getProcessor()).thenReturn(cmTemplateProcessor);
     }
 
 }


### PR DESCRIPTION
This commit includes 4 minor changes.

- **StreamReplicationManagerConfigProvider** - Changed the bootstrap.servers property value calculation to only contain the core broker hosts if the core_broker hostgroup is present and CDH>=7.2.12. Because of the kafka scaling feature, having the scaleable brokers included in the bootstrap.servers causes issues when deleting nodes.

- **KafkaVolumeConfigProvider** - KAFKA_BROKER is now a shared roleType, the value of log.dirs will be calculated based on the minimum volume count.

- **CruiseControlRoleConfigProvider** - Removed the configuration that set kafka as an auth_admin, since now it is part of the CSD.

- **streaming.json** - Set the minimumNodeCount of the core_broker host group to 3.

Tested:

1. Manually on provisioned cluster
2. Unit tests