### PR TITLE
CB-12707 - Put original repaired node back to DELETED_ON_PROVIDER_SIDE if repair fails if stack upscale failed

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -341,9 +341,11 @@ public class AzureResourceConnector extends AbstractResourceConnector {
         Collection<CloudResource> result = new ArrayList<>();
         for (CloudInstance instance : instances) {
             String instanceId = instance.getInstanceId();
-            for (CloudResource resource : resources) {
-                if (instanceId.equalsIgnoreCase(resource.getName()) || instanceId.equalsIgnoreCase(resource.getInstanceId())) {
-                    result.add(resource);
+            if (instanceId != null) {
+                for (CloudResource resource : resources) {
+                    if (instanceId.equalsIgnoreCase(resource.getName()) || instanceId.equalsIgnoreCase(resource.getInstanceId())) {
+                        result.add(resource);
+                    }
                 }
             }
         }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -194,6 +194,7 @@ public enum ResourceEvent {
     STACK_INFRASTRUCTURE_START_FAILED("stack.infrastructure.start.failed"),
     STACK_INFRASTRUCTURE_STOP_FAILED("stack.infrastructure.stop.failed"),
     STACK_REPAIR_DETECTION_STARTED("stack.repair.detection.started"),
+    STACK_INSTANCE_METADATA_RESTORED("stack.instance.metadata.restored"),
     STACK_REPAIR_FAILED("stack.repair.failed"),
     STACK_DATALAKE_UPDATE("stack.datalake.update"),
     STACK_DATALAKE_UPDATE_FINISHED("stack.datalake.update.finished"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -30,6 +30,7 @@ stack.infrastructure.subnets.updating=Updating allowed subnets
 stack.infrastructure.subnets.updated=Allowed subnets updated
 stack.infrastructure.update.failed=Stack update failed. Reason: {0}
 stack.infrastructure.create.failed=Infrastructure creation failed. Reason: {0}
+stack.instance.metadata.restored=Repair failed for instance, metadata restored for host: {0}
 stack.infrastructure.rollback=Infrastructure rollback. Reason: {0}
 stack.infrastructure.rollback.failed=Infrastructure rollback failed. Reason: {0}
 stack.infrastructure.delete.failed=Infrastructure termination failed. Reason: {0}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
@@ -248,7 +248,7 @@ public class InstanceMetaData implements ProvisionEntity {
         return InstanceStatus.SERVICES_HEALTHY.equals(instanceStatus) || InstanceStatus.SERVICES_RUNNING.equals(instanceStatus);
     }
 
-    public boolean isUnhealthy() {
+    public boolean isServicesUnhealthy() {
         return InstanceStatus.SERVICES_UNHEALTHY.equals(instanceStatus);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/downscale/StackDownscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/downscale/StackDownscaleActions.java
@@ -80,7 +80,7 @@ public class StackDownscaleActions {
                 variables.put(INSTANCES, instances);
 
                 final Map<String, String> addressesByFqdn = candidatesInstanceMetadata.stream()
-                        .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
+                        .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null && instanceMetaData.getPrivateIp() != null)
                         .collect(toMap(InstanceMetaData::getDiscoveryFQDN, InstanceMetaData::getPrivateIp));
                 clusterPublicEndpointManagementService.downscale(stack, addressesByFqdn);
                 Selectable request = new DownscaleStackCollectResourcesRequest(context.getCloudContext(),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack.upscale;
 
+import static com.sequenceiq.cloudbreak.core.flow2.stack.upscale.AbstractStackUpscaleAction.HOSTNAMES;
+
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -347,7 +350,9 @@ public class StackUpscaleActions {
         return new AbstractStackFailureAction<StackUpscaleState, StackUpscaleEvent>() {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) {
-                stackUpscaleService.handleStackUpscaleFailure(isRepair(variables), payload.getException(), payload.getResourceId());
+                Set<String> hostNames = (Set<String>) variables.getOrDefault(HOSTNAMES, new HashSet<>());
+                stackUpscaleService.handleStackUpscaleFailure(isRepair(variables), hostNames, payload.getException(),
+                        payload.getResourceId());
                 getMetricService().incrementMetricCounter(MetricType.STACK_UPSCALE_FAILED, context.getStackView(), payload.getException());
                 sendEvent(context);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
@@ -99,7 +99,7 @@ public class StackUpscaleService {
         validateResourceResults(context, payload.getErrorDetails(), results);
         Set<Resource> resourceSet = transformResults(results, context.getStack());
         if (resourceSet.isEmpty()) {
-            metadataSetupService.cleanupRequestedInstances(context.getStack(), context.getInstanceGroupName());
+            metadataSetupService.cleanupRequestedInstancesWithoutFQDN(context.getStack(), context.getInstanceGroupName());
             throw new OperationException("Failed to upscale the cluster since all create request failed. Resource set is empty");
         }
         LOGGER.debug("Adding new instances to the stack is DONE");
@@ -155,15 +155,15 @@ public class StackUpscaleService {
         stackUpdater.updateStackStatus(stack.getId(), DetailedStackStatus.UPSCALE_COMPLETED, "Stack upscale has been finished successfully.");
     }
 
-    public void handleStackUpscaleFailure(Boolean upscaleForRepair, Exception exception, Long stackId) {
+    public void handleStackUpscaleFailure(Boolean upscaleForRepair, Set<String> hostNames, Exception exception, Long stackId) {
         LOGGER.info("Exception during the upscale of stack", exception);
         try {
             String errorReason = exception.getMessage();
-            metadataSetupService.cleanupRequestedInstances(stackId);
             if (!upscaleForRepair) {
                 stackUpdater.updateStackStatus(stackId, DetailedStackStatus.UPSCALE_FAILED, "Stack update failed. " + errorReason);
                 flowMessageService.fireEventAndLog(stackId, UPDATE_FAILED.name(), STACK_INFRASTRUCTURE_UPDATE_FAILED, errorReason);
             } else {
+                metadataSetupService.handleRepairFail(stackId, hostNames);
                 stackUpdater.updateStackStatus(stackId, DetailedStackStatus.REPAIR_FAILED, "Stack repair failed. " + errorReason);
                 flowMessageService.fireEventAndLog(stackId, UPDATE_FAILED.name(), STACK_REPAIR_FAILED, errorReason);
             }
@@ -199,7 +199,8 @@ public class StackUpscaleService {
         List<CloudResourceStatus> templates = results.stream().filter(result -> CommonResourceType.TEMPLATE == result.getCloudResource().getType()
                 .getCommonResourceType()).collect(Collectors.toList());
         if (!templates.isEmpty() && (templates.get(0).isFailed() || templates.get(0).isDeleted())) {
-            throw new OperationException(format("Failed to upscale the stack for %s due to: %s", context.getCloudContext(), templates.get(0).getStatusReason()));
+            throw new OperationException(format("Failed to upscale the stack for %s due to: %s",
+                    context.getCloudContext(), templates.get(0).getStatusReason()));
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/RemoveHostsHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/orchestration/RemoveHostsHandler.java
@@ -68,7 +68,7 @@ public class RemoveHostsHandler implements EventHandler<RemoveHostsRequest> {
         Selectable result;
         try {
             Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
-            if (stack.getPrimaryGatewayInstance().isReachable()) {
+            if (stack.getPrimaryGatewayInstance() != null && stack.getPrimaryGatewayInstance().isReachable()) {
                 List<GatewayConfig> allGatewayConfigs = gatewayConfigService.getAllGatewayConfigs(stack);
                 PollingResult orchestratorRemovalPollingResult =
                         removeHostsFromOrchestrator(stack, new ArrayList<>(hostNames), hostOrchestrator, allGatewayConfigs);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
@@ -46,7 +46,7 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
     @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceGroup.stack.id= :stackId")
     Set<InstanceMetaData> findAllInStack(@Param("stackId") Long stackId);
 
-    @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceGroup.stack.id= :stackId")
+    @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceGroup.stack.id= :stackId AND i.instanceStatus <> 'TERMINATED'")
     Set<InstanceMetaData> findAllWithoutInstanceGroupInStack(@Param("stackId") Long stackId);
 
     @EntityGraph(value = "InstanceMetaData.instanceGroup", type = EntityGraphType.LOAD)
@@ -98,6 +98,11 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
     @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceMetadataType = 'GATEWAY_PRIMARY' AND i.instanceStatus <> 'TERMINATED' "
             + "AND i.instanceGroup.stack.id= :stackId")
     Optional<InstanceMetaData> getPrimaryGatewayInstanceMetadata(@Param("stackId") Long stackId);
+
+    @Query("SELECT i FROM InstanceMetaData i WHERE i.discoveryFQDN = :discoveryFQDN AND i.instanceStatus = 'TERMINATED' AND i.instanceId IS NOT null "
+            + "AND i.instanceGroup.stack.id= :stackId ORDER BY i.terminationDate DESC")
+    List<InstanceMetaData> getTerminatedInstanceMetadataWithInstanceIdByFQDNOrdered(@Param("stackId") Long stackId,
+            @Param("discoveryFQDN") String discoveryFQDN, Pageable pageable);
 
     @Query("SELECT i FROM InstanceMetaData i WHERE i.instanceMetadataType = 'GATEWAY_PRIMARY' AND i.instanceStatus = 'TERMINATED' "
             + "AND i.instanceGroup.stack.id= :stackId ORDER BY i.terminationDate DESC")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/InstanceMetaDataService.java
@@ -28,6 +28,7 @@ import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceTemplate;
 import com.sequenceiq.cloudbreak.cloud.model.VolumeSetAttributes;
 import com.sequenceiq.cloudbreak.cloud.service.ResourceRetriever;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
@@ -98,6 +99,10 @@ public class InstanceMetaDataService {
                 instanceMetaData.setInstanceGroup(instanceGroup);
                 if (hostNameIterator.hasNext()) {
                     String hostName = hostNameIterator.next();
+                    repository.findHostInStack(stack.getId(), hostName).ifPresent(existingHost -> {
+                        throw new CloudbreakServiceException("There is an existing host with the same FQDN. It can happen if you retried a failed repair. " +
+                                "Please start the repairing process again instead of retry.");
+                    });
                     LOGGER.info("We have hostname to be allocated: {}, set it to this instanceMetadata: {}", hostName, instanceMetaData);
                     instanceMetaData.setDiscoveryFQDN(hostName);
                     subnetAzPairs = getSubnetAzPairsFilteredByHostNameIfRepair(environment, stack, repair, instanceGroup.getGroupName(), hostName);
@@ -255,6 +260,16 @@ public class InstanceMetaDataService {
             return repository.getPrimaryGatewayInstanceMetadata(stackId);
         } catch (AccessDeniedException ignore) {
             LOGGER.debug("No primary gateway for stack [{}]", stackId);
+            return Optional.empty();
+        }
+    }
+
+    public Optional<InstanceMetaData> getTerminatedInstanceMetadataWithInstanceIdByFQDNOrdered(long stackId, String hostName) {
+        try {
+            List<InstanceMetaData> result = repository.getTerminatedInstanceMetadataWithInstanceIdByFQDNOrdered(stackId, hostName, PageRequest.of(0, 1));
+            return result.isEmpty() ? Optional.empty() : Optional.of(result.get(0));
+        } catch (AccessDeniedException ignore) {
+            LOGGER.debug("Cannot fetch last terminated instance metadata for stack [{}] and hostname [{}]", stackId, hostName);
             return Optional.empty();
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
@@ -213,10 +213,14 @@ public class StackSyncService {
             InstanceSyncState state) {
         if (!instance.isTerminated() || !instance.isDeletedOnProvider()) {
             if (instance.getInstanceId() == null) {
-                instanceStateCounts.put(InstanceSyncState.DELETED, instanceStateCounts.get(InstanceSyncState.DELETED) + 1);
-                LOGGER.debug("Instance with private id '{}' don't have instanceId, setting its state to DELETED.",
-                        instance.getPrivateId());
-                instanceMetaDataService.updateInstanceStatus(instance, InstanceStatus.TERMINATED);
+                if (instance.getDiscoveryFQDN() == null) {
+                    instanceStateCounts.put(InstanceSyncState.DELETED, instanceStateCounts.get(InstanceSyncState.DELETED) + 1);
+                    LOGGER.debug("Instance with private id '{}' don't have instanceId and FQDN, setting its state to DELETED.",
+                            instance.getPrivateId());
+                    instanceMetaDataService.updateInstanceStatus(instance, InstanceStatus.TERMINATED);
+                } else {
+                    LOGGER.debug("Instance with private id '{}' don't have instanceId but it has FQDN", instance.getInstanceId());
+                }
             } else {
                 instanceStateCounts.put(state, instanceStateCounts.get(state) + 1);
                 LOGGER.debug("Instance '{}' is reported as deleted on the cloud provider, setting its state to {}.",

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairServiceTest.java
@@ -622,6 +622,7 @@ public class ClusterRepairServiceTest {
         instanceGroup.setGroupName(groupName);
         instanceGroup.setTemplate(createTemplate(volumeTemplates));
         InstanceMetaData instanceMetaData = createInstanceMetaData("instanceId", InstanceStatus.SERVICES_UNHEALTHY);
+        instanceMetaData.setDiscoveryFQDN("fqdn");
         instanceMetaData.setInstanceGroup(instanceGroup);
         instanceGroup.setInstanceMetaData(Set.of(instanceMetaData));
         return instanceGroup;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRepairTests.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -23,6 +24,7 @@ import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.mock.Method;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.util.SdxUtil;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
@@ -73,6 +75,59 @@ public class MockSdxRepairTests extends AbstractMockTest {
                 List.of(MASTER),
                 instanceBasePath -> getExecuteQueryToMockInfrastructure().call(instanceBasePath + "/terminate", w -> w),
                 SdxClusterStatusResponse.CLUSTER_AMBIGUOUS);
+    }
+
+    @Test(dataProvider = TEST_CONTEXT_WITH_MOCK)
+    @Description(
+            given = "there is a running Cloudbreak",
+            when = "terminate instances and repair an sdx cluster",
+            then = "repair should fail and repaired instance should be in deleted on provider side"
+    )
+    public void repairTerminatedMasterAndItFailedButInstanceShouldBeDeletedOnProviderSide(MockedTestContext testContext) {
+        String sdxInternal = resourcePropertyProvider().getName();
+        String networkKey = "someOtherNetwork";
+
+        SdxDatabaseRequest sdxDatabaseRequest = new SdxDatabaseRequest();
+        sdxDatabaseRequest.setAvailabilityType(SdxDatabaseAvailabilityType.NON_HA);
+        CustomDomainSettingsV4Request customDomain = new CustomDomainSettingsV4Request();
+        customDomain.setDomainName("dummydomainname");
+        customDomain.setHostname("dummyhostname");
+        customDomain.setClusterNameAsSubdomain(true);
+        customDomain.setHostgroupNameAsHostname(true);
+        testContext
+                .given(networkKey, EnvironmentNetworkTestDto.class)
+                .withMock(new EnvironmentNetworkMockParams())
+                .given(EnvironmentTestDto.class)
+                .withNetwork(networkKey)
+                .withCreateFreeIpa(Boolean.FALSE)
+                .withName(resourcePropertyProvider().getEnvironmentName())
+                .when(getEnvironmentTestClient().create())
+                .await(EnvironmentStatus.AVAILABLE)
+                .given(sdxInternal, SdxInternalTestDto.class)
+                .withDatabase(sdxDatabaseRequest)
+                .withCustomDomain(customDomain)
+                .when(sdxTestClient.createInternal(), key(sdxInternal))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
+                .then((tc, testDto, client) -> {
+                    List<String> instancesToDelete = new ArrayList<>(sdxUtil.getInstanceIds(testDto, client, MASTER.getName()));
+                    instancesToDelete.forEach(instanceId -> getExecuteQueryToMockInfrastructure()
+                            .call("/" + testDto.getCrn() + "/spi/" + instanceId + "/terminate", w -> w));
+                    getExecuteQueryToMockInfrastructure().executeMethod(Method.build("POST"), "/" + testDto.getCrn() + "/spi/disable_add_instance",
+                            new HashMap<>(), null, response -> { }, w -> w);
+                    return testDto;
+                })
+                .await(SdxClusterStatusResponse.CLUSTER_AMBIGUOUS, Duration.ofSeconds(POLLING_INTERVAL_FOR_REPAIR_SECONDS))
+                .when(sdxTestClient.repairInternal(MASTER.getName()), key(sdxInternal))
+                .awaitForMasterDeletedOnProvider()
+                .awaitForFlowFail()
+                .then((tc, testDto, client) -> {
+                    getExecuteQueryToMockInfrastructure().executeMethod(Method.build("POST"), "/" + testDto.getCrn() + "/spi/enable_add_instance",
+                            new HashMap<>(), null, response -> { }, w -> w);
+                    return testDto;
+                })
+                .when(sdxTestClient.repairInternal(MASTER.getName()), key(sdxInternal))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))
+                .validate();
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, invocationCount = 1)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
@@ -25,16 +25,17 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
             throw new TestFailException(String.format("Cluster '%s' has been getting terminated (status:'%s'), waiting is cancelled.", name,
                     actualStatuses));
         }
+        if (waitObject.isInDesiredStatus()) {
+            LOGGER.info("Cluster '{}' is in desired state (status:'{}').", name, actualStatuses);
+            return true;
+        }
         if (waitObject.isFailed()) {
             Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
             LOGGER.error("Cluster '{}' is in failed state (status:'{}'), waiting is cancelled.", name, actualStatuses);
             throw new TestFailException(String.format("Cluster '%s' is in failed state. Status: '%s' statusReason: '%s'",
                     name, actualStatuses, actualStatusReasons));
         }
-        if (waitObject.isInDesiredStatus()) {
-            LOGGER.info("Cluster '{}' is in desired state (status:'{}').", name, actualStatuses);
-            return true;
-        }
+
         return waitObject.isInDesiredStatus();
     }
 

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/spi/SpiDto.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/spi/SpiDto.java
@@ -14,6 +14,8 @@ public class SpiDto {
 
     private List<CloudVmMetaDataStatus> vmMetaDataStatuses;
 
+    private boolean addInstanceDisabled;
+
     public SpiDto(String mockuuid, CloudStack cloudStack) {
         this.cloudStack = cloudStack;
         this.mockuuid = mockuuid;
@@ -31,4 +33,13 @@ public class SpiDto {
     public CloudStack getCloudStack() {
         return cloudStack;
     }
+
+    public boolean isAddInstanceDisabled() {
+        return addInstanceDisabled;
+    }
+
+    public void setAddInstanceDisabled(boolean addInstanceDisabled) {
+        this.addInstanceDisabled = addInstanceDisabled;
+    }
+
 }

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/spi/SpiStoreService.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/spi/SpiStoreService.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -75,10 +76,25 @@ public class SpiStoreService {
     public List<CloudVmMetaDataStatus> resize(String mockUuid, List<Group> groups) {
         LOGGER.info("Resize {}", mockUuid);
         SpiDto spiDto = read(mockUuid);
+        if (spiDto.isAddInstanceDisabled()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Add instance disabled");
+        }
         List<CloudVmMetaDataStatus> instances = defaultModelService.createInstances(mockUuid, spiDto, groups);
         LOGGER.info("{} will be resized with {}", mockUuid, instances);
         spiDto.getVmMetaDataStatuses().addAll(instances);
         return instances;
+    }
+
+    public void disableAddInstance(String mockUuid) {
+        LOGGER.info("Disable add instance for uuid: {}", mockUuid);
+        SpiDto spiDto = read(mockUuid);
+        spiDto.setAddInstanceDisabled(true);
+    }
+
+    public void enableAddInstance(String mockUuid) {
+        LOGGER.info("Enable add instance for uuid: {}", mockUuid);
+        SpiDto spiDto = read(mockUuid);
+        spiDto.setAddInstanceDisabled(false);
     }
 
     public void terminate(String mockUuid) {

--- a/mock-infrastructure/src/main/java/com/sequenceiq/mock/spi/controller/SpiController.java
+++ b/mock-infrastructure/src/main/java/com/sequenceiq/mock/spi/controller/SpiController.java
@@ -61,6 +61,16 @@ public class SpiController {
         return vms;
     }
 
+    @PostMapping("/disable_add_instance")
+    public void disableAddInstance(@PathVariable("mock_uuid") String mockuuid) {
+        spiStoreService.disableAddInstance(mockuuid);
+    }
+
+    @PostMapping("/enable_add_instance")
+    public void enableAddInstance(@PathVariable("mock_uuid") String mockuuid) {
+        spiStoreService.enableAddInstance(mockuuid);
+    }
+
     @DeleteMapping("/terminate")
     public void terminate(@PathVariable("mock_uuid") String mockuuid) {
         spiStoreService.terminate(mockuuid);


### PR DESCRIPTION
Node can disappear at repair. It can happen if stack upscale fails at repair. In this scenario the old node is deleted, but the new node is in REQUESTED status. But requested nodes without instance id are cleaned up in many ways. For example if upscale fails, the upscale fail handling logic deletes these kind of nodes. It results the repaired node will disappear.

My solution: if a stack upscale fails, then we take back the original deleted node to DELETED_ON_PROVIDER_SIDE.
In this case the retry will not work. Reason is because retry will retry the upscale process and it would uspcale a new node next to the original node which is in DELETED_ON_PROVIDER_SIDE status. It is handled, retry (upscale) will fail if there is an another node with the same FQDN at upscale (e.g. the original node in DELETED_ON_PROVIDER_SIDE status).

Other solution would be if we just don't remove the upscaled node if it fails, but it is very hard to figure out which status we use in this case. As I experienced UI can repair SERVICES_UNHEALTHY nodes only and it will cause much trouble if user don't use retry but the user initiates a new repair for this failed upscaled node. Another thing is we ha cleanup codes for instances without instance ids as I mentioned before.

First I tried to implement the second solution but it was very hard to cover every edge cases and it leads to very complicated codes. The solution I choose looked more cleaner and easier to understand.