### PR TITLE
CB-13685 Implement getFreeIpaUpgradeOptions in FreeIpaUpgradeV1Contro…

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/BaseImageV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/BaseImageV4Response.java
@@ -30,4 +30,12 @@ public class BaseImageV4Response extends ImageV4Response {
     public void setClouderaManagerRepo(ClouderaManagerRepositoryV4Response clouderaManagerRepo) {
         this.clouderaManagerRepo = clouderaManagerRepo;
     }
+
+    @Override
+    public String toString() {
+        return "BaseImageV4Response{" +
+                "cdhStacks=" + cdhStacks +
+                ", clouderaManagerRepo=" + clouderaManagerRepo +
+                "} " + super.toString();
+    }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/BaseStackDetailsV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/BaseStackDetailsV4Response.java
@@ -28,4 +28,12 @@ public class BaseStackDetailsV4Response implements JsonEntity {
     public void setStackBuildNumber(String stackBuildNumber) {
         this.stackBuildNumber = stackBuildNumber;
     }
+
+    @Override
+    public String toString() {
+        return "BaseStackDetailsV4Response{" +
+                "version='" + version + '\'' +
+                ", stackBuildNumber='" + stackBuildNumber + '\'' +
+                '}';
+    }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/ClouderaManagerStackDetailsV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/ClouderaManagerStackDetailsV4Response.java
@@ -17,4 +17,11 @@ public class ClouderaManagerStackDetailsV4Response extends BaseStackDetailsV4Res
     public void setRepository(ClouderaManagerStackRepoDetailsV4Response repository) {
         this.repository = repository;
     }
+
+    @Override
+    public String toString() {
+        return "ClouderaManagerStackDetailsV4Response{" +
+                "repository=" + repository +
+                "} " + super.toString();
+    }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/ImageBasicInfoV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/ImageBasicInfoV4Response.java
@@ -21,4 +21,11 @@ public class ImageBasicInfoV4Response {
     public void setUuid(String uuid) {
         this.uuid = uuid;
     }
+
+    @Override
+    public String toString() {
+        return "ImageBasicInfoV4Response{" +
+                "uuid='" + uuid + '\'' +
+                '}';
+    }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/ImageV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/ImageV4Response.java
@@ -197,4 +197,26 @@ public class ImageV4Response extends ImageBasicInfoV4Response implements JsonEnt
     public void setSourceImageId(String sourceImageId) {
         this.sourceImageId = sourceImageId;
     }
+
+    @Override
+    public String toString() {
+        return "ImageV4Response{" +
+                "date='" + date + '\'' +
+                ", created=" + created +
+                ", description='" + description + '\'' +
+                ", os='" + os + '\'' +
+                ", osType='" + osType + '\'' +
+                ", version='" + version + '\'' +
+                ", cmBuildNumber='" + cmBuildNumber + '\'' +
+                ", repository=" + repository +
+                ", imageSetsByProvider=" + imageSetsByProvider +
+                ", stackDetails=" + stackDetails +
+                ", preWarmParcels=" + preWarmParcels +
+                ", preWarmCsd=" + preWarmCsd +
+                ", defaultImage=" + defaultImage +
+                ", packageVersions=" + packageVersions +
+                ", baseParcelUrl='" + baseParcelUrl + '\'' +
+                ", sourceImageId='" + sourceImageId + '\'' +
+                "} " + super.toString();
+    }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/ImagesV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/ImagesV4Response.java
@@ -19,6 +19,8 @@ public class ImagesV4Response implements JsonEntity {
 
     private List<ImageV4Response> cdhImages;
 
+    private List<ImageV4Response> freeipaImages;
+
     private Set<String> supportedVersions;
 
     public List<BaseImageV4Response> getBaseImages() {
@@ -43,5 +45,23 @@ public class ImagesV4Response implements JsonEntity {
 
     public Set<String> getSupportedVersions() {
         return supportedVersions;
+    }
+
+    public List<ImageV4Response> getFreeipaImages() {
+        return freeipaImages;
+    }
+
+    public void setFreeipaImages(List<ImageV4Response> freeipaImages) {
+        this.freeipaImages = freeipaImages;
+    }
+
+    @Override
+    public String toString() {
+        return "ImagesV4Response{" +
+                "baseImages=" + baseImages +
+                ", cdhImages=" + cdhImages +
+                ", freeipaImages=" + freeipaImages +
+                ", supportedVersions=" + supportedVersions +
+                '}';
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
@@ -11,10 +11,9 @@ import javax.inject.Inject;
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
-import com.sequenceiq.authorization.annotation.AccountIdNotNeeded;
-import com.sequenceiq.cloudbreak.service.image.DefaultImageCatalogService;
 import org.springframework.stereotype.Controller;
 
+import com.sequenceiq.authorization.annotation.AccountIdNotNeeded;
 import com.sequenceiq.authorization.annotation.CheckPermissionByAccount;
 import com.sequenceiq.authorization.annotation.CheckPermissionByRequestProperty;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
@@ -42,6 +41,7 @@ import com.sequenceiq.cloudbreak.authorization.ImageCatalogFiltering;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
 import com.sequenceiq.cloudbreak.common.type.ResourceEvent;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
+import com.sequenceiq.cloudbreak.service.image.DefaultImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.structuredevent.CloudbreakRestRequestThreadLocalService;
@@ -77,7 +77,7 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public ImageCatalogV4Response getByName(Long workspaceId, @ResourceName String name, Boolean withImages) {
-        ImageCatalog catalog = imageCatalogService.get(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
+        ImageCatalog catalog = imageCatalogService.getImageCatalogByName(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId());
         ImageCatalogV4Response imageCatalogResponse = converterUtil.convert(catalog, ImageCatalogV4Response.class);
         Images images = imageCatalogService.propagateImagesIfRequested(restRequestThreadLocalService.getRequestedWorkspaceId(), name, withImages);
         if (images != null) {
@@ -89,7 +89,7 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public ImageCatalogV4Response getByCrn(Long workspaceId, @ResourceCrn String crn, Boolean withImages) {
-        ImageCatalog catalog = imageCatalogService.get(NameOrCrn.ofCrn(crn), restRequestThreadLocalService.getRequestedWorkspaceId());
+        ImageCatalog catalog = imageCatalogService.getImageCatalogByName(NameOrCrn.ofCrn(crn), restRequestThreadLocalService.getRequestedWorkspaceId());
         ImageCatalogV4Response imageCatalogResponse = converterUtil.convert(catalog, ImageCatalogV4Response.class);
         Images images = imageCatalogService.propagateImagesIfRequested(restRequestThreadLocalService.getRequestedWorkspaceId(), catalog.getName(), withImages);
         if (images != null) {
@@ -145,7 +145,7 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.DESCRIBE_IMAGE_CATALOG)
     public ImageCatalogV4Request getRequest(Long workspaceId, @ResourceName String name) {
-        ImageCatalog imageCatalog = imageCatalogService.get(restRequestThreadLocalService.getRequestedWorkspaceId(), name);
+        ImageCatalog imageCatalog = imageCatalogService.getImageCatalogByName(restRequestThreadLocalService.getRequestedWorkspaceId(), name);
         return converterUtil.convert(imageCatalog, ImageCatalogV4Request.class);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/imagecatalog/ImagesToImagesV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/imagecatalog/ImagesToImagesV4ResponseConverter.java
@@ -16,6 +16,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.Cloudera
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ClouderaManagerStackRepoDetailsV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
+import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.StackDetails;
@@ -31,6 +32,9 @@ public class ImagesToImagesV4ResponseConverter extends AbstractConversionService
     @Inject
     private ImageBasedDefaultCDHEntries imageBasedDefaultCDHEntries;
 
+    @Inject
+    private ConverterUtil converterUtil;
+
     @Override
     public ImagesV4Response convert(Images source) {
         ImagesV4Response res = new ImagesV4Response();
@@ -39,6 +43,7 @@ public class ImagesToImagesV4ResponseConverter extends AbstractConversionService
         List<ImageV4Response> cdhImages = convertImages(source.getCdhImages(), StackType.CDH);
         res.setCdhImages(cdhImages);
         res.setSupportedVersions(source.getSuppertedVersions());
+        res.setFreeipaImages(converterUtil.convertAll(source.getFreeIpaImages(), ImageV4Response.class));
         return res;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/ImageToStackImageV4ResponseConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/ImageToStackImageV4ResponseConverter.java
@@ -49,17 +49,7 @@ public class ImageToStackImageV4ResponseConverter extends AbstractConversionServ
     private void decorateWithImageCatalogUrl(Image source, StackImageV4Response image) {
         if (Strings.isNullOrEmpty(source.getImageCatalogUrl())) {
             LOGGER.debug(String.format("Persisted image catalog url is null for image catalog '%s'", source.getImageCatalogName()));
-            ImageCatalog imageCatalog = null;
-            if (source.getImageCatalogName() != null) {
-                try {
-                    LOGGER.debug(String.format("Try to lookup image catalog '%s' from workspace %d",
-                            source.getImageCatalogName(), restRequestThreadLocalService.getRequestedWorkspaceId()));
-                    imageCatalog = imageCatalogService.get(restRequestThreadLocalService.getRequestedWorkspaceId(), source.getImageCatalogName());
-                } catch (Exception ex) {
-                    LOGGER.debug(String.format("Failed to lookup image catalog '%s' from workspace %d",
-                            source.getImageCatalogName(), restRequestThreadLocalService.getRequestedWorkspaceId()));
-                }
-            }
+            ImageCatalog imageCatalog = getImageCatalog(source);
             if (shouldLookupImageCatalogUrlByCloudbreakUser(imageCatalog)) {
                 CloudbreakUser cloudbreakUser = legacyRestRequestThreadLocalService.getCloudbreakUser();
                 LOGGER.debug(String.format("Lookup the url of '%s' user's image catalog.", cloudbreakUser == null ? null : cloudbreakUser.getUserCrn()));
@@ -68,6 +58,22 @@ public class ImageToStackImageV4ResponseConverter extends AbstractConversionServ
             }
         } else {
             image.setCatalogUrl(source.getImageCatalogUrl());
+        }
+    }
+
+    private ImageCatalog getImageCatalog(Image source) {
+        if (source.getImageCatalogName() != null) {
+            try {
+                LOGGER.debug(String.format("Try to lookup image catalog '%s' from workspace %d",
+                        source.getImageCatalogName(), restRequestThreadLocalService.getRequestedWorkspaceId()));
+                return imageCatalogService.getImageCatalogByName(restRequestThreadLocalService.getRequestedWorkspaceId(), source.getImageCatalogName());
+            } catch (Exception ex) {
+                LOGGER.debug(String.format("Failed to lookup image catalog '%s' from workspace %d",
+                        source.getImageCatalogName(), restRequestThreadLocalService.getRequestedWorkspaceId()));
+                return null;
+            }
+        } else {
+            return null;
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
@@ -260,7 +260,8 @@ public class StackCommonService {
 
     public FlowIdentifier retryInWorkspace(NameOrCrn nameOrCrn, Long workspaceId) {
         Long stackId = stackService.getIdByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
-        return operationRetryService.retry(stackId);
+        FlowIdentifier retry = operationRetryService.retry(stackId);
+        return retry;
     }
 
     public List<RetryableFlow> getRetryableFlows(String name, Long workspaceId) {
@@ -324,7 +325,7 @@ public class StackCommonService {
     public ImageChangeDto createImageChangeDto(NameOrCrn nameOrCrn, Long workspaceId, StackImageChangeV4Request stackImageChangeRequest) {
         Long stackId = stackService.getIdByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         if (StringUtils.isNotBlank(stackImageChangeRequest.getImageCatalogName())) {
-            ImageCatalog imageCatalog = imageCatalogService.get(workspaceId, stackImageChangeRequest.getImageCatalogName());
+            ImageCatalog imageCatalog = imageCatalogService.getImageCatalogByName(workspaceId, stackImageChangeRequest.getImageCatalogName());
             return new ImageChangeDto(stackId, stackImageChangeRequest.getImageId(), imageCatalog.getName(), imageCatalog.getImageCatalogUrl());
         } else {
             return new ImageChangeDto(stackId, stackImageChangeRequest.getImageId());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogService.java
@@ -45,7 +45,7 @@ public class CustomImageCatalogService {
 
     public ImageCatalog getImageCatalog(Long workspaceId, String imageCatalogName) {
         LOGGER.debug(String.format("Get custom image catalog '%s' from workspace '%d'", imageCatalogName, workspaceId));
-        ImageCatalog imageCatalog = imageCatalogService.get(workspaceId, imageCatalogName);
+        ImageCatalog imageCatalog = imageCatalogService.getImageCatalogByName(workspaceId, imageCatalogName);
 
         if (Strings.isNullOrEmpty(imageCatalog.getImageCatalogUrl())) {
             return imageCatalog;
@@ -67,7 +67,7 @@ public class CustomImageCatalogService {
 
     public ImageCatalog delete(Long workspaceId, String imageCatalogName) {
         LOGGER.debug(String.format("Delete custom image catalog '%s' in workspace '%d'", imageCatalogName, workspaceId));
-        ImageCatalog imageCatalog = imageCatalogService.get(workspaceId, imageCatalogName);
+        ImageCatalog imageCatalog = imageCatalogService.getImageCatalogByName(workspaceId, imageCatalogName);
         if (Strings.isNullOrEmpty(imageCatalog.getImageCatalogUrl())) {
             return imageCatalogService.delete(workspaceId, imageCatalogName);
         } else {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageService.java
@@ -197,7 +197,7 @@ public class ImageService {
             return imageCatalogService.getDefaultImageCatalog(user);
         } else {
             try {
-                return imageCatalogService.get(workspaceId, imageSettings.getCatalog());
+                return imageCatalogService.getImageCatalogByName(workspaceId, imageSettings.getCatalog());
             } catch (NotFoundException e) {
                 throw new CloudbreakImageCatalogException(e.getMessage());
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityService.java
@@ -180,7 +180,7 @@ public class ClusterUpgradeAvailabilityService {
         String imageCatalogName = image.getImageCatalogName();
         String imageCatalogUrl = image.getImageCatalogUrl();
         try {
-            imageCatalogUrl = imageCatalogService.get(workspace.getId(), imageCatalogName).getImageCatalogUrl();
+            imageCatalogUrl = imageCatalogService.getImageCatalogByName(workspace.getId(), imageCatalogName).getImageCatalogUrl();
             LOGGER.info("Image catalog with name {} and url {} is used for image filtering.", imageCatalogName, imageCatalogUrl);
         } catch (NotFoundException ex) {
             LOGGER.info("Image catalog with name {} not found. The following image catalog url will be used for image filtering: {}.",

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/imagecatalog/ImagesToImagesV4ResponseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/imagecatalog/ImagesToImagesV4ResponseConverterTest.java
@@ -19,6 +19,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
+import com.sequenceiq.cloudbreak.api.util.ConverterUtil;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.StackDetails;
@@ -35,6 +36,9 @@ public class ImagesToImagesV4ResponseConverterTest extends AbstractEntityConvert
 
     @Mock
     private ImageBasedDefaultCDHEntries imageBasedDefaultCDHEntries;
+
+    @Mock
+    private ConverterUtil converterUtil;
 
     @InjectMocks
     private ImagesToImagesV4ResponseConverter underTest = new ImagesToImagesV4ResponseConverter();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/ImageToStackImageV4ResponseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/ImageToStackImageV4ResponseConverterTest.java
@@ -53,7 +53,7 @@ public class ImageToStackImageV4ResponseConverterTest {
         Image image = anImageWithoutImageCatalogUrl();
 
         when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(WORKSPACE_ID);
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
 
         StackImageV4Response actual = victim.convert(image);
         assertNull(actual.getCatalogUrl());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/StackCommonServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/StackCommonServiceTest.java
@@ -69,7 +69,7 @@ class StackCommonServiceTest {
         ImageCatalog catalog = new ImageCatalog();
         catalog.setName(stackImageChangeRequest.getImageCatalogName());
         catalog.setImageCatalogUrl("catalogUrl");
-        when(imageCatalogService.get(WORKSPACE_ID, stackImageChangeRequest.getImageCatalogName())).thenReturn(catalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, stackImageChangeRequest.getImageCatalogName())).thenReturn(catalog);
         when(stackService.getIdByNameOrCrnInWorkspace(STACK_NAME, WORKSPACE_ID)).thenReturn(STACK_ID);
 
         ImageChangeDto result = underTest.createImageChangeDto(STACK_NAME, WORKSPACE_ID, stackImageChangeRequest);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogServiceTest.java
@@ -89,7 +89,7 @@ public class CustomImageCatalogServiceTest {
     public void testGetImageCatalog() {
         ImageCatalog expected = new ImageCatalog();
 
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(expected);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(expected);
 
         ImageCatalog actual = victim.getImageCatalog(WORKSPACE_ID, IMAGE_CATALOG_NAME);
 
@@ -101,7 +101,7 @@ public class CustomImageCatalogServiceTest {
         ImageCatalog expected = new ImageCatalog();
         expected.setImageCatalogUrl(IMAGE_CATALOG_URL);
 
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(expected);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(expected);
 
         assertThrows(BadRequestException.class, () -> victim.getImageCatalog(WORKSPACE_ID, IMAGE_CATALOG_NAME));
     }
@@ -137,7 +137,7 @@ public class CustomImageCatalogServiceTest {
     public void testDelete() {
         ImageCatalog expected = new ImageCatalog();
 
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(expected);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(expected);
         when(imageCatalogService.delete(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(expected);
 
         ImageCatalog actual = victim.delete(WORKSPACE_ID, IMAGE_CATALOG_NAME);
@@ -150,7 +150,7 @@ public class CustomImageCatalogServiceTest {
         ImageCatalog expected = new ImageCatalog();
         expected.setImageCatalogUrl(IMAGE_CATALOG_URL);
 
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(expected);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(expected);
 
         assertThrows(BadRequestException.class, () -> victim.delete(WORKSPACE_ID, IMAGE_CATALOG_NAME));
     }
@@ -162,7 +162,7 @@ public class CustomImageCatalogServiceTest {
         ImageCatalog imageCatalog = new ImageCatalog();
         imageCatalog.setCustomImages(Collections.singleton(expected));
 
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
 
         CustomImage actual = victim.getCustomImage(WORKSPACE_ID, IMAGE_CATALOG_NAME, IMAGE_NAME);
 
@@ -174,7 +174,7 @@ public class CustomImageCatalogServiceTest {
         ImageCatalog imageCatalog = new ImageCatalog();
         imageCatalog.setImageCatalogUrl(IMAGE_CATALOG_URL);
 
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
 
         assertThrows(BadRequestException.class, () -> victim.getCustomImage(WORKSPACE_ID, IMAGE_CATALOG_NAME, IMAGE_NAME));
     }
@@ -185,7 +185,7 @@ public class CustomImageCatalogServiceTest {
         CustomImage expected = new CustomImage();
         expected.setName(IMAGE_NAME);
 
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
 
         assertThrows(NotFoundException.class, () -> victim.getCustomImage(WORKSPACE_ID, IMAGE_CATALOG_NAME, IMAGE_NAME));
     }
@@ -213,7 +213,7 @@ public class CustomImageCatalogServiceTest {
 
         doAnswer(invocation -> ((Supplier<CustomImage>) invocation.getArgument(0)).get())
                 .when(transactionService).required(any(Supplier.class));
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
         when(imageCatalogService.pureSave(imageCatalog)).thenReturn(imageCatalog);
 
         CustomImage actual = victim.createCustomImage(WORKSPACE_ID, ACCOUNT_ID, CREATOR, IMAGE_CATALOG_NAME, expected);
@@ -243,7 +243,7 @@ public class CustomImageCatalogServiceTest {
 
         doAnswer(invocation -> ((Supplier<CustomImage>) invocation.getArgument(0)).get())
                 .when(transactionService).required(any(Supplier.class));
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
         when(imageCatalogService.getSourceImageByImageType(customImage)).thenThrow(new CloudbreakImageCatalogException(""));
 
 
@@ -258,7 +258,7 @@ public class CustomImageCatalogServiceTest {
 
         doAnswer(invocation -> ((Supplier<CustomImage>) invocation.getArgument(0)).get())
                 .when(transactionService).required(any(Supplier.class));
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
 
         assertThrows(BadRequestException.class, () -> victim.createCustomImage(WORKSPACE_ID, ACCOUNT_ID, CREATOR, IMAGE_CATALOG_NAME, null));
     }
@@ -271,7 +271,7 @@ public class CustomImageCatalogServiceTest {
 
         doAnswer(invocation -> ((Supplier<CustomImage>) invocation.getArgument(0)).get())
                 .when(transactionService).required(any(Supplier.class));
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
         when(imageCatalogService.pureSave(imageCatalog)).thenReturn(imageCatalog);
 
         CustomImage actual = victim.deleteCustomImage(WORKSPACE_ID, IMAGE_CATALOG_NAME, IMAGE_NAME);
@@ -287,7 +287,7 @@ public class CustomImageCatalogServiceTest {
 
         doAnswer(invocation -> ((Supplier<CustomImage>) invocation.getArgument(0)).get())
                 .when(transactionService).required(any(Supplier.class));
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
 
         assertThrows(BadRequestException.class, () -> victim.deleteCustomImage(WORKSPACE_ID, IMAGE_CATALOG_NAME, IMAGE_NAME));
     }
@@ -302,7 +302,7 @@ public class CustomImageCatalogServiceTest {
 
         doAnswer(invocation -> ((Supplier<CustomImage>) invocation.getArgument(0)).get())
                 .when(transactionService).required(any(Supplier.class));
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
         when(imageCatalogService.pureSave(imageCatalog)).thenReturn(imageCatalog);
 
         CustomImage actual = victim.updateCustomImage(WORKSPACE_ID, CREATOR, IMAGE_CATALOG_NAME, updatedCustomImage);
@@ -331,7 +331,7 @@ public class CustomImageCatalogServiceTest {
 
         doAnswer(invocation -> ((Supplier<CustomImage>) invocation.getArgument(0)).get())
                 .when(transactionService).required(any(Supplier.class));
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
         when(imageCatalogService.pureSave(imageCatalog)).thenReturn(imageCatalog);
 
         CustomImage actual = victim.updateCustomImage(WORKSPACE_ID, CREATOR, IMAGE_CATALOG_NAME, updatedCustomImage);
@@ -361,7 +361,7 @@ public class CustomImageCatalogServiceTest {
 
         doAnswer(invocation -> ((Supplier<CustomImage>) invocation.getArgument(0)).get())
                 .when(transactionService).required(any(Supplier.class));
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
         when(imageCatalogService.pureSave(imageCatalog)).thenReturn(imageCatalog);
 
         CustomImage actual = victim.updateCustomImage(WORKSPACE_ID, CREATOR, IMAGE_CATALOG_NAME, updatedCustomImage);
@@ -384,7 +384,7 @@ public class CustomImageCatalogServiceTest {
 
         doAnswer(invocation -> ((Supplier<CustomImage>) invocation.getArgument(0)).get())
                 .when(transactionService).required(any(Supplier.class));
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
         when(imageCatalogService.pureSave(imageCatalog)).thenReturn(imageCatalog);
 
         CustomImage actual = victim.updateCustomImage(WORKSPACE_ID, CREATOR, IMAGE_CATALOG_NAME, updatedCustomImage);
@@ -407,7 +407,7 @@ public class CustomImageCatalogServiceTest {
 
         doAnswer(invocation -> ((Supplier<CustomImage>) invocation.getArgument(0)).get())
                 .when(transactionService).required(any(Supplier.class));
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
 
         assertThrows(BadRequestException.class, () -> victim.updateCustomImage(WORKSPACE_ID, CREATOR, IMAGE_CATALOG_NAME, customImage));
     }
@@ -425,7 +425,7 @@ public class CustomImageCatalogServiceTest {
 
         doAnswer(invocation -> ((Supplier<CustomImage>) invocation.getArgument(0)).get())
                 .when(transactionService).required(any(Supplier.class));
-        when(imageCatalogService.get(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, IMAGE_CATALOG_NAME)).thenReturn(imageCatalog);
         when(imageCatalogService.getSourceImageByImageType(savedCustomImage)).thenThrow(new CloudbreakImageCatalogException(""));
 
         assertThrows(NotFoundException.class, () -> victim.updateCustomImage(WORKSPACE_ID, CREATOR, IMAGE_CATALOG_NAME, updatedCustomImage));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceTest.java
@@ -584,7 +584,7 @@ public class ImageCatalogServiceTest {
         String name = "img-name";
         ImageCatalog imageCatalog = new ImageCatalog();
         when(imageCatalogRepository.findByNameAndWorkspaceId(name, ORG_ID)).thenReturn(Optional.of(imageCatalog));
-        ImageCatalog actual = underTest.get(ORG_ID, name);
+        ImageCatalog actual = underTest.getImageCatalogByName(ORG_ID, name);
 
         assertEquals(actual, imageCatalog);
     }
@@ -595,7 +595,7 @@ public class ImageCatalogServiceTest {
         ImageCatalog actual = ThreadBasedUserCrnProvider.doAs(CrnTestUtil.getUserCrnBuilder()
                 .setAccountId("ACCOUNT_ID")
                 .setResource("USER")
-                .build().toString(), () -> underTest.get(ORG_ID, name));
+                .build().toString(), () -> underTest.getImageCatalogByName(ORG_ID, name));
 
         verify(imageCatalogRepository, times(0)).findByNameAndWorkspace(eq(name), any(Workspace.class));
 
@@ -743,7 +743,7 @@ public class ImageCatalogServiceTest {
         ImageCatalog catalog = getImageCatalog();
         when(imageCatalogRepository.findByNameAndWorkspaceId(catalog.getName(), catalog.getWorkspace().getId())).thenReturn(Optional.of(catalog));
 
-        ImageCatalog result = underTest.get(NameOrCrn.ofName(catalog.getName()), catalog.getWorkspace().getId());
+        ImageCatalog result = underTest.getImageCatalogByName(NameOrCrn.ofName(catalog.getName()), catalog.getWorkspace().getId());
 
         assertEquals(catalog, result);
         verify(imageCatalogRepository, times(1)).findByNameAndWorkspaceId(anyString(), anyLong());
@@ -755,7 +755,7 @@ public class ImageCatalogServiceTest {
         ImageCatalog catalog = getImageCatalog();
         when(imageCatalogRepository.findByResourceCrnAndArchivedFalseAndImageCatalogUrlIsNotNull(catalog.getResourceCrn())).thenReturn(Optional.of(catalog));
 
-        ImageCatalog result = underTest.get(NameOrCrn.ofCrn(catalog.getResourceCrn()), catalog.getWorkspace().getId());
+        ImageCatalog result = underTest.getImageCatalogByName(NameOrCrn.ofCrn(catalog.getResourceCrn()), catalog.getWorkspace().getId());
 
         assertEquals(catalog, result);
         verify(imageCatalogRepository, times(1)).findByResourceCrnAndArchivedFalseAndImageCatalogUrlIsNotNull(anyString());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageServiceTest.java
@@ -10,6 +10,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -26,15 +28,13 @@ import com.sequenceiq.cloudbreak.cloud.CloudConnector;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.utils.BlueprintUtils;
+import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
-import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
 import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.StackMatrixService;
 import com.sequenceiq.cloudbreak.workspace.model.Workspace;
-
-import java.util.stream.Stream;
 
 public class ImageServiceTest {
 
@@ -98,7 +98,7 @@ public class ImageServiceTest {
         imageSettingsV4Request.setId("anImageId");
         imageSettingsV4Request.setOs(OS);
         when(blueprintUtils.getCDHStackVersion(any())).thenReturn(STACK_VERSION);
-        when(imageCatalogService.get(WORKSPACE_ID, "aCatalog")).thenReturn(getImageCatalog());
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, "aCatalog")).thenReturn(getImageCatalog());
     }
 
     @Test
@@ -158,7 +158,8 @@ public class ImageServiceTest {
 
     @Test
     public void testDetermineImageFromCatalogWithNonExistingCatalogName() {
-        when(imageCatalogService.get(WORKSPACE_ID, "aCatalog")).thenThrow(new NotFoundException("Image catalog not found with name: aCatalog"));
+        when(imageCatalogService.getImageCatalogByName(WORKSPACE_ID, "aCatalog"))
+                .thenThrow(new NotFoundException("Image catalog not found with name: aCatalog"));
         ImageSettingsV4Request imageRequest = new ImageSettingsV4Request();
         imageRequest.setCatalog("aCatalog");
         imageRequest.setOs(OS);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterUpgradeAvailabilityServiceTest.java
@@ -161,7 +161,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         when(clusterRepairService.repairWithDryRun(stack.getId())).thenReturn(result);
         when(result.isError()).thenReturn(false);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
-        when(imageCatalogService.get(stack.getWorkspace().getId(), CATALOG_NAME)).thenReturn(imageCatalogDomain);
+        when(imageCatalogService.getImageCatalogByName(stack.getWorkspace().getId(), CATALOG_NAME)).thenReturn(imageCatalogDomain);
         when(imageCatalogProvider.getImageCatalogV3(CATALOG_URL)).thenReturn(imageCatalog);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         when(clusterUpgradeImageFilter.filter(accountId, imageCatalog, stack.getCloudPlatform(), imageFilterParams)).thenReturn(filteredImages);
@@ -199,7 +199,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         when(clusterRepairService.repairWithDryRun(stack.getId())).thenReturn(result);
         when(result.isError()).thenReturn(false);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
-        when(imageCatalogService.get(stack.getWorkspace().getId(), CATALOG_NAME)).thenThrow(new NotFoundException("not found"));
+        when(imageCatalogService.getImageCatalogByName(stack.getWorkspace().getId(), CATALOG_NAME)).thenThrow(new NotFoundException("not found"));
         when(imageCatalogProvider.getImageCatalogV3(FALLBACK_CATALOG_URL)).thenReturn(imageCatalog);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         when(clusterUpgradeImageFilter.filter(accountId, imageCatalog, stack.getCloudPlatform(), imageFilterParams)).thenReturn(filteredImages);
@@ -231,7 +231,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         UpgradeV4Response response = new UpgradeV4Response();
 
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
-        when(imageCatalogService.get(stack.getWorkspace().getId(), CATALOG_NAME)).thenReturn(imageCatalogDomain);
+        when(imageCatalogService.getImageCatalogByName(stack.getWorkspace().getId(), CATALOG_NAME)).thenReturn(imageCatalogDomain);
         when(imageCatalogProvider.getImageCatalogV3(CATALOG_URL)).thenReturn(imageCatalog);
         ImageFilterResult filteredImages = createFilteredImages(properImage);
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImageFromCatalog, lockComponents, activatedParcels,
@@ -285,7 +285,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         response.setUpgradeCandidates(List.of(imageInfo));
         Stack stack = createStack(createStackStatus(Status.CREATE_FAILED), StackType.WORKLOAD);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
-        when(imageCatalogService.get(stack.getWorkspace().getId(), CATALOG_NAME)).thenReturn(imageCatalogDomain);
+        when(imageCatalogService.getImageCatalogByName(stack.getWorkspace().getId(), CATALOG_NAME)).thenReturn(imageCatalogDomain);
         when(imageCatalogProvider.getImageCatalogV3(CATALOG_URL)).thenReturn(imageCatalog);
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImageFromCatalog, lockComponents, activatedParcels,
                 stack.getType(), null, STACK_ID, new InternalUpgradeSettings(false, true, true));
@@ -330,7 +330,7 @@ public class ClusterUpgradeAvailabilityServiceTest {
         when(clusterRepairService.repairWithDryRun(stack.getId())).thenReturn(result);
         when(result.isError()).thenReturn(true);
         when(imageService.getImage(stack.getId())).thenReturn(currentImage);
-        when(imageCatalogService.get(stack.getWorkspace().getId(), CATALOG_NAME)).thenReturn(imageCatalogDomain);
+        when(imageCatalogService.getImageCatalogByName(stack.getWorkspace().getId(), CATALOG_NAME)).thenReturn(imageCatalogDomain);
         when(imageCatalogProvider.getImageCatalogV3(CATALOG_URL)).thenReturn(imageCatalog);
         ImageFilterParams imageFilterParams = new ImageFilterParams(currentImageFromCatalog, lockComponents, activatedParcels, stack.getType(), null,
                 STACK_ID, new InternalUpgradeSettings(false, true, true));

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/upgrade/model/FreeIpaUpgradeOptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/upgrade/model/FreeIpaUpgradeOptions.java
@@ -14,6 +14,8 @@ public class FreeIpaUpgradeOptions {
 
     private List<ImageInfoResponse> images;
 
+    private ImageInfoResponse currentImage;
+
     public List<ImageInfoResponse> getImages() {
         return images;
     }
@@ -22,10 +24,19 @@ public class FreeIpaUpgradeOptions {
         this.images = images;
     }
 
+    public ImageInfoResponse getCurrentImage() {
+        return currentImage;
+    }
+
+    public void setCurrentImage(ImageInfoResponse currentImage) {
+        this.currentImage = currentImage;
+    }
+
     @Override
     public String toString() {
         return "FreeIpaUpgradeOptions{" +
                 "images=" + images +
+                ", currentImage=" + currentImage +
                 '}';
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaUpgradeV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaUpgradeV1Controller.java
@@ -11,7 +11,6 @@ import com.sequenceiq.authorization.annotation.CheckPermissionByRequestProperty;
 import com.sequenceiq.authorization.annotation.CheckPermissionByResourceCrn;
 import com.sequenceiq.authorization.annotation.RequestObject;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
-import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.freeipa.api.v1.freeipa.upgrade.FreeIpaUpgradeV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.freeipa.upgrade.model.FreeIpaUpgradeOptions;
 import com.sequenceiq.freeipa.api.v1.freeipa.upgrade.model.FreeIpaUpgradeRequest;
@@ -38,6 +37,7 @@ public class FreeIpaUpgradeV1Controller implements FreeIpaUpgradeV1Endpoint {
     @Override
     @CheckPermissionByResourceCrn(action = UPGRADE_FREEIPA)
     public FreeIpaUpgradeOptions getFreeIpaUpgradeOptions(@ResourceCrn String environmentCrn, String catalog) {
-        throw new BadRequestException("Not implemented");
+        String accountId = crnService.getCurrentAccountId();
+        return upgradeService.collectUpgradeOptions(accountId, environmentCrn, catalog);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/entity/ImageEntity.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/entity/ImageEntity.java
@@ -4,6 +4,7 @@ import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
 
 import java.util.Objects;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -42,6 +43,9 @@ public class ImageEntity {
     private String imageId;
 
     private String imageCatalogName;
+
+    @Column(name = "image_date")
+    private String date;
 
     public String getImageName() {
         return imageName;
@@ -115,16 +119,27 @@ public class ImageEntity {
         this.imageCatalogName = imageCatalogName;
     }
 
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+
     @Override
     public String toString() {
-        return "Image{"
-                + "imageName='" + imageName + '\''
-                + ", os='" + os + '\''
-                + ", osType='" + osType + '\''
-                + ", imageCatalogUrl='" + imageCatalogUrl + '\''
-                + ", imageId='" + imageId + '\''
-                + ", imageCatalogName='" + imageCatalogName + '\''
-                + ", userdata=" + userdata + '}';
+        return "ImageEntity{" +
+                "id=" + id +
+                ", imageName='" + imageName + '\'' +
+                ", userdata='" + userdata + '\'' +
+                ", os='" + os + '\'' +
+                ", osType='" + osType + '\'' +
+                ", imageCatalogUrl='" + imageCatalogUrl + '\'' +
+                ", imageId='" + imageId + '\'' +
+                ", imageCatalogName='" + imageCatalogName + '\'' +
+                ", date='" + date + '\'' +
+                '}';
     }
 
     @Override
@@ -147,11 +162,12 @@ public class ImageEntity {
                 && Objects.equals(osType, that.osType)
                 && Objects.equals(imageCatalogUrl, that.imageCatalogUrl)
                 && Objects.equals(imageId, that.imageId)
-                && Objects.equals(imageCatalogName, that.imageCatalogName);
+                && Objects.equals(imageCatalogName, that.imageCatalogName)
+                && Objects.equals(date, that.date);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, imageName, userdata, os, osType, imageCatalogUrl, imageId, imageCatalogName);
+        return Objects.hash(id, imageName, userdata, os, osType, imageCatalogUrl, imageId, imageCatalogName, date);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageProvider.java
@@ -1,11 +1,14 @@
 package com.sequenceiq.freeipa.service.image;
 
+import java.util.List;
+import java.util.Optional;
+
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
-
-import java.util.Optional;
 
 public interface ImageProvider {
 
     Optional<ImageWrapper> getImage(ImageSettingsRequest imageSettings, String region, String platform);
+
+    List<ImageWrapper> getImages(ImageSettingsRequest imageSettings, String region, String platform);
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/UpgradeImageService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/upgrade/UpgradeImageService.java
@@ -1,7 +1,15 @@
 package com.sequenceiq.freeipa.service.upgrade;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,6 +20,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.upgrade.model.ImageInfoResponse;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.image.ImageNotFoundException;
 import com.sequenceiq.freeipa.service.image.ImageService;
 
 @Service
@@ -19,12 +28,18 @@ public class UpgradeImageService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpgradeImageService.class);
 
+    private static final String DATE_FORMAT = "yyyy-MM-dd";
+
     @Inject
     private ImageService imageService;
 
     public ImageInfoResponse selectImage(Stack stack, ImageSettingsRequest imageSettingsRequest) {
         Pair<ImageWrapper, String> imageWrapperAndName = imageService.fetchImageWrapperAndName(stack, imageSettingsRequest);
         LOGGER.info("Selected image {} from request {}", imageWrapperAndName, imageSettingsRequest);
+        return convertImageWrapperAndNameToImageInfoResponse(imageWrapperAndName);
+    }
+
+    private ImageInfoResponse convertImageWrapperAndNameToImageInfoResponse(Pair<ImageWrapper, String> imageWrapperAndName) {
         ImageInfoResponse imageInfoResponse = new ImageInfoResponse();
         imageInfoResponse.setImageName(imageWrapperAndName.getRight());
         imageInfoResponse.setDate(imageWrapperAndName.getLeft().getImage().getDate());
@@ -35,7 +50,7 @@ public class UpgradeImageService {
         return imageInfoResponse;
     }
 
-    public ImageInfoResponse currentImage(Stack stack) {
+    public ImageInfoResponse fetchCurrentImage(Stack stack) {
         ImageEntity imageEntity = imageService.getByStackId(stack.getId());
         ImageInfoResponse imageInfoResponse = new ImageInfoResponse();
         imageInfoResponse.setImageName(imageEntity.getImageName());
@@ -43,7 +58,57 @@ public class UpgradeImageService {
         imageInfoResponse.setCatalogName(imageEntity.getImageCatalogName());
         imageInfoResponse.setOs(imageEntity.getOs());
         imageInfoResponse.setId(imageEntity.getImageId());
+        imageInfoResponse.setDate(imageEntity.getDate());
         LOGGER.info("Current image: {}", imageInfoResponse);
         return imageInfoResponse;
+    }
+
+    public List<ImageInfoResponse> findTargetImages(Stack stack, ImageSettingsRequest imageSettingsRequest, ImageInfoResponse currentImage) {
+        Optional<String> currentImageDate = getCurrentImageDate(stack, currentImage);
+        List<Pair<ImageWrapper, String>> imagesWrapperAndName = imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest);
+        return imagesWrapperAndName.stream()
+                .filter(imageWrapperAndName -> currentImageDate.isPresent()
+                        && isCandidateImageNewerThanCurrent(imageWrapperAndName.getLeft(), currentImageDate.get()))
+                .filter(imageWrapperAndName -> !currentImage.getId().equals(imageWrapperAndName.getLeft().getImage().getUuid()))
+                .map(this::convertImageWrapperAndNameToImageInfoResponse)
+                .collect(Collectors.toList());
+    }
+
+    private boolean isCandidateImageNewerThanCurrent(ImageWrapper candidate, String currentImageDate) {
+        try {
+            SimpleDateFormat imageDateFormat = new SimpleDateFormat(DATE_FORMAT);
+            Date candidateDate = imageDateFormat.parse(candidate.getImage().getDate());
+            Date currentDate = imageDateFormat.parse(currentImageDate);
+            return candidateDate.after(currentDate);
+        } catch (ParseException e) {
+            LOGGER.warn("Couldn't parse dates, return false. Current date: [{}], candidate date: [{}]", currentImageDate, candidate.getImage().getDate(), e);
+            return false;
+        }
+    }
+
+    private Optional<String> getCurrentImageDate(Stack stack, ImageInfoResponse currentImage) {
+        if (StringUtils.isNotBlank(currentImage.getDate())) {
+            LOGGER.debug("Current image has a date field filled with {}", currentImage.getDate());
+            return Optional.of(currentImage.getDate());
+        } else {
+            return getCurrentImageDateFromCatalog(stack, currentImage);
+        }
+    }
+
+    private Optional<String> getCurrentImageDateFromCatalog(Stack stack, ImageInfoResponse currentImage) {
+        try {
+            String catalog = Optional.ofNullable(currentImage.getCatalog()).orElse(currentImage.getCatalogName());
+            LOGGER.debug("Current image date field is empty. Using catalog [{}] to get image date", catalog);
+            ImageSettingsRequest imageSettings = new ImageSettingsRequest();
+            imageSettings.setCatalog(catalog);
+            imageSettings.setId(currentImage.getId());
+            imageSettings.setOs(currentImage.getOs());
+            ImageWrapper image = imageService.getImage(imageSettings, stack.getRegion(), stack.getCloudPlatform().toLowerCase());
+            LOGGER.debug("Image date from catalog: {}", image.getImage().getDate());
+            return Optional.ofNullable(image.getImage().getDate());
+        } catch (ImageNotFoundException e) {
+            LOGGER.warn("Image not found, returning empty date", e);
+            return Optional.empty();
+        }
     }
 }

--- a/freeipa/src/main/resources/schema/app/20210908133927_CB-13685_alter_image_table_add_date_column.sql
+++ b/freeipa/src/main/resources/schema/app/20210908133927_CB-13685_alter_image_table_add_date_column.sql
@@ -1,0 +1,11 @@
+-- // CB-13685 alter image table add date column
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE image ADD COLUMN IF NOT EXISTS image_date VARCHAR(255);
+ALTER TABLE image_history ADD COLUMN IF NOT EXISTS image_date VARCHAR(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE image DROP COLUMN IF EXISTS image_date;
+ALTER TABLE image_history DROP COLUMN IF EXISTS image_date;

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/FreeIpaImageProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/FreeIpaImageProviderTest.java
@@ -1,28 +1,39 @@
 package com.sequenceiq.freeipa.service.image;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
 import com.sequenceiq.freeipa.api.model.image.Image;
 import com.sequenceiq.freeipa.api.model.image.ImageCatalog;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.test.util.ReflectionTestUtils;
 
-import java.io.IOException;
-import java.util.Optional;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.when;
-
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FreeIpaImageProviderTest {
 
     private static final String DEFAULT_CATALOG_URL = "https://cloudbreak-imagecatalog.s3.amazonaws.com/freeipa-image-catalog.json";
@@ -62,7 +73,7 @@ public class FreeIpaImageProviderTest {
     @Spy
     private ObjectMapper objectMapper;
 
-    @Before
+    @BeforeEach
     public void setup() throws Exception {
         ImageCatalog imageCatalog = setupImageCatalogProvider(CUSTOM_IMAGE_CATALOG_URL, CATALOG_FILE);
         imageCatalog.getImages().getFreeipaImages().get(0);
@@ -76,9 +87,11 @@ public class FreeIpaImageProviderTest {
     public void testGetImageGivenNoInputWithInvalidAppVersion() {
         ReflectionTestUtils.setField(underTest, FreeIpaImageProvider.class, "freeIpaVersion", "2.21.0-dcv.1", null);
         ImageSettingsRequest is = setupImageSettingsRequest(null, null, "centos7");
+
         Image image = underTest.getImage(is, DEFAULT_REGION, DEFAULT_PLATFORM).get().getImage();
+
         assertEquals("centos7", image.getOs());
-        assertEquals("Assuming the latest image to be selected", "2019-05-09", image.getDate());
+        assertEquals("2019-05-09", image.getDate());
         assertEquals("91851893-8340-411d-afb7-e1b55107fb10", image.getUuid());
     }
 
@@ -94,45 +107,129 @@ public class FreeIpaImageProviderTest {
         doTestGetImageGivenNoInput();
     }
 
+    @Test
+    public void testGetImagesGivenNoInputWithInvalidAppVersion() {
+        ReflectionTestUtils.setField(underTest, FreeIpaImageProvider.class, "freeIpaVersion", "2.21.0-dcv.1", null);
+        ImageSettingsRequest is = setupImageSettingsRequest(null, null, "centos7");
+
+        List<ImageWrapper> images = underTest.getImages(is, DEFAULT_REGION, DEFAULT_PLATFORM);
+
+        assertTrue(images.isEmpty());
+    }
+
     private void doTestGetImageGivenNoInput() {
         ImageSettingsRequest is = setupImageSettingsRequest(null, null, null);
+
         Image image = underTest.getImage(is, DEFAULT_REGION, DEFAULT_PLATFORM).get().getImage();
+
         assertEquals(DEFAULT_OS, image.getOs());
-        assertEquals("Assuming the latest image to be selected", LATEST_DATE_NO_INPUT, image.getDate());
+        assertEquals(LATEST_DATE_NO_INPUT, image.getDate());
         assertEquals("71851893-8340-411d-afb7-e1b55107fb10", image.getUuid());
     }
 
     @Test
     public void testGetImageGivenAllInput() {
         ImageSettingsRequest is = setupImageSettingsRequest(EXISTING_ID, CUSTOM_IMAGE_CATALOG_URL, DEFAULT_OS);
+
         Image image = underTest.getImage(is, DEFAULT_REGION, DEFAULT_PLATFORM).get().getImage();
+
         assertEquals(DEFAULT_OS, image.getOs());
-        assertEquals("Assuming the latest image to be selected", LATEST_DATE, image.getDate());
+        assertEquals(LATEST_DATE, image.getDate());
+        assertEquals(IMAGE_UUID, image.getUuid());
+    }
+
+    @Test
+    public void testGetImagesGivenAllInput() {
+        ImageSettingsRequest is = setupImageSettingsRequest(EXISTING_ID, CUSTOM_IMAGE_CATALOG_URL, DEFAULT_OS);
+
+        List<ImageWrapper> images = underTest.getImages(is, DEFAULT_REGION, DEFAULT_PLATFORM);
+
+        assertEquals(1, images.size());
+        ImageWrapper imageWrapper = images.get(0);
+        assertEquals(CUSTOM_IMAGE_CATALOG_URL, imageWrapper.getCatalogUrl());
+        assertNull(imageWrapper.getCatalogName());
+        Image image = imageWrapper.getImage();
+        assertEquals(DEFAULT_OS, image.getOs());
+        assertEquals(LATEST_DATE, image.getDate());
         assertEquals(IMAGE_UUID, image.getUuid());
     }
 
     @Test
     public void testGetImageGivenAllInputNonExistentOS() {
         ImageSettingsRequest is = setupImageSettingsRequest(EXISTING_ID, CUSTOM_IMAGE_CATALOG_URL, NON_EXISTING_OS);
+
         Image image = underTest.getImage(is, DEFAULT_REGION, DEFAULT_PLATFORM).get().getImage();
+
         assertEquals(DEFAULT_OS, image.getOs());
-        assertEquals("Assuming the latest image to be selected", LATEST_DATE, image.getDate());
+        assertEquals(LATEST_DATE, image.getDate());
+        assertEquals(IMAGE_UUID, image.getUuid());
+    }
+
+    @Test
+    public void testGetImagesGivenAllInputNonExistentOS() {
+        ImageSettingsRequest is = setupImageSettingsRequest(EXISTING_ID, CUSTOM_IMAGE_CATALOG_URL, NON_EXISTING_OS);
+
+        List<ImageWrapper> images = underTest.getImages(is, DEFAULT_REGION, DEFAULT_PLATFORM);
+
+        assertEquals(1, images.size());
+        ImageWrapper imageWrapper = images.get(0);
+        assertEquals(CUSTOM_IMAGE_CATALOG_URL, imageWrapper.getCatalogUrl());
+        assertNull(imageWrapper.getCatalogName());
+        Image image = imageWrapper.getImage();
+        assertEquals(DEFAULT_OS, image.getOs());
+        assertEquals(LATEST_DATE, image.getDate());
         assertEquals(IMAGE_UUID, image.getUuid());
     }
 
     @Test
     public void testGetImageGivenIdInputFound() {
         ImageSettingsRequest is = setupImageSettingsRequest(EXISTING_ID, null, null);
+
         Image image = underTest.getImage(is, DEFAULT_REGION, DEFAULT_PLATFORM).get().getImage();
+
         assertEquals(DEFAULT_OS, image.getOs());
-        assertEquals("Assuming the latest image to be selected", LATEST_DATE, image.getDate());
+        assertEquals(LATEST_DATE, image.getDate());
+        assertEquals(IMAGE_UUID, image.getUuid());
+    }
+
+    @Test
+    public void testGetImagesGivenIdInputFound() {
+        ImageSettingsRequest is = setupImageSettingsRequest(EXISTING_ID, null, null);
+
+        List<ImageWrapper> images = underTest.getImages(is, DEFAULT_REGION, DEFAULT_PLATFORM);
+
+        assertEquals(1, images.size());
+        ImageWrapper imageWrapper = images.get(0);
+        assertEquals(DEFAULT_CATALOG_URL, imageWrapper.getCatalogUrl());
+        assertNull(imageWrapper.getCatalogName());
+        Image image = imageWrapper.getImage();
+        assertEquals(DEFAULT_OS, image.getOs());
+        assertEquals(LATEST_DATE, image.getDate());
         assertEquals(IMAGE_UUID, image.getUuid());
     }
 
     @Test
     public void testGetImageGivenUuidInputFound() {
         ImageSettingsRequest is = setupImageSettingsRequest(IMAGE_UUID, null, null);
+
         Image image = underTest.getImage(is, DEFAULT_REGION, DEFAULT_PLATFORM).get().getImage();
+
+        assertEquals(IMAGE_UUID, image.getUuid());
+    }
+
+    @Test
+    public void testGetImagesGivenUuidInputFound() {
+        ImageSettingsRequest is = setupImageSettingsRequest(IMAGE_UUID, null, null);
+
+        List<ImageWrapper> images = underTest.getImages(is, DEFAULT_REGION, DEFAULT_PLATFORM);
+
+        assertEquals(1, images.size());
+        ImageWrapper imageWrapper = images.get(0);
+        assertEquals(DEFAULT_CATALOG_URL, imageWrapper.getCatalogUrl());
+        assertNull(imageWrapper.getCatalogName());
+        Image image = imageWrapper.getImage();
+        assertEquals(DEFAULT_OS, image.getOs());
+        assertEquals(LATEST_DATE, image.getDate());
         assertEquals(IMAGE_UUID, image.getUuid());
     }
 
@@ -141,21 +238,70 @@ public class FreeIpaImageProviderTest {
         ImageSettingsRequest is = setupImageSettingsRequest(NON_EXISTING_ID, null, null);
 
         Optional<ImageWrapper> result = underTest.getImage(is, DEFAULT_REGION, DEFAULT_PLATFORM);
+
         assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void testGetImagesGivenIdInputNotFound() {
+        ImageSettingsRequest is = setupImageSettingsRequest(NON_EXISTING_ID, null, null);
+
+        List<ImageWrapper> images = underTest.getImages(is, DEFAULT_REGION, DEFAULT_PLATFORM);
+
+        assertTrue(images.isEmpty());
     }
 
     @Test
     public void testGetImageGivenUuidInputFoundWithNotDefaultOs() {
         ImageSettingsRequest is = setupImageSettingsRequest(NON_DEFAULT_OS_IMAGE_UUID, null, null);
+
         Image image = underTest.getImage(is, DEFAULT_REGION, DEFAULT_PLATFORM).get().getImage();
+
         assertEquals(NON_DEFAULT_OS_IMAGE_UUID, image.getUuid());
+    }
+
+    @Test
+    public void testGetImagesGivenUuidInputNotFoundWithNotDefaultOs() {
+        ImageSettingsRequest is = setupImageSettingsRequest(NON_DEFAULT_OS_IMAGE_UUID, null, null);
+
+        List<ImageWrapper> images = underTest.getImages(is, DEFAULT_REGION, DEFAULT_PLATFORM);
+
+        assertTrue(images.isEmpty());
+    }
+
+    @Test
+    public void testGetImagesNoInput() {
+        ImageSettingsRequest imageSettingsRequest = setupImageSettingsRequest(null, null, null);
+
+        List<ImageWrapper> images = underTest.getImages(imageSettingsRequest, DEFAULT_REGION, DEFAULT_PLATFORM);
+
+        assertEquals(2, images.size());
+        assertThat(images, everyItem(allOf(
+                hasProperty("image",
+                        hasProperty("os", is(DEFAULT_OS))
+                ),
+                hasProperty("catalogUrl", is(DEFAULT_CATALOG_URL)),
+                hasProperty("catalogName", is(nullValue()))
+        )));
+        assertThat(images, hasItem(allOf(
+                hasProperty("image", allOf(
+                        hasProperty("uuid", is(IMAGE_UUID)),
+                        hasProperty("date", is(LATEST_DATE))
+                ))
+        )));
+        assertThat(images, hasItem(allOf(
+                hasProperty("image", allOf(
+                        hasProperty("uuid", is("71851893-8340-411d-afb7-e1b55107fb10")),
+                        hasProperty("date", is(LATEST_DATE_NO_INPUT))
+                ))
+        )));
     }
 
     private ImageCatalog setupImageCatalogProvider(String catalogUrl, String catalogFile) throws IOException {
         String catalogJson = FileReaderUtils.readFileFromClasspath(catalogFile);
         ImageCatalog catalog = objectMapper.readValue(catalogJson, ImageCatalog.class);
-        when(imageCatalogProvider.getImageCatalog(catalogUrl)).thenReturn(catalog);
-        when(imageCatalogProvider.getImageCatalog(DEFAULT_CATALOG_URL)).thenReturn(catalog);
+        lenient().when(imageCatalogProvider.getImageCatalog(catalogUrl)).thenReturn(catalog);
+        lenient().when(imageCatalogProvider.getImageCatalog(DEFAULT_CATALOG_URL)).thenReturn(catalog);
         return catalog;
     }
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/UpgradeImageServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/UpgradeImageServiceTest.java
@@ -2,13 +2,17 @@ package com.sequenceiq.freeipa.service.upgrade;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,6 +23,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.upgrade.model.ImageInfoResponse;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 import com.sequenceiq.freeipa.entity.ImageEntity;
 import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.image.ImageNotFoundException;
 import com.sequenceiq.freeipa.service.image.ImageService;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,6 +44,7 @@ class UpgradeImageServiceTest {
         when(imageService.fetchImageWrapperAndName(stack, imageSettingsRequest)).thenReturn(Pair.of(imageWrapper, "imageName"));
 
         ImageInfoResponse imageInfoResponse = underTest.selectImage(stack, imageSettingsRequest);
+
         assertEquals(imageWrapper.getCatalogName(), imageInfoResponse.getCatalogName());
         assertEquals(imageWrapper.getCatalogUrl(), imageInfoResponse.getCatalog());
         assertEquals(image.getDate(), imageInfoResponse.getDate());
@@ -58,7 +64,8 @@ class UpgradeImageServiceTest {
         imageEntity.setOs("linux");
         when(imageService.getByStackId(1L)).thenReturn(imageEntity);
 
-        ImageInfoResponse imageInfoResponse = underTest.currentImage(stack);
+        ImageInfoResponse imageInfoResponse = underTest.fetchCurrentImage(stack);
+
         assertEquals(imageEntity.getImageCatalogName(), imageInfoResponse.getCatalogName());
         assertEquals(imageEntity.getImageCatalogUrl(), imageInfoResponse.getCatalog());
         assertNull(imageInfoResponse.getDate());
@@ -66,4 +73,178 @@ class UpgradeImageServiceTest {
         assertEquals(imageEntity.getOs(), imageInfoResponse.getOs());
     }
 
+    @Test
+    public void testFindTargetImages() {
+        Stack stack = new Stack();
+        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
+        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
+        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+
+        ImageInfoResponse currentImage = new ImageInfoResponse();
+        currentImage.setDate("2021-08-21");
+        currentImage.setId("111-222");
+
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+
+        assertEquals(1, targetImages.size());
+        ImageInfoResponse imageInfoResponse = targetImages.get(0);
+        assertEquals(imageWrapper.getCatalogName(), imageInfoResponse.getCatalogName());
+        assertEquals(imageWrapper.getCatalogUrl(), imageInfoResponse.getCatalog());
+        assertEquals(image.getDate(), imageInfoResponse.getDate());
+        assertEquals(image.getUuid(), imageInfoResponse.getId());
+        assertEquals(image.getOs(), imageInfoResponse.getOs());
+    }
+
+    @Test
+    public void testFindTargetImagesNoNewerImage() {
+        Stack stack = new Stack();
+        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
+        Image image = new Image("2021-07-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
+        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+
+        ImageInfoResponse currentImage = new ImageInfoResponse();
+        currentImage.setDate("2021-08-21");
+        currentImage.setId("111-222");
+
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+
+        assertTrue(targetImages.isEmpty());
+    }
+
+    @Test
+    public void testFindTargetImagesImageWithSameId() {
+        Stack stack = new Stack();
+        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
+        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
+        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+
+        ImageInfoResponse currentImage = new ImageInfoResponse();
+        currentImage.setDate("2021-08-21");
+        currentImage.setId("1234-456");
+
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+
+        assertTrue(targetImages.isEmpty());
+    }
+
+    @Test
+    public void testFindTargetImagesCurrentImageMissingDate() {
+        Stack stack = new Stack();
+        stack.setCloudPlatform("AWS");
+        stack.setRegion("reg");
+        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
+        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
+        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+        ArgumentCaptor<ImageSettingsRequest> captor = ArgumentCaptor.forClass(ImageSettingsRequest.class);
+        Image currentImageFromCatalog = new Image("2021-08-01", "desc", "linux", "222-333", Map.of(), "magicOs");
+        ImageWrapper currentImageWrapperFromCatalog = new ImageWrapper(currentImageFromCatalog, "asdf", "Asdf");
+        when(imageService.getImage(captor.capture(), eq(stack.getRegion()), eq(stack.getCloudPlatform().toLowerCase())))
+                .thenReturn(currentImageWrapperFromCatalog);
+
+        ImageInfoResponse currentImage = new ImageInfoResponse();
+        currentImage.setId("222-333");
+        currentImage.setCatalog("cat");
+        currentImage.setCatalogName("catName");
+        currentImage.setOs("zOs");
+
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+
+        assertEquals(1, targetImages.size());
+        ImageInfoResponse imageInfoResponse = targetImages.get(0);
+        assertEquals(imageWrapper.getCatalogName(), imageInfoResponse.getCatalogName());
+        assertEquals(imageWrapper.getCatalogUrl(), imageInfoResponse.getCatalog());
+        assertEquals(image.getDate(), imageInfoResponse.getDate());
+        assertEquals(image.getUuid(), imageInfoResponse.getId());
+        assertEquals(image.getOs(), imageInfoResponse.getOs());
+        ImageSettingsRequest settingsRequest = captor.getValue();
+        assertEquals(currentImage.getCatalog(), settingsRequest.getCatalog());
+        assertEquals(currentImage.getId(), settingsRequest.getId());
+        assertEquals(currentImage.getOs(), settingsRequest.getOs());
+    }
+
+    @Test
+    public void testFindTargetImagesCurrentImageMissingDateAndNoDateFromCatalog() {
+        Stack stack = new Stack();
+        stack.setCloudPlatform("AWS");
+        stack.setRegion("reg");
+        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
+        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
+        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+        ArgumentCaptor<ImageSettingsRequest> captor = ArgumentCaptor.forClass(ImageSettingsRequest.class);
+        Image currentImageFromCatalog = new Image(null, "desc", "linux", "222-333", Map.of(), "magicOs");
+        ImageWrapper currentImageWrapperFromCatalog = new ImageWrapper(currentImageFromCatalog, "asdf", "Asdf");
+        when(imageService.getImage(captor.capture(), eq(stack.getRegion()), eq(stack.getCloudPlatform().toLowerCase())))
+                .thenReturn(currentImageWrapperFromCatalog);
+
+        ImageInfoResponse currentImage = new ImageInfoResponse();
+        currentImage.setId("222-333");
+        currentImage.setCatalogName("cat");
+        currentImage.setOs("zOs");
+
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+
+        assertTrue(targetImages.isEmpty());
+        ImageSettingsRequest settingsRequest = captor.getValue();
+        assertEquals(currentImage.getCatalogName(), settingsRequest.getCatalog());
+        assertEquals(currentImage.getId(), settingsRequest.getId());
+        assertEquals(currentImage.getOs(), settingsRequest.getOs());
+    }
+
+    @Test
+    public void testFindTargetImagesCurrentImageMissingDateAndNoImageFoundInCatalog() {
+        Stack stack = new Stack();
+        stack.setCloudPlatform("AWS");
+        stack.setRegion("reg");
+        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
+        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
+        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
+        ArgumentCaptor<ImageSettingsRequest> captor = ArgumentCaptor.forClass(ImageSettingsRequest.class);
+        when(imageService.getImage(captor.capture(), eq(stack.getRegion()), eq(stack.getCloudPlatform().toLowerCase())))
+                .thenThrow(new ImageNotFoundException("Image not found"));
+
+        ImageInfoResponse currentImage = new ImageInfoResponse();
+        currentImage.setId("222-333");
+        currentImage.setCatalogName("cat");
+        currentImage.setOs("zOs");
+
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+
+        assertTrue(targetImages.isEmpty());
+        ImageSettingsRequest settingsRequest = captor.getValue();
+        assertEquals(currentImage.getCatalogName(), settingsRequest.getCatalog());
+        assertEquals(currentImage.getId(), settingsRequest.getId());
+        assertEquals(currentImage.getOs(), settingsRequest.getOs());
+    }
+
+    @Test
+    public void testFindTargetImagesImageWithWrongDateFormatIgnored() {
+        Stack stack = new Stack();
+        ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
+        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
+        Image image2 = new Image("20210901", "desc", "linux", "1234-789", Map.of(), "magicOs");
+        ImageWrapper imageWrapper2 = new ImageWrapper(image2, "catalogURL", "catalogName");
+        when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest))
+                .thenReturn(List.of(Pair.of(imageWrapper, "imageName"), Pair.of(imageWrapper2, "imageName2")));
+
+        ImageInfoResponse currentImage = new ImageInfoResponse();
+        currentImage.setDate("2021-08-21");
+        currentImage.setId("111-222");
+
+        List<ImageInfoResponse> targetImages = underTest.findTargetImages(stack, imageSettingsRequest, currentImage);
+
+        assertEquals(1, targetImages.size());
+        ImageInfoResponse imageInfoResponse = targetImages.get(0);
+        assertEquals(imageWrapper.getCatalogName(), imageInfoResponse.getCatalogName());
+        assertEquals(imageWrapper.getCatalogUrl(), imageInfoResponse.getCatalog());
+        assertEquals(image.getDate(), imageInfoResponse.getDate());
+        assertEquals(image.getUuid(), imageInfoResponse.getId());
+        assertEquals(image.getOs(), imageInfoResponse.getOs());
+    }
 }


### PR DESCRIPTION
…ller

- `ImageProvider` interface an related classes has been added the `getImages` method for fetching all available images
- all FreeIPA image is returned which is present in the catalog `versions` part, and have date field filled, and is newer than the curren image and the ID is different
- `ImageEntity` is enriched with a string date field to enable returning the date of the current image on the API
- upgrade and fetching upgrade options would use the current image's catalog instead of the default if not defined in the request
- `FreeIpaUpgradeOptions` contains the current image
- added `toString` implementation to API model classes