### PR TITLE
CB-14281 Eliminate NPE in HostgroupView constructor due to null FQDN

### DIFF
--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/HostgroupView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/views/HostgroupView.java
@@ -2,9 +2,13 @@ package com.sequenceiq.cloudbreak.template.views;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
 
 import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.domain.VolumeTemplate;
@@ -31,42 +35,12 @@ public class HostgroupView {
     private final Integer temporaryStorageVolumeCount;
 
     public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType, Collection<String> hosts) {
-        this.name = name;
-        this.volumeCount = volumeCount;
-        instanceGroupConfigured = true;
-        this.instanceGroupType = instanceGroupType;
-        this.hosts = hosts != null
-            ? Collections.unmodifiableSortedSet(new TreeSet<>(hosts) {
-                    @Override
-                    public String toString() {
-                        return String.join(",", this);
-                    }
-                })
-            : Collections.emptySortedSet();
-        nodeCount = this.hosts.size();
-        volumeTemplates = Collections.emptySet();
-        temporaryStorage = null;
-        temporaryStorageVolumeCount = null;
+        this(name, volumeCount, instanceGroupType, hosts, Collections.emptySet());
     }
 
     public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType,
             Collection<String> hosts, Set<VolumeTemplate> volumeTemplates) {
-        this.name = name;
-        this.volumeCount = volumeCount;
-        instanceGroupConfigured = true;
-        this.instanceGroupType = instanceGroupType;
-        this.hosts = hosts != null
-                ? Collections.unmodifiableSortedSet(new TreeSet<>(hosts) {
-            @Override
-            public String toString() {
-                return String.join(",", this);
-            }
-        })
-                : Collections.emptySortedSet();
-        nodeCount = this.hosts.size();
-        this.volumeTemplates = Collections.unmodifiableSet(volumeTemplates);
-        temporaryStorage = null;
-        temporaryStorageVolumeCount = null;
+        this(name, volumeCount, instanceGroupType, hosts, volumeTemplates, null, null);
     }
 
     public HostgroupView(String name, int volumeCount, InstanceGroupType instanceGroupType,
@@ -76,7 +50,7 @@ public class HostgroupView {
         instanceGroupConfigured = true;
         this.instanceGroupType = instanceGroupType;
         this.hosts = hosts != null
-                ? Collections.unmodifiableSortedSet(new TreeSet<>(hosts) {
+                ? Collections.unmodifiableSortedSet(new TreeSet<>(filterNullOrEmpty(hosts)) {
             @Override
             public String toString() {
                 return String.join(",", this);
@@ -147,5 +121,9 @@ public class HostgroupView {
 
     public Integer getTemporaryStorageVolumeCount() {
         return temporaryStorageVolumeCount;
+    }
+
+    private List<String> filterNullOrEmpty(Collection<String> hosts) {
+        return hosts.stream().filter(StringUtils::isNotEmpty).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
**Background**

Follow-up to ENGESC-10576. According to https://jira.cloudera.com/browse/ENGESC-10576?focusedCommentId=4771478&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-4771478 , there is an NPE in the `TreeSet` constructor. The complete code flow is:
 * `RotateClusterCertificatesFlowEventChainFactory.createFlowTriggerEventQueue()` (core) -> `SaltUpdateFlowConfig` -> `SaltUpdateActions.uploadRecipesAction()` (core)
 ** The scenario encountered in ENGESC-10576  most probably involved the above code path.
 ** There are further irrelevant trigger procedures that can also lead to `UploadRecipesHandler` invocation in other places:
 *** `ClusterCreationFlowConfig` -> `ClusterCreationActions.uploadRecipesAction()` (core)
 *** `ClusterOperationService.updateSalt()` -> `ReactorFlowManager.triggerSaltUpdate()` (core)
 *** `BackupDatalakeDatabaseFlowEventChainFactory.createFlowTriggerEventQueue()` (core)
 *** `UpgradeDatalakeFlowEventChainFactory.createFlowTriggerEventQueue()` (core)
 *** `UpgradeDistroxFlowEventChainFactory.createFlowTriggerEventQueue()` (core)
 ** There is also the `ClusterUpscaleActions.uploadUpscaleRecipesAction()` -> `UploadUpscaleRecipesHandler.accept()` (core), but that code path is again irrelevant.
 * -> `UploadRecipesHandler.accept()`
 * -> `RecipeEngine.uploadRecipes()`
 * -> `OrchestratorRecipeExecutor.uploadRecipes()`
 * -> `OrchestratorRecipeExecutor.getHostgroupToRecipeMap()`
 * -> `StackToTemplatePreparationObjectConverter.convert()`
 * -> `TemplatePreparationObject$Builder.withHostgroups()`
 * -> `HostgroupView.<init>`
 * -> `HostgroupView$3.<init>`
 * -> `TreeSet.<init>`
 * ... -> `TreeMap.compare()`

In all cases, upon the completion of `UploadRecipesHandler` / `UploadUpscaleRecipesHandler`, the subsequent flow step invokes `KeytabConfigurationHandler` (core) that takes care of populating Salt pillar `keytab:CM` .
**Action items**
 * Make `HostgroupView` constructors NPE-safe
 * Filter out `null` or empty FQDNs in `TemplatePreparationObject$Builder.withHostgroups()`
 * Fix similar usages of `InstanceMetaData.getDiscoveryFQDN()` that may result in NPE