### PR TITLE
CB-14533 Rest responses of SDX and DistroX differ - part of epic: CB-…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
@@ -190,7 +190,7 @@ public class StackCommonService {
         Stack stack = stackService.getByNameOrCrnInWorkspace(nameOrCrn, workspaceId);
         MDCBuilder.buildMdcContext(stack);
         if (stack.getStackStatus().getStatus().isStopState()) {
-            String message = String.format("Syncing CM and parcel versions from CM cannot be initiated as cluster is in %s state",
+            String message = String.format("Reading CM and parcel versions from CM cannot be initiated as the cluster is in %s state",
                     stack.getStackStatus().getStatus());
             LOGGER.debug(message);
             throw new BadRequestException(message);

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxSyncComponentVersionsFromCmResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxSyncComponentVersionsFromCmResponse.java
@@ -4,25 +4,13 @@ import com.sequenceiq.flow.api.model.FlowIdentifier;
 
 public class SdxSyncComponentVersionsFromCmResponse {
 
-    private String reason;
-
     private FlowIdentifier flowIdentifier;
 
     public SdxSyncComponentVersionsFromCmResponse() {
     }
 
-    public SdxSyncComponentVersionsFromCmResponse(String reason, FlowIdentifier flowIdentifier) {
-        this.reason = reason;
+    public SdxSyncComponentVersionsFromCmResponse(FlowIdentifier flowIdentifier) {
         this.flowIdentifier = flowIdentifier;
-    }
-
-    public SdxSyncComponentVersionsFromCmResponse(String reason) {
-        this.reason = reason;
-        this.flowIdentifier = FlowIdentifier.notTriggered();
-    }
-
-    public String getReason() {
-        return reason;
     }
 
     public FlowIdentifier getFlowIdentifier() {
@@ -31,9 +19,8 @@ public class SdxSyncComponentVersionsFromCmResponse {
 
     @Override
     public String toString() {
-        return "SdxSyncCmResponse{" +
-                "reason='" + reason + '\'' +
-                ", flowIdentifier=" + flowIdentifier +
+        return "SdxSyncComponentVersionsFromCmResponse{" +
+                "flowIdentifier=" + flowIdentifier +
                 '}';
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -361,14 +361,14 @@ public class SdxController implements SdxEndpoint {
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.SYNC_COMPONENT_VERSIONS_FROM_CM_DATALAKE)
     public SdxSyncComponentVersionsFromCmResponse syncComponentVersionsFromCmByName(@ResourceName String name) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        return sdxService.syncComponentVersionsFromCm(userCrn, NameOrCrn.ofName(name));
+        return new SdxSyncComponentVersionsFromCmResponse(sdxService.syncComponentVersionsFromCm(userCrn, NameOrCrn.ofName(name)));
     }
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.SYNC_COMPONENT_VERSIONS_FROM_CM_DATALAKE)
     public SdxSyncComponentVersionsFromCmResponse syncComponentVersionsFromCmByCrn(@ResourceCrn String crn) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        return sdxService.syncComponentVersionsFromCm(userCrn, NameOrCrn.ofCrn(crn));
+        return new SdxSyncComponentVersionsFromCmResponse(sdxService.syncComponentVersionsFromCm(userCrn, NameOrCrn.ofCrn(crn)));
     }
 
     private SdxCluster getSdxClusterByName(String name) {


### PR DESCRIPTION
…12736, After a failed DL/DH upgrade sync runtime versions

Both SDX and DistroX have an endpoint to initiate the readout of CM and active parcel versions from CM server and store them into DB. The two endpoint, however, do differ. The SDX endpoint does have an extra reason field, used to communicate an error. In DistroX this is solved with sending BadRequestException.

This commit unifies the two endpoints, in that the SDX endpoint will behave the same as the distroX, and will only return the FlowIdentifier. On error, it will throw a BadRequestException.
Besides that, error messages are made a bit more understandable.

See detailed description in the commit message.