### PR TITLE
CB-14129 Update tag specifications

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/config/AwsConfig.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/config/AwsConfig.java
@@ -26,7 +26,7 @@ public class AwsConfig {
     @Value("${cb.aws.tag.key.max.length:127}")
     private Integer maxKeyLength;
 
-    @Value("${cb.aws.tag.key.validator:^(?!aws|\\s)([\\w\\d+-=._:/@\\s]+)(?<!\\s+)$}")
+    @Value("${cb.aws.tag.key.validator:^(?!aws|\\s)([\\w\\d+=._:/@\\s-]+)(?<!\\s)$}")
     private String keyValidator;
 
     @Value("${cb.aws.tag.value.min.length:1}")
@@ -35,7 +35,7 @@ public class AwsConfig {
     @Value("${cb.aws.tag.value.max.length:255}")
     private Integer maxValueLength;
 
-    @Value("${cb.aws.tag.value.validator:^(?!\\s)([\\w\\d+-=._:/@\\s]+)(?<!\\s+)$}")
+    @Value("${cb.aws.tag.value.validator:^(?!\\s)([\\w\\d+\\-=._:/@\\s]+)(?<!\\s)$}")
     private String valueValidator;
 
     @Inject

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/conf/AzureConfig.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/conf/AzureConfig.java
@@ -9,7 +9,7 @@ import com.sequenceiq.cloudbreak.cloud.model.TagSpecification;
 @Configuration
 public class AzureConfig {
 
-    @Value("${cb.azure.tag.amount:15}")
+    @Value("${cb.azure.tag.amount:50}")
     private Integer maxAmount;
 
     @Value("${cb.azure.tag.key.min.length:1}")
@@ -18,7 +18,7 @@ public class AzureConfig {
     @Value("${cb.azure.tag.key.max.length:512}")
     private Integer maxKeyLength;
 
-    @Value("${cb.azure.tag.key.validator:^(?!microsoft|azure|windows|\\s)[^,]*$}")
+    @Value("${cb.azure.tag.key.validator:^(?!microsoft|azure|windows|\\s)[^,<>%&\\\\/\\?]*(?<!\\s)$}")
     private String keyValidator;
 
     @Value("${cb.azure.tag.value.min.length:1}")
@@ -27,7 +27,7 @@ public class AzureConfig {
     @Value("${cb.azure.tag.value.max.length:256}")
     private Integer maxValueLength;
 
-    @Value("${cb.azure.tag.value.validator:.*$}")
+    @Value("${cb.azure.tag.value.validator:^(?!\\s)[^,<>%&\\\\/\\?]*(?<!\\s)$}")
     private String valueValidator;
 
     @Bean(name = "AzureTagSpecification")

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/conf/GcpConfig.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/conf/GcpConfig.java
@@ -22,16 +22,16 @@ public class GcpConfig {
     @Value("${cb.gcp.tag.key.max.length:63}")
     private Integer maxKeyLength;
 
-    @Value("${cb.gcp.tag.key.validator:^([a-z]+)([a-z\\d-_]+)$}")
+    @Value("${cb.gcp.tag.key.validator:^(?!\\s)([a-z]+)([\\w\\d_\\-]+)(?<!\\s)$}")
     private String keyValidator;
 
-    @Value("${cb.gcp.tag.value.min.length:1}")
+    @Value("${cb.gcp.tag.value.min.length:0}")
     private Integer minValueLength;
 
     @Value("${cb.gcp.tag.value.max.length:63}")
     private Integer maxValueLength;
 
-    @Value("${cb.gcp.tag.value.validator:^([a-z0-9]+)([a-z\\d-_]+)$}")
+    @Value("${cb.gcp.tag.value.validator:^(?!\\s)([a-z\\d_\\-]*)(?<!\\s)$}")
     private String valueValidator;
 
     @Bean(name = "GcpTagSpecification")

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/config/OpenStackConfig.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/config/OpenStackConfig.java
@@ -18,7 +18,7 @@ public class OpenStackConfig {
     @Value("${cb.openstack.tag.key.max.length:127}")
     private Integer maxKeyLength;
 
-    @Value("${cb.openstack.tag.key.validator:^(?!\\s+)([\\w\\d+-=._:/@\\s]+)$}")
+    @Value("${cb.openstack.tag.key.validator:^(?!\\s)([\\w\\d\\-=._:/@\\s]+)(?<!\\s)$}")
     private String keyValidator;
 
     @Value("${cb.openstack.tag.value.min.length:1}")
@@ -27,7 +27,7 @@ public class OpenStackConfig {
     @Value("${cb.openstack.tag.value.max.length:255}")
     private Integer maxValueLength;
 
-    @Value("${cb.openstack.tag.value.validator:^([\\w\\d+-=._:/@\\s]+)$}")
+    @Value("${cb.openstack.tag.value.validator:^(?!\\s)([\\w\\d\\-=._:/@\\s]+)(?<!\\s)$}")
     private String valueValidator;
 
     @Bean(name = "OpenStackTagSpecification")

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/TagValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/TagValidatorTest.java
@@ -26,18 +26,11 @@ import com.sequenceiq.cloudbreak.cloud.azure.validator.AzureTagValidator;
 import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Variant;
+import com.sequenceiq.cloudbreak.common.type.CloudConstants;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 
 @ExtendWith(SpringExtension.class)
 class TagValidatorTest {
-
-    public static final String AZURE = "AZURE";
-
-    public static final String BAD_KEY = "azureprefix";
-
-    public static final String GOOD_VALUE = "azure@cloudera.com prx:pfx:<>&^%";
-
-    public static final String GOOD_KEY = "azprefix";
 
     @Inject
     private TagValidator tagValidatorUnderTest;
@@ -46,11 +39,11 @@ class TagValidatorTest {
     Collection<DynamicTest> testFactoryOnTagValidator() {
         return Arrays.asList(
                 DynamicTest.dynamicTest("tag key is invalid",
-                        () -> testNegative(BAD_KEY, GOOD_VALUE, "tag names are not well")),
+                        () -> testNegative("", "azure@cloudera.com prx:pfx:^!=-", "too short")),
                 DynamicTest.dynamicTest("tag key is invalid, regular expression is printed",
-                        () -> testNegative(BAD_KEY, GOOD_VALUE, "regular expression")),
+                        () -> testNegative("azureprefix", "azure@cloudera.com prx:pfx:^!=-", "regular expression")),
                 DynamicTest.dynamicTest("tag value is valid ",
-                        () -> testPositive(GOOD_KEY, GOOD_VALUE)),
+                        () -> testPositive("azprefix", "azure@cloudera.com prx:pfx:^!=-")),
                 DynamicTest.dynamicTest("tag value is valid ",
                         () -> testPositive("cod_database_name", "appletree")),
                 DynamicTest.dynamicTest("tag value is valid ",
@@ -59,14 +52,14 @@ class TagValidatorTest {
     }
 
     public void testNegative(String tag, String value, String messagePortion) {
-        ValidationResult result = tagValidatorUnderTest.validateTags(AZURE, Map.of(tag, value));
+        ValidationResult result = tagValidatorUnderTest.validateTags(CloudConstants.AZURE, Map.of(tag, value));
         Assertions.assertTrue(result.hasError(), "tag validation should fail");
         Assertions.assertTrue(result.getErrors().size() == 1, "tag validation should have one error only");
         Assertions.assertTrue(result.getErrors().get(0).contains(messagePortion));
     }
 
     public void testPositive(String tag, String value) {
-        ValidationResult result = tagValidatorUnderTest.validateTags(AZURE, Map.of(tag, value));
+        ValidationResult result = tagValidatorUnderTest.validateTags(CloudConstants.AZURE, Map.of(tag, value));
         Assertions.assertFalse(result.hasError(), "tag validation should pass");
     }
 
@@ -87,8 +80,8 @@ class TagValidatorTest {
             PlatformParameters parameter = parameters();
             CloudConnector mock = Mockito.mock(CloudConnector.class);
             when(mock.parameters()).thenReturn(parameter);
-            when(mock.platform()).thenReturn(Platform.platform(AZURE));
-            when(mock.variant()).thenReturn(Variant.variant(AZURE));
+            when(mock.platform()).thenReturn(Platform.platform(CloudConstants.AZURE));
+            when(mock.variant()).thenReturn(Variant.variant(CloudConstants.AZURE));
             return mock;
         }
 


### PR DESCRIPTION
Updated AWS, Azure, GCP and OpenStack tag specifications:
- Reflect the latest restrictions (see links in Jira)
- Fixed '-' issue where it was interpreted as a range
- Leading and trailing spaces are restricted

See detailed description in the commit message.