### PR TITLE
CB-14023 Create weekly job for high node count scale e2e test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -242,6 +242,14 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
                 .validate();
     }
 
+    protected void createEnvironmentWithFreeIpaAndDatalake(TestContext testContext) {
+        initiateEnvironmentCreation(testContext);
+        initiateDatalakeCreation(testContext);
+        waitForEnvironmentCreation(testContext);
+        waitForUserSync(testContext);
+        waitForDatalakeCreation(testContext);
+    }
+
     protected void createDefaultUser(TestContext testContext) {
         testContext.as();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/diagnostics/DiagnosticsTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/diagnostics/DiagnosticsTests.java
@@ -28,9 +28,8 @@ public class DiagnosticsTests extends AbstractE2ETest {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpa(testContext);
         initializeDefaultBlueprints(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/AwsDistroXEphemeralTemporaryStorageStopStartTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/AwsDistroXEphemeralTemporaryStorageStopStartTest.java
@@ -49,8 +49,7 @@ public class AwsDistroXEphemeralTemporaryStorageStopStartTest extends AbstractE2
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
@@ -39,8 +39,7 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXImagesTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXImagesTests.java
@@ -45,8 +45,7 @@ public class DistroXImagesTests extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Ignore("This test case should be re-enabled in case of InternalSDXDistroXTest has been removed")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXRepairTests.java
@@ -37,8 +37,7 @@ public class DistroXRepairTests extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleEdgeCasesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleEdgeCasesTest.java
@@ -30,8 +30,7 @@ public class DistroXScaleEdgeCasesTest extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
@@ -24,11 +24,7 @@ public class DistroXScaleTest extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        initiateEnvironmentCreation(testContext);
-        initiateDatalakeCreation(testContext);
-        waitForEnvironmentCreation(testContext);
-        waitForUserSync(testContext);
-        waitForDatalakeCreation(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTestParameters.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTestParameters.java
@@ -6,76 +6,49 @@ public class DistroXScaleTestParameters {
 
     private static final String TIMES = "times";
 
-    private static final String HOSTGROUP = "hostgroup";
+    private static final String HOST_GROUP = "host_group";
 
-    private static final String SCALE_UP = "scale_up";
+    private static final String SCALE_UP_TARGET = "scale_up_target";
 
-    private static final String SCALE_DOWN = "scale_down";
+    private static final String SCALE_DOWN_TARGET = "scale_down_target";
 
-    private static final String IMAGE_CATALOG_NAME = "image_catalog";
+    private static final String DEFAULT_TIMES = "1";
 
-    private static final String IMAGE_CATALOG_URL = "image_catalog_url";
+    private static final String DEFAULT_SCALE_UP_TARGET = "55";
 
-    private static final String IMAGE_ID = "image_id";
+    private static final String DEFAULT_SCALE_DOWN_TARGET = "5";
 
-    private static final int DEFAULT_TIMES = 10;
-
-    private static final int DEFAULT_SCALE_UP = 100;
-
-    private static final int DEFAULT_SCALE_DOWN = 10;
-
-    private static final String DEFAULT_HOSTGROUP = "worker";
-
-    private static final String DEFAULT_IMAGE_CATALOG_NAME = "bigscale_catalog";
+    private static final String DEFAULT_HOST_GROUP = "worker";
 
     private int times;
 
-    private int scaleUp;
+    private int scaleUpTarget;
 
-    private int scaleDown;
+    private int scaleDownTarget;
 
-    private String hostgroup;
-
-    private String imageCatalogName;
-
-    private String imageCatalogUrl;
-
-    private String imageId;
-
-    private DistroXScaleTestParameters() {
-    }
+    private String hostGroup;
 
     DistroXScaleTestParameters(Map<String, String> allParameters) {
-        String times = allParameters.get(TIMES);
-        String scaleUp = allParameters.get(SCALE_UP);
-        String scaleDown = allParameters.get(SCALE_DOWN);
-        String hostGroup = allParameters.get(HOSTGROUP);
-        String imageCatalogName = allParameters.get(IMAGE_CATALOG_NAME);
-
-        setHostgroup(hostGroup == null ? DEFAULT_HOSTGROUP : hostGroup);
-        setScaleUp(scaleUp == null ? DEFAULT_SCALE_UP : Integer.parseInt(scaleUp));
-        setScaleDown(scaleDown == null ? DEFAULT_SCALE_DOWN : Integer.parseInt(scaleDown));
-        setTimes(times == null ? DEFAULT_TIMES : Integer.parseInt(times));
-        setImageCatalogName(imageCatalogName == null ? DEFAULT_IMAGE_CATALOG_NAME : imageCatalogName);
-
-        imageCatalogUrl = allParameters.get(IMAGE_CATALOG_URL);
-        imageId = allParameters.get(IMAGE_ID);
+        setHostGroup(allParameters.getOrDefault(HOST_GROUP, DEFAULT_HOST_GROUP));
+        setScaleUpTarget(Integer.parseInt(allParameters.getOrDefault(SCALE_UP_TARGET, DEFAULT_SCALE_UP_TARGET)));
+        setScaleDownTarget(Integer.parseInt(allParameters.getOrDefault(SCALE_DOWN_TARGET, DEFAULT_SCALE_DOWN_TARGET)));
+        setTimes(Integer.parseInt(allParameters.getOrDefault(TIMES, DEFAULT_TIMES)));
     }
 
-    public int getScaleUp() {
-        return scaleUp;
+    public int getScaleUpTarget() {
+        return scaleUpTarget;
     }
 
-    public void setScaleUp(int scaleUp) {
-        this.scaleUp = scaleUp;
+    public void setScaleUpTarget(int scaleUpTarget) {
+        this.scaleUpTarget = scaleUpTarget;
     }
 
-    public int getScaleDown() {
-        return scaleDown;
+    public int getScaleDownTarget() {
+        return scaleDownTarget;
     }
 
-    public void setScaleDown(int scaleDown) {
-        this.scaleDown = scaleDown;
+    public void setScaleDownTarget(int scaleDownTarget) {
+        this.scaleDownTarget = scaleDownTarget;
     }
 
     public int getTimes() {
@@ -86,39 +59,11 @@ public class DistroXScaleTestParameters {
         this.times = times;
     }
 
-    public String getHostgroup() {
-        return hostgroup;
+    public String getHostGroup() {
+        return hostGroup;
     }
 
-    public void setHostgroup(String hostgroup) {
-        this.hostgroup = hostgroup;
-    }
-
-    public String getImageCatalogName() {
-        return imageCatalogName;
-    }
-
-    public void setImageCatalogName(String imageCatalogName) {
-        this.imageCatalogName = imageCatalogName;
-    }
-
-    public String getImageCatalogUrl() {
-        return imageCatalogUrl;
-    }
-
-    public void setImageCatalogUrl(String imageCatalogUrl) {
-        this.imageCatalogUrl = imageCatalogUrl;
-    }
-
-    public String getImageId() {
-        return imageId;
-    }
-
-    public void setImageId(String imageId) {
-        this.imageId = imageId;
-    }
-
-    public boolean isImageCatalogConfigured() {
-        return imageCatalogUrl != null && imageId != null;
+    public void setHostGroup(String hostGroup) {
+        this.hostGroup = hostGroup;
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/InternalSdxSshAndCmAccessTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/InternalSdxSshAndCmAccessTest.java
@@ -42,8 +42,7 @@ public class InternalSdxSshAndCmAccessTest extends PreconditionSdxE2ETest {
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
@@ -42,8 +42,7 @@ public class SdxBackupRestoreTest extends PreconditionSdxE2ETest {
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createSdx(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT, description = "We need to wait the CB-13322 to be resolved")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
@@ -13,11 +13,9 @@ import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
-import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class PreconditionSdxE2ETest extends AbstractE2ETest {
 
@@ -62,27 +60,5 @@ public class PreconditionSdxE2ETest extends AbstractE2ETest {
                 .sdxEndpoint()
                 .getDetailByCrn(testDto.getCrn(), Collections.emptySet())
                 .getStackV4Response().getInstanceGroups();
-    }
-
-    protected void createSdx(TestContext testContext) {
-        testContext
-                .given(SdxTestDto.class)
-                    .withCloudStorage(getCloudStorageRequest(testContext))
-                .when(sdxTestClient.create())
-                .await(SdxClusterStatusResponse.RUNNING)
-                .awaitForHealthyInstances()
-                .when(sdxTestClient.describe())
-                .validate();
-    }
-
-    protected void createInternalSdx(TestContext testContext) {
-        testContext
-                .given(SdxInternalTestDto.class)
-                    .withCloudStorage(getCloudStorageRequest(testContext))
-                .when(sdxTestClient.createInternal())
-                .await(SdxClusterStatusResponse.RUNNING)
-                .awaitForHealthyInstances()
-                .when(sdxTestClient.describeInternal())
-                .validate();
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/YcloudHybridCloudTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/YcloudHybridCloudTest.java
@@ -86,7 +86,8 @@ public class YcloudHybridCloudTest extends AbstractMockTest {
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpa(testContext);
+        createDefaultEnvironment(testContext);
+        createDefaultFreeIpa(testContext);
         createDefaultImageCatalog(testContext);
     }
 

--- a/integration-test/src/main/resources/testsuites/e2e/distrox-bigscale-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/distrox-bigscale-tests.yaml
@@ -2,13 +2,10 @@ name: "distrox-bigscale-tests"
 tests:
   - name: "distrox_bigscale_tests"
     parameters: {
-      hostgroup: compute,
-      scale_up: 100,
-      scale_down: 10,
+      host_group: compute,
+      scale_up_target: 55,
+      scale_down_target: 5,
       times: 10,
-      image_catalog: "rc-catalog",
-      image_catalog_url: "https://cloudbreak-imagecatalog.s3.amazonaws.com/v3-rc-cb-image-catalog.json",
-      image_id: "bc98d75b-ebc9-4d64-57b9-3a931925e8bb"
     }
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXScaleTest


### PR DESCRIPTION
- cleanup scale test parameters class
- remove unused methods from AbstractIntegrationTest
- cleanup DistroxScaleTest
- initiate env and datalake creation at the same time in DistroxScaleTest
- create freeipa along with environment creation, not separately

See detailed description in the commit message.