### PR TITLE
CB-13241 Create external test group variables for BasicEnvironmentVirtualGroupTest

### DIFF
--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -125,6 +125,11 @@ integrationtest:
       upgrade:
         imageId: 9c1c8959-86a7-4b7d-af5a-be252f8b395d
         catalog: https://cloudbreak-imagecatalog.s3.us-west-1.amazonaws.com/freeipa-upgrade-test-catalog.json
+    l0:
+      adminGroupName: testgroupa
+      adminGroupCrn: "crn:altus:iam:us-west-1:f8e2f110-fc7e-4e46-ae55-381aacc6718c:group:testgroupa/ebc27aff-7d91-4f76-bf98-e81dbbd615e9"
+      userGroupName: testgroupb
+      userGroupCrn: "crn:altus:iam:us-west-1:f8e2f110-fc7e-4e46-ae55-381aacc6718c:group:testgroupb/b983b572-9774-4f8f-8377-861b511442de"
 
   # azure parameters
   azure:


### PR DESCRIPTION
`ADMIN_GROUP_NAME`, `ADMIN_GROUP_CRN`, `USER_GROUP_NAME` and `USER_GROUP_CRN` are hardcoded values right at [BasicEnvironmentVirtualGroupTest](https://github.com/hortonworks/cloudbreak/blob/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/BasicEnvironmentVirtualGroupTest.java). From now on we have new test user groups in separate test accounts as well. So it is logical and legitimate that external variables are introduced.

This is the pair for [Cloudbreak Ansible Playbooks#158](https://github.com/hortonworks/cloudbreak-ansible-playbooks/pull/158)