### PR TITLE
CB-12707 wait for NODE_FAILURE instead of CLUSTER_AMBIGUOUS

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRepairTests.java
@@ -116,7 +116,7 @@ public class MockSdxRepairTests extends AbstractMockTest {
                             new HashMap<>(), null, response -> { }, w -> w);
                     return testDto;
                 })
-                .await(SdxClusterStatusResponse.CLUSTER_AMBIGUOUS, Duration.ofSeconds(POLLING_INTERVAL_FOR_REPAIR_SECONDS))
+                .await(SdxClusterStatusResponse.NODE_FAILURE, Duration.ofSeconds(POLLING_INTERVAL_FOR_REPAIR_SECONDS))
                 .when(sdxTestClient.repairInternal(MASTER.getName()), key(sdxInternal))
                 .awaitForMasterDeletedOnProvider()
                 .awaitForFlowFail()


### PR DESCRIPTION
See detailed description in the commit message.