### PR TITLE
CB-14120 Re-enabling certificate renewal tests for 7.2.12

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxSecurityTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxSecurityTests.java
@@ -42,7 +42,7 @@ public class SdxSecurityTests extends PreconditionSdxE2ETest {
     @Inject
     private DatalakeAuditGrpcServiceAssertion datalakeAuditGrpcServiceAssertion;
 
-    @Test(dataProvider = TEST_CONTEXT, enabled = false)
+    @Test(dataProvider = TEST_CONTEXT)
     @UseSpotInstances
     @Description(
             given = "there is a running Cloudbreak, and an SDX cluster in available state",


### PR DESCRIPTION
1. 7.2.12 images are built.
2. Tested end-to-end in mow-dev.

This reverts commit 4f4130737965c7705c1102fad0347206da1686fb.