### PR TITLE
CB-14106 REST endpoint for distrox - part of epic: CB-12736, After a …

### DIFF
--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
@@ -64,6 +64,7 @@ public enum AuthorizationResourceAction {
     SET_DATAHUB_MAINTENANCE_MODE("datahub/setDatahubMaintenanceMode", AuthorizationResourceType.DATAHUB),
     ROTATE_AUTOTLS_CERT_DATAHUB("datahub/rotateAutoTlsCertDatahub", AuthorizationResourceType.DATAHUB),
     UPGRADE_DATAHUB("datahub/upgradeDatahub", AuthorizationResourceType.DATAHUB),
+    SYNC_COMPONENT_VERSIONS_FROM_CM_DATAHUB("datahub/syncComponentVersionsFromCm", AuthorizationResourceType.DATAHUB),
     DESCRIBE_DATABASE("environments/describeDatabase", AuthorizationResourceType.DATABASE),
     DESCRIBE_DATABASE_SERVER("environments/describeDatabaseServer", AuthorizationResourceType.DATABASE_SERVER),
     DELETE_DATABASE("environments/deleteDatabase", AuthorizationResourceType.DATABASE),

--- a/authorization-common/src/main/resources/legacyRights.json
+++ b/authorization-common/src/main/resources/legacyRights.json
@@ -54,6 +54,7 @@
   "datahub/setDatahubMaintenanceMode": "datahub/write",
   "datahub/rotateAutoTlsCertDatahub": "datahub/write",
   "datahub/upgradeDatahub": "datahub/write",
+  "datahub/syncComponentVersionsFromCm": "datahub/write",
   "environments/describeDatabase": "datalake/read",
   "environments/describeDatabaseServer": "datalake/read",
   "environments/deleteDatabase": "datalake/write",

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/DistroXSyncCmV1Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/DistroXSyncCmV1Response.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response;
+
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+
+public class DistroXSyncCmV1Response {
+    private final FlowIdentifier flowIdentifier;
+
+    public DistroXSyncCmV1Response(FlowIdentifier flowIdentifier) {
+        this.flowIdentifier = flowIdentifier;
+    }
+
+    public FlowIdentifier getFlowIdentifier() {
+        return flowIdentifier;
+    }
+
+    @Override
+    public String toString() {
+        return "DistroXSyncCmV1Response{" +
+                "flowIdentifier=" + flowIdentifier +
+                '}';
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
@@ -58,8 +58,8 @@ import javax.ws.rs.core.MediaType;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.CertificatesRotationV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.CertificatesRotationV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.DistroXSyncCmV1Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.GeneratedBlueprintV4Response;
-import com.sequenceiq.flow.api.model.RetryableFlowResponse;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
@@ -79,6 +79,7 @@ import com.sequenceiq.distrox.api.v1.distrox.model.diagnostics.model.CmDiagnosti
 import com.sequenceiq.distrox.api.v1.distrox.model.diagnostics.model.DiagnosticsCollectionV1Request;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.FlowProgressResponse;
+import com.sequenceiq.flow.api.model.RetryableFlowResponse;
 import com.sequenceiq.flow.api.model.operation.OperationView;
 
 import io.swagger.annotations.Api;
@@ -437,4 +438,16 @@ public interface DistroXV1Endpoint {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = ROTATE_CERTIFICATES, nickname = "rotateAutoTlsCertificatesByCrn")
     CertificatesRotationV4Response rotateAutoTlsCertificatesByCrn(@PathParam("crn") String crn, @Valid CertificatesRotationV4Request rotateCertificateRequest);
+
+    @POST
+    @Path("{name}/sync_component_versions_from_cm")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "syncs from distrox cluster CM the CM and parcel versions", produces = MediaType.APPLICATION_JSON, nickname = "syncDistroxCm")
+    DistroXSyncCmV1Response syncComponentVersionsFromCmByName(@PathParam("name") String name);
+
+    @POST
+    @Path("crn/{crn}/sync_component_versions_from_cm")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "syncs from distrox cluster CM the CM and parcel versions", produces = MediaType.APPLICATION_JSON, nickname = "syncDistroxCmByCrn")
+    DistroXSyncCmV1Response syncComponentVersionsFromCmByCrn(@PathParam("crn") String crn);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -124,8 +124,8 @@ public class StackV4Controller extends NotificationController implements StackV4
     @Override
     @InternalOnly
     public FlowIdentifier syncCm(Long workspaceId, String name, @InitiatorUserCrn String initiatorUserCrn, ClouderaManagerSyncV4Request syncRequest) {
-        return stackOperations.syncCm(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(), syncRequest.getCandidateImageUuids());
-    }
+        return stackOperations.syncComponentVersionsFromCm(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(),
+                syncRequest.getCandidateImageUuids());    }
 
     @Override
     @CheckPermissionByAccount(action = AuthorizationResourceAction.POWERUSER_ONLY)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -229,7 +229,7 @@ public class ReactorFlowManager {
         return reactorNotifier.notify(stackId, selector, new StackEvent(selector, stackId));
     }
 
