### PR TITLE
CB-14534: Change DATAHUB/DATALAKE image types to RUNTIME

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4CreateImageRequestToCustomImageConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4CreateImageRequestToCustomImageConverter.java
@@ -15,7 +15,7 @@ public class CustomImageCatalogV4CreateImageRequestToCustomImageConverter {
 
     public CustomImage convert(CustomImageCatalogV4CreateImageRequest source) {
         CustomImage result = new CustomImage();
-        result.setImageType(ImageType.valueOf(source.getImageType()));
+        result.setImageType(convertImageType(source.getImageType()));
         result.setBaseParcelUrl(source.getBaseParcelUrl());
         result.setCustomizedImageId(source.getSourceImageId());
         result.setVmImage(getVmImages(source.getVmImages()));
@@ -31,5 +31,10 @@ public class CustomImageCatalogV4CreateImageRequestToCustomImageConverter {
 
             return vmImage;
         }).collect(Collectors.toSet());
+    }
+
+    private ImageType convertImageType(String imageType) {
+        ImageType type = ImageType.valueOf(imageType);
+        return type == ImageType.DATAHUB || type == ImageType.DATALAKE ? ImageType.RUNTIME : type;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4UpdateImageRequestToCustomImageConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4UpdateImageRequestToCustomImageConverter.java
@@ -15,7 +15,7 @@ public class CustomImageCatalogV4UpdateImageRequestToCustomImageConverter {
 
     public CustomImage convert(CustomImageCatalogV4UpdateImageRequest source) {
         CustomImage result = new CustomImage();
-        result.setImageType(source.getImageType() != null ? ImageType.valueOf(source.getImageType()) : null);
+        result.setImageType(source.getImageType() != null ? convertImageType(source.getImageType()) : null);
         result.setBaseParcelUrl(source.getBaseParcelUrl());
         result.setCustomizedImageId(source.getSourceImageId());
         result.setVmImage(source.getVmImages() != null ? getVmImages(source.getVmImages()) : null);
@@ -31,5 +31,10 @@ public class CustomImageCatalogV4UpdateImageRequestToCustomImageConverter {
 
             return vmImage;
         }).collect(Collectors.toSet());
+    }
+
+    private ImageType convertImageType(String imageType) {
+        ImageType type = ImageType.valueOf(imageType);
+        return type == ImageType.DATAHUB || type == ImageType.DATALAKE ? ImageType.RUNTIME : type;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest.java
@@ -21,6 +21,10 @@ public class CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest {
 
     private static final String VALID_IMAGE_TYPE = "RUNTIME";
 
+    private static final String DEPRECATED_IMAGE_TYPE1 = "DATALAKE";
+
+    private static final String DEPRECATED_IMAGE_TYPE2 = "DATAHUB";
+
     private static final String INVALID_IMAGE_TYPE = "invalid image type";
 
     private static final String REGION = "region";
@@ -40,6 +44,44 @@ public class CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest {
         source.setSourceImageId(SOURCE_IMAGE_ID);
         source.setBaseParcelUrl(BASE_PARCEL_URL);
         source.setImageType(VALID_IMAGE_TYPE);
+        source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
+
+        CustomImage result = victim.convert(source);
+        assertEquals(SOURCE_IMAGE_ID, result.getCustomizedImageId());
+        assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
+        assertEquals(ImageType.RUNTIME, result.getImageType());
+        assertEquals(1, result.getVmImage().size());
+
+        VmImage vmImage = result.getVmImage().stream().findFirst().get();
+        assertEquals(REGION, vmImage.getRegion());
+        assertEquals(IMAGE_REFERENCE, vmImage.getImageReference());
+    }
+
+    @Test
+    public void shouldConvertDatalakeImageType() {
+        CustomImageCatalogV4CreateImageRequest source = new CustomImageCatalogV4CreateImageRequest();
+        source.setSourceImageId(SOURCE_IMAGE_ID);
+        source.setBaseParcelUrl(BASE_PARCEL_URL);
+        source.setImageType(DEPRECATED_IMAGE_TYPE1);
+        source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
+
+        CustomImage result = victim.convert(source);
+        assertEquals(SOURCE_IMAGE_ID, result.getCustomizedImageId());
+        assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
+        assertEquals(ImageType.RUNTIME, result.getImageType());
+        assertEquals(1, result.getVmImage().size());
+
+        VmImage vmImage = result.getVmImage().stream().findFirst().get();
+        assertEquals(REGION, vmImage.getRegion());
+        assertEquals(IMAGE_REFERENCE, vmImage.getImageReference());
+    }
+
+    @Test
+    public void shouldConvertDatahubImageType() {
+        CustomImageCatalogV4CreateImageRequest source = new CustomImageCatalogV4CreateImageRequest();
+        source.setSourceImageId(SOURCE_IMAGE_ID);
+        source.setBaseParcelUrl(BASE_PARCEL_URL);
+        source.setImageType(DEPRECATED_IMAGE_TYPE2);
         source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
 
         CustomImage result = victim.convert(source);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest.java
@@ -22,6 +22,10 @@ public class CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest {
 
     private static final String VALID_IMAGE_TYPE = "RUNTIME";
 
+    private static final String DEPRECATED_IMAGE_TYPE1 = "DATALAKE";
+
+    private static final String DEPRECATED_IMAGE_TYPE2 = "DATAHUB";
+
     private static final String INVALID_IMAGE_TYPE = "invalid image type";
 
     private static final String REGION = "region";
@@ -41,6 +45,44 @@ public class CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest {
         source.setSourceImageId(SOURCE_IMAGE_ID);
         source.setBaseParcelUrl(BASE_PARCEL_URL);
         source.setImageType(VALID_IMAGE_TYPE);
+        source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
+
+        CustomImage result = victim.convert(source);
+        assertEquals(SOURCE_IMAGE_ID, result.getCustomizedImageId());
+        assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
+        assertEquals(ImageType.RUNTIME, result.getImageType());
+        assertEquals(1, result.getVmImage().size());
+
+        VmImage vmImage = result.getVmImage().stream().findFirst().get();
+        assertEquals(REGION, vmImage.getRegion());
+        assertEquals(IMAGE_REFERENCE, vmImage.getImageReference());
+    }
+
+    @Test
+    public void shouldConvertDatalakeImageType() {
+        CustomImageCatalogV4UpdateImageRequest source = new CustomImageCatalogV4UpdateImageRequest();
+        source.setSourceImageId(SOURCE_IMAGE_ID);
+        source.setBaseParcelUrl(BASE_PARCEL_URL);
+        source.setImageType(DEPRECATED_IMAGE_TYPE1);
+        source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
+
+        CustomImage result = victim.convert(source);
+        assertEquals(SOURCE_IMAGE_ID, result.getCustomizedImageId());
+        assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
+        assertEquals(ImageType.RUNTIME, result.getImageType());
+        assertEquals(1, result.getVmImage().size());
+
+        VmImage vmImage = result.getVmImage().stream().findFirst().get();
+        assertEquals(REGION, vmImage.getRegion());
+        assertEquals(IMAGE_REFERENCE, vmImage.getImageReference());
+    }
+
+    @Test
+    public void shouldConvertDatahubImageType() {
+        CustomImageCatalogV4UpdateImageRequest source = new CustomImageCatalogV4UpdateImageRequest();
+        source.setSourceImageId(SOURCE_IMAGE_ID);
+        source.setBaseParcelUrl(BASE_PARCEL_URL);
+        source.setImageType(DEPRECATED_IMAGE_TYPE2);
         source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
 
         CustomImage result = victim.convert(source);


### PR DESCRIPTION
DATAHUB/DATALAKE image types must be changed to RUNTIME value in case of create/update custom image operations. The corresponding modification in cdp cli has been done, but request from the previous version of cli should also be handled so that the proper image type will be stored in the db.