### PR TITLE
CB-14171: Retry joining IPA if the DNS record is missing

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/template/join_ipa.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/template/join_ipa.j2
@@ -28,4 +28,21 @@ echo "$PW" | kinit {{ pillar['sssd-ipa']['principal'] }}
 
 ipa env
 
+HOSTNAME=$(hostname)
+
+# check the dns record 3 times with a 10 seconds interval (see CB-14171)
+for attempt in {1..3}
+do
+  sleep 10
+  echo "checking dns record hostname for ${HOSTNAME}, attempt ${attempt}"
+  if ipa dnsrecord-show {{ pillar['sssd-ipa']['domain'] }}. "${HOSTNAME}"; then
+    echo "ipa-client-install created the DNS record for ${HOSTNAME}"
+    break
+  fi
+  if [[ "$attempt" -eq 3 ]]; then
+    echo "Failed to add DNS record for ${HOSTNAME}"
+    false
+  fi
+done
+
 set +e


### PR DESCRIPTION
Fix the ipa registration for datalake and datahub nodes sot that
during the initial ipa client registration the operations are retried
if the DNS entry is not added. The existence of a DNS record (any
type of record) is validated. If there isn't a record then the salt
operation fails which will cause it to be retried. On the retry, the
ipa client is uninstalled then reinstalled and then the DNS record is
rechecked.

At a later point, the DNS record will be modified to ensure that the
A record exsits. However the later modification requires the a DNS
record (of any type) to already exist.

This was validated manually on a local deployment of cloudbreak using
a light duty datalake.

See detailed description in the commit message.