### PR TITLE
CB-13887 Fix spot tests when there is no spot capacity

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/CloudbreakTestDto.java
@@ -53,4 +53,12 @@ public interface CloudbreakTestDto extends Orderable, Assignable {
         throw new IllegalStateException(String.format("Error happened, getCrn() is not implemented for TestDto: %s", this));
     }
 
+    default <E extends Enum<E>> String getAwaitExceptionKey(E desiredStatus) {
+        return getAwaitExceptionKey(Map.of("status", desiredStatus));
+    }
+
+    default <E extends Enum<E>> String getAwaitExceptionKey(Map<String, E> desiredStatuses) {
+        return String.format("await %s for desired statuses %s", this, desiredStatuses);
+    }
+
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -49,6 +49,7 @@ import com.sequenceiq.it.cloudbreak.mock.ImageCatalogMockServerSetup;
 import com.sequenceiq.it.cloudbreak.util.azure.azurecloudblob.AzureCloudBlobUtil;
 import com.sequenceiq.sdx.api.model.SdxCloudStorageRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 
 public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
 
@@ -168,6 +169,21 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
     protected void createDatalake(TestContext testContext) {
         testContext
                 .given(SdxInternalTestDto.class)
+                    .withCloudStorage(getCloudStorageRequest(testContext))
+                .when(sdxTestClient.createInternal())
+                .await(SdxClusterStatusResponse.RUNNING)
+                .awaitForHealthyInstances()
+                .when(sdxTestClient.describeInternal())
+                .validate();
+    }
+
+    protected void createDatalakeWithoutDatabase(TestContext testContext) {
+        SdxDatabaseRequest database = new SdxDatabaseRequest();
+        database.setCreate(false);
+
+        testContext
+                .given(SdxInternalTestDto.class)
+                    .withDatabase(database)
                     .withCloudStorage(getCloudStorageRequest(testContext))
                 .when(sdxTestClient.createInternal())
                 .await(SdxClusterStatusResponse.RUNNING)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ResourceAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ResourceAwait.java
@@ -45,7 +45,7 @@ public class ResourceAwait {
                 Log.await(null, String.format("[%s] is failed for statuses %s: %s, name: %s",
                         entity, desiredStatuses, ResponseUtil.getErrorMessage(e), entity.getName()));
             }
-            testContext.getExceptionMap().put("await " + entity + " for desired statuses " + desiredStatuses, e);
+            testContext.getExceptionMap().put(entity.getAwaitExceptionKey(desiredStatuses), e);
         }
         return entity;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakWaitObject.java
@@ -97,7 +97,7 @@ public class CloudbreakWaitObject implements WaitObject {
 
     @Override
     public boolean isFailedCheck() {
-        return desiredStatuses.equals(STACK_FAILED);
+        return desiredStatuses.equals(STACK_FAILED) || desiredStatuses.get(STATUS).equals(Status.CREATE_FAILED);
     }
 
     public String getAccountId() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeWaitObject.java
@@ -108,6 +108,6 @@ public class DatalakeWaitObject implements WaitObject {
 
     @Override
     public boolean isFailedCheck() {
-        return false;
+        return desiredStatus.equals(PROVISIONING_FAILED);
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java
@@ -108,6 +108,6 @@ public class FreeIpaWaitObject implements WaitObject {
 
     @Override
     public boolean isFailedCheck() {
-        return false;
+        return desiredStatus.equals(CREATE_FAILED);
     }
 }


### PR DESCRIPTION
Await failed when the stack failed to create, so the then validation never ran. The solution was to remove the await exception from the TestContext.

See detailed description in the commit message.