### PR TITLE
CB-13731 Mark datalake to cloudbreak flow trigger events as idempotent.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterCertificatesRotationTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterCertificatesRotationTriggerEvent.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.event;
 
+import java.util.Objects;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.CertificateRotationType;
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
@@ -22,5 +24,11 @@ public class ClusterCertificatesRotationTriggerEvent extends StackEvent {
 
     public CertificateRotationType getCertificateRotationType() {
         return certificateRotationType;
+    }
+
+    @Override
+    public boolean equalsEvent(StackEvent other) {
+        return isClassAndEqualsEvent(ClusterCertificatesRotationTriggerEvent.class, other,
+                event -> Objects.equals(certificateRotationType, event.certificateRotationType));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterRecoveryTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterRecoveryTriggerEvent.java
@@ -14,4 +14,9 @@ public class ClusterRecoveryTriggerEvent extends StackEvent {
     public ClusterRecoveryTriggerEvent(String selector, Long stackId, Promise<AcceptResult> accepted) {
         super(selector, stackId, accepted);
     }
+
+    @Override
+    public boolean equalsEvent(StackEvent other) {
+        return isClassAndEqualsEvent(ClusterRecoveryTriggerEvent.class, other);
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterUpgradeTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/ClusterUpgradeTriggerEvent.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.event;
 
+import java.util.Objects;
+
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
@@ -21,5 +23,11 @@ public class ClusterUpgradeTriggerEvent extends StackEvent {
 
     public String getImageId() {
         return imageId;
+    }
+
+    @Override
+    public boolean equalsEvent(StackEvent other) {
+        return isClassAndEqualsEvent(ClusterUpgradeTriggerEvent.class, other,
+                event -> Objects.equals(imageId, event.imageId));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseBackupTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseBackupTriggerEvent.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.event;
 
+import java.util.Objects;
+
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.BackupRestoreEvent;
 
 import reactor.rx.Promise;
@@ -18,5 +21,13 @@ public class DatabaseBackupTriggerEvent extends BackupRestoreEvent {
     public DatabaseBackupTriggerEvent(String event, Long resourceId, Promise<AcceptResult> accepted,
             String backupLocation, String backupId, boolean closeConnections) {
         super(event, resourceId, accepted, backupLocation, backupId, closeConnections);
+    }
+
+    @Override
+    public boolean equalsEvent(StackEvent other) {
+        return isClassAndEqualsEvent(DatabaseBackupTriggerEvent.class, other,
+                event -> Objects.equals(getBackupId(), event.getBackupId())
+                        && Objects.equals(getBackupLocation(), event.getBackupLocation())
+                        && getCloseConnections() == event.getCloseConnections());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseRestoreTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/DatabaseRestoreTriggerEvent.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.event;
 
+import java.util.Objects;
+
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.dr.BackupRestoreEvent;
 
 import reactor.rx.Promise;
@@ -14,5 +17,13 @@ public class DatabaseRestoreTriggerEvent extends BackupRestoreEvent {
     public DatabaseRestoreTriggerEvent(String event, Long resourceId, Promise<AcceptResult> accepted,
             String backupLocation, String backupId) {
         super(event, resourceId, accepted, backupLocation, backupId);
+    }
+
+    @Override
+    public boolean equalsEvent(StackEvent other) {
+        return isClassAndEqualsEvent(DatabaseRestoreTriggerEvent.class, other,
+                event -> Objects.equals(getBackupId(), event.getBackupId())
+                        && Objects.equals(getBackupLocation(), event.getBackupLocation())
+                        && getCloseConnections() == event.getCloseConnections());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackImageUpdateTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackImageUpdateTriggerEvent.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.event;
 
+import java.util.Objects;
+
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.service.image.ImageChangeDto;
@@ -48,5 +50,13 @@ public class StackImageUpdateTriggerEvent extends StackEvent {
 
     public String getImageCatalogUrl() {
         return imageCatalogUrl;
+    }
+
+    @Override
+    public boolean equalsEvent(StackEvent other) {
+        return isClassAndEqualsEvent(StackImageUpdateTriggerEvent.class, other,
+                event -> Objects.equals(newImageId, event.newImageId)
+                        && Objects.equals(imageCatalogName, event.imageCatalogName)
+                        && Objects.equals(imageCatalogUrl, event.imageCatalogUrl));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackSyncTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/StackSyncTriggerEvent.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.event;
 
+import java.util.Objects;
+
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
@@ -21,5 +23,11 @@ public class StackSyncTriggerEvent extends StackEvent {
 
     public Boolean getStatusUpdateEnabled() {
         return statusUpdateEnabled;
+    }
+
+    @Override
+    public boolean equalsEvent(StackEvent other) {
+        return isClassAndEqualsEvent(StackSyncTriggerEvent.class, other,
+                event -> Objects.equals(statusUpdateEnabled, event.statusUpdateEnabled));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/StackEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/StackEvent.java
@@ -1,15 +1,17 @@
 package com.sequenceiq.cloudbreak.reactor.api.event;
 
+import java.util.Objects;
+import java.util.function.Predicate;
+
 import org.apache.commons.lang3.StringUtils;
 
 import com.sequenceiq.cloudbreak.common.event.AcceptResult;
-import com.sequenceiq.cloudbreak.common.event.Acceptable;
-import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.event.IdempotentEvent;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 
 import reactor.rx.Promise;
 
-public class StackEvent implements Selectable, Acceptable {
+public class StackEvent implements IdempotentEvent<StackEvent> {
     private final String selector;
 
     private final Long stackId;
@@ -54,5 +56,23 @@ public class StackEvent implements Selectable, Acceptable {
                 ", stackId=" + stackId +
                 ", accepted=" + accepted +
                 '}';
+    }
+
+    @Override
+    public boolean equalsEvent(StackEvent other) {
+        return isClassAndEqualsEvent(StackEvent.class, other);
+    }
+
+    protected <T extends StackEvent> boolean isClassAndEqualsEvent(Class<T> clazz, StackEvent other) {
+        return isClassAndEqualsEvent(clazz, other, stackEvent -> true);
+    }
+
+    protected <T extends StackEvent> boolean isClassAndEqualsEvent(Class<T> clazz, StackEvent other, Predicate<T> equalsSubclass) {
+        if (!clazz.equals(getClass())) {
+            return false;
+        }
+        return Objects.equals(selector, other.selector)
+                && Objects.equals(stackId, other.stackId)
+                && equalsSubclass.test((T) other);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterRepairTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/orchestration/ClusterRepairTriggerEvent.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
@@ -53,5 +54,14 @@ public class ClusterRepairTriggerEvent extends StackEvent {
         Map<String, List<String>> result = new HashMap<>();
         map.forEach((key, value) -> result.put(key, new ArrayList<>(value)));
         return result;
+    }
+
+    @Override
+    public boolean equalsEvent(StackEvent other) {
+        return isClassAndEqualsEvent(ClusterRepairTriggerEvent.class, other,
+                event -> removeOnly == event.removeOnly
+                        && restartServices == event.restartServices
+                        && Objects.equals(failedNodesMap, event.failedNodesMap)
+                        && Objects.equals(stackId, event.stackId));
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
@@ -282,6 +282,9 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
         if (!previousTrigger.getClass().equals(currentTrigger.getClass())) {
             return false;
         }
+        if (previousTrigger == currentTrigger) {
+            return true;
+        }
         return ((IdempotentEvent) currentTrigger).equalsEvent((IdempotentEvent) previousTrigger);
     }
 


### PR DESCRIPTION
See detailed description in the commit message.