### PR TITLE
CB-14274 Integrate with Telemetry solution for GCP CMEK

### DIFF
--- a/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/EnvironmentDetailsToCDPEnvironmentDetailsConverter.java
+++ b/structuredevent-service-cdp/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/EnvironmentDetailsToCDPEnvironmentDetailsConverter.java
@@ -20,6 +20,8 @@ import com.sequenceiq.environment.environment.domain.Region;
 import com.sequenceiq.environment.network.dto.NetworkDto;
 import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
+import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
+import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 
 @Component
@@ -74,6 +76,7 @@ public class EnvironmentDetailsToCDPEnvironmentDetailsConverter {
 
             cdpEnvironmentDetails.setAwsDetails(convertAwsDetails(srcEnvironmentDetails.getParameters()));
             cdpEnvironmentDetails.setAzureDetails(convertAzureDetails(srcEnvironmentDetails.getParameters()));
+            cdpEnvironmentDetails.setGcpDetails(convertGcpDetails(srcEnvironmentDetails.getParameters()));
 
             Map<String, String> userTags = srcEnvironmentDetails.getUserDefinedTags();
             if (userTags != null && !userTags.isEmpty()) {
@@ -102,6 +105,20 @@ public class EnvironmentDetailsToCDPEnvironmentDetailsConverter {
                         .map(AzureParametersDto::getAzureResourceEncryptionParametersDto)
                         .map(AzureResourceEncryptionParametersDto::getEncryptionKeyUrl);
                 builder.setResourceEncryptionEnabled(encryptionKeyUrl.isPresent());
+            }
+        }
+        return builder.build();
+    }
+
+    private UsageProto.CDPEnvironmentGcpDetails convertGcpDetails(ParametersDto parametersDto) {
+        UsageProto.CDPEnvironmentGcpDetails.Builder builder = UsageProto.CDPEnvironmentGcpDetails.newBuilder();
+        if (parametersDto != null) {
+            GcpParametersDto gcpParametersDto = parametersDto.getGcpParametersDto();
+            if (gcpParametersDto != null) {
+                Optional<String> encryptionKey = Optional.of(gcpParametersDto)
+                        .map(GcpParametersDto::getGcpResourceEncryptionParametersDto)
+                        .map(GcpResourceEncryptionParametersDto::getEncryptionKey);
+                builder.setResourceEncryptionEnabled(encryptionKey.isPresent());
             }
         }
         return builder.build();

--- a/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/EnvironmentDetailsToCDPEnvironmentDetailsConverterTest.java
+++ b/structuredevent-service-cdp/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/EnvironmentDetailsToCDPEnvironmentDetailsConverterTest.java
@@ -26,6 +26,8 @@ import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceGroupDto;
+import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
+import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameter.dto.ResourceGroupUsagePattern;
 
@@ -140,6 +142,34 @@ public class EnvironmentDetailsToCDPEnvironmentDetailsConverterTest {
         UsageProto.CDPEnvironmentDetails cdpEnvironmentDetails = underTest.convert(environmentDetails);
 
         Assertions.assertFalse(cdpEnvironmentDetails.getAzureDetails().getResourceEncryptionEnabled());
+    }
+
+    @Test
+    public void testConversionResourceEncryptionEnabledWhenGcpUsingResourceEncryptionEnabledShouldReturnResourceEncryptionEnabledTrue() {
+        ParametersDto parametersDto = ParametersDto.builder()
+                .withGcpParameters(GcpParametersDto.builder()
+                        .withEncryptionParameters(GcpResourceEncryptionParametersDto.builder()
+                                .withEncryptionKey("dummyEncryptionKeyUrl")
+                                .build())
+                        .build())
+                .build();
+
+        when(environmentDetails.getParameters()).thenReturn(parametersDto);
+
+        UsageProto.CDPEnvironmentDetails cdpEnvironmentDetails = underTest.convert(environmentDetails);
+
+        Assertions.assertTrue(cdpEnvironmentDetails.getGcpDetails().getResourceEncryptionEnabled());
+    }
+
+    @Test
+    public void testConversionResourceEncryptionEnabledWhenGcpNOTResourceEncryptionEnabledShouldReturnResourceEncryptionEnabledFalse() {
+        ParametersDto parametersDto = ParametersDto.builder().build();
+
+        when(environmentDetails.getParameters()).thenReturn(parametersDto);
+
+        UsageProto.CDPEnvironmentDetails cdpEnvironmentDetails = underTest.convert(environmentDetails);
+
+        Assertions.assertFalse(cdpEnvironmentDetails.getGcpDetails().getResourceEncryptionEnabled());
     }
 
     @Test

--- a/usage-collection/src/main/proto/usage.proto
+++ b/usage-collection/src/main/proto/usage.proto
@@ -975,6 +975,8 @@ message CDPEnvironmentDetails {
   // added tags that are product-specific. The format of this is a map serialized
   // into a string as json. e.g.:   "tags": "{\"key1\":\"value1\",\"key2\":\"value2\"}"
   string userTags = 8;
+  // GCP specific details of the environment
+  CDPEnvironmentGcpDetails gcpDetails = 9;
 }
 
 message CDPFreeIPADetails {
@@ -992,6 +994,12 @@ message CDPEnvironmentAzureDetails {
   bool singleResourceGroup = 1;
   // True if user provides encryption key URL to encrypt Azure managed disks with CMK
   bool resourceEncryptionEnabled = 2;
+}
+
+// GCP specific environment details
+message CDPEnvironmentGcpDetails {
+  // True if user provides encryption key URL to encrypt GCP managed disks with CMEK
+  bool resourceEncryptionEnabled = 1;
 }
 
 // AWS specific environment details


### PR DESCRIPTION
CB-14274 Integrate with Telemetry solution for GCP CMEK
Adding a new property to CDPEnvironmentDetails, CDPEnvironmentGcpDetails which has entity bool resourceEncryptionEnabled, this is set only when encryptionKey is present.
As encryptionKey is present only when "CDP_CB_GCP_DISK_ENCRYPTION_WITH_CMEK" is enabled and encryptionKey is provided during environment creation, checking its presence is sufficient to know if user is using "GCP SSE with CMEK".

Thunderhead PR- https://github.infra.cloudera.com/thunderhead/thunderhead/pull/6016
