### PR TITLE
CB-14255 Stack.toString() and Cluster.toString() threw a NPE because …

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/Cluster.java
@@ -825,9 +825,13 @@ public class Cluster implements ProvisionEntity, WorkspaceAwareResource {
 
     @Override
     public String toString() {
+        String resourceCrn = "Stack not set yet";
+        if (stack != null) {
+            resourceCrn = stack.getResourceCrn();
+        }
         return "Cluster{" +
                 "id=" + id +
-                ", stackResourceCrn='" + stack.getResourceCrn() + '\'' +
+                ", stackResourceCrn='" + resourceCrn + '\'' +
                 ", name='" + name + '\'' +
                 ", status=" + status +
                 ", statusReason='" + statusReason + '\'' +


### PR DESCRIPTION
…during the stack/cluster preparation the stack is null. Until this, we need to check the stack in clsuter

See detailed description in the commit message.