### PR TITLE
CB-12461 Update userdata during freeipa upgrade

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/ResourceConnector.java
@@ -208,6 +208,16 @@ public interface ResourceConnector<R> {
     List<CloudResourceStatus> update(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources) throws Exception;
 
     /**
+     * Update yser data for the cluster instances which contains parameters for user-data scricpt run during intsances' bootstrap.
+     *
+     * @param authenticatedContext the authenticated context which holds the client object
+     * @param stack                contains the full description of the new infrastructure (e.g new security groups)
+     * @param userData             the user data
+     * @throws Exception in case of any error
+     */
+    void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) throws Exception;
+
+    /**
      * Update of infrastructure on Cloud platform, add new instances. It does not need to wait/block until the infrastructure update is
      * finished, but it can return immediately and the {@link #check(AuthenticatedContext, List)} method is invoked to check regularly whether the
      * infrastructure and all resources have already been updated or not.

--- a/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/ResourceConnectorTest.java
+++ b/cloud-api/src/test/java/com/sequenceiq/cloudbreak/cloud/ResourceConnectorTest.java
@@ -111,6 +111,11 @@ class ResourceConnectorTest {
         }
 
         @Override
+        public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+
+        }
+
+        @Override
         public void checkUpdate(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources) throws Exception {
             return;
         }

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AutoScalingGroupHandler.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AutoScalingGroupHandler.java
@@ -35,8 +35,13 @@ public class AutoScalingGroupHandler {
 
     public Map<AutoScalingGroup, String> getAutoScalingGroups(AmazonCloudFormationClient cloudFormationClient,
             AmazonAutoScalingClient autoScalingClient, CloudResource cfResource) {
+        return getAutoScalingGroups(cloudFormationClient, autoScalingClient, cfResource.getName());
+    }
+
+    public Map<AutoScalingGroup, String> getAutoScalingGroups(AmazonCloudFormationClient cloudFormationClient,
+            AmazonAutoScalingClient autoScalingClient, String stackName) {
         DescribeStackResourcesRequest resourcesRequest = new DescribeStackResourcesRequest();
-        resourcesRequest.setStackName(cfResource.getName());
+        resourcesRequest.setStackName(stackName);
         DescribeStackResourcesResult resourcesResult = cloudFormationClient.describeStackResources(resourcesRequest);
         Map<String, String> autoScalingGroups = resourcesResult.getStackResources().stream()
                 .filter(stackResource -> "AWS::AutoScaling::AutoScalingGroup".equalsIgnoreCase(stackResource.getResourceType()))

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsImageUpdateService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsImageUpdateService.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.cloud.aws.connector.resource.AwsUpdateService;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
@@ -22,11 +23,11 @@ public class AwsImageUpdateService {
 
     public void updateImage(AuthenticatedContext authenticatedContext, CloudStack stack, CloudResource cfResource) {
         String cfTemplate = stack.getTemplate();
-        if (cfTemplate.contains("AWS::AutoScaling::LaunchConfiguration")) {
+        if (cfTemplate.contains(AwsUpdateService.LAUNCH_CONFIGURATION)) {
             awsLaunchConfigurationImageUpdateService.updateImage(authenticatedContext, stack, cfResource);
-        } else if (cfTemplate.contains("AWS::EC2::LaunchTemplate")) {
+        } else if (cfTemplate.contains(AwsUpdateService.LAUNCH_TEMPLATE)) {
             awsLaunchTemplateUpdateService.updateFields(authenticatedContext,
-                    cfResource, Map.of(LaunchTemplateField.IMAGE_ID, stack.getImage().getImageName()));
+                    cfResource.getName(), Map.of(LaunchTemplateField.IMAGE_ID, stack.getImage().getImageName()));
         } else {
             throw new NotImplementedException("Image update for stack template is not implemented yet.");
         }

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/LaunchTemplateField.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/LaunchTemplateField.java
@@ -2,5 +2,6 @@ package com.sequenceiq.cloudbreak.cloud.aws;
 
 public enum LaunchTemplateField {
     IMAGE_ID,
-    DESCRIPTION
+    DESCRIPTION,
+    USER_DATA
 }

--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsResourceConnector.java
@@ -165,6 +165,12 @@ public class AwsResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> cloudResources, String userData)
+            throws Exception {
+        awsUpdateService.updateUserData(authenticatedContext, stack, cloudResources, userData);
+    }
+
+    @Override
     public void checkUpdate(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources) throws Exception {
         awsUpdateService.checkUpdate(authenticatedContext, stack, resources);
     }

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsImageUpdateServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsImageUpdateServiceTest.java
@@ -46,8 +46,9 @@ public class AwsImageUpdateServiceTest {
 
         underTest.updateImage(ac, stack, cfResource);
 
+        String cfName = cfResource.getName();
         verify(awsLaunchConfigurationImageUpdateService).updateImage(ac, stack, cfResource);
-        verify(awsLaunchTemplateUpdateService, never()).updateFields(eq(ac), eq(cfResource), anyMap());
+        verify(awsLaunchTemplateUpdateService, never()).updateFields(eq(ac), eq(cfName), anyMap());
     }
 
     @Test
@@ -57,7 +58,8 @@ public class AwsImageUpdateServiceTest {
 
         underTest.updateImage(ac, stack, cfResource);
 
-        verify(awsLaunchTemplateUpdateService).updateFields(eq(ac), eq(cfResource), anyMap());
+        String cfName = cfResource.getName();
+        verify(awsLaunchTemplateUpdateService).updateFields(eq(ac), eq(cfName), anyMap());
         verify(awsLaunchConfigurationImageUpdateService, never()).updateImage(ac, stack, cfResource);
     }
 
@@ -67,7 +69,8 @@ public class AwsImageUpdateServiceTest {
 
         Assertions.assertThrows(NotImplementedException.class, () -> underTest.updateImage(ac, stack, cfResource));
 
-        verify(awsLaunchTemplateUpdateService, never()).updateFields(eq(ac), eq(cfResource), anyMap());
+        String cfName = cfResource.getName();
+        verify(awsLaunchTemplateUpdateService, never()).updateFields(eq(ac), eq(cfName), anyMap());
         verify(awsLaunchConfigurationImageUpdateService, never()).updateImage(ac, stack, cfResource);
     }
 }

--- a/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsLaunchTemplateUpdateServiceTest.java
+++ b/cloud-aws-cloudformation/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/AwsLaunchTemplateUpdateServiceTest.java
@@ -126,7 +126,7 @@ public class AwsLaunchTemplateUpdateServiceTest {
         when(autoScalingClient.updateAutoScalingGroup(any(UpdateAutoScalingGroupRequest.class))).thenReturn(new UpdateAutoScalingGroupResult());
 
         // WHEN
-        underTest.updateFields(ac, cfResource, Map.of(LaunchTemplateField.IMAGE_ID, stack.getImage().getImageName()));
+        underTest.updateFields(ac, cfResource.getName(), Map.of(LaunchTemplateField.IMAGE_ID, stack.getImage().getImageName()));
 
         // THEN no exception
     }
@@ -145,13 +145,13 @@ public class AwsLaunchTemplateUpdateServiceTest {
         when(cloudFormationClient.getTemplate(any())).thenReturn(new GetTemplateResult().withTemplateBody(cfTemplateBody));
 
         Map<AutoScalingGroup, String> autoScalingGroupsResult = createAutoScalingGroupHandler();
-        when(autoScalingGroupHandler.getAutoScalingGroups(cloudFormationClient, autoScalingClient, cfResource)).thenReturn(autoScalingGroupsResult);
+        when(autoScalingGroupHandler.getAutoScalingGroups(cloudFormationClient, autoScalingClient, cfResource.getName())).thenReturn(autoScalingGroupsResult);
         when(ec2Client.createLaunchTemplateVersion(any(CreateLaunchTemplateVersionRequest.class))).thenReturn(new CreateLaunchTemplateVersionResult()
                 .withWarning(new ValidationWarning().withErrors(new ValidationError().withCode("1").withMessage("error"))));
 
         // WHEN and THEN exception
         Assert.assertThrows(CloudConnectorException.class,
-                () -> underTest.updateFields(ac, cfResource, Map.of(LaunchTemplateField.IMAGE_ID, stack.getImage().getImageName())));
+                () -> underTest.updateFields(ac, cfResource.getName(), Map.of(LaunchTemplateField.IMAGE_ID, stack.getImage().getImageName())));
     }
 
     private Map<AutoScalingGroup, String> createAutoScalingGroupHandler() {

--- a/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeResourceConnector.java
+++ b/cloud-aws-native/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsNativeResourceConnector.java
@@ -54,6 +54,11 @@ public class AwsNativeResourceConnector extends AbstractResourceConnector {
     }
 
     @Override
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+        LOGGER.info("Update userdata is not implemented on AWS Native!");
+    }
+
+    @Override
     public TlsInfo getTlsInfo(AuthenticatedContext authenticatedContext, CloudStack cloudStack) {
         Network network = cloudStack.getNetwork();
         AwsNetworkView networkView = new AwsNetworkView(network);

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureResourceConnector.java
@@ -313,6 +313,11 @@ public class AzureResourceConnector extends AbstractResourceConnector {
     }
 
     @Override
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+        LOGGER.info("Update userdata is not implemented on Azure!");
+    }
+
+    @Override
     public List<CloudResourceStatus> upscale(AuthenticatedContext ac, CloudStack stack, List<CloudResource> resources) {
         AzureClient client = ac.getParameter(AzureClient.class);
         AzureStackView azureStackView = azureStackViewProvider.getAzureStack(new AzureCredentialView(ac.getCloudCredential()), stack, client, ac);

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpResourceConnector.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Lists;
@@ -28,6 +30,7 @@ import com.sequenceiq.common.api.type.ResourceType;
 
 @Service
 public class GcpResourceConnector extends AbstractResourceConnector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GcpResourceConnector.class);
 
     @Inject
     private LoadBalancerResourceService loadBalancerResourceService;
@@ -107,5 +110,10 @@ public class GcpResourceConnector extends AbstractResourceConnector {
     @Override
     public List<CloudResourceStatus> check(AuthenticatedContext authenticatedContext, List<CloudResource> resources) {
         return List.of();
+    }
+
+    @Override
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+        LOGGER.info("Update userdata is not implemented on GCP!");
     }
 }

--- a/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
+++ b/cloud-mock/src/main/java/com/sequenceiq/cloudbreak/cloud/mock/MockResourceConnector.java
@@ -133,6 +133,11 @@ public class MockResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+
+    }
+
+    @Override
     public void checkUpdate(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources) throws Exception {
         return;
     }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/heat/OpenStackResourceConnector.java
@@ -408,6 +408,11 @@ public class OpenStackResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) throws Exception {
+
+    }
+
+    @Override
     public void checkUpdate(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources) throws Exception {
         return;
     }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeResourceConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/OpenStackNativeResourceConnector.java
@@ -3,6 +3,8 @@ package com.sequenceiq.cloudbreak.cloud.openstack.nativ;
 import java.util.Collections;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
@@ -18,6 +20,7 @@ import com.sequenceiq.common.api.type.ResourceType;
 
 @Service
 public class OpenStackNativeResourceConnector extends AbstractResourceConnector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenStackNativeResourceConnector.class);
 
     @Override
     public TlsInfo getTlsInfo(AuthenticatedContext authenticatedContext, CloudStack cloudStack) {
@@ -48,5 +51,10 @@ public class OpenStackNativeResourceConnector extends AbstractResourceConnector 
     public List<CloudResourceStatus> launchLoadBalancers(AuthenticatedContext authenticatedContext, CloudStack stack, PersistenceNotifier persistenceNotifier)
             throws Exception {
         throw new UnsupportedOperationException("Load balancers are not supported for the open stack native resource connector.");
+    }
+
+    @Override
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+        LOGGER.info("Update userdata is not implemented on OpenStack Native!");
     }
 }

--- a/cloud-template/src/test/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnectorTest.java
+++ b/cloud-template/src/test/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnectorTest.java
@@ -55,6 +55,11 @@ public class AbstractResourceConnectorTest {
             }
 
             @Override
+            public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+
+            }
+
+            @Override
             public TlsInfo getTlsInfo(AuthenticatedContext authenticatedContext, CloudStack cloudStack) {
                 return null;
             }

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/YarnResourceConnector.java
@@ -240,6 +240,11 @@ public class YarnResourceConnector implements ResourceConnector<Object> {
     }
 
     @Override
+    public void updateUserData(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources, String userData) {
+        LOGGER.info("Update userdata is not implemented on Yarn!");
+    }
+
+    @Override
     public void checkUpdate(AuthenticatedContext authenticatedContext, CloudStack stack, List<CloudResource> resources) throws Exception {
         return;
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/FreeIpaFlowInformation.java
@@ -23,12 +23,14 @@ import com.sequenceiq.freeipa.flow.stack.start.StackStartFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.stop.StackStopFlowConfig;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationEvent;
 import com.sequenceiq.freeipa.flow.stack.termination.StackTerminationFlowConfig;
+import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataFlowConfig;
 
 @Component
 public class FreeIpaFlowInformation implements ApplicationFlowInformation {
 
     private static final List<Class<? extends FlowConfiguration<?>>> RESTARTABLE_FLOWS = List.of(
             ImageChangeFlowConfig.class,
+            UpdateUserDataFlowConfig.class,
             StackProvisionFlowConfig.class,
             StackTerminationFlowConfig.class,
             FreeIpaProvisionFlowConfig.class,

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/UpgradeFlowEventChainFactory.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/chain/UpgradeFlowEventChainFactory.java
@@ -29,6 +29,8 @@ import com.sequenceiq.freeipa.flow.freeipa.upgrade.UpgradeEvent;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.event.UpscaleEvent;
 import com.sequenceiq.freeipa.flow.stack.image.change.event.ImageChangeEvent;
+import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateRequest;
 
 @Component
 public class UpgradeFlowEventChainFactory implements FlowEventChainFactory<UpgradeEvent> {
@@ -51,6 +53,8 @@ public class UpgradeFlowEventChainFactory implements FlowEventChainFactory<Upgra
                 .withOperationId(event.getOperationId()));
         createBackupTriggerEvent(event).ifPresent(flowEventChain::add);
         flowEventChain.add(new ImageChangeEvent(IMAGE_CHANGE_EVENT.event(), event.getResourceId(), event.getImageSettingsRequest())
+                .withOperationId(event.getOperationId()));
+        flowEventChain.add(new UserDataUpdateRequest(UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT.event(), event.getResourceId())
                 .withOperationId(event.getOperationId()));
 
         int nonPrimaryGwInstanceCount = event.getInstanceIds().size();

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/UpdateUserDataEvents.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/UpdateUserDataEvents.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.freeipa.flow.stack.update;
+
+import com.sequenceiq.flow.core.FlowEvent;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateOnProviderResult;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateSuccess;
+
+public enum UpdateUserDataEvents implements FlowEvent {
+    UPDATE_USERDATA_TRIGGER_EVENT,
+    UPDATE_USERDATA_IN_DB_FINISHED_EVENT(UserDataUpdateOnProviderResult.selector(UserDataUpdateSuccess.class)),
+    UPDATE_USERDATA_ON_PROVIDER_FINISHED_EVENT(UserDataUpdateOnProviderResult.selector(UserDataUpdateOnProviderResult.class)),
+    UPDATE_USERDATA_FAILED_EVENT,
+    UPDATE_USERDATA_FAILURE_HANDLED_EVENT,
+    UPDATE_USERDATA_FINISHED_EVENT;
+
+    private final String event;
+
+    UpdateUserDataEvents(String event) {
+        this.event = event;
+    }
+
+    UpdateUserDataEvents() {
+        event = name();
+    }
+
+    @Override
+    public String event() {
+        return event;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/UpdateUserDataFlowConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/UpdateUserDataFlowConfig.java
@@ -1,0 +1,80 @@
+package com.sequenceiq.freeipa.flow.stack.update;
+
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents.UPDATE_USERDATA_FAILURE_HANDLED_EVENT;
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents.UPDATE_USERDATA_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents.UPDATE_USERDATA_IN_DB_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents.UPDATE_USERDATA_ON_PROVIDER_FINISHED_EVENT;
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataState.FINAL_STATE;
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataState.INIT_STATE;
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataState.UPDATE_USERDATA_FAILED_STATE;
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataState.UPDATE_USERDATA_FINISHED_STATE;
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataState.UPDATE_USERDATA_ON_PROVIDER_STATE;
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataState.UPDATE_USERDATA_STATE;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.flow.core.config.AbstractFlowConfiguration;
+
+@Component
+public class UpdateUserDataFlowConfig extends AbstractFlowConfiguration<UpdateUserDataState, UpdateUserDataEvents> {
+
+    private static final List<Transition<UpdateUserDataState, UpdateUserDataEvents>> TRANSITIONS =
+            new Transition.Builder<UpdateUserDataState, UpdateUserDataEvents>()
+                    .defaultFailureEvent(UpdateUserDataEvents.UPDATE_USERDATA_FAILED_EVENT)
+
+                    .from(INIT_STATE)
+                    .to(UPDATE_USERDATA_STATE)
+                    .event(UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT)
+                    .noFailureEvent()
+
+                    .from(UPDATE_USERDATA_STATE)
+                    .to(UPDATE_USERDATA_ON_PROVIDER_STATE)
+                    .event(UPDATE_USERDATA_IN_DB_FINISHED_EVENT)
+                    .defaultFailureEvent()
+
+                    .from(UPDATE_USERDATA_ON_PROVIDER_STATE)
+                    .to(UPDATE_USERDATA_FINISHED_STATE)
+                    .event(UPDATE_USERDATA_ON_PROVIDER_FINISHED_EVENT)
+                    .defaultFailureEvent()
+
+                    .from(UPDATE_USERDATA_FINISHED_STATE)
+                    .to(FINAL_STATE)
+                    .event(UPDATE_USERDATA_FINISHED_EVENT)
+                    .defaultFailureEvent()
+
+                    .build();
+
+    private static final FlowEdgeConfig<UpdateUserDataState, UpdateUserDataEvents> EDGE_CONFIG =
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, UPDATE_USERDATA_FAILED_STATE, UPDATE_USERDATA_FAILURE_HANDLED_EVENT);
+
+    public UpdateUserDataFlowConfig() {
+        super(UpdateUserDataState.class, UpdateUserDataEvents.class);
+    }
+
+    @Override
+    protected List<Transition<UpdateUserDataState, UpdateUserDataEvents>> getTransitions() {
+        return TRANSITIONS;
+    }
+
+    @Override
+    protected FlowEdgeConfig<UpdateUserDataState, UpdateUserDataEvents> getEdgeConfig() {
+        return EDGE_CONFIG;
+    }
+
+    @Override
+    public UpdateUserDataEvents[] getEvents() {
+        return UpdateUserDataEvents.values();
+    }
+
+    @Override
+    public UpdateUserDataEvents[] getInitEvents() {
+        return new UpdateUserDataEvents[]{UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT};
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "UserData update";
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/UpdateUserDataState.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/UpdateUserDataState.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.freeipa.flow.stack.update;
+
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.FlowState;
+import com.sequenceiq.flow.core.RestartAction;
+import com.sequenceiq.freeipa.flow.InitializeMDCContextRestartAction;
+
+public enum UpdateUserDataState implements FlowState {
+    INIT_STATE,
+    UPDATE_USERDATA_STATE,
+    UPDATE_USERDATA_ON_PROVIDER_STATE,
+    UPDATE_USERDATA_FAILED_STATE,
+    UPDATE_USERDATA_FINISHED_STATE,
+    FINAL_STATE;
+
+    private Class<? extends AbstractAction<?, ?, ?, ?>> action;
+
+    UpdateUserDataState(Class<? extends AbstractAction<?, ?, ?, ?>> action) {
+        this.action = action;
+    }
+
+    UpdateUserDataState() {
+    }
+
+    @Override
+    public Class<? extends AbstractAction<?, ?, ?, ?>> action() {
+        return action;
+    }
+
+    @Override
+    public Class<? extends RestartAction> restartAction() {
+        return InitializeMDCContextRestartAction.class;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/action/AbstractUserDataUpdateAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/action/AbstractUserDataUpdateAction.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.freeipa.flow.stack.update.action;
+
+import static com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone.availabilityZone;
+import static com.sequenceiq.cloudbreak.cloud.model.Location.location;
+import static com.sequenceiq.cloudbreak.cloud.model.Region.region;
+
+import javax.inject.Inject;
+
+import org.springframework.statemachine.StateContext;
+
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.common.event.Payload;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.flow.core.AbstractAction;
+import com.sequenceiq.flow.core.FlowParameters;
+import com.sequenceiq.freeipa.converter.cloud.CredentialToCloudCredentialConverter;
+import com.sequenceiq.freeipa.converter.cloud.StackToCloudStackConverter;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.OperationAwareAction;
+import com.sequenceiq.freeipa.flow.stack.StackContext;
+import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataState;
+import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents;
+import com.sequenceiq.freeipa.service.CredentialService;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+public abstract class AbstractUserDataUpdateAction<P extends Payload> extends AbstractAction<UpdateUserDataState, UpdateUserDataEvents, StackContext, P>
+        implements OperationAwareAction {
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private StackToCloudStackConverter cloudStackConverter;
+
+    @Inject
+    private CredentialToCloudCredentialConverter credentialConverter;
+
+    @Inject
+    private CredentialService credentialService;
+
+    protected AbstractUserDataUpdateAction(Class<P> payloadClass) {
+        super(payloadClass);
+    }
+
+    @Override
+    protected StackContext createFlowContext(FlowParameters flowParameters, StateContext<UpdateUserDataState, UpdateUserDataEvents> stateContext, P payload) {
+        Stack stack = stackService.getByIdWithListsInTransaction(payload.getResourceId());
+        MDCBuilder.buildMdcContext(stack);
+        Location location = location(region(stack.getRegion()), availabilityZone(stack.getAvailabilityZone()));
+        CloudContext cloudContext = CloudContext.Builder.builder()
+                .withId(stack.getId())
+                .withName(stack.getName())
+                .withCrn(stack.getResourceCrn())
+                .withPlatform(stack.getCloudPlatform())
+                .withVariant(stack.getPlatformvariant())
+                .withLocation(location)
+                .withUserName(stack.getOwner())
+                .withAccountId(stack.getAccountId())
+                .build();
+        CloudCredential cloudCredential = credentialConverter.convert(credentialService.getCredentialByEnvCrn(stack.getEnvironmentCrn()));
+        CloudStack cloudStack = cloudStackConverter.convert(stack);
+        return new StackContext(flowParameters, stack, cloudContext, cloudCredential, cloudStack);
+    }
+
+    public StackToCloudStackConverter getCloudStackConverter() {
+        return cloudStackConverter;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/action/UserDataUpdateActions.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/action/UserDataUpdateActions.java
@@ -1,0 +1,124 @@
+package com.sequenceiq.freeipa.flow.stack.update.action;
+
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents.UPDATE_USERDATA_FAILED_EVENT;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.statemachine.action.Action;
+
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.freeipa.converter.cloud.ResourceToCloudResourceConverter;
+import com.sequenceiq.freeipa.entity.Resource;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.flow.stack.StackContext;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateFailed;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateOnProviderRequest;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateOnProviderResult;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateRequest;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateSuccess;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+import com.sequenceiq.freeipa.service.resource.ResourceService;
+
+@Configuration
+public class UserDataUpdateActions {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserDataUpdateActions.class);
+
+    @Inject
+    private ResourceService resourceService;
+
+    @Inject
+    private ResourceToCloudResourceConverter resourceToCloudResourceConverter;
+
+    @Inject
+    private OperationService operationService;
+
+    @Bean(name = "UPDATE_USERDATA_STATE")
+    public AbstractUserDataUpdateAction<?> updateUserData() {
+        return new AbstractUserDataUpdateAction<>(UserDataUpdateRequest.class) {
+            @Override
+            protected void doExecute(StackContext context, UserDataUpdateRequest payload, Map<Object, Object> variables) throws Exception {
+                LOGGER.info("Recreate userdata for new freeipa instances");
+                setOperationId(variables, payload.getOperationId());
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackContext context) {
+                return new UserDataUpdateRequest(context.getStack().getId());
+            }
+
+            @Override
+            protected Object getFailurePayload(UserDataUpdateRequest payload, Optional<StackContext> flowContext, Exception ex) {
+                return new UserDataUpdateFailed(payload.getResourceId(), ex);
+            }
+        };
+    }
+
+    @Bean(name = "UPDATE_USERDATA_ON_PROVIDER_STATE")
+    public AbstractUserDataUpdateAction<?> updateUserDataOnProviderSide() {
+        return new AbstractUserDataUpdateAction<>(UserDataUpdateSuccess.class) {
+            @Override
+            protected void doExecute(StackContext context, UserDataUpdateSuccess payload, Map<Object, Object> variables) {
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackContext context) {
+                Stack stack = context.getStack();
+                String userData = stack.getImage().getUserdata();
+                List<CloudResource> cloudResources = getCloudResources(stack.getId());
+                return new UserDataUpdateOnProviderRequest(context.getCloudContext(), context.getCloudCredential(), context.getCloudStack(),
+                        cloudResources, userData);
+            }
+
+            @Override
+            protected Object getFailurePayload(UserDataUpdateSuccess payload, Optional<StackContext> flowContext, Exception ex) {
+                return new UserDataUpdateFailed(UPDATE_USERDATA_FAILED_EVENT.event(), payload.getResourceId(), ex);
+            }
+
+            private List<CloudResource> getCloudResources(Long stackId) {
+                List<Resource> resources = resourceService.findAllByStackId(stackId);
+                return resources.stream()
+                        .map(r -> resourceToCloudResourceConverter.convert(r))
+                        .collect(Collectors.toList());
+            }
+        };
+    }
+
+    @Bean(name = "UPDATE_USERDATA_FINISHED_STATE")
+    public AbstractUserDataUpdateAction<?> finishUserDataUpdate() {
+        return new AbstractUserDataUpdateAction<>(UserDataUpdateOnProviderResult.class) {
+            @Override
+            protected void doExecute(StackContext context, UserDataUpdateOnProviderResult payload, Map<Object, Object> variables) {
+                sendEvent(context);
+            }
+
+            @Override
+            protected Selectable createRequest(StackContext context) {
+                return new StackEvent(UpdateUserDataEvents.UPDATE_USERDATA_FINISHED_EVENT.selector(), context.getStack().getId());
+            }
+
+            @Override
+            protected Object getFailurePayload(UserDataUpdateOnProviderResult payload, Optional<StackContext> flowContext, Exception ex) {
+                return new UserDataUpdateFailed(UPDATE_USERDATA_FAILED_EVENT.event(), payload.getResourceId(), ex);
+            }
+        };
+    }
+
+    @Bean(name = "UPDATE_USERDATA_FAILED_STATE")
+    public Action<?, ?> handleUpdateUserDataFailure() {
+        return new UserDataUpdateFailureHandlerAction();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/action/UserDataUpdateFailureHandlerAction.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/action/UserDataUpdateFailureHandlerAction.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.freeipa.flow.stack.update.action;
+
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents.UPDATE_USERDATA_FAILURE_HANDLED_EVENT;
+
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.freeipa.flow.OperationAwareAction;
+import com.sequenceiq.freeipa.flow.stack.AbstractStackFailureAction;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.StackFailureContext;
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+import com.sequenceiq.freeipa.flow.stack.image.change.ImageChangeState;
+import com.sequenceiq.freeipa.flow.stack.image.change.event.ImageChangeEvents;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+
+class UserDataUpdateFailureHandlerAction extends AbstractStackFailureAction<ImageChangeState, ImageChangeEvents> implements OperationAwareAction {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserDataUpdateFailureHandlerAction.class);
+
+    @Inject
+    private OperationService operationService;
+
+    @Override
+    protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) throws Exception {
+        LOGGER.error("UserData change failed", payload.getException());
+        if (isOperationIdSet(variables)) {
+            operationService.failOperation(context.getStack().getAccountId(), getOperationId(variables), payload.getException().getMessage());
+        }
+        sendEvent(context, new StackEvent(UPDATE_USERDATA_FAILURE_HANDLED_EVENT.event(), context.getStack().getId()));
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateFailed.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateFailed.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.freeipa.flow.stack.update.event;
+
+import com.sequenceiq.freeipa.flow.stack.StackFailureEvent;
+
+public class UserDataUpdateFailed extends StackFailureEvent {
+    public UserDataUpdateFailed(Long stackId, Exception exception) {
+        super(stackId, exception);
+    }
+
+    public UserDataUpdateFailed(String selector, Long stackId, Exception exception) {
+        super(selector, stackId, exception);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateOnProviderRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateOnProviderRequest.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.freeipa.flow.stack.update.event;
+
+import java.util.List;
+
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.event.resource.CloudStackRequest;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+
+public class UserDataUpdateOnProviderRequest extends CloudStackRequest<UserDataUpdateOnProviderResult> {
+    private final List<CloudResource> cloudResources;
+
+    private final String userData;
+
+    public UserDataUpdateOnProviderRequest(CloudContext cloudContext, CloudCredential cloudCredential, CloudStack cloudStack, List<CloudResource> cloudResources,
+            String userData) {
+        super(cloudContext, cloudCredential, cloudStack);
+        this.cloudResources = cloudResources;
+        this.userData = userData;
+    }
+
+    public List<CloudResource> getCloudResources() {
+        return cloudResources;
+    }
+
+    public String getUserData() {
+        return userData;
+    }
+
+    @Override
+    public String toString() {
+        return "UserDataUpdateOnProviderRequest{" +
+                "cloudResources=" + cloudResources +
+                ", userData='" + userData + '\'' +
+                "} " + super.toString();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateOnProviderResult.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateOnProviderResult.java
@@ -1,0 +1,10 @@
+package com.sequenceiq.freeipa.flow.stack.update.event;
+
+import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+
+public class UserDataUpdateOnProviderResult extends CloudPlatformResult implements Selectable {
+    public UserDataUpdateOnProviderResult(Long resourceId) {
+        super(resourceId);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateRequest.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateRequest.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.freeipa.flow.stack.update.event;
+
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+
+public class UserDataUpdateRequest extends StackEvent {
+    private String operationId;
+
+    public UserDataUpdateRequest(Long stackId) {
+        super(stackId);
+    }
+
+    public UserDataUpdateRequest(String selector, Long stackId) {
+        super(selector, stackId);
+    }
+
+    public UserDataUpdateRequest withOperationId(String operationId) {
+        this.operationId = operationId;
+        return this;
+    }
+
+    public String getOperationId() {
+        return operationId;
+    }
+
+    @Override
+    public String toString() {
+        return "UserDataUpdateRequest{" +
+                "operationId='" + operationId + '\'' +
+                "} " + super.toString();
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateSuccess.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/event/UserDataUpdateSuccess.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.freeipa.flow.stack.update.event;
+
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+
+public class UserDataUpdateSuccess extends StackEvent {
+    public UserDataUpdateSuccess(Long stackId) {
+        super(stackId);
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/handler/UpdateUserDataHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/handler/UpdateUserDataHandler.java
@@ -1,0 +1,53 @@
+package com.sequenceiq.freeipa.flow.stack.update.handler;
+
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents.UPDATE_USERDATA_FAILED_EVENT;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+import com.sequenceiq.freeipa.flow.stack.StackEvent;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateFailed;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateRequest;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateSuccess;
+import com.sequenceiq.freeipa.service.image.userdata.UserDataService;
+
+import reactor.bus.Event;
+
+@Component
+public class UpdateUserDataHandler extends ExceptionCatcherEventHandler<UserDataUpdateRequest> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpdateUserDataHandler.class);
+
+    @Inject
+    private UserDataService userDataService;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(UserDataUpdateRequest.class);
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<UserDataUpdateRequest> event) {
+        LOGGER.error("Updating user data in the stack's image entity has failed", e);
+        return new UserDataUpdateFailed(UPDATE_USERDATA_FAILED_EVENT.event(), resourceId, e);
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent<UserDataUpdateRequest> event) {
+        StackEvent request = event.getData();
+        try {
+            LOGGER.info("Updating userData in the stack's current used image entity...");
+            userDataService.createUserData(request.getResourceId());
+            return new UserDataUpdateSuccess(request.getResourceId());
+        } catch (Exception e) {
+            LOGGER.error("Updating user data in the stack's image entity has failed", e);
+            return new UserDataUpdateFailed(UPDATE_USERDATA_FAILED_EVENT.event(), request.getResourceId(), e);
+        }
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/handler/UpdateUserDataOnProviderHandler.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/update/handler/UpdateUserDataOnProviderHandler.java
@@ -1,0 +1,67 @@
+package com.sequenceiq.freeipa.flow.stack.update.handler;
+
+import static com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents.UPDATE_USERDATA_FAILED_EVENT;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.CloudConnector;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.flow.event.EventSelectorUtil;
+import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+import com.sequenceiq.freeipa.converter.cloud.ResourceToCloudResourceConverter;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateFailed;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateOnProviderRequest;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateOnProviderResult;
+import com.sequenceiq.freeipa.service.resource.ResourceService;
+
+import reactor.bus.Event;
+
+@Component
+public class UpdateUserDataOnProviderHandler extends ExceptionCatcherEventHandler<UserDataUpdateOnProviderRequest> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpdateUserDataOnProviderHandler.class);
+
+    @Inject
+    private ResourceService resourceService;
+
+    @Inject
+    private ResourceToCloudResourceConverter resourceToCloudResourceConverter;
+
+    @Inject
+    private CloudPlatformConnectors cloudPlatformConnectors;
+
+    @Override
+    public String selector() {
+        return EventSelectorUtil.selector(UserDataUpdateOnProviderRequest.class);
+    }
+
+    @Override
+    protected Selectable defaultFailureEvent(Long resourceId, Exception e, Event<UserDataUpdateOnProviderRequest> event) {
+        LOGGER.error("Updating user data on provider side has failed", e);
+        return new UserDataUpdateFailed(UPDATE_USERDATA_FAILED_EVENT.event(), resourceId, e);
+    }
+
+    @Override
+    protected Selectable doAccept(HandlerEvent<UserDataUpdateOnProviderRequest> event) {
+        UserDataUpdateOnProviderRequest request = event.getData();
+        try {
+            LOGGER.info("Updating userData on cloud provider side...");
+            CloudConnector<?> connector = cloudPlatformConnectors.get(request.getCloudContext().getPlatformVariant());
+            AuthenticatedContext auth = connector.authentication().authenticate(request.getCloudContext(), request.getCloudCredential());
+            CloudStack stack = request.getCloudStack();
+
+            connector.resources().updateUserData(auth, stack, request.getCloudResources(), request.getUserData());
+            return new UserDataUpdateOnProviderResult(request.getResourceId());
+        } catch (Exception e) {
+            LOGGER.error("Updating user data on provider side has failed", e);
+            return new UserDataUpdateFailed(UPDATE_USERDATA_FAILED_EVENT.event(), request.getResourceId(), e);
+        }
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeFlowEventChainFactoryTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/chain/UpgradeFlowEventChainFactoryTest.java
@@ -27,6 +27,8 @@ import com.sequenceiq.freeipa.flow.freeipa.upgrade.UpgradeEvent;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.UpscaleFlowEvent;
 import com.sequenceiq.freeipa.flow.freeipa.upscale.event.UpscaleEvent;
 import com.sequenceiq.freeipa.flow.stack.image.change.event.ImageChangeEvent;
+import com.sequenceiq.freeipa.flow.stack.update.UpdateUserDataEvents;
+import com.sequenceiq.freeipa.flow.stack.update.event.UserDataUpdateRequest;
 
 class UpgradeFlowEventChainFactoryTest {
 
@@ -45,7 +47,7 @@ class UpgradeFlowEventChainFactoryTest {
 
         assertEquals("FreeIPA upgrade flow", eventQueue.getFlowChainName());
         Queue<Selectable> queue = eventQueue.getQueue();
-        assertEquals(10, queue.size());
+        assertEquals(11, queue.size());
 
         SaltUpdateTriggerEvent saltUpdateTriggerEvent = (SaltUpdateTriggerEvent) queue.poll();
         assertEquals(OPERATION_ID, saltUpdateTriggerEvent.getOperationId());
@@ -58,6 +60,11 @@ class UpgradeFlowEventChainFactoryTest {
         assertEquals(STACK_ID, imageChangeEvent.getResourceId());
         assertEquals(IMAGE_CHANGE_EVENT.event(), imageChangeEvent.selector());
         assertEquals(imageSettingsRequest, imageChangeEvent.getRequest());
+
+        UserDataUpdateRequest userDataUpdateRequest = (UserDataUpdateRequest) queue.poll();
+        assertEquals(OPERATION_ID, userDataUpdateRequest.getOperationId());
+        assertEquals(STACK_ID, userDataUpdateRequest.getResourceId());
+        assertEquals(UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT.event(), userDataUpdateRequest.selector());
 
         UpscaleEvent upscaleEvent1 = (UpscaleEvent) queue.poll();
         assertEquals(OPERATION_ID, upscaleEvent1.getOperationId());
@@ -148,7 +155,7 @@ class UpgradeFlowEventChainFactoryTest {
 
         assertEquals("FreeIPA upgrade flow", eventQueue.getFlowChainName());
         Queue<Selectable> queue = eventQueue.getQueue();
-        assertEquals(11, queue.size());
+        assertEquals(12, queue.size());
 
         SaltUpdateTriggerEvent saltUpdateTriggerEvent = (SaltUpdateTriggerEvent) queue.poll();
         assertEquals(OPERATION_ID, saltUpdateTriggerEvent.getOperationId());
@@ -167,6 +174,11 @@ class UpgradeFlowEventChainFactoryTest {
         assertEquals(STACK_ID, imageChangeEvent.getResourceId());
         assertEquals(IMAGE_CHANGE_EVENT.event(), imageChangeEvent.selector());
         assertEquals(imageSettingsRequest, imageChangeEvent.getRequest());
+
+        UserDataUpdateRequest userDataUpdateRequest = (UserDataUpdateRequest) queue.poll();
+        assertEquals(OPERATION_ID, userDataUpdateRequest.getOperationId());
+        assertEquals(STACK_ID, userDataUpdateRequest.getResourceId());
+        assertEquals(UpdateUserDataEvents.UPDATE_USERDATA_TRIGGER_EVENT.event(), userDataUpdateRequest.selector());
 
         UpscaleEvent upscaleEvent1 = (UpscaleEvent) queue.poll();
         assertEquals(OPERATION_ID, upscaleEvent1.getOperationId());


### PR DESCRIPTION
CB-12461 Update userdata during freeipa upgrade 

* After the image change flow a new flow is introduced for the user data update
* This is only needed on aws as the user data is stored in launch template for autoscaling groups, on other providers the user data is created before instance creation
* Currently only LaunchTemplate update is supported
