### PR TITLE
CB-14107 Set CDP_RAW_S3 enabled locally

### DIFF
--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -712,9 +712,6 @@ public class MockUserManagementService extends UserManagementImplBase {
         if (razEnabled) {
             builder.addEntitlements(createEntitlement(CDP_RAZ));
         }
-        if (rawS3Enabled) {
-            builder.addEntitlements(createEntitlement(CDP_RAW_S3));
-        }
         if (ccmV2Enabled) {
             builder.addEntitlements(createEntitlement(CDP_CCM_V2));
         }
@@ -856,6 +853,7 @@ public class MockUserManagementService extends UserManagementImplBase {
                                 .addEntitlements(createEntitlement(OJDBC_TOKEN_DH))
                                 .addEntitlements(createEntitlement(CDP_FREEIPA_UPGRADE))
                                 .addEntitlements(createEntitlement(DATAHUB_STREAMING_SCALING))
+                                .addEntitlements(createEntitlement(CDP_RAW_S3))
                                 .setGlobalPasswordPolicy(workloadPasswordPolicy)
                                 .setAccountId(request.getAccountId())
                                 .setExternalAccountId("external-" + request.getAccountId())

--- a/mock-thunderhead/src/test/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementServiceTest.java
+++ b/mock-thunderhead/src/test/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementServiceTest.java
@@ -205,9 +205,6 @@ public class MockUserManagementServiceTest {
                 {"razEnabled false", "razEnabled", false, "CDP_RAZ", false},
                 {"razEnabled true", "razEnabled", true, "CDP_RAZ", true},
 
-                {"rawS3Enabled false", "rawS3Enabled", false, "CDP_RAW_S3", false},
-                {"rawS3Enabled true", "rawS3Enabled", true, "CDP_RAW_S3", true},
-
                 {"ccmV2Enabled false", "ccmV2Enabled", false, "CDP_CCM_V2", false},
                 {"ccmV2Enabled true", "ccmV2Enabled", true, "CDP_CCM_V2", true},
 


### PR DESCRIPTION
Enable CDP_RAW_S3 by default in thunderhead mock.

See detailed description in the commit message.