### PR TITLE
CB-14026 Fix missing zone in GCP during FreeIPA upscale

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/multiaz/MultiAzValidator.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/multiaz/MultiAzValidator.java
@@ -59,9 +59,14 @@ public class MultiAzValidator {
 
     public boolean supportedForInstanceMetadataGeneration(InstanceGroup instanceGroup) {
         if (instanceGroup.getInstanceGroupNetwork() != null) {
-            return supportedInstanceMetadataPlatforms.contains(instanceGroup.getInstanceGroupNetwork().cloudPlatform());
+            boolean platformSupportsMultiAz = supportedInstanceMetadataPlatforms.contains(instanceGroup.getInstanceGroupNetwork().cloudPlatform());
+            LOGGER.debug("Multi AZ support on platform result: [{}]", platformSupportsMultiAz);
+            return platformSupportsMultiAz;
+        } else {
+            LOGGER.debug("instanceGroup.getInstanceGroupNetwork() is null");
+            return false;
         }
-        return false;
+
     }
 
     private Set<String> collectSubnetIds(Iterable<InstanceGroup> instanceGroups) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaCreationService.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.cloud.event.platform.GetPlatformTemplateRequest;
@@ -120,9 +119,6 @@ public class FreeIpaCreationService {
     private CachedEnvironmentClientService cachedEnvironmentClientService;
 
     @Inject
-    private EntitlementService entitlementService;
-
-    @Inject
     private MultiAzValidator multiAzValidator;
 
     @Value("${info.app.version:}")
@@ -197,8 +193,7 @@ public class FreeIpaCreationService {
                 instanceMetaData.setPrivateId(privateIdNumber++);
                 instanceMetaData.setInstanceStatus(InstanceStatus.REQUESTED);
             }
-            multiAzCalculatorService.calculateByRoundRobin(multiAzCalculatorService.prepareSubnetAzMap(environment),
-                    instanceGroup, stack.getPlatformvariant());
+            multiAzCalculatorService.calculateByRoundRobin(multiAzCalculatorService.prepareSubnetAzMap(environment), instanceGroup);
         }
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/multiaz/MultiAzCalculatorServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/multiaz/MultiAzCalculatorServiceTest.java
@@ -1,0 +1,132 @@
+package com.sequenceiq.freeipa.service.multiaz;
+
+import static com.sequenceiq.cloudbreak.common.network.NetworkConstants.SUBNET_IDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceStatus;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceGroupNetwork;
+import com.sequenceiq.freeipa.entity.InstanceMetaData;
+
+@ExtendWith(MockitoExtension.class)
+class MultiAzCalculatorServiceTest {
+
+    private static final String SUB_1 = "SUB1";
+
+    private static final String SUB_2 = "SUB2";
+
+    private static final Map<String, String> SUBNET_AZ_PAIRS = Map.of(SUB_1, "AZ1", SUB_2, "AZ2", "ONLYINAZMAP", "AZ3");
+
+    @Mock
+    private MultiAzValidator multiAzValidator;
+
+    @InjectMocks
+    private MultiAzCalculatorService underTest;
+
+    @Test
+    public void testCalculateCurrentSubnetUsage() {
+        InstanceGroupNetwork instanceGroupNetwork = new InstanceGroupNetwork();
+        instanceGroupNetwork.setAttributes(Json.silent(Map.of(SUBNET_IDS, List.of(SUB_1, SUB_2, "ONLYINIG"))));
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setInstanceGroupNetwork(instanceGroupNetwork);
+        InstanceMetaData deletedInstance = createInstanceMetadata(SUB_1);
+        deletedInstance.setInstanceStatus(InstanceStatus.TERMINATED);
+        instanceGroup.setInstanceMetaData(Set.of(createInstanceMetadata(SUB_1), createInstanceMetadata(SUB_1), createInstanceMetadata(SUB_2),
+                createInstanceMetadata(null), createInstanceMetadata(" "), createInstanceMetadata("IGNORED"), deletedInstance));
+
+        Map<String, Integer> result = underTest.calculateCurrentSubnetUsage(SUBNET_AZ_PAIRS, instanceGroup);
+
+        assertEquals(2, result.size());
+        assertEquals(2, result.get(SUB_1));
+        assertEquals(1, result.get(SUB_2));
+    }
+
+    @Test
+    public void testUpdateSubnetIdForSingleInstanceIfEligible() {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        when(multiAzValidator.supportedForInstanceMetadataGeneration(instanceGroup)).thenReturn(Boolean.TRUE);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+
+        underTest.updateSubnetIdForSingleInstanceIfEligible(SUBNET_AZ_PAIRS, new HashMap<>(Map.of(SUB_1, 2, SUB_2, 1)), instanceMetaData, instanceGroup);
+
+        assertEquals(SUB_2, instanceMetaData.getSubnetId());
+    }
+
+    @Test
+    public void testUpdateSubnetIdForSingleInstanceIfEligibleValidatorReturnFalse() {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        when(multiAzValidator.supportedForInstanceMetadataGeneration(instanceGroup)).thenReturn(Boolean.FALSE);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+
+        underTest.updateSubnetIdForSingleInstanceIfEligible(SUBNET_AZ_PAIRS, new HashMap<>(Map.of(SUB_1, 2, SUB_2, 1)), instanceMetaData, instanceGroup);
+
+        assertNull(instanceMetaData.getSubnetId());
+    }
+
+    @Test
+    public void testUpdateSubnetIdForSingleInstanceIfEligibleSubnetUsageEmpty() {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+
+        underTest.updateSubnetIdForSingleInstanceIfEligible(SUBNET_AZ_PAIRS, new HashMap<>(), instanceMetaData, instanceGroup);
+
+        assertNull(instanceMetaData.getSubnetId());
+    }
+
+    @Test
+    public void testUpdateSubnetIdForSingleInstanceIfEligibleDontModifyExisting() {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        when(multiAzValidator.supportedForInstanceMetadataGeneration(instanceGroup)).thenReturn(Boolean.TRUE);
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setSubnetId("ASDF");
+
+        underTest.updateSubnetIdForSingleInstanceIfEligible(SUBNET_AZ_PAIRS, new HashMap<>(Map.of(SUB_1, 2, SUB_2, 1)), instanceMetaData, instanceGroup);
+
+        assertEquals("ASDF", instanceMetaData.getSubnetId());
+    }
+
+    @Test
+    public void testCalculateRoundRobin() {
+        InstanceGroupNetwork instanceGroupNetwork = new InstanceGroupNetwork();
+        instanceGroupNetwork.setAttributes(Json.silent(Map.of(SUBNET_IDS, List.of(SUB_1, SUB_2, "ONLYINIG"))));
+        InstanceGroup instanceGroup = new InstanceGroup();
+        instanceGroup.setInstanceGroupNetwork(instanceGroupNetwork);
+        InstanceMetaData deletedInstance = createInstanceMetadata(SUB_1);
+        deletedInstance.setInstanceStatus(InstanceStatus.TERMINATED);
+        instanceGroup.setInstanceMetaData(Set.of(createInstanceMetadata(null), createInstanceMetadata(null), createInstanceMetadata(null),
+                createInstanceMetadata(SUB_2), createInstanceMetadata(null), createInstanceMetadata(" "), createInstanceMetadata("IGNORED"),
+                deletedInstance));
+        when(multiAzValidator.supportedForInstanceMetadataGeneration(instanceGroup)).thenReturn(Boolean.TRUE);
+
+        underTest.calculateByRoundRobin(SUBNET_AZ_PAIRS, instanceGroup);
+
+        assertEquals(3, instanceGroup.getNotDeletedInstanceMetaDataSet().stream()
+                .filter(im -> SUB_1.equals(im.getSubnetId()) && "AZ1".equals(im.getAvailabilityZone())).count());
+        assertEquals(2, instanceGroup.getNotDeletedInstanceMetaDataSet().stream()
+                .filter(im -> SUB_2.equals(im.getSubnetId()) && "AZ2".equals(im.getAvailabilityZone())).count());
+        assertEquals(3, instanceGroup.getNotDeletedInstanceMetaDataSet().stream()
+                .filter(im -> SUB_2.equals(im.getSubnetId())).count());
+        assertEquals(1, instanceGroup.getNotDeletedInstanceMetaDataSet().stream().filter(im -> "IGNORED".equals(im.getSubnetId())).count());
+    }
+
+    private InstanceMetaData createInstanceMetadata(String subnetId) {
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setSubnetId(subnetId);
+        instanceMetaData.setInstanceStatus(InstanceStatus.CREATED);
+        return instanceMetaData;
+    }
+}


### PR DESCRIPTION
- default to `CloudContext` based location if instance based not present
- when creating new instances during upscale, use the same logic to fill in zone data as during creation

See detailed description in the commit message.