### PR TITLE
CB-14257 enable multi-AZ only on HA Datalakes.

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterShape.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterShape.java
@@ -1,8 +1,18 @@
 package com.sequenceiq.sdx.api.model;
 
 public enum SdxClusterShape {
-    CUSTOM,
-    LIGHT_DUTY,
-    MEDIUM_DUTY_HA,
-    MICRO_DUTY
+    CUSTOM(Boolean.FALSE),
+    LIGHT_DUTY(Boolean.FALSE),
+    MEDIUM_DUTY_HA(Boolean.TRUE),
+    MICRO_DUTY(Boolean.FALSE);
+
+    private final boolean multiAzEnabledByDefault;
+
+    SdxClusterShape(Boolean multiAzEnabledByDefault) {
+        this.multiAzEnabledByDefault = multiAzEnabledByDefault;
+    }
+
+    public boolean isMultiAzEnabledByDefault() {
+        return multiAzEnabledByDefault;
+    }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/MultiAzDecorator.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/MultiAzDecorator.java
@@ -10,33 +10,48 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.instancegroup.network.aws.InstanceGroupAwsNetworkV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.InstanceGroupV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.network.InstanceGroupNetworkV4Request;
 import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
 import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
 
 @Component
 public class MultiAzDecorator {
 
     private static final Set<Tunnel> PUBLIC_SUBNET_SUPPORTED_TUNNEL = Set.of(Tunnel.DIRECT, Tunnel.CLUSTER_PROXY);
 
-    public void decorateStackRequestWithMultiAz(StackV4Request stackV4Request, DetailedEnvironmentResponse environment) {
+    public void decorateStackRequestWithAwsNative(StackV4Request stackV4Request) {
         stackV4Request.setVariant("AWS_NATIVE");
+    }
+
+    public void decorateStackRequestWithMultiAz(StackV4Request stackV4Request, DetailedEnvironmentResponse environment, SdxClusterShape clusterShape) {
         stackV4Request.getInstanceGroups().forEach(ig -> {
             if (ig.getNetwork() == null) {
                 ig.setNetwork(new InstanceGroupNetworkV4Request());
                 InstanceGroupAwsNetworkV4Parameters networkParameter = ig.getNetwork().createAws();
                 List<String> subnetIds;
-                if (ig.getType() == InstanceGroupType.GATEWAY) {
-                    subnetIds = getSubnetsForGateway(environment);
+                if (clusterShape.isMultiAzEnabledByDefault()) {
+                    subnetIds = collectMultiAzSubnetIdsForGroup(environment, ig);
                 } else {
-                    subnetIds = new ArrayList<>(environment.getNetwork().getSubnetIds());
+                    subnetIds = List.of(environment.getNetwork().getPreferedSubnetId());
                 }
                 networkParameter.setSubnetIds(subnetIds);
             }
         });
+    }
+
+    private List<String> collectMultiAzSubnetIdsForGroup(DetailedEnvironmentResponse environment, InstanceGroupV4Request ig) {
+        List<String> subnetIds;
+        if (ig.getType() == InstanceGroupType.GATEWAY) {
+            subnetIds = getSubnetsForGateway(environment);
+        } else {
+            subnetIds = new ArrayList<>(environment.getNetwork().getSubnetIds());
+        }
+        return subnetIds;
     }
 
     private List<String> getSubnetsForGateway(DetailedEnvironmentResponse environment) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/StackRequestManifester.java
@@ -153,9 +153,7 @@ public class StackRequestManifester {
             setupCloudStorageAccountMapping(stackRequest, environment.getCrn(), environment.getIdBrokerMappingSource(), environment.getCloudPlatform());
             validateCloudStorage(sdxCluster, environment, stackRequest);
             setupInstanceVolumeEncryption(stackRequest, environment);
-            if (entitlementService.awsNativeDataLakeEnabled(ThreadBasedUserCrnProvider.getAccountId()) && sdxCluster.isEnableMultiAz()) {
-                multiAzDecorator.decorateStackRequestWithMultiAz(stackRequest, environment);
-            }
+            setupMultiAz(sdxCluster, environment, stackRequest);
             return stackRequest;
         } catch (IOException e) {
             LOGGER.error("Can not parse JSON to stack request");
@@ -402,4 +400,10 @@ public class StackRequestManifester {
         }
     }
 
+    private void setupMultiAz(SdxCluster sdxCluster, DetailedEnvironmentResponse environment, StackV4Request stackRequest) {
+        if (entitlementService.awsNativeDataLakeEnabled(ThreadBasedUserCrnProvider.getAccountId()) && sdxCluster.isEnableMultiAz()) {
+            multiAzDecorator.decorateStackRequestWithAwsNative(stackRequest);
+            multiAzDecorator.decorateStackRequestWithMultiAz(stackRequest, environment, sdxCluster.getClusterShape());
+        }
+    }
 }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/MultiAzDecoratorTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/sdx/MultiAzDecoratorTest.java
@@ -1,0 +1,102 @@
+package com.sequenceiq.datalake.service.sdx;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.instancegroup.InstanceGroupV4Request;
+import com.sequenceiq.cloudbreak.cloud.model.CloudSubnet;
+import com.sequenceiq.cloudbreak.cloud.model.network.SubnetType;
+import com.sequenceiq.common.api.type.InstanceGroupType;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentNetworkResponse;
+import com.sequenceiq.sdx.api.model.SdxClusterShape;
+
+class MultiAzDecoratorTest {
+
+    private static final String PREFERRED_SUBNET_ID = "aPreferredSubnetId";
+
+    private static final String PREFERRED_SUBNET_ID2 = "anotherPreferredSubnetId";
+
+    private MultiAzDecorator underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new MultiAzDecorator();
+    }
+
+    @Test
+    void decorateStackRequestWithMultiAzShouldUseTheSingleEnvironmentPreferredSubnetIdWhenClusterShapeIsNotHA() {
+        StackV4Request stackV4Request = new StackV4Request();
+        stackV4Request.setInstanceGroups(List.of(getInstanceGroupV4Request(InstanceGroupType.GATEWAY), getInstanceGroupV4Request(InstanceGroupType.CORE)));
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setPreferedSubnetId(PREFERRED_SUBNET_ID);
+        DetailedEnvironmentResponse environment = new DetailedEnvironmentResponse();
+        environment.setNetwork(network);
+
+        underTest.decorateStackRequestWithMultiAz(stackV4Request, environment, SdxClusterShape.LIGHT_DUTY);
+
+        Assertions.assertTrue(stackV4Request.getInstanceGroups().stream()
+                .allMatch(ig -> ig.getNetwork().getAws().getSubnetIds().stream()
+                        .allMatch(PREFERRED_SUBNET_ID::equals)));
+    }
+
+    @Test
+    void decorateStackRequestWithMultiAzShouldPickMultipleSubnetsWhenClusterShapeIsHA() {
+        StackV4Request stackV4Request = new StackV4Request();
+        stackV4Request.setInstanceGroups(List.of(getInstanceGroupV4Request(InstanceGroupType.GATEWAY), getInstanceGroupV4Request(InstanceGroupType.CORE)));
+        Set<String> subnetIds = Set.of(PREFERRED_SUBNET_ID, PREFERRED_SUBNET_ID2);
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setPreferedSubnetId(PREFERRED_SUBNET_ID);
+        network.setPreferedSubnetIds(subnetIds);
+        network.setSubnetIds(subnetIds);
+        network.setSubnetMetas(Map.of(
+                PREFERRED_SUBNET_ID, new CloudSubnet("id1", PREFERRED_SUBNET_ID, "eu-central-1a", "10.0.0.0/24", false, true, true, SubnetType.PUBLIC),
+                PREFERRED_SUBNET_ID2, new CloudSubnet("id1", PREFERRED_SUBNET_ID2, "eu-central-1b", "10.0.1.0/24", false, true, true, SubnetType.PUBLIC)
+        ));
+        DetailedEnvironmentResponse environment = new DetailedEnvironmentResponse();
+        environment.setNetwork(network);
+        environment.setTunnel(Tunnel.DIRECT);
+
+        underTest.decorateStackRequestWithMultiAz(stackV4Request, environment, SdxClusterShape.MEDIUM_DUTY_HA);
+
+        Assertions.assertTrue(stackV4Request.getInstanceGroups().stream()
+                .allMatch(ig -> ig.getNetwork().getAws().getSubnetIds().containsAll(subnetIds)));
+    }
+
+    @Test
+    void decorateStackRequestWithMultiAzShouldPickMultipleSubnetsButOneSubnetPerAzForGatewayGroupWhenClusterShapeIsHA() {
+        StackV4Request stackV4Request = new StackV4Request();
+        stackV4Request.setInstanceGroups(List.of(getInstanceGroupV4Request(InstanceGroupType.GATEWAY), getInstanceGroupV4Request(InstanceGroupType.CORE)));
+        Set<String> subnetIds = Set.of(PREFERRED_SUBNET_ID, PREFERRED_SUBNET_ID2);
+        EnvironmentNetworkResponse network = new EnvironmentNetworkResponse();
+        network.setPreferedSubnetId(PREFERRED_SUBNET_ID);
+        network.setPreferedSubnetIds(subnetIds);
+        network.setSubnetIds(subnetIds);
+        network.setSubnetMetas(Map.of(
+                PREFERRED_SUBNET_ID, new CloudSubnet("id1", PREFERRED_SUBNET_ID, "eu-central-1a", "10.0.0.0/24", false, true, true, SubnetType.PUBLIC),
+                PREFERRED_SUBNET_ID2, new CloudSubnet("id1", PREFERRED_SUBNET_ID2, "eu-central-1a", "10.0.1.0/24", false, true, true, SubnetType.PUBLIC)
+        ));
+        DetailedEnvironmentResponse environment = new DetailedEnvironmentResponse();
+        environment.setNetwork(network);
+        environment.setTunnel(Tunnel.DIRECT);
+
+        underTest.decorateStackRequestWithMultiAz(stackV4Request, environment, SdxClusterShape.MEDIUM_DUTY_HA);
+
+        Assertions.assertTrue(stackV4Request.getInstanceGroups().stream()
+                .allMatch(ig -> InstanceGroupType.GATEWAY.equals(
+                        ig.getType()) ? ig.getNetwork().getAws().getSubnetIds().size() == 1 : ig.getNetwork().getAws().getSubnetIds().containsAll(subnetIds)));
+    }
+
+    private InstanceGroupV4Request getInstanceGroupV4Request(InstanceGroupType instanceGroupType) {
+        InstanceGroupV4Request instanceGroup = new InstanceGroupV4Request();
+        instanceGroup.setType(instanceGroupType);
+        return instanceGroup;
+    }
+}


### PR DESCRIPTION
Enable multi-AZ only on HA Datalakes. It doesn't make sense to use multiple subnet on non-HA Datalakes as it perform worse and more expensive.

+ one more UT for @topolyai5 's gateway subnet selector logic 😄 