### PR TITLE
CB-14039 Resize Light Duty SDX instances.

### DIFF
--- a/datalake/src/main/resources/duties/7.2.0/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.0/aws/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "r5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.0/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.0/azure/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "Standard_D8s_v3",
+        "instanceType": "Standard_DS13_v2",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.0/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.0/yarn/light_duty.json
@@ -23,8 +23,8 @@
       "name": "master",
       "template": {
         "yarn": {
-          "cpus": 4,
-          "memory": 16384
+          "cpus": 32,
+          "memory": 65536
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/duties/7.2.1/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.1/aws/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "r5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.1/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.1/azure/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "Standard_D8s_v3",
+        "instanceType": "Standard_DS13_v2",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.1/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.1/yarn/light_duty.json
@@ -23,8 +23,8 @@
       "name": "master",
       "template": {
         "yarn": {
-          "cpus": 4,
-          "memory": 16384
+          "cpus": 32,
+          "memory": 65536
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/duties/7.2.10/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.10/aws/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "r5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.10/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.10/azure/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "Standard_D8s_v3",
+        "instanceType": "Standard_DS13_v2",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.10/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.10/gcp/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "e2-standard-8",
+        "instanceType": "e2-highmem-8",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.10/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.10/yarn/light_duty.json
@@ -23,8 +23,8 @@
       "name": "master",
       "template": {
         "yarn": {
-          "cpus": 4,
-          "memory": 16384
+          "cpus": 32,
+          "memory": 65536
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/duties/7.2.11/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.11/aws/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "r5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.11/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.11/azure/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "Standard_D8s_v3",
+        "instanceType": "Standard_DS13_v2",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.11/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.11/gcp/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "e2-standard-8",
+        "instanceType": "e2-highmem-8",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.11/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.11/yarn/light_duty.json
@@ -23,8 +23,8 @@
       "name": "master",
       "template": {
         "yarn": {
-          "cpus": 4,
-          "memory": 16384
+          "cpus": 32,
+          "memory": 65536
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/duties/7.2.12/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.12/aws/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "r5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.12/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.12/azure/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "Standard_D8s_v3",
+        "instanceType": "Standard_DS13_v2",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.12/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.12/gcp/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "e2-standard-8",
+        "instanceType": "e2-highmem-8",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.12/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.12/yarn/light_duty.json
@@ -23,8 +23,8 @@
       "name": "master",
       "template": {
         "yarn": {
-          "cpus": 4,
-          "memory": 16384
+          "cpus": 32,
+          "memory": 65536
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/duties/7.2.13/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.13/aws/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "r5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.13/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.13/azure/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "Standard_D8s_v3",
+        "instanceType": "Standard_DS13_v2",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.13/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.13/gcp/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "e2-standard-8",
+        "instanceType": "e2-highmem-8",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.13/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.13/yarn/light_duty.json
@@ -23,8 +23,8 @@
       "name": "master",
       "template": {
         "yarn": {
-          "cpus": 4,
-          "memory": 16384
+          "cpus": 32,
+          "memory": 65536
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/duties/7.2.2/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.2/aws/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "r5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.2/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.2/azure/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "Standard_D8s_v3",
+        "instanceType": "Standard_DS13_v2",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.2/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.2/yarn/light_duty.json
@@ -23,8 +23,8 @@
       "name": "master",
       "template": {
         "yarn": {
-          "cpus": 4,
-          "memory": 16384
+          "cpus": 32,
+          "memory": 65536
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/duties/7.2.6/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/aws/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "r5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.6/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/azure/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "Standard_D8s_v3",
+        "instanceType": "Standard_DS13_v2",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.6/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/gcp/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "e2-standard-8",
+        "instanceType": "e2-highmem-8",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.6/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.6/yarn/light_duty.json
@@ -23,8 +23,8 @@
       "name": "master",
       "template": {
         "yarn": {
-          "cpus": 4,
-          "memory": 16384
+          "cpus": 32,
+          "memory": 65536
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/duties/7.2.7/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/aws/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "r5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.7/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/azure/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "Standard_D8s_v3",
+        "instanceType": "Standard_DS13_v2",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.7/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/gcp/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "e2-standard-8",
+        "instanceType": "e2-highmem-8",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.7/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.7/yarn/light_duty.json
@@ -23,8 +23,8 @@
       "name": "master",
       "template": {
         "yarn": {
-          "cpus": 4,
-          "memory": 16384
+          "cpus": 32,
+          "memory": 65536
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/duties/7.2.8/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.8/aws/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "r5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.8/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.8/azure/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "Standard_D8s_v3",
+        "instanceType": "Standard_DS13_v2",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.8/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.8/gcp/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "e2-standard-8",
+        "instanceType": "e2-highmem-8",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.8/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.8/yarn/light_duty.json
@@ -23,8 +23,8 @@
       "name": "master",
       "template": {
         "yarn": {
-          "cpus": 4,
-          "memory": 16384
+          "cpus": 32,
+          "memory": 65536
         }
       },
       "nodeCount": 1,

--- a/datalake/src/main/resources/duties/7.2.9/aws/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.9/aws/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "m5.2xlarge",
+        "instanceType": "r5.2xlarge",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.9/azure/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.9/azure/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "Standard_D8s_v3",
+        "instanceType": "Standard_DS13_v2",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.9/gcp/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.9/gcp/light_duty.json
@@ -27,7 +27,7 @@
     {
       "name": "master",
       "template": {
-        "instanceType": "e2-standard-8",
+        "instanceType": "e2-highmem-8",
         "attachedVolumes": [
           {
             "count": 1,

--- a/datalake/src/main/resources/duties/7.2.9/yarn/light_duty.json
+++ b/datalake/src/main/resources/duties/7.2.9/yarn/light_duty.json
@@ -23,8 +23,8 @@
       "name": "master",
       "template": {
         "yarn": {
-          "cpus": 4,
-          "memory": 16384
+          "cpus": 32,
+          "memory": 65536
         }
       },
       "nodeCount": 1,


### PR DESCRIPTION
This resizes the Light Duty SDX master node from 7.2.0 to 7.2.12 to have more ram, typically 32GB to 64GB.

See detailed description in the commit message.