### PR TITLE
CB-13858. Update default cdp-telemetry package version.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/init.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/init.sls
@@ -3,7 +3,7 @@
 {%- from 'fluent/settings.sls' import fluent with context %}
 {%- from 'databus/settings.sls' import databus with context %}
 
-{% set cdp_telemetry_version = '0.4.9' %}
+{% set cdp_telemetry_version = '0.4.13' %}
 {% set cldr_service_delivery_repo = 'https://cloudera-service-delivery-cache.s3.amazonaws.com'%}
 {% set cdp_telemetry_rpm_location = cldr_service_delivery_repo + '/telemetry/cdp-telemetry/'%}
 {% set cdp_telemetry_rpm_repo_url = cdp_telemetry_rpm_location + 'cdp_telemetry-' + cdp_telemetry_version + '.x86_64.rpm' %}


### PR DESCRIPTION
details:
- with this change, if --update-package option will be used for collecting diagnostics, that can automatically update telemetry binary to this version (if it can be accessed from the network)

See detailed description in the commit message.