### PR TITLE
CB-14135 Filter out nodes without FQDN when composing pillars for mount

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -364,6 +364,7 @@ public class ClusterHostServiceRunner {
         saveDockerPillar(cluster.getExecutorType(), servicePillar);
 
         Map<String, Map<String, String>> mountPathMap = stack.getInstanceGroups().stream().flatMap(group -> group.getInstanceMetaDataSet().stream()
+                .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
                 .collect(Collectors.toMap(
                         InstanceMetaData::getDiscoveryFQDN,
                         node -> singletonMap("mount_path", getMountPath(group)),


### PR DESCRIPTION
If a node stuck in CREATED state, it does not have FQDN. It can cause the following:

New node(s) could not be added to the cluster. Reason Failed: Orchestrator component went failed in 60 min(s), message: com.fasterxml.jackson.databind.JsonMappingException: Null key for a Map not allowed in JSON (use a converting NullKeySerializer?) (through reference chain: com.sequenceiq.cloudbreak.orchestrator.salt.domain.Pillar["json"]->java.util.Collections$SingletonMap["mount"]->java.util.HashMap["null"])