### PR TITLE
CB-14213: Removed master group check in RDS config for ProfilerAdmin and ProfilerMetrics.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/ProfilerAdminConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/ProfilerAdminConfigProvider.java
@@ -28,7 +28,7 @@ public class ProfilerAdminConfigProvider extends AbstractRdsConfigProvider {
     private boolean isRdsConfigNeedForProfilerAdmin(Blueprint blueprint) {
         String blueprintText = blueprint.getBlueprintText();
         CmTemplateProcessor cmTemplateProcessor = cmTemplateProcessorFactory.get(blueprintText);
-        return cmTemplateProcessor.isComponentExistsInHostGroup("PROFILER_ADMIN_AGENT", "master");
+        return cmTemplateProcessor.isCMComponentExistsInBlueprint("PROFILER_ADMIN_AGENT");
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/ProfilerMetricsConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/ProfilerMetricsConfigProvider.java
@@ -28,7 +28,7 @@ public class ProfilerMetricsConfigProvider extends AbstractRdsConfigProvider {
     private boolean isRdsConfigNeedForProfilerMetrics(Blueprint blueprint) {
         String blueprintText = blueprint.getBlueprintText();
         CmTemplateProcessor cmTemplateProcessor = cmTemplateProcessorFactory.get(blueprintText);
-        return cmTemplateProcessor.isComponentExistsInHostGroup("PROFILER_METRICS_AGENT", "master");
+        return cmTemplateProcessor.isCMComponentExistsInBlueprint("PROFILER_METRICS_AGENT");
     }
 
     @Override

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/profilermanager/ProfilerAdminRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/profilermanager/ProfilerAdminRoleConfigProvider.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
@@ -15,19 +16,32 @@ import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.c
 @Component
 public class ProfilerAdminRoleConfigProvider extends AbstractRdsRoleConfigProvider {
 
+    @VisibleForTesting
+    static final String PROFILER_ADMIN_DATABASE_HOST = "profiler_admin_database_host";
+
+    @VisibleForTesting
+    static final String PROFILER_ADMIN_DATABASE_NAME = "profiler_admin_database_name";
+
+    @VisibleForTesting
+    static final String PROFILER_ADMIN_DATABASE_TYPE = "profiler_admin_database_type";
+
+    @VisibleForTesting
+    static final String PROFILER_ADMIN_DATABASE_USER = "profiler_admin_database_user";
+
+    @VisibleForTesting
+    static final String PROFILER_ADMIN_DATABASE_PASSWORD = "profiler_admin_database_password";
+
     @Override
     protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
-        switch (roleType) {
-            case ProfilerManagerRoles.PROFILER_ADMIN_AGENT:
-                RdsView profilerManagerRdsView = getRdsView(source);
-                return List.of(config("profiler_admin_database_host", profilerManagerRdsView.getHost()),
-                        config("profiler_admin_database_name", profilerManagerRdsView.getDatabaseName()),
-                        config("profiler_admin_database_type", ConfigUtils.getDbTypePostgres(profilerManagerRdsView, ProfilerManagerRoles.PROFILER_MANAGER)),
-                        config("profiler_admin_database_user", profilerManagerRdsView.getConnectionUserName()),
-                        config("profiler_admin_database_password", profilerManagerRdsView.getConnectionPassword()));
-            default:
-                return List.of();
+        if (ProfilerManagerRoles.PROFILER_ADMIN_AGENT.equals(roleType)) {
+            RdsView profilerManagerRdsView = getRdsView(source);
+            return List.of(config(PROFILER_ADMIN_DATABASE_HOST, profilerManagerRdsView.getHost()),
+                    config(PROFILER_ADMIN_DATABASE_NAME, profilerManagerRdsView.getDatabaseName()),
+                    config(PROFILER_ADMIN_DATABASE_TYPE, ConfigUtils.getDbTypePostgres(profilerManagerRdsView, ProfilerManagerRoles.PROFILER_MANAGER)),
+                    config(PROFILER_ADMIN_DATABASE_USER, profilerManagerRdsView.getConnectionUserName()),
+                    config(PROFILER_ADMIN_DATABASE_PASSWORD, profilerManagerRdsView.getConnectionPassword()));
         }
+        return List.of();
     }
 
     @Override

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/profilermanager/ProfilerMetricsRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/profilermanager/ProfilerMetricsRoleConfigProvider.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
+import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfigProvider;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils;
@@ -15,19 +16,32 @@ import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.c
 @Component
 public class ProfilerMetricsRoleConfigProvider extends AbstractRdsRoleConfigProvider {
 
+    @VisibleForTesting
+    static final String PROFILER_METRICS_DATABASE_HOST = "profiler_metrics_database_host";
+
+    @VisibleForTesting
+    static final String PROFILER_METRICS_DATABASE_NAME = "profiler_metrics_database_name";
+
+    @VisibleForTesting
+    static final String PROFILER_METRICS_DATABASE_TYPE = "profiler_metrics_database_type";
+
+    @VisibleForTesting
+    static final String PROFILER_METRICS_DATABASE_USER = "profiler_metrics_database_user";
+
+    @VisibleForTesting
+    static final String PROFILER_METRICS_DATABASE_PASSWORD = "profiler_metrics_database_password";
+
     @Override
     protected List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, TemplatePreparationObject source) {
-        switch (roleType) {
-            case ProfilerManagerRoles.PROFILER_METRICS_AGENT:
-                RdsView profilerManagerRdsView = getRdsView(source);
-                return List.of(config("profiler_metrics_database_host", profilerManagerRdsView.getHost()),
-                        config("profiler_metrics_database_name", profilerManagerRdsView.getDatabaseName()),
-                        config("profiler_metrics_database_type", ConfigUtils.getDbTypePostgres(profilerManagerRdsView, ProfilerManagerRoles.PROFILER_MANAGER)),
-                        config("profiler_metrics_database_user", profilerManagerRdsView.getConnectionUserName()),
-                        config("profiler_metrics_database_password", profilerManagerRdsView.getConnectionPassword()));
-            default:
-                return List.of();
+        if (ProfilerManagerRoles.PROFILER_METRICS_AGENT.equals(roleType)) {
+            RdsView profilerManagerRdsView = getRdsView(source);
+            return List.of(config(PROFILER_METRICS_DATABASE_HOST, profilerManagerRdsView.getHost()),
+                    config(PROFILER_METRICS_DATABASE_NAME, profilerManagerRdsView.getDatabaseName()),
+                    config(PROFILER_METRICS_DATABASE_TYPE, ConfigUtils.getDbTypePostgres(profilerManagerRdsView, ProfilerManagerRoles.PROFILER_MANAGER)),
+                    config(PROFILER_METRICS_DATABASE_USER, profilerManagerRdsView.getConnectionUserName()),
+                    config(PROFILER_METRICS_DATABASE_PASSWORD, profilerManagerRdsView.getConnectionPassword()));
         }
+        return List.of();
     }
 
     @Override

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/profilermanager/ProfilerAdminRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/profilermanager/ProfilerAdminRoleConfigProviderTest.java
@@ -18,7 +18,12 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.sequenceiq.cloudbreak.TestUtil.rdsConfig;
-import static org.junit.Assert.assertEquals;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager.ProfilerAdminRoleConfigProvider.PROFILER_ADMIN_DATABASE_HOST;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager.ProfilerAdminRoleConfigProvider.PROFILER_ADMIN_DATABASE_NAME;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager.ProfilerAdminRoleConfigProvider.PROFILER_ADMIN_DATABASE_TYPE;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager.ProfilerAdminRoleConfigProvider.PROFILER_ADMIN_DATABASE_USER;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager.ProfilerAdminRoleConfigProvider.PROFILER_ADMIN_DATABASE_PASSWORD;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProfilerAdminRoleConfigProviderTest {
@@ -42,21 +47,22 @@ public class ProfilerAdminRoleConfigProviderTest {
                 profilerAdmin =
                 roleConfigs.get("profiler_manager-PROFILER_ADMIN_AGENT-BASE");
 
-        assertEquals(5, profilerAdmin.size());
-        assertEquals("profiler_admin_database_host", profilerAdmin.get(0).getName());
-        assertEquals("10.1.1.1", profilerAdmin.get(0).getValue());
+        assertThat(profilerAdmin.size()).isEqualTo(5);
 
-        assertEquals("profiler_admin_database_name", profilerAdmin.get(1).getName());
-        assertEquals("profiler_agent", profilerAdmin.get(1).getValue());
+        assertThat(profilerAdmin.get(0).getName()).isEqualTo(PROFILER_ADMIN_DATABASE_HOST);
+        assertThat(profilerAdmin.get(0).getValue()).isEqualTo("10.1.1.1");
 
-        assertEquals("profiler_admin_database_type", profilerAdmin.get(2).getName());
-        assertEquals("POSTGRES", profilerAdmin.get(2).getValue());
+        assertThat(profilerAdmin.get(1).getName()).isEqualTo(PROFILER_ADMIN_DATABASE_NAME);
+        assertThat(profilerAdmin.get(1).getValue()).isEqualTo("profiler_agent");
 
-        assertEquals("profiler_admin_database_user", profilerAdmin.get(3).getName());
-        assertEquals("heyitsme", profilerAdmin.get(3).getValue());
+        assertThat(profilerAdmin.get(2).getName()).isEqualTo(PROFILER_ADMIN_DATABASE_TYPE);
+        assertThat(profilerAdmin.get(2).getValue()).isEqualTo("POSTGRES");
 
-        assertEquals("profiler_admin_database_password", profilerAdmin.get(4).getName());
-        assertEquals("iamsoosecure", profilerAdmin.get(4).getValue());
+        assertThat(profilerAdmin.get(3).getName()).isEqualTo(PROFILER_ADMIN_DATABASE_USER);
+        assertThat(profilerAdmin.get(3).getValue()).isEqualTo("heyitsme");
+
+        assertThat(profilerAdmin.get(4).getName()).isEqualTo(PROFILER_ADMIN_DATABASE_PASSWORD);
+        assertThat(profilerAdmin.get(4).getValue()).isEqualTo("iamsoosecure");
     }
 
     private TemplatePreparationObject getTemplatePreparationObject() {
@@ -65,6 +71,41 @@ public class ProfilerAdminRoleConfigProviderTest {
 
         return Builder.builder().withHostgroupViews(Set.of(master, worker))
                 .withRdsConfigs(Set.of(rdsConfig(DatabaseType.PROFILER_AGENT))).build();
+    }
+
+    @Test
+    public void testGetRoleConfigsInGatewayHostGroup() {
+        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.CORE, 1);
+        HostgroupView gateway = new HostgroupView("gateway", 1, InstanceGroupType.GATEWAY, 1);
+
+        String inputJson = getBlueprintText("input/profilermanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, gateway))
+                .withRdsConfigs(Set.of(rdsConfig(DatabaseType.PROFILER_AGENT)))
+                .build();
+
+        Map<String, List<ApiClusterTemplateConfig>> roleConfigs =
+                underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
+        List<ApiClusterTemplateConfig> profilerAdmin =
+                roleConfigs.get("profiler_manager-PROFILER_ADMIN_AGENT-BASE");
+
+        assertThat(profilerAdmin.size()).isEqualTo(5);
+
+        assertThat(profilerAdmin.get(0).getName()).isEqualTo(PROFILER_ADMIN_DATABASE_HOST);
+        assertThat(profilerAdmin.get(0).getValue()).isEqualTo("10.1.1.1");
+
+        assertThat(profilerAdmin.get(1).getName()).isEqualTo(PROFILER_ADMIN_DATABASE_NAME);
+        assertThat(profilerAdmin.get(1).getValue()).isEqualTo("profiler_agent");
+
+        assertThat(profilerAdmin.get(2).getName()).isEqualTo(PROFILER_ADMIN_DATABASE_TYPE);
+        assertThat(profilerAdmin.get(2).getValue()).isEqualTo("POSTGRES");
+
+        assertThat(profilerAdmin.get(3).getName()).isEqualTo(PROFILER_ADMIN_DATABASE_USER);
+        assertThat(profilerAdmin.get(3).getValue()).isEqualTo("heyitsme");
+
+        assertThat(profilerAdmin.get(4).getName()).isEqualTo(PROFILER_ADMIN_DATABASE_PASSWORD);
+        assertThat(profilerAdmin.get(4).getValue()).isEqualTo("iamsoosecure");
     }
 
     private String getBlueprintText(String path) {

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/profilermanager/ProfilerMetricsRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/profilermanager/ProfilerMetricsRoleConfigProviderTest.java
@@ -18,7 +18,12 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.sequenceiq.cloudbreak.TestUtil.rdsConfig;
-import static org.junit.Assert.assertEquals;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager.ProfilerMetricsRoleConfigProvider.PROFILER_METRICS_DATABASE_HOST;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager.ProfilerMetricsRoleConfigProvider.PROFILER_METRICS_DATABASE_NAME;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager.ProfilerMetricsRoleConfigProvider.PROFILER_METRICS_DATABASE_TYPE;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager.ProfilerMetricsRoleConfigProvider.PROFILER_METRICS_DATABASE_USER;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.profilermanager.ProfilerMetricsRoleConfigProvider.PROFILER_METRICS_DATABASE_PASSWORD;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ProfilerMetricsRoleConfigProviderTest {
@@ -42,21 +47,22 @@ public class ProfilerMetricsRoleConfigProviderTest {
                 profilerMetrics =
                 roleConfigs.get("profiler_manager-PROFILER_METRICS_AGENT-BASE");
 
-        assertEquals(5, profilerMetrics.size());
-        assertEquals("profiler_metrics_database_host", profilerMetrics.get(0).getName());
-        assertEquals("10.1.1.1", profilerMetrics.get(0).getValue());
+        assertThat(profilerMetrics.size()).isEqualTo(5);
 
-        assertEquals("profiler_metrics_database_name", profilerMetrics.get(1).getName());
-        assertEquals("profiler_metric", profilerMetrics.get(1).getValue());
+        assertThat(profilerMetrics.get(0).getName()).isEqualTo(PROFILER_METRICS_DATABASE_HOST);
+        assertThat(profilerMetrics.get(0).getValue()).isEqualTo("10.1.1.1");
 
-        assertEquals("profiler_metrics_database_type", profilerMetrics.get(2).getName());
-        assertEquals("POSTGRES", profilerMetrics.get(2).getValue());
+        assertThat(profilerMetrics.get(1).getName()).isEqualTo(PROFILER_METRICS_DATABASE_NAME);
+        assertThat(profilerMetrics.get(1).getValue()).isEqualTo("profiler_metric");
 
-        assertEquals("profiler_metrics_database_user", profilerMetrics.get(3).getName());
-        assertEquals("heyitsme", profilerMetrics.get(3).getValue());
+        assertThat(profilerMetrics.get(2).getName()).isEqualTo(PROFILER_METRICS_DATABASE_TYPE);
+        assertThat(profilerMetrics.get(2).getValue()).isEqualTo("POSTGRES");
 
-        assertEquals("profiler_metrics_database_password", profilerMetrics.get(4).getName());
-        assertEquals("iamsoosecure", profilerMetrics.get(4).getValue());
+        assertThat(profilerMetrics.get(3).getName()).isEqualTo(PROFILER_METRICS_DATABASE_USER);
+        assertThat(profilerMetrics.get(3).getValue()).isEqualTo("heyitsme");
+
+        assertThat(profilerMetrics.get(4).getName()).isEqualTo(PROFILER_METRICS_DATABASE_PASSWORD);
+        assertThat(profilerMetrics.get(4).getValue()).isEqualTo("iamsoosecure");
     }
 
     private TemplatePreparationObject getTemplatePreparationObject() {
@@ -65,6 +71,41 @@ public class ProfilerMetricsRoleConfigProviderTest {
 
         return Builder.builder().withHostgroupViews(Set.of(master, worker))
                 .withRdsConfigs(Set.of(rdsConfig(DatabaseType.PROFILER_METRIC))).build();
+    }
+
+    @Test
+    public void testGetRoleConfigsInGatewayHostGroup() {
+        HostgroupView master = new HostgroupView("master", 1, InstanceGroupType.CORE, 1);
+        HostgroupView gateway = new HostgroupView("gateway", 1, InstanceGroupType.GATEWAY, 1);
+
+        String inputJson = getBlueprintText("input/profilermanager.bp");
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(inputJson);
+        TemplatePreparationObject preparationObject = Builder.builder()
+                .withHostgroupViews(Set.of(master, gateway))
+                .withRdsConfigs(Set.of(rdsConfig(DatabaseType.PROFILER_METRIC)))
+                .build();
+
+        Map<String, List<ApiClusterTemplateConfig>> roleConfigs =
+                underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
+        List<ApiClusterTemplateConfig> profilerMetrics =
+                roleConfigs.get("profiler_manager-PROFILER_METRICS_AGENT-BASE");
+
+        assertThat(profilerMetrics.size()).isEqualTo(5);
+
+        assertThat(profilerMetrics.get(0).getName()).isEqualTo(PROFILER_METRICS_DATABASE_HOST);
+        assertThat(profilerMetrics.get(0).getValue()).isEqualTo("10.1.1.1");
+
+        assertThat(profilerMetrics.get(1).getName()).isEqualTo(PROFILER_METRICS_DATABASE_NAME);
+        assertThat(profilerMetrics.get(1).getValue()).isEqualTo("profiler_metric");
+
+        assertThat(profilerMetrics.get(2).getName()).isEqualTo(PROFILER_METRICS_DATABASE_TYPE);
+        assertThat(profilerMetrics.get(2).getValue()).isEqualTo("POSTGRES");
+
+        assertThat(profilerMetrics.get(3).getName()).isEqualTo(PROFILER_METRICS_DATABASE_USER);
+        assertThat(profilerMetrics.get(3).getValue()).isEqualTo("heyitsme");
+
+        assertThat(profilerMetrics.get(4).getName()).isEqualTo(PROFILER_METRICS_DATABASE_PASSWORD);
+        assertThat(profilerMetrics.get(4).getValue()).isEqualTo("iamsoosecure");
     }
 
     private String getBlueprintText(String path) {

--- a/template-manager-cmtemplate/src/test/resources/input/profilermanager.bp
+++ b/template-manager-cmtemplate/src/test/resources/input/profilermanager.bp
@@ -1,0 +1,124 @@
+{
+  "cdhVersion": "7.2.13",
+  "displayName": "Profiler-Cluster",
+  "services": [
+    {
+      "refName": "hdfs",
+      "serviceType": "HDFS",
+      "roleConfigGroups": [
+        {
+          "refName": "hdfs-NAMENODE-BASE",
+          "roleType": "NAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-SECONDARYNAMENODE-BASE",
+          "roleType": "SECONDARYNAMENODE",
+          "base": true
+        },
+        {
+          "refName": "hdfs-DATANODE-BASE",
+          "roleType": "DATANODE",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "hive",
+      "displayName": "Hive Metastore",
+      "roleConfigGroups": [
+        {
+          "base": true,
+          "refName": "hive-GATEWAY-BASE",
+          "roleType": "GATEWAY"
+        },
+        {
+          "base": true,
+          "refName": "hive-HIVEMETASTORE-BASE",
+          "roleType": "HIVEMETASTORE",
+          "configs": [
+            {
+              "name": "hive_compactor_initiator_on",
+              "value": "false"
+            }
+          ]
+        }
+      ],
+      "serviceType": "HIVE"
+    },
+    {
+      "refName": "zookeeper",
+      "serviceType": "ZOOKEEPER",
+      "roleConfigGroups": [
+        {
+          "refName": "zookeeper-SERVER-BASE",
+          "roleType": "SERVER",
+          "base": true
+        }
+      ]
+    },
+    {
+      "refName": "profiler_manager",
+      "serviceConfigs": [
+        {
+          "name": "hdfs_service",
+          "ref": "hdfs"
+        },
+        {
+          "name": "zookeeper_service",
+          "ref": "zookeeper"
+        },
+        {
+          "name": "hive_service",
+          "ref": "hive"
+        }
+      ],
+      "roleConfigGroups": [
+        {
+          "refName": "profiler_manager-PROFILER_ADMIN_AGENT-BASE",
+          "roleType": "PROFILER_ADMIN_AGENT",
+          "base": true
+        },
+        {
+          "refName": "profiler_manager-DATA_DISCOVERY_SERVICE_AGENT-BASE",
+          "roleType": "DATA_DISCOVERY_SERVICE_AGENT",
+          "base": true
+        },
+        {
+          "refName": "profiler_manager-PROFILER_METRICS_AGENT-BASE",
+          "roleType": "PROFILER_METRICS_AGENT",
+          "base": true
+        },
+        {
+          "refName": "profiler_manager-GATEWAY-BASE",
+          "roleType": "GATEWAY",
+          "base": true
+        }
+      ],
+      "serviceType": "PROFILER_MANAGER"
+    }
+  ],
+  "hostTemplates": [
+   {
+      "cardinality": 1,
+      "refName": "master",
+      "roleConfigGroupsRefNames": [
+        "hive-HIVEMETASTORE-BASE",
+        "zookeeper-SERVER-BASE",
+        "hdfs-NAMENODE-BASE",
+        "hdfs-SECONDARYNAMENODE-BASE",
+        "hdfs-DATANODE-BASE"
+      ]
+   },
+   {
+      "refName": "gateway",
+      "cardinality": 1,
+      "roleConfigGroupsRefNames": [
+        "profiler_manager-PROFILER_ADMIN_AGENT-BASE",
+        "profiler_manager-DATA_DISCOVERY_SERVICE_AGENT-BASE",
+        "profiler_manager-PROFILER_METRICS_AGENT-BASE",
+        "profiler_manager-GATEWAY-BASE"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
As Data catalog team is planning to add the Profiler Manager service into SDX blueprint. And it can be possible that the service can be part of GATEWAY/MASTER instance. We don't want to restrict it to the master node only. 

Testing:
1. I have done the testing by adding the profiler manager service into the GATEWAY instance of Medium DUTY SDX cluster, it worked. 