### PR TITLE
CB-14221 Consistently choose when to provide load-balancer SAN

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProvider.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.san;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_4_3;
+import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERA_STACK_VERSION_7_2_11;
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.isVersionNewerOrEqualThanLimited;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -12,9 +12,9 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
-import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
+import com.sequenceiq.cloudbreak.cmtemplate.CmTemplateProcessor;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
 import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
 import com.sequenceiq.cloudbreak.service.stack.LoadBalancerPersistenceService;
@@ -29,14 +29,13 @@ public class LoadBalancerSANProvider {
     @Inject
     private LoadBalancerPersistenceService loadBalancerPersistenceService;
 
-    @Inject
-    private ClusterComponentConfigProvider clusterComponentConfigProvider;
-
     public Optional<String> getLoadBalancerSAN(Stack stack) {
         checkNotNull(stack);
         checkNotNull(stack.getCluster());
-        ClouderaManagerRepo clouderaManagerRepo = clusterComponentConfigProvider.getClouderaManagerRepoDetails(stack.getCluster().getId());
-        if (isVersionNewerOrEqualThanLimited(clouderaManagerRepo.getVersion(), CLOUDERAMANAGER_VERSION_7_4_3)) {
+        Cluster cluster = stack.getCluster();
+        CmTemplateProcessor cmTemplateProcessor = new CmTemplateProcessor(cluster.getBlueprint().getBlueprintText());
+        String cdhVersion = cmTemplateProcessor.getStackVersion();
+        if (isVersionNewerOrEqualThanLimited(cdhVersion, CLOUDERA_STACK_VERSION_7_2_11)) {
             Set<LoadBalancer> loadBalancers = loadBalancerPersistenceService.findByStackId(stack.getId());
             if (!loadBalancers.isEmpty()) {
                 Optional<LoadBalancer> loadBalancer = loadBalancerConfigService.selectLoadBalancer(loadBalancers, LoadBalancerType.PUBLIC);


### PR DESCRIPTION
1. Load balancer SAN needs to be generated only for CDH-7.2.11+/CM-7.4.3+ clusters which are created newly.
2. The only reliable mechanism for finding such clusters excluding the upgrade is to get the version number of CDH from the blueprint text.
3. This will avoid problems generated during the upgrade of older clusters to 7.2.11+/7.4.3+ where some features like case-insensitive DNS are handled correctly only in 7.2.11+/7.4.3+ and not all the hosts have this version.
4. This is how the Oozie HA feature setup is also done in LoadBalancerConfigService.