### PR TITLE
CDPD-25645 For Parquet setting SNAPPY as default compression

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-ha.bp
@@ -153,7 +153,7 @@
             "name": "hive_service_config_safety_valve",
             "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
                         <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>
-                        <property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+                        <property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>parquet.compression</name><value>SNAPPY</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering-spark3.bp
@@ -298,7 +298,7 @@
             "name": "hive_service_config_safety_valve",
             "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property>
                         <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>
-                        <property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+                        <property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>parquet.compression</name><value>SNAPPY</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-data-engineering.bp
@@ -288,7 +288,7 @@
             "name": "hive_service_config_safety_valve",
             "value": "<property><name>fs.s3a.ssl.channel.mode</name><value>openssl</value></property><property><name>hive.txn.acid.dir.cache.duration</name><value>0</value></property><property><name>hive.server2.tez.session.lifetime</name><value>30m</value></property>
                         <property><name>hive.blobstore.supported.schemes</name><value>s3,s3a,s3n,abfs,gs</value></property><property><name>hive.orc.splits.include.fileid</name><value>false</value></property><property><name>hive.hook.proto.events.clean.freq</name><value>1h</value></property>
-                        <property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property>"
+                        <property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>parquet.compression</name><value>SNAPPY</value></property>"
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
1. This change will land in 2.48 which is after 7.2.11 release. So only updating 7.2.12 templates for full coverage in testing and enabling customers to delete and recreate clusters without change in behaviour.
2. Tested that the default is changed to SNAPPY compression after this safety valve setting by creating an external table and loading the data.