### PR TITLE
CB-13922 AWS datalake creation fails 'A load balancer cannot be attac…

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/GroupNetwork.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/GroupNetwork.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.model;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -9,12 +10,20 @@ import com.sequenceiq.common.api.type.OutboundInternetTraffic;
 public class GroupNetwork extends DynamicModel {
     private final Set<GroupSubnet> subnets;
 
+    private final Set<GroupSubnet> endpointGatewaySubnets;
+
     private final OutboundInternetTraffic outboundInternetTraffic;
 
     public GroupNetwork(OutboundInternetTraffic outboundInternetTraffic, Set<GroupSubnet> subnets, Map<String, Object> parameters) {
+        this(outboundInternetTraffic, subnets, new HashSet<>(), parameters);
+    }
+
+    public GroupNetwork(OutboundInternetTraffic outboundInternetTraffic, Set<GroupSubnet> subnets, Set<GroupSubnet> endpointGatewaySubnets,
+            Map<String, Object> parameters) {
         super(parameters);
         this.outboundInternetTraffic = outboundInternetTraffic;
         this.subnets = subnets;
+        this.endpointGatewaySubnets = endpointGatewaySubnets;
     }
 
     public OutboundInternetTraffic getOutboundInternetTraffic() {
@@ -25,11 +34,16 @@ public class GroupNetwork extends DynamicModel {
         return subnets;
     }
 
+    public Set<GroupSubnet> getEndpointGatewaySubnets() {
+        return endpointGatewaySubnets;
+    }
+
     @Override
     public String toString() {
         return "GroupNetwork{" +
                 ", outboundInternetTraffic=" + outboundInternetTraffic +
                 ", subnets=" + subnets +
+                ", endpointGatewaySubnets=" + endpointGatewaySubnets +
                 '}';
     }
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/common/network/NetworkConstants.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/common/network/NetworkConstants.java
@@ -10,6 +10,8 @@ public class NetworkConstants {
 
     public static final String ENDPOINT_GATEWAY_SUBNET_ID = "endpointGatewaySubnetId";
 
+    public static final String ENDPOINT_GATEWAY_SUBNET_IDS = "endpointGatewaySubnetIds";
+
     public static final String INTERNET_GATEWAY_ID = "internetGatewayId";
 
     public static final String CLOUD_PLATFORM = "cloudPlatform";

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/instancegroup/network/aws/InstanceGroupAwsNetworkV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/instancegroup/network/aws/InstanceGroupAwsNetworkV4Parameters.java
@@ -24,6 +24,9 @@ public class InstanceGroupAwsNetworkV4Parameters extends MappableBase implements
     @ApiModelProperty
     private List<String> subnetIds = new ArrayList<>();
 
+    @ApiModelProperty
+    private List<String> endpointGatewaySubnetIds = new ArrayList<>();
+
     public List<String> getSubnetIds() {
         return subnetIds;
     }
@@ -32,10 +35,19 @@ public class InstanceGroupAwsNetworkV4Parameters extends MappableBase implements
         this.subnetIds = subnetIds;
     }
 
+    public List<String> getEndpointGatewaySubnetIds() {
+        return endpointGatewaySubnetIds;
+    }
+
+    public void setEndpointGatewaySubnetIds(List<String> endpointGatewaySubnetIds) {
+        this.endpointGatewaySubnetIds = endpointGatewaySubnetIds;
+    }
+
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
         putIfValueNotNull(map, NetworkConstants.SUBNET_IDS, subnetIds);
+        putIfValueNotNull(map, NetworkConstants.ENDPOINT_GATEWAY_SUBNET_IDS, endpointGatewaySubnetIds);
         return map;
     }
 
@@ -49,5 +61,6 @@ public class InstanceGroupAwsNetworkV4Parameters extends MappableBase implements
     @Override
     public void parse(Map<String, Object> parameters) {
         subnetIds = getStringList(parameters, NetworkConstants.SUBNET_IDS);
+        endpointGatewaySubnetIds = getStringList(parameters, NetworkConstants.ENDPOINT_GATEWAY_SUBNET_IDS);
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/network/aws/InstanceGroupAwsNetworkV1Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/network/aws/InstanceGroupAwsNetworkV1Parameters.java
@@ -24,12 +24,23 @@ public class InstanceGroupAwsNetworkV1Parameters extends MappableBase implements
     @ApiModelProperty
     private List<String> subnetIds = new ArrayList<>();
 
+    @ApiModelProperty
+    private List<String> endpointGatewaySubnetIds = new ArrayList<>();
+
     public List<String> getSubnetIds() {
         return subnetIds;
     }
 
     public void setSubnetIds(List<String> subnetIds) {
         this.subnetIds = subnetIds;
+    }
+
+    public List<String> getEndpointGatewaySubnetIds() {
+        return endpointGatewaySubnetIds;
+    }
+
+    public void setEndpointGatewaySubnetIds(List<String> endpointGatewaySubnetIds) {
+        this.endpointGatewaySubnetIds = endpointGatewaySubnetIds;
     }
 
     @Override
@@ -42,12 +53,14 @@ public class InstanceGroupAwsNetworkV1Parameters extends MappableBase implements
     @Override
     public void parse(Map<String, Object> parameters) {
         subnetIds = getStringList(parameters, NetworkConstants.SUBNET_IDS);
+        endpointGatewaySubnetIds = getStringList(parameters, NetworkConstants.ENDPOINT_GATEWAY_SUBNET_IDS);
     }
 
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
         map.put(NetworkConstants.SUBNET_IDS, subnetIds);
+        map.put(NetworkConstants.ENDPOINT_GATEWAY_SUBNET_IDS, endpointGatewaySubnetIds);
         return map;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -466,14 +466,21 @@ public class StackToCloudStackConverter {
             Json attributes = instanceGroupNetwork.getAttributes();
             Map<String, Object> params = attributes == null ? Collections.emptyMap() : attributes.getMap();
             Set<GroupSubnet> subnets = new HashSet<>();
+            Set<GroupSubnet> endpointGatewaySubnets = new HashSet<>();
             if (params != null) {
                 List<String> subnetIds = (List<String>) params.getOrDefault(NetworkConstants.SUBNET_IDS, new ArrayList<>());
                 for (String subnetId : subnetIds) {
                     GroupSubnet groupSubnet = new GroupSubnet(subnetId);
                     subnets.add(groupSubnet);
                 }
+                List<String> endpointGatewaySubnetIds = (List<String>) params.getOrDefault(NetworkConstants.ENDPOINT_GATEWAY_SUBNET_IDS,
+                        new ArrayList<>());
+                for (String endpointGatewaySubnetId : endpointGatewaySubnetIds) {
+                    GroupSubnet groupSubnet = new GroupSubnet(endpointGatewaySubnetId);
+                    endpointGatewaySubnets.add(groupSubnet);
+                }
             }
-            groupNetwork = new GroupNetwork(getOutboundInternetTraffic(stackNetwork), subnets, params);
+            groupNetwork = new GroupNetwork(getOutboundInternetTraffic(stackNetwork), subnets, endpointGatewaySubnets, params);
         }
         return groupNetwork;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
@@ -43,6 +43,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.In
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.network.InstanceGroupNetworkV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.TagsV4Request;
 import com.sequenceiq.cloudbreak.cloud.PlatformParametersConsts;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Region;
@@ -54,6 +55,7 @@ import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.mappable.ProviderParameterCalculator;
+import com.sequenceiq.cloudbreak.common.network.NetworkConstants;
 import com.sequenceiq.cloudbreak.common.service.Clock;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
 import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
@@ -79,6 +81,7 @@ import com.sequenceiq.cloudbreak.tag.request.CDPTagMergeRequest;
 import com.sequenceiq.cloudbreak.util.PasswordUtil;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.common.api.telemetry.model.Telemetry;
+import com.sequenceiq.common.api.type.PublicEndpointAccessGateway;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
 
@@ -403,6 +406,7 @@ public class StackV4RequestToStackConverter extends AbstractConversionServiceAwa
                 String subnetId = getSubnetIdIfExist(network);
                 setNetworkByProvider(source, instanceGroup, instanceGroupNetworkV4Request, subnetId);
             }
+            setupEndpointGatewayNetwork(instanceGroup.getNetwork(), stack, instanceGroup.getName(), environment);
         }
     }
 
