### PR TITLE
CDPSDX-3144: Data lake restore failed status

### DIFF
--- a/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeRestoreActions.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/flow/dr/restore/DatalakeRestoreActions.java
@@ -313,9 +313,9 @@ public class DatalakeRestoreActions {
             protected void doExecute(SdxContext context, DatalakeRestoreFailedEvent payload, Map<Object, Object> variables) {
                 Exception exception = payload.getException();
                 LOGGER.error("Datalake database restore could not be started for datalake with id: {}", payload.getResourceId(), exception);
-                SdxCluster sdxCluster = sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.DATALAKE_RESTORE_FAILED,
-                        ResourceEvent.DATALAKE_RESTORE_FAILED,
-                        "Datalake restore failed", payload.getResourceId());
+                SdxCluster sdxCluster = sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.RUNNING,
+                        ResourceEvent.DATALAKE_RESTORE_FINISHED,
+                        "Datalake is running, Datalake restore failed", payload.getResourceId());
 
                 eventSenderService.sendEventAndNotification(sdxCluster, context.getFlowTriggerUserCrn(), ResourceEvent.DATALAKE_RESTORE_FAILED);
 


### PR DESCRIPTION
Datalake shows "datalake restore failed" status.  Although this won't block datalake operations, we want to modify it to data lake available status. The status reason is "Datalake is running, Datalake restore failed".

See detailed description in the commit message.