### PR TITLE
CB-6830 Disabling AwsDistroXSpotInstanceTest.testDistroXOnSpotInstance

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests.yaml
@@ -9,6 +9,5 @@ tests:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxImagesTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRepairTests
-      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.spot.AwsDistroXSpotInstanceTest
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxSecurityTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.AwsDistroXEphemeralTemporaryStorageTest


### PR DESCRIPTION
It's unstable due to Amazon(Could not launch Spot Instances. UnfulfillableCapacity - Unable to fulfill capacity due to your request configuration. Please adjust your request and try again. Launching EC2 instance failed)