### PR TITLE
CB-14221 Seperate out SAN generation logic for LB into a separate cla…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProvider.java
@@ -1,0 +1,58 @@
+package com.sequenceiq.cloudbreak.san;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_4_3;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
+import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.stack.LoadBalancerPersistenceService;
+import com.sequenceiq.common.api.type.LoadBalancerType;
+
+@Service
+public class LoadBalancerSANProvider {
+
+    @Inject
+    private LoadBalancerConfigService loadBalancerConfigService;
+
+    @Inject
+    private LoadBalancerPersistenceService loadBalancerPersistenceService;
+
+    @Inject
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+
+    public Optional<String> getLoadBalancerSAN(Stack stack) {
+        checkNotNull(stack);
+        checkNotNull(stack.getCluster());
+        ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(stack.getCluster().getId());
+        if (isVersionNewerOrEqualThanLimited(clouderaManagerRepo.getVersion(), CLOUDERAMANAGER_VERSION_7_4_3)) {
+            Set<LoadBalancer> loadBalancers = loadBalancerPersistenceService.findByStackId(stack.getId());
+            if (!loadBalancers.isEmpty()) {
+                Optional<LoadBalancer> loadBalancer = loadBalancerConfigService.selectLoadBalancer(loadBalancers, LoadBalancerType.PUBLIC);
+                return loadBalancer.flatMap(this::getBestSANForLB);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> getBestSANForLB(LoadBalancer lb) {
+        if (isNotBlank(lb.getFqdn())) {
+            return Optional.of("DNS:" + lb.getFqdn());
+        }
+        if (isNotBlank(lb.getDns())) {
+            return Optional.of("DNS:" + lb.getDns());
+        }
+        return Optional.of("IP:" + lb.getIp());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProviderTest.java
@@ -1,0 +1,103 @@
+package com.sequenceiq.cloudbreak.san;
+
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_4_2;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_4_3;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
+import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
+import com.sequenceiq.cloudbreak.service.stack.LoadBalancerPersistenceService;
+import com.sequenceiq.common.api.type.LoadBalancerType;
+
+@ExtendWith(MockitoExtension.class)
+class LoadBalancerSANProviderTest {
+
+    public static final long ID = 1L;
+
+    @InjectMocks
+    private LoadBalancerSANProvider loadBalancerSANProvider;
+
+    @Mock
+    private LoadBalancerConfigService loadBalancerConfigService;
+
+    @Mock
+    private LoadBalancerPersistenceService loadBalancerPersistenceService;
+
+    @Mock
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+
+    @Mock
+    private ClouderaManagerRepo clouderaManagerRepo;
+
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() {
+        loadBalancerSANProvider = new LoadBalancerSANProvider();
+        stack = new Stack();
+        stack.setId(ID);
+        Cluster cluster = new Cluster();
+        cluster.setId(ID);
+        stack.setCluster(cluster);
+
+        ReflectionTestUtils.setField(loadBalancerSANProvider, "loadBalancerConfigService", loadBalancerConfigService);
+        ReflectionTestUtils.setField(loadBalancerSANProvider, "loadBalancerPersistenceService", loadBalancerPersistenceService);
+        ReflectionTestUtils.setField(loadBalancerSANProvider, "clusterComponentConfigProvider", clusterComponentConfigProvider);
+
+        when(clusterComponentConfigProvider.getClouderaManagerRepoDetails(ID)).thenReturn(clouderaManagerRepo);
+        when(clouderaManagerRepo.getVersion()).thenReturn(CLOUDERAMANAGER_VERSION_7_4_3.getVersion());
+    }
+
+    @Test
+    void newerVersionHasNoLoadBalancer() {
+        assertTrue(loadBalancerSANProvider.getLoadBalancerSAN(stack).isEmpty());
+    }
+
+    @Test
+    void olderVersionHasNoLoadBalancer() {
+        when(clouderaManagerRepo.getVersion()).thenReturn(CLOUDERAMANAGER_VERSION_7_4_2.getVersion());
+        assertTrue(loadBalancerSANProvider.getLoadBalancerSAN(stack).isEmpty());
+    }
+
+    @Test
+    void newerVersionHasLoadBalancerWithDNS() {
+        loadBalancerSetUp("foobar.timbuk2.com");
+        assertEquals("DNS:foobar.timbuk2.com", loadBalancerSANProvider.getLoadBalancerSAN(stack).get());
+    }
+
+    @Test
+    void newerVersionHasLoadBalancerWithoutDNS() {
+        loadBalancerSetUp(null);
+        assertEquals("IP:10.10.10.10", loadBalancerSANProvider.getLoadBalancerSAN(stack).get());
+    }
+
+    private void loadBalancerSetUp(String dns) {
+        LoadBalancer loadBalancer = new LoadBalancer();
+        if (dns != null) {
+            loadBalancer.setDns("foobar.timbuk2.com");
+        }
+        loadBalancer.setIp("10.10.10.10");
+        Set<LoadBalancer> loadBalancers = new HashSet<>();
+        loadBalancers.add(loadBalancer);
+        when(loadBalancerPersistenceService.findByStackId(ID)).thenReturn(loadBalancers);
+        when(loadBalancerConfigService.selectLoadBalancer(loadBalancers, LoadBalancerType.PUBLIC)).thenReturn(Optional.of(loadBalancer));
+    }
+}


### PR DESCRIPTION
…ss for reuse and testability

1. There are two code paths where SAN is required, provisioning and cert renewal.
2. In this change the SAN generation logic is separated from provisioning and made as a common service.
3. In the next change cert renewal interface will be refactored to accept the SAN value from the caller.