### PR TITLE
CB-13882 Allow Data Hub maintenance upgrade for data engineering cust…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/PermittedServicesForUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/PermittedServicesForUpgradeService.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.service.upgrade.image;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+
+@Component
+class PermittedServicesForUpgradeService {
+
+    private static final String DEFAULT_MINIMUM_VERSION = "7.2.9";
+
+    @Value("${cb.upgrade.permittedServicesForUpgrade}")
+    private Set<String> permittedServicesForUpgrade;
+
+    private Map<String, String> serviceNameToMinimumVersionMap;
+
+    private final VersionComparator versionComparator = new VersionComparator();
+
+    @PostConstruct
+    void init() {
+        serviceNameToMinimumVersionMap = permittedServicesForUpgrade.stream()
+                .map(x -> x.split(":"))
+                .collect(Collectors.toMap(extractServiceName(), extractServiceMinimumVersion()));
+    }
+
+    boolean isAllowedForUpgrade(String serviceName, String blueprintVersion) {
+        return findMinimumVersionForService(serviceName)
+                .map(serviceMinimumVersion -> versionComparator.compare(() -> serviceMinimumVersion, () -> blueprintVersion) <= 0)
+                .orElse(false);
+    }
+
+    private Optional<String> findMinimumVersionForService(String serviceName) {
+        return Optional.ofNullable(serviceNameToMinimumVersionMap.get(serviceName));
+    }
+
+    private Function<String[], String> extractServiceMinimumVersion() {
+        return serviceNameVersionPair -> serviceNameVersionPair.length > 1 ? StringUtils.strip(serviceNameVersionPair[1]) : DEFAULT_MINIMUM_VERSION;
+    }
+
+    private Function<String[], String> extractServiceName() {
+        return serviceNameVersionPair -> StringUtils.strip(serviceNameVersionPair[0]);
+    }
+
+    @Override
+    public String toString() {
+        return "PermittedServicesForUpgradeService{" +
+                "serviceNameToMinimumVersionMap=" + serviceNameToMinimumVersionMap +
+                '}';
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -736,23 +736,23 @@ cb:
       sdx:
         enabled: false
     permittedServicesForUpgrade: >
-      DAS,
-      HDFS,
-      HIVE,
-      HIVE_ON_TEZ,
-      HUE,
-      KNOX,
-      LIVY,
-      LIVY_FOR_SPARK3,
-      OOZIE,
-      QUEUEMANAGER,
-      SPARK3_ON_YARN,
-      SPARK_ON_YARN,
-      SQOOP_CLIENT,
-      TEZ,
-      YARN,
-      ZEPPELIN,
-      ZOOKEEPER
+        DAS: 7.2.9,
+        HDFS: 7.2.9,
+        HIVE: 7.2.9,
+        HIVE_ON_TEZ: 7.2.9,
+        HUE: 7.2.9,
+        KNOX: 7.2.9,
+        LIVY: 7.2.9,
+        LIVY_FOR_SPARK3: 7.2.9,
+        OOZIE: 7.2.9,
+        QUEUEMANAGER: 7.2.9,
+        SPARK3_ON_YARN: 7.2.9,
+        SPARK_ON_YARN: 7.2.9,
+        SQOOP_CLIENT: 7.2.9,
+        TEZ: 7.2.9,
+        YARN: 7.2.9,
+        ZEPPELIN: 7.2.9,
+        ZOOKEEPER: 7.2.9
 
 cluster:
   monitoring:

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/PermittedServicesForUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/PermittedServicesForUpgradeServiceTest.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.service.upgrade.image;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class PermittedServicesForUpgradeServiceTest {
+
+    private final PermittedServicesForUpgradeService underTest = new PermittedServicesForUpgradeService();
+
+    @ParameterizedTest(name = "{3}")
+    @MethodSource("serviceAndVersionDataProvider")
+    void test(String serviceName, String serviceVersion, boolean expectedAllowedResult, String testCaseDescription) {
+        setUpPermittedServices(Set.of("Service1: 1.2.3 "));
+
+        assertEquals(expectedAllowedResult, underTest.isAllowedForUpgrade(serviceName, serviceVersion));
+    }
+
+    static Object[][] serviceAndVersionDataProvider() {
+        return new Object[][] {
+                {"Service2", "100.100.100", false, "A service not listed is not accepted"},
+                {"Service1", "1.2.2", false, "A service with a too low version is not allowed"},
+                {"Service1", "1.2.3", true, "A service with the minimum required version is allowed"},
+                {"Service1", "1.2.4", true, "A service above the minimum required version is allowed"}
+        };
+    }
+
+    private void setUpPermittedServices(Set<String> servicesWithMinimumVersion) {
+        ReflectionTestUtils.setField(underTest, "permittedServicesForUpgrade", servicesWithMinimumVersion);
+        underTest.init();
+    }
+
+}


### PR DESCRIPTION
…omer template 7.2.9 onwards

Data hub upgrades for custom templates is possible on two ways:
- either with entitlement
- or if all the used services in the blueprint are among allowed services for upgrade, listed in application.yml

Present commit restricts latter option: only blueprints with version 7.2.9 or above can be upgraded. The commit takes into account that some services may want to enable upgrade from a later version, so a minimum version per service is defined.

See detailed description in the commit message.