### PR TITLE
CB-14099 Separate longrunning e2e test suite files by cloud provider

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
@@ -1,0 +1,8 @@
+name: "aws-longrunning-e2e-tests"
+tests:
+  - name: "aws-longrunning-e2e-tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXUpgradeTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.AwsDistroXEphemeralTemporaryStorageStopStartTest

--- a/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
@@ -1,0 +1,7 @@
+name: "azure-longrunning-e2e-tests"
+tests:
+  - name: "azure-longrunning-e2e-tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXUpgradeTests

--- a/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
@@ -1,0 +1,5 @@
+name: "gcp-longrunning-e2e-tests"
+tests:
+  - name: "gcp-longrunning-e2e-tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests


### PR DESCRIPTION
See detailed description in the commit message.