### PR TITLE
CB-13963 This commit reduces the namber of cases when we use "ambigou…

### DIFF
--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandlerTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ClusterStatusSyncHandlerTest.java
@@ -152,10 +152,22 @@ public class ClusterStatusSyncHandlerTest {
     }
 
     @Test
-    public void testOnApplicationEventWhenCBStatusAmbigious() {
+    public void testOnApplicationEventWhenCBStatusUnreachable() {
         Cluster cluster = getACluster(ClusterState.RUNNING);
         when(clusterService.findById(anyLong())).thenReturn(cluster);
-        when(cloudbreakCommunicator.getStackStatusByCrn(anyString())).thenReturn(getStackResponse(Status.AMBIGUOUS));
+        when(cloudbreakCommunicator.getStackStatusByCrn(anyString())).thenReturn(getStackResponse(Status.UNREACHABLE));
+
+        underTest.onApplicationEvent(new ClusterStatusSyncEvent(AUTOSCALE_CLUSTER_ID));
+
+        verify(clusterService).setState(AUTOSCALE_CLUSTER_ID, ClusterState.SUSPENDED);
+        verify(cloudbreakCommunicator).getStackStatusByCrn(CLOUDBREAK_STACK_CRN);
+    }
+
+    @Test
+    public void testOnApplicationEventWhenCBStatusNodeFailure() {
+        Cluster cluster = getACluster(ClusterState.RUNNING);
+        when(clusterService.findById(anyLong())).thenReturn(cluster);
+        when(cloudbreakCommunicator.getStackStatusByCrn(anyString())).thenReturn(getStackResponse(Status.NODE_FAILURE));
 
         underTest.onApplicationEvent(new ClusterStatusSyncEvent(AUTOSCALE_CLUSTER_ID));
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -151,7 +151,6 @@ public enum ResourceEvent {
     STACK_SYNC_INSTANCE_STATUS_COULDNT_DETERMINE("stack.sync.instance.status.couldnt.determine"),
     STACK_SYNC_INSTANCE_OPERATION_IN_PROGRESS("stack.sync.instance.operation.in.progress"),
     STACK_SYNC_INSTANCE_STOPPED_ON_PROVIDER("stack.sync.instance.stopped.on.provider"),
-    STACK_SYNC_INSTANCE_STATE_SYNCED("stack.sync.instance.state.synced"),
     STACK_SYNC_HOST_DELETED("stack.sync.host.deleted"),
     STACK_SYNC_INSTANCE_REMOVAL_FAILED("stack.sync.instance.removal.failed"),
     STACK_SYNC_HOST_UPDATED("stack.sync.host.updated"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -225,7 +225,6 @@ stack.sync.instance.status.retrieval.failed=Couldn''t retrieve the status of ins
 stack.sync.instance.status.couldnt.determine=The state of one or more instances couldn''t be determined. Try syncing later.
 stack.sync.instance.operation.in.progress=An operation on one or more instances is in progress. Try syncing later.
 stack.sync.instance.stopped.on.provider=Some instances were stopped on the cloud provider. Restart or terminate them and try syncing later.
-stack.sync.instance.state.synced=Synced instance states with the cloud provider.
 stack.sync.host.deleted=Deleted host {0} from Cloudera Manager as it is marked as terminated by the cloud provider.
 stack.sync.instance.removal.failed=Instance {0} is terminated but couldn''t remove host from Cloudera Manager because it still reports the host as healthy. Try syncing later.
 stack.sync.host.updated=Host {0} state has been updated to: {1}.

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -240,7 +240,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
         clusterService.updateClusterCertExpirationState(stack.getCluster(), hostCertExpiring);
         clusterOperationService.reportHealthChange(stack.getResourceCrn(), newFailedNodeNamesWithReason, newHealtyHostNames);
         if (!failedInstances.isEmpty()) {
-            clusterService.updateClusterStatusByStackId(stack.getId(), Status.AMBIGUOUS);
+            clusterService.updateClusterStatusByStackId(stack.getId(), Status.NODE_FAILURE);
         } else if (statesFromAvailableAllowed().contains(stack.getCluster().getStatus())) {
             clusterService.updateClusterStatusByStackId(stack.getId(), Status.AVAILABLE);
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.service.stack.flow;
 
-import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AMBIGUOUS;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UNREACHABLE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.AVAILABLE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETED_ON_PROVIDER_SIDE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.DELETE_FAILED;
@@ -10,7 +10,6 @@ import static com.sequenceiq.cloudbreak.cloud.model.CloudInstance.INSTANCE_NAME;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.CLUSTER_FAILED_NODES_REPORTED_CLUSTER_EVENT;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_SYNC_INSTANCE_DELETED_BY_PROVIDER_CBMETADATA;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_SYNC_INSTANCE_DELETED_CBMETADATA;
-import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_SYNC_INSTANCE_STATE_SYNCED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_SYNC_INSTANCE_STATUS_RETRIEVAL_FAILED;
 
 import java.util.Collection;
@@ -239,23 +238,19 @@ public class StackSyncService {
             if (syncConfig.isCmServerRunning()) {
                 if (stack.getStatus() != AVAILABLE) {
                     updateStackStatusIfEnabled(stack.getId(), DetailedStackStatus.AVAILABLE, SYNC_STATUS_REASON, syncConfig.isStackStatusUpdateEnabled());
-                    eventService.fireCloudbreakEvent(stack.getId(), AVAILABLE.name(), STACK_SYNC_INSTANCE_STATE_SYNCED);
                 }
             } else {
-                if (stack.getStatus() != AMBIGUOUS) {
+                if (stack.getStatus() != UNREACHABLE) {
                     updateStackStatusIfEnabled(stack.getId(), DetailedStackStatus.CLUSTER_MANAGER_NOT_RESPONDING, CM_SERVER_NOT_RESPONDING,
                             syncConfig.isStackStatusUpdateEnabled());
-                    eventService.fireCloudbreakEvent(stack.getId(), AMBIGUOUS.name(), STACK_SYNC_INSTANCE_STATE_SYNCED);
                 }
             }
         } else if (isAllStopped(instanceStateCounts, instances.size()) && stack.getStatus() != STOPPED) {
             updateStackStatusIfEnabled(stack.getId(), DetailedStackStatus.STOPPED, SYNC_STATUS_REASON, syncConfig.isStackStatusUpdateEnabled());
             updateClusterStatusIfEnabled(stack.getId(), STOPPED, syncConfig.isStackStatusUpdateEnabled());
-            eventService.fireCloudbreakEvent(stack.getId(), STOPPED.name(), STACK_SYNC_INSTANCE_STATE_SYNCED);
         } else if (isAllDeletedOnProvider(instanceStateCounts, instances.size()) && stack.getStatus() != DELETE_FAILED) {
             updateStackStatusIfEnabled(stack.getId(), DetailedStackStatus.DELETED_ON_PROVIDER_SIDE, SYNC_STATUS_REASON, syncConfig.isStackStatusUpdateEnabled());
             updateClusterStatusIfEnabled(stack.getId(), DELETED_ON_PROVIDER_SIDE, syncConfig.isStackStatusUpdateEnabled());
-            eventService.fireCloudbreakEvent(stack.getId(), DELETED_ON_PROVIDER_SIDE.name(), STACK_SYNC_INSTANCE_STATE_SYNCED);
         }
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRepairTests.java
@@ -72,7 +72,7 @@ public class MockSdxRepairTests extends AbstractMockTest {
         testRepair(testContext,
                 List.of(MASTER),
                 instanceBasePath -> getExecuteQueryToMockInfrastructure().call(instanceBasePath + "/terminate", w -> w),
-                SdxClusterStatusResponse.CLUSTER_AMBIGUOUS);
+                SdxClusterStatusResponse.NODE_FAILURE);
     }
 
     @Test(dataProvider = TEST_CONTEXT_WITH_MOCK, invocationCount = 1)


### PR DESCRIPTION
…s" as a state. I have split the ambigous state into two different states, that are aligned with FreeIPA states as well. The two new states are:

- Unreachable -> when CM is not reachable e.g. CM is down, Nginx / cluster / proxy etc is down
- Node Failure ->  when we have node failure (e.g CM is down), or when we have service failure. e.g after CR 7.2.12.

There are oppurtunities to separate Node Failure into Agent Failure / Service failure states, but for that the next step is to refactor the state management in the InstanceMetadata.

See detailed description in the commit message.