### PR TITLE
CB-14221 Cert renewal needs subAltName if it was set during provisioning

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -116,8 +116,8 @@ public interface ClusterApi {
         return clusterModificationService().getRoleConfigValueByServiceType(clusterName, roleConfigGroup, serviceType, configName);
     }
 
-    default void rotateHostCertificates(String sshUser, KeyPair sshKeyPair) throws CloudbreakException {
-        clusterSecurityService().rotateHostCertificates(sshUser, sshKeyPair);
+    default void rotateHostCertificates(String sshUser, KeyPair sshKeyPair, String subAltName) throws CloudbreakException {
+        clusterSecurityService().rotateHostCertificates(sshUser, sshKeyPair, subAltName);
     }
 
     default ClusterStatus getStatus(boolean blueprintPresent) {

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSecurityService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterSecurityService.java
@@ -44,5 +44,5 @@ public interface ClusterSecurityService {
 
     String getMasterKey();
 
-    void rotateHostCertificates(String sshUser, KeyPair sshKeyPair) throws CloudbreakException;
+    void rotateHostCertificates(String sshUser, KeyPair sshKeyPair, String subAltName) throws CloudbreakException;
 }


### PR DESCRIPTION
1. The following refactoring enables the cert renewal command to get the subAltName.
2. The interfaces must be refactored because the cluster-cm module does not have the ability to talk to the database.
3. A unit test is added to make sure that subAltName is indeed passed to the CM batch api call to rotate the certificate.