### PR TITLE
CB-14505 Maven publish fix after upgrading to Gradle 7

### DIFF
--- a/Release.md
+++ b/Release.md
@@ -29,7 +29,7 @@ A development version is released after a pull request is merged into the master
 
 The development release also creates and pushes a git tag to the repository with the same version number. If the latest tag before the build is a `dev` tag, the build number will increment the dev number like `0.6.0-dev.13`. If it was an `rc` tag, the minor version is incremented and the dev version starts from 1, like `0.7.0-dev.1`. To create a dev version (and upload it to the repository) run this gradle command on the master:
 
-`./gradlew clean build uploadBootArchives release -Prelease.scope=minor -Prelease.stage=dev`
+`./gradlew clean build publishBootJavaPublicationToMavenRepository release -Prelease.scope=minor -Prelease.stage=dev`
 
 ### Example 3: Release candidates
 
@@ -39,10 +39,10 @@ The first release candidate can be created if the dev version seems stable enoug
 
 The release task also creates a git tag and pushes a git tag with the same version. If this task is completed, the latest tag on the master branch will be a `rc` so the next master build will increment the minor version. After the `rc-<major>.<minor>` branch was created, the new features can go into master, but it is possible that the first `rc` needs to be patched before a final version is released. If a pull request is merged to the `rc-<major>.<minor>` branch the next rc version (`0.6.0-rc.2`) will be released and the gradle task will tag the commit on the `rc` branch with the same version. If the latest tag on the `rc` branch is a `final release`, the patch version will be incremented and the `rc` will start from 1 like `0.6.1-rc.1`. To create a release candidate run this gradle command:
 
-`./gradlew clean build uploadBootArchives release -Prelease.scope=minor -Prelease.stage=rc`
+`./gradlew clean build publishBootJavaPublicationToMavenRepository release -Prelease.scope=minor -Prelease.stage=rc`
 
 ### Example 4: Final releases
 
 When the `rc` branch is considered stable a final version is released. The final release should be created on a new branch named `release-<major.minor>` (e.g.: `release-0.6`) from the latest commit on the `rc` branch. The final version is based on the latest release candidate tag (e.g.: if the latest rc was `0.6.2-rc.2` the final version will be `0.6.2`) and the gradle task also tags the git commit with the final version. To release a final version run this gradle command:
 
-`./gradlew clean build uploadBootArchives release -Prelease.scope=minor -Prelease.stage=final`
+`./gradlew clean build publishBootJavaPublicationToMavenRepository release -Prelease.scope=minor -Prelease.stage=final`

