### PR TITLE
DISTX-705 Set Azure buffer dir to Yarn local dir

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-data-engineering-ha.bp
@@ -33,7 +33,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property><property><name>fs.azure.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/abfs</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-data-engineering-spark3.bp
@@ -25,7 +25,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property><property><name>fs.azure.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/abfs</value></property>"
           }
         ],
         "roleConfigGroups": [

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-data-engineering.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-data-engineering.bp
@@ -32,7 +32,7 @@
           },
           {
             "name": "core_site_safety_valve",
-            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property>"
+            "value": "<property><name>fs.s3a.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/s3a</value></property><property><name>fs.s3a.committer.name</name><value>directory</value></property><property><name>fs.azure.buffer.dir</name><value>${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/abfs</value></property>"
           }
         ],
         "roleConfigGroups": [


### PR DESCRIPTION
[DISTX-705](https://jira.cloudera.com/browse/DISTX-705)
Fixes for CDPD-13652 in 7.2.12 introduced disk buffering for abfs streams. This also requires cleaning up the buffer directory as part of failed yarn jobs. Hence configuring following in 7.2.13 DE templates
fs.azure.buffer.dir=${env.LOCAL_DIRS:-${hadoop.tmp.dir}}/abfs

FYI, 7.2.12 templates were changed in the previous PR #11495

