### PR TITLE
CB-14065 Check for active commands before CM upgrade

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterStatusService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.cluster.api;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -24,4 +25,5 @@ public interface ClusterStatusService {
 
     Optional<String> getClusterManagerVersion();
 
+    List<String> getActiveCommandsList();
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ActiveCommandsValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ActiveCommandsValidator.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.service.upgrade.validation.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+
+@Component
+public class ActiveCommandsValidator implements ServiceUpgradeValidator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ActiveCommandsValidator.class);
+
+    @Inject
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Override
+    public void validate(ServiceUpgradeValidationRequest validationRequest) {
+        ClusterApi connector = clusterApiConnectors.getConnector(validationRequest.getStack());
+        List<String> activeCommands = connector.clusterStatusService().getActiveCommandsList();
+        if (CollectionUtils.isNotEmpty(activeCommands)) {
+            throw new UpgradeValidationFailedException("There are active commands running on CM, upgrade is not possible. Active commands: "
+                    + activeCommands.stream().collect(Collectors.joining(",")));
+        }
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ActiveCommandsValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/validation/service/ActiveCommandsValidatorTest.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.cloudbreak.service.upgrade.validation.service;
+
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
+import com.sequenceiq.cloudbreak.cluster.api.ClusterStatusService;
+import com.sequenceiq.cloudbreak.common.exception.UpgradeValidationFailedException;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+
+@ExtendWith(MockitoExtension.class)
+public class ActiveCommandsValidatorTest {
+    @InjectMocks
+    private ActiveCommandsValidator underTest;
+
+    @Mock
+    private ClusterApiConnectors clusterApiConnectors;
+
+    @Mock
+    private ClusterApi connector;
+
+    @Mock
+    private ClusterStatusService clusterStatusService;
+
+    private Stack stack;
+
+    @BeforeEach
+    public void before() {
+        stack = createStack();
+    }
+
+    @Test
+    public void testValidateIfActiveCommandsListIsEmpty() {
+        // GIVEN
+        when(clusterApiConnectors.getConnector(stack)).thenReturn(connector);
+        when(connector.clusterStatusService()).thenReturn(clusterStatusService);
+        // WHEN
+        underTest.validate(new ServiceUpgradeValidationRequest(stack, true));
+        // THEN no exception is thrown
+    }
+
+    @Test
+    public void testValidateIfActiveCommandsListIsNull() {
+        // GIVEN
+        when(clusterApiConnectors.getConnector(stack)).thenReturn(connector);
+        when(connector.clusterStatusService()).thenReturn(clusterStatusService);
+        when(clusterStatusService.getActiveCommandsList()).thenReturn(null);
+        // WHEN
+        underTest.validate(new ServiceUpgradeValidationRequest(stack, true));
+        // THEN no exception is thrown
+    }
+
+    @Test
+    public void testValidateIfActiveCommandsListIsNotEmpty() {
+        // GIVEN
+        when(clusterApiConnectors.getConnector(stack)).thenReturn(connector);
+        when(connector.clusterStatusService()).thenReturn(clusterStatusService);
+        when(clusterStatusService.getActiveCommandsList()).thenReturn(List.of("command"));
+        // WHEN
+        Assertions.assertThrows(UpgradeValidationFailedException.class, () -> underTest.validate(new ServiceUpgradeValidationRequest(stack, true)));
+        // THEN exception is thrown
+    }
+
+    private Stack createStack() {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText("");
+        Cluster cluster = new Cluster();
+        cluster.setName("cluster");
+        cluster.setBlueprint(blueprint);
+        Stack stack = new Stack();
+        stack.setCluster(cluster);
+        return stack;
+    }
+}


### PR DESCRIPTION
CB-14065 Check for active commands before CM upgrade 

* Extend the upgrade validation flow with checking if there are active commands running on CM side
* If active commands are running on CM side the validation will be failed.
