### PR TITLE
CB-13718 - Cloudbreak does not retry failed cluster upgrade command f…

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerCommandsService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerCommandsService.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import java.math.BigDecimal;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.cloudera.api.swagger.CommandsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+
+@Service
+public class ClouderaManagerCommandsService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerCommandsService.class);
+
+    @Inject
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    public ApiCommand getApiCommand(ApiClient client, BigDecimal commandId) throws ApiException {
+        CommandsResourceApi commandsResourceApi = clouderaManagerApiFactory.getCommandsResourceApi(client);
+        ApiCommand apiCommand = commandsResourceApi.readCommand(commandId);
+        LOGGER.debug("Get Api command by id {} result is {}", commandId, apiCommand);
+        return apiCommand;
+    }
+
+    public ApiCommand retryApiCommand(ApiClient client, BigDecimal commandId) throws ApiException {
+        CommandsResourceApi commandsResourceApi = clouderaManagerApiFactory.getCommandsResourceApi(client);
+        ApiCommand retryApiCommand = commandsResourceApi.retry(commandId);
+        LOGGER.debug("Retry Api command by id {} result is {}", commandId, retryApiCommand);
+        return retryApiCommand;
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerUpgradeService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerUpgradeService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cm;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 import javax.inject.Inject;
@@ -14,7 +15,7 @@ import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiCdhUpgradeArgs;
 import com.cloudera.api.swagger.model.ApiCommand;
-import com.cloudera.api.swagger.model.ApiCommandList;
+import com.sequenceiq.cloudbreak.cm.commands.SyncApiCommandRetriever;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
 import com.sequenceiq.cloudbreak.cm.polling.PollingResultErrorHandler;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -26,29 +27,24 @@ class ClouderaManagerUpgradeService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClouderaManagerUpgradeService.class);
 
-    private static final String SUMMARY = "SUMMARY";
-
     @Inject
     private ClouderaManagerPollingServiceProvider clouderaManagerPollingServiceProvider;
 
     @Inject
     private PollingResultErrorHandler pollingResultErrorHandler;
 
