### PR TITLE
CB-14237 Fail handling: Add REQUESTED states to convertStatus method …

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/Status.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/Status.java
@@ -175,15 +175,19 @@ public enum Status {
             case REQUESTED:
             case CREATE_IN_PROGRESS:
                 return CREATE_FAILED;
+            case UPDATE_REQUESTED:
             case UPDATE_IN_PROGRESS:
                 return UPDATE_FAILED;
+            case RECOVERY_REQUESTED:
             case RECOVERY_IN_PROGRESS:
                 return RECOVERY_FAILED;
             case DELETE_IN_PROGRESS:
             case PRE_DELETE_IN_PROGRESS:
                 return DELETE_FAILED;
+            case START_REQUESTED:
             case START_IN_PROGRESS:
                 return START_FAILED;
+            case STOP_REQUESTED:
             case STOP_IN_PROGRESS:
                 return STOP_FAILED;
             case BACKUP_IN_PROGRESS:


### PR DESCRIPTION
…in Status field

We have a fail handler for missed error handling in handlers/actions. In CB Core we are using a status converter to map status to a failed state if an error unexpectedly happened in handlers/actions. The REQUESTED states are missing, so if a flow fails unexpectedly before it can put the status to IN_PROGRESS, then we don't put the stack to FAILED status. This is why we need REQUESTED states like UPDATE_REQUESTED, START_REQUESTED to be mapped to a fail state.

See detailed description in the commit message.