### PR TITLE
CB-13522 Update scaling restrictions for NIFI template

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/BlackListedDownScaleRole.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/BlackListedDownScaleRole.java
@@ -1,15 +1,15 @@
 package com.sequenceiq.cloudbreak.cmtemplate;
 
+import java.util.Objects;
+import java.util.Optional;
+
 import com.sequenceiq.cloudbreak.auth.altus.model.Entitlement;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlRoles;
 import com.sequenceiq.cloudbreak.common.type.Versioned;
 
-import java.util.Objects;
-import java.util.Optional;
-
 public enum BlackListedDownScaleRole implements EntitledForServiceScale {
     KAFKA_BROKER(Entitlement.DATAHUB_STREAMING_SCALING, "7.2.12", CruiseControlRoles.CRUISECONTROL),
-    NIFI_NODE(Entitlement.DATAHUB_FLOW_SCALING),
+    NIFI_NODE(Entitlement.DATAHUB_FLOW_SCALING, "7.2.11"),
     ZEPPELIN_SERVER(Entitlement.DATAHUB_DEFAULT_SCALING),
     NAMENODE(Entitlement.DATAHUB_DEFAULT_SCALING);
 


### PR DESCRIPTION

    For NiFI scaling up:
        if DATAHUB_FLOW_SCALING entitlement is not enabled (already done)
        if runtime version is lower than 7.2.8 (already done)
    For NiFI scaling down:
        if DATAHUB_FLOW_SCALING entitlement is not enabled (already done)
        if runtime version is lower than 7.2.11
