### PR TITLE
CB-14271: Added smm credentials to pgpass in Salt for backup-restore service.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/.pgpass
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/.pgpass
@@ -3,4 +3,5 @@
 {{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:hive:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
 {{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:ranger:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
 {{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:postgres:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
+{{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:smm:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
 {% endif %}


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-14271

This change serves to add an extra row to the backup restore .pgpass Salt file in order to enable backing up and restoring the Streams Messaging Manager database.

This has been tested on an Azure light duty datalake Streams Messaging Light Duty datahub, and has worked there.