### PR TITLE
CB-14102: Fix ipa dns record errors so that it retries on more errors

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/add_dns_record.j2
@@ -22,9 +22,17 @@ for attempt in {1..3}
 do
   sleep 10
   echo "add dns a-record hostname for ${HOSTNAME}, attempt ${attempt}"
+  IPA_STDERR=$(mktemp)
   retVal=0
-  ipa dnsrecord-mod {{ pillar['sssd-ipa']['domain'] }}. "${HOSTNAME}" "--a-rec=${IPADDR}" --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} || retVal=$?
-  if [[ "$retVal" -le 1 ]]; then
+  alreadyExists=0
+  ipa dnsrecord-mod {{ pillar['sssd-ipa']['domain'] }}. "${HOSTNAME}" "--a-rec=${IPADDR}" --ttl {{ pillar['sssd-ipa']['dns_ttl'] }} 2>"${IPA_STDERR}" || retVal=$?
+  cat "${IPA_STDERR}" >&2
+  if grep "ERROR: no modifications to be performed" ${IPA_STDERR} &>/dev/null; then
+    alreadyExists=1
+    echo "DNS a-record already exists for ${HOSTNAME}"
+  fi
+  rm "${IPA_STDERR}"
+  if [[ "$retVal" -eq 0 || ( "$retVal" -eq 1 && "$alreadyExists" -eq 1 ) ]]; then
     break
   elif [[ "$attempt" -eq 3 ]]; then
     echo "Failed to set DNS A-record for ${HOSTNAME}"


### PR DESCRIPTION
Fix the DNS record add script so that it retries when the following
error happens with err code 1:
ipa: ERROR: Configured time limit exceeded

Only retry when the error code is 1 and the error message is:
ipa: ERROR: no modifications to be performed

This was manually tested.

See detailed description in the commit message.