### PR TITLE
CB-14148 Validate user and resource account id in authz

### DIFF
--- a/authorization-common/src/main/java/com/sequenceiq/authorization/service/ResourceCrnAthorizationFactory.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/service/ResourceCrnAthorizationFactory.java
@@ -15,6 +15,7 @@ import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.authorization.service.model.AuthorizationRule;
 import com.sequenceiq.authorization.service.model.HasRight;
+import com.sequenceiq.authorization.utils.CrnAccountValidator;
 
 @Component
 public class ResourceCrnAthorizationFactory extends TypedAuthorizationFactory<CheckPermissionByResourceCrn> {
@@ -30,10 +31,14 @@ public class ResourceCrnAthorizationFactory extends TypedAuthorizationFactory<Ch
     @Inject
     private DefaultResourceAuthorizationProvider defaultResourceAuthorizationProvider;
 
+    @Inject
+    private CrnAccountValidator crnAccountValidator;
+
     @Override
     public Optional<AuthorizationRule> doGetAuthorization(CheckPermissionByResourceCrn methodAnnotation, String userCrn, ProceedingJoinPoint proceedingJoinPoint,
             MethodSignature methodSignature) {
         String resourceCrn = commonPermissionCheckingUtils.getParameter(proceedingJoinPoint, methodSignature, ResourceCrn.class, String.class);
+        crnAccountValidator.validateSameAccount(userCrn, resourceCrn);
         AuthorizationResourceAction action = methodAnnotation.action();
         LOGGER.debug("Getting authorization rule to authorize user [{}] for action [{}] over resource [{}]", userCrn, action, resourceCrn);
         return calcAuthorization(resourceCrn, action);

--- a/authorization-common/src/main/java/com/sequenceiq/authorization/service/ResourceCrnListAuthorizationFactory.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/service/ResourceCrnListAuthorizationFactory.java
@@ -18,6 +18,7 @@ import com.sequenceiq.authorization.annotation.ResourceCrnList;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.authorization.service.model.AuthorizationRule;
 import com.sequenceiq.authorization.service.model.HasRightOnAll;
+import com.sequenceiq.authorization.utils.CrnAccountValidator;
 
 @Component
 public class ResourceCrnListAuthorizationFactory extends TypedAuthorizationFactory<CheckPermissionByResourceCrnList> {
@@ -33,12 +34,16 @@ public class ResourceCrnListAuthorizationFactory extends TypedAuthorizationFacto
     @Inject
     private EnvironmentBasedAuthorizationProvider environmentBasedAuthorizationProvider;
 
+    @Inject
+    private CrnAccountValidator crnAccountValidator;
+
     @Override
     public Optional<AuthorizationRule> doGetAuthorization(CheckPermissionByResourceCrnList methodAnnotation, String userCrn,
             ProceedingJoinPoint proceedingJoinPoint, MethodSignature methodSignature) {
         AuthorizationResourceAction action = methodAnnotation.action();
         Collection<String> resourceCrns = commonPermissionCheckingUtils
                 .getParameter(proceedingJoinPoint, methodSignature, ResourceCrnList.class, Collection.class);
+        crnAccountValidator.validateSameAccount(userCrn, resourceCrns);
         LOGGER.debug("Getting authorization rule to authorize user [{}] for action [{}] over resources [{}]", userCrn, action,
                 Joiner.on(",").join(resourceCrns));
         return calcAuthorization(resourceCrns, action);

--- a/authorization-common/src/main/java/com/sequenceiq/authorization/utils/CrnAccountValidator.java
+++ b/authorization-common/src/main/java/com/sequenceiq/authorization/utils/CrnAccountValidator.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.authorization.utils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.auth.crn.InternalCrnBuilder;
+
+@Component
+public class CrnAccountValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CrnAccountValidator.class);
+
+    public void validateSameAccount(String userCrn, String resourceCrn) {
+        validateSameAccount(userCrn, List.of(resourceCrn));
+    }
+
+    public void validateSameAccount(String userCrnValue, Collection<String> resourceCrns) {
+        if ((Crn.isCrn(userCrnValue) && InternalCrnBuilder.isInternalCrn(userCrnValue))
+                || CollectionUtils.isEmpty(resourceCrns)) {
+            return;
+        }
+        Crn userCrn = Crn.ofUser(userCrnValue);
+        for (String resourceCrn : resourceCrns) {
+            validateSameAccount(userCrn, Crn.safeFromString(resourceCrn));
+        }
+    }
+
+    private void validateSameAccount(Crn userCrn, Crn resourceCrn) {
+        if (!Objects.equals(userCrn.getAccountId(), resourceCrn.getAccountId())) {
+            LOGGER.warn("User {} tried to access {} from different account.", userCrn, resourceCrn);
+            throw new AccessDeniedException(String.format("Can't access resource from different account.", resourceCrn, userCrn.getAccountId()));
+        }
+    }
+}

--- a/authorization-common/src/test/java/com/sequenceiq/authorization/service/RequestPropertyAuthorizationFactoryTest.java
+++ b/authorization-common/src/test/java/com/sequenceiq/authorization/service/RequestPropertyAuthorizationFactoryTest.java
@@ -35,6 +35,7 @@ import com.sequenceiq.authorization.resource.AuthorizationVariableType;
 import com.sequenceiq.authorization.service.model.AuthorizationRule;
 import com.sequenceiq.authorization.service.model.HasRight;
 import com.sequenceiq.authorization.service.model.HasRightOnAll;
+import com.sequenceiq.authorization.utils.CrnAccountValidator;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RequestPropertyAuthorizationFactoryTest {
@@ -62,6 +63,9 @@ public class RequestPropertyAuthorizationFactoryTest {
 
     @Mock
     private ResourceNameListAuthorizationFactory resourceNameListAuthorizationFactory;
+
+    @Mock
+    private CrnAccountValidator crnAccountValidator;
 
     @InjectMocks
     private RequestPropertyAuthorizationFactory underTest;

--- a/authorization-common/src/test/java/com/sequenceiq/authorization/service/ResourceCrnAthorizationProviderTest.java
+++ b/authorization-common/src/test/java/com/sequenceiq/authorization/service/ResourceCrnAthorizationProviderTest.java
@@ -23,6 +23,7 @@ import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.authorization.service.model.AuthorizationRule;
 import com.sequenceiq.authorization.service.model.HasRight;
 import com.sequenceiq.authorization.service.model.HasRightOnAny;
+import com.sequenceiq.authorization.utils.CrnAccountValidator;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ResourceCrnAthorizationProviderTest {
@@ -43,6 +44,9 @@ public class ResourceCrnAthorizationProviderTest {
 
     @Mock
     private DefaultResourceAuthorizationProvider defaultResourceAuthorizationProvider;
+
+    @Mock
+    private CrnAccountValidator crnAccountValidator;
 
     @InjectMocks
     private ResourceCrnAthorizationFactory underTest;

--- a/authorization-common/src/test/java/com/sequenceiq/authorization/service/ResourceCrnListAuthorizationFactoryTest.java
+++ b/authorization-common/src/test/java/com/sequenceiq/authorization/service/ResourceCrnListAuthorizationFactoryTest.java
@@ -24,6 +24,7 @@ import com.sequenceiq.authorization.annotation.ResourceCrnList;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.authorization.service.model.AuthorizationRule;
 import com.sequenceiq.authorization.service.model.HasRightOnAll;
+import com.sequenceiq.authorization.utils.CrnAccountValidator;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ResourceCrnListAuthorizationFactoryTest {
@@ -42,6 +43,9 @@ public class ResourceCrnListAuthorizationFactoryTest {
 
     @Mock
     private EnvironmentBasedAuthorizationProvider environmentBasedAuthorizationProvider;
+
+    @Mock
+    private CrnAccountValidator crnAccountValidator;
 
     @InjectMocks
     private ResourceCrnListAuthorizationFactory underTest;

--- a/authorization-common/src/test/java/com/sequenceiq/authorization/utils/CrnAccountValidatorTest.java
+++ b/authorization-common/src/test/java/com/sequenceiq/authorization/utils/CrnAccountValidatorTest.java
@@ -1,0 +1,72 @@
+package com.sequenceiq.authorization.utils;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.AccessDeniedException;
+
+import com.sequenceiq.cloudbreak.auth.crn.CrnParseException;
+
+public class CrnAccountValidatorTest {
+
+    private static final String ACCOUNT_1 = "account1";
+
+    private static final String ACCOUNT_2 = "account2";
+
+    private static final String INVALID_CRN = "INVALID_CRN";
+
+    private final CrnAccountValidator underTest = new CrnAccountValidator();
+
+    @Test
+    public void validIfUserIsInternal() {
+        assertDoesNotThrow(() ->
+                underTest.validateSameAccount("crn:cdp:iam:us-west-1:altus:user:__internal__actor__", environmentCrn(ACCOUNT_1)));
+    }
+
+    @Test
+    public void throwsAccessDeniedIfAccountsNotMatch() {
+        assertThrowsException(userCrn(ACCOUNT_1), List.of(environmentCrn(ACCOUNT_1), environmentCrn(ACCOUNT_2)), AccessDeniedException.class,
+                "Can't access resource from different account.");
+    }
+
+    @Test
+    public void throwsIllegalArgumentIfUserCrnIsInvalid() {
+        assertThrowsException(INVALID_CRN, environmentCrn(ACCOUNT_1), IllegalArgumentException.class,
+                "INVALID_CRN is not a valid user crn");
+    }
+
+    @Test
+    public void throwsIllegalArgumentIfResourceCrnIsInvalid() {
+        assertThrowsException(userCrn(ACCOUNT_1), INVALID_CRN, CrnParseException.class,
+                "INVALID_CRN does not match the CRN pattern");
+    }
+
+    @Test
+    public void throwsIllegalArgumentIfFirstParamIsNotUserCrn() {
+        assertThrowsException(environmentCrn(ACCOUNT_1), environmentCrn(ACCOUNT_1), IllegalArgumentException.class,
+                "crn:cdp:environments:us-west-1:account1:environment:1 is not a valid user crn");
+    }
+
+    private String userCrn(String accountId) {
+        return String.format("crn:cdp:iam:us-west-1:%s:user:1", accountId);
+    }
+
+    private String environmentCrn(String accountId) {
+        return String.format("crn:cdp:environments:us-west-1:%s:environment:1", accountId);
+    }
+
+    private <T extends RuntimeException> void assertThrowsException(String userCrn, String resourceCrn, Class<T> exceptionClass, String message) {
+        T exception = assertThrows(exceptionClass, () -> underTest.validateSameAccount(userCrn, List.of(resourceCrn)));
+        assertEquals(message, exception.getMessage());
+    }
+
+    private <T extends RuntimeException> void assertThrowsException(String userCrn, Collection<String> resourceCrns, Class<T> exceptionClass, String message) {
+        T exception = assertThrows(exceptionClass, () -> underTest.validateSameAccount(userCrn, resourceCrns));
+        assertEquals(message, exception.getMessage());
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/service/integration/EnvironmentServiceIntegrationTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/service/integration/EnvironmentServiceIntegrationTest.java
@@ -91,6 +91,10 @@ public class EnvironmentServiceIntegrationTest {
 
     private static final String TEST_RESOURCE_CRN = String.format("crn:cdp:environments:us-west-1:%s:credential:asdasd", TEST_ACCOUNT_ID);
 
+    private static final String TEST_RESOURCE_CRN_IN_OTHER_ACCOUNT = String.format("crn:cdp:environments:us-west-1:%s:credential:asdasd", "otherAccountId");
+
+    private static final String NOT_EXISTING_RESOURCE_CRN = String.format("crn:cdp:environments:us-west-1:%s:credential:nonexisting", TEST_ACCOUNT_ID);
+
     private static final String USER_CODE = "1234";
 
     private static final String VERIFICATION_URL = "http://cloudera.com";
@@ -268,7 +272,12 @@ public class EnvironmentServiceIntegrationTest {
 
     @Test
     public void testCredentialGetByCrnNotFound() {
-        assertThrows(NotFoundException.class, () -> client.credentialV1Endpoint().getByResourceCrn("nonexisting"));
+        assertThrows(NotFoundException.class, () -> client.credentialV1Endpoint().getByResourceCrn(NOT_EXISTING_RESOURCE_CRN));
+    }
+
+    @Test
+    public void testCredentialGetByCrnAccessDeniedIfAccountDoesntMatch() {
+        assertThrows(ForbiddenException.class, () -> client.credentialV1Endpoint().getByResourceCrn(TEST_RESOURCE_CRN_IN_OTHER_ACCOUNT));
     }
 
     @Test
@@ -294,7 +303,7 @@ public class EnvironmentServiceIntegrationTest {
 
     @Test
     public void testCredentialDeleteByCrnNotFound() {
-        assertThrows(NotFoundException.class, () -> client.credentialV1Endpoint().deleteByResourceCrn("nonexisting"));
+        assertThrows(NotFoundException.class, () -> client.credentialV1Endpoint().deleteByResourceCrn(NOT_EXISTING_RESOURCE_CRN));
     }
 
     @Test


### PR DESCRIPTION
Validate if the user's account is the same as the requested resources. If not throw an access denied exception. The exception intentionally doesn't contain information about the user crn or the resources crn since it can be a programming error and we don't want to leak resource crns to users in other accounts. When the account validation fails we log it on WARN level.