### PR TITLE
CB-13786: Implement Data Lake Event Service

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEventEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEventEndpoint.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.sdx.api.endpoint;
+
+import static com.sequenceiq.cloudbreak.structuredevent.rest.endpoint.CDPStructuredEventOperationDescriptions.AUDIT_EVENTS_NOTES;
+import static com.sequenceiq.cloudbreak.structuredevent.rest.endpoint.CDPStructuredEventOperationDescriptions.AuditOpDescription.LIST_FOR_RESOURCE;
+
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.springframework.validation.annotation.Validated;
+
+import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.cloudbreak.structuredevent.event.StructuredEventType;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+@Validated
+@Path("/sdx/events")
+@RetryAndMetrics
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(value = "/sdx", protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+public interface SdxEventEndpoint {
+
+    @GET
+    @Path("")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = LIST_FOR_RESOURCE, produces = MediaType.APPLICATION_JSON, notes = AUDIT_EVENTS_NOTES,
+            nickname = "getCDPAuditEventsForResource")
+    List<CDPStructuredEvent> getAuditEvents(
+            @QueryParam("resourceCrn") @NotNull(message = "The 'resourceCrn' query parameter must be specified.") String resourceCrn,
+            @QueryParam("types") List<StructuredEventType> types);
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/configuration/EndpointConfig.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/configuration/EndpointConfig.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Configuration;
 import com.sequenceiq.authorization.controller.AuthorizationInfoController;
 import com.sequenceiq.authorization.info.AuthorizationUtilEndpoint;
 import com.sequenceiq.cloudbreak.structuredevent.rest.controller.CDPStructuredEventV1Controller;
+import com.sequenceiq.datalake.controller.SdxEventController;
 import com.sequenceiq.datalake.controller.diagnostics.DiagnosticsController;
 import com.sequenceiq.datalake.controller.mapper.DefaultExceptionMapper;
 import com.sequenceiq.datalake.controller.mapper.WebApplicaitonExceptionMapper;
@@ -58,7 +59,8 @@ public class EndpointConfig extends ResourceConfig {
             DatabaseServerController.class,
             SdxBackupController.class,
             SdxRestoreController.class,
-            CDPStructuredEventV1Controller.class
+            CDPStructuredEventV1Controller.class,
+            SdxEventController.class
     );
 
     @Value("${info.app.version:unspecified}")
@@ -78,10 +80,6 @@ public class EndpointConfig extends ResourceConfig {
 
     @PostConstruct
     private void init() {
-        // todo: uncomment me for CB-13786
-//        if (auditEnabled) {
-//            register(CDPStructuredEventFilter.class);
-//        }
         registerEndpoints();
         registerExceptionMappers();
         register(serverTracingDynamicFeature);

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/SdxEventController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/SdxEventController.java
@@ -1,0 +1,76 @@
+package com.sequenceiq.datalake.controller;
+
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Controller;
+
+import com.sequenceiq.authorization.annotation.CustomPermissionCheck;
+import com.sequenceiq.authorization.utils.EventAuthorizationDto;
+import com.sequenceiq.authorization.utils.EventAuthorizationUtils;
+import com.sequenceiq.cloudbreak.structuredevent.event.StructuredEventType;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.db.CDPStructuredEventDBService;
+import com.sequenceiq.sdx.api.endpoint.SdxEventEndpoint;
+
+@Controller
+public class SdxEventController implements SdxEventEndpoint {
+
+    public static final int DEFAULT_PAGE_SIZE = 100;
+
+    public static final int DEFAULT_STARTING_PAGE = 0;
+
+    @Inject
+    private CDPStructuredEventDBService cdpStructuredEventDBService;
+
+    @Inject
+    private EventAuthorizationUtils eventAuthorizationUtils;
+
+    /**
+     * Retrieves audit events for the provided Data Lake CRN.
+     *
+     * @param resourceCrn a Data Lake CRN
+     * @param types       types of structured events to retrieve
+     * @return structured events for the provided Data Lake CRN
+     */
+    @Override
+    @CustomPermissionCheck
+    public List<CDPStructuredEvent> getAuditEvents(String resourceCrn, List<StructuredEventType> types) {
+        PageRequest pageable = PageRequest.of(DEFAULT_STARTING_PAGE, DEFAULT_PAGE_SIZE, Sort.by("timestamp").descending());
+
+        List<CDPStructuredEvent> dlEvents = cdpStructuredEventDBService.getPagedEventsOfResource(types, resourceCrn, pageable).getContent();
+
+        if (dlEvents.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        // TODO Pull the events from CB service and merge them.
+
+        // custom permission check
+        eventAuthorizationUtils.checkPermissionBasedOnResourceTypeAndCrn(collectDtosFromEvents(dlEvents));
+
+        return dlEvents;
+    }
+
+    /**
+     * Converts a collection of {@code CDPStructuredEvent}s to simple objects containing Resource CRN and Type.
+     * <p>
+     * This method essentially does a projection, where the collection of events is mapped to a set of objects that contain fewer properties.
+     *
+     * @param events collection of structured events to map
+     * @return set of derived resource CRNs and Types associated with provided events.
+     */
+    private Set<EventAuthorizationDto> collectDtosFromEvents(Collection<? extends CDPStructuredEvent> events) {
+        return events.stream().map(CDPStructuredEvent::getOperation)
+                .map(details -> new EventAuthorizationDto(details.getResourceCrn(), details.getResourceType()))
+                .collect(toSet());
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/events/DatalakeUrlParser.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/events/DatalakeUrlParser.java
@@ -7,10 +7,8 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.structuredevent.rest.urlparser.CDPRestUrlParser;
 
-// todo: https://jira.cloudera.com/browse/CB-13786 consider renaming to BackupRestoreParser
 @Component
 public class DatalakeUrlParser extends CDPRestUrlParser {
-    // todo: https://jira.cloudera.com/browse/CB-13786 implement me
     @Override
     protected Pattern getPattern() {
         return null;

--- a/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/repository/SdxClusterRepository.java
@@ -41,6 +41,8 @@ public interface SdxClusterRepository extends AccountAwareResourceRepository<Sdx
 
     Optional<SdxCluster> findByAccountIdAndEnvCrnAndDeletedIsNullAndDetachedIsTrue(@Param("accountId") String accountId, @Param("crn") String crn);
 
+    List<SdxCluster> findByAccountIdAndEnvCrn(@Param("accountId") String accountId, @Param("crn") String crn);
+
     @Query("SELECT s.envCrn FROM SdxCluster s WHERE s.accountId = :accountId AND s.crn = :crn AND s.deleted is null AND s.detached = false")
     Optional<String> findEnvCrnByAccountIdAndCrnAndDeletedIsNullAndDetachedIsFalse(@Param("accountId") String accountId, @Param("crn") String crn);
 

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/SdxEventControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/SdxEventControllerTest.java
@@ -1,0 +1,116 @@
+package com.sequenceiq.datalake.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+
+import com.sequenceiq.authorization.utils.EventAuthorizationUtils;
+import com.sequenceiq.cloudbreak.structuredevent.event.StructuredEventType;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPOperationDetails;
+import com.sequenceiq.cloudbreak.structuredevent.event.cdp.CDPStructuredEvent;
+import com.sequenceiq.cloudbreak.structuredevent.service.db.CDPStructuredEventDBService;
+import com.sequenceiq.datalake.entity.SdxCluster;
+import com.sequenceiq.datalake.repository.SdxClusterRepository;
+
+class SdxEventControllerTest {
+
+    public static final String EXPECTED_ZIP_HEADER_KEY = "content-disposition";
+
+    public static final String EXPECTED_ZIP_HEADER_VALUE = "[attachment; filename = audit-environment.zip]";
+
+    private static final String RESOURCE_CRN = "crn:cdp:environments:us-west-1:460c0d8f-ae8e-4dce-9cd7-2351762eb9ac:environment:" +
+            "6b2b1600-8ac6-4c26-aa34-dab36f4bd243";
+
+    private static final List<StructuredEventType> TEST_EVENT_TYPES = List.of(StructuredEventType.FLOW, StructuredEventType.NOTIFICATION);
+
+    @Mock
+    private CDPStructuredEventDBService mockCdpStructuredEventDBService;
+
+    @Mock
+    private EventAuthorizationUtils mockEventAuthorizationUtils;
+
+    @Mock
+    private SdxClusterRepository mockSdxClusterRepository;
+
+    @InjectMocks
+    private SdxEventController datalakeEventController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void testNoAuthorizationWhenEventsReturnedIsEmpty() {
+        when(mockCdpStructuredEventDBService.getPagedEventsOfResource(eq(TEST_EVENT_TYPES), any(), any()))
+                .thenReturn(Page.empty());
+        List<CDPStructuredEvent> result = datalakeEventController.getAuditEvents(RESOURCE_CRN, TEST_EVENT_TYPES);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(mockEventAuthorizationUtils, never()).checkPermissionBasedOnResourceTypeAndCrn(any());
+    }
+
+    @Test
+    void testGetAuditEventsWhenNotEmptyPageComingBackFromDbServiceThenAuthzHappens() {
+        Page<CDPStructuredEvent> mockPage = mock(Page.class);
+
+        SdxCluster sdxCluster = new SdxCluster();
+        sdxCluster.setCrn(RESOURCE_CRN);
+        when(mockSdxClusterRepository.findByAccountIdAndEnvCrn(any(), any())).thenReturn(List.of(sdxCluster));
+
+        when(mockPage.getContent()).thenReturn(List.of(createTestCDPStructuredEvent()));
+        when(mockCdpStructuredEventDBService.getPagedEventsOfResource(eq(TEST_EVENT_TYPES), any(), any()))
+                .thenReturn(mockPage);
+
+        List<CDPStructuredEvent> result = datalakeEventController.getAuditEvents(RESOURCE_CRN, TEST_EVENT_TYPES);
+
+        assertNotNull(result);
+        assertEquals(1, result.size());
+
+        verify(mockEventAuthorizationUtils, times(1)).checkPermissionBasedOnResourceTypeAndCrn(any());
+    }
+
+    private CDPStructuredEvent createTestCDPStructuredEvent() {
+        return createTestCDPStructuredEvent(0L);
+    }
+
+    private CDPStructuredEvent createTestCDPStructuredEvent(Long timestamp) {
+        CDPOperationDetails operationDetails = new CDPOperationDetails();
+        operationDetails.setResourceCrn("someCrn");
+        operationDetails.setResourceType("environment");
+        operationDetails.setTimestamp(timestamp);
+
+        CDPStructuredEvent cdpStructuredEvent = new CDPStructuredEvent() {
+            @Override
+            public String getStatus() {
+                return SENT;
+            }
+
+            @Override
+            public Long getDuration() {
+                return 1L;
+            }
+        };
+        cdpStructuredEvent.setOperation(operationDetails);
+        return cdpStructuredEvent;
+    }
+
+}

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/filter/CDPStructuredEventFilter.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/filter/CDPStructuredEventFilter.java
@@ -27,11 +27,11 @@ import com.sequenceiq.cloudbreak.structuredevent.rest.urlparser.CDPRestUrlParser
 
 /**
  * Inspects all requests to a service and determines if it should mark the request or response up with additional Structured Event metadata.
- *
+ * <p>
  * Uses implementations of {@code CDPRestUrlParser} to determine if additional actions should be taken on a request.
- *
+ * <p>
  * Activation of this filter is controlled by the {@code contentLogging} configuration value.
- *
+ * <p>
  * To use this class, it should be registered in an {@code EndpointConfig}.
  */
 @Component
@@ -64,6 +64,12 @@ public class CDPStructuredEventFilter implements WriterInterceptor, ContainerReq
     @Autowired
     private List<CDPRestUrlParser> cdpRestUrlParsers;
 
+    /**
+     * Add structured event parameters to the properties to the request context.
+     *
+     * @param requestContext the context on which to attach additional properties.
+     * @throws IOException if the request entity stream cannot be read correctly.
+     */
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
         boolean loggingEnabled = isLoggingEnabled(requestContext);
@@ -78,6 +84,15 @@ public class CDPStructuredEventFilter implements WriterInterceptor, ContainerReq
         }
     }
 
+    /**
+     * On response, attaches a logging stream to the request context, or sends a structured event.
+     * <p>
+     * The filter essentially helps send a structured event or sends it itself.
+     * <ul>
+     *     <li>When there is a response entity, {@code LoggingStream} is attached and used in {@code aroundWriteTo} to send a structured event.</li>
+     *     <li>When there isn't a response entity, send a structured event directly.</li>
+     * </ul>
+     */
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) {
         if (BooleanUtils.isTrue((Boolean) requestContext.getProperty(LOGGING_ENABLED_PROPERTY))) {
@@ -119,7 +134,7 @@ public class CDPStructuredEventFilter implements WriterInterceptor, ContainerReq
 
     /**
      * Iterates through implementations of {@code CDPRestUrlParser} to extract URL parameters if possible.
-     *
+     * <p>
      * The list of URL parsers is autowired by Spring.
      *
      * @param requestContext the source of URL parameters, parseable by one of the REST URL parsers

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparser/CDPRestUrlParser.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparser/CDPRestUrlParser.java
@@ -25,7 +25,6 @@ import javax.ws.rs.container.ContainerRequestContext;
  */
 public abstract class CDPRestUrlParser {
 
-    //todo: make these an enum of ParameterKeys
     public static final String RESOURCE_TYPE = "RESOURCE_TYPE";
 
     public static final String RESOURCE_ID = "RESOURCE_ID";
@@ -106,13 +105,10 @@ public abstract class CDPRestUrlParser {
      */
     protected abstract Pattern getPattern();
 
-    // as far as I can tell, this is always null
     protected Pattern getAntiPattern() {
         return null;
     }
 
-    // todo: the only required implementation looks to be getResourceName, all the others can return null.
-    // provide implementations here for the others, but keep getResourceName abstract
     protected abstract String getResourceName(Matcher matcher);
 
     protected abstract String getResourceCrn(Matcher matcher);

--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/db/CDPStructuredEventDBService.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/db/CDPStructuredEventDBService.java
@@ -63,7 +63,8 @@ public class CDPStructuredEventDBService extends AbstractAccountAwareResourceSer
 
     private ValidationResult validate(CDPStructuredEvent event) {
         ValidationResult.ValidationResultBuilder builder = ValidationResult.builder();
-        if (StringUtils.isEmpty(event.getOperation().getResourceCrn())) {
+
+        if (!StringUtils.hasText(event.getOperation().getResourceCrn())) {
             builder.error("Resource crn cannot be null or empty");
         }
         return builder.build();

--- a/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/controller/CDPStructuredEventV1ControllerTest.java
+++ b/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/rest/controller/CDPStructuredEventV1ControllerTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.structuredevent.rest.controller;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -117,19 +118,13 @@ class CDPStructuredEventV1ControllerTest {
     }
 
     @Test
-    void testGetAuditEventsZipWhenNotEmptyPageComingBackFromDbServiceThenNoHeaderShouldBeInTheResponse() {
-        Page<CDPStructuredEvent> mockPage = mock(Page.class);
-        when(mockPage.getContent()).thenReturn(List.of(createTestCDPStructuredEvent()));
-        when(mockStructuredEventDBService.getPagedEventsOfResource(eq(TEST_EVENT_TYPES), eq(RESOURCE_CRN), any(PageRequest.class))).thenReturn(mockPage);
+    void testGetAuditEventsZipWhenNotEmptyPageComingBackFromDbServiceThenZipHeaderShouldBeInResponse() {
+        when(mockStructuredEventDBService.getEventsOfResource(eq(TEST_EVENT_TYPES), eq(RESOURCE_CRN))).thenReturn(List.of(createTestCDPStructuredEvent()));
 
         Response response = underTest.getAuditEventsZip(RESOURCE_CRN, TEST_EVENT_TYPES);
 
         assertNotNull(response);
-        assertTrue(response.getHeaders().isEmpty());
-    }
-
-    private void checkZipHeader(Response response) {
-        assertNotNull(response);
+        assertFalse(response.getHeaders().isEmpty());
         assertTrue(response.getHeaders().containsKey(EXPECTED_ZIP_HEADER_KEY));
         assertEquals(EXPECTED_ZIP_HEADER_VALUE, response.getHeaders().get(EXPECTED_ZIP_HEADER_KEY).toString());
     }


### PR DESCRIPTION
Close [CB-13786](https://jira.cloudera.com/browse/CB-13786).

Adds `/dl/api/v1/datalake_events?resourceCrn=...` and `/dl/api/v1/datalake_events/zip?resourceCrn=...` urls.

Endpoints return a list of structured events related to the _environment_ CRN provided in the query parameter.

-----

The big idea here is to provide a way to stitch together the events that have happened in an environment, for use later as part of DL migration.
We originally discussed aggregating this data on the _server side_ but coordinating page offsets between two services based on timestamp was turning out to be more complicated than expected. There was a lot of state that I was going to need to coordinate across requests, so like DB changes would have been made and other things.

So, this is going to rely on the client to stitch together the events -- make separate requests to the `datalake_events` and `environment/structured_events` urls, then merge and sort them by timestamp to present a cohesive history on the UI.

-----

Example testing script, running against `cbd` with Datalake and Cloudbreak services running in Intellij:
```bash
#! /bin/bash

set -eux

ENVIRONMENT_CRN="crn:cdp:environments:us-west-1:bderriso:environment:1234106e-224d-4c85-9d68-3ed6b7fd8c62"
TENANT_NAME="bderriso"
USER_NAME="bderriso@cloudera"
ACTOR_CRN="crn:cdp:iam:us-west-1:${TENANT_NAME}:user:${USER_NAME}"

curl "http://localhost:8086/dl/api/v1/datalake_events?resourceCrn=${ENVIRONMENT_CRN}"\
  --header "x-cdp-actor-crn: ${ACTOR_CRN}"
```


-----

Yet todo:
* [x] review todos in the commits
* [x] write tests