### PR TITLE
DISTX-577 Implement cloud-provider load-balancer support for GCP data…

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancingIpResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpLoadBalancingIpResourceBuilder.java
@@ -1,6 +1,5 @@
 package com.sequenceiq.cloudbreak.cloud.gcp.loadbalancer;
 
-import java.util.Collection;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -15,7 +14,7 @@ import com.sequenceiq.cloudbreak.cloud.gcp.context.GcpContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
-import com.sequenceiq.cloudbreak.cloud.model.Group;
+import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
 import com.sequenceiq.common.api.type.ResourceType;
 
 /**
@@ -28,6 +27,8 @@ public class GcpLoadBalancingIpResourceBuilder extends AbstractGcpLoadBalancerBu
 
     private static final int ORDER = 3;
 
+    private static final int KNOX_PORT = 8443;
+
     private static final Logger LOGGER = LoggerFactory.getLogger(GcpLoadBalancingIpResourceBuilder.class);
 
     @Inject
@@ -38,10 +39,10 @@ public class GcpLoadBalancingIpResourceBuilder extends AbstractGcpLoadBalancerBu
 
     @Override
     public List<CloudResource> create(GcpContext context, AuthenticatedContext auth, CloudLoadBalancer loadBalancer) {
-        String groupName = loadBalancer.getPortToTargetGroupMapping().values().stream()
-                .flatMap(Collection::stream).map(Group::getName).findFirst().orElse("lb");
+        Integer hcPort = loadBalancer.getPortToTargetGroupMapping().keySet().stream().map(TargetGroupPortPair::getHealthCheckPort).findFirst().orElse(KNOX_PORT);
         if (!context.getNoPublicIp()) {
-            String resourceName = getResourceNameService().resourceName(resourceType(), auth.getCloudContext().getName(), loadBalancer.getType(), groupName);
+            String resourceName =
+                    getResourceNameService().resourceName(resourceType(), auth.getCloudContext().getName(), loadBalancer.getType(), hcPort.toString());
             return List.of(new CloudResource.Builder().type(resourceType())
                 .name(resourceName)
                 .build());

--- a/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpForwardingRuleResourceBuilderTest.java
+++ b/cloud-gcp/src/test/java/com/sequenceiq/cloudbreak/cloud/gcp/loadbalancer/GcpForwardingRuleResourceBuilderTest.java
@@ -194,6 +194,27 @@ public class GcpForwardingRuleResourceBuilderTest {
 
     @Test
     public void buildforSharedVPC() throws Exception {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("hcport", 8443);
+        parameters.put("trafficports", List.of(443, 11443));
+        resource = new CloudResource.Builder()
+                .type(ResourceType.GCP_FORWARDING_RULE)
+                .status(CommonStatus.CREATED)
+                .group("master")
+                .name("super")
+                .params(parameters)
+                .persistent(true)
+                .build();
+
+        backendResource = new CloudResource.Builder()
+                .type(ResourceType.GCP_BACKEND_SERVICE)
+                .status(CommonStatus.CREATED)
+                .group("master")
+                .name("backendsuper")
+                .params(parameters)
+                .persistent(true)
+                .build();
+
         mockCalls(LoadBalancerType.PRIVATE);
         when(gcpStackUtil.getSharedProjectId(any())).thenReturn("custom-project");
 
@@ -205,7 +226,10 @@ public class GcpForwardingRuleResourceBuilderTest {
         Assert.assertEquals("https://www.googleapis.com/compute/v1/projects/custom-project/regions/us-west2/subnetworks/default-subnet",
                 arg.getSubnetwork());
         Assert.assertEquals("super", cloudResources.get(0).getName());
-        Assertions.assertEquals(8080, cloudResources.get(0).getParameter("hcport", Integer.class));
+        Assertions.assertEquals(8443, cloudResources.get(0).getParameter("hcport", Integer.class));
+        List<Integer> ports = (List<Integer>) cloudResources.get(0).getParameters().get("trafficports");
+        Assertions.assertTrue(ports.contains(443));
+        Assertions.assertTrue(ports.contains(11443));
     }
 
     @Test
@@ -251,6 +275,5 @@ public class GcpForwardingRuleResourceBuilderTest {
         lenient().when(gcpStackUtil.getNetworkUrl(anyString(), anyString())).thenCallRealMethod();
         lenient().when(gcpStackUtil.getSubnetUrl(anyString(), anyString(), anyString())).thenCallRealMethod();
         lenient().when(gcpLoadBalancerTypeConverter.getScheme(any(CloudLoadBalancer.class))).thenCallRealMethod();
-
     }
 }

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/TargetGroupType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/TargetGroupType.java
@@ -3,5 +3,6 @@ package com.sequenceiq.common.api.type;
 public enum TargetGroupType {
     KNOX,
     CM,
-    OOZIE
+    OOZIE,
+    OOZIE_GCP
 }

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-data-engineering-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-data-engineering-ha.bp
@@ -558,7 +558,7 @@
       },
       {
         "refName": "manager",
-        "cardinality": 1,
+        "cardinality": 2,
         "roleConfigGroupsRefNames": [
           "knox-KNOX_GATEWAY-BASE",
           "oozie-OOZIE_SERVER-BASE",

--- a/core/src/main/resources/defaults/clustertemplates/7.2.13/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.13/gcp/dataengineering-ha.json
@@ -11,6 +11,7 @@
     "externalDatabase": {
       "availabilityType": "HA"
     },
+    "enableLoadBalancer": true,
     "instanceGroups": [
       {
         "name": "manager",
@@ -27,7 +28,7 @@
           },
           "instanceType": "e2-standard-16"
         },
-        "nodeCount": 1,
+        "nodeCount": 2,
         "type": "GATEWAY",
         "recoveryMode": "MANUAL"
       },

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProvider.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Component;
 
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
-import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.AbstractRdsRoleConfigProvider;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
@@ -44,14 +43,6 @@ public class OozieRoleConfigProvider extends AbstractRdsRoleConfigProvider {
                     config(OOZIE_DATABASE_TYPE, oozieRdsView.getSubprotocol()),
                     config(OOZIE_DATABASE_USER, oozieRdsView.getConnectionUserName()),
                     config(OOZIE_DATABASE_PASSWORD, oozieRdsView.getConnectionPassword())));
-                if (isOozieHA(source) && CloudPlatform.GCP == source.getCloudPlatform()) {
-                    // There is no load-balancer for GCP yet. For base and callback urls use the hostname of the Oozie server.
-                    config.add(config(OOZIE_CONFIG_SAFETY_VALVE,
-                        "<property><name>oozie.base.url</name>"
-                            + "<value>https://${oozie.http.hostname}:${oozie.https.port}/oozie</value></property>"
-                            + "<property><name>oozie.service.CallbackService.base.url</name>"
-                            + "<value>https://${oozie.http.hostname}:${oozie.https.port}/oozie/callback</value></property>"));
-                }
                 return config;
             default:
                 return List.of();

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/oozie/OozieRoleConfigProviderTest.java
@@ -64,7 +64,7 @@ public class OozieRoleConfigProviderTest {
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = underTest.getRoleConfigs(cmTemplateProcessor, preparationObject);
         List<ApiClusterTemplateConfig> oozieServer = roleConfigs.get("oozie-OOZIE_SERVER-BASE");
 
-        assertEquals(6, oozieServer.size());
+        assertEquals(5, oozieServer.size());
         assertEquals("oozie_database_host", oozieServer.get(0).getName());
         assertEquals("testhost", oozieServer.get(0).getValue());
 
@@ -79,12 +79,6 @@ public class OozieRoleConfigProviderTest {
 
         assertEquals("oozie_database_password", oozieServer.get(4).getName());
         assertEquals("testpassword", oozieServer.get(4).getValue());
-
-        assertEquals("oozie_config_safety_valve", oozieServer.get(5).getName());
-        assertEquals("<property><name>oozie.base.url</name>"
-            + "<value>https://${oozie.http.hostname}:${oozie.https.port}/oozie</value></property>"
-            + "<property><name>oozie.service.CallbackService.base.url</name>"
-            + "<value>https://${oozie.http.hostname}:${oozie.https.port}/oozie/callback</value></property>", oozieServer.get(5).getValue());
     }
 
     @Test


### PR DESCRIPTION
…hub clusters for Knox and Oozie HA

1. The permissions are added to the SRE provisioned projects' service accounts.
2. The feature is still in tech preview. So even if there are problems due to load-balancer integration we can still fix it in future releases.
3. Tested end to end in private stack.
4. Now that all three cloud providers support load-balancer for 7.2.13 updated the host group cardinality of manager to 2.
5. Remove the load-balancer workaround for GCP.
6. Load-balancer modifications to make forwarding to two ports in the same instance group with single private IP work. Health check for Oozie in GCP will be in the Knox port, which will be documented.