### PR TITLE
CB-14173: Add intermediary `clouderamanager` for backup and restore sls.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/.pgpass
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/.pgpass
@@ -1,6 +1,6 @@
 {% set configure_remote_db = salt['pillar.get']('postgres:configure_remote_db', 'None') %}
 {% if 'None' != configure_remote_db %}
-{{ pillar['postgres']['remote_db_url'] }}:{{ pillar['postgres']['remote_db_port'] }}:hive:{{ pillar['postgres']['remote_admin'] }}:{{ pillar['postgres']['remote_admin_pw'] }}
-{{ pillar['postgres']['remote_db_url'] }}:{{ pillar['postgres']['remote_db_port'] }}:ranger:{{ pillar['postgres']['remote_admin'] }}:{{ pillar['postgres']['remote_admin_pw'] }}
-{{ pillar['postgres']['remote_db_url'] }}:{{ pillar['postgres']['remote_db_port'] }}:postgres:{{ pillar['postgres']['remote_admin'] }}:{{ pillar['postgres']['remote_admin_pw'] }}
+{{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:hive:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
+{{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:ranger:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
+{{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:postgres:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/backup.sls
@@ -6,7 +6,7 @@ include:
 {% if 'None' != configure_remote_db %}
 backup_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:close_connections')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
+    - name: /opt/salt/scripts/backup_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:clouderamanager:remote_db_url')}} {{salt['pillar.get']('postgres:clouderamanager:remote_db_port')}} {{salt['pillar.get']('postgres:clouderamanager:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:close_connections')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
     - require:
       - sls: postgresql.disaster_recovery
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/restore.sls
@@ -6,7 +6,7 @@ include:
 {% if 'None' != configure_remote_db %}
 restore_postgresql_db:
   cmd.run:
-    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:remote_db_url')}} {{salt['pillar.get']('postgres:remote_db_port')}} {{salt['pillar.get']('postgres:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
+    - name: /opt/salt/scripts/restore_db.sh {{salt['pillar.get']('disaster_recovery:object_storage_url')}} {{salt['pillar.get']('postgres:clouderamanager:remote_db_url')}} {{salt['pillar.get']('postgres:clouderamanager:remote_db_port')}} {{salt['pillar.get']('postgres:clouderamanager:remote_admin')}} {{salt['pillar.get']('disaster_recovery:ranger_admin_group')}} {{salt['pillar.get']('disaster_recovery:database_name') or ''}}
     - require:
         - sls: postgresql.disaster_recovery
 


### PR DESCRIPTION
Closes [CB-14173](https://jira.cloudera.com/browse/CB-14173).

I added an additional property to look up the values needed for `.pgpass`.

However, this only uncovered another issue on the DH -- we'll need to add the `smm` table to the `.pgpass` file in order to connect to that database. We can do that, but this obviously doesn't scale long term.

This is a limitation to my original design, and means that we'll probably need to rethink how credentials are supplied to the backup/restore scripts as they connect to DB instances.

