### PR TITLE
CDPSDX-3121 Set direct.sql for HMS in the datalake

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-medium-ha.bp
@@ -421,6 +421,10 @@
               { 
                 "name": "hive_compactor_initiator_on",
                 "value": "false"
+              },
+              {
+                "name": "hive_service_config_safety_valve",
+                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>hive.metastore.try.direct.sql</name><value>true</value></property>"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-micro.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-micro.bp
@@ -366,6 +366,10 @@
               {
                 "name": "hive_compactor_initiator_on",
                 "value": "false"
+              },
+              {
+                "name": "hive_service_config_safety_valve",
+                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>hive.metastore.try.direct.sql</name><value>true</value></property>"
               }
             ]
           }

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx.bp
@@ -366,6 +366,10 @@
               { 
                 "name": "hive_compactor_initiator_on",
                 "value": "false"
+              },
+              {
+                "name": "hive_service_config_safety_valve",
+                "value": "<property><name>hive.metastore.try.direct.sql.ddl</name><value>true</value></property><property><name>hive.metastore.try.direct.sql</name><value>true</value></property>"
               }
             ]
           }


### PR DESCRIPTION
Sets the hive.metastore.try.direct.sql.ddl and hive.metastore.try.direct.sql HMS safety valve settings to 'true'.
This is the other part of the change in CDPD-25578. Both the DH and DL need the safety valve setting to get the
performance improvement.

See detailed description in the commit message.