### PR TITLE
CB-14106 REST endpoint to execute cm sync in DistroX - part of epic: …

### DIFF
--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
@@ -64,6 +64,7 @@ public enum AuthorizationResourceAction {
     SET_DATAHUB_MAINTENANCE_MODE("datahub/setDatahubMaintenanceMode", AuthorizationResourceType.DATAHUB),
     ROTATE_AUTOTLS_CERT_DATAHUB("datahub/rotateAutoTlsCertDatahub", AuthorizationResourceType.DATAHUB),
     UPGRADE_DATAHUB("datahub/upgradeDatahub", AuthorizationResourceType.DATAHUB),
+    SYNC_COMPONENT_VERSIONS_FROM_CM_DATAHUB("datahub/syncComponentVersionsFromCm", AuthorizationResourceType.DATAHUB),
     DESCRIBE_DATABASE("environments/describeDatabase", AuthorizationResourceType.DATABASE),
     DESCRIBE_DATABASE_SERVER("environments/describeDatabaseServer", AuthorizationResourceType.DATABASE_SERVER),
     DELETE_DATABASE("environments/deleteDatabase", AuthorizationResourceType.DATABASE),

--- a/authorization-common/src/main/resources/legacyRights.json
+++ b/authorization-common/src/main/resources/legacyRights.json
@@ -54,6 +54,7 @@
   "datahub/setDatahubMaintenanceMode": "datahub/write",
   "datahub/rotateAutoTlsCertDatahub": "datahub/write",
   "datahub/upgradeDatahub": "datahub/write",
+  "datahub/syncComponentVersionsFromCm": "datahub/write",
   "environments/describeDatabase": "datalake/read",
   "environments/describeDatabaseServer": "datalake/read",
   "environments/deleteDatabase": "datalake/write",

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
@@ -77,6 +77,7 @@ import com.sequenceiq.distrox.api.v1.distrox.model.cluster.DistroXMultiDeleteV1R
 import com.sequenceiq.distrox.api.v1.distrox.model.diagnostics.docs.DiagnosticsOperationDescriptions;
 import com.sequenceiq.distrox.api.v1.distrox.model.diagnostics.model.CmDiagnosticsCollectionV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.diagnostics.model.DiagnosticsCollectionV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.upgrade.DistroXSyncCmV1Response;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
 import com.sequenceiq.flow.api.model.operation.OperationView;
@@ -437,4 +438,17 @@ public interface DistroXV1Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ROTATE_CERTIFICATES, nickname = "rotateAutoTlsCertificatesByCrn")
     CertificatesRotationV4Response rotateAutoTlsCertificatesByCrn(@PathParam("crn") String crn, @Valid CertificatesRotationV4Request rotateCertificateRequest);