-    public FlowIdentifier triggerCmSync(Long stackId, Set<String> candidateImageUuids) {
+    public FlowIdentifier triggerSyncComponentVersionsFromCm(Long stackId, Set<String> candidateImageUuids) {
         String selector = CM_SYNC_TRIGGER_EVENT.event();
         return reactorNotifier.notify(stackId, selector, new CmSyncTriggerEvent(stackId, candidateImageUuids));
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -200,8 +200,8 @@ public class StackOperationService {
         }
     }
 
-    public FlowIdentifier syncCm(Stack stack, Set<String> candidateImageUuids) {
-        return flowManager.triggerCmSync(stack.getId(), candidateImageUuids);
+    public FlowIdentifier syncComponentVersionsFromCm(Stack stack, Set<String> candidateImageUuids) {
+        return flowManager.triggerSyncComponentVersionsFromCm(stack.getId(), candidateImageUuids);
     }
 
     private FlowIdentifier stop(Stack stack, Cluster cluster, boolean updateCluster, User user) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/StackOperations.java
@@ -231,8 +231,8 @@ public class StackOperations implements ResourcePropertyProvider {
         return stackCommonService.syncInWorkspace(nameOrCrn, workspaceId);
     }
 
-    public FlowIdentifier syncCm(NameOrCrn nameOrCrn, Long workspaceId, Set<String> candidateImageUuids) {
-        return stackCommonService.syncCmInWorkspace(nameOrCrn, workspaceId, candidateImageUuids);
+    public FlowIdentifier syncComponentVersionsFromCm(NameOrCrn nameOrCrn, Long workspaceId, Set<String> candidateImageUuids) {
+        return stackCommonService.syncComponentVersionsFromCmInWorkspace(nameOrCrn, workspaceId, candidateImageUuids);
     }
 
     public FlowIdentifier retry(NameOrCrn nameOrCrn, Long workspaceId) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -134,7 +134,7 @@ public class ReactorFlowManagerTest {
         underTest.triggerDatalakeDatabaseRestore(STACK_ID, null, null);
         underTest.triggerAutoTlsCertificatesRotation(STACK_ID, new CertificatesRotationV4Request());
         underTest.triggerStackLoadBalancerUpdate(STACK_ID);
-        underTest.triggerCmSync(STACK_ID, Set.of());
+        underTest.triggerSyncComponentVersionsFromCm(STACK_ID, Set.of());
         underTest.triggerDatalakeClusterRecovery(STACK_ID);
 
         int count = 0;

--- a/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/Flow2Handler.java
@@ -203,7 +203,7 @@ public class Flow2Handler implements Consumer<Event<? extends Payload>> {
 
     private AcceptResult handleNewFlowRequest(String key, Payload payload, FlowParameters flowParameters, String flowChainId, String flowChainType,
             Map<Object, Object> contextParams) throws TransactionExecutionException {
-        LOGGER.debug("Flow trigger arrived: key: {}, payload: {}", key, payload);
+        LOGGER.debug("{}, payload: {}", key, payload);
         FlowConfiguration<?> flowConfig = getFlowConfiguration(key);
         FlowTriggerConditionResult flowTriggerConditionResult = flowConfig.getFlowTriggerCondition().isFlowTriggerable(payload.getResourceId());
         if (!flowTriggerConditionResult.isTriggerable()) {


### PR DESCRIPTION
…failed DL/DH upgrade sync runtime versions

Customer should be able to manually issue a cdp-cli command to execute the syncing of CM versions stored in CB Component and ClusterComponent tables to that of CM. For that one endpoint is introduced on distrox. The code doing the actual sync was introduced in an earlier commit.

See detailed description in the commit message.