### PR TITLE
CB-13736 Environment deletion failed on mow-int-eu1 control plane

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/create/SdxCreateActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/create/SdxCreateActions.java
@@ -41,6 +41,7 @@ import com.sequenceiq.datalake.metric.SdxMetricService;
 import com.sequenceiq.datalake.service.AbstractSdxAction;
 import com.sequenceiq.datalake.service.sdx.ProvisionerService;
 import com.sequenceiq.datalake.service.sdx.SdxService;
+import com.sequenceiq.datalake.service.sdx.status.DatalakeStatusUpdateException;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.flow.core.Flow;
 import com.sequenceiq.flow.core.FlowEvent;
@@ -244,6 +245,8 @@ public class SdxCreateActions {
                     metricService.incrementMetricCounter(MetricType.SDX_CREATION_FAILED, sdxCluster);
                 } catch (NotFoundException notFoundException) {
                     LOGGER.info("Can not set status to SDX_CREATION_FAILED because data lake was not found");
+                } catch (DatalakeStatusUpdateException datalakeStatusUpdateException) {
+                    LOGGER.info("Status update for data lake failed (possible reason: ongoing parallel deletion flow): ", exception.getMessage());
                 }
                 Flow flow = getFlow(context.getFlowParameters().getFlowId());
                 flow.setFlowFailed(payload.getException());


### PR DESCRIPTION
- during sdx creation flow, user initiated environment deletion
- during sdx deletion, sdx set status to DELETE_REQUESTED and started to terminate related RDS
- because of RDS termination, sdx creation flow failed
- during sdx creation flow failure handling, sdx tries to set status to PROVISION_FAILED but it has thrown an unhandled exception, since we cannot set status from any "delete in progress" to PROVISION_FAILED
- unhandled exception will go to general sdx failure handling, which (SdxFlowInformation) tries to set status based on current status, since it was EXTERNAL_DATABASE_DELETION_IN_PROGRESS, the failure handler will set status to DELETE_FAILED
- because of DELETE_FAILED status, environment deletion will fail also, freeipa will continue to provision ipa server and it will cause extra costs for users
- solution: catch unhandled exception regarding status set from any "delete in progress" status to PROVISION_FAILED, thus there will be no unhandled exception and sdx failure handling will not ste status to DELETE_FAILED

See detailed description in the commit message.