### PR TITLE
CB-13745: Encryption support for Azure SQL Database instances

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersConsts.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/PlatformParametersConsts.java
@@ -32,6 +32,10 @@ public class PlatformParametersConsts {
 
     public static final String RESOURCE_CRN_PARAMETER = "resourceCrn";
 
+    public static final String ENCRYPTION_KEY_URL = "keyVaultUrl";
+
+    public static final String ENCRYPTION_KEY_RESOURCE_GROUP_NAME = "keyVaultResourceGroupName";
+
     private PlatformParametersConsts() {
 
     }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerView.java
@@ -26,6 +26,12 @@ public class AzureDatabaseServerView {
     @VisibleForTesting
     static final String STORAGE_AUTO_GROW = "storageAutoGrow";
 
+    @VisibleForTesting
+    static final String KEY_VAULT_URL = "keyVaultUrl";
+
+    @VisibleForTesting
+    static final String KEY_VAULT_RESOURCE_GROUP_NAME = "keyVaultResourceGroupName";
+
     private static final int NUM_MB_IN_GB = 1024;
 
     private final DatabaseServer databaseServer;
@@ -104,6 +110,14 @@ public class AzureDatabaseServerView {
 
     public String getLocation() {
         return databaseServer.getLocation();
+    }
+
+    public String getKeyVaultUrl() {
+        return databaseServer.getStringParameter(KEY_VAULT_URL);
+    }
+
+    public String getKeyVaultResourceGroupName() {
+        return databaseServer.getStringParameter(KEY_VAULT_RESOURCE_GROUP_NAME);
     }
 
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerViewTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureDatabaseServerViewTest.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.cloud.azure.view;
 import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.BACKUP_RETENTION_DAYS;
 import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.DB_VERSION;
 import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.GEO_REDUNDANT_BACKUP;
+import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.KEY_VAULT_RESOURCE_GROUP_NAME;
+import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.KEY_VAULT_URL;
 import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.SKU_CAPACITY;
 import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.SKU_FAMILY;
 import static com.sequenceiq.cloudbreak.cloud.azure.view.AzureDatabaseServerView.SKU_TIER;
@@ -144,6 +146,20 @@ public class AzureDatabaseServerViewTest {
         when(server.getLocation()).thenReturn("some-location");
 
         assertThat(underTest.getLocation()).isEqualTo("some-location");
+    }
+
+    @Test
+    public void testKeyVaultUrl() {
+        when(server.getStringParameter(KEY_VAULT_URL)).thenReturn("dummyUrl");
+
+        assertThat(underTest.getKeyVaultUrl()).isEqualTo("dummyUrl");
+    }
+
+    @Test
+    public void testKeyVaultResourceGroupName() {
+        when(server.getStringParameter(KEY_VAULT_RESOURCE_GROUP_NAME)).thenReturn("dummyResourceGroupName");
+
+        assertThat(underTest.getKeyVaultResourceGroupName()).isEqualTo("dummyResourceGroupName");
     }
 
 }


### PR DESCRIPTION
CB-13745: Encryption support for Azure SQL Database instances.
Azure provides [data encryption](https://docs.microsoft.com/en-us/azure/postgresql/concepts-data-encryption-postgresql) for the SQL Databases using encryption key url and encryption key resource group name. This PR adds the required parameters in arm-template, provides "get, wrap and unwrap" permissions to key vault for the service principalId of the DB.

[Reference ](https://docs.microsoft.com/en-us/azure/postgresql/howto-data-encryption-cli#for-a-new-server)

**The screenshot shows the DB created as part of environment setup with CMK set.**

<img width="1137" alt="Screenshot 2021-08-18 at 7 23 49 PM" src="https://user-images.githubusercontent.com/32215750/129922996-02be74bc-958f-4577-adea-3d228c92d5ed.png">


**The screenshot shows the encryption parameters in template used for launching DB instance.** 

<img width="1491" alt="Screenshot 2021-08-18 at 8 40 21 PM" src="https://user-images.githubusercontent.com/32215750/129924012-7f611cf5-cec4-4a4f-959e-9b8a55bad4c8.png">

