### PR TITLE
Merge 2.48 to master

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/ExtendedHostStatuses.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/status/ExtendedHostStatuses.java
@@ -52,6 +52,7 @@ public class ExtendedHostStatuses {
     public String statusReasonForHost(HostName hostName) {
         return emptyIfNull(hostsHealth.get(hostName)).stream()
                 .sorted(Comparator.comparing(HealthCheck::getType))
+                .filter(hc -> HealthCheckResult.UNHEALTHY == hc.getResult())
                 .map(HealthCheck::getReason)
                 .flatMap(Optional::stream)
                 .collect(Collectors.joining(" "));

--- a/cluster-api/src/test/java/com/sequenceiq/cloudbreak/cluster/status/ExtendedHostStatusesTest.java
+++ b/cluster-api/src/test/java/com/sequenceiq/cloudbreak/cluster/status/ExtendedHostStatusesTest.java
@@ -65,18 +65,22 @@ public class ExtendedHostStatusesTest {
     @Test
     public void testGetReason() {
         assertEquals("reason2 reason3 reason1", new ExtendedHostStatuses(Map.of(TEST_HOST,
+                Set.of(createHealthCheck(SERVICES, UNHEALTHY, "reason3"),
+                        createHealthCheck(CERT, UNHEALTHY, "reason1"),
+                        createHealthCheck(HOST, UNHEALTHY, "reason2")))).statusReasonForHost(TEST_HOST));
+        assertEquals("", new ExtendedHostStatuses(Map.of(TEST_HOST,
                 Set.of(createHealthCheck(SERVICES, HEALTHY, "reason3"),
                         createHealthCheck(CERT, HEALTHY, "reason1"),
                         createHealthCheck(HOST, HEALTHY, "reason2")))).statusReasonForHost(TEST_HOST));
         assertEquals("reason1 reason2 reason3", new ExtendedHostStatuses(Map.of(TEST_HOST,
-                Set.of(createHealthCheck(SERVICES, HEALTHY, "reason2"),
-                        createHealthCheck(CERT, HEALTHY, "reason3"),
-                        createHealthCheck(HOST, HEALTHY, "reason1")))).statusReasonForHost(TEST_HOST));
+                Set.of(createHealthCheck(SERVICES, UNHEALTHY, "reason2"),
+                        createHealthCheck(CERT, UNHEALTHY, "reason3"),
+                        createHealthCheck(HOST, UNHEALTHY, "reason1")))).statusReasonForHost(TEST_HOST));
         ExtendedHostStatuses extendedHostStatuses2 = new ExtendedHostStatuses(Map.of(TEST_HOST,
-                Set.of(createHealthCheck(SERVICES, HEALTHY, "reason2"),
-                        createHealthCheck(CERT, HEALTHY, "reason3"),
-                        createHealthCheck(HOST, HEALTHY, "reason1")),
-                TEST_HOST_2, Set.of(createHealthCheck(HOST, HEALTHY, "whatever"))));
+                Set.of(createHealthCheck(SERVICES, UNHEALTHY, "reason2"),
+                        createHealthCheck(CERT, UNHEALTHY, "reason3"),
+                        createHealthCheck(HOST, UNHEALTHY, "reason1")),
+                TEST_HOST_2, Set.of(createHealthCheck(HOST, UNHEALTHY, "whatever"))));
         assertEquals("reason1 reason2 reason3", extendedHostStatuses2.statusReasonForHost(TEST_HOST));
         assertEquals("whatever", extendedHostStatuses2.statusReasonForHost(TEST_HOST_2));
     }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
