### PR TITLE
CB-13986 Upscaled Azure VMs are not rolled back in case of CloudExcep…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentService.java
@@ -1,18 +1,22 @@
 package com.sequenceiq.cloudbreak.cloud.azure.template;
 
+import java.util.stream.Collectors;
+
 import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
+import com.microsoft.azure.CloudError;
+import com.microsoft.azure.CloudException;
 import com.microsoft.azure.management.resources.Deployment;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureInstanceTemplateOperation;
-import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarketplaceImage;
-import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarketplaceImageProviderService;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureResourceGroupMetadataProvider;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureStorage;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureTemplateBuilder;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
 import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarketplaceImage;
+import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarketplaceImageProviderService;
 import com.sequenceiq.cloudbreak.cloud.azure.validator.AzureImageFormatValidator;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureCredentialView;
 import com.sequenceiq.cloudbreak.cloud.azure.view.AzureStackView;
@@ -20,6 +24,8 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.service.Retry;
+import com.sequenceiq.cloudbreak.service.RetryService;
 
 @Component
 public class AzureTemplateDeploymentService {
@@ -42,6 +48,9 @@ public class AzureTemplateDeploymentService {
     @Inject
     private AzureTemplateBuilder azureTemplateBuilder;
 
+    @Inject
+    private RetryService retry;
+
     public Deployment getTemplateDeployment(AzureClient client, CloudStack stack, AuthenticatedContext ac, AzureStackView azureStackView,
             AzureInstanceTemplateOperation azureInstanceTemplateOperation) {
         CloudContext cloudContext = ac.getCloudContext();
@@ -49,7 +58,20 @@ public class AzureTemplateDeploymentService {
         String resourceGroupName = azureResourceGroupMetadataProvider.getResourceGroupName(cloudContext, stack);
         String template = getTemplate(stack, azureStackView, ac, ac.getCloudContext(), stackName, client, azureInstanceTemplateOperation);
         String parameters = azureTemplateBuilder.buildParameters(ac.getCloudCredential(), stack.getNetwork(), stack.getImage());
-        return client.createTemplateDeployment(resourceGroupName, stackName, template, parameters);
+
+        return retry.testWith1SecDelayMax5Times(() -> {
+            try {
+                return client.createTemplateDeployment(resourceGroupName, stackName, template, parameters);
+            } catch (CloudException e) {
+                if (e.body() != null && e.body().details() != null) {
+                    String details = e.body().details().stream().map(CloudError::message).collect(Collectors.joining(", "));
+                    if (details.contains("Please check the power state later")) {
+                        throw new Retry.ActionFailedException("VMs not started in time.", e);
+                    }
+                }
+                throw e;
+            }
+        });
     }
 
     private String getTemplate(CloudStack stack, AzureStackView azureStackView, AuthenticatedContext ac, CloudContext cloudContext,

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentServiceTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/template/AzureTemplateDeploymentServiceTest.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.cloudbreak.cloud.azure.template;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.microsoft.azure.CloudError;
+import com.microsoft.azure.CloudException;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureImage;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureInstanceTemplateOperation;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureResourceGroupMetadataProvider;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureStorage;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureTemplateBuilder;
+import com.sequenceiq.cloudbreak.cloud.azure.AzureUtils;
+import com.sequenceiq.cloudbreak.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarketplaceImageProviderService;
+import com.sequenceiq.cloudbreak.cloud.azure.validator.AzureImageFormatValidator;
+import com.sequenceiq.cloudbreak.cloud.azure.view.AzureStackView;
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
+import com.sequenceiq.cloudbreak.service.Retry;
+import com.sequenceiq.cloudbreak.service.RetryService;
+
+@ExtendWith(MockitoExtension.class)
+class AzureTemplateDeploymentServiceTest {
+
+    @Mock
+    private AzureStorage azureStorage;
+
+    @Mock
+    private AzureUtils azureUtils;
+
+    @Mock
+    private AzureResourceGroupMetadataProvider azureResourceGroupMetadataProvider;
+
+    @Mock
+    private AzureMarketplaceImageProviderService azureMarketplaceImageProviderService;
+
+    @Mock
+    private AzureImageFormatValidator azureImageFormatValidator;
+
+    @Mock
+    private AzureTemplateBuilder azureTemplateBuilder;
+
+    @Mock
+    private RetryService retry;
+
+    @InjectMocks
+    private AzureTemplateDeploymentService underTest;
+
+    @Test
+    public void testGetTemplateDeploymentWhenFailed() {
+        CloudStack stack = mock(CloudStack.class);
+        CloudContext cloudContext = CloudContext.Builder.builder().withId(1L).build();
+        AuthenticatedContext ac = new AuthenticatedContext(cloudContext, new CloudCredential());
+        AzureStackView stackView = mock(AzureStackView.class);
+        when(azureResourceGroupMetadataProvider.getResourceGroupName(any(CloudContext.class), any(CloudStack.class))).thenReturn("rg1");
+        when(azureImageFormatValidator.isMarketplaceImageFormat(any())).thenReturn(false);
+        when(azureStorage.getCustomImage(any(), any(), any())).thenReturn(new AzureImage("1", "image1", true));
+        when(azureTemplateBuilder.build(eq("stack1"), eq("1"), any(), any(), any(), any(), any(), any())).thenReturn("template");
+        when(retry.testWith1SecDelayMax5Times(any(Supplier.class))).thenAnswer(invocation -> invocation.getArgument(0, Supplier.class).get());
+        when(azureUtils.getStackName(any())).thenReturn("stack1");
+        AzureClient client = mock(AzureClient.class);
+        CloudError cloudError = new CloudError().withMessage("Error happened");
+        cloudError.details().add(new CloudError().withMessage("Please check the power state later"));
+        when(client.createTemplateDeployment(eq("rg1"), eq("stack1"), eq("template"), any())).thenThrow(new CloudException("Error", null, cloudError));
+
+        Retry.ActionFailedException actionFailedException = assertThrows(Retry.ActionFailedException.class,
+                () -> underTest.getTemplateDeployment(client, stack, ac, stackView, AzureInstanceTemplateOperation.PROVISION));
+
+        assertEquals("VMs not started in time.", actionFailedException.getMessage());
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActions.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack.upscale;
 
 import static com.sequenceiq.cloudbreak.core.flow2.stack.upscale.AbstractStackUpscaleAction.HOSTNAMES;
+import static com.sequenceiq.cloudbreak.core.flow2.stack.upscale.AbstractStackUpscaleAction.INSTANCEGROUPNAME;
 
 import java.util.HashSet;
 import java.util.List;
@@ -359,8 +360,9 @@ public class StackUpscaleActions {
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) {
                 Set<String> hostNames = (Set<String>) variables.getOrDefault(HOSTNAMES, new HashSet<>());
+                String instanceGroupName = (String) variables.getOrDefault(INSTANCEGROUPNAME, null);
                 stackUpscaleService.handleStackUpscaleFailure(isRepair(variables), hostNames, payload.getException(),
-                        payload.getResourceId());
+                        payload.getResourceId(), instanceGroupName);
                 getMetricService().incrementMetricCounter(MetricType.STACK_UPSCALE_FAILED, context.getStackView(), payload.getException());
                 sendEvent(context);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupService.java
@@ -123,10 +123,10 @@ public class MetadataSetupService {
         });
     }
 
-    public void cleanupRequestedInstancesWithoutFQDN(Stack stack, String instanceGroupName) {
+    public void cleanupRequestedInstancesWithoutFQDN(Long stackId, String instanceGroupName) {
         try {
             transactionService.required(() -> {
-                Optional<InstanceGroup> ig = instanceGroupService.findOneWithInstanceMetadataByGroupNameInStack(stack.getId(), instanceGroupName);
+                Optional<InstanceGroup> ig = instanceGroupService.findOneWithInstanceMetadataByGroupNameInStack(stackId, instanceGroupName);
                 if (ig.isPresent()) {
                     List<InstanceMetaData> requestedInstances = instanceMetaDataService.findAllByInstanceGroupAndInstanceStatus(ig.get(),
                             InstanceStatus.REQUESTED);


### PR DESCRIPTION
…tion

- Retry deployment if Azure cannot start VMs in time, but there is a chance it has not yet failed.
- Rollback if other CloudException occurs, e.g. quota limit
- Use the Deployment object to rollback resources.
- Cleanup requested instances (without FQDN) if upscale fails

See detailed description in the commit message.