### PR TITLE
CB-13867 CM service config port in CP should be 9443 in case of CCMV2

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/service/ClusterProxyService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/service/ClusterProxyService.java
@@ -120,7 +120,7 @@ public class ClusterProxyService {
         if (stack.getTunnel().useCcmV1()) {
             requestBuilder.withTunnelEntries(tunnelEntries(stack));
         } else if (stack.getTunnel().useCcmV2OrJumpgate()) {
-            requestBuilder.withCcmV2Entries(ccmV2Configs(stack));
+            requestBuilder.withServices(serviceConfigsForCcmV2(stack)).withCcmV2Entries(ccmV2Configs(stack));
         }
         return requestBuilder.build();
     }
@@ -132,7 +132,7 @@ public class ClusterProxyService {
         if (stack.getTunnel().useCcmV1()) {
             requestBuilder.withTunnelEntries(tunnelEntries(stack));
         } else if (stack.getTunnel().useCcmV2OrJumpgate()) {
-            requestBuilder.withCcmV2Entries(ccmV2Configs(stack)).withKnoxUrl(knoxUrlForCcmV2(stack));
+            requestBuilder.withServices(serviceConfigsForCcmV2(stack)).withCcmV2Entries(ccmV2Configs(stack)).withKnoxUrl(knoxUrlForCcmV2(stack));
         }
         return requestBuilder.build();
     }
@@ -143,6 +143,16 @@ public class ClusterProxyService {
         List<ClusterServiceConfig> clusterServiceConfigs = getClusterServiceConfigsForGWs(stack);
         clusterServiceConfigs.add(cmServiceConfig(stack, null, "cloudera-manager", clusterManagerUrl(stack)));
         clusterServiceConfigs.add(cmServiceConfig(stack, clientCertificates(stack), CB_INTERNAL, primaryGWInternalAdminUrl));
+        LOGGER.info("Service configs: {}", clusterServiceConfigs);
+        return clusterServiceConfigs;
+    }
+
+    private List<ClusterServiceConfig> serviceConfigsForCcmV2(Stack stack) {
+        String internalAdminUrl = internalAdminUrl(stack, ServiceFamilies.GATEWAY.getDefaultPort());
+        LOGGER.info("Primary GW internal admin URL is: {}", internalAdminUrl);
+        List<ClusterServiceConfig> clusterServiceConfigs = getClusterServiceConfigsForGWs(stack);
+        clusterServiceConfigs.add(cmServiceConfig(stack, clientCertificates(stack), "cloudera-manager", internalAdminUrl));
+        clusterServiceConfigs.add(cmServiceConfig(stack, clientCertificates(stack), CB_INTERNAL, internalAdminUrl));
         LOGGER.info("Service configs: {}", clusterServiceConfigs);
         return clusterServiceConfigs;
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/clusterproxy/ClusterProxyServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/clusterproxy/ClusterProxyServiceTest.java
@@ -136,7 +136,6 @@ class ClusterProxyServiceTest {
                 "testAgentCrn", "testAgentCrn-i-def456", "10.10.10.11", ServiceFamilies.GATEWAY.getDefaultPort())));
         assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfigWithInstanceId(PRIMARY_PUBLIC_IP, PRIMARY_INSTANCE_ID)));
         assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfigWithInstanceId(OTHER_PUBLIC_IP, OTHER_INSTANCE_ID)));
-        assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfig()));
         assertTrue(proxyRegisterationReq.getServices().contains(cmInternalServiceConfig()));
 
         assertEquals(false, proxyRegisterationReq.isUseTunnel(), "CCMV1 tunnel should be disabled.");
@@ -190,7 +189,6 @@ class ClusterProxyServiceTest {
         assertEquals("https://10.10.10.10:9443/knox/test-cluster", proxyRegisterationReq.getUriOfKnox(), "CCMV2 Knox URI should match");
         assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfigWithInstanceId(PRIMARY_PUBLIC_IP, PRIMARY_INSTANCE_ID)));
         assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfigWithInstanceId(OTHER_PUBLIC_IP, OTHER_INSTANCE_ID)));
-        assertTrue(proxyRegisterationReq.getServices().contains(cmServiceConfig()));
         assertTrue(proxyRegisterationReq.getServices().contains(cmInternalServiceConfig()));
 
         assertEquals(false, proxyRegisterationReq.isUseTunnel(), "CCMV1 tunnel should be disabled.");
@@ -279,7 +277,6 @@ class ClusterProxyServiceTest {
         assertEquals(4, requestSent.getServices().size());
         assertTrue(requestSent.getServices().contains(cmServiceConfigWithInstanceId(PRIMARY_PUBLIC_IP, PRIMARY_INSTANCE_ID)));
         assertTrue(requestSent.getServices().contains(cmServiceConfigWithInstanceId(OTHER_PUBLIC_IP, OTHER_INSTANCE_ID)));
-        assertTrue(requestSent.getServices().contains(cmServiceConfig()));
         assertTrue(requestSent.getServices().contains(cmInternalServiceConfig()));
     }
 


### PR DESCRIPTION
This fixes the bug introduced here: https://github.com/hortonworks/cloudbreak/commit/b106d4102bce00d1970850562cfb36636ce4b5d1