### PR TITLE
CB-13083 Adding new Impala Parameter: 'startup_filesystem_check_directories' and initializing it to read managed and external hive warehouse locations via safety valve

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaCloudStorageServiceConfigProvider.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.impala;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_11;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreCloudStorageServiceConfigProvider.HMS_METASTORE_DIR;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hive.HiveMetastoreCloudStorageServiceConfigProvider.HMS_METASTORE_EXTERNAL_DIR;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ImpalaCloudStorageServiceConfigProvider implements CmTemplateComponentConfigProvider {
+
+    private static final String IMPALA_CMD_ARGS_SAFETY_VALVE = "impala_cmd_args_safety_valve";
+
+    private static final String IMPALA_STARTUP_FILESYSTEM_CHECK_DIRS = "--startup_filesystem_check_directories=";
+
+    @Override
+    public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor processor, TemplatePreparationObject source) {
+        List<ApiClusterTemplateConfig> configs = new ArrayList<>();
+        String cdhVersion = processor.getStackVersion();
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_11)) {
+            List<String> cloudPaths = new ArrayList<>();
+            ConfigUtils.getStorageLocationForServiceProperty(source, HMS_METASTORE_DIR)
+                    .ifPresent(location -> cloudPaths.add(location.getValue()));
+            ConfigUtils.getStorageLocationForServiceProperty(source, HMS_METASTORE_EXTERNAL_DIR)
+                    .ifPresent(location -> cloudPaths.add(location.getValue()));
+            if (!cloudPaths.isEmpty()) {
+                String hmsWarehousePaths = cloudPaths.stream().collect(Collectors.joining(","));
+                configs.add(ConfigUtils.config(IMPALA_CMD_ARGS_SAFETY_VALVE, IMPALA_STARTUP_FILESYSTEM_CHECK_DIRS + hmsWarehousePaths));
+            }
+        }
+        return configs;
+    }
+
+    @Override
+    public String getServiceType() {
+        return ImpalaRoles.SERVICE_IMPALA;
+    }
+
+    @Override
+    public List<String> getRoleTypes() {
+        return List.of(ImpalaRoles.ROLE_IMPALAD);
+    }
+
+    @Override
+    public boolean isConfigurationNeeded(CmTemplateProcessor cmTemplateProcessor, TemplatePreparationObject source) {
+        return source.getFileSystemConfigurationView().isPresent() &&
+                cmTemplateProcessor.isRoleTypePresentInService(getServiceType(), getRoleTypes());
+
+    }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaCloudStorageServiceConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/impala/ImpalaCloudStorageServiceConfigProviderTest.java
@@ -1,0 +1,99 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.impala;
+
+import static com.sequenceiq.cloudbreak.template.TemplatePreparationObject.Builder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.domain.StorageLocation;
+import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
+import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
+import com.sequenceiq.cloudbreak.template.filesystem.s3.S3FileSystemConfigurationsView;
+import com.sequenceiq.cloudbreak.template.views.HostgroupView;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+import com.sequenceiq.common.api.filesystem.S3FileSystem;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+@ExtendWith(MockitoExtension.class)
+class ImpalaCloudStorageServiceConfigProviderTest {
+
+    private final ImpalaCloudStorageServiceConfigProvider underTest = new ImpalaCloudStorageServiceConfigProvider();
+
+    @Test
+    public void testImpalaCloudStorageServiceConfigs() {
+        CmTemplateProcessor templateProcessor = new CmTemplateProcessor(getBlueprintText("input/clouderamanager-host-with-uppercase.bp"));
+        TemplatePreparationObject templatePreparationObject = getTemplatePreparationObject(true);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, templatePreparationObject);
+
+        assertEquals(1, serviceConfigs.size());
+        assertEquals("impala_cmd_args_safety_valve", serviceConfigs.get(0).getName());
+        assertEquals("--startup_filesystem_check_directories=" +
+                "s3a://bucket/warehouse/tablespace/managed/hive," +
+                "s3a://bucket/warehouse/tablespace/external/hive", serviceConfigs.get(0).getValue());
+    }
+
+    @Test
+    public void testImpalaCloudStorageServiceConfigsWithoutStorageConfigured() {
+        CmTemplateProcessor templateProcessor = new CmTemplateProcessor(getBlueprintText("input/clouderamanager-host-with-uppercase.bp"));
+        TemplatePreparationObject templatePreparationObject = getTemplatePreparationObject(false);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, templatePreparationObject);
+
+        assertEquals(0, serviceConfigs.size());
+    }
+
+    @Test
+    public void testImpalaCloudStorageServiceConfigsWithLowerCdhVersion() {
+        CmTemplateProcessor templateProcessor = new CmTemplateProcessor(getBlueprintText("input/cdp-data-mart.bp"));
+        TemplatePreparationObject templatePreparationObject = getTemplatePreparationObject(true);
+
+        List<ApiClusterTemplateConfig> serviceConfigs = underTest.getServiceConfigs(templateProcessor, templatePreparationObject);
+
+        assertEquals(0, serviceConfigs.size());
+    }
+
+    private TemplatePreparationObject getTemplatePreparationObject(boolean includeLocations) {
+        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.GATEWAY, 1);
+        HostgroupView coordinator = new HostgroupView("coordinator", 1, InstanceGroupType.CORE, 1);
+        HostgroupView executor = new HostgroupView("executor", 2, InstanceGroupType.CORE, 2);
+
+        List<StorageLocationView> locations = new ArrayList<>();
+
+        if (includeLocations) {
+            locations.add(new StorageLocationView(getHiveWarehouseStorageLocation()));
+            locations.add(new StorageLocationView(getHiveWarehouseExternalStorageLocation()));
+        }
+        S3FileSystemConfigurationsView fileSystemConfigurationsView =
+                new S3FileSystemConfigurationsView(new S3FileSystem(), locations, false);
+        return Builder.builder()
+                .withFileSystemConfigurationView(fileSystemConfigurationsView)
+                .withHostgroupViews(Set.of(master, coordinator, executor)).build();
+    }
+
+    private StorageLocation getHiveWarehouseStorageLocation() {
+        StorageLocation managed = new StorageLocation();
+        managed.setProperty("hive.metastore.warehouse.dir");
+        managed.setValue("s3a://bucket/warehouse/tablespace/managed/hive");
+        return managed;
+    }
+
+    private StorageLocation getHiveWarehouseExternalStorageLocation() {
+        StorageLocation external = new StorageLocation();
+        external.setProperty("hive.metastore.warehouse.external.dir");
+        external.setValue("s3a://bucket/warehouse/tablespace/external/hive");
+        return external;
+    }
+
+    private String getBlueprintText(String path) {
+        return FileReaderUtils.readFileFromClasspathQuietly(path);
+    }
+}

