### PR TITLE
CB-14040 Azure load balancer metadata collection failing

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollector.java
@@ -25,9 +25,6 @@ public class AzureLoadBalancerMetadataCollector {
     private static final Logger LOGGER = LoggerFactory.getLogger(AzureLoadBalancerMetadataCollector.class);
 
     @Inject
-    private AzureUtils azureUtils;
-
-    @Inject
     private AvailabilitySetNameService availabilitySetNameService;
 
     public Map<String, Object> getParameters(AuthenticatedContext ac, String resourceGroup, String loadBalancerName) {
@@ -62,7 +59,7 @@ public class AzureLoadBalancerMetadataCollector {
     }
 
     private String generateAvailabilitySetName(AuthenticatedContext ac, LoadBalancerBackend backend) {
-        String stackName = azureUtils.getStackName(ac.getCloudContext());
+        String stackName = ac.getCloudContext().getName();
         String groupName = backend.inner().name().replace("-pool", "");
         return availabilitySetNameService.generateName(stackName, groupName);
     }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollectorTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerMetadataCollectorTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.azure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -53,9 +52,6 @@ public class AzureLoadBalancerMetadataCollectorTest {
     private AzureClient azureClient;
 
     @Mock
-    private AzureUtils azureUtils;
-
-    @Mock
     private AvailabilitySetNameService availabilitySetNameService;
 
     @InjectMocks
@@ -76,7 +72,6 @@ public class AzureLoadBalancerMetadataCollectorTest {
 
         when(azureClient.getLoadBalancerRules(eq(RESOURCE_GROUP), eq(LB_NAME))).thenReturn(rules);
         when(azureClient.getAvailabilitySet(eq(RESOURCE_GROUP), anyString())).thenReturn(mock(AvailabilitySet.class));
-        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
         when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName))).thenReturn(availabilitySetName);
 
         Map<String, Object> parameters = underTest.getParameters(ac, RESOURCE_GROUP, LB_NAME);
@@ -105,7 +100,6 @@ public class AzureLoadBalancerMetadataCollectorTest {
 
         when(azureClient.getLoadBalancerRules(eq(RESOURCE_GROUP), eq(LB_NAME))).thenReturn(rules);
         when(azureClient.getAvailabilitySet(eq(RESOURCE_GROUP), anyString())).thenReturn(mock(AvailabilitySet.class));
-        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
         when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName0))).thenReturn(availabilitySetName0);
         when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName1))).thenReturn(availabilitySetName1);
         when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName2))).thenReturn(availabilitySetName2);
@@ -137,7 +131,6 @@ public class AzureLoadBalancerMetadataCollectorTest {
         when(azureClient.getAvailabilitySet(eq(RESOURCE_GROUP), eq(availabilitySetName0))).thenReturn(mock(AvailabilitySet.class));
         when(azureClient.getAvailabilitySet(eq(RESOURCE_GROUP), eq(availabilitySetName1))).thenReturn(null);
         when(azureClient.getAvailabilitySet(eq(RESOURCE_GROUP), eq(availabilitySetName2))).thenReturn(mock(AvailabilitySet.class));
-        when(azureUtils.getStackName(any())).thenReturn(STACK_NAME);
         when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName0))).thenReturn(availabilitySetName0);
         when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName1))).thenReturn(availabilitySetName1);
         when(availabilitySetNameService.generateName(eq(STACK_NAME), eq(groupName2))).thenReturn(availabilitySetName2);
@@ -151,7 +144,7 @@ public class AzureLoadBalancerMetadataCollectorTest {
         Location location = Location.location(Region.region("region"), AvailabilityZone.availabilityZone("az"));
         CloudContext context = CloudContext.Builder.builder()
                 .withId(5L)
-                .withName("name")
+                .withName(STACK_NAME)
                 .withCrn("crn")
                 .withPlatform("platform")
                 .withVariant("variant")

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigConverter.java
@@ -112,7 +112,8 @@ public class LoadBalancerConfigConverter {
         AzureTargetGroupConfigDb azureTargetGroupConfigDb = new AzureTargetGroupConfigDb();
         for (Integer port : trafficPorts) {
             String availabilitySetName = azureMetadata.getAvailabilitySetByPort(port);
-            azureTargetGroupConfigDb.addPortAvailabilitySetMapping(port, List.of(availabilitySetName));
+            List<String> availabilitySetNames = List.of(StringUtils.isEmpty(availabilitySetName) ? MISSING_CLOUD_RESOURCE : availabilitySetName);
+            azureTargetGroupConfigDb.addPortAvailabilitySetMapping(port, availabilitySetNames);
         }
         targetGroupConfigDbWrapper.setAzureConfig(azureTargetGroupConfigDb);
         return targetGroupConfigDbWrapper;

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hue/HueConfigProvider.java
@@ -9,6 +9,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
@@ -23,6 +25,8 @@ import com.sequenceiq.cloudbreak.template.views.RdsView;
 
 @Component
 public class HueConfigProvider extends AbstractRdsRoleConfigProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HueConfigProvider.class);
 
     private static final String HUE_DATABASE_HOST = "hue-hue_database_host";
 
@@ -123,8 +127,10 @@ public class HueConfigProvider extends AbstractRdsRoleConfigProvider {
             if (!proxyHosts.isEmpty()) {
                 String proxyHostsString = String.join(",", proxyHosts);
                 if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERAMANAGER_VERSION_7_1_0)) {
+                    LOGGER.debug("Using {} settings of [{}]", HUE_KNOX_PROXYHOSTS, proxyHostsString);
                     result.add(new ApiClusterTemplateVariable().name(HUE_KNOX_PROXYHOSTS).value(proxyHostsString));
                 } else {
+                    LOGGER.debug("Adding knox proxy hosts [{}] to {}", proxyHostsString, HUE_SAFETY_VALVE);
                     String valveValue = SAFETY_VALVE_KNOX_PROXYHOSTS_KEY_PATTERN.concat(proxyHostsString);
                     result.add(new ApiClusterTemplateVariable().name(HUE_SAFETY_VALVE).value(valveValue));
                 }


### PR DESCRIPTION
Updates the load balancer metadata collection logic to use the correct stack name (the CB name instead
of the Azure stack name), and checks if the metadata is null before attempting to add it to an
immutable list.

Tested with unit tests.