### PR TITLE
CB-14381 Upgrade fails to download second CSD. Added a new class for …

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CsdParcelNameMatcher.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CsdParcelNameMatcher.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import static com.sequenceiq.cloudbreak.service.image.CsdSegments.segments;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.google.common.base.Strings;
+
+@Service
+public class CsdParcelNameMatcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CsdParcelNameMatcher.class);
+
+    private Map<String, CsdSegments> parcelCsdSegmentsMapping = Map.of(
+            "CFM", segments("NIFI", "NIFIREGISTRY"),
+            "FLINK", segments("FLINK", "SQL_STREAM_BUILDER")
+    );
+
+    public boolean matching(String csdUrl, String parcelName) {
+        boolean nameMatchingWithParcel;
+        Optional<CsdSegments> matchingSegments = getMatchingSegments(parcelName);
+        if (matchingSegments.isPresent()) {
+            LOGGER.debug("{} parcel name was found in the mapping and now searching the component name in the csd url '{}'",
+                    parcelName, csdUrl);
+            Optional<String> firstComponentWhichIsMatching = matchingSegments.get().getComponentList()
+                    .stream()
+                    .filter(segment -> matchingString(csdUrl, segment))
+                    .findFirst();
+            nameMatchingWithParcel = firstComponentWhichIsMatching.isPresent();
+        } else {
+            LOGGER.debug("{} parcel name was NOT found in the mapping and now searching the parcel name in the csd url '{}'",
+                    parcelName, csdUrl);
+            nameMatchingWithParcel = matchingString(csdUrl, parcelName);
+        }
+        return nameMatchingWithParcel;
+    }
+
+    private Optional<CsdSegments> getMatchingSegments(String parcelName) {
+        if (!Strings.isNullOrEmpty(parcelName)) {
+            return Optional.ofNullable(parcelCsdSegmentsMapping.get(parcelName.toUpperCase()));
+        }
+        return Optional.empty();
+    }
+
+    private boolean matchingString(String csdUrl, String component) {
+        return !Strings.isNullOrEmpty(csdUrl)
+                && !Strings.isNullOrEmpty(component)
+                && csdUrl.toLowerCase().contains(component.toLowerCase());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CsdSegments.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/CsdSegments.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class CsdSegments {
+
+    private final Set<String> componentList;
+
+    private CsdSegments(String... components) {
+        this.componentList = Arrays.stream(components).collect(Collectors.toSet());
+    }
+
+    public Set<String> getComponentList() {
+        return componentList;
+    }
+
+    public static CsdSegments segments(String... components) {
+        return new CsdSegments(components);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/PreWarmParcelParser.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/PreWarmParcelParser.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -18,6 +20,9 @@ import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 public class PreWarmParcelParser {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PreWarmParcelParser.class);
+
+    @Inject
+    private CsdParcelNameMatcher csdParcelNameMatcher;
 
     public Optional<ClouderaManagerProduct> parseProductFromParcel(List<String> parcel, List<String> csdList) {
         Optional<String> url = parcel.stream().filter(parcelPart -> parcelPart.startsWith("http://") || parcelPart.startsWith("https://"))
@@ -46,7 +51,7 @@ public class PreWarmParcelParser {
 
     private List<String> collectCsdParcels(List<String> csdList, String name) {
         return csdList.stream()
-                .filter(csd -> csd.toLowerCase().contains(name.toLowerCase()))
+                .filter(csd -> csdParcelNameMatcher.matching(csd, name))
                 .collect(Collectors.toList());
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CsdParcelNameMatcherTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CsdParcelNameMatcherTest.java
@@ -1,0 +1,190 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CsdParcelNameMatcherTest {
+
+    @InjectMocks
+    private CsdParcelNameMatcher underTest;
+
+    @ParameterizedTest(name = "csdurl {0} & parcelName {1} should match {2}")
+    @MethodSource("testCsdAndNameMatchingData")
+    public void testMatcher(String csdUrl, String parcelName, boolean expectedToMatch) {
+
+        boolean result = underTest.matching(csdUrl, parcelName);
+
+        Assert.assertEquals(expectedToMatch, result);
+    }
+
+    static Object[][] testCsdAndNameMatchingData() {
+        return new Object[][]{
+                {
+                        null,
+                        "FLINK",
+                        false
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/FLINK-1.13.2-csadh1.5.0.0-cdh7.2.12.0-35-17431883.jar",
+                        null,
+                        false
+                },
+                // FLINK
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/FLINK-1.13.2-csadh1.5.0.0-cdh7.2.12.0-35-17431883.jar",
+                        "FLINK",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/FLINK-1.13.2-csadh1.5.0.0-cdh7.2.12.0-35-17431883.jar",
+                        "flink",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/flink-1.13.2-csadh1.5.0.0-cdh7.2.12.0-35-17431883.jar",
+                        "FLINK",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/FLINK-1.13.2-csadh1.5.0.0-cdh7.2.12.0-35-17431883.jar",
+                        "ZLINK",
+                        false
+                },
+                // SQL_STREAM_BUILDER
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/sql_stream_builder-1.13.2-csadh1.5.0.0-cdh7.2.12.0-35-17431883.jar",
+                        "FLINK",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/SQL_STREAM_BUILDER-1.13.2-csadh1.5.0.0-cdh7.2.12.0-35-17431883.jar",
+                        "SQL_STREAM_BUILDER",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/SQL_STREAM_BUILDER-1.13.2-csadh1.5.0.0-cdh7.2.12.0-35-17431883.jar",
+                        "SQLSTREAM_BUILDER",
+                        false
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/SQL_STREAM_BUILDER-1.13.2-csadh1.5.0.0-cdh7.2.12.0-35-17431883.jar",
+                        "sql_stream_builder",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/sql_stream_builder-1.13.2-csadh1.5.0.0-cdh7.2.12.0-35-17431883.jar",
+                        "SQL_STREAM_BUILDER",
+                        true
+                },
+                // NIFI
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFI-1.13.2.2.2.3.0-56.jar",
+                        "NIFI",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFI-1.13.2.2.2.3.0-56.jar",
+                        "FIFI",
+                        false
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFI-1.13.2.2.2.3.0-56.jar",
+                        "nifi",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/nifi-1.13.2.2.2.3.0-56.jar",
+                        "NIFI",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFI-1.13.2.2.2.3.0-56.jar",
+                        "CFM",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFI-1.13.2.2.2.3.0-56.jar",
+                        "CFM",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFI-1.13.2.2.2.3.0-56.jar",
+                        "CFM",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/nifi-1.13.2.2.2.3.0-56.jar",
+                        "CFM",
+                        true
+                },
+                // NIFIREGISTRY
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFIREGISTRY-0.8.0.2.2.3.0-56.jar",
+                        "NIFIREGISTRY",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFIREGISTRY-0.8.0.2.2.3.0-56.jar",
+                        "NIFI_REGISTRY",
+                        false
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFIREGISTRY-0.8.0.2.2.3.0-56.jar",
+                        "nifiregistry",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/nifiregistry-0.8.0.2.2.3.0-56.jar",
+                        "NIFIREGISTRY",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFIREGISTRY-0.8.0.2.2.3.0-56.jar",
+                        "CFM",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFIREGISTRY-0.8.0.2.2.3.0-56.jar",
+                        "CFM",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/NIFIREGISTRY-0.8.0.2.2.3.0-56.jar",
+                        "CFM",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/nifiregistry-0.8.0.2.2.3.0-56.jar",
+                        "CFM",
+                        true
+                },
+                // SPARK3
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/spark3-0.8.0.2.2.3.0-56.jar",
+                        "SPARK3",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/SPARK3-0.8.0.2.2.3.0-56.jar",
+                        "spark3",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/spark3-0.8.0.2.2.3.0-56.jar",
+                        "SPARK3",
+                        true
+                },
+                {
+                        "http://cloudera-build-us-west-1.vpc.cloudera.com/spark3-0.8.0.2.2.3.0-56.jar",
+                        "spark2",
+                        false
+                },
+
+        };
+    }
+}


### PR DESCRIPTION
…filtering flink and nifi. If there is no mapping then we are falling back to the name checking. The check is not case sensitive so also covered that use cases with tests.

See detailed description in the commit message.