### PR TITLE
CB-13956 Freeipa Unable to find com.sequenceiq.freeipa.entity.SecurityGroup with id

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/health/HealthDetailsFreeIpaResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/health/HealthDetailsFreeIpaResponse.java
@@ -84,4 +84,14 @@ public class HealthDetailsFreeIpaResponse {
         this.status = status;
     }
 
+    @Override
+    public String toString() {
+        return "HealthDetailsFreeIpaResponse{" +
+                "environmentCrn='" + environmentCrn + '\'' +
+                ", name='" + name + '\'' +
+                ", crn='" + crn + '\'' +
+                ", nodeHealthDetails=" + nodeHealthDetails +
+                ", status=" + status +
+                '}';
+    }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/list/ListFreeIpaResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/list/ListFreeIpaResponse.java
@@ -91,4 +91,17 @@ public class ListFreeIpaResponse {
     public void setAvailabilityStatus(AvailabilityStatus availabilityStatus) {
         this.availabilityStatus = availabilityStatus;
     }
+
+    @Override
+    public String toString() {
+        return "ListFreeIpaResponse{" +
+                "environmentCrn='" + environmentCrn + '\'' +
+                ", name='" + name + '\'' +
+                ", crn='" + crn + '\'' +
+                ", domain='" + domain + '\'' +
+                ", status=" + status +
+                ", statusString='" + statusString + '\'' +
+                ", availabilityStatus=" + availabilityStatus +
+                '}';
+    }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/reboot/RebootInstancesRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/reboot/RebootInstancesRequest.java
@@ -51,4 +51,13 @@ public class RebootInstancesRequest {
     public void setInstanceIds(List<String> instanceIds) {
         this.instanceIds = instanceIds;
     }
+
+    @Override
+    public String toString() {
+        return "RebootInstancesRequest{" +
+                "environmentCrn='" + environmentCrn + '\'' +
+                ", forceReboot=" + forceReboot +
+                ", instanceIds=" + instanceIds +
+                '}';
+    }
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/repair/RepairInstancesRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/repair/RepairInstancesRequest.java
@@ -52,4 +52,13 @@ public class RepairInstancesRequest {
     public void setInstanceIds(List<String> instanceIds) {
         this.instanceIds = instanceIds;
     }
+
+    @Override
+    public String toString() {
+        return "RepairInstancesRequest{" +
+                "environmentCrn='" + environmentCrn + '\'' +
+                ", forceRepair=" + forceRepair +
+                ", instanceIds=" + instanceIds +
+                '}';
+    }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceGroup.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/InstanceGroup.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.freeipa.entity;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -23,8 +24,8 @@ import javax.persistence.SequenceGenerator;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonToString;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
-
 import com.sequenceiq.freeipa.entity.util.InstanceGroupTypeConverter;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @NamedEntityGraph(name = "InstanceGroup.instanceMetaData",
@@ -179,5 +180,28 @@ public class InstanceGroup implements Comparable<InstanceGroup> {
 
     public Set<InstanceMetaData> getInstanceMetaData() {
         return instanceMetaData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        } else {
+            InstanceGroup that = (InstanceGroup) o;
+            return Objects.equals(id, that.id)
+                    && Objects.equals(template, that.template)
+                    && Objects.equals(instanceGroupNetwork, that.instanceGroupNetwork)
+                    && Objects.equals(groupName, that.groupName)
+                    && instanceGroupType == that.instanceGroupType
+                    && Objects.equals(attributes, that.attributes)
+                    && Objects.equals(nodeCount, that.nodeCount);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, template, instanceGroupNetwork, groupName, instanceGroupType, attributes, nodeCount);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/SecurityGroup.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/SecurityGroup.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.freeipa.entity;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.persistence.CascadeType;
@@ -47,10 +48,6 @@ public class SecurityGroup {
         this.securityRules = securityRules;
     }
 
-    public String getFirstSecurityGroupId() {
-        return securityGroupIds == null || securityGroupIds.isEmpty() ? null : securityGroupIds.iterator().next();
-    }
-
     public Set<String> getSecurityGroupIds() {
         return securityGroupIds;
     }
@@ -65,5 +62,32 @@ public class SecurityGroup {
 
     public void setName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        } else {
+            SecurityGroup that = (SecurityGroup) o;
+            return Objects.equals(id, that.id) && Objects.equals(name, that.name);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
+    }
+
+    @Override
+    public String toString() {
+        return "SecurityGroup{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", securityRules=" + securityRules +
+                ", securityGroupIds=" + securityGroupIds +
+                '}';
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/SecurityRule.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/SecurityRule.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.freeipa.entity;
 
+import java.util.Objects;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -93,5 +95,23 @@ public class SecurityRule {
                 + ", protocol='" + protocol + '\''
                 + ", modifiable=" + modifiable
                 + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        } else {
+            SecurityRule that = (SecurityRule) o;
+            return modifiable == that.modifiable && Objects.equals(id, that.id) && Objects.equals(cidr, that.cidr) && Objects.equals(ports, that.ports)
+                    && Objects.equals(protocol, that.protocol);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, cidr, ports, protocol, modifiable);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/Stack.java
@@ -11,6 +11,7 @@ import static com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.ST
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -494,5 +495,48 @@ public class Stack implements AccountAwareResource {
                 ", minaSshdServiceId='" + minaSshdServiceId + '\'' +
                 ", ccmV2AgentCrn='" + ccmV2AgentCrn + '\'' +
                 '}';
+    }
+
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o == null || getClass() != o.getClass()) {
+            return false;
+        } else {
+            Stack stack = (Stack) o;
+            return Objects.equals(id, stack.id)
+                    && Objects.equals(resourceCrn, stack.resourceCrn)
+                    && Objects.equals(name, stack.name)
+                    && Objects.equals(environmentCrn, stack.environmentCrn)
+                    && Objects.equals(accountId, stack.accountId)
+                    && Objects.equals(region, stack.region)
+                    && Objects.equals(created, stack.created)
+                    && Objects.equals(platformvariant, stack.platformvariant)
+                    && Objects.equals(availabilityZone, stack.availabilityZone)
+                    && Objects.equals(cloudPlatform, stack.cloudPlatform)
+                    && Objects.equals(gatewayport, stack.gatewayport)
+                    && Objects.equals(useCcm, stack.useCcm)
+                    && tunnel == stack.tunnel
+                    && Objects.equals(clusterProxyRegistered, stack.clusterProxyRegistered)
+                    && Objects.equals(terminated, stack.terminated)
+                    && Objects.equals(tags, stack.tags)
+                    && Objects.equals(telemetry, stack.telemetry)
+                    && Objects.equals(backup, stack.backup)
+                    && Objects.equals(template, stack.template)
+                    && Objects.equals(owner, stack.owner)
+                    && Objects.equals(appVersion, stack.appVersion)
+                    && Objects.equals(minaSshdServiceId, stack.minaSshdServiceId)
+                    && Objects.equals(ccmV2AgentCrn, stack.ccmV2AgentCrn)
+                    && Objects.equals(version, stack.version);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, resourceCrn, name, environmentCrn, accountId, region, created, platformvariant, availabilityZone, cloudPlatform, gatewayport,
+                useCcm, tunnel, clusterProxyRegistered, terminated, tags, telemetry, backup, template, owner, appVersion, minaSshdServiceId, ccmV2AgentCrn,
+                version);
     }
 }


### PR DESCRIPTION
When a FreeIPA cluster gets terminated, `SecurityGroup` is set to `null` in `InstanceGroup` and saved in a transaction while setting the `Stack` to terminated.
It looks like somehow the transaction is not respected when fetching a `Stack` with all the many to one connections.
It seems this is caused by this:
`HHH000100: Fail-safe cleanup (collections) : org.hibernate.engine.loading.internal.CollectionLoadContext@7cfa719d<rs=HikariProxyResultSet@735958073 wrapping org.postgresql.jdbc.PgResultSet@364baac2>`

To avoid this there are some possible solutions:
- switch from `Set` to `List` in relations between entities
- in `equals` and `hashCode` methods the `Set` types should be ignored

In this commit the latter is implemented.

See detailed description in the commit message.