### PR TITLE
CB-13379 Ease conflict resolution problems in FreeIPA HA setup

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
@@ -28,7 +28,7 @@ join_ipa:
 {% else %}
     - name: runuser -l root -c 'export PW="{{salt['pillar.get']('sssd-ipa:password')}}" && /opt/salt/scripts/join_ipa.sh && echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/log/ipa-join-executed'
 {% endif %}
-    - unless: test -f /var/log/ipa-join-executed
+    - unless: test -f /var/log/ipa-join-executed && test -f /var/log/dnsrecord-add-executed
     - runas: root
     - failhard: True
     - require:

--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
@@ -17,19 +17,20 @@ FQDN=$(hostname -f)
 IPADDR=$(hostname -i)
 REVERSE_IP=$(hostname -i | awk -F. '{print $4"."$3"." $2"."$1}')
 
-# add dns a-record 3 times with a 10 seconds interval (see CDPSDX-1981)
+# add dns a-record 3 times with a 10 seconds interval (see CDPSDX-1981, CB-13379)
 for attempt in {1..3}
 do
-  echo "add dns a-record hostname for ${HOSTNAME}, attempt ${attempt}"
-  if ! ipa dnsrecord-find {{ pillar['sssd-ipa']['domain'] }}. "--name=${HOSTNAME}" "--a-rec=${IPADDR}"  --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} --all; then
-    ipa dnsrecord-add {{ pillar['sssd-ipa']['domain'] }}. "${HOSTNAME}" "--a-rec=${IPADDR}" --ttl {{ pillar['sssd-ipa']['dns_ttl'] }}
-  fi
   sleep 10
+  echo "add dns a-record hostname for ${HOSTNAME}, attempt ${attempt}"
+  retVal=0
+  ipa dnsrecord-mod {{ pillar['sssd-ipa']['domain'] }}. "${HOSTNAME}" "--a-rec=${IPADDR}" --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} || retVal=$?
+  if [[ "$retVal" -le 1 ]]; then
+    break
+  elif [[ "$attempt" -eq 3 ]]; then
+    echo "Failed to set DNS A-record for ${HOSTNAME}"
+    false
+  fi
 done
-if ! ipa dnsrecord-find {{ pillar['sssd-ipa']['domain'] }}. "--name=${HOSTNAME}" "--a-rec=${IPADDR}"  --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} --all; then
-  echo "Failed to set DNS A-record for ${HOSTNAME}"
-  false
-fi
 
 for zone in $(ipa dnszone-find --raw | grep "idnsname:.*\.in-addr\.arpa\." | cut -d':' -f2 | awk '{ print length, $0 }' | sort -n -r | awk '{ print $2 }' | xargs)
 do


### PR DESCRIPTION
1. There is a chance that ipa-client-install and ipa dnsrecord-add could go to different FreeIPA hosts.
2. The replication may not have been complete when the ipa dnsrecord-add was done.
3. Also the repeated addition of records could end up in similar case above and could even lead to deletion of records due to conflict.
4. The conflict can not be automatically resolved by FreeIPA because multi valued DNs are not possible to be converted to hostnames.
5. Also it is two record additions with same or different values.
6. To overcome all these obstacles in this change trying to use dnsrecord-mod instead of dnsrecord-add.
7. This way I hope the nsuniqueid is not added to the idnsname which is leading to multi valued DNs and which becomes an unresolvable conflict.

Basic bash testing done, need to test this at scale

See detailed description in the commit message.