### PR TITLE
CB-14024 SRM config provider should add security.protocol

### DIFF
--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/srm/StreamsReplicationManagerConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/srm/StreamsReplicationManagerConfigProviderTest.java
@@ -37,7 +37,7 @@ class StreamsReplicationManagerConfigProviderTest {
     void getServiceConfigsPlain() {
         var source = source(false, "broker-1", "broker-2");
         var expected = List.of(
-                config("streams.replication.manager.config", "bootstrap.servers=broker-1:9092,broker-2:9092"),
+                config("streams.replication.manager.config", "bootstrap.servers=broker-1:9092,broker-2:9092" + "|" + "security.protocol=SASL_SSL"),
                 config("clusters", "primary,secondary"));
         assertThat(underTest.getServiceConfigs(null, source)).hasSameElementsAs(expected);
     }
@@ -46,7 +46,7 @@ class StreamsReplicationManagerConfigProviderTest {
     void getServiceConfigsSsl() {
         var source = source(true, "broker-1", "broker-2");
         var expected = List.of(
-                config("streams.replication.manager.config", "bootstrap.servers=broker-1:9093,broker-2:9093"),
+                config("streams.replication.manager.config", "bootstrap.servers=broker-1:9093,broker-2:9093" + "|" + "security.protocol=SASL_SSL"),
                 config("clusters", "primary,secondary"));
         assertThat(underTest.getServiceConfigs(null, source)).hasSameElementsAs(expected);
     }
@@ -70,7 +70,18 @@ class StreamsReplicationManagerConfigProviderTest {
         var source = sourceForCoreBroker(true);
         cdhMainVersionIs("7.2.12");
         var expected = List.of(
-                config("streams.replication.manager.config", "bootstrap.servers=corebroker-1:9093,corebroker-2:9093"),
+                config("streams.replication.manager.config", "bootstrap.servers=corebroker-1:9093,corebroker-2:9093" + "|" + "security.protocol=SASL_SSL"),
+                config("clusters", "primary,secondary")
+        );
+        assertThat(underTest.getServiceConfigs(null, source)).hasSameElementsAs(expected);
+    }
+
+    @Test
+    void getServiceConfigsWithCoreBroker7213() {
+        var source = sourceForCoreBroker(true);
+        cdhMainVersionIs("7.2.13");
+        var expected = List.of(
+                config("streams.replication.manager.config", "bootstrap.servers=corebroker-1:9093,corebroker-2:9093" + "|" + "security.protocol=SASL_SSL"),
                 config("clusters", "primary,secondary")
         );
         assertThat(underTest.getServiceConfigs(null, source)).hasSameElementsAs(expected);
@@ -100,7 +111,6 @@ class StreamsReplicationManagerConfigProviderTest {
         when(source.getHostGroupsWithComponent(KAFKA_BROKER)).thenReturn(Stream.of(hostGroup));
         when(source.getBlueprintView()).thenReturn(blueprintView);
 
-        // Correct versioning is not relevant for this source, but need to set a version
         cdhMainVersionIs("7.2.12");
 
         return source;


### PR DESCRIPTION
The SRM CSD does not generate a "security.protocol" configuration anymore. Because of this, 7.2.12 streaming clusters fail to come up after start.
This commit extends the SRM configuration provider to  add "security.protocol=SASL_SSL" to the array config of SRM for CDH>=7.2.12.

Tested:

- Unit tests
- Provisioned cluster