### PR TITLE
CB-14463 Handle existing reverse record more gracefully

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/dns/DnsRecordService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/freeipa/dns/DnsRecordService.java
@@ -26,6 +26,7 @@ import com.sequenceiq.freeipa.api.v1.dns.model.AddDnsARecordRequest;
 import com.sequenceiq.freeipa.api.v1.dns.model.AddDnsCnameRecordRequest;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
+import com.sequenceiq.freeipa.client.FreeIpaClientExceptionUtil;
 import com.sequenceiq.freeipa.client.RetryableFreeIpaClientException;
 import com.sequenceiq.freeipa.client.model.DnsRecord;
 import com.sequenceiq.freeipa.client.model.DnsZone;
@@ -158,9 +159,18 @@ public class DnsRecordService {
     private void createDnsARecord(FreeIpaClient client, String zone, String hostname, String ip, boolean createReverse) throws FreeIpaClientException {
         LOGGER.info("Creating A record in zone [{}] with hostname [{}] with IP [{}]. Create reverse set to [{}]",
                 zone, hostname, ip, createReverse);
-        Optional<DnsRecord> record = ignoreEmptyModExceptionWithValue(() -> client.addDnsARecord(zone, hostname, ip, createReverse),
-                "Record [{}] pointing to [{}] is already exists, nothing to do.", hostname, ip);
-        LOGGER.info("A record [{}] pointing to [{}] is created successfully. Created record: {}", hostname, ip, record);
+        try {
+            Optional<DnsRecord> record = ignoreEmptyModExceptionWithValue(() -> client.addDnsARecord(zone, hostname, ip, createReverse),
+                    "Record [{}] pointing to [{}] is already exists, nothing to do.", hostname, ip);
+            LOGGER.info("A record [{}] pointing to [{}] is created successfully. Created record: {}", hostname, ip, record);
+        } catch (FreeIpaClientException e) {
+            if (FreeIpaClientExceptionUtil.isDuplicateEntryException(e)) {
+                LOGGER.warn("Duplicate entry, usually reverse entry already exists.", e);
+                throw new DnsRecordConflictException(e.getMessage());
+            } else {
+                throw e;
+            }
+        }
     }
 
     @Retryable(value = RetryableFreeIpaClientException.class,

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/dns/DnsRecordServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/freeipa/dns/DnsRecordServiceTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.freeipa.service.freeipa.dns;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -295,6 +296,25 @@ public class DnsRecordServiceTest {
         dnsRecord.setArecord(List.of("asdf"));
         dnsRecord.setIdnsname(request.getHostname());
         when(freeIpaClient.showDnsRecord(DOMAIN, request.getHostname())).thenReturn(dnsRecord);
+
+        Assertions.assertThrows(DnsRecordConflictException.class, () -> underTest.addDnsARecord(ACCOUNT_ID, request));
+    }
+
+    @Test
+    public void testARecordCreateReturnDuplicate() throws FreeIpaClientException {
+        AddDnsARecordRequest request = new AddDnsARecordRequest();
+        request.setEnvironmentCrn(ENV_CRN);
+        request.setHostname("Asdf");
+        request.setIp("1.1.1.2");
+        request.setCreateReverse(true);
+
+        Stack stack = createStack();
+        when(stackService.getByEnvironmentCrnAndAccountId(ENV_CRN, ACCOUNT_ID)).thenReturn(stack);
+        FreeIpa freeIpa = createFreeIpa();
+        when(freeIpaService.findByStack(stack)).thenReturn(freeIpa);
+        when(freeIpaClientFactory.getFreeIpaClientForStack(stack)).thenReturn(freeIpaClient);
+        when(freeIpaClient.addDnsARecord(anyString(), eq(request.getHostname()), eq(request.getIp()), eq(true)))
+                .thenThrow(new FreeIpaClientException("Duplicate", new JsonRpcClientException(4002, "Duplicate reverse", null)));
 
         Assertions.assertThrows(DnsRecordConflictException.class, () -> underTest.addDnsARecord(ACCOUNT_ID, request));
     }


### PR DESCRIPTION
When adding a new A record to FreeIPA, it's possible to request for creation of a reverse record.
If the reverse record already exists it would cause an internel server error. Instead of it, FMS will return a `DnsRecordConflictException`/409 error.

See detailed description in the commit message.