### PR TITLE
Revert "CB-14120 Re-enabling certificate renewal tests for 7.2.12"

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxSecurityTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxSecurityTests.java
@@ -42,7 +42,7 @@ public class SdxSecurityTests extends PreconditionSdxE2ETest {
     @Inject
     private DatalakeAuditGrpcServiceAssertion datalakeAuditGrpcServiceAssertion;
 
-    @Test(dataProvider = TEST_CONTEXT)
+    @Test(dataProvider = TEST_CONTEXT, enabled = false)
     @UseSpotInstances
     @Description(
             given = "there is a running Cloudbreak, and an SDX cluster in available state",


### PR DESCRIPTION
This reverts commit 68442884f0851fb70f89de1dbe89ed83d1e4f9bc.

See detailed description in the commit message.