### PR TITLE
Avoid a circular dependency in application context by removing an unn…

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/credential/service/CredentialPrerequisiteService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/credential/service/CredentialPrerequisiteService.java
@@ -29,7 +29,6 @@ import com.sequenceiq.common.model.CredentialType;
 import com.sequenceiq.environment.credential.attributes.CredentialAttributes;
 import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.environment.credential.exception.CredentialOperationException;
-import com.sequenceiq.environment.experience.ExperienceConnectorService;
 import com.sequenceiq.environment.user.UserPreferencesService;
 import com.sequenceiq.flow.reactor.ErrorHandlerAwareReactorEventFactory;
 
@@ -48,11 +47,8 @@ public class CredentialPrerequisiteService {
 
     private final EntitlementService entitlementService;
 
-    private ExperienceConnectorService experienceConnectorService;
-
     public CredentialPrerequisiteService(EventBus eventBus, UserPreferencesService userPreferencesService, ErrorHandlerAwareReactorEventFactory eventFactory,
-            ExperienceConnectorService experienceConnectorService, EntitlementService entitlementService) {
-        this.experienceConnectorService = experienceConnectorService;
+            EntitlementService entitlementService) {
         this.userPreferencesService = userPreferencesService;
         this.entitlementService = entitlementService;
         this.eventFactory = eventFactory;


### PR DESCRIPTION
…ecessary dependency

1. The following circular dependency is visible only when built in Mac and deployed in Linux.
2. After removing this dependency the circular dependency issue in the above situation is gone.
3. It is good to remove such dependencies even though it is not affecting the builds produced by releng.

```
***************************
APPLICATION FAILED TO START
***************************
Description:
The dependencies of some of the beans in the application context form a cycle:
┌─────┐
|  commonExperienceConnectorService defined in URL [jar:file:/environment.jar!/BOOT-INF/classes!/com/sequenceiq/environment/experience/common/CommonExperienceConnectorService.class]
↑     ↓
|  commonExperienceWebTargetProvider defined in URL [jar:file:/environment.jar!/BOOT-INF/classes!/com/sequenceiq/environment/experience/common/CommonExperienceWebTargetProvider.class]
↑     ↓
|  appConfig (field private java.util.List com.sequenceiq.environment.configuration.AppConfig.environmentNetworkValidators)
↑     ↓
|  azureEnvironmentNetworkValidator defined in URL [jar:file:/environment.jar!/BOOT-INF/classes!/com/sequenceiq/environment/environment/validation/network/azure/AzureEnvironmentNetworkValidator.class]
↑     ↓
|  cloudNetworkService defined in URL [jar:file:/environment.jar!/BOOT-INF/classes!/com/sequenceiq/environment/network/CloudNetworkService.class]
↑     ↓
|  platformParameterService (field private com.sequenceiq.environment.credential.service.CredentialService com.sequenceiq.environment.platformresource.PlatformParameterService.credentialService)
↑     ↓
|  credentialService (field private com.sequenceiq.environment.credential.service.ServiceProviderCredentialAdapter com.sequenceiq.environment.credential.service.CredentialService.credentialAdapter)
↑     ↓
|  serviceProviderCredentialAdapter (field private com.sequenceiq.environment.credential.service.CredentialPrerequisiteService com.sequenceiq.environment.credential.service.ServiceProviderCredentialAdapter.credentialPrerequisiteService)
↑     ↓
|  credentialPrerequisiteService defined in URL [jar:file:/environment.jar!/BOOT-INF/classes!/com/sequenceiq/environment/credential/service/CredentialPrerequisiteService.class]
↑     ↓
|  experienceConnectorService defined in URL [jar:file:/environment.jar!/BOOT-INF/classes!/com/sequenceiq/environment/experience/ExperienceConnectorService.class]
↑     ↓
|  commonExperienceService defined in URL [jar:file:/environment.jar!/BOOT-INF/classes!/com/sequenceiq/environment/experience/common/CommonExperienceService.class]
└─────┘
```

See detailed description in the commit message.