### PR TITLE
CDPD-27965 Atlas is up but Knox throws service connectivity error trying to connect to Atlas

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.1.0/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.1.0/cdp-sdx.bp
@@ -114,6 +114,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.0/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.0/cdp-sdx.bp
@@ -114,6 +114,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.1/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.1/cdp-sdx.bp
@@ -136,6 +136,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx-medium-ha.bp
@@ -187,6 +187,10 @@
               {
                 "name": "atlas_solr_replication_factor",
                 "value": "2"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx.bp
@@ -136,6 +136,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx-medium-ha.bp
@@ -187,6 +187,10 @@
               {
                 "name": "atlas_solr_replication_factor",
                 "value": "2"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx.bp
@@ -136,6 +136,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx-medium-ha.bp
@@ -187,6 +187,10 @@
               {
                 "name": "atlas_solr_replication_factor",
                 "value": "2"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx-micro.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx-micro.bp
@@ -136,6 +136,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-medium-ha.bp
@@ -187,6 +187,10 @@
               {
                 "name": "atlas_solr_replication_factor",
                 "value": "2"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-micro.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-micro.bp
@@ -136,6 +136,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx.bp
@@ -136,6 +136,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
@@ -171,6 +171,10 @@
               {
                 "name": "atlas_solr_replication_factor",
                 "value": "2"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx.bp
@@ -136,6 +136,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx-medium-ha.bp
@@ -171,6 +171,10 @@
               {
                 "name": "atlas_solr_replication_factor",
                 "value": "2"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx.bp
@@ -136,6 +136,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
@@ -187,6 +187,10 @@
               {
                 "name": "atlas_solr_replication_factor",
                 "value": "2"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx.bp
@@ -136,6 +136,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx-medium-ha.bp
@@ -187,6 +187,10 @@
               {
                 "name": "atlas_solr_replication_factor",
                 "value": "2"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx.bp
@@ -136,6 +136,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx-medium-ha.bp
@@ -187,6 +187,10 @@
               {
                 "name": "atlas_solr_replication_factor",
                 "value": "2"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx.bp
@@ -136,6 +136,10 @@
               {
                 "name": "atlas_authentication_method_file",
                 "value": "false"
+              },
+              {
+                "name": "atlas_ssl_exclude_protocols",
+                "value": "TLSv1,TLSv1.1"
               }
             ],
             "refName": "atlas-ATLAS_SERVER-BASE",


### PR DESCRIPTION
Adds the "atlas_ssl_exclude_protocols" : "TLSv1,TLSv1.1" setting to all SDX blueprints.
Tested via creating two datalakes (one 7.2.12, one 7.2.2) and verifying the service configuration
was set as expected, and the Atlas UI was accessible via Knox proxy.

See detailed description in the commit message.