### PR TITLE
CB-14439 Ignore the Parcel removal related issues during upgrade

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
 import com.sequenceiq.cloudbreak.cluster.status.ClusterStatus;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -80,8 +81,8 @@ public interface ClusterApi {
         clusterModificationService().downloadAndDistributeParcels(components, patchUpgrade);
     }
 
-    default void removeUnusedParcels(Set<ClusterComponent> usedParcelComponents) throws CloudbreakException {
-        clusterModificationService().removeUnusedParcels(usedParcelComponents);
+    default ParcelOperationStatus removeUnusedParcels(Set<ClusterComponent> usedParcelComponents) throws CloudbreakException {
+        return clusterModificationService().removeUnusedParcels(usedParcelComponents);
     }
 
     default void ensureComponentsAreStopped(Map<String, String> components, String hostname) throws CloudbreakException {

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
+import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.host.HostGroup;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
@@ -38,9 +39,7 @@ public interface ClusterModificationService {
 
     Optional<String> getRoleConfigValueByServiceType(String clusterName, String roleConfigGroup, String serviceType, String configName);
 
-    default void removeUnusedParcels(Set<ClusterComponent> usedParcelComponents) throws CloudbreakException {
-        throw new UnsupportedOperationException("Interface not implemented.");
-    }
+    ParcelOperationStatus removeUnusedParcels(Set<ClusterComponent> usedParcelComponents) throws CloudbreakException;
 
     default void stopComponents(Map<String, String> components, String hostname) {
         throw new UnsupportedOperationException("Interface not implemented.");

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ParcelOperationStatus.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/model/ParcelOperationStatus.java
@@ -1,0 +1,77 @@
+package com.sequenceiq.cloudbreak.cluster.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class ParcelOperationStatus {
+
+    private Map<String, String> successful = new HashMap<>();
+
+    private Map<String, String> failed = new HashMap<>();
+
+    public ParcelOperationStatus() {
+    }
+
+    public ParcelOperationStatus(Map<String, String> successful, Map<String, String> failed) {
+        this.successful = new HashMap<>(successful);
+        this.failed = new HashMap<>(failed);
+    }
+
+    public Map<String, String> getSuccessful() {
+        return successful;
+    }
+
+    public void setSuccessful(Map<String, String> successful) {
+        this.successful = successful;
+    }
+
+    public Map<String, String> getFailed() {
+        return failed;
+    }
+
+    public void setFailed(Map<String, String> failed) {
+        this.failed = failed;
+    }
+
+    public void addSuccesful(String parcelName, String parcelVersion) {
+        successful.put(parcelName, parcelVersion);
+    }
+
+    public void addFailed(String parcelName, String parcelVersion) {
+        failed.put(parcelName, parcelVersion);
+    }
+
+    public ParcelOperationStatus merge(ParcelOperationStatus operationStatus) {
+        successful.putAll(operationStatus.successful);
+        failed.putAll(operationStatus.failed);
+        successful.entrySet().removeIf(entry -> failed.containsKey(entry.getKey()));
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ParcelOperationStatus that = (ParcelOperationStatus) o;
+        return Objects.equals(successful, that.successful) && Objects.equals(failed, that.failed);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(successful, failed);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", ParcelOperationStatus.class.getSimpleName() + "[", "]")
+                .add("successful=" + successful)
+                .add("failed=" + failed)
+                .toString();
+    }
+}

--- a/cluster-api/src/test/java/com/sequenceiq/cloudbreak/cluster/model/ParcelOperationStatusTest.java
+++ b/cluster-api/src/test/java/com/sequenceiq/cloudbreak/cluster/model/ParcelOperationStatusTest.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.cluster.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class ParcelOperationStatusTest {
+
+    @Test
+    public void testMerge() {
+        ParcelOperationStatus status1 = new ParcelOperationStatus(Map.of(), Map.of("parcel1", "v1"));
+        ParcelOperationStatus status2 = new ParcelOperationStatus(Map.of("parcel2", "v2"), Map.of());
+        ParcelOperationStatus status3 = new ParcelOperationStatus(Map.of("parcel3", "v3"), Map.of("parcel2", "v2"));
+
+        ParcelOperationStatus result = status1.merge(status2).merge(status3);
+
+        assertEquals(1, result.getSuccessful().size());
+        assertEquals("v3", result.getSuccessful().get("parcel3"));
+        assertEquals(2, result.getFailed().size());
+        assertEquals("v1", result.getFailed().get("parcel1"));
+        assertEquals("v2", result.getFailed().get("parcel2"));
+    }
+}

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -62,6 +62,7 @@ import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
 import com.sequenceiq.cloudbreak.cloud.model.component.StackRepoDetails;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterModificationService;
+import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
 import com.sequenceiq.cloudbreak.cluster.service.ClouderaManagerProductsProvider;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterClientInitException;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
@@ -402,8 +403,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
         ParcelsResourceApi parcelsResourceApi = clouderaManagerApiFactory.getParcelsResourceApi(apiClient);
         for (ClouderaManagerProduct product : products) {
             LOGGER.info("Removing unused {} parcels.", product.getName());
-            clouderaManagerParcelDecommissionService.removeUnusedParcelVersions(apiClient, parcelsResourceApi, parcelResourceApi, stack, product.getName(),
-                    product.getVersion());
+            clouderaManagerParcelDecommissionService.removeUnusedParcelVersions(apiClient, parcelsResourceApi, parcelResourceApi, stack, product);
         }
     }
 
@@ -751,7 +751,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
     }
 
     @Override
-    public void removeUnusedParcels(Set<ClusterComponent> usedParcelComponents) {
+    public ParcelOperationStatus removeUnusedParcels(Set<ClusterComponent> usedParcelComponents) {
         ParcelsResourceApi parcelsResourceApi = clouderaManagerApiFactory.getParcelsResourceApi(apiClient);
         ParcelResourceApi parcelResourceApi = clouderaManagerApiFactory.getParcelResourceApi(apiClient);
         Map<String, ClouderaManagerProduct> cmProducts = new HashMap<>();
@@ -759,9 +759,15 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
             ClouderaManagerProduct product = clusterComponent.getAttributes().getSilent(ClouderaManagerProduct.class);
             cmProducts.put(product.getName(), product);
         }
-        clouderaManagerParcelDecommissionService.deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, stack.getName(), cmProducts);
-        clouderaManagerParcelDecommissionService.undistributeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, cmProducts);
-        clouderaManagerParcelDecommissionService.removeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, cmProducts);
+        ParcelOperationStatus deactivateStatus = clouderaManagerParcelDecommissionService
+                .deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, stack.getName(), cmProducts);
+        ParcelOperationStatus undistributeStatus = clouderaManagerParcelDecommissionService
+                .undistributeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, cmProducts);
+        ParcelOperationStatus removalStatus = clouderaManagerParcelDecommissionService
+                .removeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, cmProducts);
+        ParcelOperationStatus result = removalStatus.merge(deactivateStatus).merge(undistributeStatus);
+        LOGGER.info("Result of the parcel removal: {}", result);
+        return result;
     }
 
     private int startServices() throws ApiException, CloudbreakException {

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionService.java
@@ -5,11 +5,11 @@ import static com.sequenceiq.cloudbreak.polling.PollingResult.isTimeout;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.function.Predicate;
 
 import javax.inject.Inject;
 
@@ -25,6 +25,7 @@ import com.cloudera.api.swagger.model.ApiParcel;
 import com.cloudera.api.swagger.model.ApiParcelList;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
 import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
+import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
 import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
@@ -42,117 +43,126 @@ class ClouderaManagerParcelDecommissionService {
         try {
             return getClouderaManagerParcelsByStatus(parcelsResourceApi, stackName, parcelStatus)
                     .stream()
-                    .collect(Collectors.toMap(ApiParcel::getProduct, ApiParcel::getVersion));
+                    .collect(toMap(ApiParcel::getProduct, ApiParcel::getVersion));
         } catch (ApiException e) {
             LOGGER.info("Unable to fetch the list of activated parcels", e);
             throw new ClouderaManagerOperationFailedException("Unable to fetch the list of activated parcels", e);
         }
     }
 
-    public void deactivateUnusedParcels(ParcelsResourceApi parcelsResourceApi, ParcelResourceApi parcelResourceApi, String stackName, Map<String,
-            ClouderaManagerProduct> cmProducts) {
+    public ParcelOperationStatus deactivateUnusedParcels(ParcelsResourceApi parcelsResourceApi, ParcelResourceApi parcelResourceApi,
+            String stackName, Map<String, ClouderaManagerProduct> cmProducts) {
         Map<String, String> installedComponents = getParcelsInStatus(parcelsResourceApi, stackName, ParcelStatus.ACTIVATED);
         Map<String, String> filteredParcels = installedComponents.entrySet().stream()
                 .filter(entry -> !cmProducts.containsKey(entry.getKey()))
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
-        deactivateParcels(parcelResourceApi, stackName, filteredParcels);
+                .collect(toMap(Entry::getKey, Entry::getValue));
+        return deactivateParcels(parcelResourceApi, stackName, filteredParcels);
     }
 
-    public void undistributeUnusedParcels(ApiClient apiClient, ParcelsResourceApi parcelsResourceApi, ParcelResourceApi parcelResourceApi, Stack stack,
-            Map<String, ClouderaManagerProduct> cmProducts) {
+    public ParcelOperationStatus undistributeUnusedParcels(ApiClient apiClient, ParcelsResourceApi parcelsResourceApi,
+            ParcelResourceApi parcelResourceApi, Stack stack, Map<String, ClouderaManagerProduct> cmProducts) {
         Map<String, String> distributedComponents = getParcelsInStatus(parcelsResourceApi, stack.getName(), ParcelStatus.DISTRIBUTED);
         Map<String, String> filteredParcels = distributedComponents.entrySet().stream()
                 .filter(entry -> !cmProducts.containsKey(entry.getKey()))
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
-        undistributeParcels(apiClient, parcelResourceApi, stack, filteredParcels);
+                .collect(toMap(Entry::getKey, Entry::getValue));
+        return undistributeParcels(apiClient, parcelResourceApi, stack, filteredParcels);
     }
 
-    public void removeUnusedParcels(ApiClient apiClient, ParcelsResourceApi parcelsResourceApi, ParcelResourceApi parcelResourceApi, Stack stack,
-            Map<String, ClouderaManagerProduct> cmProducts) {
+    public ParcelOperationStatus removeUnusedParcels(ApiClient apiClient, ParcelsResourceApi parcelsResourceApi,
+            ParcelResourceApi parcelResourceApi, Stack stack, Map<String, ClouderaManagerProduct> cmProducts) {
         Map<String, String> downloadedParcels = getParcelsInStatus(parcelsResourceApi, stack.getName(), ParcelStatus.DOWNLOADED);
         Map<String, String> filteredParcels = downloadedParcels.entrySet().stream()
                 .filter(entry -> !cmProducts.containsKey(entry.getKey()))
-                .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
-        removeParcels(apiClient, parcelResourceApi, stack, filteredParcels);
+                .collect(toMap(Entry::getKey, Entry::getValue));
+        return removeParcels(apiClient, parcelResourceApi, stack, filteredParcels);
     }
 
     public void removeUnusedParcelVersions(ApiClient apiClient, ParcelsResourceApi parcelsResourceApi, ParcelResourceApi parcelResourceApi, Stack stack,
-            String parcel, String usedVersion) throws ApiException {
+            ClouderaManagerProduct product) throws ApiException {
+        String parcelName = product.getName();
+        String parcelVersion = product.getVersion();
         Map<String, String> unusedDistributedParcelVersions =
                 getClouderaManagerParcelsByStatus(parcelsResourceApi, stack.getName(), ParcelStatus.DISTRIBUTED).stream()
-                        .filter(apiParcel -> apiParcel.getProduct().equals(parcel) && !apiParcel.getVersion().equals(usedVersion))
-                        .collect(Collectors.toMap(ApiParcel::getProduct, ApiParcel::getVersion));
+                        .filter(apiParcel -> apiParcel.getProduct().equals(parcelName) && !apiParcel.getVersion().equals(parcelVersion))
+                        .collect(toMap(ApiParcel::getProduct, ApiParcel::getVersion));
+
         undistributeParcels(apiClient, parcelResourceApi, stack, unusedDistributedParcelVersions);
 
         Map<String, String> unusedDownloadedParcelVersions =
                 getClouderaManagerParcelsByStatus(parcelsResourceApi, stack.getName(), ParcelStatus.DOWNLOADED).stream()
-                        .filter(apiParcel -> apiParcel.getProduct().equals(parcel) && !apiParcel.getVersion().equals(usedVersion))
-                        .collect(Collectors.toMap(ApiParcel::getProduct, ApiParcel::getVersion));
+                        .filter(apiParcel -> apiParcel.getProduct().equals(parcelName) && !apiParcel.getVersion().equals(parcelVersion))
+                        .collect(toMap(ApiParcel::getProduct, ApiParcel::getVersion));
         removeParcels(apiClient, parcelResourceApi, stack, unusedDownloadedParcelVersions);
     }
 
-    private void deactivateParcels(ParcelResourceApi parcelResourceApi, String stackName, Map<String, String> installedComponents) {
-        Set<String> failedDeactivations = new HashSet<>();
-        for (Map.Entry<String, String> installedComp : installedComponents.entrySet()) {
-            String product = "[" + installedComp.getKey() + ":" + installedComp.getValue() + "]";
+    private ParcelOperationStatus deactivateParcels(ParcelResourceApi parcelResourceApi, String stackName, Map<String, String> installedParcels) {
+        ParcelOperationStatus deactivateStatus = new ParcelOperationStatus();
+        for (Entry<String, String> installedParcel : installedParcels.entrySet()) {
+            Parcel parcel = new Parcel(installedParcel.getKey(), installedParcel.getValue());
             try {
-                LOGGER.debug("Deactivating {} product", product);
-                parcelResourceApi.deactivateCommand(stackName, installedComp.getKey(), installedComp.getValue());
+                LOGGER.debug("Deactivating {} parcel", parcel);
+                parcelResourceApi.deactivateCommand(stackName, parcel.getName(), parcel.getVersion());
+                deactivateStatus.addSuccesful(parcel.getName(), parcel.getVersion());
+                LOGGER.info("Successfully deactivated parcel: {}", parcel);
             } catch (ApiException e) {
-                LOGGER.info(String.format("Unable to deactivate product: %s", product), e);
-                failedDeactivations.add(product);
+                LOGGER.info(String.format("Unable to deactivate parcel: %s", parcel), e);
+                deactivateStatus.addFailed(parcel.getName(), parcel.getVersion());
             }
         }
-        if (!failedDeactivations.isEmpty()) {
-            throw new ClouderaManagerOperationFailedException(String.format("Deactivation failed on the following products: %s", failedDeactivations));
-        }
+        return deactivateStatus;
     }
 
-    private void undistributeParcels(ApiClient apiClient, ParcelResourceApi parcelResourceApi, Stack stack, Map<String, String> parcels) {
-        Set<String> failedDistribution = new HashSet<>();
-        for (Map.Entry<String, String> distributedComponent : parcels.entrySet()) {
-            String product = "[" + distributedComponent.getKey() + ":" + distributedComponent.getValue() + "]";
+    private ParcelOperationStatus undistributeParcels(ApiClient apiClient, ParcelResourceApi parcelResourceApi, Stack stack, Map<String, String> parcels) {
+        ParcelOperationStatus undistributeStatus = new ParcelOperationStatus();
+        for (Entry<String, String> distributedParcel : parcels.entrySet()) {
+            Parcel parcel = new Parcel(distributedParcel.getKey(), distributedParcel.getValue());
             try {
-                LOGGER.debug("Undistributing {} product", product);
-                parcelResourceApi.startRemovalOfDistributionCommand(stack.getName(), distributedComponent.getKey(), distributedComponent.getValue());
+                LOGGER.debug("Undistributing {} parcel", parcel);
+                parcelResourceApi.startRemovalOfDistributionCommand(stack.getName(), parcel.getName(), parcel.getVersion());
+                undistributeStatus.addSuccesful(parcel.getName(), parcel.getVersion());
+                LOGGER.info("Successfully undistributed parcel: {}", parcel);
             } catch (ApiException e) {
-                LOGGER.info(String.format("Unable to undistribute product: %s", product), e);
-                failedDistribution.add(product);
+                LOGGER.info(String.format("Unable to undistribute parcel: %s", parcel), e);
+                undistributeStatus.addFailed(parcel.getName(), parcel.getVersion());
             }
         }
-        if (!failedDistribution.isEmpty()) {
-            throw new ClouderaManagerOperationFailedException(String.format("Undistribution failed on the following products: %s", failedDistribution));
-        }
-        PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmParcelStatus(stack, apiClient, parcels,
+        Map<String, String> pollableParcels = parcels.entrySet().stream()
+                .filter(filterParcels(undistributeStatus.getSuccessful().keySet()))
+                .collect(toMap(Entry::getKey, Entry::getValue));
+        PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmParcelStatus(stack, apiClient, pollableParcels,
                 ParcelStatus.DOWNLOADED);
         if (isExited(pollingResult)) {
             throw new CancellationException("Cluster was terminated while waiting for parcels undistribution");
         } else if (isTimeout(pollingResult)) {
             throw new ClouderaManagerOperationFailedException("Timeout while Cloudera Manager undistribute parcels.");
         }
+        return undistributeStatus;
     }
 
-    private void removeParcels(ApiClient apiClient, ParcelResourceApi parcelResourceApi, Stack stack, Map<String, String> parcels) {
-        Set<String> failedDeletion = new HashSet<>();
-        for (Map.Entry<String, String> downloadedParcel : parcels.entrySet()) {
-            String product = "[" + downloadedParcel.getKey() + ":" + downloadedParcel.getValue() + "]";
+    private ParcelOperationStatus removeParcels(ApiClient apiClient, ParcelResourceApi parcelResourceApi, Stack stack, Map<String, String> parcels) {
+        ParcelOperationStatus removalStatus = new ParcelOperationStatus();
+        for (Entry<String, String> downloadedParcel : parcels.entrySet()) {
+            Parcel parcel = new Parcel(downloadedParcel.getKey(), downloadedParcel.getValue());
             try {
-                LOGGER.debug("Removing {} product", product);
-                parcelResourceApi.removeDownloadCommand(stack.getName(), downloadedParcel.getKey(), downloadedParcel.getValue());
+                LOGGER.debug("Removing {} parcel", parcel);
+                parcelResourceApi.removeDownloadCommand(stack.getName(), parcel.getName(), parcel.getVersion());
+                removalStatus.addSuccesful(parcel.getName(), parcel.getVersion());
+                LOGGER.info("Successfully removed parcel: {}", parcel);
             } catch (ApiException e) {
-                LOGGER.info(String.format("Unable to delete product: %s", product), e);
-                failedDeletion.add(product);
+                LOGGER.info(String.format("Unable to delete parcel: %s", parcel), e);
+                removalStatus.addFailed(parcel.getName(), parcel.getVersion());
             }
         }
-        if (!failedDeletion.isEmpty()) {
-            throw new ClouderaManagerOperationFailedException(String.format("Deletion failed on the following products: %s", failedDeletion));
-        }
-        PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmParcelDelete(stack, apiClient, parcels);
+        Map<String, String> pollableParcels = parcels.entrySet().stream()
+                .filter(filterParcels(removalStatus.getSuccessful().keySet()))
+                .collect(toMap(Entry::getKey, Entry::getValue));
+        PollingResult pollingResult = clouderaManagerPollingServiceProvider.startPollingCmParcelDelete(stack, apiClient, pollableParcels);
         if (isExited(pollingResult)) {
             throw new CancellationException("Cluster was terminated while waiting for parcels deletion");
         } else if (isTimeout(pollingResult)) {
             throw new ClouderaManagerOperationFailedException("Timeout while Cloudera Manager deletes parcels.");
         }
+        return removalStatus;
     }
 
     private List<ApiParcel> getClouderaManagerParcelsByStatus(ParcelsResourceApi parcelsResourceApi, String stackName, ParcelStatus parcelStatus)
@@ -167,5 +177,33 @@ class ClouderaManagerParcelDecommissionService {
 
     private ApiParcelList getClouderaManagerParcels(ParcelsResourceApi parcelsResourceApi, String stackName) throws ApiException {
         return parcelsResourceApi.readParcels(stackName, "summary");
+    }
+
+    private Predicate<Entry<String, String>> filterParcels(Set<String> parcels) {
+        return parcel -> parcels.contains(parcel.getKey());
+    }
+
+    private static class Parcel {
+        private final String name;
+
+        private final String version;
+
+        private Parcel(String name, String version) {
+            this.name = name;
+            this.version = version;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        @Override
+        public String toString() {
+            return '[' + name + ':' + version + ']';
+        }
     }
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerParcelDecommissionServiceTest.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cm;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -10,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,13 +19,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.cloudera.api.swagger.ParcelResourceApi;
 import com.cloudera.api.swagger.ParcelsResourceApi;
+import com.cloudera.api.swagger.client.ApiClient;
 import com.cloudera.api.swagger.client.ApiException;
 import com.cloudera.api.swagger.model.ApiParcel;
 import com.cloudera.api.swagger.model.ApiParcelList;
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
 import com.sequenceiq.cloudbreak.cm.model.ParcelStatus;
 import com.sequenceiq.cloudbreak.cm.polling.ClouderaManagerPollingServiceProvider;
 import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,6 +45,9 @@ public class ClouderaManagerParcelDecommissionServiceTest {
     @Mock
     private ParcelsResourceApi parcelsResourceApi;
 
+    @Mock
+    private ApiClient apiClient;
+
     @Test
     public void testDeactivateUnusedComponents() throws Exception {
         // GIVEN
@@ -52,15 +58,18 @@ public class ClouderaManagerParcelDecommissionServiceTest {
         ApiParcelList parcelList = createApiParcelList(activatedParcels, ParcelStatus.ACTIVATED);
         when(parcelsResourceApi.readParcels("stackname", "summary")).thenReturn(parcelList);
         // WHEN
-        underTest.deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, "stackname", usedComponents);
+        ParcelOperationStatus operationStatus = underTest.deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, "stackname", usedComponents);
         // THEN
         verify(parcelResourceApi, times(1)).deactivateCommand("stackname", "product3", "version3");
         verify(parcelResourceApi, times(0)).deactivateCommand("stackname", "product1", "version1");
         verify(parcelResourceApi, times(0)).deactivateCommand("stackname", "product2", "version2");
+        assertEquals(1, operationStatus.getSuccessful().size());
+        assertEquals(0, operationStatus.getFailed().size());
+        assertEquals("version3", operationStatus.getSuccessful().get("product3"));
     }
 
     @Test
-    public void testDeactivateUnusedComponentsWhenDeactivateThrowException() throws Exception {
+    public void testDeactivateUnusedComponentsWhenDeactivationFailsOnParcel() throws Exception {
         // GIVEN
         Map<String, ClouderaManagerProduct> usedComponents = new HashMap<>();
         usedComponents.put("product1", createClouderaManagerProduct("product1", "version1"));
@@ -70,8 +79,101 @@ public class ClouderaManagerParcelDecommissionServiceTest {
         when(parcelsResourceApi.readParcels("stackname", "summary")).thenReturn(parcelList);
         when(parcelResourceApi.deactivateCommand("stackname", "product3", "version3")).thenThrow(new ApiException());
         // WHEN and THEN
-        Assertions.assertThrows(ClouderaManagerOperationFailedException.class, () -> underTest.deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi,
-                "stackname", usedComponents));
+        ParcelOperationStatus operationStatus = underTest.deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, "stackname", usedComponents);
+        verify(parcelResourceApi, times(1)).deactivateCommand("stackname", "product3", "version3");
+        assertEquals(0, operationStatus.getSuccessful().size());
+        assertEquals(1, operationStatus.getFailed().size());
+        assertEquals("version3", operationStatus.getFailed().get("product3"));
+    }
+
+    @Test
+    public void testUndistributeUnusedComponents() throws Exception {
+        // GIVEN
+        Map<String, ClouderaManagerProduct> usedComponents = new HashMap<>();
+        usedComponents.put("product1", createClouderaManagerProduct("product1", "version1"));
+        usedComponents.put("prodcut2", createClouderaManagerProduct("product2", "version2"));
+        Map<String, String> distributedParcels = Map.of("product1", "version1", "product3", "version3");
+        ApiParcelList parcelList = createApiParcelList(distributedParcels, ParcelStatus.DISTRIBUTED);
+        when(parcelsResourceApi.readParcels("stackname", "summary")).thenReturn(parcelList);
+        Stack stack = mock(Stack.class);
+        when(stack.getName()).thenReturn("stackname");
+        // WHEN
+        ParcelOperationStatus operationStatus = underTest.undistributeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, usedComponents);
+        // THEN
+        verify(parcelResourceApi, times(1)).startRemovalOfDistributionCommand("stackname", "product3", "version3");
+        verify(parcelResourceApi, times(0)).startRemovalOfDistributionCommand("stackname", "product1", "version1");
+        verify(parcelResourceApi, times(0)).startRemovalOfDistributionCommand("stackname", "product2", "version2");
+        assertEquals(1, operationStatus.getSuccessful().size());
+        assertEquals(0, operationStatus.getFailed().size());
+        assertEquals("version3", operationStatus.getSuccessful().get("product3"));
+    }
+
+    @Test
+    public void testUndistributeUnusedComponentsAndUndistributionFails() throws Exception {
+        // GIVEN
+        Map<String, ClouderaManagerProduct> usedComponents = new HashMap<>();
+        usedComponents.put("product1", createClouderaManagerProduct("product1", "version1"));
+        usedComponents.put("prodcut2", createClouderaManagerProduct("product2", "version2"));
+        Map<String, String> distributedParcels = Map.of("product1", "version1", "product3", "version3");
+        ApiParcelList parcelList = createApiParcelList(distributedParcels, ParcelStatus.DISTRIBUTED);
+        when(parcelsResourceApi.readParcels("stackname", "summary")).thenReturn(parcelList);
+        when(parcelResourceApi.startRemovalOfDistributionCommand("stackname", "product3", "version3")).thenThrow(new ApiException());
+        Stack stack = mock(Stack.class);
+        when(stack.getName()).thenReturn("stackname");
+        // WHEN
+        ParcelOperationStatus operationStatus = underTest.undistributeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, usedComponents);
+        // THEN
+        verify(parcelResourceApi, times(1)).startRemovalOfDistributionCommand("stackname", "product3", "version3");
+        verify(parcelResourceApi, times(0)).startRemovalOfDistributionCommand("stackname", "product1", "version1");
+        verify(parcelResourceApi, times(0)).startRemovalOfDistributionCommand("stackname", "product2", "version2");
+        assertEquals(0, operationStatus.getSuccessful().size());
+        assertEquals(1, operationStatus.getFailed().size());
+        assertEquals("version3", operationStatus.getFailed().get("product3"));
+    }
+
+    @Test
+    public void testRemoveUnusedComponents() throws Exception {
+        // GIVEN
+        Map<String, ClouderaManagerProduct> usedComponents = new HashMap<>();
+        usedComponents.put("product1", createClouderaManagerProduct("product1", "version1"));
+        usedComponents.put("prodcut2", createClouderaManagerProduct("product2", "version2"));
+        Map<String, String> distributedParcels = Map.of("product1", "version1", "product3", "version3");
+        ApiParcelList parcelList = createApiParcelList(distributedParcels, ParcelStatus.DOWNLOADED);
+        when(parcelsResourceApi.readParcels("stackname", "summary")).thenReturn(parcelList);
+        Stack stack = mock(Stack.class);
+        when(stack.getName()).thenReturn("stackname");
+        // WHEN
+        ParcelOperationStatus operationStatus = underTest.removeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, usedComponents);
+        // THEN
+        verify(parcelResourceApi, times(1)).removeDownloadCommand("stackname", "product3", "version3");
+        verify(parcelResourceApi, times(0)).removeDownloadCommand("stackname", "product1", "version1");
+        verify(parcelResourceApi, times(0)).removeDownloadCommand("stackname", "product2", "version2");
+        assertEquals(0, operationStatus.getFailed().size());
+        assertEquals(1, operationStatus.getSuccessful().size());
+        assertEquals("version3", operationStatus.getSuccessful().get("product3"));
+    }
+
+    @Test
+    public void testRemoveUnusedComponentsWhenRemovalFails() throws Exception {
+        // GIVEN
+        Map<String, ClouderaManagerProduct> usedComponents = new HashMap<>();
+        usedComponents.put("product1", createClouderaManagerProduct("product1", "version1"));
+        usedComponents.put("prodcut2", createClouderaManagerProduct("product2", "version2"));
+        Map<String, String> distributedParcels = Map.of("product1", "version1", "product3", "version3");
+        ApiParcelList parcelList = createApiParcelList(distributedParcels, ParcelStatus.DOWNLOADED);
+        when(parcelsResourceApi.readParcels("stackname", "summary")).thenReturn(parcelList);
+        Stack stack = mock(Stack.class);
+        when(stack.getName()).thenReturn("stackname");
+        when(parcelResourceApi.removeDownloadCommand("stackname", "product3", "version3")).thenThrow(new ApiException());
+        // WHEN
+        ParcelOperationStatus operationStatus = underTest.removeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, usedComponents);
+        // THEN
+        verify(parcelResourceApi, times(1)).removeDownloadCommand("stackname", "product3", "version3");
+        verify(parcelResourceApi, times(0)).removeDownloadCommand("stackname", "product1", "version1");
+        verify(parcelResourceApi, times(0)).removeDownloadCommand("stackname", "product2", "version2");
+        assertEquals(1, operationStatus.getFailed().size());
+        assertEquals(0, operationStatus.getSuccessful().size());
+        assertEquals("version3", operationStatus.getFailed().get("product3"));
     }
 
     private ClusterComponent createClusterComponent(ClouderaManagerProduct clouderaManagerProduct) {
@@ -86,6 +188,7 @@ public class ClouderaManagerParcelDecommissionServiceTest {
         ClouderaManagerProduct product = new ClouderaManagerProduct();
         product.setName(name);
         product.setVersion(version);
+        product.setDisplayName(name);
         return product;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeService.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerRepo;
+import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.CsdParcelDecorator;
@@ -70,10 +71,11 @@ public class ClusterManagerUpgradeService {
     @Inject
     private CsdParcelDecorator csdParcelDecorator;
 
-    public void removeUnusedComponents(Long stackId, Set<ClusterComponent> clusterComponentsByBlueprint) throws CloudbreakException {
+    public ParcelOperationStatus removeUnusedComponents(Long stackId, Set<ClusterComponent> clusterComponentsByBlueprint) throws CloudbreakException {
         Stack stack = stackService.getByIdWithListsInTransaction(stackId);
-        clusterApiConnectors.getConnector(stack).removeUnusedParcels(clusterComponentsByBlueprint);
-        clusterComponentUpdater.removeUnusedCdhProductsFromClusterComponents(stack.getCluster().getId(), clusterComponentsByBlueprint);
+        ParcelOperationStatus removalStatus = clusterApiConnectors.getConnector(stack).removeUnusedParcels(clusterComponentsByBlueprint);
+        clusterComponentUpdater.removeUnusedCdhProductsFromClusterComponents(stack.getCluster().getId(), clusterComponentsByBlueprint, removalStatus);
+        return removalStatus;
     }
 
     public void upgradeClusterManager(Long stackId, boolean runtimeServicesStartNeeded) throws CloudbreakOrchestratorException, CloudbreakException {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/cluster/ClusterManagerUpgradeServiceTest.java
@@ -19,6 +19,7 @@ import com.sequenceiq.cloudbreak.TestUtil;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.ClusterHostServiceRunner;
 import com.sequenceiq.cloudbreak.core.bootstrap.service.host.decorator.CsdParcelDecorator;
@@ -152,12 +153,14 @@ public class ClusterManagerUpgradeServiceTest {
         Set<ClusterComponent> clusterComponentsByBlueprint = Collections.emptySet();
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
         when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
+        when(clusterApi.removeUnusedParcels(any())).thenReturn(new ParcelOperationStatus());
 
         underTest.removeUnusedComponents(STACK_ID, clusterComponentsByBlueprint);
 
         verify(stackService).getByIdWithListsInTransaction(STACK_ID);
         verify(clusterApiConnectors).getConnector(stack);
         verify(clusterApi).removeUnusedParcels(clusterComponentsByBlueprint);
-        verify(clusterComponentUpdater).removeUnusedCdhProductsFromClusterComponents(stack.getCluster().getId(), clusterComponentsByBlueprint);
+        verify(clusterComponentUpdater).removeUnusedCdhProductsFromClusterComponents(stack.getCluster().getId(), clusterComponentsByBlueprint,
+                new ParcelOperationStatus());
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterComponentUpdaterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterComponentUpdaterTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -13,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
 import com.sequenceiq.cloudbreak.cluster.service.ClusterComponentConfigProvider;
 import com.sequenceiq.cloudbreak.common.type.ComponentType;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
@@ -39,7 +41,7 @@ public class ClusterComponentUpdaterTest {
 
         when(clusterComponentConfigProvider.getComponentsByClusterId(CLUSTER_ID)).thenReturn(clusterComponentsFromDb);
 
-        underTest.removeUnusedCdhProductsFromClusterComponents(CLUSTER_ID, clusterComponentsByBlueprint);
+        underTest.removeUnusedCdhProductsFromClusterComponents(CLUSTER_ID, clusterComponentsByBlueprint, new ParcelOperationStatus(Map.of(), Map.of()));
 
         verify(clusterComponentConfigProvider).getComponentsByClusterId(CLUSTER_ID);
         verifyNoMoreInteractions(clusterComponentConfigProvider);
@@ -53,7 +55,7 @@ public class ClusterComponentUpdaterTest {
 
         when(clusterComponentConfigProvider.getComponentsByClusterId(CLUSTER_ID)).thenReturn(clusterComponentsFromDb);
 
-        underTest.removeUnusedCdhProductsFromClusterComponents(CLUSTER_ID, clusterComponentsByBlueprint);
+        underTest.removeUnusedCdhProductsFromClusterComponents(CLUSTER_ID, clusterComponentsByBlueprint, new ParcelOperationStatus(Map.of(), Map.of()));
 
         verify(clusterComponentConfigProvider).getComponentsByClusterId(CLUSTER_ID);
         verifyNoMoreInteractions(clusterComponentConfigProvider);
@@ -68,7 +70,8 @@ public class ClusterComponentUpdaterTest {
 
         when(clusterComponentConfigProvider.getComponentsByClusterId(CLUSTER_ID)).thenReturn(clusterComponentsFromDb);
 
-        underTest.removeUnusedCdhProductsFromClusterComponents(CLUSTER_ID, clusterComponentsByBlueprint);
+        underTest.removeUnusedCdhProductsFromClusterComponents(CLUSTER_ID, clusterComponentsByBlueprint,
+                new ParcelOperationStatus(Map.of("FLINK", "version"), Map.of()));
 
         verify(clusterComponentConfigProvider).getComponentsByClusterId(CLUSTER_ID);
         verify(clusterComponentConfigProvider).deleteClusterComponents(Set.of(flinkComponent));


### PR DESCRIPTION
The first step of the upgrade process is to deactivate and remove all unused
parcels. This is mainly because we have limited root disk space and removing
these parcels free up space on the disk. When CB tries to identify which
parcels are in use it uses the target image. This is because we have lots of
clusters on older runtime where the image catalog entry points to an internal
cloudera repo hence CB is not able to check the parcel metadata to correlate
them to the services in the blueprint. However, since upgrade is only permitted
if the image points to archive.cloudera.com this correlation can be chekced on
the target image.

There is a special case where this logic fails: spark3 service moved from the
external Spark parcel to the default CDH parcel. This results in a state when
the original cluster runtime needs the Spark parcel, but not the new runtime
version. Due to this CB tried to remove the Spark parcel on the base cluster
version.

To fix this issue, CB will now LOG and ignore the removal related issues, but
will try to remove them after the upgrade as well. The current process looks
like this:

- Try to deactivate and remove all unused parcels based on the target image
- Upgrade CM
- Upgrade the runtime
- Remove the older version of the parcel for the runtime
- Try to deactivate and remove all unused parcels again

