### PR TITLE
CB-14323: Save the target image to the DB when the upgrade starts

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ClusterUpgradeTargetImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ClusterUpgradeTargetImageService.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.type.ComponentType;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.domain.stack.Component;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
+import com.sequenceiq.cloudbreak.service.stack.StackImageService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@Service
+public class ClusterUpgradeTargetImageService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterUpgradeTargetImageService.class);
+
+    private static final String TARGET_IMAGE = "TARGET_IMAGE";
+
+    @Inject
+    private ComponentConfigProviderService componentConfigProviderService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private StackImageService stackImageService;
+
+    @Inject
+    private ImageProvider imageProvider;
+
+    public void saveImage(Long stackId, StatedImage targetImage) {
+        Optional<Component> existingTargetImage = findTargetImage(stackId);
+        if (existingTargetImage.isPresent() && isTheSameImage(targetImage, existingTargetImage.get())) {
+            LOGGER.debug("The target image {} is already present for stack {}", targetImage.getImage().getUuid(), stackId);
+        } else {
+            existingTargetImage.ifPresent(this::removeOldTargetImage);
+            Component targetImageComponent = createTargetImageComponent(stackId, targetImage);
+            LOGGER.debug("Saving target image component for cluster upgrade. {}", targetImageComponent);
+            componentConfigProviderService.store(targetImageComponent);
+        }
+    }
+
+    private void removeOldTargetImage(Component existingTargetImage) {
+        LOGGER.debug("Deleting previous target image component {}", existingTargetImage);
+        componentConfigProviderService.deleteComponents(Collections.singleton(existingTargetImage));
+    }
+
+    private Optional<Component> findTargetImage(Long stackId) {
+        return stackImageService.findImageComponentByName(stackId, TARGET_IMAGE);
+    }
+
+    private boolean isTheSameImage(StatedImage targetImage, Component existingTargetImage) {
+        Image image = imageProvider.convertJsonToImage(existingTargetImage.getAttributes());
+        return Objects.equals(image.getImageId(), targetImage.getImage().getUuid()) &&
+                Objects.equals(image.getImageCatalogName(), targetImage.getImageCatalogName()) &&
+                Objects.equals(image.getImageCatalogUrl(), targetImage.getImageCatalogUrl());
+    }
+
+    private Component createTargetImageComponent(Long stackId, StatedImage targetImage) {
+        Stack stack = stackService.getById(stackId);
+        Image imageModel = stackImageService.getImageModelFromStatedImage(stack, getCurrentImage(stack), targetImage);
+        return new Component(ComponentType.IMAGE, TARGET_IMAGE, new Json(imageModel), stack);
+    }
+
+    private Image getCurrentImage(Stack stack) {
+        try {
+            return stackImageService.getCurrentImage(stack);
+        } catch (CloudbreakImageNotFoundException e) {
+            String errorMessage = "Image not found in the database for this cluster.";
+            LOGGER.error(errorMessage, e);
+            throw new CloudbreakServiceException(errorMessage, e);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageProvider.java
@@ -2,7 +2,6 @@ package com.sequenceiq.cloudbreak.service.image;
 
 import java.io.IOException;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -47,20 +46,18 @@ public class ImageProvider {
                 .stream()
                 .map(InstanceMetaData::getImage)
                 .filter(json -> !json.getMap().isEmpty())
-                .map(convertJsonToImage())
+                .map(this::convertJsonToImage)
                 .collect(Collectors.toSet());
     }
 
-    private Function<Json, Image> convertJsonToImage() {
-        return imageJson -> {
-            try {
-                return imageJson.get(Image.class);
-            } catch (IOException e) {
-                String message = "Failed to convert Json to Image";
-                LOGGER.error(message, e);
-                throw new CloudbreakRuntimeException(message, e);
-            }
-        };
+    public Image convertJsonToImage(Json imageJson) {
+        try {
+            return imageJson.get(Image.class);
+        } catch (IOException e) {
+            String message = "Failed to convert Json to Image";
+            LOGGER.error(message, e);
+            throw new CloudbreakRuntimeException(message, e);
+        }
     }
 
     private Set<String> getImageIds(Set<Image> imagesFromInstances) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackImageService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackImageService.java
@@ -2,6 +2,9 @@ package com.sequenceiq.cloudbreak.service.stack;
 
 import static com.sequenceiq.cloudbreak.cloud.model.Platform.platform;
 
+import java.util.Collections;
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -59,6 +62,16 @@ public class StackImageService {
         }
     }
 
+    public void removeImageByComponentName(Long stackId, String imageComponentName) {
+        Optional<Component> imageComponent = findImageComponentByName(stackId, imageComponentName);
+        if (imageComponent.isPresent()) {
+            LOGGER.debug("Deleting image component {} from stack {}", imageComponentName, stackId);
+            componentConfigProviderService.deleteComponents(Collections.singleton(imageComponent.get()));
+        } else {
+            LOGGER.warn("There is no image component found for stack {} with name {}", stackId, imageComponentName);
+        }
+    }
+
     public Image getCurrentImage(Stack stack) throws CloudbreakImageNotFoundException {
             return componentConfigProviderService.getImage(stack.getId());
     }
@@ -94,5 +107,11 @@ public class StackImageService {
             LOGGER.info("Could not find image", e);
             throw new CloudbreakServiceException("Could not find image", e);
         }
+    }
+
+    public Optional<Component> findImageComponentByName(Long stackId, String componentName) {
+        Component targetImageComponent = componentConfigProviderService.getComponent(stackId, ComponentType.IMAGE, componentName);
+        LOGGER.debug("The following target image found for stack {}, {}", stackId, targetImageComponent);
+        return Optional.ofNullable(targetImageComponent);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ClusterUpgradeTargetImageServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ClusterUpgradeTargetImageServiceTest.java
@@ -1,0 +1,167 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.type.ComponentType;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.domain.stack.Component;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.service.ComponentConfigProviderService;
+import com.sequenceiq.cloudbreak.service.stack.StackImageService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+public class ClusterUpgradeTargetImageServiceTest {
+
+    private static final long STACK_ID = 1L;
+
+    private static final String IMAGE_ID = "image-id";
+
+    private static final String TARGET_IMAGE = "TARGET_IMAGE";
+
+    private static final String STACK_VERSION = "7.2.3";
+
+    private static final String IMAGE_CATALOG_URL = "image-catalog-url";
+
+    private static final String IMAGE_CATALOG_NAME = "image-catalog-name";
+
+    @InjectMocks
+    private ClusterUpgradeTargetImageService underTest;
+
+    @Mock
+    private ComponentConfigProviderService componentConfigProviderService;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private StackImageService stackImageService;
+
+    @Mock
+    private ImageProvider imageProvider;
+
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private StatedImage targetStatedImage;
+
+    @Mock
+    private Image currentImage;
+
+    @Test
+    void testSaveImageShouldSaveTheTargetImageWhenIsNotPresent() throws IOException, CloudbreakImageNotFoundException {
+        Image targetModelImage = createTargetModelImage(IMAGE_ID, IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME);
+        when(stackImageService.findImageComponentByName(STACK_ID, TARGET_IMAGE)).thenReturn(Optional.empty());
+        when(stackService.getById(STACK_ID)).thenReturn(stack);
+        when(stackImageService.getCurrentImage(stack)).thenReturn(currentImage);
+        when(stackImageService.getImageModelFromStatedImage(stack, currentImage, targetStatedImage)).thenReturn(targetModelImage);
+
+        underTest.saveImage(STACK_ID, targetStatedImage);
+
+        verify(stackImageService).findImageComponentByName(STACK_ID, TARGET_IMAGE);
+        verify(stackService).getById(STACK_ID);
+        ArgumentCaptor<Component> targetComponentCaptor = ArgumentCaptor.forClass(Component.class);
+        verify(componentConfigProviderService).store(targetComponentCaptor.capture());
+        Component targetComponent = targetComponentCaptor.getValue();
+        assertEquals(ComponentType.IMAGE, targetComponent.getComponentType());
+        assertEquals(TARGET_IMAGE, targetComponent.getName());
+        assertEquals(stack, targetComponent.getStack());
+        assertEquals(targetModelImage.getImageId(), targetComponent.getAttributes().get(Image.class).getImageId());
+    }
+
+    @Test
+    void testSaveImageShouldRemoveTheOldTargetImageAndSaveTheTargetImageWhenAnOldImageIsPresent() throws IOException, CloudbreakImageNotFoundException {
+        StatedImage targetImage = ImageTestUtil.getImageFromCatalog(true, IMAGE_ID, STACK_VERSION, IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME);
+        Image targetModelImage = createTargetModelImage(IMAGE_ID, IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME);
+        Image oldTargetImage = createTargetModelImage("old-image-id", IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME);
+        Optional<Component> existingTargetImageComponent = createExistingTargetImageComponent(oldTargetImage);
+        when(imageProvider.convertJsonToImage(existingTargetImageComponent.get().getAttributes())).thenReturn(oldTargetImage);
+        when(stackImageService.findImageComponentByName(STACK_ID, TARGET_IMAGE)).thenReturn(existingTargetImageComponent);
+        when(stackService.getById(STACK_ID)).thenReturn(stack);
+        when(stackImageService.getCurrentImage(stack)).thenReturn(currentImage);
+        when(stackImageService.getImageModelFromStatedImage(stack, currentImage, targetImage)).thenReturn(targetModelImage);
+
+        underTest.saveImage(STACK_ID, targetImage);
+
+        verify(stackImageService).getCurrentImage(stack);
+        verify(stackImageService).findImageComponentByName(STACK_ID, TARGET_IMAGE);
+        verify(stackService).getById(STACK_ID);
+        ArgumentCaptor<Component> targetComponentCaptor = ArgumentCaptor.forClass(Component.class);
+        verify(componentConfigProviderService).store(targetComponentCaptor.capture());
+        Component targetComponent = targetComponentCaptor.getValue();
+        assertEquals(ComponentType.IMAGE, targetComponent.getComponentType());
+        assertEquals(TARGET_IMAGE, targetComponent.getName());
+        assertEquals(stack, targetComponent.getStack());
+        assertEquals(targetModelImage.getImageId(), targetComponent.getAttributes().get(Image.class).getImageId());
+    }
+
+    @Test
+    void testSaveImageShouldRemoveTheOldTargetImageAndSaveTheTargetImageWhenAnOldImageIsPresentAndTheImageCatalogNameIsNotTheSame()
+            throws IOException, CloudbreakImageNotFoundException {
+        StatedImage targetImage = ImageTestUtil.getImageFromCatalog(true, IMAGE_ID, STACK_VERSION, IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME);
+        Image targetModelImage = createTargetModelImage(IMAGE_ID, IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME);
+        Image oldTargetImage = createTargetModelImage(IMAGE_ID, "old-image-catalog-url", IMAGE_CATALOG_NAME);
+        Optional<Component> existingTargetImageComponent = createExistingTargetImageComponent(oldTargetImage);
+        when(imageProvider.convertJsonToImage(existingTargetImageComponent.get().getAttributes())).thenReturn(oldTargetImage);
+        when(stackImageService.findImageComponentByName(STACK_ID, TARGET_IMAGE)).thenReturn(existingTargetImageComponent);
+        when(stackService.getById(STACK_ID)).thenReturn(stack);
+        when(stackImageService.getCurrentImage(stack)).thenReturn(currentImage);
+        when(stackImageService.getImageModelFromStatedImage(stack, currentImage, targetImage)).thenReturn(targetModelImage);
+
+        underTest.saveImage(STACK_ID, targetImage);
+
+        verify(stackImageService).getCurrentImage(stack);
+        verify(stackImageService).findImageComponentByName(STACK_ID, TARGET_IMAGE);
+        verify(stackService).getById(STACK_ID);
+        ArgumentCaptor<Component> targetComponentCaptor = ArgumentCaptor.forClass(Component.class);
+        verify(componentConfigProviderService).store(targetComponentCaptor.capture());
+        Component targetComponent = targetComponentCaptor.getValue();
+        assertEquals(ComponentType.IMAGE, targetComponent.getComponentType());
+        assertEquals(TARGET_IMAGE, targetComponent.getName());
+        assertEquals(stack, targetComponent.getStack());
+        assertEquals(targetModelImage.getImageId(), targetComponent.getAttributes().get(Image.class).getImageId());
+    }
+
+    @Test
+    void testSaveImageShouldNotSaveTheTargetImageWhenIsAlreadyPresent() {
+        StatedImage targetImage = ImageTestUtil.getImageFromCatalog(true, IMAGE_ID, STACK_VERSION, IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME);
+        Image targetModelImageImage = createTargetModelImage(IMAGE_ID, IMAGE_CATALOG_URL, IMAGE_CATALOG_NAME);
+        Optional<Component> existingTargetImageComponent = createExistingTargetImageComponent(targetModelImageImage);
+        when(stackImageService.findImageComponentByName(STACK_ID, TARGET_IMAGE)).thenReturn(existingTargetImageComponent);
+        when(imageProvider.convertJsonToImage(existingTargetImageComponent.get().getAttributes())).thenReturn(targetModelImageImage);
+
+        underTest.saveImage(STACK_ID, targetImage);
+
+        verify(stackImageService).findImageComponentByName(STACK_ID, TARGET_IMAGE);
+        verify(imageProvider).convertJsonToImage(existingTargetImageComponent.get().getAttributes());
+        verifyNoInteractions(stackService);
+        verifyNoInteractions(componentConfigProviderService);
+    }
+
+    private Optional<Component> createExistingTargetImageComponent(Image image) {
+        return Optional.of(new Component(ComponentType.IMAGE, TARGET_IMAGE, new Json(image), stack));
+    }
+
+    private Image createTargetModelImage(String imageId, String imageCatalogUrl, String imageCatalogName) {
+        return new Image(null, Collections.emptyMap(), null, null, imageCatalogUrl, imageCatalogName, imageId, new HashMap<>());
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageTestUtil.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageTestUtil.java
@@ -15,6 +15,11 @@ public class ImageTestUtil {
     private ImageTestUtil() {
     }
 
+    public static StatedImage getImageFromCatalog(boolean prewarmed, String uuid, String stackVersion, String imageCatalogUrl, String imageCatalogName) {
+        Image image = getImage(prewarmed, uuid, stackVersion);
+        return StatedImage.statedImage(image, imageCatalogUrl, imageCatalogName);
+    }
+
     public static StatedImage getImageFromCatalog(boolean prewarmed, String uuid, String stackVersion) {
         Image image = getImage(prewarmed, uuid, stackVersion);
         return StatedImage.statedImage(image, "url", "name");


### PR DESCRIPTION
At the beginning of the upgrade, we need to save the target image for later use in the CM syncer flow.
-Save the target image to the Component table with component type IMAGE and name TARGET_IMAGE
-Remove the target image from the database at the end of the upgrade