### PR TITLE
CB-14327: Use the current image catalog to get the target image for disk space validation.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeDiskSpaceValidationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeDiskSpaceValidationHandler.java
@@ -14,7 +14,7 @@ import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationEvent;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationFailureEvent;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
+import com.sequenceiq.cloudbreak.service.image.ImageService;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.upgrade.validation.DiskSpaceValidationService;
@@ -32,7 +32,7 @@ public class ClusterUpgradeDiskSpaceValidationHandler extends ExceptionCatcherEv
     private DiskSpaceValidationService diskSpaceValidationService;
 
     @Inject
-    private ImageCatalogService imageCatalogService;
+    private ImageService imageService;
 
     @Inject
     private StackService stackService;
@@ -43,9 +43,8 @@ public class ClusterUpgradeDiskSpaceValidationHandler extends ExceptionCatcherEv
         ClusterUpgradeValidationEvent request = event.getData();
         Long stackId = request.getResourceId();
         try {
-            StatedImage image = imageCatalogService.getImage(request.getImageId());
-            diskSpaceValidationService.validateFreeSpaceForUpgrade(getStack(stackId), image.getImageCatalogUrl(), image.getImageCatalogName(),
-                    request.getImageId());
+            StatedImage targetImage = imageService.getCurrentImage(stackId);
+            diskSpaceValidationService.validateFreeSpaceForUpgrade(getStack(stackId), targetImage);
             return new ClusterUpgradeDiskSpaceValidationFinishedEvent(request.getResourceId());
         } catch (UpgradeValidationFailedException e) {
             LOGGER.warn("Cluster upgrade validation failed", e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/DiskSpaceValidationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/DiskSpaceValidationService.java
@@ -21,6 +21,7 @@ import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.resource.ResourceService;
 import com.sequenceiq.cloudbreak.util.StackUtil;
 
@@ -52,8 +53,8 @@ public class DiskSpaceValidationService {
     @Inject
     private ParcelSizeService parcelSizeService;
 
-    public void validateFreeSpaceForUpgrade(Stack stack, String imageCatalogUrl, String imageCatalogName, String imageId) throws CloudbreakException {
-        long requiredFreeSpace = parcelSizeService.getRequiredFreeSpace(imageCatalogUrl, imageCatalogName, imageId, stack);
+    public void validateFreeSpaceForUpgrade(Stack stack, StatedImage targetImage) throws CloudbreakException {
+        long requiredFreeSpace = parcelSizeService.getRequiredFreeSpace(targetImage, stack);
         Map<String, String> freeDiskSpaceByNodes = getFreeDiskSpaceByNodes(stack);
         LOGGER.debug("Required free space for parcels {} KB. Free space by nodes in KB: {}", requiredFreeSpace, freeDiskSpaceByNodes);
         Map<String, String> notEligibleNodes = getNotEligibleNodes(freeDiskSpaceByNodes, requiredFreeSpace, stack.getNotTerminatedGatewayInstanceMetadata());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/ParcelUrlProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/ParcelUrlProvider.java
@@ -15,11 +15,8 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
-import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
-import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
-import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.parcel.ParcelService;
 
@@ -29,21 +26,9 @@ class ParcelUrlProvider {
     @Inject
     private ParcelService parcelService;
 
-    @Inject
-    private ImageCatalogService imageCatalogService;
-
-    Set<String> getRequiredParcelsFromImage(String imageCatalogUrl, String imageCatalogName, String imageId, Stack stack) {
-        StatedImage targetImage = getTargetImage(imageCatalogUrl, imageCatalogName, imageId);
+    Set<String> getRequiredParcelsFromImage(StatedImage targetImage, Stack stack) {
         String cdhParcelUrl = getCdhParcelUrl(targetImage);
         return StackType.DATALAKE.equals(stack.getType()) ? Collections.singleton(cdhParcelUrl) : getAllParcel(cdhParcelUrl, targetImage, stack);
-    }
-
-    private StatedImage getTargetImage(String imageCatalogUrl, String imageCatalogName, String imageId) {
-        try {
-            return imageCatalogService.getImage(imageCatalogUrl, imageCatalogName, imageId);
-        } catch (CloudbreakImageNotFoundException | CloudbreakImageCatalogException e) {
-            throw new CloudbreakServiceException(e.getMessage(), e);
-        }
     }
 
     private String getCdhParcelUrl(StatedImage targetImage) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeDiskSpaceValidationHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeDiskSpaceValidationHandlerTest.java
@@ -1,0 +1,112 @@
+package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.handler;
+
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationHandlerSelectors.VALIDATE_DISK_SPACE_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors.FAILED_CLUSTER_UPGRADE_VALIDATION_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationStateSelectors.FINISH_CLUSTER_UPGRADE_DISK_SPACE_VALIDATION_EVENT;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.common.event.Selectable;
+import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationEvent;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.image.ImageService;
+import com.sequenceiq.cloudbreak.service.image.ImageTestUtil;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.upgrade.validation.DiskSpaceValidationService;
+import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
+
+import reactor.bus.Event;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterUpgradeDiskSpaceValidationHandlerTest {
+
+    private static final String IMAGE_ID = "fe2ad098-88e9-4ffd-b1fa-780a2d353dc5";
+
+    private static final long STACK_ID = 1L;
+
+    private static final String IMAGE_CATALOG_NAME = "test-catalog";
+
+    private static final String IMAGE_CATALOG_URL = "catalog-url";
+
+    @InjectMocks
+    private ClusterUpgradeDiskSpaceValidationHandler underTest;
+
+    @Mock
+    private DiskSpaceValidationService diskSpaceValidationService;
+
+    @Mock
+    private ImageService imageService;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private Stack stack;
+
+    @Test
+    public void testHandlerToRetrieveTheImageFromTheCurrentImageCatalog()
+            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException, CloudbreakException {
+        StatedImage targetImage = createStatedImage();
+        when(imageService.getCurrentImage(STACK_ID)).thenReturn(targetImage);
+        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+
+        Selectable nextFlowStepSelector = underTest.doAccept(createEvent());
+
+        assertEquals(FINISH_CLUSTER_UPGRADE_DISK_SPACE_VALIDATION_EVENT.name(), nextFlowStepSelector.selector());
+        verify(imageService).getCurrentImage(STACK_ID);
+        verify(stackService).getByIdWithListsInTransaction(STACK_ID);
+        verify(diskSpaceValidationService).validateFreeSpaceForUpgrade(stack, targetImage);
+    }
+
+    @Test
+    public void testHandlerShouldReturnFinishEventWhenImageServiceThrowsAnException() throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        when(imageService.getCurrentImage(STACK_ID)).thenThrow(new CloudbreakImageNotFoundException("Image not found"));
+
+        Selectable nextFlowStepSelector = underTest.doAccept(createEvent());
+
+        assertEquals(FINISH_CLUSTER_UPGRADE_DISK_SPACE_VALIDATION_EVENT.name(), nextFlowStepSelector.selector());
+        verify(imageService).getCurrentImage(STACK_ID);
+        verifyNoInteractions(stackService);
+        verifyNoInteractions(diskSpaceValidationService);
+    }
+
+    @Test
+    public void testHandlerShouldReturnValidationFailedEventWhenTheDiskValidationFailed()
+            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException, CloudbreakException {
+        StatedImage targetImage = createStatedImage();
+        when(imageService.getCurrentImage(STACK_ID)).thenReturn(targetImage);
+        when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
+        doThrow(new UpgradeValidationFailedException("Validation failed")).when(diskSpaceValidationService).validateFreeSpaceForUpgrade(stack, targetImage);
+
+        Selectable nextFlowStepSelector = underTest.doAccept(createEvent());
+
+        assertEquals(FAILED_CLUSTER_UPGRADE_VALIDATION_EVENT.name(), nextFlowStepSelector.selector());
+        verify(imageService).getCurrentImage(STACK_ID);
+        verify(stackService).getByIdWithListsInTransaction(STACK_ID);
+        verify(diskSpaceValidationService).validateFreeSpaceForUpgrade(stack, targetImage);
+    }
+
+    private HandlerEvent<ClusterUpgradeValidationEvent> createEvent() {
+        return new HandlerEvent<>(new Event<>(new ClusterUpgradeValidationEvent(VALIDATE_DISK_SPACE_EVENT.selector(), STACK_ID, IMAGE_ID)));
+    }
+
+    private StatedImage createStatedImage() {
+        return StatedImage.statedImage(ImageTestUtil.getImage(false, IMAGE_ID, null), IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/ParcelUrlProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/ParcelUrlProviderTest.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.service.upgrade.validation;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -23,10 +22,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.StackDetails;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.StackRepoDetails;
-import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
-import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
-import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
@@ -56,79 +52,29 @@ public class ParcelUrlProviderTest {
     private ParcelUrlProvider underTest;
 
     @Test
-    public void testGetRequiredParcelsFromImageWhenTheStackTypeIsWorkload() throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+    public void testGetRequiredParcelsFromImageWhenTheStackTypeIsWorkload() {
         Stack stack = createStack(StackType.WORKLOAD);
         StatedImage image = createImage(createStackRepoDetails(STACK_BASE_URL, STACK_REPO_VERSION));
 
-        when(imageCatalogService.getImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID)).thenReturn(image);
         when(parcelService.getComponentsByImage(stack, image.getImage())).thenReturn(createClusterComponents());
 
-        Set<String> actual = underTest.getRequiredParcelsFromImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID, stack);
+        Set<String> actual = underTest.getRequiredParcelsFromImage(image, stack);
 
         assertEquals(2, actual.size());
         assertTrue(actual.contains("http://testCDH-2.7.6-el7.parcel"));
         assertTrue(actual.contains("http://test/spark/SPARK3-el7.parcel"));
-        verify(imageCatalogService).getImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID);
         verify(parcelService).getComponentsByImage(stack, image.getImage());
     }
 
     @Test
-    public void testGetRequiredParcelsFromImageWhenTheStackTypeIsDataLake() throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+    public void testGetRequiredParcelsFromImageWhenTheStackTypeIsDataLake() {
         Stack stack = createStack(StackType.DATALAKE);
         StatedImage image = createImage(createStackRepoDetails(STACK_BASE_URL, STACK_REPO_VERSION));
 
-        when(imageCatalogService.getImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID)).thenReturn(image);
-
-        Set<String> actual = underTest.getRequiredParcelsFromImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID, stack);
+        Set<String> actual = underTest.getRequiredParcelsFromImage(image, stack);
 
         assertEquals(1, actual.size());
         assertTrue(actual.contains("http://testCDH-2.7.6-el7.parcel"));
-        verify(imageCatalogService).getImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID);
-        verifyNoInteractions(parcelService);
-    }
-
-    @Test(expected = CloudbreakServiceException.class)
-    public void testGetRequiredParcelsFromImageShouldThrowExceptionWhenTheImageCatalogThrowsAnException()
-            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
-        Stack stack = createStack(StackType.DATALAKE);
-
-        when(imageCatalogService.getImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID)).thenThrow(new CloudbreakImageNotFoundException("Error"));
-
-        underTest.getRequiredParcelsFromImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID, stack);
-
-        verify(imageCatalogService).getImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID);
-        verifyNoInteractions(parcelService);
-    }
-
-    @Test
-    public void testGetRequiredParcelsFromImageShouldThrowExceptionThenTheStackRepoVersionIsNotAvailable()
-            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
-        Stack stack = createStack(StackType.DATALAKE);
-        StatedImage image = createImage(createStackRepoDetails(STACK_BASE_URL, null));
-
-        when(imageCatalogService.getImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID)).thenReturn(image);
-
-        Exception exception = assertThrows(CloudbreakServiceException.class,
-                () -> underTest.getRequiredParcelsFromImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID, stack));
-
-        assertEquals("Stack repository version is not found on image: image-id", exception.getMessage());
-        verify(imageCatalogService).getImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID);
-        verifyNoInteractions(parcelService);
-    }
-
-    @Test
-    public void testGetRequiredParcelsFromImageShouldThrowExceptionThenTheStackBaseUrlIsNotAvailable()
-            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
-        Stack stack = createStack(StackType.DATALAKE);
-        StatedImage image = createImage(createStackRepoDetails(null, STACK_REPO_VERSION));
-
-        when(imageCatalogService.getImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID)).thenReturn(image);
-
-        Exception exception = assertThrows(CloudbreakServiceException.class,
-                () -> underTest.getRequiredParcelsFromImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID, stack));
-
-        assertEquals("Stack base URL is not found on image: image-id", exception.getMessage());
-        verify(imageCatalogService).getImage(IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME, IMAGE_ID);
         verifyNoInteractions(parcelService);
     }
 


### PR DESCRIPTION
Problem
If you used a custom image catalog for your cluster the disk space validation tried to find the target image in the default image catalog.

Solution
The validation flow using the current image catalog to retrieve the target image.