### PR TITLE
DISTX-707. Add zeppelin service to spark3 DE template

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-data-engineering-spark3.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-data-engineering-spark3.bp
@@ -196,6 +196,31 @@
         ]
       },
       {
+        "refName": "zeppelin",
+        "serviceType": "ZEPPELIN",
+        "serviceConfigs": [
+          {
+            "name": "yarn_service",
+            "ref": "yarn"
+          },
+          {
+            "name": "hdfs_service",
+            "ref": "hdfs"
+          },
+          {
+            "name": "spark3_on_yarn_service",
+            "ref": "spark3_on_yarn"
+          }
+        ],
+        "roleConfigGroups": [
+          {
+            "refName": "zeppelin-ZEPPELIN_SERVER-BASE",
+            "roleType": "ZEPPELIN_SERVER",
+            "base": true
+          }
+        ]
+      },
+      {
         "refName": "tez",
         "serviceType": "TEZ",
         "serviceConfigs": [
@@ -373,6 +398,7 @@
           "spark3_on_yarn-SPARK_YARN_HISTORY_SERVER-BASE",
           "livy_for_spark3-GATEWAY-BASE",
           "livy_for_spark3-LIVY_SERVER-BASE",
+          "zeppelin-ZEPPELIN_SERVER-BASE",
           "zookeeper-SERVER-BASE",
           "yarn-JOBHISTORY-BASE",
           "yarn-RESOURCEMANAGER-BASE",


### PR DESCRIPTION
This is to extend 7.2.13 - Data Engineering Spark3 template with Zeppelin service which now has spark3 support.