@@ -492,6 +496,50 @@ public class StackV4RequestToStackConverter extends AbstractConversionServiceAwa
             }
         }
         return subnetId;
+    }
+
+    private String getStackEndpointGatwaySubnetIdIfExists(Stack stack) {
+        return Optional.ofNullable(stack.getNetwork())
+                .map(Network::getAttributes)
+                .map(Json::getMap)
+                .map(attr -> attr.get(NetworkConstants.ENDPOINT_GATEWAY_SUBNET_ID))
+                .map(Object::toString)
+                .orElse(null);
+    }
+
+    private void setupEndpointGatewayNetwork(InstanceGroupNetworkV4Request instanceGroupNetworkV4Request, Stack stack, String instanceGroupName,
+            DetailedEnvironmentResponse environment) {
+        if (CloudPlatform.AWS.name().equals(stack.getCloudPlatform()) && instanceGroupNetworkV4Request != null &&
+                instanceGroupNetworkV4Request.getAws() != null) {
+            EnvironmentNetworkResponse envNetwork = environment == null ? null : environment.getNetwork();
+            if (envNetwork != null) {
+                if (PublicEndpointAccessGateway.ENABLED.equals(envNetwork.getPublicEndpointAccessGateway())) {
+                    LOGGER.info("Found AWS stack with endpoint gatewy enabled. Selecting endpoint gateway subnet ids.");
+                    List<String> subnetIds = instanceGroupNetworkV4Request.getAws().getSubnetIds();
+                    LOGGER.debug("Endpoint gateway selection: Found instance group network subnet list of {} for instance group {}",
+                            subnetIds, instanceGroupName);
+                    List<String> allAvailabilityZones = envNetwork.getSubnetMetas().values().stream()
+                            .filter(subnetMeta -> subnetIds.contains(subnetMeta.getId()))
+                            .map(CloudSubnet::getAvailabilityZone)
+                            .collect(Collectors.toList());
+                    LOGGER.debug("Endpoint gatway selection: Instance group network has availability zones {}", allAvailabilityZones);
+                    List<String> endpointGatewaySubnetIds = envNetwork.getGatewayEndpointSubnetMetas().values().stream()
+                            .filter(subnetMeta -> allAvailabilityZones.contains(subnetMeta.getAvailabilityZone()))
+                            .map(CloudSubnet::getId)
+                            .collect(Collectors.toList());
+
+                    if (endpointGatewaySubnetIds.isEmpty()) {
+                        String endpointGatewaySubnetId = getStackEndpointGatwaySubnetIdIfExists(stack);
+                        LOGGER.info("Unable to find endpoint gateway subnet metas to match AZs {}. Falling back to subnet {}.",
+                                allAvailabilityZones, endpointGatewaySubnetId);
+                        instanceGroupNetworkV4Request.getAws().setEndpointGatewaySubnetIds(List.of(endpointGatewaySubnetId));
+                    } else {
+                        LOGGER.info("Selected endpoint gateway subnets {} for instance group {}", endpointGatewaySubnetIds, instanceGroupName);
+                        instanceGroupNetworkV4Request.getAws().setEndpointGatewaySubnetIds(endpointGatewaySubnetIds);
+                    }
+                }
+            }
+        }
     }
 
     private void setNetworkIfApplicable(StackV4Request source, Stack stack, DetailedEnvironmentResponse environment) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceGroupNetworkParameterConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceGroupNetworkParameterConverter.java
@@ -165,6 +165,12 @@ public class InstanceGroupNetworkParameterConverter {
             } else if (source.getValue() != null) {
                 response.setSubnetIds(List.of(source.getValue().getPreferedSubnetId()));
             }
+            List<String> endpointGatewaySubnetIds = key.getEndpointGatewaySubnetIds();
+            if (subnetIdsDefined(endpointGatewaySubnetIds)) {
+                response.setEndpointGatewaySubnetIds(endpointGatewaySubnetIds);
+            } else if (source.getValue() != null) {
+                response.setEndpointGatewaySubnetIds(List.copyOf(source.getValue().getEndpointGatewaySubnetIds()));
+            }
         }
 
         return response;


### PR DESCRIPTION
…hed to multiple subnets in the same Availability Zone'

Adds new logic to attach an endpoint gateway subnet to each instance group network if the endpoint
gateway is enabled. The public endpoint gateway LB will now only use the defined endpoint gateway
subnets, and not the instance subnets.

Tested via created an SPN enabled environment in local CB.