### PR TITLE
CB-13178 - Gather Azure medium duty datalake load balancer configs and return via cdp cli

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AvailabilitySetNameService.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/AvailabilitySetNameService.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.cloud.model.instance;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AvailabilitySetNameService {
+
+    public String generateName(String prefix, String instanceGroupName) {
+        return String.format("%s-%s-as", prefix, instanceGroupName);
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollector.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import com.microsoft.azure.management.compute.AvailabilitySet;
+import com.microsoft.azure.management.network.LoadBalancerBackend;
+import com.microsoft.azure.management.network.LoadBalancingRule;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.view.AzureLoadBalancerMetadataView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AvailabilitySetNameService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AzureLoadBalancerMetadataCollector {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureLoadBalancerMetadataCollector.class);
+
+    @Inject
+    private AzureUtils azureUtils;
+
+    @Inject
+    private AvailabilitySetNameService availabilitySetNameService;
+
+    public Map<String, Object> getParameters(AuthenticatedContext ac, String resourceGroup, String loadBalancerName) {
+        LOGGER.info("Parsing Azure load balancer parameters for load balancer {}", loadBalancerName);
+        Map<String, Object> parameters = parseTargetGroupCloudParams(ac, resourceGroup, loadBalancerName);
+        parameters.put(AzureLoadBalancerMetadataView.LOADBALANCER_NAME, loadBalancerName);
+        return parameters;
+    }
+
+    private Map<String, Object> parseTargetGroupCloudParams(AuthenticatedContext ac, String resourceGroup, String loadBalancerName) {
+        Map<String, Object> parameters = new HashMap<>();
+        AzureClient azureClient = ac.getParameter(AzureClient.class);
+        Map<String, LoadBalancingRule> rules = azureClient.getLoadBalancerRules(resourceGroup, loadBalancerName);
+
+        Map<Integer, String> portToAsMapping = rules.values().stream()
+                .collect(Collectors.toMap(LoadBalancingRule::backendPort, rule -> generateAvailabilitySetName(ac, rule.backend())));
+        LOGGER.debug("Found port to availability set mapping [{}] for load balancer {}", portToAsMapping, loadBalancerName);
+
+        portToAsMapping.forEach((port, availabilitySetName) -> {
+            // Validate an availability set with the expected name actually exists
+            Optional<AvailabilitySet> availabilitySet = Optional.ofNullable(azureClient.getAvailabilitySet(resourceGroup, availabilitySetName));
+            if (availabilitySet.isPresent()) {
+                LOGGER.debug("Found availability set with name {}", availabilitySetName);
+                parameters.put(AzureLoadBalancerMetadataView.getAvailabilitySetParam(port), availabilitySetName);
+            } else {
+                LOGGER.warn("Expected availability set with name {} in resource group {}, but unable to find one.",
+                        availabilitySetName, resourceGroup);
+                parameters.put(AzureLoadBalancerMetadataView.getAvailabilitySetParam(port), null);
+            }
+        });
+        return parameters;
+    }
+
+    private String generateAvailabilitySetName(AuthenticatedContext ac, LoadBalancerBackend backend) {
+        String stackName = azureUtils.getStackName(ac.getCloudContext());
+        String groupName = backend.inner().name().replace("-pool", "");
+        return availabilitySetNameService.generateName(stackName, groupName);
+    }
+}

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollector.java
@@ -53,6 +53,9 @@ public class AzureMetadataCollector implements MetadataCollector {
     @Inject
     private AzureVmPublicIpProvider azureVmPublicIpProvider;
 
+    @Inject
+    private AzureLoadBalancerMetadataCollector azureLbMetadataCollector;
+
     @Override
     @Retryable(backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 10000), maxAttempts = 5)
     public List<CloudVmMetaDataStatus> collect(AuthenticatedContext authenticatedContext, List<CloudResource> resources, List<CloudInstance> vms,
@@ -155,10 +158,12 @@ public class AzureMetadataCollector implements MetadataCollector {
                 }
 
                 if (ip.isPresent()) {
+                    Map<String, Object> parameters = azureLbMetadataCollector.getParameters(ac, resourceGroup, loadBalancerName);
                     CloudLoadBalancerMetadata loadBalancerMetadata = new CloudLoadBalancerMetadata.Builder()
                         .withType(type)
                         .withIp(ip.get())
                         .withName(loadBalancerName)
+                        .withParameters(parameters)
                         .build();
                     cloudLoadBalancerMetadata.add(loadBalancerMetadata);
                     LOGGER.debug("Saved metadata for load balancer: {}", loadBalancerMetadata);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -62,6 +62,7 @@ import com.microsoft.azure.management.marketplaceordering.v2015_06_01.implementa
 import com.microsoft.azure.management.msi.Identity;
 import com.microsoft.azure.management.network.LoadBalancer;
 import com.microsoft.azure.management.network.LoadBalancerFrontend;
+import com.microsoft.azure.management.network.LoadBalancingRule;
 import com.microsoft.azure.management.network.Network;
 import com.microsoft.azure.management.network.NetworkInterface;
 import com.microsoft.azure.management.network.NetworkInterfaces;
@@ -777,6 +778,10 @@ public class AzureClient {
 
         LOGGER.info("Private IPs for load balancer {} retrieved: {}", loadBalancerName, loadbalancerPrivateIps);
         return loadbalancerPrivateIps;
+    }
+
+    public Map<String, LoadBalancingRule> getLoadBalancerRules(String resourceGroupName, String loadBalancerName) {
+        return getLoadBalancer(resourceGroupName, loadBalancerName).loadBalancingRules();
     }
 
     public PagedList<Identity> listIdentities() {

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureLoadBalancerMetadataView.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/view/AzureLoadBalancerMetadataView.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.cloud.azure.view;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancerMetadata;
+
+public class AzureLoadBalancerMetadataView {
+
+    public static final String LOADBALANCER_NAME = "loadBalancerName";
+
+    public static final String AVAILABILITY_SET_PREFIX = "availabilitySetName";
+
+    private final CloudLoadBalancerMetadata cloudLoadBalancerMetadata;
+
+    public AzureLoadBalancerMetadataView(CloudLoadBalancerMetadata cloudLoadBalancerMetadata) {
+        this.cloudLoadBalancerMetadata = cloudLoadBalancerMetadata;
+    }
+
+    public String getLoadbalancerName() {
+        return cloudLoadBalancerMetadata.getStringParameter(LOADBALANCER_NAME);
+    }
+
+    public String getAvailabilitySetByPort(int port) {
+        return cloudLoadBalancerMetadata.getStringParameter(getAvailabilitySetParam(port));
+    }
+
+    public static String getAvailabilitySetParam(int port) {
+        return AVAILABILITY_SET_PREFIX + port;
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollectorTest.java
@@ -1,0 +1,181 @@
+package com.sequenceiq.cloudbreak.cloud.azure;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.microsoft.azure.management.compute.AvailabilitySet;
+import com.microsoft.azure.management.network.LoadBalancerBackend;
+import com.microsoft.azure.management.network.LoadBalancingRule;
+import com.microsoft.azure.management.network.implementation.BackendAddressPoolInner;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.view.AzureLoadBalancerMetadataView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Region;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AvailabilitySetNameService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AzureLoadBalancerMetadataCollectorTest {
+
+    private static final Long WORKSPACE_ID = 1L;
+
+    private static final String RESOURCE_GROUP = "my-resource-group";
+
+    private static final String LB_NAME = "load-balancer-name";
+
+    private static final String GROUP_NAME = "group-name-%d";
+
+    private static final String GROUP_PATTERN = GROUP_NAME + "%s";
+
+    private static final String POOL_SUFFIX = "-pool";
+
+    private static final String AS_SUFFIX = "-as";
+
+    private static final String STACK_NAME = "stackName";
+
+    @Mock
+    private AzureClient azureClient;
+
+    @Mock
+    private AzureUtils azureUtils;
+
+    @Mock
+    private AvailabilitySetNameService availabilitySetNameService;
+
+    @InjectMocks
+    private AzureLoadBalancerMetadataCollector underTest;
+
+    @Test
+    public void testCollectInternalLoadBalancer() {
+        int numPorts = 1;
+        AuthenticatedContext ac = authenticatedContext();
+        Map<String, LoadBalancingRule> rules = getLoadBalancingRules(numPorts);
+        String availabilitySetName = String.format(GROUP_PATTERN, 0, AS_SUFFIX);
+        String groupName = String.format(GROUP_NAME, 0);
+
+        Map<String, Object> expectedParameters = Map.of(
+                AzureLoadBalancerMetadataView.LOADBALANCER_NAME, LB_NAME,
+                AzureLoadBalancerMetadataView.AVAILABILITY_SET_PREFIX + 0, availabilitySetName
+        );
+
+        when(azureClient.getLoadBalancerRules(eq(RESOURCE_GROUP), eq(LB_NAME))).thenReturn(rules);
+        when(azureClient.getAvailabilitySet(eq(RESOURCE_GROUP), anyString())).thenReturn(mock(AvailabilitySet.class));
+        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
+        when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName))).thenReturn(availabilitySetName);
+
+        Map<String, Object> parameters = underTest.getParameters(ac, RESOURCE_GROUP, LB_NAME);
+
+        assertEquals(expectedParameters, parameters);
+    }
+
+    @Test
+    public void testCollectLoadBalancerMultiplePorts() {
+        int numPorts = 3;
+        AuthenticatedContext ac = authenticatedContext();
+        Map<String, LoadBalancingRule> rules = getLoadBalancingRules(numPorts);
+        String availabilitySetName0 = String.format(GROUP_PATTERN, 0, AS_SUFFIX);
+        String availabilitySetName1 = String.format(GROUP_PATTERN, 1, AS_SUFFIX);
+        String availabilitySetName2 = String.format(GROUP_PATTERN, 2, AS_SUFFIX);
+        String groupName0 = String.format(GROUP_NAME, 0);
+        String groupName1 = String.format(GROUP_NAME, 1);
+        String groupName2 = String.format(GROUP_NAME, 2);
+
+        Map<String, Object> expectedParameters = Map.of(
+                AzureLoadBalancerMetadataView.LOADBALANCER_NAME, LB_NAME,
+                AzureLoadBalancerMetadataView.AVAILABILITY_SET_PREFIX + 0, availabilitySetName0,
+                AzureLoadBalancerMetadataView.AVAILABILITY_SET_PREFIX + 1, availabilitySetName1,
+                AzureLoadBalancerMetadataView.AVAILABILITY_SET_PREFIX + 2, availabilitySetName2
+        );
+
+        when(azureClient.getLoadBalancerRules(eq(RESOURCE_GROUP), eq(LB_NAME))).thenReturn(rules);
+        when(azureClient.getAvailabilitySet(eq(RESOURCE_GROUP), anyString())).thenReturn(mock(AvailabilitySet.class));
+        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
+        when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName0))).thenReturn(availabilitySetName0);
+        when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName1))).thenReturn(availabilitySetName1);
+        when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName2))).thenReturn(availabilitySetName2);
+
+        Map<String, Object> parameters = underTest.getParameters(ac, RESOURCE_GROUP, LB_NAME);
+
+        assertEquals(expectedParameters, parameters);
+    }
+
+    @Test
+    public void testCollectLoadBalancerMissingAvailabilitySet() {
+        int numPorts = 3;
+        AuthenticatedContext ac = authenticatedContext();
+        Map<String, LoadBalancingRule> rules = getLoadBalancingRules(numPorts);
+        String availabilitySetName0 = String.format(GROUP_PATTERN, 0, AS_SUFFIX);
+        String availabilitySetName1 = String.format(GROUP_PATTERN, 1, AS_SUFFIX);
+        String availabilitySetName2 = String.format(GROUP_PATTERN, 2, AS_SUFFIX);
+        String groupName0 = String.format(GROUP_NAME, 0);
+        String groupName1 = String.format(GROUP_NAME, 1);
+        String groupName2 = String.format(GROUP_NAME, 2);
+
+        Map<String, Object> expectedParameters = new HashMap<>();
+        expectedParameters.put(AzureLoadBalancerMetadataView.LOADBALANCER_NAME, LB_NAME);
+        expectedParameters.put(AzureLoadBalancerMetadataView.AVAILABILITY_SET_PREFIX + 0, availabilitySetName0);
+        expectedParameters.put(AzureLoadBalancerMetadataView.AVAILABILITY_SET_PREFIX + 1, null);
+        expectedParameters.put(AzureLoadBalancerMetadataView.AVAILABILITY_SET_PREFIX + 2, availabilitySetName2);
+
+        when(azureClient.getLoadBalancerRules(eq(RESOURCE_GROUP), eq(LB_NAME))).thenReturn(rules);
+        when(azureClient.getAvailabilitySet(eq(RESOURCE_GROUP), eq(availabilitySetName0))).thenReturn(mock(AvailabilitySet.class));
+        when(azureClient.getAvailabilitySet(eq(RESOURCE_GROUP), eq(availabilitySetName1))).thenReturn(null);
+        when(azureClient.getAvailabilitySet(eq(RESOURCE_GROUP), eq(availabilitySetName2))).thenReturn(mock(AvailabilitySet.class));
+        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
+        when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName0))).thenReturn(availabilitySetName0);
+        when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName1))).thenReturn(availabilitySetName1);
+        when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName2))).thenReturn(availabilitySetName2);
+
+        Map<String, Object> parameters = underTest.getParameters(ac, RESOURCE_GROUP, LB_NAME);
+
+        assertEquals(expectedParameters, parameters);
+    }
+
+    private AuthenticatedContext authenticatedContext() {
+        Location location = Location.location(Region.region("region"), AvailabilityZone.availabilityZone("az"));
+        CloudContext context = CloudContext.Builder.builder()
+                .withId(5L)
+                .withName("name")
+                .withCrn("crn")
+                .withPlatform("platform")
+                .withVariant("variant")
+                .withLocation(location)
+                .withWorkspaceId(WORKSPACE_ID)
+                .build();
+        CloudCredential credential = new CloudCredential("crn", null, null, false);
+        AuthenticatedContext authenticatedContext = new AuthenticatedContext(context, credential);
+        authenticatedContext.putParameter(AzureClient.class, azureClient);
+        return authenticatedContext;
+    }
+
+    private Map<String, LoadBalancingRule> getLoadBalancingRules(int numPorts) {
+        Map<String, LoadBalancingRule> rules = new HashMap<>();
+        for (int i = 0; i < numPorts; i++) {
+            LoadBalancingRule rule = mock(LoadBalancingRule.class);
+            LoadBalancerBackend backend = mock(LoadBalancerBackend.class);
+            BackendAddressPoolInner inner = mock(BackendAddressPoolInner.class);
+            when(inner.name()).thenReturn(String.format(GROUP_PATTERN, i, POOL_SUFFIX));
+            when(backend.inner()).thenReturn(inner);
+            when(rule.backend()).thenReturn(backend);
+            when(rule.backendPort()).thenReturn(i);
+            rules.put(String.valueOf(i), rule);
+        }
+        return rules;
+    }
+}

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureMetadataCollectorTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.cloud.azure;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -100,6 +101,9 @@ public class AzureMetadataCollectorTest {
 
     @Mock
     private CloudContext mockCloudContext;
+
+    @Mock
+    private AzureLoadBalancerMetadataCollector azureLbMetadataCollector;
 
     @Test
     public void testCollectShouldReturnsTheAllVmMetadata() {
@@ -201,6 +205,7 @@ public class AzureMetadataCollectorTest {
             .thenReturn(List.of(PUBLIC_IP));
 
         when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+        when(azureLbMetadataCollector.getParameters(any(), anyString(), anyString())).thenReturn(Map.of());
 
         List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PUBLIC), resources);
 
@@ -225,6 +230,7 @@ public class AzureMetadataCollectorTest {
                 .thenReturn(List.of(PUBLIC_IP, SECOND_PUBLIC_IP));
 
         when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+        when(azureLbMetadataCollector.getParameters(any(), anyString(), anyString())).thenReturn(Map.of());
 
         List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PUBLIC), resources);
 
