### PR TITLE
CB-13455 Enabling CMEK for GCP to encrypt FREEIPA disk

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/GcpInstanceTemplate.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/instance/GcpInstanceTemplate.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.cloud.model.instance;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.Volume;
+import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
+
+public class GcpInstanceTemplate extends InstanceTemplate {
+    /**
+     * Key denoting the method  of the disk encryption method to be used for GCP resources. If set to KMS,
+     * it would indicate the CMEK needs to be used. Default value would be RSA.
+     * <p>
+     *     Permitted values:
+     *     <ul>
+     *         <li>{@ENUM RAW} </li>
+     *         <li>{@ENUM KMS}: {@link #VOLUME_ENCRYPTION_KEY_ID}  will be used to encrypt the resource. </li>
+     *         <li>{@ENUM RSA}: Default Google managed encryption of resources. </li>
+     *         <li>{@code null}: RSA wil be considered as default value if null is provided. </li>
+     *     </ul>
+     * </p>
+     */
+    public static final String KEY_ENCRYPTION_METHOD = "keyEncryptionMethod";
+
+    public GcpInstanceTemplate(String flavor, String groupName, Long privateId, Collection<Volume> volumes, InstanceStatus status,
+            Map<String, Object> parameters, Long templateId, String imageId) {
+        super(flavor, groupName, privateId, volumes, status, parameters, templateId, imageId, TemporaryStorage.ATTACHED_VOLUMES);
+    }
+}

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/CustomGcpDiskEncryptionCreatorService.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/service/CustomGcpDiskEncryptionCreatorService.java
@@ -39,6 +39,7 @@ import org.springframework.stereotype.Service;
 import com.google.api.services.compute.model.CustomerEncryptionKey;
 import com.sequenceiq.cloudbreak.client.RestClientUtil;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.GcpInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 
 @Service
