### PR TITLE
CB-12873: Re-load DL remote data context when DH is started

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -72,6 +72,14 @@ public interface ClusterApi {
         return clusterModificationService().startCluster();
     }
 
+    default void startClusterMgmtServices() throws CloudbreakException {
+        clusterModificationService().startClusterMgmtServices();
+    }
+
+    default int startClusterServices() throws CloudbreakException {
+        return clusterModificationService().deployConfigAndStartClusterServices();
+    }
+
     default Map<String, String> gatherInstalledParcels(String stackName) {
         return clusterModificationService().gatherInstalledParcels(stackName);
     }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -22,6 +22,10 @@ public interface ClusterModificationService {
 
     int startCluster() throws CloudbreakException;
 
+    void startClusterMgmtServices() throws CloudbreakException;
+
+    int deployConfigAndStartClusterServices() throws CloudbreakException;
+
     Map<String, String> getComponentsByCategory(String blueprintName, String hostGroupName);
 
     String getStackRepositoryJson(StackRepoDetails repoDetails, String stackRepoId);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerSetupService.java
@@ -359,14 +359,14 @@ public class ClouderaManagerSetupService implements ClusterSetupService {
         try {
             ApiClient rootClient = clouderaManagerApiClientProvider.getRootClient(stack.getGatewayPort(), user, password, clientConfig);
             CdpResourceApi cdpResourceApi = clouderaManagerApiFactory.getCdpResourceApi(rootClient);
-            LOGGER.debug("Get remote context from Datalake cluster: {}", stack.getName());
+            LOGGER.info("Get remote context from Datalake cluster: {}", stack.getName());
             ApiRemoteDataContext remoteDataContext = cdpResourceApi.getRemoteContextByCluster(stack.getName());
             return JsonUtil.writeValueAsString(remoteDataContext);
         } catch (ApiException | ClouderaManagerClientInitException e) {
-            LOGGER.info("Error while getting remote context of Datalake cluster: {}", stack.getName(), e);
+            LOGGER.error("Error while getting remote context of Datalake cluster: {}", stack.getName(), e);
             throw new ClouderaManagerOperationFailedException("Error while getting remote context of Datalake cluster", e);
         } catch (JsonProcessingException e) {
-            LOGGER.info("Failed to serialize remote context.", e);
+            LOGGER.error("Failed to serialize remote context.", e);
             throw new ClouderaManagerOperationFailedException("Failed to serialize remote context.", e);
         }
     }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -319,6 +319,8 @@ public enum ResourceEvent {
     CLUSTER_CM_CLUSTER_SERVICES_STOPPED("cm.cluster.services.stopped"),
     CLUSTER_CM_CLUSTER_SERVICES_STARTED("cm.cluster.services.started"),
     CLUSTER_CM_CLUSTER_SERVICES_STARTING("cm.cluster.services.starting"),
+    CLUSTER_CM_UPDATING_REMOTE_DATA_CONTEXT("cm.cluster.updating.remote.data.context"),
+    CLUSTER_CM_UPDATED_REMOTE_DATA_CONTEXT("cm.cluster.updated.remote.data.context"),
     CLUSTER_CM_SECURITY_GROUP_TOO_STRICT("cm.cluster.securitygroup.too.strict"),
     CLUSTER_CM_SERVICE_DEREGISTER_FAILED("cm.cluster.service.deregister.failed"),
     CLUSTER_CM_COMMAND_FAILED("cm.cluster.command.failed"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -174,6 +174,8 @@ cm.cluster.services.started=Cloudera Manager services have been started.
 cm.cluster.services.starting=Starting Cloudera Manager services.
 cm.cluster.services.stopping=Stopping Cloudera Manager services.
 cm.cluster.services.stopped=Cloudera Manager services have been stopped.
+cm.cluster.updating.remote.data.context=Cloudera Manager updating remote data context, started.
+cm.cluster.updated.remote.data.context=Cloudera Manager updating remote data context, complete.
 cm.cluster.securitygroup.too.strict=The security group of the Cloudera Manager node is probably too strict. Please check if all the necessary ports are reachable. Error message: {0}.
 cm.cluster.service.deregister.failed=Failed to deregister service(s) from Cloudera Manager. This has to be done manually. It's possible that CM or the instance is not running. 
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandler.java
@@ -2,8 +2,14 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster;
 
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.core.cluster.ClusterBuilderService;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartResult;
@@ -17,8 +23,17 @@ import reactor.bus.EventBus;
 
 @Component
 public class ClusterStartHandler implements EventHandler<ClusterStartRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterStartHandler.class);
+
     @Inject
     private ClusterApiConnectors apiConnectors;
+
+    @Inject
+    private ClusterBuilderService clusterBuilderService;
+
+    @Inject
+    private EntitlementService entitlementService;
 
     @Inject
     private StackService stackService;
@@ -37,7 +52,16 @@ public class ClusterStartHandler implements EventHandler<ClusterStartRequest> {
         ClusterStartResult result;
         try {
             Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
-            int requestId = apiConnectors.getConnector(stack).startCluster();
+            int requestId;
+            if (stack.getType() == StackType.WORKLOAD &&
+            entitlementService.isDatalakeLightToMediumMigrationEnabled(ThreadBasedUserCrnProvider.getAccountId())) {
+                LOGGER.info("Triggering update of remote data context");
+                apiConnectors.getConnector(stack).startClusterMgmtServices();
+                clusterBuilderService.configureManagementServices(stack.getId());
+                requestId = apiConnectors.getConnector(stack).startClusterServices();
+            } else {
+                requestId = apiConnectors.getConnector(stack).startCluster();
+            }
             result = new ClusterStartResult(request, requestId);
         } catch (Exception e) {
             result = new ClusterStartResult(e.getMessage(), e, request);


### PR DESCRIPTION
When DH is started, CM is started first and then the remote data context of datalake is fetched and client configuration of DH is refreshed before the DH services are started.

Here is the summary of the changes
1. Start CM management services
2. Fetch the RDC of the data lake
3. Push the RDC to DH
4. Trigger deploy client config
5. Start the cluster services