### PR TITLE
CB-14120 Re-enabling certificate renewal tests for 7.2.12

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxSecurityTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxSecurityTests.java
@@ -42,7 +42,7 @@ public class SdxSecurityTests extends PreconditionSdxE2ETest {
     @Inject
     private DatalakeAuditGrpcServiceAssertion datalakeAuditGrpcServiceAssertion;
 
-    @Test(dataProvider = TEST_CONTEXT, enabled = false)
+    @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(
             given = "there is a running Cloudbreak, and an SDX cluster in available state",


### PR DESCRIPTION
1. CB-14221 started passing the subAltName for the auto-tls renewal.
2. Though the certificate is not issued with the subAltName, the certificate is actually renewed successfully.
3. This means only Hue/Yarn to Oozie communication will fail if the certificates are renewed but they do not have subAltName. This scenario is only possible for DE HA clusters in 7.2.11.