### PR TITLE
CB-14110 we shouldn't limit the custom template upgrades with the DH …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/BlueprintUpgradeOptionValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/image/BlueprintUpgradeOptionValidator.java
@@ -25,7 +25,7 @@ class BlueprintUpgradeOptionValidator {
         LOGGER.debug("Validating blueprint upgrade option. Name: {}, type: {}, upgradeOption: {}, lockComponents: {}", blueprint.getName(),
                 blueprint.getStatus(), blueprint.getBlueprintUpgradeOption(), lockComponents);
         return isDefaultBlueprint(blueprint) ? isEnabledForDefaultBlueprint(lockComponents, blueprint, skipValidations, dataHubUpgradeEntitled)
-                : isEnabledForCustomBlueprint(blueprint, skipValidations);
+                : isEnabledForCustomBlueprint(blueprint, skipValidations, dataHubUpgradeEntitled);
     }
 
     private boolean isDefaultBlueprint(Blueprint blueprint) {
@@ -61,10 +61,10 @@ class BlueprintUpgradeOptionValidator {
         return Optional.ofNullable(blueprint.getBlueprintUpgradeOption()).orElse(ENABLED);
     }
 
-    private BlueprintValidationResult isEnabledForCustomBlueprint(Blueprint blueprint, boolean skipValidations) {
+    private BlueprintValidationResult isEnabledForCustomBlueprint(Blueprint blueprint, boolean skipValidations, boolean dataHubUpgradeEntitled) {
         BlueprintValidationResult result;
-        if (skipValidations) {
-            LOGGER.debug("Custom blueprint options are not validated if the request is internal");
+        if (skipValidations || dataHubUpgradeEntitled) {
+            LOGGER.debug("Custom blueprint options are not validated if the request is internal or the DH upgrade entitlement is granted");
             result = createResult(true);
         } else {
             result = customTemplateUpgradeValidator.isValid(blueprint);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/BlueprintUpgradeOptionValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/image/BlueprintUpgradeOptionValidatorTest.java
@@ -57,7 +57,7 @@ public class BlueprintUpgradeOptionValidatorTest {
     public void testIsValidBlueprintShouldReturnTrueWhenTheTemplateIsAValidCustomTemplate() {
         Blueprint blueprint = createBlueprint(ResourceStatus.USER_MANAGED, BlueprintUpgradeOption.ENABLED);
         when(customTemplateUpgradeValidator.isValid(blueprint)).thenReturn(new BlueprintValidationResult(true));
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, false, true);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, false, false);
         assertTrue(actual.isValid());
         assertNull(actual.getReason());
         verify(customTemplateUpgradeValidator).isValid(blueprint);
@@ -68,16 +68,24 @@ public class BlueprintUpgradeOptionValidatorTest {
         Blueprint blueprint = createBlueprint(ResourceStatus.USER_MANAGED, BlueprintUpgradeOption.ENABLED);
         BlueprintValidationResult result = new BlueprintValidationResult(false, "Custom template not eligible.");
         when(customTemplateUpgradeValidator.isValid(blueprint)).thenReturn(result);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, false, true);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, false, false);
         assertFalse(actual.isValid());
         assertEquals(result.getReason(), actual.getReason());
         verify(customTemplateUpgradeValidator).isValid(blueprint);
     }
 
     @Test
+    public void testIsValidBlueprintShouldReturnTrueWhenTheTemplateIsANotValidCustomTemplateButTheEntitlementIsGranted() {
+        Blueprint blueprint = createBlueprint(ResourceStatus.USER_MANAGED, BlueprintUpgradeOption.ENABLED);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, false, true);
+        assertTrue(actual.isValid());
+        verifyNoInteractions(customTemplateUpgradeValidator);
+    }
+
+    @Test
     public void testIsValidBlueprintShouldReturnTrueWhenTheTemplateIsANotValidCustomTemplateButInternalApiUsed() {
         Blueprint blueprint = createBlueprint(ResourceStatus.USER_MANAGED, BlueprintUpgradeOption.DISABLED);
-        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, true, true);
+        BlueprintValidationResult actual = underTest.isValidBlueprint(blueprint, false, true, false);
         assertTrue(actual.isValid());
         assertNull(actual.getReason());
         verifyNoInteractions(customTemplateUpgradeValidator);


### PR DESCRIPTION
…upgrade entitlement

If the CDP_RUNTIME_UPGRADE_DATAHUB entitlement is granted we shouldn't limit the type
of customer templates that can be upgraded. Neither the version nor the type of services
should be limited.

See detailed description in the commit message.