### PR TITLE
CB-14462. Don't create UserSyncPoller bean

### DIFF
--- a/freeipa/src/main/resources/application.yml
+++ b/freeipa/src/main/resources/application.yml
@@ -99,7 +99,7 @@ freeipa:
   usersync:
     max-subjects-per-request: 10
     poller:
-      enabled: true
+      enabled: false
       initial-delay-millis: 60000
       fixed-delay-millis: 300000
       cooldown-duration: PT10M


### PR DESCRIPTION
The UserSyncPoller is part of the polling automated usersync
solution (CDPCP-659). This approach was superceded by workload iam
and is not needed anymore.

The poller retrieves all Stacks with a spoecified DetailedStackStatus.
The stack status is stored in a separate table from the stack.
The hibernate query to return the stacks is rather inefficient. The
UserSyncPoller is disabled in lieu of optimizing the query.

See detailed description in the commit message.