### PR TITLE
CB-14538. Regression: post-install scripts should be executed anyway,…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/recipe/RecipeEngine.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/recipe/RecipeEngine.java
@@ -108,8 +108,8 @@ public class RecipeEngine {
         Collection<Recipe> recipes = hostGroupService.getRecipesByHostGroups(hostGroups);
         if (shouldExecuteRecipeOnStack(recipes, POST_CLUSTER_INSTALL)) {
             uploadRecipesIfNeeded(stack, hostGroups);
-            orchestratorRecipeExecutor.postClusterInstall(stack);
         }
+        orchestratorRecipeExecutor.postClusterInstall(stack);
     }
 
     public void executePreTerminationRecipes(Stack stack, Set<HostGroup> hostGroups, boolean forced) throws CloudbreakException {


### PR DESCRIPTION
… even if no post-install scripts.

details:
hdfs folders are not created for users - which is the part of post-install script executions, therefore you cannot skip post-install recipe executions in case there are no post-install recipes.

See detailed description in the commit message.