### PR TITLE
CB-14458 Generate Freeipa image catalog with the currently used image

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -35,6 +35,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIp
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.detachchildenv.DetachChildEnvironmentRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.imagecatalog.ChangeImageCatalogRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.imagecatalog.GenerateImageCatalogResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.reboot.RebootInstancesRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.repair.RepairInstancesRequest;
@@ -210,4 +211,11 @@ public interface FreeIpaV1Endpoint {
     @ApiOperation(value = FreeIpaOperationDescriptions.CHANGE_IMAGE_CATALOG, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "changeImageCatalog")
     void changeImageCatalog(@QueryParam("environment") @NotEmpty String environmentCrn, @Valid @NotNull ChangeImageCatalogRequest changeImageCatalogRequest);
+
+    @GET
+    @Path("generate_image_catalog")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = FreeIpaOperationDescriptions.GENERATE_IMAGE_CATALOG, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
+            nickname = "generateImageCatalog")
+    GenerateImageCatalogResponse generateImageCatalog(@QueryParam("environment") @NotEmpty String environmentCrn);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -27,6 +27,7 @@ public final class FreeIpaOperationDescriptions {
     public static final String RETRY = "Retries the latest failed operation";
     public static final String LIST_RETRYABLE_FLOWS = "List retryable failed flows";
     public static final String CHANGE_IMAGE_CATALOG = "Changes the image catalog used for creating instances";
+    public static final String GENERATE_IMAGE_CATALOG = "Generates an image catalog that only contains the currently used image for creating instances";
 
     private FreeIpaOperationDescriptions() {
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/FreeIpaVersions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/FreeIpaVersions.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.api.model.image;
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class FreeIpaVersions {
 
+    private static final String IMAGES_PROPERTY = "images";
+
     private final List<String> versions;
 
     private final List<String> defaults;
@@ -20,7 +22,7 @@ public class FreeIpaVersions {
     public FreeIpaVersions(
             @JsonProperty("versions") List<String> versions,
             @JsonProperty("defaults") List<String> defaults,
-            @JsonProperty("images") List<String> imageIds) {
+            @JsonProperty(IMAGES_PROPERTY) List<String> imageIds) {
         this.versions = Optional.ofNullable(versions).orElse(List.of());
         this.defaults = Optional.ofNullable(defaults).orElse(List.of());
         this.imageIds = Optional.ofNullable(imageIds).orElse(List.of());
@@ -34,6 +36,7 @@ public class FreeIpaVersions {
         return defaults;
     }
 
+    @JsonProperty(IMAGES_PROPERTY)
     public List<String> getImageIds() {
         return imageIds;
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/Image.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/Image.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.api.model.image;
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image;
 
 import java.util.Map;
 import java.util.Objects;
@@ -9,6 +9,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Image {
+
+    private static final String OS_TYPE_PROPERTY = "os_type";
+
+    private static final String IMAGES_PROPERTY = "images";
+
+    private static final String PACKAGE_VERSIONS_PROPERTY = "package-versions";
+
+    private final long created;
 
     private final String date;
 
@@ -22,20 +30,30 @@ public class Image {
 
     private final Map<String, Map<String, String>> imageSetsByProvider;
 
+    private final Map<String, String> packageVersions;
+
     @JsonCreator
     public Image(
+            @JsonProperty(value = "created") Long created,
             @JsonProperty(value = "date", required = true) String date,
             @JsonProperty(value = "description", required = true) String description,
             @JsonProperty(value = "os", required = true) String os,
             @JsonProperty(value = "uuid", required = true) String uuid,
-            @JsonProperty(value = "images", required = true) Map<String, Map<String, String>> imageSetsByProvider,
-            @JsonProperty("os_type") String osType) {
+            @JsonProperty(value = IMAGES_PROPERTY, required = true) Map<String, Map<String, String>> imageSetsByProvider,
+            @JsonProperty(OS_TYPE_PROPERTY) String osType,
+            @JsonProperty(PACKAGE_VERSIONS_PROPERTY) Map<String, String> packageVersions) {
+        this.created = Objects.requireNonNullElse(created, 0L);
         this.date = date;
         this.description = description;
         this.os = os;
         this.osType = osType;
         this.uuid = uuid;
         this.imageSetsByProvider = imageSetsByProvider;
+        this.packageVersions = packageVersions;
+    }
+
+    public long getCreated() {
+        return created;
     }
 
     public String getDate() {
@@ -54,12 +72,19 @@ public class Image {
         return uuid;
     }
 
+    @JsonProperty(OS_TYPE_PROPERTY)
     public String getOsType() {
         return osType;
     }
 
+    @JsonProperty(IMAGES_PROPERTY)
     public Map<String, Map<String, String>> getImageSetsByProvider() {
         return imageSetsByProvider;
+    }
+
+    @JsonProperty(PACKAGE_VERSIONS_PROPERTY)
+    public Map<String, String> getPackageVersions() {
+        return packageVersions;
     }
 
     @Override

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/ImageCatalog.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/ImageCatalog.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.api.model.image;
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image;
 
 import java.util.List;
 import java.util.Optional;

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/Images.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/Images.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.api.model.image;
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image;
 
 import static java.util.Collections.emptyList;
 
@@ -11,14 +11,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Images {
 
+    private static final String FREEIPA_IMAGES_PROPERTY = "freeipa-images";
+
     private final List<Image> images;
 
     @JsonCreator
     public Images(
-            @JsonProperty("freeipa-images") List<Image> images) {
+            @JsonProperty(FREEIPA_IMAGES_PROPERTY) List<Image> images) {
         this.images = (images == null) ? emptyList() : images;
     }
 
+    @JsonProperty(FREEIPA_IMAGES_PROPERTY)
     public List<Image> getFreeipaImages() {
         return images;
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/Versions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/Versions.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.freeipa.api.model.image;
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,13 +10,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Versions {
 
+    private static final String FREEIPA_VERSIONS_PROPERTY = "freeipa";
+
     private final List<FreeIpaVersions> freeIpaVersions;
 
     @JsonCreator
-    public Versions(@JsonProperty("freeipa") List<FreeIpaVersions> freeIpaVersions) {
+    public Versions(@JsonProperty(FREEIPA_VERSIONS_PROPERTY) List<FreeIpaVersions> freeIpaVersions) {
         this.freeIpaVersions = Optional.ofNullable(freeIpaVersions).orElse(List.of());
     }
 
+    @JsonProperty(FREEIPA_VERSIONS_PROPERTY)
     public List<FreeIpaVersions> getFreeIpaVersions() {
         return freeIpaVersions;
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/imagecatalog/GenerateImageCatalogResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/imagecatalog/GenerateImageCatalogResponse.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.imagecatalog;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.ImageCatalog;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel("GenerateImageCatalogV1Response")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GenerateImageCatalogResponse {
+
+    @NotNull
+    private ImageCatalog imageCatalog;
+
+    public ImageCatalog getImageCatalog() {
+        return imageCatalog;
+    }
+
+    public void setImageCatalog(ImageCatalog imageCatalog) {
+        this.imageCatalog = imageCatalog;
+    }
+
+    @Override
+    public String toString() {
+        return "GenerateImageCatalogResponse{" +
+                "imageCatalog=" + imageCatalog +
+                '}';
+    }
+}

--- a/freeipa-api/src/test/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/ImageCatalogTest.java
+++ b/freeipa-api/src/test/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/image/ImageCatalogTest.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.sequenceiq.cloudbreak.util.FileReaderUtils;
+
+class ImageCatalogTest {
+
+    @Test
+    void shouldSerializeAndDeserializeTheSame() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectWriter objectWriter = objectMapper.writer().withDefaultPrettyPrinter();
+        String catalogString = FileReaderUtils.readFileFromClasspath("image-catalog.json");
+
+        Assertions.assertNotNull(catalogString);
+        Assertions.assertNotEquals("", catalogString);
+
+        ImageCatalog imageCatalog = objectMapper.readValue(catalogString, ImageCatalog.class);
+        String firstWrite = objectWriter.writeValueAsString(imageCatalog);
+        ImageCatalog imageCatalogFromJson = objectMapper.readValue(firstWrite, ImageCatalog.class);
+        String secondWrite = objectWriter.writeValueAsString(imageCatalogFromJson);
+
+        Assertions.assertEquals(firstWrite, secondWrite);
+    }
+
+}

--- a/freeipa-api/src/test/resources/image-catalog.json
+++ b/freeipa-api/src/test/resources/image-catalog.json
@@ -1,0 +1,63 @@
+{
+  "images": {
+    "freeipa-images": [
+      {
+        "created": 1633952426,
+        "date": "2021-10-11",
+        "description": "Official Cloudbreak image",
+        "os": "centos7",
+        "uuid": "f377c56e-9ad8-47fe-9b53-c3a554500897",
+        "images": {
+          "aws": {
+            "af-south-1": "ami-025b004a8fd7f243a",
+            "ap-northeast-1": "ami-06fe46bb49d304fc1",
+            "ap-northeast-2": "ami-0559ec785867d0bfb",
+            "ap-south-1": "ami-05dde3defc0fd826f",
+            "ap-southeast-1": "ami-0001505ad62ce9faa",
+            "ap-southeast-2": "ami-0b042120ee2be9c7d",
+            "ca-central-1": "ami-02ab8a208cf4f4c51",
+            "eu-central-1": "ami-0e671d06666b4d3f5",
+            "eu-north-1": "ami-0797a196cf7868a6a",
+            "eu-south-1": "ami-0d08585cdf60b9f11",
+            "eu-west-1": "ami-0bdc85d6427edfae4",
+            "eu-west-2": "ami-03e9ec920d203e64d",
+            "eu-west-3": "ami-0142a560c0eb69457",
+            "me-south-1": "ami-03cc53a1e6142d84f",
+            "sa-east-1": "ami-06a17b3e9ee35a780",
+            "us-east-1": "ami-062bc2e3c1f632af6",
+            "us-east-2": "ami-0181d6b939697b36c",
+            "us-west-1": "ami-0d2f8b997a3abea48",
+            "us-west-2": "ami-0da242e152baee137"
+          }
+        },
+        "os_type": "redhat7",
+        "package-versions": {
+          "cdp-logging-agent": "0.2.11",
+          "cdp-telemetry": "0.4.17",
+          "cloudbreak_images": "51b1a82",
+          "freeipa-health-agent": "0.1-20210517150203gitab017e0",
+          "freeipa-plugin": "1.0-20200319002729gitc964030",
+          "inverting-proxy-agent": "2.0.3-b1",
+          "inverting-proxy-agent_gbn": "17606589",
+          "salt": "3000.8",
+          "salt-bootstrap": "0.13.4-2020-09-30T15:03:43"
+        }
+      }
+    ]
+  },
+  "versions": {
+    "freeipa": [
+      {
+        "versions": [
+          "2.49.0-b135-1-gb13840b"
+        ],
+        "defaults": [
+          "f377c56e-9ad8-47fe-9b53-c3a554500897"
+        ],
+        "images": [
+          "f377c56e-9ad8-47fe-9b53-c3a554500897"
+        ]
+      }
+    ]
+  }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.freeipa.controller;
 
+import static com.sequenceiq.authorization.resource.AuthorizationResourceAction.DESCRIBE_ENVIRONMENT;
 import static com.sequenceiq.authorization.resource.AuthorizationResourceAction.EDIT_ENVIRONMENT;
 import static com.sequenceiq.authorization.resource.AuthorizationResourceAction.REPAIR_FREEIPA;
 import static com.sequenceiq.authorization.resource.AuthorizationVariableType.CRN;
@@ -43,6 +44,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIp
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.detachchildenv.DetachChildEnvironmentRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.health.HealthDetailsFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.imagecatalog.ChangeImageCatalogRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.imagecatalog.GenerateImageCatalogResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.reboot.RebootInstancesRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.repair.RepairInstancesRequest;
@@ -58,6 +60,7 @@ import com.sequenceiq.freeipa.service.binduser.BindUserCreateService;
 import com.sequenceiq.freeipa.service.freeipa.cert.root.FreeIpaRootCertificateService;
 import com.sequenceiq.freeipa.service.freeipa.cleanup.CleanupService;
 import com.sequenceiq.freeipa.service.image.ImageCatalogChangeService;
+import com.sequenceiq.freeipa.service.image.ImageCatalogGeneratorService;
 import com.sequenceiq.freeipa.service.image.ImageChangeService;
 import com.sequenceiq.freeipa.service.operation.FreeIpaRetryService;
 import com.sequenceiq.freeipa.service.stack.ChildEnvironmentService;
@@ -140,6 +143,9 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
 
     @Inject
     private ImageCatalogChangeService imageCatalogChangeService;
+
+    @Inject
+    private ImageCatalogGeneratorService imageCatalogGeneratorService;
 
     @Override
     @CheckPermissionByRequestProperty(path = "environmentCrn", type = CRN, action = EDIT_ENVIRONMENT)
@@ -319,5 +325,12 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
     public void changeImageCatalog(@ResourceCrn String environmentCrn, ChangeImageCatalogRequest changeImageCatalogRequest) {
         String accountId = crnService.getCurrentAccountId();
         imageCatalogChangeService.changeImageCatalog(environmentCrn, accountId, changeImageCatalogRequest.getImageCatalog());
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = DESCRIBE_ENVIRONMENT)
+    public GenerateImageCatalogResponse generateImageCatalog(@ResourceCrn @NotEmpty String environmentCrn) {
+        String accountId = crnService.getCurrentAccountId();
+        return imageCatalogGeneratorService.generate(environmentCrn, accountId);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/image/ImageToImageEntityConverter.java
@@ -2,7 +2,7 @@ package com.sequenceiq.freeipa.converter.image;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.freeipa.api.model.image.Image;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
 import com.sequenceiq.freeipa.entity.ImageEntity;
 
 @Component

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/dto/ImageWrapper.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/dto/ImageWrapper.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.freeipa.dto;
 
-import com.sequenceiq.freeipa.api.model.image.Image;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
 
 public class ImageWrapper {
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/CoreImageProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/CoreImageProvider.java
@@ -16,7 +16,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.ImageCatalogV4Endp
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
-import com.sequenceiq.freeipa.api.model.image.Image;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 
@@ -74,7 +74,8 @@ public class CoreImageProvider implements ImageProvider {
     }
 
     private Optional<Image> convert(ImageV4Response response) {
-        return Optional.ofNullable(response).map(r ->
-                new Image(r.getDate(), r.getDescription(), r.getOs(), r.getUuid(), r.getImageSetsByProvider(), r.getOsType()));
+        return Optional.ofNullable(response)
+                .map(r -> new Image(r.getCreated(), r.getDate(), r.getDescription(), r.getOs(), r.getUuid(), r.getImageSetsByProvider(), r.getOsType(),
+                        r.getPackageVersions()));
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/FreeIpaImageProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/FreeIpaImageProvider.java
@@ -22,9 +22,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.freeipa.api.model.image.FreeIpaVersions;
-import com.sequenceiq.freeipa.api.model.image.Image;
-import com.sequenceiq.freeipa.api.model.image.ImageCatalog;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.FreeIpaVersions;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.ImageCatalog;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageCatalogGeneratorService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageCatalogGeneratorService.java
@@ -1,0 +1,37 @@
+package com.sequenceiq.freeipa.service.image;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.ImageCatalog;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.imagecatalog.GenerateImageCatalogResponse;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@Service
+public class ImageCatalogGeneratorService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageCatalogGeneratorService.class);
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private ImageService imageService;
+
+    public GenerateImageCatalogResponse generate(String environmentCrn, String accountId) {
+        final Stack stack = stackService.getByEnvironmentCrnAndAccountId(environmentCrn, accountId);
+        MDCBuilder.buildMdcContext(stack);
+
+        LOGGER.info("Generating image catalog for environment {} stack {}", environmentCrn, stack.getId());
+        final ImageCatalog imageCatalog = imageService.generateImageCatalogForStack(stack);
+
+        final GenerateImageCatalogResponse response = new GenerateImageCatalogResponse();
+        response.setImageCatalog(imageCatalog);
+        return response;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageCatalogProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/image/ImageCatalogProvider.java
@@ -30,11 +30,11 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sequenceiq.cloudbreak.client.RestClientUtil;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
-import com.sequenceiq.freeipa.api.model.image.FreeIpaVersions;
-import com.sequenceiq.freeipa.api.model.image.Image;
-import com.sequenceiq.freeipa.api.model.image.ImageCatalog;
-import com.sequenceiq.freeipa.api.model.image.Images;
-import com.sequenceiq.freeipa.api.model.image.Versions;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.FreeIpaVersions;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.ImageCatalog;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Images;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Versions;
 
 @Service
 public class ImageCatalogProvider {

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
@@ -38,6 +38,7 @@ import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.controller.validation.AttachChildEnvironmentRequestValidator;
 import com.sequenceiq.freeipa.controller.validation.CreateFreeIpaRequestValidator;
 import com.sequenceiq.freeipa.service.freeipa.cert.root.FreeIpaRootCertificateService;
+import com.sequenceiq.freeipa.service.image.ImageCatalogGeneratorService;
 import com.sequenceiq.freeipa.service.stack.ChildEnvironmentService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaCreationService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaDeletionService;
@@ -88,6 +89,9 @@ class FreeIpaV1ControllerTest {
 
     @Mock
     private FreeIpaFiltering freeIpaFiltering;
+
+    @Mock
+    private ImageCatalogGeneratorService imageCatalogGeneratorService;
 
     @BeforeEach
     void setUp() {
@@ -223,5 +227,14 @@ class FreeIpaV1ControllerTest {
 
         underTest.repairInstances(request);
         verify(repairInstancesService, times(1)).repairInstances(crnService.getCurrentAccountId(), request);
+    }
+
+    @Test
+    void generateImageCatalog() {
+        when(crnService.getCurrentAccountId()).thenReturn(ACCOUNT_ID);
+
+        underTest.generateImageCatalog(ENVIRONMENT_CRN);
+
+        verify(imageCatalogGeneratorService).generate(ENVIRONMENT_CRN, ACCOUNT_ID);
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/CoreImageProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/CoreImageProviderTest.java
@@ -22,7 +22,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.ImageCatalogV4Endp
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
-import com.sequenceiq.freeipa.api.model.image.Image;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/FreeIpaImageProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/FreeIpaImageProviderTest.java
@@ -28,8 +28,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sequenceiq.cloudbreak.util.FileReaderUtils;
-import com.sequenceiq.freeipa.api.model.image.Image;
-import com.sequenceiq.freeipa.api.model.image.ImageCatalog;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.ImageCatalog;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageCatalogGeneratorServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageCatalogGeneratorServiceTest.java
@@ -1,0 +1,45 @@
+package com.sequenceiq.freeipa.service.image;
+
+import static org.mockito.Mockito.when;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.ImageCatalog;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.imagecatalog.GenerateImageCatalogResponse;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class ImageCatalogGeneratorServiceTest {
+
+    private static final String ENVIRONMENT_CRN = "test:environment:crn";
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private ImageService imageService;
+
+    @InjectMocks
+    private ImageCatalogGeneratorService underTest;
+
+    @Test
+    void generate() {
+        Stack stack = new Stack();
+        when(stackService.getByEnvironmentCrnAndAccountId(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(stack);
+        ImageCatalog imageCatalog = new ImageCatalog(null, null);
+        when(imageService.generateImageCatalogForStack(stack)).thenReturn(imageCatalog);
+
+        GenerateImageCatalogResponse result = underTest.generate(ENVIRONMENT_CRN, ACCOUNT_ID);
+
+        Assertions.assertThat(result.getImageCatalog()).isEqualTo(imageCatalog);
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageCatalogProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/image/ImageCatalogProviderTest.java
@@ -19,9 +19,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sequenceiq.freeipa.TestUtil;
-import com.sequenceiq.freeipa.api.model.image.FreeIpaVersions;
-import com.sequenceiq.freeipa.api.model.image.Image;
-import com.sequenceiq.freeipa.api.model.image.ImageCatalog;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.FreeIpaVersions;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.ImageCatalog;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ImageCatalogProviderTest {
@@ -57,7 +57,7 @@ public class ImageCatalogProviderTest {
         ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
 
         ImageCatalog catalog = underTest.getImageCatalog(IMAGE_CATALOG_JSON);
-        List<com.sequenceiq.freeipa.api.model.image.Image> images = catalog.getImages().getFreeipaImages();
+        List<com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image> images = catalog.getImages().getFreeipaImages();
         assertEquals(4, images.size());
         assertEquals("61851893-8340-411d-afb7-e1b55107fb10", images.get(0).getUuid());
 

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/UpgradeImageServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/upgrade/UpgradeImageServiceTest.java
@@ -17,8 +17,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.sequenceiq.freeipa.api.model.image.Image;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.image.Image;
 import com.sequenceiq.freeipa.api.v1.freeipa.upgrade.model.ImageInfoResponse;
 import com.sequenceiq.freeipa.dto.ImageWrapper;
 import com.sequenceiq.freeipa.entity.ImageEntity;
@@ -39,7 +39,7 @@ class UpgradeImageServiceTest {
     public void testSelectImage() {
         Stack stack = new Stack();
         ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
-        Image image = new Image("now", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        Image image = createImage("now");
         ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
         when(imageService.fetchImageWrapperAndName(stack, imageSettingsRequest)).thenReturn(Pair.of(imageWrapper, "imageName"));
 
@@ -77,7 +77,7 @@ class UpgradeImageServiceTest {
     public void testFindTargetImages() {
         Stack stack = new Stack();
         ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
-        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        Image image = createImage("2021-09-01");
         ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
         when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
 
@@ -100,7 +100,7 @@ class UpgradeImageServiceTest {
     public void testFindTargetImagesNoNewerImage() {
         Stack stack = new Stack();
         ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
-        Image image = new Image("2021-07-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        Image image = createImage("2021-07-01");
         ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
         when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
 
@@ -117,7 +117,7 @@ class UpgradeImageServiceTest {
     public void testFindTargetImagesImageWithSameId() {
         Stack stack = new Stack();
         ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
-        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        Image image = createImage("2021-09-01");
         ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
         when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
 
@@ -136,11 +136,11 @@ class UpgradeImageServiceTest {
         stack.setCloudPlatform("AWS");
         stack.setRegion("reg");
         ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
-        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        Image image = createImage("2021-09-01");
         ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
         when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
         ArgumentCaptor<ImageSettingsRequest> captor = ArgumentCaptor.forClass(ImageSettingsRequest.class);
-        Image currentImageFromCatalog = new Image("2021-08-01", "desc", "linux", "222-333", Map.of(), "magicOs");
+        Image currentImageFromCatalog = createImage("2021-08-01");
         ImageWrapper currentImageWrapperFromCatalog = new ImageWrapper(currentImageFromCatalog, "asdf", "Asdf");
         when(imageService.getImage(captor.capture(), eq(stack.getRegion()), eq(stack.getCloudPlatform().toLowerCase())))
                 .thenReturn(currentImageWrapperFromCatalog);
@@ -172,11 +172,11 @@ class UpgradeImageServiceTest {
         stack.setCloudPlatform("AWS");
         stack.setRegion("reg");
         ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
-        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        Image image = createImage("2021-09-01");
         ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
         when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
         ArgumentCaptor<ImageSettingsRequest> captor = ArgumentCaptor.forClass(ImageSettingsRequest.class);
-        Image currentImageFromCatalog = new Image(null, "desc", "linux", "222-333", Map.of(), "magicOs");
+        Image currentImageFromCatalog = createImage(null);
         ImageWrapper currentImageWrapperFromCatalog = new ImageWrapper(currentImageFromCatalog, "asdf", "Asdf");
         when(imageService.getImage(captor.capture(), eq(stack.getRegion()), eq(stack.getCloudPlatform().toLowerCase())))
                 .thenReturn(currentImageWrapperFromCatalog);
@@ -201,7 +201,7 @@ class UpgradeImageServiceTest {
         stack.setCloudPlatform("AWS");
         stack.setRegion("reg");
         ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
-        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        Image image = createImage("2021-09-01");
         ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
         when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest)).thenReturn(List.of(Pair.of(imageWrapper, "imageName")));
         ArgumentCaptor<ImageSettingsRequest> captor = ArgumentCaptor.forClass(ImageSettingsRequest.class);
@@ -226,9 +226,9 @@ class UpgradeImageServiceTest {
     public void testFindTargetImagesImageWithWrongDateFormatIgnored() {
         Stack stack = new Stack();
         ImageSettingsRequest imageSettingsRequest = new ImageSettingsRequest();
-        Image image = new Image("2021-09-01", "desc", "linux", "1234-456", Map.of(), "magicOs");
+        Image image = createImage("2021-09-01");
         ImageWrapper imageWrapper = new ImageWrapper(image, "catalogURL", "catalogName");
-        Image image2 = new Image("20210901", "desc", "linux", "1234-789", Map.of(), "magicOs");
+        Image image2 = createImage("20210901");
         ImageWrapper imageWrapper2 = new ImageWrapper(image2, "catalogURL", "catalogName");
         when(imageService.fetchImagesWrapperAndName(stack, imageSettingsRequest))
                 .thenReturn(List.of(Pair.of(imageWrapper, "imageName"), Pair.of(imageWrapper2, "imageName2")));
@@ -246,5 +246,9 @@ class UpgradeImageServiceTest {
         assertEquals(image.getDate(), imageInfoResponse.getDate());
         assertEquals(image.getUuid(), imageInfoResponse.getId());
         assertEquals(image.getOs(), imageInfoResponse.getOs());
+    }
+
+    private Image createImage(String date) {
+        return new Image(123L, date, "desc", "linux", "1234-456", Map.of(), "magicOs", Map.of());
     }
 }


### PR DESCRIPTION
The new catalog contains exactly one image, that is currently used by the input environment's freeipa stack. It is the default image in the catalog. The catalog contains exactly one version, that is the current Freeipa service version.
To achieve this, the image catalog related entities had to be moved to freeipa-api module, and modified so that the generated json from these entities match the image catalog format.

See detailed description in the commit message.