### PR TITLE
CB-13835 Implement Yarn object storage connector

### DIFF
--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnConnector.java
@@ -15,6 +15,7 @@ import com.sequenceiq.cloudbreak.cloud.EncryptionResources;
 import com.sequenceiq.cloudbreak.cloud.InstanceConnector;
 import com.sequenceiq.cloudbreak.cloud.MetadataCollector;
 import com.sequenceiq.cloudbreak.cloud.NetworkConnector;
+import com.sequenceiq.cloudbreak.cloud.ObjectStorageConnector;
 import com.sequenceiq.cloudbreak.cloud.PlatformParameters;
 import com.sequenceiq.cloudbreak.cloud.PlatformResources;
 import com.sequenceiq.cloudbreak.cloud.ResourceConnector;
@@ -51,6 +52,9 @@ public class YarnConnector implements CloudConnector<Object> {
 
     @Inject
     private YarnPlatformResources platformResources;
+
+    @Inject
+    private YarnObjectStorageConnector objectStorage;
 
     @Override
     public Authenticator authentication() {
@@ -120,5 +124,10 @@ public class YarnConnector implements CloudConnector<Object> {
     @Override
     public EncryptionResources encryptionResources() {
         return null;
+    }
+
+    @Override
+    public ObjectStorageConnector objectStorage() {
+        return objectStorage;
     }
 }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnObjectStorageConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnObjectStorageConnector.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.cloud.yarn;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.ObjectStorageConnector;
+import com.sequenceiq.cloudbreak.cloud.model.Platform;
+import com.sequenceiq.cloudbreak.cloud.model.Variant;
+import com.sequenceiq.cloudbreak.cloud.model.base.ResponseStatus;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataRequest;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageMetadataResponse;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateRequest;
+import com.sequenceiq.cloudbreak.cloud.model.objectstorage.ObjectStorageValidateResponse;
+
+@Service
+public class YarnObjectStorageConnector implements ObjectStorageConnector {
+
+    @Override
+    public ObjectStorageMetadataResponse getObjectStorageMetadata(ObjectStorageMetadataRequest request) {
+        return ObjectStorageMetadataResponse.builder()
+                .withStatus(ResponseStatus.OK)
+                .build();
+    }
+
+    @Override
+    public ObjectStorageValidateResponse validateObjectStorage(ObjectStorageValidateRequest request) {
+        return ObjectStorageValidateResponse.builder()
+                .withStatus(ResponseStatus.OK)
+                .build();
+    }
+
+    @Override
+    public Platform platform() {
+        return YarnConstants.YARN_PLATFORM;
+    }
+
+    @Override
+    public Variant variant() {
+        return YarnConstants.YARN_VARIANT;
+    }
+}


### PR DESCRIPTION
Yarn does not actually use object storage, so it is just a minimal implementation meant to satisfy storage validation logics.

See detailed description in the commit message.