### PR TITLE
CB-13844 only use the v45 client when the CM server is already upgraded

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -153,14 +153,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
         String user = cluster.getCloudbreakAmbariUser();
         String password = cluster.getCloudbreakAmbariPassword();
         try {
-            ClouderaManagerRepo clouderaManagerRepoDetails = clusterComponentConfigProvider.getClouderaManagerRepoDetails(cluster.getId());
-            if (isVersionNewerOrEqualThanLimited(clouderaManagerRepoDetails::getVersion, CLOUDERAMANAGER_VERSION_7_5_1)) {
-                LOGGER.debug("Cloudera Manager version {} is newer than {} hence using v45 API", clouderaManagerRepoDetails.getVersion(),
-                        CLOUDERAMANAGER_VERSION_7_5_1.getVersion());
-                apiClient = clouderaManagerApiClientProvider.getV45Client(stack.getGatewayPort(), user, password, clientConfig);
-            } else {
-                apiClient = clouderaManagerApiClientProvider.getV31Client(stack.getGatewayPort(), user, password, clientConfig);
-            }
+            apiClient = clouderaManagerApiClientProvider.getV31Client(stack.getGatewayPort(), user, password, clientConfig);
         } catch (ClouderaManagerClientInitException e) {
             throw new ClusterClientInitException(e);
         }
@@ -340,11 +333,21 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
         String currentCMVersion = clouderaManagerRepo.getVersion();
         Versioned baseCMVersion = CLOUDERAMANAGER_VERSION_7_5_1;
         if (isVersionNewerOrEqualThanLimited(currentCMVersion, baseCMVersion)) {
-            LOGGER.debug("Cloudera Manager version {} is newer than {} hence calling post runtime upgrade command",
+            LOGGER.debug("Cloudera Manager version {} is newer than {} hence calling post runtime upgrade command using /v45 API",
                     currentCMVersion, baseCMVersion.getVersion());
             eventService.fireCloudbreakEvent(stack.getId(), UPDATE_IN_PROGRESS.name(), ResourceEvent.CLUSTER_UPGRADE_START_POST_UPGRADE);
             waitForRestartCommandIfThereIsAny(clustersResourceApi);
-            clouderaManagerUpgradeService.callPostRuntimeUpgradeCommand(clustersResourceApi, stack, apiClient);
+            Cluster cluster = stack.getCluster();
+            String user = cluster.getCloudbreakAmbariUser();
+            String password = cluster.getCloudbreakAmbariPassword();
+            try {
+                ApiClient v45Client = clouderaManagerApiClientProvider.getV45Client(stack.getGatewayPort(), user, password, clientConfig);
+                ClustersResourceApi clustersResourceV45Api = clouderaManagerApiFactory.getClustersResourceApi(v45Client);
+                clouderaManagerUpgradeService.callPostRuntimeUpgradeCommand(clustersResourceV45Api, stack, v45Client);
+            } catch (ClouderaManagerClientInitException e) {
+                LOGGER.info("Couldn't build CM v45 client", e);
+                throw new CloudbreakException(e);
+            }
         } else {
             LOGGER.debug("Cloudera Manager version {} is older than {} hence NOT calling post runtime upgrade command",
                     currentCMVersion, baseCMVersion.getVersion());


### PR DESCRIPTION
The first step of the upgrade process is to deactivate and remove the unused parcels.
However, when the execution get's there we've already updated the database to use
the new image and new components including the CM server version. Due to this it
was incorrectly determined that the v45 API is available. As part of this PR I'm
reverting the change and always use the v31 API except when the post upgrade command
needs to be invoked.

See detailed description in the commit message.