+    @Inject
+    private SyncApiCommandRetriever syncApiCommandRetriever;
+
+    @Inject
+    private ClouderaManagerCommandsService clouderaManagerCommandsService;
+
     void callUpgradeCdhCommand(String stackProductVersion, ClustersResourceApi clustersResourceApi, Stack stack, ApiClient apiClient)
             throws ApiException, CloudbreakException {
         LOGGER.info("Upgrading the CDP Runtime...");
-        Optional<ApiCommand> optionalUpgradeCommand = findUpgradeApiCommand(clustersResourceApi, stack);
         try {
-            ApiCommand upgradeCommand;
-            if (optionalUpgradeCommand.isPresent()) {
-                upgradeCommand = optionalUpgradeCommand.get();
-                LOGGER.debug("Upgrade of CDP Runtime is already running with id: [{}]", upgradeCommand.getId());
-            } else {
-                ApiCdhUpgradeArgs upgradeArgs = new ApiCdhUpgradeArgs();
-                upgradeArgs.setCdhParcelVersion(stackProductVersion);
-                upgradeCommand = clustersResourceApi.upgradeCdhCommand(stack.getName(), upgradeArgs);
-            }
-            PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCdpRuntimeUpgrade(stack, apiClient, upgradeCommand.getId());
+            BigDecimal upgradeCommandId = determineUpgradeLogic(stackProductVersion, clustersResourceApi, stack, apiClient);
+            PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCdpRuntimeUpgrade(stack, apiClient, upgradeCommandId);
             pollingResultErrorHandler.handlePollingResult(pollingResult, "Cluster was terminated while waiting for CDP Runtime to be upgraded",
                     "Timeout during CDP Runtime upgrade.");
         } catch (ApiException ex) {
@@ -62,10 +58,49 @@ class ClouderaManagerUpgradeService {
         LOGGER.info("Runtime is successfully upgraded!");
     }
 
-    private Optional<ApiCommand> findUpgradeApiCommand(ClustersResourceApi clustersResourceApi, Stack stack) throws ApiException {
-        ApiCommandList apiCommandList = clustersResourceApi.listActiveCommands(stack.getName(), SUMMARY);
-        return apiCommandList.getItems().stream()
-                .filter(cmd -> "UpgradeCluster".equals(cmd.getName()))
-                .findFirst();
+    private BigDecimal determineUpgradeLogic(String stackProductVersion, ClustersResourceApi clustersResourceApi, Stack stack, ApiClient apiClient)
+            throws ApiException {
+        Optional<BigDecimal> optionalUpgradeCommand = findUpgradeApiCommandId(clustersResourceApi, stack);
+        BigDecimal upgradeCommandId;
+        if (optionalUpgradeCommand.isPresent()) {
+            upgradeCommandId = optionalUpgradeCommand.get();
+            ApiCommand upgradeCommand = clouderaManagerCommandsService.getApiCommand(apiClient, upgradeCommandId);
+            Boolean commandActive = upgradeCommand.getActive();
+            Boolean commandSuccess = upgradeCommand.getSuccess();
+            Boolean commandCanRetry = upgradeCommand.getCanRetry();
+            if (commandActive) {
+                LOGGER.debug("Upgrade of CDP Runtime is already running with id: [{}]", upgradeCommandId);
+            } else {
+                if (!commandSuccess && commandCanRetry) {
+                    LOGGER.debug("Retrying previous failed upgrade with command id {}", upgradeCommandId);
+                    upgradeCommandId = clouderaManagerCommandsService.retryApiCommand(apiClient, upgradeCommandId).getId();
+                } else {
+                    LOGGER.debug("Last upgrade command ({}) is not active, it was {} successful and {} retryable, submitting it now", upgradeCommandId,
+                            commandSuccess ? "" : "not",
+                            commandCanRetry ? "" : "not");
+                    upgradeCommandId = callUpgrade(stackProductVersion, clustersResourceApi, stack);
+                }
+            }
+        } else {
+            LOGGER.debug("There is no upgrade command submitted yet, submitting it now");
+            upgradeCommandId = callUpgrade(stackProductVersion, clustersResourceApi, stack);
+        }
+        return upgradeCommandId;
     }
+
+    private BigDecimal callUpgrade(String stackProductVersion, ClustersResourceApi clustersResourceApi, Stack stack) throws ApiException {
+        ApiCdhUpgradeArgs upgradeArgs = new ApiCdhUpgradeArgs();
+        upgradeArgs.setCdhParcelVersion(stackProductVersion);
+        return clustersResourceApi.upgradeCdhCommand(stack.getName(), upgradeArgs).getId();
+    }
+
+    private Optional<BigDecimal> findUpgradeApiCommandId(ClustersResourceApi clustersResourceApi, Stack stack) {
+        try {
+            return syncApiCommandRetriever.getCommandId("UpgradeCluster", clustersResourceApi, stack);
+        } catch (CloudbreakException | ApiException e) {
+            LOGGER.warn("Unexpected error during CM command table fetching, assuming no such command exists", e);
+            return Optional.empty();
+        }
+    }
+
 }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/commands/AbstractCommandTableResource.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/commands/AbstractCommandTableResource.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +46,7 @@ public abstract class AbstractCommandTableResource {
                     .execute();
             if (response.code() >= ERROR_CODES_FROM) {
                 LOGGER.debug("{} request against Cloudera Manager API returned with status code: {}, response: {}",
-                        request.httpUrl().toString(), response.toString(), response.code());
+                        request.httpUrl().toString(), response, response.code());
                 throw new CloudbreakException(
                         String.format("%s request against CM API returned with status code: %d",
                                 getUriPath(), response.code()));
@@ -115,14 +114,6 @@ public abstract class AbstractCommandTableResource {
      */
     private void enhanceRequestParams(Map<String, List<String>> headers, List<Pair> queryParams, Map<String, String> headerParams) {
         queryParams.add(new Pair("limit", "501"));
-        long startTime = new DateTime()
-                .minusMinutes(INTERVAL_MINUTES)
-                .toDate().toInstant().toEpochMilli();
-        long endTime = new DateTime()
-                .plusMinutes(INTERVAL_MINUTES)
-                .toDate().toInstant().toEpochMilli();
-        queryParams.add(new Pair("startTime", Long.toString(startTime)));
-        queryParams.add(new Pair("endTime", Long.toString(endTime)));
         if (headers.containsKey("Set-Cookie")) {
             LOGGER.debug("Copying Set-Cookie header from listActiveCommands to commandTable request (as Cookie header)");
             headerParams.put("Cookie", headers.get("Set-Cookie").get(0));

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/commands/SyncApiCommandRetriever.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/commands/SyncApiCommandRetriever.java
@@ -120,7 +120,7 @@ public class SyncApiCommandRetriever {
         LOGGER.debug("The last {} command could not be found  by listing commands... Trying {} call", commandName, uriPath);
         List<CommandResource> commandsFromRunningCommandsTable = commandTable.getCommands(
                 commandName, api, headers);
-        LOGGER.debug("Processing of {} call has been completed", uriPath);
+        LOGGER.debug("Processing of {} call has been completed with commands {}", uriPath, commandsFromRunningCommandsTable);
         return Optional.ofNullable(getLatestCommandId(commandName, commandsFromRunningCommandsTable, commandTable.getUriPath()));
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/model/CommandResource.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/model/CommandResource.java
@@ -51,4 +51,14 @@ public class CommandResource {
     public void setSuccess(Boolean success) {
         this.success = success;
     }
+
+    @Override
+    public String toString() {
+        return "CommandResource{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", start=" + start +
+                ", success=" + success +
+                '}';
+    }
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerCommandsServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerCommandsServiceTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.cloudbreak.cm;
+
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.api.swagger.CommandsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
+import com.cloudera.api.swagger.client.ApiException;
+import com.cloudera.api.swagger.model.ApiCommand;
+import com.sequenceiq.cloudbreak.cm.client.retry.ClouderaManagerApiFactory;
+
+@ExtendWith(MockitoExtension.class)
+class ClouderaManagerCommandsServiceTest {
+
+    private static final BigDecimal COMMAND_ID = BigDecimal.ONE;
+
+    @Mock
+    private ClouderaManagerApiFactory clouderaManagerApiFactory;
+
+    @Mock
+    private ApiClient apiClient;
+
+    @Mock
+    private CommandsResourceApi commandsResourceApi;
+
+    @Mock
+    private ApiCommand apiCommand;
+
+    @InjectMocks
+    private ClouderaManagerCommandsService underTest;
+
+    @Test
+    public void testGetApiCommand() throws ApiException {
+        when(clouderaManagerApiFactory.getCommandsResourceApi(apiClient)).thenReturn(commandsResourceApi);
+        when(commandsResourceApi.readCommand(BigDecimal.ONE)).thenReturn(apiCommand);
+
+        ApiCommand actualApiCommand = underTest.getApiCommand(apiClient, COMMAND_ID);
+
+        Assertions.assertEquals(actualApiCommand, apiCommand);
+    }
+
+    @Test
+    public void testRetryApiCommand() throws ApiException {
+        when(clouderaManagerApiFactory.getCommandsResourceApi(apiClient)).thenReturn(commandsResourceApi);
+        when(commandsResourceApi.retry(BigDecimal.ONE)).thenReturn(apiCommand);
+
+        ApiCommand actualApiCommand = underTest.retryApiCommand(apiClient, COMMAND_ID);
+
+        Assertions.assertEquals(actualApiCommand, apiCommand);
+    }
+}


### PR DESCRIPTION
…rom CM

This commit modifies how Cloudbreak handles the case when there is an existing upgradeCDH command already while submitting
the callUpgradeCDH command:

- if there is no previous upgrade command then CB submits it
- else we check the command...
  - if it is active then we poll it
  - else
    - if it is not successful and retryable then we retry it
    - else we submit it again