+
+    @POST
+    @Path("{name}/sync_cm")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "syncs from distrox cluster CM the CM and parcel versions", produces = MediaType.APPLICATION_JSON, nickname = "syncDistroxCm")
+    DistroXSyncCmV1Response syncComponentVersionsFromCmByName(@PathParam("name") String name);
+
+    @POST
+    @Path("crn/{crn}/sync_cm")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "syncs from distrox cluster CM the CM and parcel versions", produces = MediaType.APPLICATION_JSON, nickname = "syncDistroxCmByCrn")
+    DistroXSyncCmV1Response syncComponentVersionsFromCmByCrn(@PathParam("crn") String crn);
+
 }

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/upgrade/DistroXSyncCmV1Request.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/upgrade/DistroXSyncCmV1Request.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.distrox.api.v1.distrox.model.upgrade;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class DistroXSyncCmV1Request {
+
+    @ApiModelProperty(ModelDescriptions.CmSyncRequest.IMAGE_IDS)
+    private Set<String> candidateImageUuids = new HashSet<>();
+
+    public Set<String> getCandidateImageUuids() {
+        return candidateImageUuids;
+    }
+
+    public void setCandidateImageUuids(Set<String> candidateImageUuids) {
+        this.candidateImageUuids = candidateImageUuids;
+    }
+
+    @Override
+    public String toString() {
+        return "DistroXSyncCmV1Request{" +
+                "candidateImageUuids=" + candidateImageUuids +
+                '}';
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/upgrade/DistroXSyncCmV1Response.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/upgrade/DistroXSyncCmV1Response.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.distrox.api.v1.distrox.model.upgrade;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+
+public class DistroXSyncCmV1Response {
+
+    private final FlowIdentifier flowIdentifier;
+
+    public DistroXSyncCmV1Response(FlowIdentifier flowIdentifier) {
+        this.flowIdentifier = flowIdentifier;
+    }
+
+    public FlowIdentifier getFlowIdentifier() {
+        return flowIdentifier;
+    }
+
+    @Override
+    public String toString() {
+        return "DistroXSyncCmV1Response{" +
+                "flowIdentifier=" + flowIdentifier +
+                '}';
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -124,7 +124,8 @@ public class StackV4Controller extends NotificationController implements StackV4
     @Override
     @InternalOnly
     public FlowIdentifier syncCm(Long workspaceId, String name, @InitiatorUserCrn String initiatorUserCrn, ClouderaManagerSyncV4Request syncRequest) {
-        return stackOperations.syncCm(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), syncRequest.getCandidateImageUuids());
+        return stackOperations.syncComponentVersionsFromCm(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(),
+                syncRequest.getCandidateImageUuids());
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -229,7 +229,7 @@ public class ReactorFlowManager {
         return reactorNotifier.notify(stackId, selector, new StackEvent(selector, stackId));
     }
 
-    public FlowIdentifier triggerCmSync(Long stackId, Set<String> candidateImageUuids) {
+    public FlowIdentifier triggerSyncComponentVersionsFromCm(Long stackId, Set<String> candidateImageUuids) {
         String selector = CM_SYNC_TRIGGER_EVENT.event();
         return reactorNotifier.notify(stackId, selector, new CmSyncTriggerEvent(stackId, candidateImageUuids));
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
@@ -175,12 +175,19 @@ public class StackCommonService {
         return put(stack, updateStackJson);
     }
 
-    public FlowIdentifier syncCmInWorkspace(NameOrCrn nameOrCrn, Long workspaceId, Set<String> candidateImageUuids) {
+    public FlowIdentifier syncComponentVersionsFromCmInWorkspace(NameOrCrn nameOrCrn, Long workspaceId, Set<String> candidateImageUuids) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         MDCBuilder.buildMdcContext(stack);
+        if (stack.getStackStatus().getStatus().isStopState()) {
+            String message = String.format("Syncing CM and parcel versions from CM cannot be initiated as cluster is in %s state",
+                    stack.getStackStatus().getStatus());
+            LOGGER.debug(message);
+            throw new BadRequestException(message);
+        }
+
         LOGGER.debug("Triggering sync from CM to db: syncing versions from CM to db, nameOrCrn: {}, workspaceId: {}, candidateImageUuids: {}",
                 nameOrCrn, workspaceId, candidateImageUuids);
-        return syncCm(stack, candidateImageUuids);
+        return syncComponentVersionsFromCm(stack, candidateImageUuids);
     }
 
     public FlowIdentifier deleteMultipleInstancesInWorkspace(NameOrCrn nameOrCrn, Long workspaceId, Set<String> instanceIds, boolean forced) {
@@ -332,8 +339,8 @@ public class StackCommonService {
         }
     }
 
-    private FlowIdentifier syncCm(Stack stack, Set<String> candidateImageUuids) {
-        return stackOperationService.syncCm(stack, candidateImageUuids);
+    private FlowIdentifier syncComponentVersionsFromCm(Stack stack, Set<String> candidateImageUuids) {
+        return stackOperationService.syncComponentVersionsFromCm(stack, candidateImageUuids);
     }
 
     private FlowIdentifier put(Stack stack, UpdateStackV4Request updateRequest) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -199,8 +199,8 @@ public class StackOperationService {
         }
     }
 
-    public FlowIdentifier syncCm(Stack stack, Set<String> candidateImageUuids) {
-        return flowManager.triggerCmSync(stack.getId(), candidateImageUuids);
+    public FlowIdentifier syncComponentVersionsFromCm(Stack stack, Set<String> candidateImageUuids) {
+        return flowManager.triggerSyncComponentVersionsFromCm(stack.getId(), candidateImageUuids);
     }
 
     private FlowIdentifier stop(Stack stack, Cluster cluster, boolean updateCluster, User user) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -52,9 +52,9 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.view.StackApiView;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.retry.RetryableFlow;
-import com.sequenceiq.cloudbreak.service.LoadBalancerUpdateService;
 import com.sequenceiq.cloudbreak.service.ClusterCommonService;
 import com.sequenceiq.cloudbreak.service.DatabaseBackupRestoreService;
+import com.sequenceiq.cloudbreak.service.LoadBalancerUpdateService;
 import com.sequenceiq.cloudbreak.service.StackCommonService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterDBValidationService;
 import com.sequenceiq.cloudbreak.service.stack.StackApiViewService;
@@ -219,8 +219,8 @@ public class StackOperations implements ResourcePropertyProvider {
         return stackCommonService.syncInWorkspace(nameOrCrn, workspaceId);
     }
 
-    public FlowIdentifier syncCm(NameOrCrn nameOrCrn, Long workspaceId, Set<String> candidateImageUuids) {
-        return stackCommonService.syncCmInWorkspace(nameOrCrn, workspaceId, candidateImageUuids);
+    public FlowIdentifier syncComponentVersionsFromCm(NameOrCrn nameOrCrn, Long workspaceId, Set<String> candidateImageUuids) {
+        return stackCommonService.syncComponentVersionsFromCmInWorkspace(nameOrCrn, workspaceId, candidateImageUuids);
     }
 
     public FlowIdentifier retry(NameOrCrn nameOrCrn, Long workspaceId) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/controller/DistroXV1Controller.java
@@ -81,6 +81,7 @@ import com.sequenceiq.distrox.api.v1.distrox.model.MultipleInstanceDeleteRequest
 import com.sequenceiq.distrox.api.v1.distrox.model.cluster.DistroXMultiDeleteV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.diagnostics.model.CmDiagnosticsCollectionV1Request;
 import com.sequenceiq.distrox.api.v1.distrox.model.diagnostics.model.DiagnosticsCollectionV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.upgrade.DistroXSyncCmV1Response;
 import com.sequenceiq.distrox.v1.distrox.StackOperations;
 import com.sequenceiq.distrox.v1.distrox.authorization.DataHubFiltering;
 import com.sequenceiq.distrox.v1.distrox.converter.DistroXMaintenanceModeV1ToMainenanceModeV4Converter;
@@ -578,6 +579,24 @@ public class DistroXV1Controller implements DistroXV1Endpoint {
                 workspaceService.getForCurrentUser().getId(),
                 rotateCertificateRequest
         );
+    }
+
+    @Override
+    @CheckPermissionByResourceName(action = AuthorizationResourceAction.SYNC_COMPONENT_VERSIONS_FROM_CM_DATAHUB)
+    public DistroXSyncCmV1Response syncComponentVersionsFromCmByName(@ResourceName String name) {
+        return launchSyncComponentVersionsFromCm(NameOrCrn.ofName(name));
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.SYNC_COMPONENT_VERSIONS_FROM_CM_DATAHUB)
+    public DistroXSyncCmV1Response syncComponentVersionsFromCmByCrn(@ResourceCrn String crn) {
+        return launchSyncComponentVersionsFromCm(NameOrCrn.ofCrn(crn));
+    }
+
+    private DistroXSyncCmV1Response launchSyncComponentVersionsFromCm(NameOrCrn nameOrCrn) {
+        Long workspaceId = workspaceService.getForCurrentUser().getId();
+        FlowIdentifier flowIdentifier = stackOperations.syncComponentVersionsFromCm(nameOrCrn, workspaceId, Set.of());
+        return new DistroXSyncCmV1Response(flowIdentifier);
     }
 
     private Object getCreateAWSClusterRequest(StackV4Request stackV4Request) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -134,7 +134,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerDatalakeDatabaseRestore(STACK_ID, null, null);
         underTest.triggerAutoTlsCertificatesRotation(STACK_ID, new CertificatesRotationV4Request());
         underTest.triggerStackLoadBalancerUpdate(STACK_ID);
-        underTest.triggerCmSync(STACK_ID, Set.of());
+        underTest.triggerSyncComponentVersionsFromCm(STACK_ID, Set.of());
         underTest.triggerDatalakeClusterRecovery(STACK_ID);
 
         int count = 0;

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/AbstractIntegrationTest.java
@@ -242,6 +242,14 @@ public abstract class AbstractIntegrationTest extends AbstractMinimalTest {
                 .validate();
     }
 
+    protected void createEnvironmentWithFreeIpaAndDatalake(TestContext testContext) {
+        initiateEnvironmentCreation(testContext);
+        initiateDatalakeCreation(testContext);
+        waitForEnvironmentCreation(testContext);
+        waitForUserSync(testContext);
+        waitForDatalakeCreation(testContext);
+    }
+
     protected void createDefaultUser(TestContext testContext) {
         testContext.as();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/diagnostics/DiagnosticsTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/diagnostics/DiagnosticsTests.java
@@ -28,9 +28,8 @@ public class DiagnosticsTests extends AbstractE2ETest {
         testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpa(testContext);
         initializeDefaultBlueprints(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/AwsDistroXEphemeralTemporaryStorageStopStartTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/AwsDistroXEphemeralTemporaryStorageStopStartTest.java
@@ -49,8 +49,7 @@ public class AwsDistroXEphemeralTemporaryStorageStopStartTest extends AbstractE2
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXEncryptedVolumeTest.java
@@ -39,8 +39,7 @@ public class DistroXEncryptedVolumeTest extends AbstractE2ETest {
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXImagesTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXImagesTests.java
@@ -45,8 +45,7 @@ public class DistroXImagesTests extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Ignore("This test case should be re-enabled in case of InternalSDXDistroXTest has been removed")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXRepairTests.java
@@ -37,8 +37,7 @@ public class DistroXRepairTests extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleEdgeCasesTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleEdgeCasesTest.java
@@ -30,8 +30,7 @@ public class DistroXScaleEdgeCasesTest extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXScaleTest.java
@@ -24,11 +24,7 @@ public class DistroXScaleTest extends AbstractE2ETest {
         createDefaultUser(testContext);
         createDefaultCredential(testContext);
         initializeDefaultBlueprints(testContext);
-        initiateEnvironmentCreation(testContext);
-        initiateDatalakeCreation(testContext);
-        waitForEnvironmentCreation(testContext);
-        waitForUserSync(testContext);
-        waitForDatalakeCreation(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/InternalSdxSshAndCmAccessTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/InternalSdxSshAndCmAccessTest.java
@@ -42,8 +42,7 @@ public class InternalSdxSshAndCmAccessTest extends PreconditionSdxE2ETest {
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createDatalake(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
@@ -42,8 +42,7 @@ public class SdxBackupRestoreTest extends PreconditionSdxE2ETest {
         createDefaultUser(testContext);
         initializeDefaultBlueprints(testContext);
         createDefaultCredential(testContext);
-        createEnvironmentWithFreeIpa(testContext);
-        createSdx(testContext);
+        createEnvironmentWithFreeIpaAndDatalake(testContext);
     }
 
     @Test(dataProvider = TEST_CONTEXT, description = "We need to wait the CB-13322 to be resolved")

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/PreconditionSdxE2ETest.java
@@ -13,11 +13,9 @@ import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
-import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
 import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
 import com.sequenceiq.it.cloudbreak.util.CloudFunctionality;
-import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class PreconditionSdxE2ETest extends AbstractE2ETest {
 
@@ -62,27 +60,5 @@ public class PreconditionSdxE2ETest extends AbstractE2ETest {
                 .sdxEndpoint()
                 .getDetailByCrn(testDto.getCrn(), Collections.emptySet())
                 .getStackV4Response().getInstanceGroups();
-    }
-
-    protected void createSdx(TestContext testContext) {
-        testContext
-                .given(SdxTestDto.class)
-                    .withCloudStorage(getCloudStorageRequest(testContext))
-                .when(sdxTestClient.create())
-                .await(SdxClusterStatusResponse.RUNNING)
-                .awaitForHealthyInstances()
-                .when(sdxTestClient.describe())
-                .validate();
-    }
-
-    protected void createInternalSdx(TestContext testContext) {
-        testContext
-                .given(SdxInternalTestDto.class)
-                    .withCloudStorage(getCloudStorageRequest(testContext))
-                .when(sdxTestClient.createInternal())
-                .await(SdxClusterStatusResponse.RUNNING)
-                .awaitForHealthyInstances()
-                .when(sdxTestClient.describeInternal())
-                .validate();
     }
 }


### PR DESCRIPTION
…CB-12736, After a failed DL/DH upgrade sync runtime versions

Customer should be able to manually issue a cdp-cli command to execute the syncing of the CM and active parcel versions from the CM server to CB Component and ClusterComponent tables.
For that end this commit introduces an endpoint in DistroX. The new endpoint calls the already existing sync cm flow.

See detailed description in the commit message.