### PR TITLE
CB-14441 Feedback from operation

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -157,6 +157,8 @@ public enum ResourceEvent {
     STACK_SYNC_INSTANCE_TERMINATED("stack.sync.instance.terminated"),
     STACK_SYNC_INSTANCE_DELETED_CBMETADATA("stack.sync.instance.deleted.cbmetadata"),
     STACK_SYNC_INSTANCE_DELETED_BY_PROVIDER_CBMETADATA("stack.sync.instance.deletedbyprovider.cbmetadata"),
+    STACK_SYNC_VERSIONS_FROM_CM_TO_DB_SUCCESS("stack.sync.versions.from.cm.to.db.succeeded"),
+    STACK_SYNC_VERSIONS_FROM_CM_TO_DB_FAILED("stack.sync.versions.from.cm.to.db.failed"),
     STACK_DELETE_IN_PROGRESS("stack.delete.in.progress"),
     STACK_ADDING_INSTANCES("stack.adding.instances"),
     STACK_METADATA_EXTEND_WITH_COUNT("stack.metadata.extend.with.count"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -237,6 +237,8 @@ stack.sync.host.updated=Host {0} state has been updated to: {1}.
 stack.sync.instance.terminated=Instance {0} is marked as terminated by the cloud provider, but couldn''t delete the host from Cloudera Manager.
 stack.sync.instance.deleted.cbmetadata=Deleted instance {0} from Cloudbreak metadata because it couldn''t be found on the cloud provider.
 stack.sync.instance.deletedbyprovider.cbmetadata=Deleted instance {0} from Cloudbreak metadata because it was deleted by the cloud provider.
+stack.sync.versions.from.cm.to.db.succeeded=Reading CM and active parcel versions from CM server succeeded: {0}
+stack.sync.versions.from.cm.to.db.failed=Reading CM and active parcel versions from CM server has failure(s): {0}
 stack.sync.instance.updated=Updated metadata of instance {0} to {1} as the cloud provider reported it as {1}.
 stack.sync.instance.failed=Updated metadata of instance {0} to failed, because update was in progress, but instance isn''t member of the cluster.
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CmSyncResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/api/event/resource/CmSyncResult.java
@@ -4,12 +4,18 @@ import com.sequenceiq.cloudbreak.reactor.api.ClusterPlatformResult;
 
 public class CmSyncResult extends ClusterPlatformResult<CmSyncRequest> {
 
-    public CmSyncResult(CmSyncRequest request) {
+    private String result;
+
+    public CmSyncResult(CmSyncRequest request, String result) {
         super(request);
+        this.result = result;
     }
 
     public CmSyncResult(String statusReason, Exception errorDetails, CmSyncRequest request) {
         super(statusReason, errorDetails, request);
     }
 
+    public String getResult() {
+        return result;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmInstalledComponentFinderService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmInstalledComponentFinderService.java
@@ -36,9 +36,9 @@ public class CmInstalledComponentFinderService {
 
     public CmParcelSyncOperationResult findParcelComponents(Stack stack, Set<Image> candidateImages) {
         Set<ClouderaManagerProduct> candidateProducts = imageReaderService.getParcels(candidateImages, stack.isDatalake());
-        Set<ParcelInfo> installedParcels = cmServerQueryService.queryActiveParcels(stack);
-        Set<ClouderaManagerProduct> installedProducts = cmProductChooserService.chooseParcelProduct(installedParcels, candidateProducts);
-        return new CmParcelSyncOperationResult(installedParcels, installedProducts);
+        Set<ParcelInfo> activeParcels = cmServerQueryService.queryActiveParcels(stack);
+        Set<ClouderaManagerProduct> activeProducts = cmProductChooserService.chooseParcelProduct(activeParcels, candidateProducts);
+        return new CmParcelSyncOperationResult(activeParcels, activeProducts);
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmProductChooserService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmProductChooserService.java
@@ -21,12 +21,12 @@ public class CmProductChooserService {
     /**
      * Using the CM parcel versions, will look for a matching product among the provided candidateProducts
      * A product is matching if the name and version both match.
-     * @param installedParcels parcels installed on the CM server
+     * @param activeParcels parcels installed on the CM server
      * @param candidateProducts A list of ClouderaManagerProducts extracted from image catalog
      * @return List of ClouderaManagerProducts installed on the DL / DH
      */
-    Set<ClouderaManagerProduct> chooseParcelProduct(Set<ParcelInfo> installedParcels, Set<ClouderaManagerProduct> candidateProducts) {
-        Set<ClouderaManagerProduct> foundProducts = installedParcels.stream()
+    Set<ClouderaManagerProduct> chooseParcelProduct(Set<ParcelInfo> activeParcels, Set<ClouderaManagerProduct> candidateProducts) {
+        Set<ClouderaManagerProduct> foundProducts = activeParcels.stream()
                 .map(ip -> findMatchingClouderaManagerProduct(candidateProducts, ip))
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmServerQueryService.java
@@ -33,9 +33,9 @@ public class CmServerQueryService {
      * @return List of parcels found in the CM
      */
     Set<ParcelInfo> queryActiveParcels(Stack stack) {
-        Map<String, String> installedParcels = apiConnectors.getConnector(stack).gatherInstalledParcels(stack.getName());
-        LOGGER.debug("Reading parcel info from CM server, found parcels: " + installedParcels);
-        return installedParcels.entrySet().stream()
+        Map<String, String> activeParcels = apiConnectors.getConnector(stack).gatherInstalledParcels(stack.getName());
+        LOGGER.debug("Reading parcel info from CM server, found parcels: " + activeParcels);
+        return activeParcels.entrySet().stream()
                 .map(es -> new ParcelInfo(es.getKey(), es.getValue()))
                 .collect(Collectors.toSet());
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/operationresult/CmParcelSyncOperationResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/sync/operationresult/CmParcelSyncOperationResult.java
@@ -7,17 +7,17 @@ import com.sequenceiq.cloudbreak.service.upgrade.sync.common.ParcelInfo;
 
 public class CmParcelSyncOperationResult {
 
-    private final Set<ParcelInfo> installedParcels;
+    private final Set<ParcelInfo> activeParcels;
 
     private final Set<ClouderaManagerProduct> foundCmProducts;
 
-    public CmParcelSyncOperationResult(Set<ParcelInfo> installedParcels, Set<ClouderaManagerProduct> foundCmProducts) {
-        this.installedParcels = installedParcels;
+    public CmParcelSyncOperationResult(Set<ParcelInfo> activeParcels, Set<ClouderaManagerProduct> foundCmProducts) {
+        this.activeParcels = activeParcels;
         this.foundCmProducts = foundCmProducts;
     }
 
-    public Set<ParcelInfo> getInstalledParcels() {
-        return installedParcels;
+    public Set<ParcelInfo> getActiveParcels() {
+        return activeParcels;
     }
 
     public Set<ClouderaManagerProduct> getFoundCmProducts() {
@@ -25,15 +25,14 @@ public class CmParcelSyncOperationResult {
     }
 
     public boolean isEmpty() {
-        return installedParcels.isEmpty();
+        return activeParcels.isEmpty();
     }
 
     @Override
     public String toString() {
         return "CmParcelSyncOperationResult{" +
-                "installedParcels=" + installedParcels +
+                "activeParcels=" + activeParcels +
                 ", foundCmProducts=" + foundCmProducts +
                 '}';
     }
-
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmInstalledComponentFinderServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmInstalledComponentFinderServiceTest.java
@@ -75,7 +75,7 @@ public class CmInstalledComponentFinderServiceTest {
 
         CmParcelSyncOperationResult cmParcelSyncOperationResult = underTest.findParcelComponents(stack, candidateImages);
 
-        assertThat(cmParcelSyncOperationResult.getInstalledParcels(), hasSize(1));
+        assertThat(cmParcelSyncOperationResult.getActiveParcels(), hasSize(1));
         verify(imageReaderService).getParcels(candidateImages, true);
         verify(cmInfoRetriever).queryActiveParcels(stack);
         verify(cmProductChooserService).chooseParcelProduct(queriedParcelInfo, candidateCmProduct);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmProductChooserServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/sync/component/CmProductChooserServiceTest.java
@@ -33,10 +33,10 @@ public class CmProductChooserServiceTest {
 
     @Test
     void testChooseParcelProductWhenMatchingNameAndVersionThenReturns() {
-        Set<ParcelInfo> installedParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_1));
+        Set<ParcelInfo> activeParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_1));
         Set<ClouderaManagerProduct> candidateProducts = Set.of(new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1));
 
-        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(installedParcels, candidateProducts);
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(activeParcels, candidateProducts);
 
         assertThat(foundProducts, hasSize(1));
         ClouderaManagerProduct foundProduct = foundProducts.iterator().next();
@@ -46,7 +46,7 @@ public class CmProductChooserServiceTest {
 
     @Test
     void testChooseParcelProductWhenMultipleMatchingNameAndVersionThenReturnsAllMatches() {
-        Set<ParcelInfo> installedParcels = Set.of(
+        Set<ParcelInfo> activeParcels = Set.of(
                 new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_1),
                 new ParcelInfo(PARCEL_NAME_2, PARCEL_VERSION_2)
         );
@@ -55,7 +55,7 @@ public class CmProductChooserServiceTest {
                 new ClouderaManagerProduct().withName(PARCEL_NAME_2).withVersion(PARCEL_VERSION_2)
         );
 
-        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(installedParcels, candidateProducts);
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(activeParcels, candidateProducts);
 
         assertThat(foundProducts, hasSize(2));
         List<ClouderaManagerProduct> foundProductList = new ArrayList<>(foundProducts);
@@ -68,13 +68,13 @@ public class CmProductChooserServiceTest {
 
     @Test
     void testChooseParcelProductWhenMultipleMatchingNameAndVersionThenReturnsOne() {
-        Set<ParcelInfo> installedParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_1));
+        Set<ParcelInfo> activeParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_1));
         Set<ClouderaManagerProduct> candidateProducts = Set.of(
                 new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1),
                 new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1)
         );
 
-        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(installedParcels, candidateProducts);
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(activeParcels, candidateProducts);
 
         assertThat(foundProducts, hasSize(1));
         ClouderaManagerProduct foundProduct = foundProducts.iterator().next();
@@ -84,20 +84,20 @@ public class CmProductChooserServiceTest {
 
     @Test
     void testChooseParcelProductWhenMatchingNameButDifferentVersionThenEmptyResult() {
-        Set<ParcelInfo> installedParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_2));
+        Set<ParcelInfo> activeParcels = Set.of(new ParcelInfo(PARCEL_NAME_1, PARCEL_VERSION_2));
         Set<ClouderaManagerProduct> candidateProducts = Set.of(new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1));
 
-        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(installedParcels, candidateProducts);
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(activeParcels, candidateProducts);
 
         assertThat(foundProducts, hasSize(0));
     }
 
     @Test
     void testChooseParcelProductWhenDifferentNameButSameVersionThenEmptyResult() {
-        Set<ParcelInfo> installedParcels = Set.of(new ParcelInfo(PARCEL_NAME_2, PARCEL_VERSION_1));
+        Set<ParcelInfo> activeParcels = Set.of(new ParcelInfo(PARCEL_NAME_2, PARCEL_VERSION_1));
         Set<ClouderaManagerProduct> candidateProducts = Set.of(new ClouderaManagerProduct().withName(PARCEL_NAME_1).withVersion(PARCEL_VERSION_1));
 
-        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(installedParcels, candidateProducts);
+        Set<ClouderaManagerProduct> foundProducts = underTest.chooseParcelProduct(activeParcels, candidateProducts);
 
         assertThat(foundProducts, hasSize(0));
     }


### PR DESCRIPTION
When reading out CM and active parcel versions from CM server no feedback was so far given to the user.
In this commit a feedback is introduced, both for success and failure scenarios. The message reports separately on reading the CM and active parcel versions. If the sync succeeds, then the new versions are reported, whereas in case of failure(s) it gives a short error message.

See detailed description in the commit message.