### PR TITLE
CB-14037 Change Light Duty Shape

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx.bp
@@ -11,7 +11,6 @@
         "cardinality": 1,
         "refName": "master",
         "roleConfigGroupsRefNames": [
-          "atlas-ATLAS_SERVER-BASE",
           "hbase-GATEWAY-BASE",
           "hbase-HBASETHRIFTSERVER-BASE",
           "hbase-REGIONSERVER-BASE",
@@ -24,13 +23,20 @@
           "hive-HIVEMETASTORE-BASE",
           "kafka-GATEWAY-BASE",
           "kafka-KAFKA_BROKER-BASE",
+          "solr-SOLR_SERVER-BASE"
+        ]
+      },
+      {
+        "cardinality": 1,
+        "refName": "gateway",
+        "roleConfigGroupsRefNames": [
+          "atlas-ATLAS_SERVER-BASE",
           "knox-KNOX_GATEWAY-BASE",
           "ranger-RANGER_ADMIN-BASE",
           "ranger-RANGER_TAGSYNC-BASE",
           "ranger-RANGER_USERSYNC-BASE",
-          "solr-SOLR_SERVER-BASE",
           "zookeeper-SERVER-BASE"
-        ]
+          ]
       },
       {
         "cardinality": 1,

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/blueprint/BlueprintV4RequestToBlueprintConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/blueprint/BlueprintV4RequestToBlueprintConverterTest.java
@@ -88,7 +88,7 @@ public class BlueprintV4RequestToBlueprintConverterTest extends AbstractJsonConv
         assertNotNull(result);
         assertEquals("CDH", result.getStackType());
         assertEquals("7.2.12", result.getStackVersion());
-        assertEquals(2, result.getHostGroupCount());
+        assertEquals(3, result.getHostGroupCount());
         assertNotNull(result.getBlueprintText());
         assertNotEquals("", result.getBlueprintText());
     }

--- a/datalake/src/main/resources/duties/7.2.12/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.12/aws/light_duty.json
@@ -25,7 +25,7 @@
       "recipeNames": []
     },
     {
-      "name": "master",
+      "name": "gateway",
       "template": {
         "instanceType": "m5.2xlarge",
         "attachedVolumes": [
@@ -38,6 +38,23 @@
       },
       "nodeCount": 1,
       "type": "GATEWAY",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "master",
+      "template": {
+        "instanceType": "m5.2xlarge",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "standard"
+          }
+        ]
+      },
+      "nodeCount": 1,
+      "type": "CORE",
       "recoveryMode": "MANUAL",
       "recipeNames": []
     }

--- a/datalake/src/main/resources/duties/7.2.12/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.12/azure/light_duty.json
@@ -37,6 +37,23 @@
         ]
       },
       "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "gateway",
+      "template": {
+        "instanceType": "Standard_D8s_v3",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "StandardSSD_LRS"
+          }
+        ]
+      },
+      "nodeCount": 1,
       "type": "GATEWAY",
       "recoveryMode": "MANUAL",
       "recipeNames": []

--- a/datalake/src/main/resources/duties/7.2.12/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.12/gcp/light_duty.json
@@ -37,6 +37,23 @@
         ]
       },
       "nodeCount": 1,
+      "type": "CORE",
+      "recoveryMode": "MANUAL",
+      "recipeNames": []
+    },
+    {
+      "name": "gateway",
+      "template": {
+        "instanceType": "e2-standard-8",
+        "attachedVolumes": [
+          {
+            "count": 1,
+            "size": 250,
+            "type": "pd-standard"
+          }
+        ]
+      },
+      "nodeCount": 1,
       "type": "GATEWAY",
       "recoveryMode": "MANUAL",
       "recipeNames": []

--- a/datalake/src/main/resources/duties/7.2.12/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.12/yarn/light_duty.json
@@ -28,6 +28,17 @@
         }
       },
       "nodeCount": 1,
+      "type": "CORE"
+    },
+    {
+      "name": "gateway",
+      "template": {
+        "yarn": {
+          "cpus": 4,
+          "memory": 16384
+        }
+      },
+      "nodeCount": 1,
       "type": "GATEWAY"
     }
   ]


### PR DESCRIPTION
In conjunction with Micro Duty, Light Duty is splitting it's services into 2 nodes, master and gateway for 7.2.12+.
Master contains Hbase, Kafka, HDFS, HMS, and Solr.  Gateway contains Atlas, Knox, Ranger, CM, and Zookeeper.

See detailed description in the commit message.