### PR TITLE
CDPAM-2112: Add agentCrn from CB request during registration

### DIFF
--- a/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/CcmV2Config.java
+++ b/cluster-proxy/src/main/java/com/sequenceiq/cloudbreak/clusterproxy/CcmV2Config.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class CcmV2Config {
 
+    @JsonProperty("agentCrn")
+    private final String agentCrn;
+
     @JsonProperty("backendId")
     private final String backendId;
 
@@ -19,7 +22,8 @@ public class CcmV2Config {
     @JsonProperty("serviceName")
     private final String serviceName;
 
-    public CcmV2Config(String gatewayHost, int gatewayPort, String backendId, String serviceName) {
+    public CcmV2Config(String agentCrn, String gatewayHost, int gatewayPort, String backendId, String serviceName) {
+        this.agentCrn = agentCrn;
         this.gatewayHost = gatewayHost;
         this.gatewayPort = gatewayPort;
         this.backendId = backendId;
@@ -29,6 +33,7 @@ public class CcmV2Config {
     @Override
     public String toString() {
         return new StringJoiner(", ", CcmV2Config.class.getSimpleName() + "[", "]")
+                .add("agentCrn='" + agentCrn + "'")
                 .add("backendId='" + backendId + "'")
                 .add("gatewayHost='" + gatewayHost + "'")
                 .add("gatewayPort=" + gatewayPort)
@@ -46,6 +51,7 @@ public class CcmV2Config {
         }
         CcmV2Config that = (CcmV2Config) o;
         return gatewayPort == that.gatewayPort &&
+                Objects.equals(agentCrn, that.agentCrn) &&
                 Objects.equals(backendId, that.backendId) &&
                 Objects.equals(gatewayHost, that.gatewayHost) &&
                 Objects.equals(serviceName, that.serviceName);
@@ -53,6 +59,6 @@ public class CcmV2Config {
 
     @Override
     public int hashCode() {
-        return Objects.hash(backendId, gatewayHost, gatewayPort, serviceName);
+        return Objects.hash(agentCrn, backendId, gatewayHost, gatewayPort, serviceName);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/service/ClusterProxyService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/service/ClusterProxyService.java
@@ -190,10 +190,18 @@ public class ClusterProxyService {
 
     private List<CcmV2Config> ccmV2Configs(Stack stack) {
         return stack.getNotTerminatedGatewayInstanceMetadata().stream().map(instanceMetaData -> {
-            CcmV2Config gatewayConfig = new CcmV2Config(instanceMetaData.getPublicIpWrapper(), ServiceFamilies.GATEWAY.getDefaultPort(),
-                    String.format(CCMV2_BACKEND_ID_FORMAT, stack.getCcmV2AgentCrn(), instanceMetaData.getInstanceId()), CLOUDERA_MANAGER_SERVICE_NAME);
-            CcmV2Config knoxConfig = new CcmV2Config(instanceMetaData.getPublicIpWrapper(), ServiceFamilies.KNOX.getDefaultPort(),
-                    String.format(CCMV2_BACKEND_ID_FORMAT, stack.getCcmV2AgentCrn(), instanceMetaData.getInstanceId()), CLOUDERA_MANAGER_SERVICE_NAME);
+            CcmV2Config gatewayConfig = new CcmV2Config(
+                    stack.getCcmV2AgentCrn(),
+                    instanceMetaData.getPublicIpWrapper(),
+                    ServiceFamilies.GATEWAY.getDefaultPort(),
+                    String.format(CCMV2_BACKEND_ID_FORMAT, stack.getCcmV2AgentCrn(), instanceMetaData.getInstanceId()),
+                    CLOUDERA_MANAGER_SERVICE_NAME);
+            CcmV2Config knoxConfig = new CcmV2Config(
+                    stack.getCcmV2AgentCrn(),
+                    instanceMetaData.getPublicIpWrapper(),
+                    ServiceFamilies.KNOX.getDefaultPort(),
+                    String.format(CCMV2_BACKEND_ID_FORMAT, stack.getCcmV2AgentCrn(), instanceMetaData.getInstanceId()),
+                    CLOUDERA_MANAGER_SERVICE_NAME);
             return List.of(gatewayConfig, knoxConfig);
         }).flatMap(List::stream).collect(Collectors.toList());
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/clusterproxy/ClusterProxyServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/clusterproxy/ClusterProxyServiceTest.java
@@ -134,13 +134,13 @@ class ClusterProxyServiceTest {
         ConfigRegistrationRequest proxyRegisterationReq = captor.getValue();
         assertEquals(true, proxyRegisterationReq.isUseCcmV2(), "CCMV2 should be enabled");
         assertTrue(proxyRegisterationReq.getCcmV2Configs().contains(new CcmV2Config(
-                "10.10.10.10", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-i-abc123", "cloudera-manager")));
+                "testAgentCrn", "10.10.10.10", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-i-abc123", "cloudera-manager")));
         assertTrue(proxyRegisterationReq.getCcmV2Configs().contains(new CcmV2Config(
-                "10.10.10.11", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-i-def456", "cloudera-manager")));
+                "testAgentCrn", "10.10.10.11", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-i-def456", "cloudera-manager")));
         assertTrue(proxyRegisterationReq.getCcmV2Configs().contains(new CcmV2Config(
-                "10.10.10.10", ServiceFamilies.KNOX.getDefaultPort(), "testAgentCrn-i-abc123", "cloudera-manager")));
+                "testAgentCrn", "10.10.10.10", ServiceFamilies.KNOX.getDefaultPort(), "testAgentCrn-i-abc123", "cloudera-manager")));
         assertTrue(proxyRegisterationReq.getCcmV2Configs().contains(new CcmV2Config(
-                "10.10.10.11", ServiceFamilies.KNOX.getDefaultPort(), "testAgentCrn-i-def456", "cloudera-manager")));
+                "testAgentCrn", "10.10.10.11", ServiceFamilies.KNOX.getDefaultPort(), "testAgentCrn-i-def456", "cloudera-manager")));
         assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfigWithInstanceId(PRIMARY_PUBLIC_IP, PRIMARY_INSTANCE_ID)));
         assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfigWithInstanceId(OTHER_PUBLIC_IP, OTHER_INSTANCE_ID)));
         assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfig()));
@@ -214,13 +214,13 @@ class ClusterProxyServiceTest {
 
         assertEquals("https://10.10.10.10:9443/knox/test-cluster", proxyRegisterationReq.getUriOfKnox(), "CCMV2 Knox URI should match");
         assertTrue(proxyRegisterationReq.getCcmV2Configs().contains(new CcmV2Config(
-                "10.10.10.10", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-i-abc123", "cloudera-manager")));
+                "testAgentCrn", "10.10.10.10", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-i-abc123", "cloudera-manager")));
         assertTrue(proxyRegisterationReq.getCcmV2Configs().contains(new CcmV2Config(
-                "10.10.10.11", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-i-def456", "cloudera-manager")));
+                "testAgentCrn", "10.10.10.11", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-i-def456", "cloudera-manager")));
         assertTrue(proxyRegisterationReq.getCcmV2Configs().contains(new CcmV2Config(
-                "10.10.10.10", ServiceFamilies.KNOX.getDefaultPort(), "testAgentCrn-i-abc123", "cloudera-manager")));
+                "testAgentCrn", "10.10.10.10", ServiceFamilies.KNOX.getDefaultPort(), "testAgentCrn-i-abc123", "cloudera-manager")));
         assertTrue(proxyRegisterationReq.getCcmV2Configs().contains(new CcmV2Config(
-                "10.10.10.11", ServiceFamilies.KNOX.getDefaultPort(), "testAgentCrn-i-def456", "cloudera-manager")));
+                "testAgentCrn", "10.10.10.11", ServiceFamilies.KNOX.getDefaultPort(), "testAgentCrn-i-def456", "cloudera-manager")));
         assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfigWithInstanceId(PRIMARY_PUBLIC_IP, PRIMARY_INSTANCE_ID)));
         assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfigWithInstanceId(OTHER_PUBLIC_IP, OTHER_INSTANCE_ID)));
         assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfig()));

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ClusterProxyService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ClusterProxyService.java
@@ -288,6 +288,7 @@ public class ClusterProxyService {
     private List<CcmV2Config> createCcmV2Configs(Stack stack, List<GatewayConfig> gatewayConfigs) {
         return gatewayConfigs.stream()
                 .map(gatewayConfig -> new CcmV2Config(
+                        stack.getCcmV2AgentCrn(),
                         gatewayConfig.getPrivateAddress(),
                         getNginxPort(stack),
                         String.format(CCMV2_BACKEND_ID_FORMAT, stack.getCcmV2AgentCrn(), gatewayConfig.getInstanceId()),

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/ClusterProxyServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/ClusterProxyServiceTest.java
@@ -118,7 +118,7 @@ public class ClusterProxyServiceTest {
 
         assertEquals(false, proxyRegisterationReq.isUseTunnel(), "CCMV1 tunnel should not be enabled");
         assertEquals(true, proxyRegisterationReq.isUseCcmV2(), ccmv2Mode.toString() + " should be enabled.");
-        assertEquals(List.of(new CcmV2Config("privateIpAddress", ServiceFamilies.GATEWAY.getDefaultPort(),
+        assertEquals(List.of(new CcmV2Config("testAgentCrn", "privateIpAddress", ServiceFamilies.GATEWAY.getDefaultPort(),
                         "testAgentCrn-testInstanceId", FREEIPA_SERVICE)),
                 proxyRegisterationReq.getCcmV2Configs(), ccmv2Mode.toString() + " config should match");
     }
@@ -166,9 +166,9 @@ public class ClusterProxyServiceTest {
         assertEquals(false, proxyRegisterationReq.isUseTunnel(), "CCMV1 tunnel should not be enabled");
         assertEquals(true, proxyRegisterationReq.isUseCcmV2(), ccmv2Mode.toString() + " should be enabled.");
         assertEquals(List.of(
-                new CcmV2Config("privateIpAddress1", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-testInstanceId1", FREEIPA_SERVICE
+                new CcmV2Config("testAgentCrn", "privateIpAddress1", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-testInstanceId1", FREEIPA_SERVICE
                 ),
-                new CcmV2Config("privateIpAddress2", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-testInstanceId2", FREEIPA_SERVICE
+                new CcmV2Config("testAgentCrn", "privateIpAddress2", ServiceFamilies.GATEWAY.getDefaultPort(), "testAgentCrn-testInstanceId2", FREEIPA_SERVICE
                 )), proxyRegisterationReq.getCcmV2Configs(), ccmv2Mode.toString() + " config should match");
     }
 


### PR DESCRIPTION
Adds back `agentCrn` as an attribute in CcmV2Config. This would allow cluster-proxy to correlate a given backend id (and its health)  to the correct `agentCrn`

See detailed description in the commit message.

This reverts part of the changes done for https://github.com/hortonworks/cloudbreak/pull/11200