### PR TITLE
CB-13541 - Restore components to before upgrade state

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/recovery/bringup/DatalakeRecoveryBringupActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/recovery/bringup/DatalakeRecoveryBringupActions.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup;
 
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupEvent.RECOVERY_BRINGUP_FAIL_HANDLED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupEvent.RECOVERY_RESTORE_COMPONENTS_FINISHED_EVENT;
 
 import java.util.Map;
 
@@ -13,7 +14,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.action.Action;
 
+import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.core.flow2.event.ClusterRecoveryTriggerEvent;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
@@ -21,7 +25,9 @@ import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.recovery.bringup.DatalakeRecoverySetupNewInstancesFailedEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.recovery.bringup.DatalakeRecoverySetupNewInstancesRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.recovery.bringup.DatalakeRecoverySetupNewInstancesSuccess;
+import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.upgrade.ImageComponentUpdaterService;
 import com.sequenceiq.flow.core.Flow;
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowParameters;
@@ -37,6 +43,33 @@ public class DatalakeRecoveryBringupActions {
 
     @Inject
     private StackService stackService;
+
+    @Inject
+    private ComponentConfigProviderService componentConfigProviderService;
+
+    @Inject
+    private ImageComponentUpdaterService imageComponentUpdaterService;
+
+    @Bean(name = "RECOVERY_RESTORE_COMPONENTS_STATE")
+    public Action<?, ?> datalakeRecoveryRestoreComponents() {
+        return new AbstractDatalakeRecoveryBringupAction<>(ClusterRecoveryTriggerEvent.class) {
+
+            @Override
+            protected void doExecute(DatalakeRecoveryBringupContext context, ClusterRecoveryTriggerEvent payload, Map<Object, Object> variables) {
+                Long stackId = context.getStackId();
+                try {
+                    Image image = componentConfigProviderService.getImage(stackId);
+                    imageComponentUpdaterService.updateForUpgrade(image.getImageId(), stackId);
+                } catch (CloudbreakImageNotFoundException e) {
+                    String message = "Image was not found for current stack, it is not possible to continue recovery. "
+                            + "Please open a Cloudera support ticket to fix this issue";
+                    LOGGER.warn(message);
+                    throw new CloudbreakServiceException(message);
+                }
+                sendEvent(context, RECOVERY_RESTORE_COMPONENTS_FINISHED_EVENT.event(), payload);
+            }
+        };
+    }
 
     @Bean(name = "RECOVERY_SETUP_NEW_INSTANCES_STATE")
     public Action<?, ?> datalakeRecoverySetupNewInstances() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/recovery/bringup/DatalakeRecoveryBringupEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/recovery/bringup/DatalakeRecoveryBringupEvent.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup;
 
+import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.recovery.bringup.DatalakeRecoveryRestoreComponentsSuccess;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.recovery.bringup.DatalakeRecoverySetupNewInstancesFailedEvent;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.recovery.bringup.DatalakeRecoverySetupNewInstancesSuccess;
 import com.sequenceiq.flow.core.FlowEvent;
@@ -8,7 +9,8 @@ import com.sequenceiq.flow.event.EventSelectorUtil;
 public enum DatalakeRecoveryBringupEvent implements FlowEvent {
 
     RECOVERY_BRINGUP_EVENT,
-    RECOVERY_BRINGUP_FINISHED_EVENT(EventSelectorUtil.selector(DatalakeRecoverySetupNewInstancesSuccess.class)),
+    RECOVERY_RESTORE_COMPONENTS_FINISHED_EVENT(EventSelectorUtil.selector(DatalakeRecoveryRestoreComponentsSuccess.class)),
+    RECOVERY_BRINGUP_NEW_INSTANCES_FINISHED_EVENT(EventSelectorUtil.selector(DatalakeRecoverySetupNewInstancesSuccess.class)),
     RECOVERY_BRINGUP_FAILED_EVENT(EventSelectorUtil.selector(DatalakeRecoverySetupNewInstancesFailedEvent.class)),
     RECOVERY_BRINGUP_FINALIZED_EVENT,
     RECOVERY_BRINGUP_FAIL_HANDLED_EVENT;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/recovery/bringup/DatalakeRecoveryBringupFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/recovery/bringup/DatalakeRecoveryBringupFlowConfig.java
@@ -4,11 +4,13 @@ import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bri
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupEvent.RECOVERY_BRINGUP_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupEvent.RECOVERY_BRINGUP_FAIL_HANDLED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupEvent.RECOVERY_BRINGUP_FINALIZED_EVENT;
-import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupEvent.RECOVERY_BRINGUP_FINISHED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupEvent.RECOVERY_BRINGUP_NEW_INSTANCES_FINISHED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupEvent.RECOVERY_RESTORE_COMPONENTS_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupState.FINAL_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupState.INIT_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupState.RECOVERY_BRINGUP_FAILED_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupState.RECOVERY_BRINGUP_FINISHED_STATE;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupState.RECOVERY_RESTORE_COMPONENTS_STATE;
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.recovery.bringup.DatalakeRecoveryBringupState.RECOVERY_SETUP_NEW_INSTANCES_STATE;
 
 import java.util.List;
@@ -24,21 +26,25 @@ public class DatalakeRecoveryBringupFlowConfig extends AbstractFlowConfiguration
 
     private static final List<Transition<DatalakeRecoveryBringupState, DatalakeRecoveryBringupEvent>> TRANSITIONS =
         new Transition.Builder<DatalakeRecoveryBringupState, DatalakeRecoveryBringupEvent>()
-            .defaultFailureEvent(RECOVERY_BRINGUP_FAILED_EVENT)
+                .defaultFailureEvent(RECOVERY_BRINGUP_FAILED_EVENT)
 
-            .from(INIT_STATE).to(RECOVERY_SETUP_NEW_INSTANCES_STATE)
-            .event(RECOVERY_BRINGUP_EVENT)
-            .defaultFailureEvent()
+                .from(INIT_STATE).to(RECOVERY_RESTORE_COMPONENTS_STATE)
+                .event(RECOVERY_BRINGUP_EVENT)
+                .defaultFailureEvent()
 
-            .from(RECOVERY_SETUP_NEW_INSTANCES_STATE).to(RECOVERY_BRINGUP_FINISHED_STATE)
-            .event(RECOVERY_BRINGUP_FINISHED_EVENT)
-            .defaultFailureEvent()
+                .from(RECOVERY_RESTORE_COMPONENTS_STATE).to(RECOVERY_SETUP_NEW_INSTANCES_STATE)
+                .event(RECOVERY_RESTORE_COMPONENTS_FINISHED_EVENT)
+                .defaultFailureEvent()
 
-            .from(RECOVERY_BRINGUP_FINISHED_STATE).to(FINAL_STATE)
-            .event(RECOVERY_BRINGUP_FINALIZED_EVENT)
-            .defaultFailureEvent()
+                .from(RECOVERY_SETUP_NEW_INSTANCES_STATE).to(RECOVERY_BRINGUP_FINISHED_STATE)
+                .event(RECOVERY_BRINGUP_NEW_INSTANCES_FINISHED_EVENT)
+                .defaultFailureEvent()
 
-            .build();
+                .from(RECOVERY_BRINGUP_FINISHED_STATE).to(FINAL_STATE)
+                .event(RECOVERY_BRINGUP_FINALIZED_EVENT)
+                .defaultFailureEvent()
+
+                .build();
 
     private static final FlowEdgeConfig<DatalakeRecoveryBringupState, DatalakeRecoveryBringupEvent> EDGE_CONFIG =
         new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, RECOVERY_BRINGUP_FAILED_STATE, RECOVERY_BRINGUP_FAIL_HANDLED_EVENT);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/recovery/bringup/DatalakeRecoveryBringupState.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/recovery/bringup/DatalakeRecoveryBringupState.java
@@ -6,6 +6,7 @@ import com.sequenceiq.flow.core.RestartAction;
 
 public enum DatalakeRecoveryBringupState implements FlowState {
     INIT_STATE,
+    RECOVERY_RESTORE_COMPONENTS_STATE,
     RECOVERY_SETUP_NEW_INSTANCES_STATE,
     RECOVERY_BRINGUP_FAILED_STATE,
     RECOVERY_BRINGUP_FINISHED_STATE,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/recovery/bringup/DatalakeRecoveryRestoreComponentsSuccess.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/cluster/upgrade/recovery/bringup/DatalakeRecoveryRestoreComponentsSuccess.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.cloudbreak.reactor.api.event.cluster.upgrade.recovery.bringup;
+
+import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
+
+public class DatalakeRecoveryRestoreComponentsSuccess extends StackEvent {
+
+    public DatalakeRecoveryRestoreComponentsSuccess(Long stackId) {
+        super(stackId);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageComponentUpdaterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ImageComponentUpdaterService.java
@@ -44,12 +44,12 @@ public class ImageComponentUpdaterService {
     @Inject
     private CloudbreakRestRequestThreadLocalService restRequestThreadLocalService;
 
-    public UpgradeImageInfo updateForUpgrade(String imageId, Long stackId) {
+    public UpgradeImageInfo updateForUpgrade(String targetImageId, Long stackId) {
         Stack stack = stackService.getById(stackId);
         try {
             restRequestThreadLocalService.setWorkspace(stack.getWorkspace());
 
-            UpgradeImageInfo upgradeImageInfo = upgradeImageInfoFactory.create(imageId, stackId);
+            UpgradeImageInfo upgradeImageInfo = upgradeImageInfoFactory.create(targetImageId, stackId);
             Set<Component> targetComponents = imageService.getComponents(
                     stack, upgradeImageInfo.getCurrentImage().getUserdata(), upgradeImageInfo.getTargetStatedImage(),
                     EnumSet.of(CDH_PRODUCT_DETAILS, CM_REPO_DETAILS)
@@ -59,7 +59,7 @@ public class ImageComponentUpdaterService {
             return upgradeImageInfo;
         } catch (CloudbreakImageNotFoundException | CloudbreakImageCatalogException e) {
             LOGGER.warn(String.format("Image was not found for stack %s", stack.getName()), e);
-            throw notFoundException("Image", imageId);
+            throw notFoundException("Image", targetImageId);
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeRecoveryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/UpgradeRecoveryService.java
@@ -24,10 +24,10 @@ public class UpgradeRecoveryService {
     @Inject
     private ReactorFlowManager flowManager;
 
-    public FlowIdentifier recoverFailedUpgrade(Long workspaceId, NameOrCrn stackNameOrCrn) {
+    public FlowIdentifier recoverCluster(Long workspaceId, NameOrCrn stackNameOrCrn) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(stackNameOrCrn, workspaceId);
         MDCBuilder.buildMdcContext(stack);
-        LOGGER.debug("Upgrade recovery has been initiated for stack {}", stackNameOrCrn.getNameOrCrn());
+        LOGGER.debug("Recovery has been initiated for stack {}", stackNameOrCrn.getNameOrCrn());
         return flowManager.triggerDatalakeClusterRecovery(stack.getId());
     }
 }

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -266,7 +266,7 @@ public class StackOperations implements ResourcePropertyProvider {
 
     public FlowIdentifier recoverCluster(@NotNull NameOrCrn nameOrCrn, Long workspaceId) {
         LOGGER.debug("Starting to recover cluster ({}) from failed upgrade", nameOrCrn);
-        return recoveryService.recoverFailedUpgrade(workspaceId, nameOrCrn);
+        return recoveryService.recoverCluster(workspaceId, nameOrCrn);
     }
 
     public FlowIdentifier updateSalt(@NotNull NameOrCrn nameOrCrn, Long workspaceId) {

--- a/flow/src/main/java/com/sequenceiq/flow/cleanup/FlowCleanupJob.java
+++ b/flow/src/main/java/com/sequenceiq/flow/cleanup/FlowCleanupJob.java
@@ -67,7 +67,7 @@ public class FlowCleanupJob extends TracedQuartzJob {
             int purgedFinalizedFlowLogs = flowLogService.purgeFinalizedFlowLogs();
             LOGGER.debug("Deleted flowlog count: {}", purgedFinalizedFlowLogs);
             LOGGER.debug("Cleaning orphan flowchainlogs");
-            int purgedOrphanFLowChainLogs = flowChainLogService.purgeOrphanFLowChainLogs();
+            int purgedOrphanFLowChainLogs = flowChainLogService.purgeOrphanFlowChainLogs();
             LOGGER.debug("Deleted flowchainlog count: {}", purgedOrphanFLowChainLogs);
             return null;
         });

--- a/flow/src/main/java/com/sequenceiq/flow/repository/FlowChainLogRepository.java
+++ b/flow/src/main/java/com/sequenceiq/flow/repository/FlowChainLogRepository.java
@@ -27,5 +27,5 @@ public interface FlowChainLogRepository extends CrudRepository<FlowChainLog, Lon
     @Query("DELETE FROM FlowChainLog fch "
             + "WHERE fch.flowChainId NOT IN ( SELECT DISTINCT fl.flowChainId FROM FlowLog fl )"
             + " AND fch.flowChainId NOT IN (SELECT DISTINCT fc.parentFlowChainId FROM FlowChainLog fc)")
-    int purgeOrphanFLowChainLogs();
+    int purgeOrphanFlowChainLogs();
 }

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowChainLogService.java
@@ -108,8 +108,8 @@ public class FlowChainLogService {
         });
     }
 
-    public int purgeOrphanFLowChainLogs() {
-        return repository.purgeOrphanFLowChainLogs();
+    public int purgeOrphanFlowChainLogs() {
+        return repository.purgeOrphanFlowChainLogs();
     }
 
     public FlowChainLog save(FlowChainLog chainLog) {


### PR DESCRIPTION
Failures during upgrade might result in the following scenarios:
 - neither the components nor the image are upgraded
 - the components are upgraded but the image is not upgraded

Hence the first effective step of recovery process is to restore the original components from the original image.
That logic is in this commit.
