### PR TITLE
CB-14212 IPA server is not updated on CM nodes after FreeIPA repair

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/sssd/ipa.sls
@@ -38,6 +38,34 @@ join_ipa:
         - PW: "{{salt['pillar.get']('sssd-ipa:password')}}"
 {% endif %}
 
+{%- if salt['pillar.get']('freeipa:host', None) != None %}
+{%- set freeipa_fqdn = salt['pillar.get']('freeipa:host') %}
+update_default_server:
+  file.replace:
+    - name: /etc/ipa/default.conf
+    - pattern: "server =.*"
+    - repl: "server = {{ freeipa_fqdn }}"
+    - require:
+        - cmd: join_ipa
+
+update_default_host:
+  file.replace:
+    - name: /etc/ipa/default.conf
+    - pattern: "host =.*"
+    - repl: "host = {{ freeipa_fqdn }}"
+    - require:
+        - cmd: join_ipa
+
+update_default_xmlrpc_uri:
+  file.replace:
+    - name: /etc/ipa/default.conf
+    - pattern: "xmlrpc_uri =.*"
+    - repl: "xmlrpc_uri = https://{{ freeipa_fqdn }}/ipa/xml"
+    - require:
+        - cmd: join_ipa
+
+{%- endif %}
+
 {% if metadata.platform == 'YARN' and not metadata.cluster_in_childenvironment %}
 dns_remove_script:
   file.managed:


### PR DESCRIPTION
`/etc/ipa/default.conf` should always point to a valid FreeIPA server, so every `ipa` command would reach the same server
- during provisioning and when there is a change on FMS side the `default.conf` would be updated to a current server
- the choosing logic queries FMS for all instances and filters for ones in `CREATED` state and choose the first in alphabetical order
- if there is no instance in created choose the first one
- the file only edited if the FreeIPA join is successful and FMS is returning a response which is not 404

See detailed description in the commit message.