### PR TITLE
CB-14390: Refine datalake/datahub image operation names

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/type/ImageType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/ImageType.java
@@ -4,5 +4,6 @@ public enum ImageType {
     FREEIPA,
     DATAHUB,
     DATALAKE,
+    RUNTIME,
     UNKNOWN
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/DefaultImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/DefaultImageCatalogService.java
@@ -63,6 +63,7 @@ public class DefaultImageCatalogService {
                 break;
             case DATAHUB:
             case DATALAKE:
+            case RUNTIME:
                 throw new BadRequestException(String.format("Runtime is required in case of '%s' image type", imageType));
             default:
                 throw new BadRequestException(String.format("Type '%s' is not supported.", type));
@@ -79,6 +80,7 @@ public class DefaultImageCatalogService {
                 throw new BadRequestException(String.format("Runtime is not supported in case of '%s' image type", imageType));
             case DATAHUB:
             case DATALAKE:
+            case RUNTIME:
                 ImageCatalog imageCatalog = getCloudbreakDefaultImageCatalog();
                 ImageFilter imageFilter = new ImageFilter(imageCatalog, Set.of(provider), null, false, null, runtime);
                 statedImage = imageCatalogService.getImagePrewarmedDefaultPreferred(imageFilter, i -> true);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
@@ -345,7 +345,7 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
 
     private StatedImages getStatedImagesFromCustomImageCatalog(ImageCatalog imageCatalog, Set<String> providers) throws CloudbreakImageCatalogException {
         try {
-            List<Image> cbImages = getImages(Set.of(ImageType.DATALAKE, ImageType.DATAHUB), imageCatalog, providers);
+            List<Image> cbImages = getImages(Set.of(ImageType.DATALAKE, ImageType.DATAHUB, ImageType.RUNTIME), imageCatalog, providers);
             List<Image> freeIpaImages = getImages(Set.of(ImageType.FREEIPA), imageCatalog, providers);
             return statedImages(new Images(null, cbImages, freeIpaImages,
                     Set.of(cbVersion)), imageCatalog.getImageCatalogUrl(), imageCatalog.getName());
@@ -772,6 +772,7 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
                 return getImageByUrl(defaultFreeIpaCatalogUrl, FREEIPA_DEFAULT_CATALOG_NAME, customImage.getCustomizedImageId());
             case DATAHUB:
             case DATALAKE:
+            case RUNTIME:
                 return getImage(customImage.getCustomizedImageId());
             default:
                 throw new CloudbreakImageCatalogException("Image type is not supported.");

--- a/core/src/main/resources/schema/app/2021101114242515_CB-14390_refine_datalake_datahub_operation_names.sql
+++ b/core/src/main/resources/schema/app/2021101114242515_CB-14390_refine_datalake_datahub_operation_names.sql
@@ -1,0 +1,10 @@
+-- // CB-14390 Refine datalake/datahub image operation names
+-- Migration SQL that makes the change goes here.
+
+UPDATE customimage SET imageType = 'RUNTIME'
+WHERE imageType = 'DATAHUB' OR imageType = 'DATALAKE';
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+UPDATE customimage SET imageType = 'DATAHUB'
+WHERE imageType = 'RUNTIME';

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest.java
@@ -19,7 +19,7 @@ public class CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest {
 
     private static final String BASE_PARCEL_URL = "base parcel url";
 
-    private static final String VALID_IMAGE_TYPE = "DATALAKE";
+    private static final String VALID_IMAGE_TYPE = "RUNTIME";
 
     private static final String INVALID_IMAGE_TYPE = "invalid image type";
 
@@ -45,7 +45,7 @@ public class CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest {
         CustomImage result = victim.convert(source);
         assertEquals(SOURCE_IMAGE_ID, result.getCustomizedImageId());
         assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
-        assertEquals(ImageType.DATALAKE, result.getImageType());
+        assertEquals(ImageType.RUNTIME, result.getImageType());
         assertEquals(1, result.getVmImage().size());
 
         VmImage vmImage = result.getVmImage().stream().findFirst().get();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest.java
@@ -20,7 +20,7 @@ public class CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest {
 
     private static final String BASE_PARCEL_URL = "base parcel url";
 
-    private static final String VALID_IMAGE_TYPE = "DATALAKE";
+    private static final String VALID_IMAGE_TYPE = "RUNTIME";
 
     private static final String INVALID_IMAGE_TYPE = "invalid image type";
 
@@ -46,7 +46,7 @@ public class CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest {
         CustomImage result = victim.convert(source);
         assertEquals(SOURCE_IMAGE_ID, result.getCustomizedImageId());
         assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
-        assertEquals(ImageType.DATALAKE, result.getImageType());
+        assertEquals(ImageType.RUNTIME, result.getImageType());
         assertEquals(1, result.getVmImage().size());
 
         VmImage vmImage = result.getVmImage().stream().findFirst().get();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageToCustomImageCatalogV4CreateImageResponseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageToCustomImageCatalogV4CreateImageResponseConverterTest.java
@@ -35,7 +35,7 @@ public class CustomImageToCustomImageCatalogV4CreateImageResponseConverterTest {
     public void shouldConvert() {
         CustomImage customImage = new CustomImage();
         customImage.setName(IMAGE_ID);
-        customImage.setImageType(ImageType.DATALAKE);
+        customImage.setImageType(ImageType.RUNTIME);
         customImage.setBaseParcelUrl(BASE_PARCEL_URL);
         customImage.setCustomizedImageId(SOURCE_IMAGE_ID);
         customImage.setVmImage(Collections.singleton(getVmImage(REGION, IMAGE_REFERENCE)));
@@ -44,7 +44,7 @@ public class CustomImageToCustomImageCatalogV4CreateImageResponseConverterTest {
         assertEquals(IMAGE_ID, result.getImageId());
         assertEquals(SOURCE_IMAGE_ID, result.getSourceImageId());
         assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
-        assertEquals(ImageType.DATALAKE.name(), result.getImageType());
+        assertEquals(ImageType.RUNTIME.name(), result.getImageType());
         assertEquals(1, result.getVmImages().size());
 
         CustomImageCatalogV4VmImageResponse vmImage = result.getVmImages().stream().findFirst().get();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageToCustomImageCatalogV4GetImageResponseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageToCustomImageCatalogV4GetImageResponseConverterTest.java
@@ -60,7 +60,7 @@ public class CustomImageToCustomImageCatalogV4GetImageResponseConverterTest {
     public void shouldConvert() throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
         CustomImage customImage = new CustomImage();
         customImage.setName(IMAGE_ID);
-        customImage.setImageType(ImageType.DATALAKE);
+        customImage.setImageType(ImageType.RUNTIME);
         customImage.setBaseParcelUrl(BASE_PARCEL_URL);
         customImage.setCustomizedImageId(SOURCE_IMAGE_ID);
         customImage.setVmImage(Collections.singleton(getVmImage(REGION, IMAGE_REFERENCE)));
@@ -75,7 +75,7 @@ public class CustomImageToCustomImageCatalogV4GetImageResponseConverterTest {
         assertEquals(IMAGE_ID, result.getImageId());
         assertEquals(SOURCE_IMAGE_ID, result.getSourceImageId());
         assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
-        assertEquals(ImageType.DATALAKE.name(), result.getImageType());
+        assertEquals(ImageType.RUNTIME.name(), result.getImageType());
         assertEquals(1, result.getVmImages().size());
         assertNotNull(result.getImageDate());
         assertEquals(SOURCE_IMAGE_DATE, result.getSourceImageDate());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageToCustomImageCatalogV4UpdateImageResponseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageToCustomImageCatalogV4UpdateImageResponseConverterTest.java
@@ -35,7 +35,7 @@ public class CustomImageToCustomImageCatalogV4UpdateImageResponseConverterTest {
     public void shouldConvert() {
         CustomImage customImage = new CustomImage();
         customImage.setName(IMAGE_ID);
-        customImage.setImageType(ImageType.DATALAKE);
+        customImage.setImageType(ImageType.RUNTIME);
         customImage.setBaseParcelUrl(BASE_PARCEL_URL);
         customImage.setCustomizedImageId(SOURCE_IMAGE_ID);
         customImage.setVmImage(Collections.singleton(getVmImage(REGION, IMAGE_REFERENCE)));
@@ -44,7 +44,7 @@ public class CustomImageToCustomImageCatalogV4UpdateImageResponseConverterTest {
         assertEquals(IMAGE_ID, result.getImageId());
         assertEquals(SOURCE_IMAGE_ID, result.getSourceImageId());
         assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
-        assertEquals(ImageType.DATALAKE.name(), result.getImageType());
+        assertEquals(ImageType.RUNTIME.name(), result.getImageType());
         assertEquals(1, result.getVmImages().size());
 
         CustomImageCatalogV4VmImageResponse vmImage = result.getVmImages().stream().findFirst().get();

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/ImageCatalogToCustomImageCatalogV4GetResponseConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/ImageCatalogToCustomImageCatalogV4GetResponseConverterTest.java
@@ -59,7 +59,7 @@ public class ImageCatalogToCustomImageCatalogV4GetResponseConverterTest {
         CustomImage customImage = getCustomImage(IMAGE_ID);
         ImageCatalog imageCatalog = new ImageCatalog();
         imageCatalog.setName(NAME);
-        customImage.setImageType(ImageType.DATALAKE);
+        customImage.setImageType(ImageType.RUNTIME);
         customImage.setCustomizedImageId(SOURCE_IMAGE_ID);
         imageCatalog.setDescription(DESCRIPTION);
         imageCatalog.setCustomImages(Collections.singleton(customImage));
@@ -83,7 +83,7 @@ public class ImageCatalogToCustomImageCatalogV4GetResponseConverterTest {
         assertEquals(SOURCE_IMAGE_DATE, imageResult.getSourceImageDate());
         assertEquals(CLOUD_PROVIDER, imageResult.getCloudProvider());
         assertNotNull(imageResult.getVersions());
-        assertEquals(ImageType.DATALAKE.name(), imageResult.getImageType());
+        assertEquals(ImageType.RUNTIME.name(), imageResult.getImageType());
     }
 
     private CustomImage getCustomImage(String name) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CustomImageCatalogServiceTest.java
@@ -222,7 +222,7 @@ public class CustomImageCatalogServiceTest {
         assertNotEquals(IMAGE_NAME, actual.getName());
         assertEquals(CUSTOMIZED_IMAGE_ID, actual.getCustomizedImageId());
         assertEquals(BASE_PARCEL_URL, actual.getBaseParcelUrl());
-        assertEquals(ImageType.DATALAKE, actual.getImageType());
+        assertEquals(ImageType.RUNTIME, actual.getImageType());
         assertEquals(CREATOR, actual.getCreator());
         assertNotNull(actual.getResourceCrn());
         assertEquals(imageCatalog, actual.getImageCatalog());
@@ -309,7 +309,7 @@ public class CustomImageCatalogServiceTest {
         assertEquals(1, imageCatalog.getCustomImages().size());
         assertEquals(CUSTOMIZED_IMAGE_ID, actual.getCustomizedImageId());
         assertEquals(BASE_PARCEL_URL, actual.getBaseParcelUrl());
-        assertEquals(ImageType.DATALAKE, actual.getImageType());
+        assertEquals(ImageType.RUNTIME, actual.getImageType());
         assertEquals(1, actual.getVmImage().size());
 
         VmImage actualVmImage = actual.getVmImage().stream().findFirst().get();
@@ -338,7 +338,7 @@ public class CustomImageCatalogServiceTest {
         assertEquals(1, imageCatalog.getCustomImages().size());
         assertEquals(CUSTOMIZED_IMAGE_ID, actual.getCustomizedImageId());
         assertEquals(BASE_PARCEL_URL, actual.getBaseParcelUrl());
-        assertEquals(ImageType.DATALAKE, actual.getImageType());
+        assertEquals(ImageType.RUNTIME, actual.getImageType());
         assertEquals(1, actual.getVmImage().size());
 
         VmImage actualVmImage = actual.getVmImage().stream().findFirst().get();
@@ -369,7 +369,7 @@ public class CustomImageCatalogServiceTest {
         assertEquals(1, imageCatalog.getCustomImages().size());
         assertEquals(CUSTOMIZED_IMAGE_ID, actual.getCustomizedImageId());
         assertEquals(BASE_PARCEL_URL, actual.getBaseParcelUrl());
-        assertEquals(ImageType.DATALAKE, actual.getImageType());
+        assertEquals(ImageType.RUNTIME, actual.getImageType());
         assertEquals(0, actual.getVmImage().size());
     }
 
@@ -391,7 +391,7 @@ public class CustomImageCatalogServiceTest {
         assertEquals(1, imageCatalog.getCustomImages().size());
         assertEquals(CUSTOMIZED_IMAGE_ID, actual.getCustomizedImageId());
         assertEquals(BASE_PARCEL_URL, actual.getBaseParcelUrl());
-        assertEquals(ImageType.DATALAKE, actual.getImageType());
+        assertEquals(ImageType.RUNTIME, actual.getImageType());
         assertEquals(1, actual.getVmImage().size());
 
         VmImage actualVmImage = actual.getVmImage().stream().findFirst().get();
@@ -438,7 +438,7 @@ public class CustomImageCatalogServiceTest {
         vmImage.setRegion(REGION);
         customImage.setName(IMAGE_NAME);
         customImage.setCustomizedImageId(CUSTOMIZED_IMAGE_ID);
-        customImage.setImageType(ImageType.DATALAKE);
+        customImage.setImageType(ImageType.RUNTIME);
         customImage.setBaseParcelUrl(BASE_PARCEL_URL);
         customImage.setVmImage(Collections.singleton(vmImage));
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CustomImageProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CustomImageProviderTest.java
@@ -48,10 +48,10 @@ public class CustomImageProviderTest {
     private CustomImageProvider underTest;
 
     @Test
-    public void testMergeSourceImageAndCustomImagePropertiesInCaseOfDatahubImage() throws Exception {
+    public void testMergeSourceImageAndCustomImagePropertiesInCaseOfRuntimeImage() throws Exception {
 
         StatedImage statedImage = getStatedImageFromCatalog(V3_CB_CATALOG_FILE, "949bffa3-17d4-4076-9d5a-bf3d23c1086b");
-        CustomImage customImage = getCustomImage(ImageType.DATAHUB, CUSTOM_IMAGE_ID, CUSTOM_BASE_PARCEL_URL);
+        CustomImage customImage = getCustomImage(ImageType.RUNTIME, CUSTOM_IMAGE_ID, CUSTOM_BASE_PARCEL_URL);
 
         StatedImage image = underTest.mergeSourceImageAndCustomImageProperties(statedImage, customImage, CUSTOM_IMAGE_CATALOG_URL, CUSTOM_CATALOG_NAME);
 
@@ -64,29 +64,6 @@ public class CustomImageProviderTest {
         assertFalse(image.getImage().getPreWarmCsd().contains(CUSTOM_BASE_PARCEL_URL));
         assertTrue(image.getImage().getImageSetsByProvider().containsKey("aws"));
         assertEquals(16, image.getImage().getImageSetsByProvider().get("aws").size());
-    }
-
-    @Test
-    public void testMergeSourceImageAndCustomImagePropertiesInCaseOfDatalakeImage() throws Exception {
-
-        StatedImage statedImage = getStatedImageFromCatalog(V3_CB_CATALOG_FILE, "232fe6b6-aec4-4fa9-bb02-2c295d319a36");
-        CustomImage customImage = getCustomImage(ImageType.DATALAKE, CUSTOM_IMAGE_ID, CUSTOM_BASE_PARCEL_URL + "/");
-
-        StatedImage image = underTest.mergeSourceImageAndCustomImageProperties(statedImage, customImage, CUSTOM_IMAGE_CATALOG_URL, CUSTOM_CATALOG_NAME);
-
-        assertEquals(customImage.getCreated(), image.getImage().getCreated());
-        assertEquals(customImage.getDescription(), image.getImage().getDescription());
-        assertEquals(CUSTOM_IMAGE_ID, image.getImage().getUuid());
-        assertEquals("http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/6458542/cm7/7.2.2/redhat7/yum/",
-                image.getImage().getRepo().get("redhat7"));
-        assertEquals("http://cloudera-build-us-west-1.vpc.cloudera.com/s3/build/6575992/cdh/7.x/parcels/",
-                image.getImage().getStackDetails().getRepo().getStack().get("redhat7"));
-        assertEquals("https://myarchive.test.com/dev.hortonworks.com/DSS/centos7/2.x/BUILDS/2.0.3.0-98/tars/dataplane_profilers",
-                image.getImage().getPreWarmParcels().get(0).get(1));
-        assertEquals("https://myarchive.test.com/DSS/centos7/2.x/BUILDS/2.0.3.0-98/tars/dataplane_profilers/PROFILER_MANAGER-2.0.3.2.0.3.0-98.jar",
-                image.getImage().getPreWarmCsd().get(0));
-        assertTrue(image.getImage().getImageSetsByProvider().containsKey("azure"));
-        assertEquals(36, image.getImage().getImageSetsByProvider().get("azure").size());
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/DefaultImageCatalogServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/DefaultImageCatalogServiceTest.java
@@ -80,7 +80,7 @@ public class DefaultImageCatalogServiceTest {
 
     @Test
     public void testGetImageFromDefaultCatalogWithoutRuntimeThrowsBadRequestInCaseOfNonFreeIpaImageType() {
-        assertThrows(BadRequestException.class, () -> victim.getImageFromDefaultCatalog(ImageType.DATAHUB.name(), "aws"));
+        assertThrows(BadRequestException.class, () -> victim.getImageFromDefaultCatalog(ImageType.RUNTIME.name(), "aws"));
     }
 
     @Test
@@ -154,7 +154,7 @@ public class DefaultImageCatalogServiceTest {
         ArgumentCaptor<ImageFilter> imageFilterArgumentCaptor = ArgumentCaptor.forClass(ImageFilter.class);
         when(imageCatalogService.getImagePrewarmedDefaultPreferred(imageFilterArgumentCaptor.capture(), Mockito.any())).thenReturn(mock(StatedImage.class));
 
-        StatedImage actual = victim.getImageFromDefaultCatalog(ImageType.DATAHUB.name(), "aws", "7.2.10");
+        StatedImage actual = victim.getImageFromDefaultCatalog(ImageType.RUNTIME.name(), "aws", "7.2.10");
 
         assertNotNull(actual);
         assertEquals(imageFilterArgumentCaptor.getValue().getClusterVersion(), "7.2.10");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceTest.java
@@ -779,24 +779,10 @@ public class ImageCatalogServiceTest {
     }
 
     @Test
-    public void testGetImageByCatalogNameWithCustomCatalogNameAndExistingDatahubImage()
+    public void testGetImageByCatalogNameWithCustomCatalogNameAndExistingRuntimeImage()
             throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException, IOException {
 
-        setupCustomImageCatalog(ImageType.DATAHUB, "949bffa3-17d4-4076-9d5a-bf3d23c1086b", CUSTOM_BASE_PARCEL_URL);
-
-        StatedImage image = underTest.getImageByCatalogName(WORKSPACE_ID, CUSTOM_IMAGE_ID, CUSTOM_CATALOG_NAME);
-        assertEquals("Test uuid", image.getImage().getUuid());
-
-        verify(customImageProvider).mergeSourceImageAndCustomImageProperties(sourceImageCaptor.capture(), any(), any(), any());
-
-        Assertions.assertThat(sourceImageCaptor.getValue().getImage().getUuid()).isEqualTo("949bffa3-17d4-4076-9d5a-bf3d23c1086b");
-    }
-
-    @Test
-    public void testGetImageByCatalogNameWithCustomCatalogNameAndExistingDatalakeImage()
-            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException, IOException {
-
-        setupCustomImageCatalog(ImageType.DATALAKE, "232fe6b6-aec4-4fa9-bb02-2c295d319a36", CUSTOM_BASE_PARCEL_URL + "/");
+        setupCustomImageCatalog(ImageType.RUNTIME, "232fe6b6-aec4-4fa9-bb02-2c295d319a36", CUSTOM_BASE_PARCEL_URL + "/");
 
         StatedImage image = underTest.getImageByCatalogName(WORKSPACE_ID, CUSTOM_IMAGE_ID, CUSTOM_CATALOG_NAME);
         assertEquals("Test uuid", image.getImage().getUuid());
@@ -834,9 +820,9 @@ public class ImageCatalogServiceTest {
     }
 
     @Test
-    public void testGetDatalakeImagesByFromCustomImageCatalogByImageCatalogName() throws CloudbreakImageCatalogException, IOException {
+    public void testGetRuntimeImagesByFromCustomImageCatalogByImageCatalogName() throws CloudbreakImageCatalogException, IOException {
         ImageCatalog imageCatalog = new ImageCatalog();
-        imageCatalog.setCustomImages(Set.of(getCustomImage(ImageType.DATALAKE, "5b60b723-4beb-40b0-5cba-47ea9c9b6e53", CUSTOM_BASE_PARCEL_URL)));
+        imageCatalog.setCustomImages(Set.of(getCustomImage(ImageType.RUNTIME, "5b60b723-4beb-40b0-5cba-47ea9c9b6e53", CUSTOM_BASE_PARCEL_URL)));
         StatedImage statedImage = StatedImage.statedImage(getImage(), CUSTOM_IMAGE_CATALOG_URL, CUSTOM_CATALOG_NAME);
 
         setupImageCatalogProvider(DEFAULT_CATALOG_URL, DEV_CATALOG_FILE);
@@ -867,7 +853,7 @@ public class ImageCatalogServiceTest {
     public void testGetImageShouldLookupCustomImageInCaseOfNullImageCatalogUrl()
             throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException, IOException {
         ImageCatalog imageCatalog = new ImageCatalog();
-        CustomImage customImage = getCustomImage(ImageType.DATALAKE, "5b60b723-4beb-40b0-5cba-47ea9c9b6e53", CUSTOM_BASE_PARCEL_URL);
+        CustomImage customImage = getCustomImage(ImageType.RUNTIME, "5b60b723-4beb-40b0-5cba-47ea9c9b6e53", CUSTOM_BASE_PARCEL_URL);
         imageCatalog.setCustomImages(Set.of(customImage));
         StatedImage statedImage = StatedImage.statedImage(getImage(), CUSTOM_IMAGE_CATALOG_URL, CUSTOM_CATALOG_NAME);
 


### PR DESCRIPTION
Based on feedback we've received over the last weeks, apparently having operation names like set-datalake-image, set-datahub-image, etc. is confusing for most people, which is understandable, because in Cloudbreak there's no difference between Datalake and Datahub images - they are just Runtime images.