### PR TITLE
CB-13928 Eliminating reserved storage on storage volumes

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/disks/mount/scripts/find-device-and-format.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/disks/mount/scripts/find-device-and-format.j2
@@ -60,6 +60,14 @@ format_disks_if_unformatted() {
             return_value=1
           fi
           log $LOG_FILE $format_result
+
+          log $LOG_FILE "Reducing reserved storage for root to 0 on device: $devicename"
+          $(tune2fs -m 0 $devicename >> $LOG_FILE 2>&1)
+          if [ ! $? -eq 0 ]; then
+            log $LOG_FILE "Reducing reserved storage on $devicename failed"
+          fi
+          tunefs_result=$(tune2fs -l $devicename | egrep "Block size:|Reserved block count")
+          log $LOG_FILE "Reserved storage on $devicename: $tunefs_result"
       fi
   done
   return $((return_value))


### PR DESCRIPTION
Reserved storage is only valuable on the root disk. On it it enables keeps enough storage for the user to ssh into the machine even, when its full. On storage volumes it is not necessary and for a 1TB disk it reserved 50GB by default.