@@ -290,9 +290,10 @@ public class ClouderaManagerClusterStatusService implements ClusterStatusService
                 .filter(health -> HOST_AGENT_CERTIFICATE_EXPIRY.equals(health.getName()))
                 .findFirst();
         if (healthCheck.isPresent()) {
-            HealthCheckResult result = !ApiHealthSummary.GOOD.equals(healthCheck.get().getSummary()) ?
-                    HealthCheckResult.UNHEALTHY : HealthCheckResult.HEALTHY;
-            return Optional.of(new HealthCheck(HealthCheckType.CERT, result, Optional.empty()));
+            HealthCheckResult result = ApiHealthSummary.BAD.equals(healthCheck.get().getSummary())
+                    || ApiHealthSummary.CONCERNING.equals(healthCheck.get().getSummary()) ? HealthCheckResult.UNHEALTHY : HealthCheckResult.HEALTHY;
+            Optional<String> reason = Optional.ofNullable(healthCheck.get().getSummary()).map(apiSum -> "Cert health on CM: " + apiSum.getValue());
+            return Optional.of(new HealthCheck(HealthCheckType.CERT, result, reason));
         }
         return Optional.empty();
     }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusServiceTest.java
@@ -122,8 +122,8 @@ public class ClouderaManagerClusterStatusServiceTest {
     public void reportsClusterStatusPendingWhenAnyServiceIsStarting() throws ApiException {
         cmIsReachable();
         servicesAre(
-            new ApiService().name("service1").serviceState(ApiServiceState.STARTING),
-            new ApiService().name("service2").serviceState(ApiServiceState.STARTED)
+                new ApiService().name("service1").serviceState(ApiServiceState.STARTING),
+                new ApiService().name("service2").serviceState(ApiServiceState.STARTED)
         );
 
         assertEquals(ClusterStatus.PENDING, subject.getStatus(true).getClusterStatus());
@@ -245,7 +245,7 @@ public class ClouderaManagerClusterStatusServiceTest {
         );
 
         ExtendedHostStatuses extendedHostStatuses = subject.getExtendedHostStatuses(Optional.of("7.2.12"));
-        assertEquals("explanation.", extendedHostStatuses.statusReasonForHost(hostName("host3")));
+        assertEquals("explanation. Cert health on CM: BAD", extendedHostStatuses.statusReasonForHost(hostName("host3")));
         assertTrue(extendedHostStatuses.isAnyCertExpiring());
         assertTrue(extendedHostStatuses.isHostHealthy(hostName("host1")));
         assertTrue(extendedHostStatuses.isHostHealthy(hostName("host2")));
@@ -275,7 +275,7 @@ public class ClouderaManagerClusterStatusServiceTest {
         hostsAre(
                 new ApiHost().hostname("host1")
                         .addHealthChecksItem(new ApiHealthCheck().name(HOST_SCM_HEALTH).summary(ApiHealthSummary.BAD)
-                            .explanation("explanation"))
+                                .explanation("explanation"))
                         .addHealthChecksItem(new ApiHealthCheck().name(HOST_AGENT_CERTIFICATE_EXPIRY).summary(ApiHealthSummary.GOOD))
                         .addRoleRefsItem(roleRef("badservice", ApiHealthSummary.BAD)),
                 new ApiHost().hostname("host2")

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterServiceTest.java
@@ -114,7 +114,7 @@ class ClusterServiceTest {
 
     static Object[][] updateClusterMetadataScenarios() {
         return new Object[][]{
-                {"CM returns HEALTHY", HEALTHY, InstanceStatus.SERVICES_HEALTHY, STATUS_REASON_SERVER},
+                {"CM returns HEALTHY", HEALTHY, InstanceStatus.SERVICES_HEALTHY, ""},
                 {"CM returns UNHEALTHY", UNHEALTHY, InstanceStatus.SERVICES_UNHEALTHY, STATUS_REASON_SERVER},
                 {"CM returns no data for the host", null, InstanceStatus.SERVICES_RUNNING, STATUS_REASON_ORIGINAL},
         };


### PR DESCRIPTION
- cert health check should be considered unhealthy only if CM reports `BAD` or `CONCERNING` state
- host health reason summary includes only the reason in case it's unhealthy
- cert check reason contains the original health summary from CMSee detailed description in the commit message.