### PR TITLE
CB-13593 Get parcels from CM can block for a long time - part of epic…

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/aspect/MeasureAspects.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/aspect/MeasureAspects.java
@@ -26,7 +26,7 @@ public class MeasureAspects {
         long start = System.currentTimeMillis();
         Object resp = proceedingJoinPoint.proceed();
 
-        LoggerFactory.getLogger(measure.value()).debug("{}.{} took {} ms",
+        LoggerFactory.getLogger(measure.value()).debug("Measuring method execution: {}.{} took {} ms",
                 methodSignature.getDeclaringType().getSimpleName(), methodSignature.getName(), System.currentTimeMillis() - start);
 
         return resp;

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerClusterStatusService.java
@@ -410,8 +410,8 @@ public class ClouderaManagerClusterStatusService implements ClusterStatusService
             ApiVersionInfo apiVersionInfo = cmApiRetryTemplate.execute(context -> clouderaManagerApiFactory.getClouderaManagerResourceApi(client).getVersion());
             return Optional.ofNullable(apiVersionInfo.getVersion());
         } catch (ApiException e) {
-            LOGGER.info("Failed to get version from CM", e);
-            return Optional.empty();
+            LOGGER.info("Failed to get version from CM: ", e);
+            throw new ClouderaManagerOperationFailedException("Failed to get CM version from CM", e);
         }
     }
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionService.java
@@ -45,7 +45,7 @@ class ClouderaManagerParcelDecommissionService {
                     .collect(Collectors.toMap(ApiParcel::getProduct, ApiParcel::getVersion));
         } catch (ApiException e) {
             LOGGER.info("Unable to fetch the list of activated parcels", e);
-            throw new ClouderaManagerOperationFailedException(e.getMessage(), e);
+            throw new ClouderaManagerOperationFailedException("Unable to fetch the list of activated parcels", e);
         }
     }
 


### PR DESCRIPTION
…: CB-12736, After a failed DL/DH upgrade sync runtime versions

When syncing CM and parcel versions from CM server CM might be unreachable. There is a check at start if CM is available and if not, no sync is carried out.

The case, when CM goes down after the availability test has been done was not treated yet. This PR makes sure that if any of the CM calls fails then no other call is started.

See detailed description in the commit message.