### PR TITLE
CB-14234: Remove unnecessary components from the database in the begining of the upgrade

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -238,6 +238,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
             ClouderaManagerResourceApi clouderaManagerResourceApi = clouderaManagerApiFactory.getClouderaManagerResourceApi(apiClient);
             checkParcelApiAvailability();
             Set<ClouderaManagerProduct> products = getProducts(components);
+            LOGGER.info("The following products will be downloaded and distributed: {}", products);
             setParcelRepo(products, clouderaManagerResourceApi);
             refreshParcelRepos(clouderaManagerResourceApi);
             if (patchUpgrade) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
@@ -34,8 +34,8 @@ import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
-import com.sequenceiq.cloudbreak.service.parcel.ParcelService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.upgrade.ClusterComponentUpdater;
 import com.sequenceiq.cloudbreak.util.NodesUnreachableException;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 
@@ -65,15 +65,15 @@ public class ClusterManagerUpgradeService {
     private ClusterHostServiceRunner clusterHostServiceRunner;
 
     @Inject
-    private ParcelService parcelService;
+    private ClusterComponentUpdater clusterComponentUpdater;
 
     @Inject
     private CsdParcelDecorator csdParcelDecorator;
 
-    public void removeUnusedComponents(Long stackId) throws CloudbreakException {
+    public void removeUnusedComponents(Long stackId, Set<ClusterComponent> clusterComponentsByBlueprint) throws CloudbreakException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        Set<ClusterComponent> blueprintProducts = parcelService.getParcelComponentsByBlueprint(stack);
-        clusterApiConnectors.getConnector(stack).removeUnusedParcels(blueprintProducts);
+        clusterApiConnectors.getConnector(stack).removeUnusedParcels(clusterComponentsByBlueprint);
+        clusterComponentUpdater.removeUnusedCdhProductsFromClusterComponents(stack.getCluster().getId(), clusterComponentsByBlueprint);
     }
 
     public void upgradeClusterManager(Long stackId, boolean runtimeServicesStartNeeded) throws CloudbreakOrchestratorException, CloudbreakException {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterUpgradeInitHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/upgrade/ClusterUpgradeInitHandler.java
@@ -58,12 +58,12 @@ public class ClusterUpgradeInitHandler extends ExceptionCatcherEventHandler<Clus
         ClusterUpgradeInitRequest request = event.getData();
         Selectable result;
         try {
-            clusterManagerUpgradeService.removeUnusedComponents(request.getResourceId());
-            Set<ClusterComponent> components = parcelService.getParcelComponentsByBlueprint(stack);
-            clusterApiConnectors.getConnector(stack).downloadAndDistributeParcels(components, request.isPatchUpgrade());
+            Set<ClusterComponent> componentsByBlueprint = parcelService.getParcelComponentsByBlueprint(stack);
+            clusterManagerUpgradeService.removeUnusedComponents(request.getResourceId(), componentsByBlueprint);
+            clusterApiConnectors.getConnector(stack).downloadAndDistributeParcels(componentsByBlueprint, request.isPatchUpgrade());
             result = new ClusterUpgradeInitSuccess(request.getResourceId());
         } catch (Exception e) {
-            LOGGER.info("Cluster Manager parcel deactivaton failed", e);
+            LOGGER.error("Cluster Manager parcel deactivation failed", e);
             result = new ClusterUpgradeFailedEvent(request.getResourceId(), e, DetailedStackStatus.CLUSTER_UPGRADE_INIT_FAILED);
         }
         return result;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterComponentUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterComponentUpdater.java
@@ -82,4 +82,23 @@ public class ClusterComponentUpdater {
         LOGGER.debug("Removing unused components: {}", unusedCdhProductDetails);
         clusterComponentConfigProvider.deleteClusterComponents(unusedCdhProductDetails);
     }
+
+    public void removeUnusedCdhProductsFromClusterComponents(Long clusterId, Set<ClusterComponent> clusterComponentsByBlueprint) {
+        Set<ClusterComponent> clusterComponentsFromDb = clusterComponentConfigProvider.getComponentsByClusterId(clusterId);
+        Set<ClusterComponent> componentsToDelete = getUnusedComponents(clusterComponentsByBlueprint, clusterComponentsFromDb);
+        if (componentsToDelete.isEmpty()) {
+            LOGGER.debug("There is no cluster component to be deleted.");
+        } else {
+            LOGGER.debug("The following cluster components will be deleted: {}", componentsToDelete);
+            clusterComponentConfigProvider.deleteClusterComponents(componentsToDelete);
+        }
+    }
+
+    private Set<ClusterComponent> getUnusedComponents(Set<ClusterComponent> clusterComponentsByBlueprint, Set<ClusterComponent> clusterComponentsFromDb) {
+        return clusterComponentsFromDb.stream()
+                .filter(clusterComponent -> ComponentType.CDH_PRODUCT_DETAILS.equals(clusterComponent.getComponentType()))
+                .filter(clusterComponent -> clusterComponentsByBlueprint.stream()
+                        .noneMatch(component -> clusterComponent.getName().equals(component.getName())))
+                .collect(Collectors.toSet());
+    }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterComponentUpdaterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterComponentUpdaterTest.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.cloudbreak.service.upgrade;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.common.type.ComponentType;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterComponentUpdaterTest {
+
+    private static final long CLUSTER_ID = 1L;
+
+    private static final String CDH = "CDH";
+
+    private static final String FLINK = "FLINK";
+
+    @InjectMocks
+    private ClusterComponentUpdater underTest;
+
+    @Mock
+    private ClusterComponentConfigProvider clusterComponentConfigProvider;
+
+    @Test
+    public void testRemoveUnusedCdhProductsFromClusterComponentsWhenThereIsNoComponentToDelete() {
+        Set<ClusterComponent> clusterComponentsByBlueprint = createComponents(Set.of(CDH, FLINK));
+        Set<ClusterComponent> clusterComponentsFromDb = createComponents(Set.of(CDH, FLINK));
+
+        when(clusterComponentConfigProvider.getComponentsByClusterId(CLUSTER_ID)).thenReturn(clusterComponentsFromDb);
+
+        underTest.removeUnusedCdhProductsFromClusterComponents(CLUSTER_ID, clusterComponentsByBlueprint);
+
+        verify(clusterComponentConfigProvider).getComponentsByClusterId(CLUSTER_ID);
+        verifyNoMoreInteractions(clusterComponentConfigProvider);
+    }
+
+    @Test
+    public void testRemoveUnusedCdhProductsFromClusterComponentsWhenThereIsNoComponentToDeleteAndAnExtraComponentIsPresent() {
+        Set<ClusterComponent> clusterComponentsByBlueprint = createComponents(Set.of(CDH, FLINK));
+        Set<ClusterComponent> clusterComponentsFromDb = createComponents(Set.of(CDH, FLINK));
+        clusterComponentsFromDb.add(createImageComponent());
+
+        when(clusterComponentConfigProvider.getComponentsByClusterId(CLUSTER_ID)).thenReturn(clusterComponentsFromDb);
+
+        underTest.removeUnusedCdhProductsFromClusterComponents(CLUSTER_ID, clusterComponentsByBlueprint);
+
+        verify(clusterComponentConfigProvider).getComponentsByClusterId(CLUSTER_ID);
+        verifyNoMoreInteractions(clusterComponentConfigProvider);
+    }
+
+    @Test
+    public void testRemoveUnusedCdhProductsFromClusterComponentsWhenThereIsOneComponentToDelete() {
+        Set<ClusterComponent> clusterComponentsByBlueprint = createComponents(Set.of(CDH));
+        ClusterComponent flinkComponent = createComponent(FLINK);
+        ClusterComponent cdhComponent = createComponent(CDH);
+        Set<ClusterComponent> clusterComponentsFromDb = Set.of(flinkComponent, cdhComponent);
+
+        when(clusterComponentConfigProvider.getComponentsByClusterId(CLUSTER_ID)).thenReturn(clusterComponentsFromDb);
+
+        underTest.removeUnusedCdhProductsFromClusterComponents(CLUSTER_ID, clusterComponentsByBlueprint);
+
+        verify(clusterComponentConfigProvider).getComponentsByClusterId(CLUSTER_ID);
+        verify(clusterComponentConfigProvider).deleteClusterComponents(Set.of(flinkComponent));
+    }
+
+    private Set<ClusterComponent> createComponents(Set<String> names) {
+        return names.stream()
+                .map(this::createComponent)
+                .collect(Collectors.toSet());
+    }
+
+    private ClusterComponent createComponent(String name) {
+        ClusterComponent component = new ClusterComponent();
+        component.setName(name);
+        component.setComponentType(ComponentType.CDH_PRODUCT_DETAILS);
+        return component;
+    }
+
+    private ClusterComponent createImageComponent() {
+        ClusterComponent component = new ClusterComponent();
+        component.setName("image");
+        component.setComponentType(ComponentType.IMAGE);
+        return component;
+    }
+
+}


### PR DESCRIPTION
Before this change when the upgrade flow started we removed the unused parcels from the CM server but those parcels are left in the database. This caused an inconsistent state because the Cloudbreak wanted to activate parcels which are not downloaded to the cluster.  
To solve this issue we need to remove those unused parcels from the clustercomponent table too.