@@ -256,6 +262,7 @@ public class AzureMetadataCollectorTest {
                 .thenReturn(List.of(PRIVATE_IP));
 
         when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+        when(azureLbMetadataCollector.getParameters(any(), anyString(), anyString())).thenReturn(Map.of());
 
         List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext,
                 List.of(LoadBalancerType.PUBLIC, LoadBalancerType.PRIVATE), resources);
@@ -290,6 +297,7 @@ public class AzureMetadataCollectorTest {
                 .thenReturn(List.of(PRIVATE_IP));
 
         when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+        when(azureLbMetadataCollector.getParameters(any(), anyString(), anyString())).thenReturn(Map.of());
 
         List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PRIVATE), resources);
 
@@ -314,6 +322,7 @@ public class AzureMetadataCollectorTest {
                 .thenReturn(List.of(PRIVATE_IP, "10.23.12.1"));
 
         when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
+        when(azureLbMetadataCollector.getParameters(any(), anyString(), anyString())).thenReturn(Map.of());
 
         List<CloudLoadBalancerMetadata> result = underTest.collectLoadBalancer(authenticatedContext, List.of(LoadBalancerType.PRIVATE), resources);
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/AzureLoadBalancerResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/AzureLoadBalancerResponse.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions.StackModelDescription;
+
+public class AzureLoadBalancerResponse implements Serializable {
+
+    @ApiModelProperty(StackModelDescription.AZURE_LB_NAME)
+    @NotNull
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/AzureTargetGroupResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/AzureTargetGroupResponse.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.loadbalancer;
+
+import java.io.Serializable;
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions.StackModelDescription;
+
+public class AzureTargetGroupResponse implements Serializable {
+
+    @ApiModelProperty(StackModelDescription.AZURE_LB_AVAILABILITY_SET)
+    @NotNull
+    private List<String> availabilitySet;
+
+    public List<String> getAvailabilitySet() {
+        return availabilitySet;
+    }
+
+    public void setAvailabilitySet(List<String> availabilitySet) {
+        this.availabilitySet = availabilitySet;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/LoadBalancerResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/LoadBalancerResponse.java
@@ -35,6 +35,9 @@ public class LoadBalancerResponse implements Serializable {
     @ApiModelProperty(StackModelDescription.LOAD_BALANCER_AWS)
     private AwsLoadBalancerResponse awsResourceId;
 
+    @ApiModelProperty(StackModelDescription.LOAD_BALANCER_AZURE)
+    private AzureLoadBalancerResponse azureResourceId;
+
     public String getFqdn() {
         return fqdn;
     }
@@ -81,5 +84,13 @@ public class LoadBalancerResponse implements Serializable {
 
     public void setAwsResourceId(AwsLoadBalancerResponse awsResourceId) {
         this.awsResourceId = awsResourceId;
+    }
+
+    public AzureLoadBalancerResponse getAzureResourceId() {
+        return azureResourceId;
+    }
+
+    public void setAzureResourceId(AzureLoadBalancerResponse azureResourceId) {
+        this.azureResourceId = azureResourceId;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/TargetGroupResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/loadbalancer/TargetGroupResponse.java
@@ -25,6 +25,9 @@ public class TargetGroupResponse implements Serializable {
     @ApiModelProperty(StackModelDescription.TARGET_GROUP_AWS)
     private AwsTargetGroupResponse awsResourceIds;
 
+    @ApiModelProperty(StackModelDescription.TARGET_GROUP_AZURE)
+    private AzureTargetGroupResponse azureResourceId;
+
     public long getPort() {
         return port;
     }
@@ -47,5 +50,13 @@ public class TargetGroupResponse implements Serializable {
 
     public void setAwsResourceIds(AwsTargetGroupResponse awsResourceIds) {
         this.awsResourceIds = awsResourceIds;
+    }
+
+    public AzureTargetGroupResponse getAzureResourceId() {
+        return azureResourceId;
+    }
+
+    public void setAzureResourceId(AzureTargetGroupResponse azureResourceId) {
+        this.azureResourceId = azureResourceId;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -272,6 +272,11 @@ public class ModelDescriptions {
         public static final String AWS_LB_ARN = "The ARN of the AWS load balancer.";
         public static final String AWS_LISTENER_ARN = "The ARN of the AWS listener for the specified port.";
         public static final String AWS_TARGETGROUP_ARN = "The ARN of the AWS target group for the specified port.";
+        public static final String LOAD_BALANCER_AZURE = "The Azure load balancer cloud resource information.";
+        public static final String TARGET_GROUP_AZURE = "The Azure target availability set information.";
+        public static final String AZURE_LB_NAME = "The Azure Load Balancer name";
+        public static final String AZURE_LB_AVAILABILITY_SET = "The availability set that contains the instances recieving traffic from the load balancer " +
+                "on the specificed port.";
     }
 
     public static class ClusterModelDescription {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancerConfigDbWrapper.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancerConfigDbWrapper.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.domain.stack.loadbalancer;
 
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsLoadBalancerConfigDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.azure.AzureLoadBalancerConfigDb;
 
 /**
  * A wrapper for the cloud provider specific load balancer metadata stored in the database. Only one
@@ -12,6 +13,8 @@ public class LoadBalancerConfigDbWrapper {
 
     private AwsLoadBalancerConfigDb awsConfig;
 
+    private AzureLoadBalancerConfigDb azureConfig;
+
     public AwsLoadBalancerConfigDb getAwsConfig() {
         return awsConfig;
     }
@@ -20,10 +23,19 @@ public class LoadBalancerConfigDbWrapper {
         this.awsConfig = awsConfig;
     }
 
+    public AzureLoadBalancerConfigDb getAzureConfig() {
+        return azureConfig;
+    }
+
+    public void setAzureConfig(AzureLoadBalancerConfigDb azureConfig) {
+        this.azureConfig = azureConfig;
+    }
+
     @Override
     public String toString() {
         return "CloudLoadBalancerConfig{" +
             "awsConfig=" + awsConfig +
+            "azureConfig=" + azureConfig +
             '}';
     }
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/TargetGroupConfigDbWrapper.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/TargetGroupConfigDbWrapper.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.domain.stack.loadbalancer;
 
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.aws.AwsTargetGroupConfigDb;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.azure.AzureTargetGroupConfigDb;
 
 /**
  * A wrapper for the cloud provider specific target group metadata stored in the database. Only one
@@ -12,6 +13,8 @@ public class TargetGroupConfigDbWrapper {
 
     private AwsTargetGroupConfigDb awsConfig;
 
+    private AzureTargetGroupConfigDb azureConfig;
+
     public AwsTargetGroupConfigDb getAwsConfig() {
         return awsConfig;
     }
@@ -20,10 +23,19 @@ public class TargetGroupConfigDbWrapper {
         this.awsConfig = awsConfig;
     }
 
+    public AzureTargetGroupConfigDb getAzureConfig() {
+        return azureConfig;
+    }
+
+    public void setAzureConfig(AzureTargetGroupConfigDb azureConfig) {
+        this.azureConfig = azureConfig;
+    }
+
     @Override
     public String toString() {
         return "TargetGroupConfigDbWrapper{" +
             "awsConfig=" + awsConfig +
+            "azureConfig=" + azureConfig +
             '}';
     }
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/azure/AzureLoadBalancerConfigDb.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/azure/AzureLoadBalancerConfigDb.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.domain.stack.loadbalancer.azure;
+
+/**
+ * The top level AWS specific load balancer metadata database object. For Azure, the Azure
+ * load balancer name is recorded.
+ */
+public class AzureLoadBalancerConfigDb {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return "AzureLoadBalancerConfigDb{" +
+                "name='" + name + '\'' +
+                '}';
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/azure/AzureTargetGroupConfigDb.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/azure/AzureTargetGroupConfigDb.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.domain.stack.loadbalancer.azure;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The top Azure specific target group metadata database object. For Azure we keep track of a mapping of
+ * the traffic port to the list of availability sets the traffic on that port is routed to.
+ *
+ * A note about the list of availability sets: The way this is currently implemented in the CB load balancer
+ * model is that there is a 1-to-1 relationship between instance groups and availabilty sets. The Azure load
+ * balancer is limited so that each load balancing rule routes traffic to a single instance group/availability set.
+ *
+ * It is possible in the future that the Azure load balancer logic will change to route traffic to multiple
+ * availability sets in a single load balancer rule. To avoid the need for database and API changes if that
+ * happens, the availiabilty set name is stored in a List. However, in the current implementation this list
+ * will always be of size one.
+ */
+public class AzureTargetGroupConfigDb {
+
+    private Map<Integer, List<String>> portAvailabilitySetMapping = new HashMap<>();
+
+    public Map<Integer, List<String>> getPortAvailabilitySetMapping() {
+        return portAvailabilitySetMapping;
+    }
+
+    public void setPortAvailabilitySetMapping(Map<Integer, List<String>> portAvailabilitySetMapping) {
+        this.portAvailabilitySetMapping = portAvailabilitySetMapping;
+    }
+
+    public void addPortAvailabilitySetMapping(Integer port, List<String> availabilitySets) {
+        portAvailabilitySetMapping.put(port, availabilitySets);
+    }
+
+    @Override
+    public String toString() {
+        return "AzureTargetGroupConfigDb{" +
+                "portAvailabilitySetMapping=" + portAvailabilitySetMapping +
+                '}';
+    }
+}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -257,6 +257,7 @@ dependencies {
   compile project(':cluster-proxy')
   compile project(':status-checker')
   compile project(':node-status-monitor-client')
+  compile project(':cloud-azure')
 
   implementation project(":notification-sender")
 
@@ -268,7 +269,7 @@ dependencies {
   implementation project(':cloud-aws-cloudformation')
   implementation project(':cloud-aws-native')
   runtime project(':cloud-mock')
-  runtime project(':cloud-azure')
+  compile project(':cloud-azure')
   runtime project(':cloud-yarn')
   runtime project(':cluster-cm')
   runtime project(':auth-connector')

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
@@ -41,6 +41,7 @@ import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.mappable.ProviderParameterCalculator;
 import com.sequenceiq.cloudbreak.common.network.NetworkConstants;
 import com.sequenceiq.cloudbreak.converter.v4.environment.network.SubnetSelector;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AvailabilitySetNameService;
 import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -86,6 +87,9 @@ public class LoadBalancerConfigService {
 
     @Inject
     private ProviderParameterCalculator providerParameterCalculator;
+
+    @Inject
+    private AvailabilitySetNameService availabilitySetNameService;
 
     public Set<String> getKnoxGatewayGroups(Stack stack) {
         LOGGER.debug("Fetching list of instance groups with Knox gateway installed");
@@ -222,7 +226,7 @@ public class LoadBalancerConfigService {
     private void attachAvailabilitySetParameters(String availabilitySetPrefix, InstanceGroup ig) {
         Map<String, Object> parameters = ig.getAttributes().getMap();
         parameters.put("availabilitySet", Map.ofEntries(
-                entry(AzureInstanceGroupParameters.NAME, String.format("%s-%s-as", availabilitySetPrefix, ig.getGroupName())),
+                entry(AzureInstanceGroupParameters.NAME, availabilitySetNameService.generateName(availabilitySetPrefix, ig.getGroupName())),
                 entry(AzureInstanceGroupParameters.FAULT_DOMAIN_COUNT, DEFAULT_FAULT_DOMAIN_COUNT),
                 entry(AzureInstanceGroupParameters.UPDATE_DOMAIN_COUNT, DEFAULT_UPDATE_DOMAIN_COUNT)));
         ig.setAttributes(new Json(parameters));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigServiceTest.java
@@ -34,6 +34,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AvailabilitySetNameService;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AzureInstanceGroupParameters;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.Json;
@@ -83,6 +84,9 @@ public class LoadBalancerConfigServiceTest extends SubnetTest {
 
     @Mock
     private LoadBalancerPersistenceService loadBalancerPersistenceService;
+
+    @Mock
+    private AvailabilitySetNameService availabilitySetNameService;
 
     // allows @InjectMocks to provide this component to the LoadBalancerConfigService
     @Spy
@@ -641,6 +645,7 @@ public class LoadBalancerConfigServiceTest extends SubnetTest {
         when(entitlementService.datalakeLoadBalancerEnabled(anyString())).thenReturn(true);
         when(blueprint.getBlueprintText()).thenReturn(getBlueprintText("input/clouderamanager-knox.bp"));
         when(subnetSelector.findSubnetById(any(), anyString())).thenReturn(Optional.of(subnet));
+        when(availabilitySetNameService.generateName(any(), any())).thenReturn("");
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
             Set<LoadBalancer> loadBalancers = underTest.createLoadBalancers(stack, environment, false);
@@ -664,6 +669,7 @@ public class LoadBalancerConfigServiceTest extends SubnetTest {
         when(entitlementService.datalakeLoadBalancerEnabled(anyString())).thenReturn(true);
         when(blueprint.getBlueprintText()).thenReturn(getBlueprintText("input/clouderamanager-knox.bp"));
         when(subnetSelector.findSubnetById(any(), anyString())).thenReturn(Optional.of(subnet));
+        when(availabilitySetNameService.generateName(any(), any())).thenReturn("");
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
             Set<LoadBalancer> loadBalancers = underTest.createLoadBalancers(stack, environment, false);
@@ -687,6 +693,7 @@ public class LoadBalancerConfigServiceTest extends SubnetTest {
         when(entitlementService.datalakeLoadBalancerEnabled(anyString())).thenReturn(true);
         when(blueprint.getBlueprintText()).thenReturn(getBlueprintText("input/de-ha.bp"));
         when(subnetSelector.findSubnetById(any(), anyString())).thenReturn(Optional.of(subnet));
+        when(availabilitySetNameService.generateName(any(), any())).thenReturn("");
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
             Set<LoadBalancer> loadBalancers = underTest.createLoadBalancers(stack, environment, false);
@@ -709,6 +716,7 @@ public class LoadBalancerConfigServiceTest extends SubnetTest {
 
         when(blueprint.getBlueprintText()).thenReturn(getBlueprintText("input/clouderamanager-knox.bp"));
         when(subnetSelector.findSubnetById(any(), anyString())).thenReturn(Optional.of(subnet));
+        when(availabilitySetNameService.generateName(any(), any())).thenReturn("");
 
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
             Set<LoadBalancer> loadBalancers = underTest.createLoadBalancers(stack, environment, false);


### PR DESCRIPTION
The Azure companion change to CB-13176. Gathers the Azure load balancer name and the availability set
name associated with each target group. That information is persisted to the database and returned
as part of the describe datalake output.

Tested with unit tests.