### PR TITLE
CB-14194 adding a new property to enable multiaz on datalake, now the…

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterDetailResponse.java
@@ -19,7 +19,8 @@ public class SdxClusterDetailResponse extends SdxClusterResponse implements Tagg
                 sdxClusterResponse.getClusterShape(), sdxClusterResponse.getCloudStorageBaseLocation(),
                 sdxClusterResponse.getCloudStorageFileSystemType(), sdxClusterResponse.getRuntime(),
                 sdxClusterResponse.getRangerRazEnabled(), sdxClusterResponse.getTags(), sdxClusterResponse.getCertExpirationState(),
-                sdxClusterResponse.getSdxClusterServiceVersion(), sdxClusterResponse.isDetached());
+                sdxClusterResponse.getSdxClusterServiceVersion(), sdxClusterResponse.isDetached(),
+                sdxClusterResponse.isEnableMultiAz());
         this.stackV4Response = stackV4Response;
     }
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequestBase.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequestBase.java
@@ -27,6 +27,8 @@ public class SdxClusterRequestBase implements TaggableRequest {
 
     private boolean enableRangerRaz;
 
+    private boolean enableMultiAz;
+
     public String getEnvironment() {
         return environment;
     }
@@ -99,6 +101,14 @@ public class SdxClusterRequestBase implements TaggableRequest {
         this.enableRangerRaz = enableRangerRaz;
     }
 
+    public boolean isEnableMultiAz() {
+        return enableMultiAz;
+    }
+
+    public void setEnableMultiAz(boolean enableMultiAz) {
+        this.enableMultiAz = enableMultiAz;
+    }
+
     public void copyTo(SdxClusterRequestBase toInstance) {
         toInstance.setEnvironment(environment);
         toInstance.setClusterShape(clusterShape);
@@ -107,6 +117,7 @@ public class SdxClusterRequestBase implements TaggableRequest {
         toInstance.setExternalDatabase(externalDatabase);
         toInstance.setAws(aws);
         toInstance.setEnableRangerRaz(enableRangerRaz);
+        toInstance.setEnableMultiAz(enableMultiAz);
     }
 
     @Override
@@ -117,6 +128,7 @@ public class SdxClusterRequestBase implements TaggableRequest {
                 ", externalDatabase=" + externalDatabase +
                 ", aws=" + aws +
                 ", enableRangerRaz=" + enableRangerRaz +
+                ", enableMultiAz=" + enableMultiAz +
                 '}';
     }
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterResponse.java
@@ -41,6 +41,8 @@ public class SdxClusterResponse {
 
     private boolean rangerRazEnabled;
 
+    private boolean enableMultiAz;
+
     private Map<String, String> tags;
 
     @ApiModelProperty(ClusterModelDescription.CERT_EXPIRATION)
@@ -58,7 +60,7 @@ public class SdxClusterResponse {
             SdxClusterShape clusterShape, String cloudStorageBaseLocation,
             FileSystemType cloudStorageFileSystemType, String runtime,
             boolean rangerRazEnabled, Map<String, String> tags, CertExpirationState certExpirationState,
-            String sdxClusterServiceVersion, boolean detached) {
+            String sdxClusterServiceVersion, boolean detached, boolean enableMultiAz) {
         this.crn = crn;
         this.name = name;
         this.status = status;
@@ -75,6 +77,7 @@ public class SdxClusterResponse {
         this.certExpirationState = certExpirationState;
         this.sdxClusterServiceVersion = sdxClusterServiceVersion;
         this.detached = detached;
+        this.enableMultiAz = enableMultiAz;
     }
 
     public String getCrn() {
@@ -229,6 +232,14 @@ public class SdxClusterResponse {
         this.detached = detached;
     }
 
+    public boolean isEnableMultiAz() {
+        return enableMultiAz;
+    }
+
+    public void setEnableMultiAz(boolean enableMultiAz) {
+        this.enableMultiAz = enableMultiAz;
+    }
+
     @Override
     public String toString() {
         return "SdxClusterResponse{" +
@@ -251,6 +262,7 @@ public class SdxClusterResponse {
                 ", certExpirationState=" + certExpirationState +
                 ", sdxClusterServiceVersion=" + sdxClusterServiceVersion +
                 ", Detached=" + detached +
+                ", enableMultiAz=" + enableMultiAz +
                 '}';
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxClusterConverter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxClusterConverter.java
@@ -47,6 +47,7 @@ public class SdxClusterConverter {
         sdxClusterResponse.setCertExpirationState(sdxCluster.getCertExpirationState());
         sdxClusterResponse.setSdxClusterServiceVersion(sdxCluster.getSdxClusterServiceVersion());
         sdxClusterResponse.setDetached(sdxCluster.isDetached());
+        sdxClusterResponse.setEnableMultiAz(sdxCluster.isEnableMultiAz());
         return sdxClusterResponse;
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/entity/SdxCluster.java
@@ -127,6 +127,8 @@ public class SdxCluster implements AccountAwareResource {
     @Column(name = "ranger_raz_enabled")
     private boolean rangerRazEnabled;
 
+    private boolean enableMultiAz;
+
     @Convert(converter = CertExpirationStateConverter.class)
     private CertExpirationState certExpirationState = CertExpirationState.VALID;
 
@@ -339,6 +341,14 @@ public class SdxCluster implements AccountAwareResource {
         this.certExpirationState = certExpirationState;
     }
 
+    public boolean isEnableMultiAz() {
+        return enableMultiAz;
+    }
+
+    public void setEnableMultiAz(boolean enableMultiAz) {
+        this.enableMultiAz = enableMultiAz;
+    }
+
     public SdxDatabaseAvailabilityType getDatabaseAvailabilityType() {
         if (databaseAvailabilityType != null) {
             return databaseAvailabilityType;
@@ -413,6 +423,7 @@ public class SdxCluster implements AccountAwareResource {
                 Objects.equals(created, that.created) &&
                 Objects.equals(databaseCrn, that.databaseCrn) &&
                 Objects.equals(cloudStorageBaseLocation, that.cloudStorageBaseLocation) &&
+                Objects.equals(enableMultiAz, that.enableMultiAz) &&
                 cloudStorageFileSystemType == that.cloudStorageFileSystemType &&
                 databaseAvailabilityType == that.databaseAvailabilityType &&
                 rangerRazEnabled == that.rangerRazEnabled &&
@@ -424,7 +435,7 @@ public class SdxCluster implements AccountAwareResource {
     public int hashCode() {
         return Objects.hash(id, accountId, crn, clusterName, initiatorUserCrn, envName, envCrn, stackCrn, clusterShape, tags, stackId, stackRequest,
                 stackRequestToCloudbreak, deleted, created, createDatabase, databaseCrn, cloudStorageBaseLocation, cloudStorageFileSystemType,
-                databaseAvailabilityType, rangerRazEnabled, certExpirationState, sdxClusterServiceVersion);
+                databaseAvailabilityType, rangerRazEnabled, certExpirationState, sdxClusterServiceVersion, enableMultiAz);
     }
 
     @Override
@@ -442,6 +453,7 @@ public class SdxCluster implements AccountAwareResource {
                 ", rangerRazEnabled=" + rangerRazEnabled +
                 ", certExpirationState=" + certExpirationState +
                 ", sdxClusterServiceVersion=" + sdxClusterServiceVersion +
+                ", enableMultiAz=" + enableMultiAz +
                 '}';
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -148,7 +148,7 @@ public class StackRequestManifester {
             setupCloudStorageAccountMapping(stackRequest, environment.getCrn(), environment.getIdBrokerMappingSource(), environment.getCloudPlatform());
             validateCloudStorage(sdxCluster, environment, stackRequest);
             setupInstanceVolumeEncryption(stackRequest, environment);
-            if (entitlementService.awsNativeDataLakeEnabled(ThreadBasedUserCrnProvider.getAccountId())) {
+            if (entitlementService.awsNativeDataLakeEnabled(ThreadBasedUserCrnProvider.getAccountId()) && sdxCluster.isEnableMultiAz()) {
                 multiAzDecorator.decorateStackRequestWithMultiAz(stackRequest, environment);
             }
             return stackRequest;

--- a/datalake/src/main/resources/schema/app/20210920112855_CB-14194_adding_multiaz_field_to_datalake_object_to_request_a_multiaz_aws_datalake.sql
+++ b/datalake/src/main/resources/schema/app/20210920112855_CB-14194_adding_multiaz_field_to_datalake_object_to_request_a_multiaz_aws_datalake.sql
@@ -1,0 +1,12 @@
+-- // CB-14194 adding multiaz field to datalake object to request a multiaz aws datalake
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE sdxcluster ADD COLUMN IF NOT EXISTS enablemultiaz boolean;
+UPDATE sdxcluster SET enablemultiaz = FALSE WHERE enablemultiaz is NULL;
+ALTER TABLE sdxcluster ALTER enablemultiaz SET DEFAULT false;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE sdxcluster DROP COLUMN IF EXISTS enablemultiaz;
+

--- a/mock-thunderhead/src/main/resources/application.yml
+++ b/mock-thunderhead/src/main/resources/application.yml
@@ -14,7 +14,7 @@ auth:
     event-generation:
       expiration-minutes: 10
     freeipa:
-      multiaz.enable: false
+      multiaz.enable: true
       ha:
         repair.enable: true
     cloudstoragevalidation.enable:
@@ -40,7 +40,7 @@ auth:
       loadbalancer.enable: false
       backup.on.upgrade.enable: false
       light.to.medium.migration.enable: false
-      multiaz.enable: false
+      multiaz.enable: true
     differentdatahubversionthandatalake.enabled: true
     database.wire.encryption.enable: true
     datahub:


### PR DESCRIPTION
… umsmock enabled datalake multiaz and user can choose whether they would like to deploy dl with multi az or not. The validation checks that it can be enabled only on aws.

See detailed description in the commit message.