### PR TITLE
CB-13515: Added conditional closing of connections to database during database backup flow.

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -409,8 +409,8 @@ public interface StackV4Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DATABASE_BACKUP_INTERNAL, nickname = "databaseBackupInternal")
     BackupV4Response backupDatabaseByNameInternal(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
-            @QueryParam("backupLocation") String backupLocation, @QueryParam("backupId") String backupId,
-            @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+            @QueryParam("backupId") String backupId, @QueryParam("backupLocation") String backupLocation,
+            @QueryParam("closeConnections") boolean closeConnections, @QueryParam("initiatorUserCrn") String initiatorUserCrn);
 
     @POST
     @Path("{name}/database_restore")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -330,16 +330,16 @@ public class StackV4Controller extends NotificationController implements StackV4
     public BackupV4Response backupDatabaseByName(Long workspaceId, String name, String backupLocation, String backupId,
             @AccountId String accountId) {
         FlowIdentifier flowIdentifier = stackOperations.backupClusterDatabase(NameOrCrn.ofName(name),
-                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId);
+                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, true);
         return new BackupV4Response(flowIdentifier);
     }
 
     @Override
     @InternalOnly
-    public BackupV4Response backupDatabaseByNameInternal(Long workspaceId, String name, String backupLocation, String backupId,
-            @InitiatorUserCrn String initiatorUserCrn) {
+    public BackupV4Response backupDatabaseByNameInternal(Long workspaceId, String name, String backupId, String backupLocation,
+            boolean closeConnections, @InitiatorUserCrn String initiatorUserCrn) {
         FlowIdentifier flowIdentifier = stackOperations.backupClusterDatabase(NameOrCrn.ofName(name),
-                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId);
+                restRequestThreadLocalService.getRequestedWorkspaceId(), backupLocation, backupId, closeConnections);
         return new BackupV4Response(flowIdentifier);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/chain/BackupDatalakeDatabaseFlowEventChainFactory.java
@@ -26,7 +26,7 @@ public class BackupDatalakeDatabaseFlowEventChainFactory implements FlowEventCha
         Queue<Selectable> flowEventChain = new ConcurrentLinkedQueue<>();
         flowEventChain.add(new StackEvent(SaltUpdateEvent.SALT_UPDATE_EVENT.event(), event.getResourceId(), event.accepted()));
         flowEventChain.add(new DatabaseBackupTriggerEvent(DATABASE_BACKUP_EVENT.event(), event.getResourceId(),
-                event.getBackupLocation(), event.getBackupId()));
+            event.getBackupLocation(), event.getBackupId(), event.getCloseConnections()));
         return new FlowTriggerEventQueue(getName(), event, flowEventChain);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/AbstractBackupRestoreActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/AbstractBackupRestoreActions.java
@@ -1,15 +1,15 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.dr;
 
+import java.util.Optional;
+
+import org.springframework.statemachine.StateContext;
+
 import com.sequenceiq.cloudbreak.reactor.api.event.StackFailureEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.BackupRestoreEvent;
 import com.sequenceiq.flow.core.AbstractAction;
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowParameters;
 import com.sequenceiq.flow.core.FlowState;