--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -74,6 +74,7 @@ publishing {
     repositories {
         maven {
             url = "$System.env.NEXUS_URL"
+            allowInsecureProtocol = true
             credentials {
                 username = "$System.env.NEXUS_USER"
                 password = "$System.env.NEXUS_PASSWORD"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -83,6 +83,7 @@ publishing {
     repositories {
         maven {
             url = "$System.env.NEXUS_URL"
+            allowInsecureProtocol = true
             credentials {
                 username = "$System.env.NEXUS_USER"
                 password = "$System.env.NEXUS_PASSWORD"

--- a/datalake/build.gradle
+++ b/datalake/build.gradle
@@ -131,6 +131,7 @@ publishing {
     repositories {
         maven {
             url = "$System.env.NEXUS_URL"
+            allowInsecureProtocol = true
             credentials {
                 username = "$System.env.NEXUS_USER"
                 password = "$System.env.NEXUS_PASSWORD"

--- a/environment/build.gradle
+++ b/environment/build.gradle
@@ -156,6 +156,7 @@ publishing {
     repositories {
         maven {
             url = "$System.env.NEXUS_URL"
+            allowInsecureProtocol = true
             credentials {
                 username = "$System.env.NEXUS_USER"
                 password = "$System.env.NEXUS_PASSWORD"

--- a/freeipa-client/build.gradle
+++ b/freeipa-client/build.gradle
@@ -23,6 +23,7 @@ publishing {
     repositories {
         maven {
             url = "$System.env.NEXUS_URL"
+            allowInsecureProtocol = true
             credentials {
                 username = "$System.env.NEXUS_USER"
                 password = "$System.env.NEXUS_PASSWORD"

--- a/freeipa/build.gradle
+++ b/freeipa/build.gradle
@@ -187,6 +187,7 @@ publishing {
     repositories {
         maven {
             url = "$System.env.NEXUS_URL"
+            allowInsecureProtocol = true
             credentials {
                 username = "$System.env.NEXUS_USER"
                 password = "$System.env.NEXUS_PASSWORD"

--- a/integration-test/build.gradle
+++ b/integration-test/build.gradle
@@ -49,6 +49,7 @@ publishing {
     repositories {
         maven {
             url = "$System.env.NEXUS_URL"
+            allowInsecureProtocol = true
             credentials {
                 username = "$System.env.NEXUS_USER"
                 password = "$System.env.NEXUS_PASSWORD"

--- a/mock-infrastructure/build.gradle
+++ b/mock-infrastructure/build.gradle
@@ -49,6 +49,7 @@ publishing {
     repositories {
         maven {
             url = "$System.env.NEXUS_URL"
+            allowInsecureProtocol = true
             credentials {
                 username = "$System.env.NEXUS_USER"
                 password = "$System.env.NEXUS_PASSWORD"

--- a/mock-thunderhead/build.gradle
+++ b/mock-thunderhead/build.gradle
@@ -49,6 +49,7 @@ publishing {
     repositories {
         maven {
             url = "$System.env.NEXUS_URL"
+            allowInsecureProtocol = true
             credentials {
                 username = "$System.env.NEXUS_USER"
                 password = "$System.env.NEXUS_PASSWORD"

--- a/redbeams/build.gradle
+++ b/redbeams/build.gradle
@@ -165,6 +165,7 @@ publishing {
     repositories {
         maven {
             url = "$System.env.NEXUS_URL"
+            allowInsecureProtocol = true
             credentials {
                 username = "$System.env.NEXUS_USER"
                 password = "$System.env.NEXUS_PASSWORD"

--- a/scripts/build-dev.sh
+++ b/scripts/build-dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 set -x
 
-./gradlew -Penv=jenkins -b build.gradle buildInfo build uploadBootArchives :freeipa-client:uploadArchives -Pversion=$VERSION --parallel --stacktrace -x checkstyleMain -x checkstyleTest -x spotbugsMain -x spotbugsTest
+./gradlew -Penv=jenkins -b build.gradle buildInfo build publishBootJavaPublicationToMavenRepository :freeipa-client:publishMavenJavaPublicationToMavenRepository -Pversion=$VERSION --parallel --stacktrace -x checkstyleMain -x checkstyleTest -x spotbugsMain -x spotbugsTest
 
 if [[ "${RUN_SONARQUBE}" == "true" ]]; then
     # removing core modul because that is instable

--- a/scripts/build-rc-patch.sh
+++ b/scripts/build-rc-patch.sh
@@ -3,7 +3,7 @@ set -x
 
 echo "Build version: $VERSION"
 
-./gradlew -Penv=jenkins -b build.gradle buildInfo build uploadBootArchives -Pversion=$VERSION --info --stacktrace --parallel -x checkstyleMain -x checkstyleTest -x spotbugsMain -x spotbugsTest
+./gradlew -Penv=jenkins -b build.gradle buildInfo build publishBootJavaPublicationToMavenRepository -Pversion=$VERSION --info --stacktrace --parallel -x checkstyleMain -x checkstyleTest -x spotbugsMain -x spotbugsTest
 
 aws s3 cp ./core/build/swagger/cb.json "s3://cloudbreak-swagger/swagger-${VERSION}.json" --acl public-read
 aws s3 cp ./environment/build/swagger/environment.json "s3://environment-swagger/swagger-${VERSION}.json" --acl public-read

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -18,7 +18,7 @@ else
   SCOPE=patch
 fi
 
-./gradlew -Penv=jenkins -b build.gradle build uploadBootArchives :freeipa-client:uploadArchives -Preckon.scope=$SCOPE -Preckon.stage=final --refresh-dependencies --info --stacktrace --parallel -x checkstyleMain -x checkstyleTest -x spotbugsMain -x spotbugsTest
+./gradlew -Penv=jenkins -b build.gradle build publishBootJavaPublicationToMavenRepository :freeipa-client:publishMavenJavaPublicationToMavenRepository -Preckon.scope=$SCOPE -Preckon.stage=final --refresh-dependencies --info --stacktrace --parallel -x checkstyleMain -x checkstyleTest -x spotbugsMain -x spotbugsTest
 RECKONED_VERSION=$(./gradlew -Penv=jenkins -b build.gradle buildInfo -Preckon.scope=$SCOPE -Preckon.stage=final | grep Reckoned)
 VERSION=${RECKONED_VERSION#Reckoned version: }
 


### PR DESCRIPTION
Maven publish plugin was replaced but the tasks that executed the Maven
artifact publication were not updated.

See detailed description in the commit message.