### PR TITLE
Cb 13711 mitigate high CPU load on database server due to inefficient SQL queries

### DIFF
--- a/core/src/main/resources/schema/app/20210823151044_CB-13711_create_index_on_instance_metadata_for_status_and_instance_group_based_queries.sql
+++ b/core/src/main/resources/schema/app/20210823151044_CB-13711_create_index_on_instance_metadata_for_status_and_instance_group_based_queries.sql
@@ -1,0 +1,10 @@
+-- // CB-13711 create index on instance metadata for status and instance group based queries
+-- Migration SQL that makes the change goes here.
+CREATE INDEX IF NOT EXISTS idx_instancemetadata_instancestatus_instancegroupid
+    ON instancemetadata (instancestatus, instancegroup_id);
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+DROP INDEX IF EXISTS idx_instancemetadata_instancestatus_instancegroupid;
+

--- a/core/src/main/resources/schema/app/20210906145328_CB-13711_create_index_on_instancegroup_availabilityzones_by_instancegroup_id_to_mitigate_database_CPU_usage_.sql
+++ b/core/src/main/resources/schema/app/20210906145328_CB-13711_create_index_on_instancegroup_availabilityzones_by_instancegroup_id_to_mitigate_database_CPU_usage_.sql
@@ -1,0 +1,12 @@
+-- // CB-13711 create index on instancegroup_availabilityzones by instancegroup_id to mitigate database CPU usage
+-- Migration SQL that makes the change goes here.
+CREATE INDEX IF NOT EXISTS idx_instancegroup_availabilityzones_instancegroupid
+    ON instancegroup_availabilityzones (instancegroup_id);
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+DROP INDEX IF EXISTS idx_instancegroup_availabilityzones_instancegroupid;
+
+
+


### PR DESCRIPTION
Cherry picking the missing indices from 2.48 line of CB as it should keep the database CPU load around 10%(at least it decreased the load from 25% to 8-10% on mow-dev).