-
-import java.util.Optional;
-
-import org.springframework.statemachine.StateContext;
 
 public abstract class AbstractBackupRestoreActions<P extends BackupRestoreEvent>
     extends AbstractAction<FlowState, FlowEvent, BackupRestoreContext, P> {
@@ -21,7 +21,7 @@ public abstract class AbstractBackupRestoreActions<P extends BackupRestoreEvent>
     @Override
     protected BackupRestoreContext createFlowContext(FlowParameters flowParameters, StateContext<FlowState, FlowEvent> stateContext,
             P payload) {
-        return BackupRestoreContext.from(flowParameters, payload, payload.getBackupLocation(), payload.getBackupId());
+        return BackupRestoreContext.from(flowParameters, payload, payload.getBackupLocation(), payload.getBackupId(), payload.getCloseConnections());
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/BackupRestoreContext.java
@@ -12,11 +12,14 @@ public class BackupRestoreContext extends CommonContext {
 
     private final String backupId;
 
-    public BackupRestoreContext(FlowParameters flowParameters, StackEvent event, String backupLocation, String backupId) {
+    private final boolean closeConnections;
+
+    public BackupRestoreContext(FlowParameters flowParameters, StackEvent event, String backupLocation, String backupId, boolean closeConnections) {
         super(flowParameters);
         this.stackId = event.getResourceId();
         this.backupLocation = backupLocation;
         this.backupId = backupId;
+        this.closeConnections = closeConnections;
     }
 
     public BackupRestoreContext(FlowParameters flowParameters, Long stackId, String backupLocation, String backupId) {
@@ -24,10 +27,11 @@ public class BackupRestoreContext extends CommonContext {
         this.stackId = stackId;
         this.backupLocation = backupLocation;
         this.backupId = backupId;
+        this.closeConnections = true;
     }
 
-    public static BackupRestoreContext from(FlowParameters flowParameters, StackEvent event, String backupLocation, String backupId) {
-        return new BackupRestoreContext(flowParameters, event, backupLocation, backupId);
+    public static BackupRestoreContext from(FlowParameters flowParameters, StackEvent event, String backupLocation, String backupId, boolean closeConnections) {
+        return new BackupRestoreContext(flowParameters, event, backupLocation, backupId, closeConnections);
     }
 
     public Long getStackId() {
@@ -40,5 +44,9 @@ public class BackupRestoreContext extends CommonContext {
 
     public String getBackupId() {
         return backupId;
+    }
+
+    public boolean getCloseConnections() {
+        return closeConnections;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/backup/DatabaseBackupActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/backup/DatabaseBackupActions.java
@@ -45,7 +45,7 @@ public class DatabaseBackupActions {
 
             @Override
             protected Selectable createRequest(BackupRestoreContext context) {
-                return new DatabaseBackupRequest(context.getStackId(), context.getBackupLocation(), context.getBackupId());
+                return new DatabaseBackupRequest(context.getStackId(), context.getBackupLocation(), context.getBackupId(), context.getCloseConnections());
             }
 
             @Override
@@ -81,7 +81,7 @@ public class DatabaseBackupActions {
                     DatabaseBackupFailedEvent payload) {
                 Flow flow = getFlow(flowParameters.getFlowId());
                 flow.setFlowFailed(payload.getException());
-                return BackupRestoreContext.from(flowParameters, payload, null, null);
+                return BackupRestoreContext.from(flowParameters, payload, null, null, true);
             }
 
             @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/restore/DatabaseRestoreActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/dr/restore/DatabaseRestoreActions.java
@@ -81,7 +81,7 @@ public class DatabaseRestoreActions {
                     DatabaseRestoreFailedEvent payload) {
                 Flow flow = getFlow(flowParameters.getFlowId());
                 flow.setFlowFailed(payload.getException());
-                return BackupRestoreContext.from(flowParameters, payload, null, null);
+                return BackupRestoreContext.from(flowParameters, payload, null, null, true);
             }
 
             @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseBackupTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseBackupTriggerEvent.java
@@ -7,12 +7,16 @@ import reactor.rx.Promise;
 
 public class DatabaseBackupTriggerEvent extends BackupRestoreEvent {
 
+    public DatabaseBackupTriggerEvent(String selector, Long stackId, String backupLocation, String backupId, boolean closeConnections) {
+        super(selector, stackId, backupLocation, backupId, closeConnections);
+    }
+
     public DatabaseBackupTriggerEvent(String selector, Long stackId, String backupLocation, String backupId) {
         super(selector, stackId, backupLocation, backupId);
     }
 
     public DatabaseBackupTriggerEvent(String event, Long resourceId, Promise<AcceptResult> accepted,
-            String backupLocation, String backupId) {
-        super(event, resourceId, accepted, backupLocation, backupId);
+            String backupLocation, String backupId, boolean closeConnections) {
+        super(event, resourceId, accepted, backupLocation, backupId, closeConnections);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -298,9 +298,9 @@ public class ReactorFlowManager {
         return reactorNotifier.notify(stackId, selector, new StackEvent(selector, stackId));
     }
 
-    public FlowIdentifier triggerDatalakeDatabaseBackup(Long stackId, String location, String backupId) {
+    public FlowIdentifier triggerDatalakeDatabaseBackup(Long stackId, String location, String backupId, boolean closeConnections) {
         String selector = FlowChainTriggers.DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT;
-        return reactorNotifier.notify(stackId, selector, new DatabaseBackupTriggerEvent(selector, stackId, location, backupId));
+        return reactorNotifier.notify(stackId, selector, new DatabaseBackupTriggerEvent(selector, stackId, location, backupId, closeConnections));
     }
 
     public FlowIdentifier triggerDatalakeDatabaseRestore(Long stackId, String location, String backupId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/BackupRestoreEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/BackupRestoreEvent.java
@@ -11,20 +11,42 @@ public class BackupRestoreEvent extends StackEvent {
 
     private final String backupId;
 
+    private final boolean closeConnections;
+
     public BackupRestoreEvent(Long stackId, String backupLocation, String backupId) {
         this (null, stackId, backupLocation, backupId);
+    }
+
+    public BackupRestoreEvent(Long stackId, String backupLocation, String backupId, boolean closeConnections) {
+        this(null, stackId, backupLocation, backupId, closeConnections);
     }
 
     public BackupRestoreEvent(String selector, Long stackId, String backupLocation, String backupId) {
         super(selector, stackId);
         this.backupLocation = backupLocation;
         this.backupId = backupId;
+        this.closeConnections = true;
+    }
+
+    public BackupRestoreEvent(String selector, Long stackId, String backupLocation, String backupId, boolean closeConnections) {
+        super(selector, stackId);
+        this.backupLocation = backupLocation;
+        this.backupId = backupId;
+        this.closeConnections = closeConnections;
     }
 
     public BackupRestoreEvent(String selector, Long stackId, Promise<AcceptResult> accepted, String backupLocation, String backupId) {
         super(selector, stackId, accepted);
         this.backupLocation = backupLocation;
         this.backupId = backupId;
+        this.closeConnections = true;
+    }
+
+    public BackupRestoreEvent(String selector, Long stackId, Promise<AcceptResult> accepted, String backupLocation, String backupId, boolean closeConnections) {
+        super(selector, stackId, accepted);
+        this.backupLocation = backupLocation;
+        this.backupId = backupId;
+        this.closeConnections = closeConnections;
     }
 
     public String getBackupLocation() {
@@ -33,5 +55,9 @@ public class BackupRestoreEvent extends StackEvent {
 
     public String getBackupId() {
         return backupId;
+    }
+
+    public boolean getCloseConnections() {
+        return closeConnections;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/backup/DatabaseBackupRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/dr/backup/DatabaseBackupRequest.java
@@ -4,7 +4,7 @@ import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.BackupRestoreEvent
 
 public class DatabaseBackupRequest extends BackupRestoreEvent {
 
-    public DatabaseBackupRequest(Long stackId, String backupLocation, String backupId) {
-        super(stackId, backupLocation, backupId);
+    public DatabaseBackupRequest(Long stackId, String backupLocation, String backupId, boolean closeConnections) {
+        super(stackId, backupLocation, backupId, closeConnections);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
@@ -9,9 +9,9 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.common.base.Strings;
 import org.springframework.stereotype.Component;
 
+import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.SaltPillarProperties;
@@ -29,7 +29,10 @@ public class BackupRestoreSaltConfigGenerator {
 
     public static final String RANGER_ADMIN_GROUP_KEY = "ranger_admin_group";
 
-    public SaltConfig createSaltConfig(String location, String backupId, String rangerAdminGroup, Stack stack) throws URISyntaxException {
+    public static final String CLOSE_CONNECTIONS = "close_connections";
+
+    public SaltConfig createSaltConfig(String location, String backupId, String rangerAdminGroup, boolean closeConnections, Stack stack)
+            throws URISyntaxException {
         String fullLocation = buildFullLocation(location, backupId, stack.getCloudPlatform());
 
         Map<String, SaltPillarProperties> servicePillar = new HashMap<>();
@@ -37,9 +40,10 @@ public class BackupRestoreSaltConfigGenerator {
         Map<String, String> disasterRecoveryValues = new HashMap<>();
         disasterRecoveryValues.put(OBJECT_STORAGE_URL_KEY, fullLocation);
         disasterRecoveryValues.put(RANGER_ADMIN_GROUP_KEY, rangerAdminGroup);
+        disasterRecoveryValues.put(CLOSE_CONNECTIONS, String.valueOf(closeConnections));
 
         servicePillar.put("disaster-recovery", new SaltPillarProperties(POSTGRESQL_DISASTER_RECOVERY_PILLAR_PATH,
-            singletonMap(DISASTER_RECOVERY_KEY, disasterRecoveryValues)));
+                singletonMap(DISASTER_RECOVERY_KEY, disasterRecoveryValues)));
 
         return new SaltConfig(servicePillar);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/backup/DatabaseBackupHandler.java
@@ -79,7 +79,8 @@ public class DatabaseBackupHandler extends ExceptionCatcherEventHandler<Database
             Set<String> gatewayFQDN = Collections.singleton(gatewayInstance.getDiscoveryFQDN());
             ExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel(stackId, cluster.getId());
             String rangerAdminGroup = rangerVirtualGroupService.getRangerVirtualGroup(stack);
-            SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), rangerAdminGroup, stack);
+            SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), rangerAdminGroup,
+                    request.getCloseConnections(), stack);
             hostOrchestrator.backupDatabase(gatewayConfig, gatewayFQDN, stackUtil.collectReachableNodes(stack), saltConfig, exitModel);
 
             result = new DatabaseBackupSuccess(stackId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/restore/DatabaseRestoreHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/restore/DatabaseRestoreHandler.java
@@ -79,7 +79,7 @@ public class DatabaseRestoreHandler extends ExceptionCatcherEventHandler<Databas
             Set<String> gatewayFQDN = Collections.singleton(gatewayInstance.getDiscoveryFQDN());
             ExitCriteriaModel exitModel = ClusterDeletionBasedExitCriteriaModel.clusterDeletionBasedModel(stackId, cluster.getId());
             String rangerAdminGroup = rangerVirtualGroupService.getRangerVirtualGroup(stack);
-            SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), rangerAdminGroup, stack);
+            SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(request.getBackupLocation(), request.getBackupId(), rangerAdminGroup, true, stack);
             hostOrchestrator.restoreDatabase(gatewayConfig, gatewayFQDN, stackUtil.collectReachableNodes(stack), saltConfig, exitModel);
 
             result = new DatabaseRestoreSuccess(stackId);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreService.java
@@ -1,20 +1,20 @@
 package com.sequenceiq.cloudbreak.service;
 
-import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
-import com.sequenceiq.cloudbreak.controller.validation.dr.BackupRestoreV4RequestValidator;
-import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
-import com.sequenceiq.cloudbreak.logger.MDCBuilder;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sequenceiq.cloudbreak.validation.ValidationResult;
-import com.sequenceiq.flow.api.model.FlowIdentifier;
-
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.controller.validation.dr.BackupRestoreV4RequestValidator;
+import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
 
 @Service
 public class DatabaseBackupRestoreService {
@@ -42,11 +42,11 @@ public class DatabaseBackupRestoreService {
         }
     }
 
-    public FlowIdentifier backupDatabase(Long workspaceId, NameOrCrn nameOrCrn, String location, String backupId) {
+    public FlowIdentifier backupDatabase(Long workspaceId, NameOrCrn nameOrCrn, String location, String backupId, boolean closeConnections) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         MDCBuilder.buildMdcContext(stack);
         LOGGER.info("Initiating database backup flow for stack {}", stack.getId());
-        return flowManager.triggerDatalakeDatabaseBackup(stack.getId(), location, backupId);
+        return flowManager.triggerDatalakeDatabaseBackup(stack.getId(), location, backupId, closeConnections);
     }
 
     public FlowIdentifier restoreDatabase(Long workspaceId, NameOrCrn nameOrCrn, String location, String backupId) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -384,10 +384,10 @@ public class StackOperations implements ResourcePropertyProvider {
         return stackCommonService.getRetryableFlows(name, workspaceId);
     }
 
-    public FlowIdentifier backupClusterDatabase(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String location, String backupId) {
+    public FlowIdentifier backupClusterDatabase(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String location, String backupId, boolean closeConnections) {
         databaseBackupRestoreService.validate(workspaceId, nameOrCrn, location, backupId);
         LOGGER.debug("Starting cluster database backup: " + nameOrCrn);
-        return databaseBackupRestoreService.backupDatabase(workspaceId, nameOrCrn, location, backupId);
+        return databaseBackupRestoreService.backupDatabase(workspaceId, nameOrCrn, location, backupId, closeConnections);
     }
 
     public FlowIdentifier restoreClusterDatabase(@NotNull NameOrCrn nameOrCrn, Long workspaceId, String location, String backupId) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -131,7 +131,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerDistroXUpgrade(STACK_ID, imageChangeDto, false, false);
         underTest.triggerSaltUpdate(STACK_ID);
         underTest.triggerPillarConfigurationUpdate(STACK_ID);
-        underTest.triggerDatalakeDatabaseBackup(STACK_ID, null, null);
+        underTest.triggerDatalakeDatabaseBackup(STACK_ID, null, null, true);
         underTest.triggerDatalakeDatabaseRestore(STACK_ID, null, null);
         underTest.triggerAutoTlsCertificatesRotation(STACK_ID, new CertificatesRotationV4Request());
         underTest.triggerStackLoadBalancerUpdate(STACK_ID);
@@ -233,7 +233,7 @@ public class ReactorFlowManagerTest {
     public void testTriggerDatabaseBackupFlowchain() {
         long stackId = 1L;
         String backupId = UUID.randomUUID().toString();
-        underTest.triggerDatalakeDatabaseBackup(stackId, BACKUP_LOCATION, backupId);
+        underTest.triggerDatalakeDatabaseBackup(stackId, BACKUP_LOCATION, backupId, true);
         ArgumentCaptor<Acceptable> captor = ArgumentCaptor.forClass(Acceptable.class);
         verify(reactorNotifier).notify(eq(stackId), eq(FlowChainTriggers.DATALAKE_DATABASE_BACKUP_CHAIN_TRIGGER_EVENT), captor.capture());
         DatabaseBackupTriggerEvent event = (DatabaseBackupTriggerEvent) captor.getValue();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
@@ -37,7 +37,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -54,7 +54,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -67,7 +67,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, placeholderStack);
+        saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
 
         disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -82,7 +82,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -97,7 +97,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -112,7 +112,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
@@ -127,7 +127,7 @@ public class BackupRestoreSaltConfigGeneratorTest {
         Stack placeholderStack = new Stack();
         placeholderStack.setCloudPlatform(cloudPlatform);
 
-        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, placeholderStack);
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
 
         Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
         Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/DatabaseBackupRestoreServiceTest.java
@@ -1,22 +1,9 @@
 package com.sequenceiq.cloudbreak.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
-
-import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
-import com.sequenceiq.cloudbreak.common.service.TransactionService;
-import com.sequenceiq.cloudbreak.controller.validation.dr.BackupRestoreV4RequestValidator;
-import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
-import com.sequenceiq.cloudbreak.domain.Blueprint;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
-import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
-import com.sequenceiq.cloudbreak.validation.ValidationResult;
-import com.sequenceiq.flow.api.model.FlowIdentifier;
-import com.sequenceiq.flow.core.FlowLogService;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -30,6 +17,20 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.service.TransactionService;
+import com.sequenceiq.cloudbreak.controller.validation.dr.BackupRestoreV4RequestValidator;
+import com.sequenceiq.cloudbreak.core.flow2.service.ReactorFlowManager;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.flow.core.FlowLogService;
 
 @ExtendWith(MockitoExtension.class)
 public class DatabaseBackupRestoreServiceTest {
@@ -88,9 +89,9 @@ public class DatabaseBackupRestoreServiceTest {
         when(stackService.findStackByNameAndWorkspaceId(any(), anyLong())).thenReturn(Optional.of(stack));
         when(stackService.getByNameOrCrnInWorkspace(any(), anyLong())).thenReturn(stack);
         when(flowLogService.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(1L)).thenReturn(Collections.EMPTY_LIST);
-        when(flowManager.triggerDatalakeDatabaseBackup(anyLong(), any(), any())).thenReturn(FlowIdentifier.notTriggered());
+        when(flowManager.triggerDatalakeDatabaseBackup(anyLong(), any(), any(), anyBoolean())).thenReturn(FlowIdentifier.notTriggered());
 
-        service.backupDatabase(WORKSPACE_ID, ofName, null, null);
+        service.backupDatabase(WORKSPACE_ID, ofName, null, null, true);
     }
 
     @Test

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxBackupEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxBackupEndpoint.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.sdx.api.endpoint;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -14,6 +16,7 @@ import org.springframework.validation.annotation.Validated;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
 import com.sequenceiq.sdx.api.model.SdxBackupResponse;
 import com.sequenceiq.sdx.api.model.SdxBackupStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxDatabaseBackupRequest;
 import com.sequenceiq.sdx.api.model.SdxDatabaseBackupResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseBackupStatusResponse;
 
@@ -66,6 +69,14 @@ public interface SdxBackupEndpoint {
     @ApiOperation(value = "backup the database backing datalake ", produces = MediaType.APPLICATION_JSON, nickname = "backupDatabase")
     SdxDatabaseBackupResponse backupDatabaseByName(@PathParam("name") String name,
             @QueryParam("backupId") String backupId, @QueryParam("backupLocation") String backupLocation);
+
+    @POST
+    @Path("{name}/backupDatabaseInternal")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "backup the database with the option of closing or not closing connections to the database ", produces = MediaType.APPLICATION_JSON,
+        nickname = "backupDatabaseInternal")
+    SdxDatabaseBackupResponse backupDatabaseByNameInternal(@PathParam("name") String name,
+            @Valid @NotNull SdxDatabaseBackupRequest backupRequest);
 
     @GET
     @Path("{name}/backupDatabaseStatus")

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/ModelDescriptions.java
@@ -4,6 +4,12 @@ public class ModelDescriptions {
 
     public static final String RECOVERY_TYPE = "Type of the recovery operation, automatic restore is performed in case of 'RECOVER_WITH_DATA'";
 
+    public static final String BACKUP_ID = "The ID of the database backup.";
+
+    public static final String BACKUP_LOCATION = "The location where the database backup will be stored.";
+
+    public static final String CLOSE_CONNECTIONS = "The conditional parameter for whether connections to the database will be closed during backup or not.";
+
     private ModelDescriptions() {
     }
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxDatabaseBackupRequest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.sdx.api.model;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel("SdxDatabaseBackupRequest")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SdxDatabaseBackupRequest {
+    @NotNull
+    @ApiModelProperty(value = ModelDescriptions.BACKUP_ID, required = true)
+    private String backupId;
+
+    @NotNull
+    @ApiModelProperty(value = ModelDescriptions.BACKUP_LOCATION, required = true)
+    private String backupLocation;
+
+    @NotNull
+    @ApiModelProperty(value = ModelDescriptions.CLOSE_CONNECTIONS, required = true)
+    private boolean closeConnections;
+
+    public String getBackupId() {
+        return backupId;
+    }
+
+    public void setBackupId(String backupId) {
+        this.backupId = backupId;
+    }
+
+    public String getBackupLocation() {
+        return backupLocation;
+    }
+
+    public void setBackupLocation(String backupLocation) {
+        this.backupLocation = backupLocation;
+    }
+
+    public boolean getCloseConnections() {
+        return closeConnections;
+    }
+
+    public void setCloseConnections(boolean closeConnections) {
+        this.closeConnections = closeConnections;
+    }
+
+    @Override
+    public String toString() {
+        return "SdxDatabaseBackupRequest{" +
+                "backupId='" + backupId + '\'' +
+                ", backupLocation='" + backupLocation + '\'' +
+                ", closeConnections=" + closeConnections +
+                '}';
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxBackupController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxBackupController.java
@@ -16,6 +16,7 @@ import com.sequenceiq.datalake.service.sdx.dr.SdxBackupRestoreService;
 import com.sequenceiq.sdx.api.endpoint.SdxBackupEndpoint;
 import com.sequenceiq.sdx.api.model.SdxBackupResponse;
 import com.sequenceiq.sdx.api.model.SdxBackupStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxDatabaseBackupRequest;
 import com.sequenceiq.sdx.api.model.SdxDatabaseBackupResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseBackupStatusResponse;
 
@@ -38,7 +39,26 @@ public class SdxBackupController implements SdxBackupEndpoint {
             sdxDatabaseBackupResponse.setOperationId(backupId);
             return sdxDatabaseBackupResponse;
         } catch (NotFoundException notFoundException) {
-            return sdxBackupRestoreService.triggerDatabaseBackup(sdxCluster, backupId, backupLocation);
+            SdxDatabaseBackupRequest backupRequest = new SdxDatabaseBackupRequest();
+            backupRequest.setBackupId(backupId);
+            backupRequest.setBackupLocation(backupLocation);
+            backupRequest.setCloseConnections(true);
+            return sdxBackupRestoreService.triggerDatabaseBackup(sdxCluster, backupRequest);
+        }
+    }
+
+    @Override
+    @CheckPermissionByResourceName(action  = AuthorizationResourceAction.BACKUP_DATALAKE)
+    public SdxDatabaseBackupResponse backupDatabaseByNameInternal(@ResourceName String name, SdxDatabaseBackupRequest backupRequest) {
+        SdxCluster sdxCluster = getSdxClusterByName(name);
+        String backupId = backupRequest.getBackupId();
+        try {
+            SdxDatabaseBackupStatusResponse response = sdxBackupRestoreService.getDatabaseBackupStatus(sdxCluster, backupId);
+            SdxDatabaseBackupResponse sdxDatabaseBackupResponse = new SdxDatabaseBackupResponse();
+            sdxDatabaseBackupResponse.setOperationId(backupId);
+            return sdxDatabaseBackupResponse;
+        } catch (NotFoundException notFoundException) {
+            return sdxBackupRestoreService.triggerDatabaseBackup(sdxCluster, backupRequest);
         }
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupStartEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeDatabaseBackupStartEvent.java
@@ -1,29 +1,28 @@
 package com.sequenceiq.datalake.flow.dr.backup.event;
 
+import static com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupEvent.DATALAKE_DATABASE_BACKUP_EVENT;
+
 import com.sequenceiq.datalake.entity.operation.SdxOperation;
 import com.sequenceiq.datalake.entity.operation.SdxOperationType;
 import com.sequenceiq.datalake.flow.dr.event.DatalakeDatabaseDrStartBaseEvent;
-
-import static com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupEvent.DATALAKE_DATABASE_BACKUP_EVENT;
+import com.sequenceiq.sdx.api.model.SdxDatabaseBackupRequest;
 
 public class DatalakeDatabaseBackupStartEvent extends DatalakeDatabaseDrStartBaseEvent {
 
-    private final String backupId;
+    private final SdxDatabaseBackupRequest backupRequest;
 
-    private final String backupLocation;
-
-    public DatalakeDatabaseBackupStartEvent(String selector, Long sdxId, String userId,
-            String backupId, String backupLocation) {
+    public DatalakeDatabaseBackupStartEvent(String selector, Long sdxId, String userId, SdxDatabaseBackupRequest backupRequest) {
         super(selector, sdxId, userId, SdxOperationType.BACKUP);
-        this.backupId = backupId;
-        this.backupLocation = backupLocation;
+        this.backupRequest = backupRequest;
     }
 
     public DatalakeDatabaseBackupStartEvent(String selector, SdxOperation drStatus, String userId,
                                             String backupId, String backupLocation) {
         super(selector, userId, drStatus);
-        this.backupId = backupId;
-        this.backupLocation = backupLocation;
+        this.backupRequest = new SdxDatabaseBackupRequest();
+        backupRequest.setBackupId(backupId);
+        backupRequest.setBackupLocation(backupLocation);
+        backupRequest.setCloseConnections(true);
     }
 
     public static DatalakeDatabaseBackupStartEvent from(DatalakeTriggerBackupEvent trigggerBackupEvent,
@@ -35,11 +34,7 @@ public class DatalakeDatabaseBackupStartEvent extends DatalakeDatabaseDrStartBas
                 trigggerBackupEvent.getBackupLocation());
     }
 
-    public String getBackupId() {
-        return backupId;
-    }
-
-    public String getBackupLocation() {
-        return backupLocation;
+    public SdxDatabaseBackupRequest getBackupRequest() {
+        return backupRequest;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeTriggerBackupEvent.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/backup/event/DatalakeTriggerBackupEvent.java
@@ -4,6 +4,7 @@ import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.datalake.entity.operation.SdxOperationType;
 import com.sequenceiq.datalake.flow.dr.backup.DatalakeBackupFailureReason;
 import com.sequenceiq.datalake.flow.dr.event.DatalakeDatabaseDrStartBaseEvent;
+
 import reactor.rx.Promise;
 
 public class DatalakeTriggerBackupEvent extends DatalakeDatabaseDrStartBaseEvent {
@@ -22,8 +23,8 @@ public class DatalakeTriggerBackupEvent extends DatalakeDatabaseDrStartBaseEvent
         this.reason = reason;
     }
 
-    public DatalakeTriggerBackupEvent(String selector, Long sdxId, String userId, String backupLocation,
-            String backupName, DatalakeBackupFailureReason reason) {
+    public DatalakeTriggerBackupEvent(String selector, Long sdxId, String userId, String backupLocation, String backupName,
+            DatalakeBackupFailureReason reason) {
         super(selector, sdxId, userId, SdxOperationType.BACKUP);
         this.backupLocation = backupLocation;
         this.backupName = backupName;

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxBackupControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxBackupControllerTest.java
@@ -43,13 +43,13 @@ class SdxBackupControllerTest {
 
         when(sdxBackupRestoreService.getDatabaseBackupStatus(sdxCluster, backupId)).thenThrow(new NotFoundException("Status entry not found"));
         sdxBackupController.backupDatabaseByName(sdxCluster.getClusterName(), backupId, "");
-        verify(sdxBackupRestoreService, times(1)).triggerDatabaseBackup(any(), anyString(), anyString());
+        verify(sdxBackupRestoreService, times(1)).triggerDatabaseBackup(any(), any());
 
         reset(sdxBackupRestoreService);
         when(sdxBackupRestoreService.getDatabaseBackupStatus(sdxCluster, backupId))
                 .thenReturn(new SdxDatabaseBackupStatusResponse(DatalakeDatabaseDrStatus.SUCCEEDED, null));
         sdxBackupController.backupDatabaseByName(sdxCluster.getClusterName(), backupId, "");
-        verify(sdxBackupRestoreService, times(0)).triggerDatabaseBackup(any(), anyString(), anyString());
+        verify(sdxBackupRestoreService, times(0)).triggerDatabaseBackup(any(), any());
     }
 
     private SdxCluster getValidSdxCluster() {

--- a/orchestrator-salt/src/main/resources/salt/pillar/postgresql/disaster_recovery.sls
+++ b/orchestrator-salt/src/main/resources/salt/pillar/postgresql/disaster_recovery.sls
@@ -2,3 +2,4 @@ disaster_recovery:
   object_storage_url:
   ranger_admin_group:
   database_name:
+  close_connections: true

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -6,7 +6,7 @@ include:
 {% if 'None' != configure_remote_db %}
 backup_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:close_connections')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
     - require:
       - sls: postgresql.disaster_recovery
 
@@ -23,7 +23,7 @@ add_root_role_to_database:
 
 backup_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}} "/var/lib/pgsql"
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:close_connections')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
     - require:
       - cmd: add_root_role_to_database
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
@@ -23,7 +23,7 @@ add_root_role_to_database:
 
 restore_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}} "/var/lib/pgsql"
+    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} "" "" "" {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
     - require:
         - cmd: add_root_role_to_database
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -7,7 +7,7 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-if [[ $# -lt 5 || $# -gt 7 ]]; then
+if [[ $# -lt 5 || $# -gt 6 || "$1" == "None" ]]; then
   echo "Invalid inputs provided"
   echo "Script accepts at least 5 and at most 7 inputs:"
   echo "  1. Object Storage Service url to retrieve backups."
@@ -16,7 +16,6 @@ if [[ $# -lt 5 || $# -gt 7 ]]; then
   echo "  4. PostgreSQL user name."
   echo "  5. Ranger admin group."
   echo "  6. (optional) Name of the database to restore. If not given, will restore ranger and hive databases."
-  echo "  7. (optional) Log file location. Must be provided along with a database name."
   exit 1
 fi
 
@@ -26,7 +25,7 @@ PORT="$3"
 USERNAME="$4"
 RANGERGROUP="$5"
 DATABASENAME="${6-}"
-LOGFILE=${7:-/var/log}/dl_postgres_restore.log
+LOGFILE=/var/log/dl_postgres_restore.log
 echo "Logs at ${LOGFILE}"
 
 BACKUPS_DIR="/var/tmp/postgres_restore_staging"


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-13515

This change specifically serves to introduce a new argument for database backups: a boolean which defines whether connections to the database are closed when the database is being backed up or left open.

This change unfortunately touches a lot of files in the codebase as the path from the general datalake API to the disaster recovery salt scripts is not inherently linear due to the amount of classes which pass around the provided arguments.

As this is only my second time working with the disaster recovery code and logic, please let me know if I misunderstood anything or need to make any changes.

As of now this test has not been tested but I want to get eyes on it as soon as possible.

This change also includes a modification to the backup and restore salt scripts so that they check for the BACKUP_LOCATION argument not being equal to "None" as that has proven to be an issue.