### PR TITLE
CB-14225 stopping primary GW node makes both of the GW nodes unhealthy

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
@@ -265,6 +265,10 @@ public class InstanceMetaData implements ProvisionEntity {
                 || InstanceStatus.DECOMMISSION_FAILED.equals(instanceStatus);
     }
 
+    public boolean isPrimaryGateway() {
+        return InstanceMetadataType.GATEWAY_PRIMARY == instanceMetadataType;
+    }
+
     public boolean isGateway() {
         return InstanceMetadataType.GATEWAY == instanceMetadataType || InstanceMetadataType.GATEWAY_PRIMARY == instanceMetadataType
                 || (instanceMetadataType == null && instanceGroup != null && InstanceGroupType.GATEWAY == instanceGroup.getInstanceGroupType());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackSyncService.java
@@ -165,9 +165,9 @@ public class StackSyncService {
             try {
                 InstanceSyncState instanceState = instanceSyncStates.getOrDefault(instance.getInstanceId(), defaultState);
                 syncInstanceStatusByState(stack, instanceStateCounts, instance, instanceState);
-                if (!syncConfig.isCmServerRunning() && InstanceSyncState.RUNNING.equals(instanceState) && instance.isGateway()) {
+                if (!syncConfig.isCmServerRunning() && InstanceSyncState.RUNNING.equals(instanceState) && instance.isPrimaryGateway()) {
                     instanceMetaDataService.updateInstanceStatus(instance, InstanceStatus.SERVICES_UNHEALTHY,
-                            "Cloudera Manager server not responding");
+                            CM_SERVER_NOT_RESPONDING);
                 }
             } catch (CloudConnectorException e) {
                 LOGGER.warn(e.getMessage(), e);


### PR DESCRIPTION
If a PGW is unhealthy then we set another GW's status to unhealthy by mistake.
