### PR TITLE
CB-13938 Extend core_settings configuration provider with new property

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/CoreConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/CoreConfigProvider.java
@@ -37,6 +37,8 @@ public class CoreConfigProvider extends AbstractRoleConfigProvider {
 
     private static final String CORE_SITE_SAFETY_VALVE = "core_site_safety_valve";
 
+    private static final String HADOOP_SECURITY_GROUPS_CACHE_BACKGROUND_RELOAD = "hadoop.security.groups.cache.background.reload";
+
     @Inject
     private S3ConfigProvider s3ConfigProvider;
 
@@ -53,6 +55,8 @@ public class CoreConfigProvider extends AbstractRoleConfigProvider {
 
         StringBuilder hdfsCoreSiteSafetyValveValue = new StringBuilder();
         s3ConfigProvider.getServiceConfigs(source, hdfsCoreSiteSafetyValveValue);
+        hdfsCoreSiteSafetyValveValue.append(ConfigUtils.getSafetyValveProperty(HADOOP_SECURITY_GROUPS_CACHE_BACKGROUND_RELOAD, "true"));
+
         if (!hdfsCoreSiteSafetyValveValue.toString().isEmpty()) {
             apiClusterTemplateConfigs.add(config(CORE_SITE_SAFETY_VALVE, hdfsCoreSiteSafetyValveValue.toString()));
         }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/CoreConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/core/CoreConfigProviderTest.java
@@ -1,9 +1,13 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.core;
 
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles.HDFS;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.hdfs.HdfsRoles.NAMENODE;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaRoles.KAFKA_BROKER;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.kafka.KafkaRoles.KAFKA_SERVICE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -14,20 +18,35 @@ import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
+import com.sequenceiq.cloudbreak.cmtemplate.configproviders.s3.S3ConfigProvider;
 import com.sequenceiq.cloudbreak.domain.StorageLocation;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.filesystem.BaseFileSystemConfigurationsView;
 import com.sequenceiq.cloudbreak.template.filesystem.StorageLocationView;
 
+@ExtendWith(MockitoExtension.class)
 public class CoreConfigProviderTest {
 
+    @InjectMocks
     private CoreConfigProvider underTest;
+
+    @Mock
+    private S3ConfigProvider s3ConfigProvider;
 
     @Before
     public void setUp() {
         underTest = new CoreConfigProvider();
+        s3ConfigProvider = new S3ConfigProvider();
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test
@@ -113,5 +132,22 @@ public class CoreConfigProviderTest {
         when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
 
         Assert.assertFalse(underTest.isConfigurationNeeded(mockTemplateProcessor, templatePreparationObject));
+    }
+
+    @Test
+    public void isHdfsSecurityGroupCacheReloadPropertyPresent() {
+        CmTemplateProcessor mockTemplateProcessor = mock(CmTemplateProcessor.class);
+        TemplatePreparationObject templatePreparationObject = mock(TemplatePreparationObject.class);
+        BaseFileSystemConfigurationsView fileSystemConfiguration = mock(BaseFileSystemConfigurationsView.class);
+        Optional<BaseFileSystemConfigurationsView> fileSystemConfigurationView = Optional.of(fileSystemConfiguration);
+
+        when(mockTemplateProcessor.isRoleTypePresentInService(KAFKA_SERVICE, List.of(KAFKA_BROKER))).thenReturn(true);
+        when(mockTemplateProcessor.isRoleTypePresentInService(HDFS, List.of(NAMENODE))).thenReturn(true);
+        when(templatePreparationObject.getFileSystemConfigurationView()).thenReturn(fileSystemConfigurationView);
+        doNothing().when(s3ConfigProvider).getServiceConfigs(any(TemplatePreparationObject.class), any(StringBuilder.class));
+        String coreSafetyValveProperty = ConfigUtils.getSafetyValveProperty("hadoop.security.groups.cache.background.reload", "true");
+        List<ApiClusterTemplateConfig> expected = List.of(config("core_site_safety_valve", coreSafetyValveProperty));
+
+        assertThat(underTest.getServiceConfigs(null, templatePreparationObject)).hasSameElementsAs(expected);
     }
 }

--- a/template-manager-cmtemplate/src/test/resources/output/kafka-without-hdfs.bp
+++ b/template-manager-cmtemplate/src/test/resources/output/kafka-without-hdfs.bp
@@ -82,6 +82,10 @@
         {
           "name": "core_defaultfs",
           "value": "s3a://cloudbreak-bucket/kafka"
+        },
+        {
+          "name": "core_site_safety_valve",
+          "value": "<property><name>hadoop.security.groups.cache.background.reload</name><value>true</value></property>"
         }
       ],
       "roleConfigGroups": [


### PR DESCRIPTION
A new property 'hadoop.security.groups.cache.background.reload' was added to core_settings. If set to true, this enables a small threadpool of (default) 3 threads to fetch the security groups in the background, and this prevents the calling threads from blocking. Since this property is not present in the CSD, a safety valve was used.
The related test class is extended with Mockito to allow dependency injection in the provider that's needed for the unit tests.

Tested:

- Unit test
- Provisioned cluster

Note:

- A ticket was raised [OPSAPS-61614](https://jira.cloudera.com/browse/OPSAPS-61614) to add the property to the CSD. Once it's completed the safety valve can be removed.