### PR TITLE
Revert "CB-13464:Add validation to check if the mentioned Key exists in AWS"

### DIFF
--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/EnvironmentValidationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/EnvironmentValidationHandler.java
@@ -140,8 +140,6 @@ public class EnvironmentValidationHandler extends EventSenderAwareHandler<Enviro
         validationBuilder.merge(validatorService.validateParameters(environmentValidationDto, environmentDto.getParameters()));
         validationBuilder.merge(validatorService.validateNetworkWithProvider(environmentValidationDto));
         validationBuilder.merge(validatorService.validateAuthentication(environmentValidationDto));
-        validationBuilder.merge(validatorService.validateAwsKeysPresent(environmentValidationDto, environmentDto.getParameters()));
-
         ValidationResult validationResult = validationBuilder.build();
         if (validationResult.hasError()) {
             throw new EnvironmentServiceException(validationResult.getFormattedErrors());

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentFlowValidatorService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentFlowValidatorService.java
@@ -14,7 +14,6 @@ import com.sequenceiq.environment.environment.validation.cloudstorage.Environmen
 import com.sequenceiq.environment.environment.validation.cloudstorage.EnvironmentBackupStorageLocationValidator;
 import com.sequenceiq.environment.environment.validation.cloudstorage.EnvironmentLogStorageConfigurationValidator;
 import com.sequenceiq.environment.environment.validation.cloudstorage.EnvironmentLogStorageLocationValidator;
-import com.sequenceiq.environment.environment.validation.validators.EncryptionKeyArnValidator;
 import com.sequenceiq.environment.environment.validation.validators.EnvironmentAuthenticationValidator;
 import com.sequenceiq.environment.environment.validation.validators.EnvironmentNetworkProviderValidator;
 import com.sequenceiq.environment.environment.validation.validators.EnvironmentParameterValidator;
@@ -42,8 +41,6 @@ public class EnvironmentFlowValidatorService {
 
     private final EnvironmentAuthenticationValidator environmentAuthenticationValidator;
 
-    private final EncryptionKeyArnValidator encryptionKeyArnValidator;
-
     public EnvironmentFlowValidatorService(
             EnvironmentRegionValidator environmentRegionValidator,
             EnvironmentNetworkProviderValidator environmentNetworkProviderValidator,
@@ -52,8 +49,7 @@ public class EnvironmentFlowValidatorService {
             EnvironmentParameterValidator environmentParameterValidator,
             EnvironmentAuthenticationValidator environmentAuthenticationValidator,
             EnvironmentLogStorageConfigurationValidator logStorageConfigurationValidator,
-            EnvironmentBackupStorageConfigurationValidator backupStorageConfigurationValidator,
-            EncryptionKeyArnValidator encryptionKeyArnValidator) {
+            EnvironmentBackupStorageConfigurationValidator backupStorageConfigurationValidator) {
         this.environmentRegionValidator = environmentRegionValidator;
         this.environmentNetworkProviderValidator = environmentNetworkProviderValidator;
         this.logStorageLocationValidator = logStorageLocationValidator;
@@ -62,7 +58,6 @@ public class EnvironmentFlowValidatorService {
         this.environmentAuthenticationValidator = environmentAuthenticationValidator;
         this.logStorageConfigurationValidator = logStorageConfigurationValidator;
         this.backupStorageConfigurationValidator = backupStorageConfigurationValidator;
-        this.encryptionKeyArnValidator = encryptionKeyArnValidator;
     }
 
     public ValidationResult.ValidationResultBuilder validateRegionsAndLocation(String location, Set<String> requestedRegions,
@@ -102,14 +97,6 @@ public class EnvironmentFlowValidatorService {
 
     public ValidationResult validateAuthentication(EnvironmentValidationDto environmentValidationDto) {
         return environmentAuthenticationValidator.validate(environmentValidationDto);
-    }
-
-    public ValidationResult validateAwsKeysPresent(EnvironmentValidationDto environmentValidationDto, ParametersDto parametersDto) {
-        ValidationResult.ValidationResultBuilder validationResultBuilder = ValidationResult.builder();
-        if (environmentValidationDto.getEnvironmentDto().getCloudPlatform().equals("AWS")) {
-            return encryptionKeyArnValidator.validate(environmentValidationDto, parametersDto);
-        }
-        return validationResultBuilder.build();
     }
 
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyArnValidator.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyArnValidator.java
@@ -1,53 +1,17 @@
 package com.sequenceiq.environment.environment.validation.validators;
 
-import static com.sequenceiq.cloudbreak.cloud.model.Region.region;
-
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
-import com.amazonaws.AmazonServiceException;
-import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
-import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
-import com.sequenceiq.cloudbreak.cloud.model.CloudEncryptionKey;
-import com.sequenceiq.cloudbreak.cloud.model.CloudEncryptionKeys;
-import com.sequenceiq.cloudbreak.cloud.model.CloudPlatformVariant;
-import com.sequenceiq.cloudbreak.cloud.model.Platform;
-import com.sequenceiq.cloudbreak.cloud.model.Region;
-import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
-import com.sequenceiq.environment.credential.v1.converter.CredentialToCloudCredentialConverter;
-import com.sequenceiq.environment.environment.dto.EnvironmentDto;
-import com.sequenceiq.environment.environment.dto.EnvironmentValidationDto;
-import com.sequenceiq.environment.parameter.dto.ParametersDto;
 
 @Component
 public class EncryptionKeyArnValidator {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(EncryptionKeyArnValidator.class);
-
     private static final Pattern ENCRYPTION_KEY_ARN_PATTERN = Pattern.compile("^arn:(aws|aws-cn|aws-us-gov):kms:[a-zA-Z0-9-]+:[0-9]+:" +
             "key/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
-
-    private CredentialToCloudCredentialConverter credentialToCloudCredentialConverter;
-
-    @Qualifier("DefaultRetryService")
-    private Retry retryService;
-
-    private CloudPlatformConnectors cloudPlatformConnectors;
-
-    public EncryptionKeyArnValidator(CredentialToCloudCredentialConverter credentialToCloudCredentialConverter,
-                                        Retry retryService, CloudPlatformConnectors cloudPlatformConnectors) {
-        this.credentialToCloudCredentialConverter = credentialToCloudCredentialConverter;
-        this.retryService = retryService;
-        this.cloudPlatformConnectors = cloudPlatformConnectors;
-    }
 
     public ValidationResult validateEncryptionKeyArn(String encryptionKeyArn) {
         ValidationResult.ValidationResultBuilder validationResultBuilder = ValidationResult.builder();
@@ -59,37 +23,6 @@ public class EncryptionKeyArnValidator {
                     "Key ARN: arn:partition:service:region:account-id:resource-type/resource-id. " +
                     "For example, arn:aws:kms:us-east-1:012345678910:key/1234abcd-12ab-34cd-56ef-1234567890ab.%n"));
         }
-        return validationResultBuilder.build();
-    }
-
-    public ValidationResult validate(EnvironmentValidationDto environmentValidationDto, ParametersDto parametersDto) {
-        ValidationResult.ValidationResultBuilder validationResultBuilder = ValidationResult.builder();
-        String encryptionKeyArn = parametersDto.getAwsParametersDto().getAwsDiskEncryptionParametersDto().getEncryptionKeyArn();
-        if (encryptionKeyArn == null || encryptionKeyArn.isEmpty()) {
-            return validationResultBuilder.build();
-        }
-
-        EnvironmentDto environmentDto = environmentValidationDto.getEnvironmentDto();
-        CloudCredential cloudCredential = credentialToCloudCredentialConverter.convert(environmentDto.getCredential());
-        Region region = region(environmentDto.getLocation().getName());
-        new CloudEncryptionKeys(new HashSet<>());
-        CloudEncryptionKeys encryptionKeys;
-        CloudPlatformVariant cloudPlatformVariant = new CloudPlatformVariant(
-                Platform.platform(environmentDto.getCloudPlatform()), null);
-
-        try {
-                encryptionKeys =  retryService.testWith2SecDelayMax15Times(() -> cloudPlatformConnectors.get(cloudPlatformVariant).
-                                    platformResources().encryptionKeys(cloudCredential, region, Collections.emptyMap()));
-            } catch (Retry.ActionFailedException | AmazonServiceException e) {
-                LOGGER.error("An unexpected error occurred while trying to fetch the KMS keys from AWS");
-                throw e;
-            }
-
-        if (encryptionKeys.getCloudEncryptionKeys().stream().map(CloudEncryptionKey::getName)
-                        .noneMatch(s -> s.equals(encryptionKeyArn))) {
-                    validationResultBuilder.error("The provided encryption key does not exist in the given region's encryption key list for this credential.");
-            }
-
         return validationResultBuilder.build();
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyArnValidatorTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/validators/EncryptionKeyArnValidatorTest.java
@@ -2,68 +2,20 @@ package com.sequenceiq.environment.environment.validation.validators;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-
-import java.util.Set;
-import java.util.function.Supplier;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Qualifier;
 
-import com.amazonaws.AmazonServiceException;
-import com.sequenceiq.cloudbreak.cloud.init.CloudPlatformConnectors;
-import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
-import com.sequenceiq.cloudbreak.cloud.model.CloudEncryptionKey;
-import com.sequenceiq.cloudbreak.cloud.model.CloudEncryptionKeys;
-import com.sequenceiq.cloudbreak.cloud.model.Region;
-import com.sequenceiq.cloudbreak.service.Retry;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
-import com.sequenceiq.environment.credential.domain.Credential;
-import com.sequenceiq.environment.credential.v1.converter.CredentialToCloudCredentialConverter;
-import com.sequenceiq.environment.environment.dto.EnvironmentDto;
-import com.sequenceiq.environment.environment.dto.EnvironmentValidationDto;
-import com.sequenceiq.environment.environment.dto.LocationDto;
-import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
-import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
-import com.sequenceiq.environment.parameter.dto.ParametersDto;
 
-@ExtendWith(MockitoExtension.class)
 class EncryptionKeyArnValidatorTest {
-
-    private static final String REGION = "dummyRegion";
 
     private EncryptionKeyArnValidator underTest;
 
-    @Mock
-    private CredentialToCloudCredentialConverter credentialToCloudCredentialConverter;
-
-    @Mock
-    @Qualifier("DefaultRetryService")
-    private Retry retryService;
-
-    @Mock
-    private Credential credential;
-
-    @Mock
-    private Region region;
-
-    @InjectMocks
-    private CloudPlatformConnectors cloudPlatformConnectors;
-
-    @Mock
-    private CloudCredential cloudCredential;
-
     @BeforeEach
     void setUp() {
-        underTest = new EncryptionKeyArnValidator(credentialToCloudCredentialConverter, retryService, cloudPlatformConnectors);
+        underTest = new EncryptionKeyArnValidator();
     }
 
     @Test
@@ -87,78 +39,5 @@ class EncryptionKeyArnValidatorTest {
                         "Key ARN: arn:partition:service:region:account-id:resource-type/resource-id. " +
                         "For example, arn:aws:kms:us-east-1:012345678910:key/1234abcd-12ab-34cd-56ef-1234567890ab.%n"),
                 validationResult.getFormattedErrors());
-    }
-
-    @Test
-    void testWithInvalidEncryptionKeyWithAwsListKeysCall() {
-        String invalidKey =  "arn:aws:kms:us-east-1:012345678910:key/1234abcd-12ab-34cd-56ef-1234567890ab";
-        EnvironmentDto environmentDto = createEnvironmentDto(invalidKey);
-        ParametersDto parametersDto = createParametersDto(invalidKey);
-        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
-        when(credentialToCloudCredentialConverter.convert(credential)).thenReturn(cloudCredential);
-        CloudEncryptionKey testInput = new CloudEncryptionKey();
-        testInput.setName("arn:aws:kms:eu-west-2:123456789012:key/1a2b3c4d-5e6f-7g8h-9i0j-1k2l3m4n5o6p");
-        CloudEncryptionKeys cloudEncryptionKeys = new CloudEncryptionKeys(Set.of(testInput));
-        when(retryService.testWith2SecDelayMax15Times(any(Supplier.class))).thenReturn(cloudEncryptionKeys);
-
-        ValidationResult validationResult = underTest.validate(environmentValidationDto, parametersDto);
-        assertTrue(validationResult.hasError());
-        assertEquals(String.format("The provided encryption key does not exist in the given region's encryption key list for this credential."),
-                        validationResult.getFormattedErrors());
-    }
-
-    @Test
-    void testWithvalidEncryptionKeyWithAwsListKeysCall() {
-        String validKey =  "arn:aws:kms:us-east-1:012345678910:key/1234abcd-12ab-34cd-56ef-1234567890ab";
-        EnvironmentDto environmentDto = createEnvironmentDto(validKey);
-        ParametersDto parametersDto = createParametersDto(validKey);
-        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
-        when(credentialToCloudCredentialConverter.convert(credential)).thenReturn(cloudCredential);
-        CloudEncryptionKey testInput = new CloudEncryptionKey();
-        testInput.setName("arn:aws:kms:us-east-1:012345678910:key/1234abcd-12ab-34cd-56ef-1234567890ab");
-        CloudEncryptionKeys cloudEncryptionKeys = new CloudEncryptionKeys(Set.of(testInput));
-        when(retryService.testWith2SecDelayMax15Times(any(Supplier.class))).thenReturn(cloudEncryptionKeys);
-
-        ValidationResult validationResult = underTest.validate(environmentValidationDto, parametersDto);
-        assertFalse(validationResult.hasError());
-    }
-
-    @Test
-    public void testWithValidEncryptionKeyAndAwsListKeysCallFailed() {
-        String validKey =  "arn:aws:kms:us-east-1:012345678910:key/1234abcd-12ab-34cd-56ef-1234567890ab";
-        EnvironmentDto environmentDto = createEnvironmentDto(validKey);
-        EnvironmentValidationDto environmentValidationDto = EnvironmentValidationDto.builder().withEnvironmentDto(environmentDto).build();
-        ParametersDto parametersDto = createParametersDto(validKey);
-        AmazonServiceException amazonServiceException = new AmazonServiceException("An unexpected error occurred while trying to fetch the KMS keys from AWS");
-        when(credentialToCloudCredentialConverter.convert(credential)).thenReturn(cloudCredential);
-        when(retryService.testWith2SecDelayMax15Times(any(Supplier.class))).thenThrow(amazonServiceException);
-        assertThrows(AmazonServiceException.class, () -> underTest.validate(environmentValidationDto, parametersDto));
-    }
-
-    private EnvironmentDto createEnvironmentDto(String encryptionKeyArn) {
-        EnvironmentDto environmentDto = EnvironmentDto.builder()
-                                        .withLocationDto(LocationDto.builder()
-                                            .withName(REGION).build())
-                                        .withCredential(credential)
-                                        .withCloudPlatform("AWS")
-                                        .withParameters(ParametersDto.builder()
-                                        .withAwsParameters(AwsParametersDto.builder()
-                                            .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
-                                                .withEncryptionKeyArn(encryptionKeyArn).build())
-                                            .build())
-                                        .build())
-                                        .build();
-        return environmentDto;
-    }
-
-    private ParametersDto createParametersDto(String encryptionKeyArn) {
-        ParametersDto parametersDto = ParametersDto.builder()
-                                        .withAwsParameters(AwsParametersDto.builder()
-                                                .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
-                                                        .withEncryptionKeyArn(encryptionKeyArn)
-                                                        .build())
-                                                .build())
-                                        .build();
-        return parametersDto;
     }
 }


### PR DESCRIPTION
Reverts hortonworks/cloudbreak#11392
@satyabollineni this PR is being reverted because causing NPE on environment creation when environment request does not contain any `awsDiskEncryptionParameters` which is not a mandatory field. So this code would cause many environment creation issues
![image](https://user-images.githubusercontent.com/2011396/136021880-5946734a-56e7-48ef-851d-b26ffa05d110.png)
![image](https://user-images.githubusercontent.com/2011396/136021970-9a14d8ae-d0f6-48c1-b7f9-767ae4630304.png)

**Faulty object reference in `EncryptionKeyArnValidator`:**
`String encryptionKeyArn = parametersDto.getAwsParametersDto().getAwsDiskEncryptionParametersDto().getEncryptionKeyArn();`

