### PR TITLE
CB-14353 disable direct CM UI debug path in NGiNX configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@
         + [Running Thunderhead Mock from the Command Line](#running-thunderhead-mock-from-the-command-line)
     * [Database development](#database-development)
     * [Building](#building)
-    * [How to reach CM UI directly(not through Knox)](#how-to-reach-cm-ui-directly-not-through-knox-)
 - [How to contribute](#how-to-contribute)
     * [Appearance](#appearance)
     * [Coding guidelines](#coding-guidelines)
@@ -569,16 +568,6 @@ Gradle is used for build and dependency management. The Gradle wrapper is added 
 ```
 ./gradlew clean build
 ```
-
-## How to reach CM UI directly(not through Knox)
-With the current design on the cluster's gateway node there is an NGiNX which is responsible for routing requests through Knox by default. 
-But there are cases when the CM UI needs to be reached directly. It is possible on the same port by the same NGiNX on the `clouderamanager/` path of the provisioned cluster.
-Please note that the trailing slash is significant for the routing to work.
-
-For example: `https://tb-nt-local.tb-local.xcu2-8y8x.workload-dev.cloudera.com/clouderamanager/`
-
-> Be aware of that this routing mechanism is based on cookies, so if you have problems to reach the CM UI directly especially when you reached any service through Knox previously then the deletion of cookies could solve your issues.
-
 
 # How to contribute
 

--- a/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
+++ b/orchestrator-salt/src/main/resources/salt/salt/nginx/conf/clouderamanager-ssl-user-facing.conf
@@ -15,20 +15,6 @@ server {
     ssl_certificate_key  /etc/certs-user-facing/server-key.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
 
-    #If hadoop-jwt token is defined do not rewrite the path to go to clouderamanager -> go to knox
-    if ($cookie_CLOUDERA_MANAGER_SESSIONID ~ .+) {
-        set $rewritecondition  "cm-cookie";
-    }
-    if ($cookie_SESSION ~ .+) {
-        set $rewritecondition  "cm-cookie";
-    }
-    if ($cookie_hadoop-jwt ~ .+) {
-        set $rewritecondition  "${rewritecondition}+hadoop-jwt-cookie";
-    }
-    if ($rewritecondition = "cm-cookie") {
-        rewrite ^([/](?!clouderamanager/).*$) /clouderamanager$1;
-    }
-
 {%- if 'HIVESERVER2' in salt['pillar.get']('gateway:location') %}
     rewrite ^/cliservice(.*)$ /{{ salt['pillar.get']('gateway:path') }}/cdp-proxy-api/hive$1;
     rewrite ^/hive2(.*)$ /{{ salt['pillar.get']('gateway:path') }}/cdp-proxy-api/hive$1;
@@ -45,18 +31,6 @@ server {
     }
     location ~ ^/favicon.403$ {
         return 403;
-    }
-
-    location ~ .*/clouderamanager/(.*) {
-        proxy_pass         {{ protocol }}://clouderamanager/$1$is_args$args;
-        proxy_redirect     http:// https://;
-        proxy_http_version 1.1;
-        proxy_set_header   Host $host;
-        proxy_set_header   X-Forwarded-Host $server_name;
-        proxy_set_header   X-Forwarded-Proto $scheme;
-        proxy_set_header   Upgrade $http_upgrade;
-        proxy_set_header   Connection $connection_upgrade;
-        proxy_set_header   Referer {{ protocol }}://$host/$1;
     }
 
     location ~ .*/ {


### PR DESCRIPTION
> CB-14353 disable direct CM UI debug path in NGiNX configuration
It has been cherry-pick-ed from 2.49.0 line of Cloudbreak.