### PR TITLE
CB-14130 Stop operation related fixes for clusters with ephemeral storage

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackStopRestrictionServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/StackStopRestrictionServiceTest.java
@@ -40,10 +40,7 @@ public class StackStopRestrictionServiceTest {
     @Test
     public void infrastructureShouldNotBeStoppableForEphemeralStorageBefore248CbVersion() {
         Set<InstanceGroup> groups = new HashSet<>();
-        groups.add(createGroup(List.of("ebs"), temporaryStorage));
         groups.add(createGroup(List.of(AwsDiskType.Ephemeral.value()), temporaryStorage));
-
-        when(componentConfigProviderService.getCloudbreakDetails(any())).thenReturn(new CloudbreakDetails("2.47.0-XXb"));
 
         StopRestrictionReason actual = underTest.isInfrastructureStoppable(createStack("AWS", groups));
 
@@ -51,7 +48,7 @@ public class StackStopRestrictionServiceTest {
     }
 
     @Test
-    public void infrastructureShouldBeStoppableForEphemeralStorageAfter248CbVersion() {
+    public void infrastructureShouldBeStoppableForEBSVolumesOnly() {
         Set<InstanceGroup> groups = new HashSet<>();
         groups.add(createGroup(List.of("ebs"), temporaryStorage));
 

--- a/orchestrator-salt/src/main/resources/salt/salt/disks/service/scripts/mount-instance-storage.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/disks/service/scripts/mount-instance-storage.j2
@@ -50,6 +50,24 @@ mount_all_sequential() {
     local return_value=0
     log $LOG_FILE "mounting storage devices ${device_uuids_arr[@]}"
     local hadoop_fs_dir_counter=1
+    if [[ $MOUNT_PATH = *"ephfs"* ]]; then
+      hadoop_fs_dir_counter=1
+    else
+      declare -a mountpoints_arr
+      declare -a dirnum_arr
+      mountpoints_arr=($(lsblk -n -oMOUNTPOINT))
+      for mp in ${mountpoints_arr[@]}; do
+        if [[ $mp == *"hadoopfs"* ]]; then
+          num="${mp#/hadoopfs/fs*}"
+          dirnum_arr+=($num)
+        fi
+      done
+      max=${dirnum_arr[0]}
+      for n in "${dirnum_arr[@]}" ; do
+          ((n > max)) && max=$n
+      done
+      hadoop_fs_dir_counter=$((max+1))
+    fi
     for uuid in ${device_uuids_arr[@]}; do
         mount_one "UUID=$uuid /hadoopfs/$MOUNT_PATH${hadoop_fs_dir_counter} $FS_TYPE defaults,noatime,nofail 0 2"
         ((hadoop_fs_dir_counter++))


### PR DESCRIPTION
Ephemeral storage only instances should not be stoppable even if
the ephemeral disk caching feature is enabled on it.

The service responsible for mounting ephemeral storage, after an
instance was started, could not determine the correct mount path,
when the ephemeral disk caching feature was not active.