### PR TITLE
CB-13644 During the upscale, we create the cloudinstances but we use …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
@@ -79,7 +78,6 @@ import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
-import com.sequenceiq.cloudbreak.service.multiaz.MultiAzCalculatorService;
 import com.sequenceiq.cloudbreak.service.stack.DefaultRootVolumeSizeProvider;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
 import com.sequenceiq.cloudbreak.service.stack.LoadBalancerPersistenceService;
@@ -131,9 +129,6 @@ public class StackToCloudStackConverter {
 
     @Inject
     private LoadBalancerConfigService loadBalancerConfigService;
-
-    @Inject
-    private MultiAzCalculatorService multiAzCalculatorService;
 
     public CloudStack convert(Stack stack) {
         return convert(stack, Collections.emptySet());
@@ -212,32 +207,13 @@ public class StackToCloudStackConverter {
 
         Map<String, Object> parameters = buildCloudInstanceParameters(
                 environment, instanceMetaData, CloudPlatform.valueOf(stack.getCloudPlatform()));
-        CloudInstance cloudInstance = new CloudInstance(
+        return new CloudInstance(
                 id,
                 instanceTemplate,
                 instanceAuthentication,
                 instanceMetaData == null ? null : instanceMetaData.getSubnetId(),
                 instanceMetaData == null ? null : instanceMetaData.getAvailabilityZone(),
                 parameters);
-        if (instanceMetaData == null) {
-            prepareCloudInstanceSubnetAndAvailabilityZone(environment, instanceGroup, cloudInstance, stack);
-        }
-        return cloudInstance;
-    }
-
-    private void prepareCloudInstanceSubnetAndAvailabilityZone(DetailedEnvironmentResponse environment, InstanceGroup instanceGroup,
-            CloudInstance cloudInstance, Stack stack) {
-        Map<String, String> subnetAzPairs = multiAzCalculatorService.prepareSubnetAzMap(environment);
-        multiAzCalculatorService.calculateByRoundRobin(
-                subnetAzPairs,
-                instanceGroup,
-                cloudInstance
-        );
-        if (Strings.isNullOrEmpty(cloudInstance.getSubnetId()) && Strings.isNullOrEmpty(cloudInstance.getAvailabilityZone())) {
-            String stackSubnetId = getStackSubnetIdIfExists(stack);
-            cloudInstance.setSubnetId(stackSubnetId);
-            cloudInstance.setAvailabilityZone(stackSubnetId == null ? null : subnetAzPairs.get(stackSubnetId));
-        }
     }
 
     private String getStackSubnetIdIfExists(Stack stack) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
@@ -121,10 +121,9 @@ public class StackUpscaleActions {
             @Override
             protected Selectable createRequest(StackScalingFlowContext context) {
                 LOGGER.debug("Assembling upscale stack event for stack: {}", context.getStack());
-                List<CloudInstance> newInstances = stackUpscaleService.buildNewInstances(context.getStack(), context.getInstanceGroupName(),
-                        getInstanceCountToCreate(context.getStack(), context.getInstanceGroupName(), context.getAdjustment()));
-                Stack updatedStack = instanceMetaDataService.saveInstanceAndGetUpdatedStack(context.getStack(), newInstances, false, context.getHostNames(),
-                        context.isRepair());
+                int instanceCountToCreate = getInstanceCountToCreate(context.getStack(), context.getInstanceGroupName(), context.getAdjustment());
+                Stack updatedStack = instanceMetaDataService.saveInstanceAndGetUpdatedStack(context.getStack(), instanceCountToCreate,
+                        context.getInstanceGroupName(), false, context.getHostNames(), context.isRepair());
                 CloudStack cloudStack = cloudStackConverter.convert(updatedStack);
                 return new UpscaleStackValidationRequest<UpscaleStackValidationResult>(context.getCloudContext(), context.getCloudCredential(), cloudStack);
             }
@@ -142,10 +141,9 @@ public class StackUpscaleActions {
             @Override
             protected Selectable createRequest(StackScalingFlowContext context) {
                 LOGGER.debug("Assembling upscale stack event for stack: {}", context.getStack());
-                List<CloudInstance> newInstances = stackUpscaleService.buildNewInstances(context.getStack(), context.getInstanceGroupName(),
-                        getInstanceCountToCreate(context.getStack(), context.getInstanceGroupName(), context.getAdjustment()));
-                Stack updatedStack = instanceMetaDataService.saveInstanceAndGetUpdatedStack(context.getStack(), newInstances, true, context.getHostNames(),
-                        context.isRepair());
+                int instanceCountToCreate = getInstanceCountToCreate(context.getStack(), context.getInstanceGroupName(), context.getAdjustment());
+                Stack updatedStack = instanceMetaDataService.saveInstanceAndGetUpdatedStack(context.getStack(), instanceCountToCreate,
+                        context.getInstanceGroupName(), true, context.getHostNames(), context.isRepair());
                 List<CloudResource> resources = cloudResourceConverter.convert(context.getStack().getResources());
                 CloudStack updatedCloudStack = cloudStackConverter.convert(updatedStack);
                 return new UpscaleStackRequest<UpscaleStackResult>(context.getCloudContext(), context.getCloudCredential(), updatedCloudStack, resources);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleService.java
@@ -8,14 +8,10 @@ import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_ADDING_INSTANC
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_INFRASTRUCTURE_UPDATE_FAILED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_METADATA_EXTEND_WITH_COUNT;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_REPAIR_FAILED;
-import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
 import static java.lang.String.format;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -26,34 +22,27 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
-import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.cloud.event.instance.CollectMetadataResult;
 import com.sequenceiq.cloudbreak.cloud.event.resource.UpscaleStackResult;
-import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmMetaDataStatus;
-import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.common.service.TransactionService.TransactionExecutionException;
-import com.sequenceiq.cloudbreak.converter.spi.StackToCloudStackConverter;
 import com.sequenceiq.cloudbreak.core.flow2.stack.CloudbreakFlowMessageService;
 import com.sequenceiq.cloudbreak.core.flow2.stack.StackContext;
 import com.sequenceiq.cloudbreak.core.flow2.stack.downscale.StackScalingFlowContext;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.event.ResourceEvent;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.OperationException;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
-import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.stack.flow.MetadataSetupService;
 import com.sequenceiq.cloudbreak.service.stack.flow.TlsSetupService;
 import com.sequenceiq.common.api.type.CommonResourceType;
-import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 
 @Service
 public class StackUpscaleService {
@@ -73,16 +62,10 @@ public class StackUpscaleService {
     private ClusterService clusterService;
 
     @Inject
-    private StackToCloudStackConverter cloudStackConverter;
-
-    @Inject
     private TlsSetupService tlsSetupService;
 
     @Inject
     private TransactionService transactionService;
-
-    @Inject
-    private EnvironmentClientService environmentClientService;
 
     public void startAddInstances(Stack stack, Integer scalingAdjustment, String hostGroupName) {
         String statusReason = format("Adding %s new instance(s) to instance group %s", scalingAdjustment, hostGroupName);
@@ -202,53 +185,4 @@ public class StackUpscaleService {
             throw new OperationException(format("Failed to upscale the stack for %s due to: %s", context.getCloudContext(), templates.get(0).getStatusReason()));
         }
     }
-
-    public List<CloudInstance> buildNewInstances(Stack stack, String extendedInstanceGroupName, int count) {
-        LOGGER.info("Build {} instances for group: {}", count, extendedInstanceGroupName);
-        Optional<InstanceGroup> extendedInstanceGroup = stack.getInstanceGroups().stream()
-                .filter(instanceGroup -> extendedInstanceGroupName.equals(instanceGroup.getGroupName()))
-                .findAny();
-        List<CloudInstance> newInstances = new ArrayList<>();
-        if (extendedInstanceGroup.isPresent()) {
-            long privateId = getFirstValidPrivateId(stack.getInstanceGroupsAsList());
-            DetailedEnvironmentResponse environment = getEnvironmentByEnvironmentCrn(stack.getEnvironmentCrn());
-            for (long i = 0; i < count; i++) {
-                newInstances.add(cloudStackConverter.buildInstance(
-                        null,
-                        extendedInstanceGroup.get(),
-                        stack.getStackAuthentication(),
-                        privateId++,
-                        InstanceStatus.CREATE_REQUESTED,
-                        environment));
-            }
-        }
-        LOGGER.debug("New instances have been built: {}", newInstances.stream().map(CloudInstance::getInstanceId).collect(Collectors.toList()));
-        return newInstances;
-    }
-
-    private DetailedEnvironmentResponse getEnvironmentByEnvironmentCrn(String environmentCrn) {
-        DetailedEnvironmentResponse environment = null;
-        if (Objects.nonNull(environmentCrn)) {
-            environment = measure(() ->
-                            ThreadBasedUserCrnProvider.doAsInternalActor(() ->
-                                    environmentClientService.getByCrn(environmentCrn)),
-                    LOGGER,
-                    "Get Environment from Environment service took {} ms");
-        }
-        return environment;
-    }
-
-    private long getFirstValidPrivateId(List<InstanceGroup> instanceGroups) {
-        LOGGER.debug("Get first valid PrivateId of instanceGroups");
-        long id = instanceGroups.stream()
-                .flatMap(ig -> ig.getAllInstanceMetaData().stream())
-                .filter(im -> im.getPrivateId() != null)
-                .map(InstanceMetaData::getPrivateId)
-                .map(i -> i + 1)
-                .max(Long::compare)
-                .orElse(0L);
-        LOGGER.debug("First valid privateId: {}", id);
-        return id;
-    }
-
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/recover/DatalakeRecoverySetupNewInstancesHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/recover/DatalakeRecoverySetupNewInstancesHandler.java
@@ -11,10 +11,8 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
-import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
 import com.sequenceiq.cloudbreak.controller.StackCreatorService;
-import com.sequenceiq.cloudbreak.core.flow2.stack.upscale.StackUpscaleService;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.recovery.bringup.DatalakeRecoverySetupNewInstancesFailedEvent;
@@ -39,9 +37,6 @@ public class DatalakeRecoverySetupNewInstancesHandler extends ExceptionCatcherEv
 
     @Inject
     private StackCreatorService stackCreatorService;
-
-    @Inject
-    private StackUpscaleService stackUpscaleService;
 
     @Inject
     private InstanceMetaDataService instanceMetaDataService;
@@ -79,9 +74,8 @@ public class DatalakeRecoverySetupNewInstancesHandler extends ExceptionCatcherEv
     private void setupNewInstances(Stack stack) {
         List<InstanceGroup> instanceGroups = stackCreatorService.sortInstanceGroups(stack);
         for (InstanceGroup instanceGroup : instanceGroups) {
-            List<CloudInstance> newInstances =
-                    stackUpscaleService.buildNewInstances(stack, instanceGroup.getGroupName(), instanceGroup.getInitialNodeCount());
-            instanceMetaDataService.saveInstanceAndGetUpdatedStack(stack, newInstances, true, Collections.emptySet(), false);
+            instanceMetaDataService.saveInstanceAndGetUpdatedStack(stack, instanceGroup.getInitialNodeCount(), instanceGroup.getGroupName(), true,
+                    Collections.emptySet(), false);
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/multiaz/MultiAzCalculatorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/multiaz/MultiAzCalculatorService.java
@@ -17,7 +17,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.controller.validation.network.MultiAzValidator;
@@ -95,19 +94,19 @@ public class MultiAzCalculatorService {
         }
     }
 
-    public void calculateByRoundRobin(Map<String, String> subnetAzPairs, InstanceGroup instanceGroup, CloudInstance cloudInstance) {
+    public void calculateByRoundRobin(Map<String, String> subnetAzPairs, InstanceGroup instanceGroup, InstanceMetaData instanceMetaData) {
         Map<String, Integer> subnetUsage = new HashMap<>();
         Set<String> subnetIds = collectSubnetIds(instanceGroup);
         initializeSubnetUsage(subnetAzPairs, subnetIds, subnetUsage);
         collectCurrentSubnetUsage(instanceGroup, subnetUsage);
 
         if (!subnetIds.isEmpty() && multiAzValidator.supportedForInstanceMetadataGeneration(instanceGroup)) {
-            if (isNullOrEmpty(cloudInstance.getSubnetId())) {
+            if (isNullOrEmpty(instanceMetaData.getSubnetId())) {
                 Integer numberOfInstanceInASubnet = searchTheSmallestInstanceCountForSubnets(subnetUsage);
                 String leastUsedSubnetId = searchTheSmallestUsedSubnetID(subnetUsage, numberOfInstanceInASubnet);
 
-                cloudInstance.setSubnetId(leastUsedSubnetId);
-                cloudInstance.setAvailabilityZone(subnetAzPairs.get(leastUsedSubnetId));
+                instanceMetaData.setSubnetId(leastUsedSubnetId);
+                instanceMetaData.setAvailabilityZone(subnetAzPairs.get(leastUsedSubnetId));
                 subnetUsage.put(leastUsedSubnetId, numberOfInstanceInASubnet + 1);
             }
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverterTest.java
@@ -11,13 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,7 +22,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -70,7 +65,6 @@ import com.sequenceiq.cloudbreak.converter.InstanceMetadataToImageIdConverter;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.FileSystem;
-import com.sequenceiq.cloudbreak.domain.Network;
 import com.sequenceiq.cloudbreak.domain.SecurityGroup;
 import com.sequenceiq.cloudbreak.domain.SecurityRule;
 import com.sequenceiq.cloudbreak.domain.StackAuthentication;
@@ -85,7 +79,6 @@ import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
 import com.sequenceiq.cloudbreak.service.image.ImageService;
-import com.sequenceiq.cloudbreak.service.multiaz.MultiAzCalculatorService;
 import com.sequenceiq.cloudbreak.service.securityrule.SecurityRuleService;
 import com.sequenceiq.cloudbreak.service.stack.DefaultRootVolumeSizeProvider;
 import com.sequenceiq.cloudbreak.service.stack.InstanceGroupService;
@@ -200,9 +193,6 @@ public class StackToCloudStackConverterTest {
     @Mock
     private LoadBalancerConfigService loadBalancerConfigService;
 
-    @Mock
-    private MultiAzCalculatorService multiAzCalculatorService;
-
     @BeforeEach
     public void setUp() {
         when(stack.getStackAuthentication()).thenReturn(stackAuthentication);
@@ -220,8 +210,6 @@ public class StackToCloudStackConverterTest {
         when(environmentClientService.getByCrn(anyString())).thenReturn(environmentResponse);
         when(loadBalancerPersistenceService.findByStackId(anyLong())).thenReturn(Collections.emptySet());
         when(targetGroupPersistenceService.findByLoadBalancerId(anyLong())).thenReturn(Collections.emptySet());
-        doNothing().when(multiAzCalculatorService).calculateByRoundRobin(anyMap(), any(InstanceGroup.class), any(CloudInstance.class));
-        when(multiAzCalculatorService.prepareSubnetAzMap(any(DetailedEnvironmentResponse.class))).thenReturn(new HashMap<>());
     }
 
     @Test
@@ -1041,11 +1029,11 @@ public class StackToCloudStackConverterTest {
         assertEquals(LoadBalancerType.PRIVATE, cloudLoadBalancer.getType());
         assertEquals(Set.of(targetGroupPortPair), cloudLoadBalancer.getPortToTargetGroupMapping().keySet());
         Set<String> groupNames = cloudLoadBalancer.getPortToTargetGroupMapping().values().stream()
-            .flatMap(Collection::stream)
-            .collect(Collectors.toSet())
-            .stream()
-            .map(Group::getName)
-            .collect(Collectors.toSet());
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet())
+                .stream()
+                .map(Group::getName)
+                .collect(Collectors.toSet());
         assertEquals(Set.of("group1", "group2"), groupNames);
     }
 
@@ -1084,12 +1072,12 @@ public class StackToCloudStackConverterTest {
 
         assertEquals(2, result.getLoadBalancers().size());
         Optional<CloudLoadBalancer> internalCloudLoadBalancer = result.getLoadBalancers().stream()
-            .filter(lb -> lb.getType() == LoadBalancerType.PRIVATE)
-            .findFirst();
+                .filter(lb -> lb.getType() == LoadBalancerType.PRIVATE)
+                .findFirst();
         assertTrue(internalCloudLoadBalancer.isPresent());
         Optional<CloudLoadBalancer> externalCloudLoadBalancer = result.getLoadBalancers().stream()
-            .filter(lb -> lb.getType() == LoadBalancerType.PUBLIC)
-            .findFirst();
+                .filter(lb -> lb.getType() == LoadBalancerType.PUBLIC)
+                .findFirst();
         assertTrue(externalCloudLoadBalancer.isPresent());
     }
 
@@ -1128,17 +1116,17 @@ public class StackToCloudStackConverterTest {
         assertEquals(1L, result.getGroups().get(0).getInstances().size());
         assertEquals(1L, result.getGroups().get(0).getDeletedInstances().size());
         assertEquals(fqdnParsedName,
-            result.getGroups().get(0).getInstances().get(0).getParameters().get(CloudInstance.DISCOVERY_NAME));
+                result.getGroups().get(0).getInstances().get(0).getParameters().get(CloudInstance.DISCOVERY_NAME));
         assertEquals(metaData.getSubnetId(),
-            result.getGroups().get(0).getInstances().get(0).getParameters().get(NetworkConstants.SUBNET_ID));
+                result.getGroups().get(0).getInstances().get(0).getParameters().get(NetworkConstants.SUBNET_ID));
         assertEquals(metaData.getInstanceName(),
-            result.getGroups().get(0).getInstances().get(0).getParameters().get(CloudInstance.INSTANCE_NAME));
+                result.getGroups().get(0).getInstances().get(0).getParameters().get(CloudInstance.INSTANCE_NAME));
         assertEquals(terminatedFqdnParsedName,
-            result.getGroups().get(0).getDeletedInstances().get(0).getParameters().get(CloudInstance.DISCOVERY_NAME));
+                result.getGroups().get(0).getDeletedInstances().get(0).getParameters().get(CloudInstance.DISCOVERY_NAME));
         assertEquals(terminatedMetaData.getSubnetId(),
-            result.getGroups().get(0).getDeletedInstances().get(0).getParameters().get(NetworkConstants.SUBNET_ID));
+                result.getGroups().get(0).getDeletedInstances().get(0).getParameters().get(NetworkConstants.SUBNET_ID));
         assertEquals(terminatedMetaData.getInstanceName(),
-            result.getGroups().get(0).getDeletedInstances().get(0).getParameters().get(CloudInstance.INSTANCE_NAME));
+                result.getGroups().get(0).getDeletedInstances().get(0).getParameters().get(CloudInstance.INSTANCE_NAME));
     }
 
     static Object[][] buildInstanceTestWhenInstanceMetaDataPresentAndSubnetAndAvailabilityZoneDataProvider() {
@@ -1200,106 +1188,4 @@ public class StackToCloudStackConverterTest {
         assertThat(parameters.get(CloudInstance.INSTANCE_NAME)).isEqualTo("worker3");
         assertThat(parameters.get(CloudInstance.FQDN)).isEqualTo("vm.empire.com");
     }
-
-    static Object[][] buildInstanceTestWhenInstanceMetaDataNullAndSubnetAndAvailabilityZoneAndRoundRobinDataProvider() {
-        return new Object[][]{
-                // testCaseName subnetId availabilityZone
-                {"subnetId=\"subnet-1\", availabilityZone=null", "subnet-1", null},
-                {"subnetId=\"subnet-1\", availabilityZone=\"az-1\"", "subnet-1", "az-1"},
-        };
-    }
-
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("buildInstanceTestWhenInstanceMetaDataNullAndSubnetAndAvailabilityZoneAndRoundRobinDataProvider")
-    void buildInstanceTestWhenInstanceMetaDataNullAndSubnetAndAvailabilityZoneAndRoundRobin(String testCaseName, String subnetId, String availabilityZone) {
-        InstanceGroup instanceGroup = new InstanceGroup();
-        Template template = new Template();
-        template.setVolumeTemplates(Set.of());
-        instanceGroup.setTemplate(template);
-        Stack stack = new Stack();
-        stack.setCloudPlatform("AWS");
-        instanceGroup.setStack(stack);
-        instanceGroup.setGroupName("worker");
-
-        DetailedEnvironmentResponse environment = new DetailedEnvironmentResponse();
-        Map<String, String> subnetAzPairs = Map.of("subnet-1", "az-1");
-        when(multiAzCalculatorService.prepareSubnetAzMap(environment)).thenReturn(subnetAzPairs);
-        doAnswer(invocation -> {
-            CloudInstance cloudInstance = invocation.getArgument(2, CloudInstance.class);
-            cloudInstance.setSubnetId(subnetId);
-            cloudInstance.setAvailabilityZone(availabilityZone);
-            return null;
-        }).when(multiAzCalculatorService).calculateByRoundRobin(eq(subnetAzPairs), eq(instanceGroup), any(CloudInstance.class));
-
-        CloudInstance cloudInstance = underTest.buildInstance(null, instanceGroup, new StackAuthentication(), 12L, InstanceStatus.CREATED, environment);
-
-        verifyCloudInstanceWhenInstanceMetaDataNull(cloudInstance, subnetId, availabilityZone);
-
-        verify(instanceMetadataToImageIdConverter, never()).convert(any(InstanceMetaData.class));
-    }
-
-    private void verifyCloudInstanceWhenInstanceMetaDataNull(CloudInstance cloudInstance, String subnetIdExpected, String availabilityZoneExpected) {
-        assertThat(cloudInstance).isNotNull();
-        assertThat(cloudInstance.getInstanceId()).isNull();
-
-        InstanceTemplate instanceTemplate = cloudInstance.getTemplate();
-        assertThat(instanceTemplate).isNotNull();
-        assertThat(instanceTemplate.getPrivateId()).isEqualTo(12L);
-        assertThat(instanceTemplate.getGroupName()).isEqualTo("worker");
-        assertThat(instanceTemplate.getStatus()).isEqualTo(InstanceStatus.CREATED);
-        assertThat(instanceTemplate.getImageId()).isNull();
-
-        assertThat(cloudInstance.getAuthentication()).isNotNull();
-
-        assertThat(cloudInstance.getSubnetId()).isEqualTo(subnetIdExpected);
-        assertThat(cloudInstance.getAvailabilityZone()).isEqualTo(availabilityZoneExpected);
-
-        Map<String, Object> parameters = cloudInstance.getParameters();
-        assertThat(parameters).isNotNull();
-        assertThat(parameters).doesNotContainKey(CloudInstance.DISCOVERY_NAME);
-        assertThat(parameters).doesNotContainKey(SUBNET_ID);
-        assertThat(parameters).doesNotContainKey(CloudInstance.INSTANCE_NAME);
-        assertThat(parameters).doesNotContainKey(CloudInstance.FQDN);
-    }
-
-    static Object[][] buildInstanceTestWhenInstanceMetaDataNullAndSubnetAndAvailabilityZoneAndStackFallbackDataProvider() {
-        return new Object[][]{
-                // testCaseName withStackNetwork
-                {"withStackNetwork=false", false},
-                {"withStackNetwork=true", true},
-        };
-    }
-
-    @ParameterizedTest(name = "{0}")
-    @MethodSource("buildInstanceTestWhenInstanceMetaDataNullAndSubnetAndAvailabilityZoneAndStackFallbackDataProvider")
-    void buildInstanceTestWhenInstanceMetaDataNullAndSubnetAndAvailabilityZoneAndStackFallback(String testCaseName, boolean withStackNetwork) {
-        InstanceGroup instanceGroup = new InstanceGroup();
-        Template template = new Template();
-        template.setVolumeTemplates(Set.of());
-        instanceGroup.setTemplate(template);
-        Stack stack = new Stack();
-        stack.setCloudPlatform("AWS");
-        String subnetId = null;
-        String availabilityZone = null;
-        if (withStackNetwork) {
-            Network network = new Network();
-            network.setAttributes(Json.silent(Map.of("subnetId", "subnet-1")));
-            stack.setNetwork(network);
-            subnetId = "subnet-1";
-            availabilityZone = "az-1";
-        }
-        instanceGroup.setStack(stack);
-        instanceGroup.setGroupName("worker");
-
-        DetailedEnvironmentResponse environment = new DetailedEnvironmentResponse();
-        Map<String, String> subnetAzPairs = Map.of("subnet-1", "az-1");
-        when(multiAzCalculatorService.prepareSubnetAzMap(environment)).thenReturn(subnetAzPairs);
-
-        CloudInstance cloudInstance = underTest.buildInstance(null, instanceGroup, new StackAuthentication(), 12L, InstanceStatus.CREATED, environment);
-
-        verifyCloudInstanceWhenInstanceMetaDataNull(cloudInstance, subnetId, availabilityZone);
-
-        verify(instanceMetadataToImageIdConverter, never()).convert(any(InstanceMetaData.class));
-    }
-
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActionsTest.java
@@ -28,7 +28,6 @@ import com.sequenceiq.cloudbreak.cloud.event.resource.UpscaleStackResult;
 import com.sequenceiq.cloudbreak.cloud.event.resource.UpscaleStackValidationRequest;
 import com.sequenceiq.cloudbreak.cloud.event.resource.UpscaleStackValidationResult;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
-import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResourceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.ResourceStatus;
@@ -112,9 +111,6 @@ class StackUpscaleActionsTest {
     @Mock
     private CloudResourceStatus cloudResourceStatus;
 
-    @Mock
-    private CloudInstance cloudInstance;
-
     @BeforeEach
     void setUp() {
         context = new StackScalingFlowContext(flowParameters, stack, cloudContext, cloudCredential, cloudStack, INSTANCE_GROUP_NAME, Set.of(), ADJUSTMENT,
@@ -141,11 +137,9 @@ class StackUpscaleActionsTest {
 
         when(stackScalabilityCondition.isScalable(stack, INSTANCE_GROUP_NAME)).thenReturn(true);
 
-        List<CloudInstance> newInstances = List.of(cloudInstance);
-        when(stackUpscaleService.buildNewInstances(stack, INSTANCE_GROUP_NAME, ADJUSTMENT)).thenReturn(newInstances);
-
         Stack updatedStack = mock(Stack.class);
-        when(instanceMetaDataService.saveInstanceAndGetUpdatedStack(stack, newInstances, false, context.getHostNames(), false)).thenReturn(updatedStack);
+        when(instanceMetaDataService.saveInstanceAndGetUpdatedStack(stack, 3, INSTANCE_GROUP_NAME, false, context.getHostNames(), false))
+                .thenReturn(updatedStack);
 
         CloudStack convertedCloudStack = mock(CloudStack.class);
         when(cloudStackConverter.convert(updatedStack)).thenReturn(convertedCloudStack);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/recover/DatalakeRecoverySetupNewInstancesHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/recover/DatalakeRecoverySetupNewInstancesHandlerTest.java
@@ -2,13 +2,13 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.upgrade.recover;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -65,16 +65,12 @@ class DatalakeRecoverySetupNewInstancesHandlerTest {
 
     @Test
     void testDoAcceptWhenSuccess() {
-        List<CloudInstance> cloudInstances = new ArrayList<>();
-        cloudInstances.add(setupCloudInstance());
-        cloudInstances.add(setupCloudInstance());
         InstanceGroup instanceGroup1 = setupInstanceGroup(1L);
         InstanceGroup instanceGroup2 = setupInstanceGroup(2L);
         List<InstanceGroup> instanceGroups = List.of(instanceGroup1, instanceGroup2);
 
         when(stackService.getByIdWithClusterInTransaction(STACK_ID)).thenReturn(stack);
         when(stackCreatorService.sortInstanceGroups(stack)).thenReturn(instanceGroups);
-        when(stackUpscaleService.buildNewInstances(eq(stack), any(), eq(0))).thenReturn(cloudInstances);
 
         Selectable nextFlowStepSelector = underTest.doAccept(getHandlerEvent());
 
@@ -82,8 +78,7 @@ class DatalakeRecoverySetupNewInstancesHandlerTest {
         verify(stackService).getByIdWithClusterInTransaction(STACK_ID);
         verify(clusterService).updateClusterStatusByStackId(STACK_ID, Status.REQUESTED);
         verify(stackCreatorService).sortInstanceGroups(stack);
-        verify(stackUpscaleService, times(2)).buildNewInstances(eq(stack), any(), eq(0));
-        verify(instanceMetaDataService, times(2)).saveInstanceAndGetUpdatedStack(eq(stack), any(), eq(true), eq(Collections.emptySet()), eq(false));
+        verify(instanceMetaDataService, times(2)).saveInstanceAndGetUpdatedStack(eq(stack), anyInt(), any(), eq(true), eq(Collections.emptySet()), eq(false));
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/multiaz/MultiAzCalculatorServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/multiaz/MultiAzCalculatorServiceTest.java
@@ -27,7 +27,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.util.CollectionUtils;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
-import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
 import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
@@ -404,14 +403,14 @@ public class MultiAzCalculatorServiceTest {
         InstanceGroup instanceGroup = instanceGroup(cloudPlatform, instanceCount, subnetCount);
         initSubnetIdAndAvailabilityZoneForInstances(existingCounts, instanceGroup);
 
-        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, null, null);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
 
         underTest.calculateByRoundRobin(
                 subnetAzPairs(subnetCount),
                 instanceGroup,
-                cloudInstance);
+                instanceMetaData);
 
-        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, cloudInstance);
+        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, instanceMetaData);
         verifySubnetIdAndAvailabilityZoneForInstancesAreUnchanged(existingCounts, instanceGroup, Set.of());
     }
 
@@ -429,14 +428,13 @@ public class MultiAzCalculatorServiceTest {
         InstanceMetaData instanceWithPrepopulatedForeignSubnetId = instanceMetaData(instanceCount, SUBNET_ID, AVAILABILITY_ZONE, InstanceStatus.REQUESTED);
         instanceGroup.getAllInstanceMetaData().add(instanceWithPrepopulatedForeignSubnetId);
 
-        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, null, null);
-
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
         underTest.calculateByRoundRobin(
                 subnetAzPairs(subnetCount),
                 instanceGroup,
-                cloudInstance);
+                instanceMetaData);
 
-        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, cloudInstance);
+        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, instanceMetaData);
         verifySubnetIdAndAvailabilityZoneForInstancesAreUnchanged(existingCounts, instanceGroup, Set.of(instanceWithPrepopulatedForeignSubnetId));
 
         assertThat(instanceWithPrepopulatedForeignSubnetId.getSubnetId()).isEqualTo(SUBNET_ID);
@@ -471,14 +469,14 @@ public class MultiAzCalculatorServiceTest {
         }
         instanceGroup.getAllInstanceMetaData().addAll(deletedInstancesWithPrepopulatedSubnetId);
 
-        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, null, null);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
 
         underTest.calculateByRoundRobin(
                 subnetAzPairs(subnetCount),
                 instanceGroup,
-                cloudInstance);
+                instanceMetaData);
 
-        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, cloudInstance);
+        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, instanceMetaData);
         verifySubnetIdAndAvailabilityZoneForInstancesAreUnchanged(existingCounts, instanceGroup, deletedInstancesWithPrepopulatedSubnetId);
 
         deletedInstancesWithPrepopulatedSubnetId.forEach(instance -> {
@@ -516,16 +514,18 @@ public class MultiAzCalculatorServiceTest {
 
         String cloudInstanceSubnetId = prepopulateCloudInstanceSubnet ? SUBNET_ID : null;
         String cloudInstanceAvailabilityZone = prepopulateCloudInstanceSubnet ? AVAILABILITY_ZONE : null;
-        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, cloudInstanceSubnetId, cloudInstanceAvailabilityZone);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setSubnetId(cloudInstanceSubnetId);
+        instanceMetaData.setAvailabilityZone(cloudInstanceAvailabilityZone);
 
         underTest.calculateByRoundRobin(
                 subnetAzPairs(NO_SUBNETS),
                 instanceGroup,
-                cloudInstance);
+                instanceMetaData);
 
         verifyCloudInstance(cloudInstanceSubnetId == null ? Set.of() : Set.of(cloudInstanceSubnetId),
                 cloudInstanceAvailabilityZone == null ? Set.of() : Set.of(cloudInstanceAvailabilityZone),
-                cloudInstance);
+                instanceMetaData);
 
         instanceGroup.getAllInstanceMetaData().forEach(instance -> {
             assertThat(instance.getSubnetId()).isNull();
@@ -541,14 +541,16 @@ public class MultiAzCalculatorServiceTest {
         InstanceGroup instanceGroup = instanceGroup(CloudPlatform.AWS, SINGLE_INSTANCE, SINGLE_SUBNET);
         initSubnetIdAndAvailabilityZoneForInstances(existingCounts, instanceGroup);
 
-        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, SUBNET_ID, AVAILABILITY_ZONE);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setSubnetId(SUBNET_ID);
+        instanceMetaData.setAvailabilityZone(AVAILABILITY_ZONE);
 
         underTest.calculateByRoundRobin(
                 subnetAzPairs(SINGLE_SUBNET),
                 instanceGroup,
-                cloudInstance);
+                instanceMetaData);
 
-        verifyCloudInstance(Set.of(SUBNET_ID), Set.of(AVAILABILITY_ZONE), cloudInstance);
+        verifyCloudInstance(Set.of(SUBNET_ID), Set.of(AVAILABILITY_ZONE), instanceMetaData);
         verifySubnetIdAndAvailabilityZoneForInstancesAreUnchanged(existingCounts, instanceGroup, Set.of());
     }
 
@@ -582,14 +584,14 @@ public class MultiAzCalculatorServiceTest {
 
         InstanceGroup instanceGroup = instanceGroup(cloudPlatform, instanceCount, subnetCount);
 
-        CloudInstance cloudInstance = new CloudInstance(INSTANCE_ID, null, null, null, null);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
 
         underTest.calculateByRoundRobin(
                 subnetAzPairs(subnetCount),
                 instanceGroup,
-                cloudInstance);
+                instanceMetaData);
 
-        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, cloudInstance);
+        verifyCloudInstance(expectedPermissibleSubnetIdIndexes, instanceMetaData);
 
         instanceGroup.getAllInstanceMetaData().forEach(instance -> {
             assertThat(instance.getSubnetId()).isNull();
@@ -696,7 +698,7 @@ public class MultiAzCalculatorServiceTest {
         });
     }
 
-    private void verifyCloudInstance(Set<Integer> expectedPermissibleSubnetIdIndexes, CloudInstance cloudInstance) {
+    private void verifyCloudInstance(Set<Integer> expectedPermissibleSubnetIdIndexes, InstanceMetaData instanceMetaData) {
         Set<String> expectedPermissibleSubnetIds = null;
         Set<String> expectedPermissibleAvailabilityZones = null;
         if (!CollectionUtils.isEmpty(expectedPermissibleSubnetIdIndexes)) {
@@ -708,27 +710,22 @@ public class MultiAzCalculatorServiceTest {
                     .collect(Collectors.toSet());
         }
 
-        verifyCloudInstance(expectedPermissibleSubnetIds, expectedPermissibleAvailabilityZones, cloudInstance);
+        verifyCloudInstance(expectedPermissibleSubnetIds, expectedPermissibleAvailabilityZones, instanceMetaData);
     }
 
-    private void verifyCloudInstance(Set<String> expectedPermissibleSubnetIds, Set<String> expectedPermissibleAvailabilityZones, CloudInstance cloudInstance) {
+    private void verifyCloudInstance(Set<String> expectedPermissibleSubnetIds, Set<String> expectedPermissibleAvailabilityZones,
+            InstanceMetaData instanceMetaData) {
         if (CollectionUtils.isEmpty(expectedPermissibleSubnetIds)) {
-            assertThat(cloudInstance.getSubnetId()).isNull();
+            assertThat(instanceMetaData.getSubnetId()).isNull();
         } else {
-            assertThat(cloudInstance.getSubnetId()).isIn(expectedPermissibleSubnetIds);
+            assertThat(instanceMetaData.getSubnetId()).isIn(expectedPermissibleSubnetIds);
         }
 
         if (CollectionUtils.isEmpty(expectedPermissibleAvailabilityZones)) {
-            assertThat(cloudInstance.getAvailabilityZone()).isNull();
+            assertThat(instanceMetaData.getAvailabilityZone()).isNull();
         } else {
-            assertThat(cloudInstance.getAvailabilityZone()).isIn(expectedPermissibleAvailabilityZones);
+            assertThat(instanceMetaData.getAvailabilityZone()).isIn(expectedPermissibleAvailabilityZones);
         }
-
-        assertThat(cloudInstance.getInstanceId()).isEqualTo(INSTANCE_ID);
-        assertThat(cloudInstance.getAuthentication()).isNull();
-        assertThat(cloudInstance.getTemplate()).isNull();
-        assertThat(cloudInstance.getParameters()).isNotNull();
-        assertThat(cloudInstance.getParameters()).isEmpty();
     }
 
     private void verifySubnetIdAndAvailabilityZoneForInstancesAreUnchanged(List<Integer> existingCounts, InstanceGroup instanceGroup,


### PR DESCRIPTION
…it to set the private id and groupname for the instance metadata. In this PR I merged these methods, and directly generate the subnet id, az, privateId and add the group name to the instance metadata

See detailed description in the commit message.