### PR TITLE
CB-13668 Add fields for Load Balancer SKU to Azure stack creation requests

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancer.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudLoadBalancer.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import com.sequenceiq.common.api.type.LoadBalancerSku;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 
 public class CloudLoadBalancer {
@@ -12,8 +13,15 @@ public class CloudLoadBalancer {
 
     private final Map<TargetGroupPortPair, Set<Group>> portToTargetGroupMapping;
 
+    private final LoadBalancerSku sku;
+
     public CloudLoadBalancer(LoadBalancerType type) {
+        this(type, LoadBalancerSku.getDefault());
+    }
+
+    public CloudLoadBalancer(LoadBalancerType type, LoadBalancerSku sku) {
         this.type = type;
+        this.sku = sku;
         portToTargetGroupMapping = new HashMap<>();
     }
 
@@ -33,10 +41,15 @@ public class CloudLoadBalancer {
         return type;
     }
 
+    public LoadBalancerSku getSku() {
+        return sku;
+    }
+
     @Override
     public String toString() {
         return "CloudLoadBalancer{" +
             "type=" + type +
+            "sku=" + sku +
             ", portToTargetGroupMapping=" + portToTargetGroupMapping +
             '}';
     }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerModelBuilder.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureLoadBalancerModelBuilder.java
@@ -8,6 +8,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudLoadBalancer;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Group;
 import com.sequenceiq.cloudbreak.cloud.model.TargetGroupPortPair;
+import com.sequenceiq.common.api.type.LoadBalancerSku;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +63,7 @@ public class AzureLoadBalancerModelBuilder {
     private AzureLoadBalancer convertCloudLoadBalancerToAzureLoadBalancer(CloudLoadBalancer cloudLoadBalancer, String stackName) {
         Set<String> instanceGroupNames = collectInstanceGroupNames(cloudLoadBalancer);
         List<AzureLoadBalancingRule> rules = collectLoadBalancingRules(cloudLoadBalancer);
-        return buildAzureLb(cloudLoadBalancer.getType(), instanceGroupNames, rules, stackName);
+        return buildAzureLb(cloudLoadBalancer.getType(), cloudLoadBalancer.getSku(), instanceGroupNames, rules, stackName);
     }
 
     private Set<String> collectInstanceGroupNames(CloudLoadBalancer cloudLoadBalancer) {
@@ -83,9 +84,11 @@ public class AzureLoadBalancerModelBuilder {
             .collect(toList());
     }
 
-    private AzureLoadBalancer buildAzureLb(LoadBalancerType type, Set<String> instanceGroupNames, List<AzureLoadBalancingRule> rules, String stackName) {
+    private AzureLoadBalancer buildAzureLb(LoadBalancerType type, LoadBalancerSku sku, Set<String> instanceGroupNames,
+            List<AzureLoadBalancingRule> rules, String stackName) {
         return new AzureLoadBalancer.Builder()
                 .setType(type)
+                .setLoadBalancerSku(sku)
                 .setInstanceGroupNames(instanceGroupNames)
                 .setRules(rules)
                 .setStackName(stackName)

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancer.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/loadbalancer/AzureLoadBalancer.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cloud.azure.loadbalancer;
 
+import com.sequenceiq.common.api.type.LoadBalancerSku;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 
 import java.util.Collection;
@@ -21,12 +22,15 @@ public class AzureLoadBalancer {
 
     private final Set<String> instanceGroupNames;
 
+    private final LoadBalancerSku sku;
+
     private AzureLoadBalancer(Builder builder) {
         this.rules = List.copyOf(builder.rules);
         this.probes = Set.copyOf(builder.probes);
         this.name = getLoadBalancerName(builder.type, builder.stackName);
         this.type = builder.type;
         this.instanceGroupNames = Set.copyOf(builder.instanceGroupNames);
+        this.sku = LoadBalancerSku.getValueOrDefault(builder.sku);
     }
 
     public static String getLoadBalancerName(LoadBalancerType type, String stackName) {
@@ -53,6 +57,10 @@ public class AzureLoadBalancer {
         return instanceGroupNames;
     }
 
+    public LoadBalancerSku getSku() {
+        return sku;
+    }
+
     @Override
     public String toString() {
         return "AzureLoadBalancer{" +
@@ -61,6 +69,7 @@ public class AzureLoadBalancer {
                 ", name='" + name + '\'' +
                 ", type=" + type +
                 ", instanceGroupNames=" + instanceGroupNames +
+                ", sku=" + sku +
                 '}';
     }
 
@@ -74,6 +83,8 @@ public class AzureLoadBalancer {
         private LoadBalancerType type;
 
         private Set<String> instanceGroupNames;
+
+        private LoadBalancerSku sku;
 
         public Builder setRules(List<AzureLoadBalancingRule> rules) {
             this.rules = rules;
@@ -92,6 +103,11 @@ public class AzureLoadBalancer {
 
         public Builder setInstanceGroupNames(Set<String> instanceGroupNames) {
             this.instanceGroupNames = instanceGroupNames;
+            return this;
+        }
+
+        public Builder setLoadBalancerSku(LoadBalancerSku sku) {
+            this.sku = sku;
             return this;
         }
 

--- a/cloud-azure/src/main/resources/templates/arm-v2.ftl
+++ b/cloud-azure/src/main/resources/templates/arm-v2.ftl
@@ -212,8 +212,14 @@
                         </#list>
                      </#if>
                      },
+                   <#if loadBalancers?? && (loadBalancers?filter(loadBalancer -> loadBalancer.sku == "STANDARD")?size > 0)>
+                     "sku": {
+                         "name": "Standard",
+                         "tier": "Regional"
+                     },
+                   </#if>
                    "properties": {
-                       <#if instanceGroup == "GATEWAY">
+                       <#if instanceGroup == "GATEWAY" || (instance.availabilitySetName?? && instance.availabilitySetName?has_content)>
                        "publicIPAllocationMethod": "Static"
                        <#else>
                        "publicIPAllocationMethod": "Dynamic"
@@ -524,7 +530,7 @@
                     ]
                   },
                   "sku": {
-                      "name": "Basic"
+                      "name": "${loadBalancer.sku.templateName}"
                   }
                 }
                 <#if loadBalancer.type == "PUBLIC">
@@ -534,7 +540,7 @@
                     "name": "${loadBalancer.name}-publicIp",
                     "location": "[parameters('region')]",
                     "sku": {
-                        "name": "Basic"
+                        "name": "${loadBalancer.sku.templateName}"
                     },
                     "properties": {
                         "publicIPAddressVersion": "IPv4",

--- a/common-model/src/main/java/com/sequenceiq/common/api/type/LoadBalancerSku.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/LoadBalancerSku.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.common.api.type;
+
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.commons.lang3.StringUtils;
+
+public enum LoadBalancerSku {
+    BASIC("Basic"),
+    STANDARD("Standard");
+
+    private final String templateName;
+
+    LoadBalancerSku(String templateName) {
+        this.templateName = templateName;
+    }
+
+    public String getTemplateName() {
+        return templateName;
+    }
+
+    public static LoadBalancerSku getDefault() {
+        return BASIC;
+    }
+
+    public static LoadBalancerSku getValueOrDefault(LoadBalancerSku sku) {
+        return sku == null ? getDefault() : sku;
+    }
+
+    public static LoadBalancerSku getValueOrDefault(String name) {
+        return StringUtils.isEmpty(name) || !EnumUtils.isValidEnum(LoadBalancerSku.class, name) ?
+                getDefault() : valueOf(name);
+    }
+}

--- a/common/src/main/java/com/sequenceiq/cloudbreak/converter/LoadBalancerSkuConverter.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/converter/LoadBalancerSkuConverter.java
@@ -1,0 +1,11 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import com.sequenceiq.common.api.type.LoadBalancerSku;
+
+public class LoadBalancerSkuConverter extends DefaultEnumConverter<LoadBalancerSku> {
+
+    @Override
+    public LoadBalancerSku getDefault() {
+        return LoadBalancerSku.getDefault();
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/stack/AzureStackV4Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/base/parameter/stack/AzureStackV4Parameters.java
@@ -6,7 +6,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.common.api.type.LoadBalancerSku;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions.StackModelDescription;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -21,6 +23,9 @@ public class AzureStackV4Parameters extends StackV4ParameterBase {
 
     @ApiModelProperty
     private boolean encryptStorage;
+
+    @ApiModelProperty(StackModelDescription.LOAD_BALANCER_SKU)
+    private LoadBalancerSku loadBalancerSku = LoadBalancerSku.getDefault();
 
     public String getResourceGroupName() {
         return resourceGroupName;
@@ -38,11 +43,20 @@ public class AzureStackV4Parameters extends StackV4ParameterBase {
         this.encryptStorage = encryptStorage;
     }
 
+    public LoadBalancerSku getLoadBalancerSku() {
+        return loadBalancerSku;
+    }
+
+    public void setLoadBalancerSku(LoadBalancerSku loadBalancerSku) {
+        this.loadBalancerSku = loadBalancerSku;
+    }
+
     @Override
     public Map<String, Object> asMap() {
         Map<String, Object> map = super.asMap();
         putIfValueNotNull(map, "resourceGroupName", resourceGroupName);
         putIfValueNotNull(map, "encryptStorage", encryptStorage);
+        putIfValueNotNull(map, "loadBalancerSku", loadBalancerSku.name());
         return map;
     }
 
@@ -58,5 +72,6 @@ public class AzureStackV4Parameters extends StackV4ParameterBase {
         super.parse(parameters);
         resourceGroupName = getParameterOrNull(parameters, "resourceGroupName");
         encryptStorage = getBoolean(parameters, "encryptStorage");
+        loadBalancerSku = LoadBalancerSku.getValueOrDefault(getParameterOrNull(parameters, "loadBalancerSku"));
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -273,6 +273,7 @@ public class ModelDescriptions {
         public static final String LOAD_BALANCER_TARGETS = "The list of target instances the load balancer routes traffic to.";
         public static final String LOAD_BALANCER_TYPE = "Whether the load balancer is internet-facing (public), or only accessible over private endpoints.";
         public static final String LOAD_BALANCER_AWS = "The AWS resource id for the load balancer.";
+        public static final String LOAD_BALANCER_SKU = "The SKU to be used for the Azure load balancer.";
         public static final String TARGET_GROUP_PORT = "The port where the load balancer receives traffic and forward it to the associated targets.";
         public static final String TARGET_GROUP_INSTANCES = "Ids for the target instances receiving traffic from the load balancer on the defined port.";
         public static final String TARGET_GROUP_AWS = "The AWS listener and target group resource ids.";

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/AzureDistroXV1Parameters.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/model/AzureDistroXV1Parameters.java
@@ -5,6 +5,8 @@ import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.sequenceiq.cloudbreak.doc.ModelDescriptions;
+import com.sequenceiq.common.api.type.LoadBalancerSku;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -20,6 +22,9 @@ public class AzureDistroXV1Parameters implements Serializable {
     @ApiModelProperty
     private boolean encryptStorage;
 
+    @ApiModelProperty(ModelDescriptions.StackModelDescription.LOAD_BALANCER_SKU)
+    private LoadBalancerSku loadBalancerSku = LoadBalancerSku.getDefault();
+
     public String getResourceGroupName() {
         return resourceGroupName;
     }
@@ -34,5 +39,13 @@ public class AzureDistroXV1Parameters implements Serializable {
 
     public void setEncryptStorage(boolean encryptStorage) {
         this.encryptStorage = encryptStorage;
+    }
+
+    public LoadBalancerSku getLoadBalancerSku() {
+        return loadBalancerSku;
+    }
+
+    public void setLoadBalancerSku(LoadBalancerSku loadBalancerSku) {
+        this.loadBalancerSku = loadBalancerSku;
     }
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancer.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/loadbalancer/LoadBalancer.java
@@ -19,9 +19,11 @@ import com.sequenceiq.cloudbreak.common.json.Json;
 import com.sequenceiq.cloudbreak.common.json.JsonToString;
 import com.sequenceiq.cloudbreak.common.json.JsonUtil;
 import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
+import com.sequenceiq.cloudbreak.converter.LoadBalancerSkuConverter;
 import com.sequenceiq.cloudbreak.domain.converter.LoadBalancerTypeConverter;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.common.api.type.LoadBalancerSku;
 import com.sequenceiq.common.api.type.LoadBalancerType;
 
 @Entity
@@ -53,6 +55,9 @@ public class LoadBalancer implements ProvisionEntity  {
     @Convert(converter = JsonToString.class)
     @Column(columnDefinition = "TEXT")
     private Json providerConfig;
+
+    @Convert(converter = LoadBalancerSkuConverter.class)
+    private LoadBalancerSku sku = LoadBalancerSku.getDefault();
 
     public Long getId() {
         return id;
@@ -145,6 +150,14 @@ public class LoadBalancer implements ProvisionEntity  {
         }
     }
 
+    public LoadBalancerSku getSku() {
+        return sku;
+    }
+
+    public void setSku(LoadBalancerSku sku) {
+        this.sku = sku;
+    }
+
     @Override
     public String toString() {
         return "LoadBalancer{" +
@@ -154,6 +167,8 @@ public class LoadBalancer implements ProvisionEntity  {
             ", type='" + type + '\'' +
             ", endpoint='" + endpoint + '\'' +
             ", fqdn='" + fqdn + '\'' +
+            ", sku='" + sku + '\'' +
+            ", providerConfig='" + providerConfig + '\'' +
             '}';
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -324,7 +324,7 @@ public class StackToCloudStackConverter {
     private List<CloudLoadBalancer> buildLoadBalancers(Stack stack, List<Group> instanceGroups) {
         List<CloudLoadBalancer> cloudLoadBalancers = new ArrayList<>();
         for (LoadBalancer loadBalancer : loadBalancerPersistenceService.findByStackId(stack.getId())) {
-            CloudLoadBalancer cloudLoadBalancer = new CloudLoadBalancer(loadBalancer.getType());
+            CloudLoadBalancer cloudLoadBalancer = new CloudLoadBalancer(loadBalancer.getType(), loadBalancer.getSku());
             for (TargetGroup targetGroup : targetGroupPersistenceService.findByLoadBalancerId(loadBalancer.getId())) {
                 Set<TargetGroupPortPair> portPairs = loadBalancerConfigService.getTargetGroupPortPairs(targetGroup);
                 Set<String> targetInstanceGroupName = instanceGroupService.findByTargetGroupId(targetGroup.getId()).stream()

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverter.java
@@ -208,7 +208,7 @@ public class StackV4RequestToStackConverter {
         determineServiceTypeTag(stack, source.getTags());
         determineServiceFeatureTag(stack, source.getTags());
 
-        Set<LoadBalancer> loadBalancers = loadBalancerConfigService.createLoadBalancers(stack, environment, source.isEnableLoadBalancer());
+        Set<LoadBalancer> loadBalancers = loadBalancerConfigService.createLoadBalancers(stack, environment, source);
         stack.setLoadBalancers(loadBalancers);
         return stack;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateLoadBalancerEntityHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/stack/loadbalancer/handler/CreateLoadBalancerEntityHandler.java
@@ -98,7 +98,7 @@ public class CreateLoadBalancerEntityHandler extends ExceptionCatcherEventHandle
             instanceGroups.forEach(ig -> ig.setTargetGroups(targetGroupPersistenceService.findByInstanceGroupId(ig.getId())));
             Set<LoadBalancer> existingLoadBalancers = loadBalancerPersistenceService.findByStackId(stack.getId());
             stack.setInstanceGroups(instanceGroups);
-            Set<LoadBalancer> newLoadBalancers = loadBalancerConfigService.createLoadBalancers(stack, environment, false);
+            Set<LoadBalancer> newLoadBalancers = loadBalancerConfigService.createLoadBalancers(stack, environment, null);
 
             Stack savedStack;
             if (doLoadBalancersAlreadyExist(existingLoadBalancers, newLoadBalancers)) {

--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXParameterConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXParameterConverter.java
@@ -27,6 +27,7 @@ public class DistroXParameterConverter {
         AzureDistroXV1Parameters response = new AzureDistroXV1Parameters();
         response.setEncryptStorage(source.isEncryptStorage());
         response.setResourceGroupName(source.getResourceGroupName());
+        response.setLoadBalancerSku(source.getLoadBalancerSku());
         return response;
     }
 
@@ -34,6 +35,7 @@ public class DistroXParameterConverter {
         AzureStackV4Parameters response = new AzureStackV4Parameters();
         response.setEncryptStorage(source.isEncryptStorage());
         response.setResourceGroupName(source.getResourceGroupName());
+        response.setLoadBalancerSku(source.getLoadBalancerSku());
         return response;
     }
 

--- a/core/src/main/resources/schema/app/20210928161018_CB-13668_Add_SKU_field_to_load_balancer_table.sql
+++ b/core/src/main/resources/schema/app/20210928161018_CB-13668_Add_SKU_field_to_load_balancer_table.sql
@@ -1,0 +1,9 @@
+-- // CB-13668 Add SKU field to load balancer table
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE loadbalancer ADD COLUMN IF NOT EXISTS sku VARCHAR(20);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE loadbalancer DROP COLUMN IF EXISTS sku;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/stacks/StackV4RequestToStackConverterTest.java
@@ -352,7 +352,7 @@ class StackV4RequestToStackConverterTest extends AbstractJsonConverterTest<Stack
         given(providerParameterCalculator.get(request)).willReturn(getMappable());
         given(clusterV4RequestToClusterConverter.convert(any(ClusterV4Request.class))).willReturn(new Cluster());
         given(telemetryConverter.convert(null, StackType.DATALAKE)).willReturn(new Telemetry());
-        given(loadBalancerConfigService.createLoadBalancers(any(), any(), eq(false))).willReturn(Set.of(loadBalancer));
+        given(loadBalancerConfigService.createLoadBalancers(any(), any(), eq(request))).willReturn(Set.of(loadBalancer));
         // WHEN
         Stack stack = underTest.convert(request);
         // THEN

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXParameterConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/DistroXParameterConverterTest.java
@@ -10,6 +10,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.Aws
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.AzureStackV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.GcpStackV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.YarnStackV4Parameters;
+import com.sequenceiq.common.api.type.LoadBalancerSku;
 import com.sequenceiq.distrox.api.v1.distrox.model.AwsDistroXV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.AzureDistroXV1Parameters;
 import com.sequenceiq.distrox.api.v1.distrox.model.GcpDistroXV1Parameters;
@@ -30,12 +31,14 @@ class DistroXParameterConverterTest {
         AzureStackV4Parameters input = new AzureStackV4Parameters();
         input.setEncryptStorage(true);
         input.setResourceGroupName("resourceGroupName");
+        input.setLoadBalancerSku(LoadBalancerSku.STANDARD);
 
         AzureDistroXV1Parameters result = underTest.convert(input);
 
         assertNotNull(result);
         assertEquals(input.isEncryptStorage(), result.isEncryptStorage());
         assertEquals(input.getResourceGroupName(), result.getResourceGroupName());
+        assertEquals(input.getLoadBalancerSku(), result.getLoadBalancerSku());
     }
 
     @Test
@@ -43,12 +46,14 @@ class DistroXParameterConverterTest {
         AzureDistroXV1Parameters input = new AzureDistroXV1Parameters();
         input.setEncryptStorage(true);
         input.setResourceGroupName("resourceGroupName");
+        input.setLoadBalancerSku(LoadBalancerSku.STANDARD);
 
         AzureStackV4Parameters result = underTest.convert(input);
 
         assertNotNull(result);
         assertEquals(input.isEncryptStorage(), result.isEncryptStorage());
         assertEquals(input.getResourceGroupName(), result.getResourceGroupName());
+        assertEquals(input.getLoadBalancerSku(), result.getLoadBalancerSku());
     }
 
     @Test

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAzureBase.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAzureBase.java
@@ -1,0 +1,16 @@
+package com.sequenceiq.sdx.api.model;
+
+import com.sequenceiq.common.api.type.LoadBalancerSku;
+
+public class SdxAzureBase {
+
+    private LoadBalancerSku loadBalancerSku;
+
+    public LoadBalancerSku getLoadBalancerSku() {
+        return loadBalancerSku;
+    }
+
+    public void setLoadBalancerSku(LoadBalancerSku loadBalancerSku) {
+        this.loadBalancerSku = loadBalancerSku;
+    }
+}

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAzureRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxAzureRequest.java
@@ -1,0 +1,4 @@
+package com.sequenceiq.sdx.api.model;
+
+public class SdxAzureRequest extends SdxAzureBase {
+}

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequestBase.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxClusterRequestBase.java
@@ -23,6 +23,8 @@ public class SdxClusterRequestBase implements TaggableRequest {
     @Valid
     private SdxAwsRequest aws;
 
+    private SdxAzureRequest azure;
+
     private Map<String, String> tags;
 
     private boolean enableRangerRaz;
@@ -107,6 +109,14 @@ public class SdxClusterRequestBase implements TaggableRequest {
 
     public void setEnableMultiAz(boolean enableMultiAz) {
         this.enableMultiAz = enableMultiAz;
+    }
+
+    public SdxAzureRequest getAzure() {
+        return azure;
+    }
+
+    public void setAzure(SdxAzureRequest azure) {
+        this.azure = azure;
     }
 
     public void copyTo(SdxClusterRequestBase toInstance) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/SdxService.java
@@ -46,6 +46,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.StackV4Endpoint;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceTemplateV4Base;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.StackResponseEntries;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.stack.AzureStackV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4Parameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.parameter.template.AwsInstanceTemplateV4SpotParameters;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackV4Request;
@@ -98,6 +99,7 @@ import com.sequenceiq.flow.core.ResourceIdProvider;
 import com.sequenceiq.flow.service.FlowCancelService;
 import com.sequenceiq.sdx.api.model.SdxAwsBase;
 import com.sequenceiq.sdx.api.model.SdxAwsSpotParameters;
+import com.sequenceiq.sdx.api.model.SdxAzureBase;
 import com.sequenceiq.sdx.api.model.SdxCloudStorageRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterRequest;
 import com.sequenceiq.sdx.api.model.SdxClusterResizeRequest;
@@ -591,8 +593,10 @@ public class SdxService implements ResourceIdProvider, ResourcePropertyProvider,
             case AWS:
                 useAwsSpotPercentageIfPresent(stackRequest, sdxClusterRequest);
                 break;
-            case GCP:
             case AZURE:
+                updateAzureLoadBalancerSkuIfPresent(stackRequest, sdxClusterRequest);
+                break;
+            case GCP:
             case YARN:
             case MOCK:
             default:
@@ -624,6 +628,16 @@ public class SdxService implements ResourceIdProvider, ResourcePropertyProvider,
                 .forEach(spot -> {
                     spot.setPercentage(sdxSpotParameters.getPercentage());
                     spot.setMaxPrice(sdxSpotParameters.getMaxPrice());
+                });
+    }
+
+    private void updateAzureLoadBalancerSkuIfPresent(StackV4Request stackRequest, SdxClusterRequest sdxClusterRequest) {
+        Optional.ofNullable(sdxClusterRequest.getAzure())
+                .map(SdxAzureBase::getLoadBalancerSku)
+                .ifPresent(sku -> {
+                    AzureStackV4Parameters azureParameters = stackRequest.createAzure();
+                    azureParameters.setLoadBalancerSku(sku);
+                    stackRequest.setAzure(azureParameters);
                 });
     }
 


### PR DESCRIPTION
Adds new Azure platform specific fields to the SDX and DistroX creation requests so that
the load balancer SKU can be specified. If not set, the SKU current defaults to "Basic".
The default value can eventually be changed in the LoadBalancerSku methods.

If the Basic SKU is set, the load balancer and the public IPs will use the basic SKU. If
the Standard SKU is set, both will use the standard SKU. This information is stored in the
database in a new "sku" column in the loadbalancer table.

Tested via unit tests and by manually setting the LB SKU to Standard (the default is Basic,
so this triggered the non-default path) and verifying the data lake with load balancers was
created successfully.

The new fields in the API request objects look like:
```
SdxClusterRequestBase : {
	SdxAzureRequest : {
		LoadBalancerSku : "Basic|Standard"
	}
}

DistroXV1Request : {
	AzureDistroXV1Parameters : {
		LoadBalancerSku : "Basic|Standard"
	}
}
```