### PR TITLE
CB-13449 Collect all CDH images for CM sync - part of epic: CB-12736,…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/RawImageProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/RawImageProvider.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.cloudbreak.service.image.catalog;
+
+import static com.sequenceiq.cloudbreak.service.image.StatedImages.statedImages;
+import static java.util.stream.Collectors.toList;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
+import com.sequenceiq.cloudbreak.service.image.ImageFilter;
+import com.sequenceiq.cloudbreak.service.image.StatedImages;
+
+@Component
+public class RawImageProvider {
+
+    public StatedImages getImages(CloudbreakImageCatalogV3 imageCatalogV3, ImageFilter imageFilter) {
+        Images catalogImages = imageCatalogV3.getImages();
+        Set<String> platforms = imageFilter.getPlatforms();
+        List<Image> baseImages = filterImagesByPlatforms(platforms, catalogImages.getBaseImages());
+        List<Image> cdhImages = filterImagesByPlatforms(platforms, catalogImages.getCdhImages());
+        List<Image> freeipaImages = filterImagesByPlatforms(platforms, catalogImages.getFreeIpaImages());
+
+        return statedImages(
+                new Images(baseImages, cdhImages, freeipaImages, catalogImages.getSuppertedVersions()),
+                imageFilter.getImageCatalog().getImageCatalogUrl(),
+                imageFilter.getImageCatalog().getName());
+    }
+
+    List<Image> filterImagesByPlatforms(Collection<String> platforms, Collection<Image> images) {
+        return images.stream()
+                .filter(isPlatformMatching(platforms))
+                .collect(toList());
+    }
+
+    private static Predicate<Image> isPlatformMatching(Collection<String> platforms) {
+        return img -> img.getImageSetsByProvider().keySet().stream().anyMatch(p -> platforms.stream().anyMatch(platform -> platform.equalsIgnoreCase(p)));
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/VersionBasedImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/VersionBasedImageCatalogService.java
@@ -1,5 +1,21 @@
 package com.sequenceiq.cloudbreak.service.image.catalog;
 
+import static java.util.stream.Collectors.toList;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakVersion;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
@@ -12,20 +28,6 @@ import com.sequenceiq.cloudbreak.service.image.PrefixMatchImages;
 import com.sequenceiq.cloudbreak.service.image.PrefixMatcherService;
 import com.sequenceiq.cloudbreak.service.image.StatedImages;
 import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterResult;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
 
 @Component
 public class VersionBasedImageCatalogService implements ImageCatalogService {
@@ -45,11 +47,16 @@ public class VersionBasedImageCatalogService implements ImageCatalogService {
     private VersionBasedImageProvider versionBasedImageProvider;
 
     @Inject
+    private RawImageProvider rawImageProvider;
+
+    @Inject
     private CloudbreakVersionListProvider cloudbreakVersionListProvider;
 
     @Override
     public StatedImages getImages(CloudbreakImageCatalogV3 imageCatalogV3, ImageFilter imageFilter) {
-        return versionBasedImageProvider.getImages(imageCatalogV3, imageFilter);
+        return StringUtils.isNotEmpty(imageFilter.getCbVersion())
+                ? versionBasedImageProvider.getImages(imageCatalogV3, imageFilter)
+                : rawImageProvider.getImages(imageCatalogV3, imageFilter);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmSyncImageCollectorService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmSyncImageCollectorService.java
@@ -62,7 +62,7 @@ public class CmSyncImageCollectorService {
     }
 
     private Set<Image> getAllImagesFromCatalog(String userCrn, Stack stack, String imageCatalogName, Long workspaceId) throws CloudbreakImageCatalogException {
-        List<Image> allCdhImages = imageCatalogService.getCdhImages(userCrn, workspaceId, imageCatalogName, stack.cloudPlatform());
+        List<Image> allCdhImages = imageCatalogService.getAllCdhImages(userCrn, workspaceId, imageCatalogName, stack.cloudPlatform());
         return new HashSet<>(allCdhImages);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/ImageReaderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/ImageReaderService.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.aspect.Measure;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
@@ -35,6 +36,7 @@ public class ImageReaderService {
      * @param datalake true if the stack is a datalake
      * @return a set of ClouderaManagerProducts present on the image
      */
+    @Measure(ImageReaderService.class)
     Set<ClouderaManagerProduct> getParcels(Set<Image> statedImages, boolean datalake) {
         Set<ClouderaManagerProduct> foundParcelProducts = statedImages.stream()
                 .map(im -> clouderaManagerProductTransformer.transform(im, true, !datalake))
@@ -49,6 +51,7 @@ public class ImageReaderService {
      * @param images images to get CM repos
      * @return a set of found CM repos
      */
+    @Measure(ImageReaderService.class)
     Set<ClouderaManagerRepo> getCmRepos(Set<Image> images) {
         Set<ClouderaManagerRepo> foundClouderaManagerRepos = images.stream()
                 .map(this::getCmComponent)

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/catalog/RawImageProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/catalog/RawImageProviderTest.java
@@ -1,0 +1,84 @@
+package com.sequenceiq.cloudbreak.service.image.catalog;
+
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AWS;
+import static com.sequenceiq.cloudbreak.common.mappable.CloudPlatform.AZURE;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
+import com.sequenceiq.cloudbreak.domain.ImageCatalog;
+import com.sequenceiq.cloudbreak.service.image.ImageFilter;
+import com.sequenceiq.cloudbreak.service.image.StatedImages;
+
+public class RawImageProviderTest {
+
+    private static final String BASE_IMAGE_AWS = "base-aws-1";
+
+    private static final String CDH_IMAGE_AWS = "cdh-aws-1";
+
+    private static final String FREEIPA_IMAGE_AWS = "freeipa-aws-1";
+
+    private static final String IMAGE_CATALOG_URL = "image-catalog-url";
+
+    private static final String IMAGE_CATALOG_NAME = "image-catalog-name";
+
+    private static final String BASE_IMAGE_AZURE = "base-az-2";
+
+    private static final String CDH_IMAGE_AZURE = "cdh-az-2";
+
+    private static final String FREEIPA_IMAGE_AZURE = "freeipa-az-2";
+
+    private final RawImageProvider underTest = new RawImageProvider();
+
+    @Test
+    void testGetImagesShouldReturnOnlyTheAwsImagesFromTheImageCatalog() {
+        ImageFilter imageFilter = createImageFilter();
+        CloudbreakImageCatalogV3 imageCatalogV3 = createImageCatalog();
+
+        StatedImages actual = underTest.getImages(imageCatalogV3, imageFilter);
+
+        assertEquals(IMAGE_CATALOG_NAME, actual.getImageCatalogName());
+        assertEquals(IMAGE_CATALOG_URL, actual.getImageCatalogUrl());
+        Images images = actual.getImages();
+        assertTrue(images.getBaseImages().stream().anyMatch(image -> BASE_IMAGE_AWS.equals(image.getUuid())));
+        assertTrue(images.getBaseImages().stream().noneMatch(image -> BASE_IMAGE_AZURE.equals(image.getUuid())));
+        assertTrue(images.getCdhImages().stream().anyMatch(image -> CDH_IMAGE_AWS.equals(image.getUuid())));
+        assertTrue(images.getCdhImages().stream().noneMatch(image -> CDH_IMAGE_AZURE.equals(image.getUuid())));
+        assertTrue(images.getFreeIpaImages().stream().anyMatch(image -> FREEIPA_IMAGE_AWS.equals(image.getUuid())));
+        assertTrue(images.getFreeIpaImages().stream().noneMatch(image -> FREEIPA_IMAGE_AZURE.equals(image.getUuid())));
+    }
+
+    private CloudbreakImageCatalogV3 createImageCatalog() {
+        return new CloudbreakImageCatalogV3(createImages(), null);
+    }
+
+    private Images createImages() {
+        return new Images(
+                List.of(createImage(BASE_IMAGE_AWS, AWS.name()), createImage(BASE_IMAGE_AZURE, AZURE.name())),
+                List.of(createImage(CDH_IMAGE_AWS, AWS.name()), createImage(CDH_IMAGE_AZURE, AZURE.name())),
+                List.of(createImage(FREEIPA_IMAGE_AWS, AWS.name()), createImage(FREEIPA_IMAGE_AZURE, AZURE.name())),
+                null);
+    }
+
+    private ImageFilter createImageFilter() {
+        ImageCatalog imageCatalog = new ImageCatalog();
+        imageCatalog.setImageCatalogUrl(IMAGE_CATALOG_URL);
+        imageCatalog.setName(IMAGE_CATALOG_NAME);
+        return new ImageFilter(imageCatalog, Collections.singleton(AWS.name()), null);
+    }
+
+    private Image createImage(String imageId, String cloudPlatform) {
+        return new Image(null, null, null, null, imageId, null, null, Map.of(cloudPlatform, Collections.emptyMap()), null, null, null, null, null, null, false,
+                null, null);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmSyncImageCollectorServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/CmSyncImageCollectorServiceTest.java
@@ -80,7 +80,7 @@ public class CmSyncImageCollectorServiceTest {
         verify(imageService).getCurrentImageCatalogName(STACK_ID);
         verify(imageCatalogService).getImageByCatalogName(WORKSPCE_ID, IMAGE_UUID_1, CURRENT_IMAGE_CATALOG_NAME);
         verify(imageService).getCurrentImage(STACK_ID);
-        verify(imageCatalogService, never()).getCdhImages(anyString(), anyLong(), anyString(), anyString());
+        verify(imageCatalogService, never()).getAllCdhImages(anyString(), anyLong(), anyString(), anyString());
     }
 
     @Test
@@ -89,7 +89,7 @@ public class CmSyncImageCollectorServiceTest {
         Set<String> candidateImageUuids = Set.of();
         List<Image> allCdhImages = List.of(getImage(IMAGE_UUID_1));
         when(imageService.getCurrentImageCatalogName(STACK_ID)).thenReturn(CURRENT_IMAGE_CATALOG_NAME);
-        when(imageCatalogService.getCdhImages(USER_CRN, WORKSPCE_ID, CURRENT_IMAGE_CATALOG_NAME, CURRENT_CLOUD_PLATFORM)).thenReturn(allCdhImages);
+        when(imageCatalogService.getAllCdhImages(USER_CRN, WORKSPCE_ID, CURRENT_IMAGE_CATALOG_NAME, CURRENT_CLOUD_PLATFORM)).thenReturn(allCdhImages);
 
         Set<Image> collectedImages = underTest.collectImages(USER_CRN, stack, candidateImageUuids);
 
@@ -98,7 +98,7 @@ public class CmSyncImageCollectorServiceTest {
                 hasProperty("uuid", is(IMAGE_UUID_1))
         ));
         verify(imageService).getCurrentImageCatalogName(STACK_ID);
-        verify(imageCatalogService).getCdhImages(USER_CRN, WORKSPCE_ID, CURRENT_IMAGE_CATALOG_NAME, CURRENT_CLOUD_PLATFORM);
+        verify(imageCatalogService).getAllCdhImages(USER_CRN, WORKSPCE_ID, CURRENT_IMAGE_CATALOG_NAME, CURRENT_CLOUD_PLATFORM);
         verify(imageService, never()).getCurrentImage(anyLong());
         verify(imageCatalogService, never()).getImageByCatalogName(anyLong(), anyString(), anyString());
     }
@@ -113,7 +113,7 @@ public class CmSyncImageCollectorServiceTest {
 
         assertThat(collectedImages, emptyCollectionOf(Image.class));
         verify(imageService).getCurrentImageCatalogName(STACK_ID);
-        verify(imageCatalogService, never()).getCdhImages(anyString(), anyLong(), anyString(), anyString());
+        verify(imageCatalogService, never()).getAllCdhImages(anyString(), anyLong(), anyString(), anyString());
         verify(imageService, never()).getCurrentImage(anyLong());
         verify(imageCatalogService, never()).getImageByCatalogName(anyLong(), anyString(), anyString());
     }
@@ -122,7 +122,7 @@ public class CmSyncImageCollectorServiceTest {
     void testCollectImagesWhenNoImageUuidAndImageCatalogExceptionThenReturnsEmpty() throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
         setupStack(true, true);
         Set<String> candidateImageUuids = Set.of();
-        when(imageCatalogService.getCdhImages(USER_CRN, WORKSPCE_ID, CURRENT_IMAGE_CATALOG_NAME, CURRENT_CLOUD_PLATFORM))
+        when(imageCatalogService.getAllCdhImages(USER_CRN, WORKSPCE_ID, CURRENT_IMAGE_CATALOG_NAME, CURRENT_CLOUD_PLATFORM))
                 .thenThrow(new CloudbreakImageCatalogException("My custom image catalog exception"));
         when(imageService.getCurrentImageCatalogName(STACK_ID)).thenReturn(CURRENT_IMAGE_CATALOG_NAME);
 
@@ -130,7 +130,7 @@ public class CmSyncImageCollectorServiceTest {
 
         assertThat(collectedImages, emptyCollectionOf(Image.class));
         verify(imageService).getCurrentImageCatalogName(STACK_ID);
-        verify(imageCatalogService).getCdhImages(USER_CRN, WORKSPCE_ID, CURRENT_IMAGE_CATALOG_NAME, CURRENT_CLOUD_PLATFORM);
+        verify(imageCatalogService).getAllCdhImages(USER_CRN, WORKSPCE_ID, CURRENT_IMAGE_CATALOG_NAME, CURRENT_CLOUD_PLATFORM);
         verify(imageService, never()).getCurrentImage(anyLong());
         verify(imageCatalogService, never()).getImageByCatalogName(anyLong(), anyString(), anyString());
     }


### PR DESCRIPTION
… After a failed DL/DH upgrade sync runtime versions

The CM and parcel version syncer service will read the versions from CM server and after a matching process are persisted to the Component and ClusterComponent tables. The goal is to make sure that cloudbreak DB tables reflect active parcel versions in CM, even in the case when the customer installs parcels say after a failed upgrade.

During the matching process the retrieved versions are matched against CM repo details and parcel product details, read from the image catalog. If the sync is activated during upgrade, the source and destination images are used. If, however, the sync is used after an upgrade, then all the images from the image catalog are used.

Currently methods in the image catalog use the version based filtering, where only a small subset of the images in the catalog are selected, typically the last patch of every line. To match against installed versions all images are needed, not only the last of a line.

This commit thus introduces an image provider that returns all images of a given platform, no other filtering is executed.

See detailed description in the commit message.