### PR TITLE
CB-14378 Fix datahub ephemeral storage e2e to expect remount after stop/start

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/AwsDistroXEphemeralTemporaryStorageStopStartTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/AwsDistroXEphemeralTemporaryStorageStopStartTest.java
@@ -100,7 +100,7 @@ public class AwsDistroXEphemeralTemporaryStorageStopStartTest extends AbstractE2
                 .when(distroXTestClient.start(), RunningParameter.key("non_eph_dx"))
                 .await(STACK_AVAILABLE, RunningParameter.key("non_eph_dx"))
                 .then((tc, testDto, client) -> {
-                    sshJClientActions.checkNoEphemeralDisksMounted(testDto.getResponse().getInstanceGroups(), List.of(HostGroupType.WORKER.getName()));
+                    sshJClientActions.checkEphemeralDisksMounted(testDto.getResponse().getInstanceGroups(), List.of(HostGroupType.WORKER.getName()), "fs");
                     return testDto;
                 })
                 .given("eph_dx", DistroXTestDto.class)


### PR DESCRIPTION
In 2.48.0, ephemeral volumes are expected to be remounted after stop and start operations under /hadoopfs/fs# (or /hadoopfs/ephfs# if the temporaryStorage field is set to EPHEMERAL_VOLUMES in the stack request). This e2e starts two clusters, previously one of them was started with an instance type without ephemeral volumes. A merge from 2.47 changed the instance type to one with an ephemeral volume, but the validation was not updated.