@@ -57,7 +58,7 @@ public class CustomGcpDiskEncryptionCreatorService {
 
     public CustomerEncryptionKey createCustomerEncryptionKey(InstanceTemplate template) {
         String key = Optional.ofNullable(template.getStringParameter(InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID)).orElse("");
-        String method = Optional.ofNullable(template.getStringParameter("keyEncryptionMethod")).orElse("RSA");
+        String method = Optional.ofNullable(template.getStringParameter(GcpInstanceTemplate.KEY_ENCRYPTION_METHOD)).orElse("RSA");
 
         switch (method) {
             case "RAW":

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/GcpInstanceTemplateV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/template/GcpInstanceTemplateV4Parameters.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceTemplateV4ParameterBase;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.KeyEncryptionMethod;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.GcpInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.doc.ModelDescriptions.TemplateModelDescription;
 import com.sequenceiq.common.api.type.EncryptionType;
@@ -47,7 +48,7 @@ public class GcpInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
         if (encryption != null) {
-            putIfValueNotNull(map, "keyEncryptionMethod", encryption.getKeyEncryptionMethod());
+            putIfValueNotNull(map, GcpInstanceTemplate.KEY_ENCRYPTION_METHOD, encryption.getKeyEncryptionMethod());
             putIfValueNotNull(map, InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, encryption.getType());
         }
         putIfValueNotNull(map, "preemptible", preemptible);
@@ -74,7 +75,7 @@ public class GcpInstanceTemplateV4Parameters extends InstanceTemplateV4Parameter
     public void parse(Map<String, Object> parameters) {
         GcpEncryptionV4Parameters encryption = new GcpEncryptionV4Parameters();
         encryption.setKey(getParameterOrNull(parameters, InstanceTemplate.VOLUME_ENCRYPTION_KEY_ID));
-        String keyEncryptionMethod = getParameterOrNull(parameters, "keyEncryptionMethod");
+        String keyEncryptionMethod = getParameterOrNull(parameters, GcpInstanceTemplate.KEY_ENCRYPTION_METHOD);
         if (keyEncryptionMethod != null) {
             encryption.setKeyEncryptionMethod(KeyEncryptionMethod.valueOf(keyEncryptionMethod));
         }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
@@ -8,12 +8,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.KeyEncryptionMethod;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsEncryptionV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4SpotParameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsPlacementGroupV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AzureEncryptionV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AzureInstanceTemplateV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.GcpEncryptionV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.GcpInstanceTemplateV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.YarnInstanceTemplateV4Parameters;
 import com.sequenceiq.common.api.type.EncryptionType;
@@ -26,6 +28,8 @@ import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.GcpIns
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.YarnInstanceTemplateV1Parameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 @Component
@@ -60,8 +64,10 @@ public class InstanceTemplateParameterConverter {
         return response;
     }
 
-    public GcpInstanceTemplateV4Parameters convert(GcpInstanceTemplateV1Parameters source) {
-        return new GcpInstanceTemplateV4Parameters();
+    public GcpInstanceTemplateV4Parameters convert(GcpInstanceTemplateV1Parameters source, DetailedEnvironmentResponse environment) {
+        GcpInstanceTemplateV4Parameters response = new GcpInstanceTemplateV4Parameters();
+        initGcpEncryptionFromEnvironment(response, environment);
+        return response;
     }
 
     public GcpInstanceTemplateV1Parameters convert(GcpInstanceTemplateV4Parameters source) {
@@ -91,6 +97,24 @@ public class InstanceTemplateParameterConverter {
             response.setEncryption(encryption);
         } else {
             LOGGER.info("Environment has not requested for SSE with CMK for Azure managed disks.");
+        }
+    }
+
+    private void initGcpEncryptionFromEnvironment(GcpInstanceTemplateV4Parameters response, DetailedEnvironmentResponse environment) {
+        String encryptionKey = Optional.of(environment)
+                .map(DetailedEnvironmentResponse::getGcp)
+                .map(GcpEnvironmentParameters::getGcpResourceEncryptionParameters)
+                .map(GcpResourceEncryptionParameters::getEncryptionKey)
+                .orElse(null);
+        if (encryptionKey != null) {
+            LOGGER.info("Applying Encryption with CMEK for GCP disks as per environment.");
+            GcpEncryptionV4Parameters encryption = new GcpEncryptionV4Parameters();
+            encryption.setType(EncryptionType.CUSTOM);
+            encryption.setKeyEncryptionMethod(KeyEncryptionMethod.KMS);
+            encryption.setKey(encryptionKey);
+            response.setEncryption(encryption);
+        } else {
+            LOGGER.info("Environment has not requested for Customer-Managed Encryption with CMEK for GCP disks.");
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateV1ToInstanceTemplateV4Converter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateV1ToInstanceTemplateV4Converter.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.template.InstanceTemplateV4Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AzureInstanceTemplateV1Parameters;
+import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.GcpInstanceTemplateV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.InstanceTemplateV1Request;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
@@ -31,7 +32,9 @@ public class InstanceTemplateV1ToInstanceTemplateV4Converter {
         AzureInstanceTemplateV1Parameters azureParametersEffective = Objects.requireNonNullElse(source.getAzure(),
                 new AzureInstanceTemplateV1Parameters());
         response.setAzure(instanceTemplateParameterConverter.convert(azureParametersEffective, environment));
-        response.setGcp(getIfNotNull(source.getGcp(), instanceTemplateParameterConverter::convert));
+        GcpInstanceTemplateV1Parameters gcpParametersEffective = Objects.requireNonNullElse(source.getGcp(),
+                new GcpInstanceTemplateV1Parameters());
+        response.setGcp(instanceTemplateParameterConverter.convert(gcpParametersEffective, environment));
         response.setYarn(getIfNotNull(source.getYarn(), instanceTemplateParameterConverter::convert));
         response.setCloudPlatform(source.getCloudPlatform());
         response.setInstanceType(source.getInstanceType());

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverterTest.java
@@ -7,12 +7,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.KeyEncryptionMethod;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AzureEncryptionV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AzureInstanceTemplateV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.GcpEncryptionV4Parameters;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.GcpInstanceTemplateV4Parameters;
 import com.sequenceiq.common.api.type.EncryptionType;
 import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.AzureInstanceTemplateV1Parameters;
+import com.sequenceiq.distrox.api.v1.distrox.model.instancegroup.template.GcpInstanceTemplateV1Parameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 class InstanceTemplateParameterConverterTest {
@@ -20,6 +26,8 @@ class InstanceTemplateParameterConverterTest {
     private static final String PRIVATE_ID = "privateId";
 
     private static final String DISK_ENCRYPTION_SET_ID = "diskEncryptionSetId";
+
+    private static final String ENCRYPTION_KEY = "encryptionKey";
 
     private InstanceTemplateParameterConverter underTest;
 
@@ -89,4 +97,62 @@ class InstanceTemplateParameterConverterTest {
         return  environment;
     }
 
+    @Test
+    void convertTestGcpInstanceTemplateV1ParametersToGcpInstanceTemplateV4ParametersWhenBasicFields() {
+        GcpInstanceTemplateV1Parameters source = new GcpInstanceTemplateV1Parameters();
+
+        DetailedEnvironmentResponse environment = createDetailedEnvironmentResponseForGcpEncryption(false, false, null);
+
+        GcpInstanceTemplateV4Parameters gcpInstanceTemplateV4Parameters = underTest.convert(source, environment);
+
+        assertThat(gcpInstanceTemplateV4Parameters).isNotNull();
+    }
+
+    static Object[][] convertTestGcpInstanceTemplateV1ParametersToGcpInstanceTemplateV4ParametersWhenEncryptionDataProvided() {
+        return new Object[][]{
+                // testCaseName withGcp withResourceEncryption encryptionKey expectedEncryption expectedEncryptionKey
+                {"withGcp=false", false, false, null, false, null},
+                {"withGcp=true, withResourceEncryption=false", true, false, null, false, null},
+                {"withGcp=true, withResourceEncryption=true, encryptionKey=null", true, true, null, false, null},
+                {"withGcp=true, withResourceEncryption=true, encryptionKey=ENCRYPTION_KEY", true, true, ENCRYPTION_KEY, true,
+                        ENCRYPTION_KEY},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("convertTestGcpInstanceTemplateV1ParametersToGcpInstanceTemplateV4ParametersWhenEncryptionDataProvided")
+    void convertTestGcpInstanceTemplateV1ParametersToGcpInstanceTemplateV4ParametersWhenEncryption(String testCaseName, boolean withGcp,
+            boolean withResourceEncryption, String encryptionKey, boolean expectedEncryption, String expectedEncryptionKey) {
+        GcpInstanceTemplateV1Parameters source = new GcpInstanceTemplateV1Parameters();
+        DetailedEnvironmentResponse environment = createDetailedEnvironmentResponseForGcpEncryption(withGcp, withResourceEncryption, encryptionKey);
+
+        GcpInstanceTemplateV4Parameters gcpInstanceTemplateV4Parameters = underTest.convert(source, environment);
+
+        assertThat(gcpInstanceTemplateV4Parameters).isNotNull();
+
+        GcpEncryptionV4Parameters encryption = gcpInstanceTemplateV4Parameters.getEncryption();
+        if (expectedEncryption) {
+            assertThat(encryption).isNotNull();
+            assertThat(encryption.getType()).isEqualTo(EncryptionType.CUSTOM);
+            assertThat(encryption.getKeyEncryptionMethod()).isEqualTo(KeyEncryptionMethod.KMS);
+            assertThat(encryption.getKey()).isEqualTo(expectedEncryptionKey);
+        } else {
+            assertThat(encryption).isNull();
+        }
+    }
+
+    private DetailedEnvironmentResponse createDetailedEnvironmentResponseForGcpEncryption(boolean withGcp, boolean withResourceEncryption,
+            String encryptionKey) {
+        DetailedEnvironmentResponse environment = new DetailedEnvironmentResponse();
+        if (withGcp) {
+            GcpEnvironmentParameters parameters = new GcpEnvironmentParameters();
+            environment.setGcp(parameters);
+            if (withResourceEncryption) {
+                GcpResourceEncryptionParameters encryption = new GcpResourceEncryptionParameters();
+                parameters.setGcpResourceEncryptionParameters(encryption);
+                encryption.setEncryptionKey(encryptionKey);
+            }
+        }
+        return  environment;
+    }
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -120,6 +120,9 @@ public class EnvironmentModelDescription {
     public static final String PARENT_ENVIRONMENT_NAME = "Parent environment name";
     public static final String PARENT_ENVIRONMENT_CLOUD_PLATFORM = "Parent environment cloud platform";
 
+    public static final String GCP_RESOURCE_ENCRYPTION_PARAMETERS = "Parameter for GCP resource encryption.";
+    public static final String ENCRYPTION_KEY = "Key Resource of the Customer Managed Encryption Key to encrypt GCP resources";
+
     public static final String FREEIPA_AWS_PARAMETERS = "Aws specific FreeIpa parameters";
     public static final String FREEIPA_AZURE_PARAMETERS = "Azure specific FreeIpa parameters";
     public static final String FREEIPA_OPENSTACK_PARAMETERS = "Openstack specific FreeIpa parameters";

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/gcp/GcpEnvironmentParameters.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/gcp/GcpEnvironmentParameters.java
@@ -2,15 +2,33 @@ package com.sequenceiq.environment.api.v1.environment.model.request.gcp;
 
 import java.io.Serializable;
 
+import javax.validation.Valid;
+
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 @ApiModel(value = "GcpEnvironmentV1Parameters")
 public class GcpEnvironmentParameters implements Serializable {
 
+    @Valid
+    @ApiModelProperty(EnvironmentModelDescription.GCP_RESOURCE_ENCRYPTION_PARAMETERS)
+    private GcpResourceEncryptionParameters gcpResourceEncryptionParameters;
+
     public GcpEnvironmentParameters() {
     }
 
-    private GcpEnvironmentParameters(Builder builder) {
+    private GcpEnvironmentParameters(GcpEnvironmentParameters.Builder builder) {
+        gcpResourceEncryptionParameters = builder.gcpResourceEncryptionParameters;
+    }
+
+    public GcpResourceEncryptionParameters getGcpResourceEncryptionParameters() {
+        return gcpResourceEncryptionParameters;
+    }
+
+    public void setGcpResourceEncryptionParameters(GcpResourceEncryptionParameters gcpResourceEncryptionParameters) {
+        this.gcpResourceEncryptionParameters = gcpResourceEncryptionParameters;
     }
 
     public static Builder builder() {
@@ -19,12 +37,20 @@ public class GcpEnvironmentParameters implements Serializable {
 
     @Override
     public String toString() {
-        return "GcpEnvironmentParameters{}";
+        return "GcpResourceEncryptionParameters{" +
+                ", gcpResourceEncryptionParameters=" + gcpResourceEncryptionParameters +
+                '}';
     }
 
     public static final class Builder {
+        private GcpResourceEncryptionParameters gcpResourceEncryptionParameters;
 
         private Builder() {
+        }
+
+        public Builder withResourceEncryptionParameters(GcpResourceEncryptionParameters gcpResourceEncryptionParameters) {
+            this.gcpResourceEncryptionParameters = gcpResourceEncryptionParameters;
+            return this;
         }
 
         public GcpEnvironmentParameters build() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/gcp/GcpResourceEncryptionParameters.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/gcp/GcpResourceEncryptionParameters.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.environment.api.v1.environment.model.request.gcp;
+
+import java.io.Serializable;
+
+import javax.validation.constraints.Pattern;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(value = "GcpResourceEncryptionV1Parameters")
+public class GcpResourceEncryptionParameters implements Serializable {
+
+    @VisibleForTesting
+    static final String ENCRYPTION_KEY_INVALID_MSG =
+            "Expected Format: '/projects/<projectName>/locations/<location>/keyRings/<KeyRing>/cryptoKeys/<KeyName>'. " +
+            "Key location should be same as resource location " +
+            "<keyName> may only contain alphanumeric characters and dashes.";
+
+    @ApiModelProperty(EnvironmentModelDescription.ENCRYPTION_KEY)
+    @Pattern(regexp = "projects\\/[a-zA-Z0-9_-]{1,63}\\/" +
+            "locations\\/[a-zA-Z0-9_-]{1,63}\\/keyRings\\/[a-zA-Z0-9_-]{1,63}\\/cryptoKeys\\/[a-zA-Z0-9_-]{1,63}",
+            message = ENCRYPTION_KEY_INVALID_MSG)
+    private String encryptionKey;
+
+    public GcpResourceEncryptionParameters() {
+    }
+
+    private GcpResourceEncryptionParameters(GcpResourceEncryptionParameters.Builder builder) {
+        this.encryptionKey = builder.encryptionKey;
+    }
+
+    public String getEncryptionKey() {
+        return encryptionKey;
+    }
+
+    public void setEncryptionKey(String encryptionKey) {
+        this.encryptionKey = encryptionKey;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "GcpResourceEncryptionParameters{" +
+                "encryptionKey='" + encryptionKey + '\'' +
+                '}';
+    }
+
+    public static class Builder {
+        private String encryptionKey;
+
+        private Builder() {
+        }
+
+        public Builder withEncryptionKey(String encryptionKey) {
+            this.encryptionKey = encryptionKey;
+            return this;
+        }
+
+        public GcpResourceEncryptionParameters build() {
+            return new GcpResourceEncryptionParameters(this);
+        }
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
@@ -180,6 +180,7 @@ public class EnvironmentCreationService {
         validationBuilder.merge(validatorService.validatePublicKey(creationDto.getAuthentication().getPublicKey()));
         validationBuilder.merge(validatorService.validateTags(creationDto));
         validationBuilder.merge(validatorService.validateEncryptionKeyUrl(creationDto));
+        validationBuilder.merge(validatorService.validateEncryptionKey(creationDto));
         validationBuilder.merge(validatorService.validateEncryptionKeyArn(creationDto));
         ValidationResult parentChildValidation = validatorService.validateParentChildRelation(environment, creationDto.getParentEnvironmentName());
         validationBuilder.merge(parentChildValidation);

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
@@ -2,6 +2,7 @@ package com.sequenceiq.environment.environment.v1.converter;
 
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.GCP;
 import static com.sequenceiq.common.model.CredentialType.ENVIRONMENT;
 import static com.sequenceiq.environment.environment.dto.EnvironmentChangeCredentialDto.EnvironmentChangeCredentialDtoBuilder.anEnvironmentChangeCredentialDto;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -40,6 +41,8 @@ import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEn
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.ResourceGroupUsage;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
 import com.sequenceiq.environment.credential.service.CredentialService;
 import com.sequenceiq.environment.credential.v1.converter.TunnelConverter;
@@ -59,6 +62,8 @@ import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceGroupDto;
+import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
+import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameter.dto.ResourceGroupCreation;
 import com.sequenceiq.environment.parameter.dto.ResourceGroupUsagePattern;
@@ -162,6 +167,8 @@ public class EnvironmentApiConverter {
             return awsParamsToParametersDto(request.getAws(), Optional.ofNullable(request.getFreeIpa()).map(AttachedFreeIpaRequest::getAws).orElse(null));
         } else if (AZURE.name().equals(cloudPlatform)) {
             return azureParamsToParametersDto(request.getAzure());
+        } else if (GCP.name().equals(cloudPlatform)) {
+            return gcpParamsToParametersDto(request.getGcp());
         }
         return null;
     }
@@ -185,6 +192,18 @@ public class EnvironmentApiConverter {
         }
         return ParametersDto.builder()
                 .withAzureParameters(azureParamsToAzureParametersDto(azureEnvironmentParameters))
+                .build();
+    }
+
+    private ParametersDto gcpParamsToParametersDto(GcpEnvironmentParameters gcpEnvironmentParameters) {
+        if (Objects.isNull(gcpEnvironmentParameters)) {
+            return ParametersDto.builder()
+                    .withGcpParameters(GcpParametersDto.builder()
+                            .build())
+                    .build();
+        }
+        return ParametersDto.builder()
+                .withGcpParameters(gcpParamsToGcpParametersDto(gcpEnvironmentParameters))
                 .build();
     }
 
@@ -234,7 +253,18 @@ public class EnvironmentApiConverter {
                                 .orElse(null)
                 )
                 .build();
+    }
 
+    private GcpParametersDto gcpParamsToGcpParametersDto(GcpEnvironmentParameters gcpEnvironmentParameters) {
+        return GcpParametersDto.builder()
+                .withEncryptionParameters(
+                        Optional.ofNullable(gcpEnvironmentParameters)
+                                .map(GcpEnvironmentParameters::getGcpResourceEncryptionParameters)
+                                .filter(gcpResourceEncryptionParameters -> Objects.nonNull(gcpResourceEncryptionParameters.getEncryptionKey()))
+                                .map(this::gcpResourceEncryptionParametersToGcpEncryptionParametersDto)
+                                .orElse(null)
+                )
+                .build();
     }
 
     private AzureResourceEncryptionParametersDto azureResourceEncryptionParametersToAzureEncryptionParametersDto(
@@ -243,6 +273,13 @@ public class EnvironmentApiConverter {
                 .withEncryptionKeyUrl(azureResourceEncryptionParameters.getEncryptionKeyUrl())
                 .withEncryptionKeyResourceGroupName(azureResourceEncryptionParameters.getEncryptionKeyResourceGroupName());
         return azureResourceEncryptionParametersDto.build();
+    }
+
+    private GcpResourceEncryptionParametersDto gcpResourceEncryptionParametersToGcpEncryptionParametersDto(
+            GcpResourceEncryptionParameters gcpResourceEncryptionParameters) {
+        GcpResourceEncryptionParametersDto.Builder gcpResourceEncryptionParametersDto = GcpResourceEncryptionParametersDto.builder()
+                .withEncryptionKey(gcpResourceEncryptionParameters.getEncryptionKey());
+        return gcpResourceEncryptionParametersDto.build();
     }
 
     private AzureResourceGroupDto buildDefaultResourceGroupDto() {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -19,6 +19,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureRe
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.ResourceGroupUsage;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.yarn.YarnEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentAuthenticationResponse;
@@ -40,6 +41,8 @@ import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceGroupDto;
+import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
+import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameter.dto.ResourceGroupUsagePattern;
 import com.sequenceiq.environment.proxy.v1.converter.ProxyConfigToProxyResponseConverter;
@@ -208,8 +211,13 @@ public class EnvironmentResponseConverter {
     }
 
     private GcpEnvironmentParameters gcpEnvParamsToGcpEnvironmentParams(ParametersDto parameters) {
+        GcpResourceEncryptionParametersDto gcpResourceEncryptionParametersDto = Optional.ofNullable(parameters.getGcpParametersDto())
+                .map(GcpParametersDto::getGcpResourceEncryptionParametersDto)
+                .orElse(null);
+
         return Optional.ofNullable(parameters.getGcpParametersDto())
-                .map(yarn -> GcpEnvironmentParameters.builder()
+                .map(gcp -> GcpEnvironmentParameters.builder()
+                        .withResourceEncryptionParameters(getIfNotNull(gcpResourceEncryptionParametersDto, this::gcpParametersToGcpResourceEncryptionParameters))
                         .build())
                 .orElse(null);
     }
@@ -239,6 +247,13 @@ public class EnvironmentResponseConverter {
                 .withEncryptionKeyUrl(azureResourceEncryptionParametersDto.getEncryptionKeyUrl())
                 .withDiskEncryptionSetId(azureResourceEncryptionParametersDto.getDiskEncryptionSetId())
                 .withEncryptionKeyResourceGroupName(azureResourceEncryptionParametersDto.getEncryptionKeyResourceGroupName())
+                .build();
+    }
+
+    private GcpResourceEncryptionParameters gcpParametersToGcpResourceEncryptionParameters(
+            GcpResourceEncryptionParametersDto gcpResourceEncryptionParametersDto) {
+        return GcpResourceEncryptionParameters.builder()
+                .withEncryptionKey(gcpResourceEncryptionParametersDto.getEncryptionKey())
                 .build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
@@ -3,7 +3,9 @@ package com.sequenceiq.environment.environment.validation;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
 import static com.sequenceiq.cloudbreak.util.SecurityGroupSeparator.getSecurityGroupIds;
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.GCP;
 import static com.sequenceiq.common.model.CredentialType.ENVIRONMENT;
+
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.logging.log4j.util.Strings.isEmpty;
 
@@ -45,6 +47,7 @@ import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
 import com.sequenceiq.environment.environment.service.EnvironmentResourceService;
 import com.sequenceiq.environment.environment.validation.validators.EncryptionKeyArnValidator;
 import com.sequenceiq.environment.environment.validation.validators.EncryptionKeyUrlValidator;
+import com.sequenceiq.environment.environment.validation.validators.EncryptionKeyValidator;
 import com.sequenceiq.environment.environment.validation.validators.NetworkCreationValidator;
 import com.sequenceiq.environment.environment.validation.validators.PublicKeyValidator;
 import com.sequenceiq.environment.environment.validation.validators.TagValidator;
@@ -83,6 +86,8 @@ public class EnvironmentValidatorService {
 
     private final EntitlementService entitlementService;
 
+    private final EncryptionKeyValidator encryptionKeyValidator;
+
     public EnvironmentValidatorService(NetworkCreationValidator networkCreationValidator,
             PlatformParameterService platformParameterService,
             EnvironmentResourceService environmentResourceService,
@@ -93,7 +98,8 @@ public class EnvironmentValidatorService {
             TagValidator tagValidator,
             EncryptionKeyArnValidator encryptionKeyArnValidator,
             EncryptionKeyUrlValidator encryptionKeyUrlValidator,
-            EntitlementService entitlementService) {
+            EntitlementService entitlementService,
+            EncryptionKeyValidator encryptionKeyValidator) {
         this.networkCreationValidator = networkCreationValidator;
         this.platformParameterService = platformParameterService;
         this.environmentResourceService = environmentResourceService;
@@ -105,6 +111,7 @@ public class EnvironmentValidatorService {
         this.encryptionKeyArnValidator = encryptionKeyArnValidator;
         this.encryptionKeyUrlValidator = encryptionKeyUrlValidator;
         this.entitlementService = entitlementService;
+        this.encryptionKeyValidator = encryptionKeyValidator;
     }
 
     public ValidationResultBuilder validateNetworkCreation(Environment environment, NetworkDto network) {
@@ -308,6 +315,27 @@ public class EnvironmentValidatorService {
                             "enabled for your account to use SSE with CMK."));
                 } else {
                     ValidationResult validationResult = encryptionKeyArnValidator.validateEncryptionKeyArn(encryptionKeyArn);
+                    resultBuilder.merge(validationResult);
+                }
+            }
+        }
+        return resultBuilder.build();
+    }
+
+    public ValidationResult validateEncryptionKey(EnvironmentCreationDto creationDto) {
+        ValidationResultBuilder resultBuilder = ValidationResult.builder();
+        if (GCP.name().equalsIgnoreCase(creationDto.getCloudPlatform())) {
+            String encryptionKey = Optional.ofNullable(creationDto.getParameters())
+                    .map(parametersDto -> parametersDto.getGcpParametersDto())
+                    .map(gcpParametersDto -> gcpParametersDto.getGcpResourceEncryptionParametersDto())
+                    .map(gcpREParamsDto -> gcpREParamsDto.getEncryptionKey()).orElse(null);
+            if (StringUtils.isNotEmpty(encryptionKey)) {
+                if (!entitlementService.isGcpDiskEncryptionWithCMEKEnabled(creationDto.getAccountId())) {
+                    resultBuilder.error(String.format("You have specified encryption-key to enable encryption for GCP resources with CMEK "
+                            + "but that feature is currently not enabled for this account."
+                            + " Please get 'CDP_CB_GCP_DISK_ENCRYPTION_WITH_CMEK' enabled for this account."));
+                } else {
+                    ValidationResult validationResult = encryptionKeyValidator.validateEncryptionKey(encryptionKey);
                     resultBuilder.merge(validationResult);
                 }
             }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyValidator.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.environment.environment.validation.validators;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+
+@Component
+public class EncryptionKeyValidator {
+
+    private static final Pattern ENCRYPTION_KEY_PATTERN = Pattern.compile("projects\\/[a-zA-Z0-9_-]{1,63}\\/" +
+            "locations\\/[a-zA-Z0-9_-]{1,63}\\/keyRings\\/[a-zA-Z0-9_-]{1,63}\\/cryptoKeys\\/[a-zA-Z0-9_-]{1,63}");
+
+    public ValidationResult validateEncryptionKey(String encryptionKey) {
+        ValidationResult.ValidationResultBuilder validationResultBuilder = ValidationResult.builder();
+        Matcher matcher = ENCRYPTION_KEY_PATTERN.matcher(encryptionKey.trim());
+        if (!matcher.matches()) {
+            validationResultBuilder.error(String.format("Expected Format: '/projects/<projectName>/locations/<location>/" +
+                    "keyRings/<keyRing>/cryptoKeys/<keyName>'. " +
+                    "Key location should be same as resource location " +
+                    "<keyName> may only contain alphanumeric characters and dashes."));
+        }
+        return validationResultBuilder.build();
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/EnvironmentParameterValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/EnvironmentParameterValidator.java
@@ -23,7 +23,7 @@ public class EnvironmentParameterValidator {
     public EnvironmentParameterValidator(List<ParameterValidator> parameterValidators) {
         parameterValidatorsByCloudPlatform = parameterValidators
                 .stream()
-                .collect(Collectors.toMap(pv -> pv.getcloudPlatform().name(), Function.identity()));
+                .collect(Collectors.toMap(pv -> pv.getCloudPlatform().name(), Function.identity()));
     }
 
     public ValidationResult validate(EnvironmentValidationDto environmentValidationDto, ParametersDto parametersDto) {

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/GcpParameters.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/dao/domain/GcpParameters.java
@@ -1,10 +1,35 @@
 package com.sequenceiq.environment.parameters.dao.domain;
 
+import static com.sequenceiq.cloudbreak.util.NullUtil.getIfNotNull;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 
+import com.sequenceiq.cloudbreak.service.secret.SecretValue;
+import com.sequenceiq.cloudbreak.service.secret.domain.AccountIdAwareResource;
+import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
+import com.sequenceiq.cloudbreak.service.secret.domain.SecretToString;
+
 @Entity
 @DiscriminatorValue("GCP")
-public class GcpParameters extends BaseParameters {
+public class GcpParameters extends BaseParameters implements AccountIdAwareResource {
 
+    @Column(name = "encryption_key")
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret encryptionKey = Secret.EMPTY;
+
+    public String getEncryptionKey() {
+        return getIfNotNull(encryptionKey, Secret::getRaw);
+    }
+
+    public String getEncryptionKeySecret() {
+        return getIfNotNull(encryptionKey, Secret::getSecret);
+    }
+
+    public void setEncryptionKey(String encryptionKey) {
+        this.encryptionKey = new Secret(encryptionKey);
+    }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/GcpEnvironmentParametersConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/v1/converter/GcpEnvironmentParametersConverter.java
@@ -1,11 +1,14 @@
 package com.sequenceiq.environment.parameters.v1.converter;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameters.dao.domain.BaseParameters;
-import com.sequenceiq.environment.parameters.dao.domain.YarnParameters;
+import com.sequenceiq.environment.parameters.dao.domain.GcpParameters;
 import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto.Builder;
@@ -15,7 +18,7 @@ public class GcpEnvironmentParametersConverter extends BaseEnvironmentParameters
 
     @Override
     protected BaseParameters createInstance() {
-        return new YarnParameters();
+        return new GcpParameters();
     }
 
     @Override
@@ -26,11 +29,24 @@ public class GcpEnvironmentParametersConverter extends BaseEnvironmentParameters
     @Override
     protected void postConvert(BaseParameters baseParameters, Environment environment, ParametersDto parametersDto) {
         super.postConvert(baseParameters, environment, parametersDto);
+        GcpParameters gcpParameters = (GcpParameters) baseParameters;
+        Optional<GcpParametersDto> gcpParametersDto = Optional.of(parametersDto)
+                .map(ParametersDto::getGcpParametersDto);
+        gcpParameters.setEncryptionKey(gcpParametersDto
+                .map(GcpParametersDto::getGcpResourceEncryptionParametersDto)
+                .map(GcpResourceEncryptionParametersDto::getEncryptionKey)
+                .orElse(null));
     }
 
     @Override
     protected void postConvertToDto(Builder builder, BaseParameters source) {
         super.postConvertToDto(builder, source);
-        builder.withGcpParameters(GcpParametersDto.builder().build());
+        GcpParameters gcpParameters = (GcpParameters) source;
+        builder.withGcpParameters(GcpParametersDto.builder()
+                .withEncryptionParameters(
+                        GcpResourceEncryptionParametersDto.builder()
+                                .withEncryptionKey(gcpParameters.getEncryptionKey())
+                                .build())
+                .build());
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AwsParameterValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AwsParameterValidator.java
@@ -84,7 +84,7 @@ public class AwsParameterValidator implements ParameterValidator {
     }
 
     @Override
-    public CloudPlatform getcloudPlatform() {
+    public CloudPlatform getCloudPlatform() {
         return CloudPlatform.AWS;
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AzureParameterValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/AzureParameterValidator.java
@@ -199,7 +199,7 @@ public class AzureParameterValidator implements ParameterValidator {
     }
 
     @Override
-    public CloudPlatform getcloudPlatform() {
+    public CloudPlatform getCloudPlatform() {
         return CloudPlatform.AZURE;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/GcpParameterValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/GcpParameterValidator.java
@@ -1,0 +1,81 @@
+package com.sequenceiq.environment.parameters.validation.validators.parameter;
+
+import java.util.Objects;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.cloudbreak.validation.ValidationResult.ValidationResultBuilder;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.dto.EnvironmentValidationDto;
+import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
+import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
+import com.sequenceiq.environment.parameter.dto.ParametersDto;
+
+@Component
+public class GcpParameterValidator implements ParameterValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GcpParameterValidator.class);
+
+    @Inject
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Inject
+    private EntitlementService entitlementService;
+
+    @Override
+    public ValidationResult validate(EnvironmentValidationDto environmentValidationDto, ParametersDto parametersDto,
+            ValidationResultBuilder validationResultBuilder) {
+
+        EnvironmentDto environmentDto = environmentValidationDto.getEnvironmentDto();
+        LOGGER.debug("ParametersDto: {}", parametersDto);
+        GcpParametersDto gcpParametersDto = parametersDto.getGcpParametersDto();
+        if (Objects.isNull(gcpParametersDto)) {
+            return validationResultBuilder.build();
+        }
+
+        ValidationResult validationResult;
+        GcpResourceEncryptionParametersDto gcpResourceEncryptionParametersDto = gcpParametersDto.getGcpResourceEncryptionParametersDto();
+        if (gcpResourceEncryptionParametersDto != null) {
+            validationResult = validateGcpEncryptionParameters(validationResultBuilder, gcpParametersDto,
+                    environmentDto.getAccountId());
+            if (validationResult.hasError()) {
+                return validationResult;
+            }
+        }
+        return validationResultBuilder.build();
+    }
+
+    private ValidationResult validateGcpEncryptionParameters(ValidationResultBuilder validationResultBuilder,
+            GcpParametersDto gcpParametersDto, String accountId) {
+
+        GcpResourceEncryptionParametersDto gcpResourceEncryptionParametersDto = gcpParametersDto.getGcpResourceEncryptionParametersDto();
+        String encryptionKey = gcpResourceEncryptionParametersDto.getEncryptionKey();
+
+        if (encryptionKey != null) {
+            if (!entitlementService.isGcpDiskEncryptionWithCMEKEnabled(accountId)) {
+                LOGGER.info("Invalid request, CDP_CB_GCP_DISK_ENCRYPTION_WITH_CMEK entitlement turned off for account {}", accountId);
+                return validationResultBuilder.error(
+                        "You specified encryptionKey to encrypt resources with CMEK, "
+                                + "but that feature is currently disabled."
+                                + "Get 'CDP_CB_GCP_DISK_ENCRYPTION_WITH_CMEK' enabled for your account to use resource encryption with CMEK.").
+                        build();
+            }
+        }
+
+        LOGGER.debug("Validation of encryption parameters is successful.");
+        return validationResultBuilder.build();
+    }
+
+    @Override
+    public CloudPlatform getCloudPlatform() {
+        return CloudPlatform.GCP;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/ParameterValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/parameters/validation/validators/parameter/ParameterValidator.java
@@ -10,5 +10,5 @@ public interface ParameterValidator {
 
     ValidationResult validate(EnvironmentValidationDto environmentValidationDto, ParametersDto parametersDto, ValidationResultBuilder validationResultBuilder);
 
-    CloudPlatform getcloudPlatform();
+    CloudPlatform getCloudPlatform();
 }

--- a/environment/src/main/resources/schema/app/20210726001206_CB-13455_add_EncryptionKey_for_create-gcp-environment_in_cli.sql
+++ b/environment/src/main/resources/schema/app/20210726001206_CB-13455_add_EncryptionKey_for_create-gcp-environment_in_cli.sql
@@ -1,0 +1,9 @@
+-- // CB-13455_add_EncryptionKey_for_create-gcp-environment_in_cli
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment_parameters ADD COLUMN IF NOT EXISTS encryption_key text;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE environment_parameters DROP COLUMN IF EXISTS encryption_key;
+

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
@@ -463,6 +463,39 @@ class EnvironmentCreationServiceTest {
     }
 
     @Test
+    void testEncryptionKeyValidationError() {
+        final EnvironmentCreationDto environmentCreationDto = EnvironmentCreationDto.builder()
+                .withName(ENVIRONMENT_NAME)
+                .withCloudPlatform("GCP")
+                .withCreator(CRN)
+                .withAccountId(ACCOUNT_ID)
+                .withAuthentication(AuthenticationDto.builder().build())
+                .build();
+        final Environment environment = new Environment();
+        environment.setName(ENVIRONMENT_NAME);
+        environment.setId(1L);
+        environment.setAccountId(ACCOUNT_ID);
+        Credential credential = new Credential();
+        credential.setCloudPlatform("GCP");
+
+        ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
+        validationResultBuilder.error("error");
+        when(validatorService.validateEncryptionKeyUrl(any())).thenReturn(validationResultBuilder.build());
+
+        when(environmentService.isNameOccupied(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(false);
+        when(environmentDtoConverter.creationDtoToEnvironment(eq(environmentCreationDto))).thenReturn(environment);
+        when(environmentResourceService.getCredentialFromRequest(any(), any())).thenReturn(credential);
+        when(validatorService.validateParentChildRelation(any(), any())).thenReturn(ValidationResult.builder().build());
+        when(validatorService.validateNetworkCreation(any(), any())).thenReturn(ValidationResult.builder());
+        when(validatorService.validateFreeIpaCreation(any())).thenReturn(ValidationResult.builder().build());
+        when(authenticationDtoConverter.dtoToAuthentication(any())).thenReturn(new EnvironmentAuthentication());
+        when(entitlementService.azureEnabled(eq(ACCOUNT_ID))).thenReturn(true);
+        when(environmentService.save(any())).thenReturn(environment);
+
+        assertThrows(BadRequestException.class, () -> environmentCreationServiceUnderTest.create(environmentCreationDto));
+    }
+
+    @Test
     void testEncryptionKeyArnValidationError() {
         final EnvironmentCreationDto environmentCreationDto = EnvironmentCreationDto.builder()
                 .withName(ENVIRONMENT_NAME)

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
@@ -53,6 +53,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureRe
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.ResourceGroupUsage;
 import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
 import com.sequenceiq.environment.credential.service.CredentialService;
 import com.sequenceiq.environment.credential.v1.converter.TunnelConverter;
 import com.sequenceiq.environment.environment.domain.ExperimentalFeatures;
@@ -349,6 +350,36 @@ public class EnvironmentApiConverterTest {
                 actual.getParameters().getAzureParametersDto().getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
     }
 
+    @Test
+    void testGcpResourceEncryptionParametersAndGcpRequest() {
+        EnvironmentRequest request = createEnvironmentRequest(GCP);
+        request.setGcp(GcpEnvironmentParameters.builder()
+                .withResourceEncryptionParameters(
+                        GcpResourceEncryptionParameters.builder()
+                                .withEncryptionKey("dummy-encryption-key")
+                                .build())
+                .build());
+        FreeIpaCreationDto freeIpaCreationDto = mock(FreeIpaCreationDto.class);
+        EnvironmentTelemetry environmentTelemetry = mock(EnvironmentTelemetry.class);
+        EnvironmentBackup environmentBackup = mock(EnvironmentBackup.class);
+        AccountTelemetry accountTelemetry = mock(AccountTelemetry.class);
+        Features features = mock(Features.class);
+        NetworkDto networkDto = mock(NetworkDto.class);
+        when(credentialService.getCloudPlatformByCredential(anyString(), anyString(), any())).thenReturn(GCP.name());
+        when(freeIpaConverter.convert(request.getFreeIpa(), "id")).thenReturn(freeIpaCreationDto);
+        when(accountTelemetry.getFeatures()).thenReturn(features);
+        when(accountTelemetryService.getOrDefault(any())).thenReturn(accountTelemetry);
+        when(telemetryApiConverter.convert(eq(request.getTelemetry()), any())).thenReturn(environmentTelemetry);
+        when(backupConverter.convert(eq(request.getBackup()))).thenReturn(environmentBackup);
+        when(tunnelConverter.convert(request.getTunnel())).thenReturn(request.getTunnel());
+        when(networkRequestToDtoConverter.convert(request.getNetwork())).thenReturn(networkDto);
+
+        EnvironmentCreationDto actual = underTest.initCreationDto(request);
+
+        assertEquals("dummy-encryption-key",
+                actual.getParameters().getGcpParametersDto().getGcpResourceEncryptionParametersDto().getEncryptionKey());
+    }
+
     private void assertLocation(LocationRequest request, LocationDto actual) {
         assertEquals(request.getName(), actual.getName());
         assertEquals(request.getLatitude(), actual.getLatitude());
@@ -373,6 +404,8 @@ public class EnvironmentApiConverterTest {
             assertAwsParameters(request, actual);
         } else if (AZURE.equals(cloudPlatform)) {
             assertAzureParameters(request, actual);
+        } else if (GCP.equals(cloudPlatform)) {
+            assertGcpParameters(request, actual);
         }
     }
 
@@ -391,6 +424,11 @@ public class EnvironmentApiConverterTest {
         assertEquals(request.getFreeIpa().getAws().getSpot().getMaxPrice(), actual.getAwsParametersDto().getFreeIpaSpotMaxPrice());
         assertEquals(request.getAws().getAwsDiskEncryptionParameters().getEncryptionKeyArn(),
                 actual.getAwsParametersDto().getAwsDiskEncryptionParametersDto().getEncryptionKeyArn());
+    }
+
+    private void assertGcpParameters(EnvironmentRequest request, ParametersDto actual) {
+        assertEquals(request.getGcp().getGcpResourceEncryptionParameters().getEncryptionKey(),
+                actual.getGcpParametersDto().getGcpResourceEncryptionParametersDto().getEncryptionKey());
     }
 
     private void assertSecurityAccess(SecurityAccessRequest request, SecurityAccessDto actual) {
@@ -478,7 +516,14 @@ public class EnvironmentApiConverterTest {
     }
 
     private GcpEnvironmentParameters createGcpRequest() {
-        return GcpEnvironmentParameters.builder().build();
+        GcpEnvironmentParameters gcpEnvironmentParameters = new GcpEnvironmentParameters();
+
+        gcpEnvironmentParameters.setGcpResourceEncryptionParameters(
+                GcpResourceEncryptionParameters.builder()
+                    .withEncryptionKey("dummy-encryption-key")
+                    .build()
+        );
+        return gcpEnvironmentParameters;
     }
 
     private AttachedFreeIpaRequest createFreeIpaRequest() {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverterTest.java
@@ -2,6 +2,7 @@ package com.sequenceiq.environment.environment.v1.converter;
 
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.GCP;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -28,6 +29,7 @@ import com.sequenceiq.environment.api.v1.credential.model.response.CredentialVie
 import com.sequenceiq.environment.api.v1.environment.model.base.CloudStorageValidation;
 import com.sequenceiq.environment.api.v1.environment.model.base.IdBrokerMappingSource;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.response.CompactRegionResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentAuthenticationResponse;
@@ -58,6 +60,8 @@ import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceGroupDto;
+import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
+import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameter.dto.ResourceGroupCreation;
 import com.sequenceiq.environment.parameter.dto.ResourceGroupUsagePattern;
@@ -97,7 +101,7 @@ public class EnvironmentResponseConverterTest {
     private NetworkDtoToResponseConverter networkDtoToResponseConverter;
 
     @ParameterizedTest
-    @EnumSource(value = CloudPlatform.class, names = {"AWS", "AZURE"})
+    @EnumSource(value = CloudPlatform.class, names = {"AWS", "AZURE", "GCP"})
     void testDtoToDetailedResponse(CloudPlatform cloudPlatform) {
         EnvironmentDto environment = createEnvironmentDto(cloudPlatform);
         CredentialResponse credentialResponse = mock(CredentialResponse.class);
@@ -213,8 +217,10 @@ public class EnvironmentResponseConverterTest {
             assertEquals(environment.getParameters().getAwsParametersDto().getS3GuardTableName(), actual.getAws().getS3guard().getDynamoDbTableName());
             assertEquals(environment.getParameters().getAwsParametersDto().getAwsDiskEncryptionParametersDto().getEncryptionKeyArn(),
                     actual.getAws().getAwsDiskEncryptionParameters().getEncryptionKeyArn());
-        } else {
+        } else if (AZURE.equals(cloudPlatform))  {
             assertAzureParameters(environment.getParameters().getAzureParametersDto(), actual.getAzure());
+        } else if (GCP.equals(cloudPlatform)) {
+            assertGcpParameters(environment.getParameters().getGcpParametersDto(), actual.getGcp());
         }
     }
 
@@ -244,6 +250,12 @@ public class EnvironmentResponseConverterTest {
                 azureEnvironmentParameters.getResourceEncryptionParameters().getEncryptionKeyUrl());
         assertEquals("dummy-des-id", azureEnvironmentParameters.getResourceEncryptionParameters().getDiskEncryptionSetId());
         assertEquals("dummyResourceGroupName", azureEnvironmentParameters.getResourceEncryptionParameters().getEncryptionKeyResourceGroupName());
+    }
+
+    private void assertGcpParameters(GcpParametersDto gcpParametersDto, GcpEnvironmentParameters gcpEnvironmentParameters) {
+        assertNotNull(gcpEnvironmentParameters);
+        assertEquals(gcpParametersDto.getGcpResourceEncryptionParametersDto().getEncryptionKey(),
+                gcpEnvironmentParameters.getGcpResourceEncryptionParameters().getEncryptionKey());
     }
 
     private EnvironmentDto createEnvironmentDto(CloudPlatform cloudPlatform) {
@@ -288,6 +300,8 @@ public class EnvironmentResponseConverterTest {
             return createAwsParameters();
         } else if (AZURE.equals(cloudPlatform)) {
             return createAzureParameters();
+        } else if (GCP.equals(cloudPlatform)) {
+            return createGcpParameters();
         } else {
             throw new RuntimeException("CloudPlatform " + cloudPlatform + " is not supported.");
         }
@@ -310,6 +324,17 @@ public class EnvironmentResponseConverterTest {
                                         .withEncryptionKeyUrl("dummy-key-url")
                                         .withDiskEncryptionSetId("dummy-des-id")
                                         .withEncryptionKeyResourceGroupName("dummyResourceGroupName")
+                                        .build())
+                        .build())
+                .build();
+    }
+
+    private ParametersDto createGcpParameters() {
+        return ParametersDto.builder()
+                .withGcpParameters(GcpParametersDto.builder()
+                        .withEncryptionParameters(
+                                GcpResourceEncryptionParametersDto.builder()
+                                        .withEncryptionKey("dummy-encryption-key")
                                         .build())
                         .build())
                 .build();

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyValidatorTest.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.environment.environment.validation.validators;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+
+class EncryptionKeyValidatorTest {
+
+    private EncryptionKeyValidator underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new EncryptionKeyValidator();
+    }
+
+    @Test
+    void testEncryptionKeyUrlValidationWithValidKeyAndCommentIsValid() {
+        String validKey = "projects/dummy-project/locations/us-west2/keyRings/dummy-ring/cryptoKeys/dummy-key";
+
+        ValidationResult validationResult = underTest.validateEncryptionKey(validKey);
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    void testEncryptionKeyUrlValidationWithInValidKeyAndCommentIsValid() {
+        String invalidKey = "projects/Invalid-project/locations/us-west2/keyRings/Invalid-ring/cryptoKeys/Invalid-key\"";
+
+        ValidationResult validationResult = underTest.validateEncryptionKey(invalidKey);
+        assertTrue(validationResult.hasError());
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/GcpEnvironmentParametersConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/v1/converter/GcpEnvironmentParametersConverterTest.java
@@ -1,0 +1,94 @@
+package com.sequenceiq.environment.parameters.v1.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.environment.domain.EnvironmentView;
+import com.sequenceiq.environment.environment.domain.EnvironmentViewConverter;
+import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
+import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
+import com.sequenceiq.environment.parameter.dto.ParametersDto;
+import com.sequenceiq.environment.parameters.dao.domain.BaseParameters;
+import com.sequenceiq.environment.parameters.dao.domain.GcpParameters;
+
+@ExtendWith(MockitoExtension.class)
+class GcpEnvironmentParametersConverterTest {
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final String ENV_NAME = "envName";
+
+    private static final String ENCRYPTION_KEY = "dummy-encryption-key";
+
+    private static final EnvironmentView ENVIRONMENT_VIEW = new EnvironmentView();
+
+    private static final long ID = 10L;
+
+    @Mock
+    private EnvironmentViewConverter environmentViewConverter;
+
+    @InjectMocks
+    private GcpEnvironmentParametersConverter underTest;
+
+    @Test
+    void createInstance() {
+        assertEquals(GcpParameters.class, underTest.createInstance().getClass());
+    }
+
+    @Test
+    void getCloudPlatform() {
+        assertEquals(CloudPlatform.GCP, underTest.getCloudPlatform());
+    }
+
+    @Test
+    void convertTest() {
+        when(environmentViewConverter.convert(any(Environment.class))).thenReturn(ENVIRONMENT_VIEW);
+        ParametersDto parameters = ParametersDto.builder()
+                .withId(ID)
+                .withGcpParameters(GcpParametersDto.builder()
+                        .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder()
+                                .withEncryptionKey(ENCRYPTION_KEY)
+                                .build())
+                        .build())
+                .build();
+        Environment environment = new Environment();
+        environment.setName(ENV_NAME);
+        environment.setAccountId(ACCOUNT_ID);
+
+        BaseParameters result = underTest.convert(environment, parameters);
+
+        assertEquals(GcpParameters.class, result.getClass());
+        GcpParameters gcpResult = (GcpParameters) result;
+        assertEquals(ENV_NAME, gcpResult.getName());
+        assertEquals(ACCOUNT_ID, gcpResult.getAccountId());
+        assertEquals(ENVIRONMENT_VIEW, gcpResult.getEnvironment());
+        assertEquals(ID, gcpResult.getId());
+        assertEquals(ENCRYPTION_KEY, gcpResult.getEncryptionKey());
+    }
+
+    @Test
+    void convertToDtoTest() {
+        EnvironmentView environmentView = ENVIRONMENT_VIEW;
+        GcpParameters parameters = new GcpParameters();
+        parameters.setAccountId(ACCOUNT_ID);
+        parameters.setEnvironment(environmentView);
+        parameters.setId(ID);
+        parameters.setName(ENV_NAME);
+        parameters.setEncryptionKey(ENCRYPTION_KEY);
+
+        ParametersDto result = underTest.convertToDto(parameters);
+
+        assertEquals(ACCOUNT_ID, result.getAccountId());
+        assertEquals(ID, result.getId());
+        assertEquals(ENV_NAME, result.getName());
+        assertEquals(ENCRYPTION_KEY, result.getGcpParametersDto().getGcpResourceEncryptionParametersDto().getEncryptionKey());
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AzureParameterValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/AzureParameterValidatorTest.java
@@ -439,7 +439,7 @@ public class AzureParameterValidatorTest {
 
     @Test
     public void testCloudPlatform() {
-        assertEquals(CloudPlatform.AZURE, underTest.getcloudPlatform());
+        assertEquals(CloudPlatform.AZURE, underTest.getCloudPlatform());
     }
 
     @Test

--- a/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/GcpParameterValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/parameters/validation/validators/GcpParameterValidatorTest.java
@@ -1,0 +1,122 @@
+package com.sequenceiq.environment.parameters.validation.validators;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.validation.ValidationResult;
+import com.sequenceiq.environment.environment.dto.EnvironmentDto;
+import com.sequenceiq.environment.environment.dto.EnvironmentValidationDto;
+import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
+import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
+import com.sequenceiq.environment.parameter.dto.ParametersDto;
+import com.sequenceiq.environment.parameter.dto.ParametersDto.Builder;
+import com.sequenceiq.environment.parameters.validation.validators.parameter.GcpParameterValidator;
+
+public class GcpParameterValidatorTest {
+
+    private static final String ENCRYPTION_KEY = "encryptionKey";
+
+    @Mock
+    private EntitlementService entitlementService;
+
+    @InjectMocks
+    private GcpParameterValidator underTest;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        when(entitlementService.isGcpDiskEncryptionWithCMEKEnabled(anyString())).thenReturn(true);
+    }
+
+    @Test
+    public void testWhenNoGcpParametersThenNoError() {
+        EnvironmentDto environmentDto = new EnvironmentDtoBuilder().build();
+        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
+
+        ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
+
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    public void testWhenFeatureTurnedOffAndEncryptionKeyProvidedThenNoError() {
+        EnvironmentDto environmentDto = new EnvironmentDtoBuilder()
+                .withGcpParameters(GcpParametersDto.builder()
+                        .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder()
+                                .withEncryptionKey(ENCRYPTION_KEY)
+                                .build())
+                        .build())
+                .build();
+        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
+
+        when(entitlementService.isGcpDiskEncryptionWithCMEKEnabled(anyString())).thenReturn(false);
+
+        ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
+
+        assertTrue(validationResult.hasError());
+    }
+
+    @Test
+    public void testWhenFeatureTurnedONAndEncryptionKeyNotProvidedThenNoError() {
+        EnvironmentDto environmentDto = new EnvironmentDtoBuilder()
+                .withGcpParameters(GcpParametersDto.builder()
+                        .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder().build())
+                        .build())
+                .build();
+        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
+
+        when(entitlementService.isGcpDiskEncryptionWithCMEKEnabled(anyString())).thenReturn(true);
+
+        ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
+
+        assertFalse(validationResult.hasError());
+    }
+
+    @Test
+    public void testWhenFeatureTurnedONAndEncryptionKeyProvidedThenNoError() {
+        EnvironmentDto environmentDto = new EnvironmentDtoBuilder()
+                .withGcpParameters(GcpParametersDto.builder()
+                        .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder()
+                                .withEncryptionKey(ENCRYPTION_KEY)
+                                .build())
+                        .build())
+                .build();
+        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
+
+        when(entitlementService.isGcpDiskEncryptionWithCMEKEnabled(anyString())).thenReturn(true);
+
+        ValidationResult validationResult = underTest.validate(environmentValidationDto, environmentDto.getParameters(), ValidationResult.builder());
+
+        assertFalse(validationResult.hasError());
+    }
+
+    private static class EnvironmentDtoBuilder {
+
+        private static final String ACCOUNT_ID = "accountId";
+
+        private final EnvironmentDto environmentDto = new EnvironmentDto();
+
+        private final Builder parametersDtoBuilder = ParametersDto.builder();
+
+        public EnvironmentDtoBuilder withGcpParameters(GcpParametersDto gcpParametersDto) {
+            parametersDtoBuilder.withGcpParameters(gcpParametersDto);
+            return this;
+        }
+
+        public EnvironmentDto build() {
+            ParametersDto parametersDto = parametersDtoBuilder.build();
+            environmentDto.setParameters(parametersDto);
+            environmentDto.setAccountId(ACCOUNT_ID);
+            return environmentDto;
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverter.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.freeipa.converter.instance;
 
+import static com.sequenceiq.freeipa.util.CloudArgsForIgConverter.DISK_ENCRYPTION_SET_ID;
+import static com.sequenceiq.freeipa.util.CloudArgsForIgConverter.GCP_KMS_ENCRYPTION_KEY;
+
+import java.util.EnumMap;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.GCP;
@@ -15,6 +19,8 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
@@ -31,9 +37,11 @@ import com.sequenceiq.freeipa.entity.InstanceGroup;
 import com.sequenceiq.freeipa.entity.InstanceMetaData;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceGroupProvider;
+import com.sequenceiq.freeipa.util.CloudArgsForIgConverter;
 
 @Component
 public class InstanceGroupRequestToInstanceGroupConverter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceGroupRequestToInstanceGroupConverter.class);
 
     @Inject
     private InstanceTemplateRequestToTemplateConverter templateConverter;
@@ -53,12 +61,14 @@ public class InstanceGroupRequestToInstanceGroupConverter {
         Stack stack,
         FreeIpaServerRequest ipaServerRequest,
         DetailedEnvironmentResponse environment,
-        String diskEncryptionSetId) {
+        EnumMap<CloudArgsForIgConverter, String> cloudArgsForIgConverter) {
         InstanceGroup instanceGroup = new InstanceGroup();
         CloudPlatform cloudPlatform = CloudPlatform.valueOf(stack.getCloudPlatform());
         instanceGroup.setTemplate(source.getInstanceTemplate() == null
-                ? defaultInstanceGroupProvider.createDefaultTemplate(cloudPlatform, accountId, diskEncryptionSetId)
-                : templateConverter.convert(source.getInstanceTemplate(), cloudPlatform, accountId, diskEncryptionSetId));
+                ? defaultInstanceGroupProvider.createDefaultTemplate(cloudPlatform, accountId,
+                    cloudArgsForIgConverter.get(DISK_ENCRYPTION_SET_ID), cloudArgsForIgConverter.get(GCP_KMS_ENCRYPTION_KEY))
+                : templateConverter.convert(source.getInstanceTemplate(), cloudPlatform, accountId,
+                    cloudArgsForIgConverter.get(DISK_ENCRYPTION_SET_ID), cloudArgsForIgConverter.get(GCP_KMS_ENCRYPTION_KEY)));
         instanceGroup.setSecurityGroup(securityGroupConverter.convert(source.getSecurityGroup()));
         instanceGroup.setInstanceGroupNetwork(hasEmptyNetworkOnStackRequest(source, networkRequest, cloudPlatform)
                 ? defaultInstanceGroupProvider.createDefaultNetwork(cloudPlatform, networkRequest)

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverter.java
@@ -8,13 +8,17 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.KeyEncryptionMethod;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AzureInstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.GcpInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -31,6 +35,7 @@ import com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceTypeProvider
 
 @Component
 public class InstanceTemplateRequestToTemplateConverter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceTemplateRequestToTemplateConverter.class);
 
     @Inject
     private MissingResourceNameGenerator missingResourceNameGenerator;
@@ -47,7 +52,8 @@ public class InstanceTemplateRequestToTemplateConverter {
     @Inject
     private EntitlementService entitlementService;
 
-    public Template convert(InstanceTemplateRequest source, CloudPlatform cloudPlatform, String accountId, String diskEncryptionSetId) {
+    public Template convert(InstanceTemplateRequest source, CloudPlatform cloudPlatform, String accountId,
+            String diskEncryptionSetId, String gcpKmsEncryptionKey) {
         Template template = new Template();
         template.setName(missingResourceNameGenerator.generateName(APIResourceType.TEMPLATE));
         template.setStatus(ResourceStatus.USER_MANAGED);
@@ -72,6 +78,13 @@ public class InstanceTemplateRequestToTemplateConverter {
             attributes.put(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID, diskEncryptionSetId);
             attributes.put(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED, true);
         }
+
+        if (gcpKmsEncryptionKey != null && cloudPlatform == CloudPlatform.GCP) {
+            attributes.put(GcpInstanceTemplate.VOLUME_ENCRYPTION_KEY_ID, gcpKmsEncryptionKey);
+            attributes.put(GcpInstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE, EncryptionType.CUSTOM);
+            attributes.put(GcpInstanceTemplate.KEY_ENCRYPTION_METHOD, KeyEncryptionMethod.KMS);
+        }
+
         template.setAttributes(new Json(attributes));
         return template;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/CreateFreeIpaRequestToStackConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/CreateFreeIpaRequestToStackConverter.java
@@ -2,8 +2,11 @@ package com.sequenceiq.freeipa.converter.stack;
 
 import static com.gs.collections.impl.utility.StringIterate.isEmpty;
 import static com.sequenceiq.cloudbreak.cloud.model.Platform.platform;
+import static com.sequenceiq.freeipa.util.CloudArgsForIgConverter.DISK_ENCRYPTION_SET_ID;
+import static com.sequenceiq.freeipa.util.CloudArgsForIgConverter.GCP_KMS_ENCRYPTION_KEY;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -42,6 +45,8 @@ import com.sequenceiq.cloudbreak.util.PasswordUtil;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpEnvironmentParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.gcp.GcpResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
@@ -60,6 +65,7 @@ import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.StackStatus;
 import com.sequenceiq.freeipa.service.tag.AccountTagService;
 import com.sequenceiq.freeipa.util.CrnService;
+import com.sequenceiq.freeipa.util.CloudArgsForIgConverter;
 
 @Component
 public class CreateFreeIpaRequestToStackConverter {
@@ -269,7 +275,20 @@ public class CreateFreeIpaRequestToStackConverter {
                 .map(AzureEnvironmentParameters::getResourceEncryptionParameters)
                 .map(AzureResourceEncryptionParameters::getDiskEncryptionSetId)
                 .orElse(null);
+
+        String gcpKmsEncryptionKey = Optional.of(environment)
+                .map(DetailedEnvironmentResponse::getGcp)
+                .map(GcpEnvironmentParameters::getGcpResourceEncryptionParameters)
+                .map(GcpResourceEncryptionParameters::getEncryptionKey)
+                .orElse(null);
+
         Set<InstanceGroup> convertedSet = new HashSet<>();
+
+        EnumMap<CloudArgsForIgConverter, String> cloudArgsForIgConverterMap = new EnumMap<>(CloudArgsForIgConverter.class);
+
+        cloudArgsForIgConverterMap.put(DISK_ENCRYPTION_SET_ID, diskEncryptionSetId);
+        cloudArgsForIgConverterMap.put(GCP_KMS_ENCRYPTION_KEY, gcpKmsEncryptionKey);
+
         source.getInstanceGroups().stream()
                 .map(ig -> {
                     FreeIpaServerRequest ipaServerRequest = source.getFreeIpa();
@@ -279,7 +298,7 @@ public class CreateFreeIpaRequestToStackConverter {
                             stack,
                             ipaServerRequest,
                             environment,
-                            diskEncryptionSetId);
+                            cloudArgsForIgConverterMap);
                 })
                 .forEach(ig -> {
                     ig.setStack(stack);

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/util/CloudArgsForIgConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/util/CloudArgsForIgConverter.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.freeipa.util;
+
+public enum CloudArgsForIgConverter {
+    DISK_ENCRYPTION_SET_ID, GCP_KMS_ENCRYPTION_KEY
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/InstanceGroupRequestToInstanceGroupConverterTest.java
@@ -1,11 +1,15 @@
 package com.sequenceiq.freeipa.converter.instance;
 
 import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.MOCK;
+import static com.sequenceiq.freeipa.util.CloudArgsForIgConverter.DISK_ENCRYPTION_SET_ID;
+import static com.sequenceiq.freeipa.util.CloudArgsForIgConverter.GCP_KMS_ENCRYPTION_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.EnumMap;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +31,7 @@ import com.sequenceiq.freeipa.entity.SecurityGroup;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.entity.Template;
 import com.sequenceiq.freeipa.service.stack.instance.DefaultInstanceGroupProvider;
+import com.sequenceiq.freeipa.util.CloudArgsForIgConverter;
 
 @ExtendWith(MockitoExtension.class)
 public class InstanceGroupRequestToInstanceGroupConverterTest {
@@ -78,11 +83,12 @@ public class InstanceGroupRequestToInstanceGroupConverterTest {
         DetailedEnvironmentResponse detailedEnvironmentResponse = new DetailedEnvironmentResponse();
 
         // GIVEN
-        given(defaultInstanceGroupProvider.createDefaultTemplate(eq(MOCK), eq(ACCOUNT_ID), eq(null))).willReturn(template);
+        given(defaultInstanceGroupProvider.createDefaultTemplate(eq(MOCK), eq(ACCOUNT_ID), eq(null), eq(null))).willReturn(template);
         given(securityGroupConverter.convert(eq(securityGroupRequest))).willReturn(securityGroup);
         // WHEN
         InstanceGroup result = underTest.convert(request, networkRequest, ACCOUNT_ID, stack, freeIpaServerRequest,
-                detailedEnvironmentResponse, null);
+                detailedEnvironmentResponse, createAndGetCloudArgsForIgCoverterMap(null, null));
+
         // THEN
         assertThat(result).isNotNull();
         assertThat(result.getGroupName()).isEqualTo(NAME);
@@ -118,7 +124,7 @@ public class InstanceGroupRequestToInstanceGroupConverterTest {
         InstanceTemplateRequest instanceTemplateRequest = mock(InstanceTemplateRequest.class);
         request.setInstanceTemplateRequest(instanceTemplateRequest);
         Template template = mock(Template.class);
-        when(templateConverter.convert(instanceTemplateRequest, MOCK, ACCOUNT_ID, null)).thenReturn(template);
+        when(templateConverter.convert(instanceTemplateRequest, MOCK, ACCOUNT_ID, "dummyDiskEncryptionSetId", "encryptionKey")).thenReturn(template);
 
         InstanceGroup result = underTest.convert(
                 request,
@@ -127,7 +133,8 @@ public class InstanceGroupRequestToInstanceGroupConverterTest {
                 stack,
                 freeIpaServerRequest,
                 detailedEnvironmentResponse,
-                null);
+                createAndGetCloudArgsForIgCoverterMap("dummyDiskEncryptionSetId", "encryptionKey"));
+
         assertThat(result).isNotNull();
         assertThat(result.getTemplate()).isSameAs(template);
     }
@@ -152,7 +159,7 @@ public class InstanceGroupRequestToInstanceGroupConverterTest {
         InstanceTemplateRequest instanceTemplateRequest = mock(InstanceTemplateRequest.class);
         request.setInstanceTemplateRequest(instanceTemplateRequest);
         Template template = mock(Template.class);
-        when(templateConverter.convert(instanceTemplateRequest, MOCK, ACCOUNT_ID, null)).thenReturn(template);
+        when(templateConverter.convert(instanceTemplateRequest, MOCK, ACCOUNT_ID, "dummyDiskEncryptionSetId", null)).thenReturn(template);
 
         InstanceGroup result = underTest.convert(
                 request,
@@ -161,7 +168,43 @@ public class InstanceGroupRequestToInstanceGroupConverterTest {
                 stack,
                 freeIpaServerRequest,
                 detailedEnvironmentResponse,
-                null);
+                createAndGetCloudArgsForIgCoverterMap("dummyDiskEncryptionSetId", null));
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTemplate()).isSameAs(template);
+    }
+
+    @Test
+    void convertTestDefaultTemplateConversionWithDiskEncryptionSetId() {
+        InstanceGroupRequest request = new InstanceGroupRequest();
+
+        Stack stack = new Stack();
+        stack.setAccountId(ACCOUNT_ID);
+        stack.setCloudPlatform(MOCK.name());
+        stack.setName(NAME);
+
+        FreeIpaServerRequest freeIpaServerRequest = new FreeIpaServerRequest();
+        freeIpaServerRequest.setHostname(HOSTNAME);
+        freeIpaServerRequest.setDomain(DOMAINNAME);
+
+        NetworkRequest networkRequest = new NetworkRequest();
+
+        DetailedEnvironmentResponse detailedEnvironmentResponse = new DetailedEnvironmentResponse();
+
+        InstanceTemplateRequest instanceTemplateRequest = mock(InstanceTemplateRequest.class);
+        request.setInstanceTemplateRequest(instanceTemplateRequest);
+        Template template = mock(Template.class);
+
+        when(templateConverter.convert(instanceTemplateRequest, MOCK, ACCOUNT_ID, "dummyDiskEncryptionSetId", null)).thenReturn(template);
+
+        InstanceGroup result = underTest.convert(
+                request,
+                networkRequest,
+                ACCOUNT_ID,
+                stack,
+                freeIpaServerRequest,
+                detailedEnvironmentResponse,
+                createAndGetCloudArgsForIgCoverterMap("dummyDiskEncryptionSetId", null));
 
         assertThat(result).isNotNull();
         assertThat(result.getTemplate()).isSameAs(template);
@@ -188,18 +231,63 @@ public class InstanceGroupRequestToInstanceGroupConverterTest {
 
         DetailedEnvironmentResponse detailedEnvironmentResponse = new DetailedEnvironmentResponse();
 
-        when(templateConverter.convert(instanceTemplateRequest, MOCK, ACCOUNT_ID, "dummyEncryptionKey")).thenReturn(template);
+        when(templateConverter.convert(instanceTemplateRequest, MOCK, ACCOUNT_ID, null, "dummyEncryptionKey")).thenReturn(template);
 
-        InstanceGroup result = underTest.convert(request,
+        InstanceGroup result = underTest.convert(
+                request,
                 networkRequest,
                 ACCOUNT_ID,
                 stack,
                 freeIpaServerRequest,
                 detailedEnvironmentResponse,
-                "dummyEncryptionKey");
+                createAndGetCloudArgsForIgCoverterMap(null, "dummyEncryptionKey"));
 
         assertThat(result).isNotNull();
         assertThat(result.getTemplate()).isSameAs(template);
     }
 
+    @Test
+    void convertTestDefaultTemplateConversionWithEncryptionKey() {
+        InstanceGroupRequest request = new InstanceGroupRequest();
+
+        InstanceTemplateRequest instanceTemplateRequest = mock(InstanceTemplateRequest.class);
+        request.setInstanceTemplateRequest(instanceTemplateRequest);
+        Template template = mock(Template.class);
+
+        Stack stack = new Stack();
+        stack.setAccountId(ACCOUNT_ID);
+        stack.setCloudPlatform(MOCK.name());
+        stack.setName(NAME);
+
+        FreeIpaServerRequest freeIpaServerRequest = new FreeIpaServerRequest();
+        freeIpaServerRequest.setHostname(HOSTNAME);
+        freeIpaServerRequest.setDomain(DOMAINNAME);
+
+        NetworkRequest networkRequest = new NetworkRequest();
+
+        DetailedEnvironmentResponse detailedEnvironmentResponse = new DetailedEnvironmentResponse();
+
+        when(templateConverter.convert(instanceTemplateRequest, MOCK, ACCOUNT_ID, null, "dummyEncryptionKey")).thenReturn(template);
+
+        InstanceGroup result = underTest.convert(
+                request,
+                networkRequest,
+                ACCOUNT_ID,
+                stack,
+                freeIpaServerRequest,
+                detailedEnvironmentResponse,
+                createAndGetCloudArgsForIgCoverterMap(null, "dummyEncryptionKey"));
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTemplate()).isSameAs(template);
+    }
+
+    EnumMap<CloudArgsForIgConverter, String> createAndGetCloudArgsForIgCoverterMap(String diskEncryptionSetId, String encryptionKey) {
+        EnumMap<CloudArgsForIgConverter, String> cloudArgsForIgConverterMap = new EnumMap<>(CloudArgsForIgConverter.class);
+
+        cloudArgsForIgConverterMap.put(DISK_ENCRYPTION_SET_ID, diskEncryptionSetId);
+        cloudArgsForIgConverterMap.put(GCP_KMS_ENCRYPTION_KEY, encryptionKey);
+
+        return cloudArgsForIgConverterMap;
+    }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/instance/template/InstanceTemplateRequestToTemplateConverterTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.freeipa.converter.instance.template;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.instance.AzureInstanceTemplate;
+import com.sequenceiq.cloudbreak.cloud.model.instance.GcpInstanceTemplate;
 import com.sequenceiq.cloudbreak.common.converter.MissingResourceNameGenerator;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -61,7 +63,7 @@ class InstanceTemplateRequestToTemplateConverterTest {
         InstanceTemplateRequest source = new InstanceTemplateRequest();
         source.setInstanceType(INSTANCE_TYPE);
 
-        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID, null);
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID, null, null);
 
         assertThat(result.getInstanceType()).isEqualTo(source.getInstanceType());
     }
@@ -73,7 +75,7 @@ class InstanceTemplateRequestToTemplateConverterTest {
         InstanceTemplateRequest source = new InstanceTemplateRequest();
         when(defaultInstanceTypeProvider.getForPlatform(CLOUD_PLATFORM.name())).thenReturn(defaultInstanceType);
 
-        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID, null);
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID, null, null);
 
         assertThat(result.getInstanceType()).isEqualTo(defaultInstanceType);
     }
@@ -84,7 +86,7 @@ class InstanceTemplateRequestToTemplateConverterTest {
         source.setInstanceType(INSTANCE_TYPE);
         source.setAws(createAwsInstanceTemplateParameters(SPOT_PERCENTAGE, SPOT_MAX_PRICE));
 
-        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID, null);
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID, null, null);
 
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
@@ -97,7 +99,7 @@ class InstanceTemplateRequestToTemplateConverterTest {
         InstanceTemplateRequest source = new InstanceTemplateRequest();
         source.setInstanceType(INSTANCE_TYPE);
 
-        Template result = underTest.convert(source, CloudPlatform.AZURE, ACCOUNT_ID, null);
+        Template result = underTest.convert(source, CloudPlatform.AZURE, ACCOUNT_ID, null, null);
 
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
@@ -110,7 +112,7 @@ class InstanceTemplateRequestToTemplateConverterTest {
         InstanceTemplateRequest source = new InstanceTemplateRequest();
         source.setInstanceType(INSTANCE_TYPE);
 
-        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID, null);
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID, null, null);
 
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
@@ -124,7 +126,7 @@ class InstanceTemplateRequestToTemplateConverterTest {
         source.setInstanceType(INSTANCE_TYPE);
         source.setAws(createAwsInstanceTemplateParameters(SPOT_PERCENTAGE, SPOT_MAX_PRICE));
 
-        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID, null);
+        Template result = underTest.convert(source, CLOUD_PLATFORM, ACCOUNT_ID, null, null);
 
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
@@ -139,7 +141,7 @@ class InstanceTemplateRequestToTemplateConverterTest {
         InstanceTemplateRequest source = new InstanceTemplateRequest();
         source.setInstanceType(INSTANCE_TYPE);
 
-        Template result = underTest.convert(source, CloudPlatform.AZURE, ACCOUNT_ID, "dummyDiskEncryptionSet");
+        Template result = underTest.convert(source, CloudPlatform.AZURE, ACCOUNT_ID, "dummyDiskEncryptionSet", "");
 
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
@@ -152,12 +154,38 @@ class InstanceTemplateRequestToTemplateConverterTest {
         InstanceTemplateRequest source = new InstanceTemplateRequest();
         source.setInstanceType(INSTANCE_TYPE);
 
-        Template result = underTest.convert(source, CloudPlatform.AZURE, ACCOUNT_ID, null);
+        Template result = underTest.convert(source, CloudPlatform.AZURE, ACCOUNT_ID, null, null);
 
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
         assertThat(attributes.<Object>getValue(AzureInstanceTemplate.DISK_ENCRYPTION_SET_ID)).isNull();
         assertThat(attributes.<Object>getValue(AzureInstanceTemplate.MANAGED_DISK_ENCRYPTION_WITH_CUSTOM_KEY_ENABLED)).isNull();
+    }
+
+    @Test
+    void shouldSetEncryptionKeyAndEncryptionMethodPropertyWhenGcpEncryptionKeyPresent() {
+        InstanceTemplateRequest source = new InstanceTemplateRequest();
+        source.setInstanceType(INSTANCE_TYPE);
+
+        Template result = underTest.convert(source, CloudPlatform.GCP, ACCOUNT_ID, anyString(), "dummyEncryptionKey");
+
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(GcpInstanceTemplate.VOLUME_ENCRYPTION_KEY_ID)).isEqualTo("dummyEncryptionKey");
+        assertThat(attributes.<Object>getValue("keyEncryptionMethod")).isEqualTo("KMS");
+    }
+
+    @Test
+    void shouldNotSetEncryptionKeyAndEncryptionMethodPropertyWhenGcpEncryptionKeyAbsent() {
+        InstanceTemplateRequest source = new InstanceTemplateRequest();
+        source.setInstanceType(INSTANCE_TYPE);
+
+        Template result = underTest.convert(source, CloudPlatform.GCP, ACCOUNT_ID, null, null);
+
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(GcpInstanceTemplate.VOLUME_ENCRYPTION_KEY_ID)).isNull();
+        assertThat(attributes.<Object>getValue("keyEncryptionMethod")).isNull();
     }
 
     private AwsInstanceTemplateParameters createAwsInstanceTemplateParameters(int spotPercentage, Double spotMaxPrice) {
@@ -168,5 +196,4 @@ class InstanceTemplateRequestToTemplateConverterTest {
         aws.setSpot(spot);
         return aws;
     }
-
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/instance/DefaultInstanceGroupProviderTest.java
@@ -53,7 +53,7 @@ class DefaultInstanceGroupProviderTest {
 
     @Test
     void createDefaultTemplateTestNoVolumeEncryptionWhenAzure() {
-        Template result = underTest.createDefaultTemplate(CloudPlatform.AZURE, ACCOUNT_ID, null);
+        Template result = underTest.createDefaultTemplate(CloudPlatform.AZURE, ACCOUNT_ID, null, null);
 
         assertThat(result).isNotNull();
         assertThat(result.getAttributes()).isNull();
@@ -61,7 +61,7 @@ class DefaultInstanceGroupProviderTest {
 
     @Test
     void createDefaultTemplateTestVolumeEncryptionAddedWhenAzure() {
-        Template result = underTest.createDefaultTemplate(CloudPlatform.AZURE, ACCOUNT_ID, "dummyDiskEncryptionSet");
+        Template result = underTest.createDefaultTemplate(CloudPlatform.AZURE, ACCOUNT_ID, "dummyDiskEncryptionSet", null);
 
         assertThat(result).isNotNull();
         Json attributes = result.getAttributes();
@@ -73,13 +73,24 @@ class DefaultInstanceGroupProviderTest {
     @Test
     void createDefaultTemplateTestVolumeEncryptionAddedWhenAws() {
 
-        Template result = underTest.createDefaultTemplate(CloudPlatform.AWS, ACCOUNT_ID, null);
+        Template result = underTest.createDefaultTemplate(CloudPlatform.AWS, ACCOUNT_ID, null, null);
 
         assertThat(result).isNotNull();
         Json attributes = result.getAttributes();
         assertThat(attributes).isNotNull();
         assertThat(attributes.<Object>getValue(AwsInstanceTemplate.EBS_ENCRYPTION_ENABLED)).isEqualTo(Boolean.TRUE);
         assertThat(attributes.<Object>getValue(InstanceTemplate.VOLUME_ENCRYPTION_KEY_TYPE)).isEqualTo(EncryptionType.DEFAULT.name());
+    }
+
+    @Test
+    void createDefaultTemplateTestVolumeEncryptionAddedWhenGcp() {
+        Template result = underTest.createDefaultTemplate(CloudPlatform.GCP, ACCOUNT_ID, null, "dummyEncryptionKey");
+
+        assertThat(result).isNotNull();
+        Json attributes = result.getAttributes();
+        assertThat(attributes).isNotNull();
+        assertThat(attributes.<Object>getValue(AzureInstanceTemplate.VOLUME_ENCRYPTION_KEY_ID)).isEqualTo("dummyEncryptionKey");
+        assertThat(attributes.<Object>getValue("keyEncryptionMethod")).isEqualTo("KMS");
     }
 
     @Test

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/GcpParametersDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/GcpParametersDto.java
@@ -2,7 +2,14 @@ package com.sequenceiq.environment.parameter.dto;
 
 public class GcpParametersDto {
 
+    private GcpResourceEncryptionParametersDto gcpResourceEncryptionParametersDto;
+
     private GcpParametersDto(Builder builder) {
+        gcpResourceEncryptionParametersDto = builder.gcpResourceEncryptionParametersDto;
+    }
+
+    public GcpResourceEncryptionParametersDto getGcpResourceEncryptionParametersDto() {
+        return gcpResourceEncryptionParametersDto;
     }
 
     public static Builder builder() {
@@ -11,13 +18,17 @@ public class GcpParametersDto {
 
     @Override
     public String toString() {
-        return "GcpParametersDto{}";
+        return "GcpParametersDto{" +
+                "gcpResourceEncryptionParametersDto=" + gcpResourceEncryptionParametersDto +
+                "}";
     }
 
     public static final class Builder {
+        private GcpResourceEncryptionParametersDto gcpResourceEncryptionParametersDto;
 
-        private Builder() {
-
+        public Builder withEncryptionParameters(GcpResourceEncryptionParametersDto gcpResourceEncryptionParametersDto) {
+            this.gcpResourceEncryptionParametersDto = gcpResourceEncryptionParametersDto;
+            return this;
         }
 
         public GcpParametersDto build() {

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/GcpResourceEncryptionParametersDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/GcpResourceEncryptionParametersDto.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.environment.parameter.dto;
+
+public class GcpResourceEncryptionParametersDto {
+
+    private final String encryptionKey;
+
+    private GcpResourceEncryptionParametersDto(GcpResourceEncryptionParametersDto.Builder builder) {
+        encryptionKey = builder.encryptionKey;
+    }
+
+    public String getEncryptionKey() {
+        return encryptionKey;
+    }
+
+    public static GcpResourceEncryptionParametersDto.Builder builder() {
+        return new GcpResourceEncryptionParametersDto.Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "GcpResourceEncryptionParametersDto{" +
+                "encryptionKey=" + encryptionKey +
+                '}';
+    }
+
+    public static final class Builder {
+        private String encryptionKey;
+
+        public GcpResourceEncryptionParametersDto.Builder withEncryptionKey(String encryptionKey) {
+            this.encryptionKey = encryptionKey;
+            return this;
+        }
+
+        public GcpResourceEncryptionParametersDto build() {
+            return new GcpResourceEncryptionParametersDto(this);
+        }
+    }
+}

--- a/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/GcpParametersDtoTest.java
+++ b/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/GcpParametersDtoTest.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.environment.parameter.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GcpParametersDtoTest {
+
+    private static final String ENCRYPTION_KEY = "dummy-encryption-key";
+
+    @Test
+    void testGcpParametersDtoWithEncryptionParametersWithEncryptionKey() {
+        GcpParametersDto dummyGcpParametersDto = GcpParametersDto.builder()
+                .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder()
+                        .withEncryptionKey(ENCRYPTION_KEY)
+                        .build())
+                .build();
+        assertEquals(dummyGcpParametersDto.getGcpResourceEncryptionParametersDto().getEncryptionKey(), ENCRYPTION_KEY);
+    }
+}

--- a/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/GcpResourceEncryptionParametersDtoTest.java
+++ b/structuredevent-model/src/test/java/com/sequenceiq/environment/parameter/dto/GcpResourceEncryptionParametersDtoTest.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.environment.parameter.dto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GcpResourceEncryptionParametersDtoTest {
+
+    private static final String ENCRYPTION_KEY = "dummy-encryption-key";
+
+    @Test
+    void testGcoResourceEncryptionParametersDtoWithEncryptionKey() {
+        GcpResourceEncryptionParametersDto dummyGcpResourceEncryptionParametersDto = createGcpResourceEncryptionParametersDto();
+        assertEquals(dummyGcpResourceEncryptionParametersDto.getEncryptionKey(), ENCRYPTION_KEY);
+    }
+
+    private GcpResourceEncryptionParametersDto createGcpResourceEncryptionParametersDto() {
+        return GcpResourceEncryptionParametersDto.builder()
+                .withEncryptionKey(ENCRYPTION_KEY)
+                .build();
+    }
+}


### PR DESCRIPTION
This change enables GCP CMEK for for resource encryption. In this change we have introduced a new parameter encryption-key which accept the GCP key resource path and encrypts the FREEIPA disk using this encryption key.
See the design doc for more details. https://docs.google.com/document/d/199zU-ECjfk4B0nIBzYq_5G6T7NM1uCCuxuVYG7_fwws/edit#heading=h.lqrcqpih6dy

Changes include:

Adding new param encryption_key to gcp-create-environment
GCP CMEK Key validation using regex and storing encryption-key in enviroment-parameters table.
Using GCP CMEK key to encrypt FREEIPA Disk by setting keyEncryptionMethod to KMS. If KeyEncryotionMethod is set to KMS then GcpDiskResourceBuilder verifies this and uses key present in VOLUME_ENCRYPTION_KEY_ID using CustomGcpDiskEncryptionService to encrypt the vm disk.
Sample Payload : https://drive.google.com/file/d/1alm7pT4J71oTZILxGHePPDTVO3w9mho4/view

Testing

Relevant unit tests have been added.
Tested locally using postman by creating environment using encryption key and without encryption key. The behaviour of disk allocation is as expected.

See detailed description in the commit message.