### PR TITLE
Use new cloudera jdk image as default

### DIFF
--- a/docker-autoscale/Dockerfile
+++ b/docker-autoscale/Dockerfile
@@ -1,4 +1,4 @@
-FROM hortonworks/hwx_openjdk:11.0-jdk-slim
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar

--- a/docker-cloudbreak/Dockerfile
+++ b/docker-cloudbreak/Dockerfile
@@ -1,4 +1,4 @@
-FROM hortonworks/hwx_openjdk:11.0-jdk-slim
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar


### PR DESCRIPTION
The old image seems to be outdated, and causes error during building the CB image.
Tested locally by creating a test image and using it in deployer to start CB.

See detailed description in the commit message.