--- a/template-manager-cmtemplate/src/test/resources/input/clouderamanager-host-with-uppercase.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/clouderamanager-host-with-uppercase.bp
@@ -1,5 +1,5 @@
 {
-  "cdhVersion": "7.2.6",
+  "cdhVersion": "7.2.11",
   "displayName": "datamart",
   "services": [
     {


### PR DESCRIPTION
1. The new parameter will verify access to the provided comma-separated list of directories. 
2. The parameter has been added via [CDPD-26295](https://jira.cloudera.com/browse/CDPD-26295)
<img width="1073" alt="HMS Managed and External" src="https://user-images.githubusercontent.com/30623280/129878515-4688877b-512c-42b8-b44c-e65bcfbf7fa3.png">
<img width="1058" alt="Log Success 1" src="https://user-images.githubusercontent.com/30623280/129878600-6bd412dc-56b7-4ec7-a6f7-cfa0f0b6a9c8.png">
<img width="1044" alt="Log Success 2" src="https://user-images.githubusercontent.com/30623280/129878622-67317a86-e40c-41b1-9aec-1e900b7399ca.png">
<img width="1161" alt="CM reflection" src="https://user-images.githubusercontent.com/30623280/129878634-eb005769-dca8-4b46-9455-19d83922d659.png">



See detailed description in the commit message.