### PR TITLE
CB-14336 Fix HBase bucketcache configuration in HbaseVolumeConfigProv…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/7.1.0/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.1.0/cdp-sdx.bp
@@ -180,7 +180,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.0/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.0/cdp-sdx.bp
@@ -180,7 +180,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.1/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.1/cdp-sdx.bp
@@ -212,7 +212,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-opdb.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-opdb.bp
@@ -146,10 +146,6 @@
                 "value": "6979321856"
               },
               {
-                "name": "hbase_bucketcache_ioengine",
-                "value": "offheap"
-              },
-              {
                 "name": "hbase_regionserver_global_memstore_upperLimit",
                 "value": "0.25"
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx-medium-ha.bp
@@ -268,7 +268,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.10/cdp-sdx.bp
@@ -212,7 +212,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-opdb.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-opdb.bp
@@ -146,10 +146,6 @@
                 "value": "6979321856"
               },
               {
-                "name": "hbase_bucketcache_ioengine",
-                "value": "offheap"
-              },
-              {
                 "name": "hbase_regionserver_global_memstore_upperLimit",
                 "value": "0.25"
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx-medium-ha.bp
@@ -268,7 +268,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.11/cdp-sdx.bp
@@ -212,7 +212,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-opdb.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-opdb.bp
@@ -146,10 +146,6 @@
                 "value": "6979321856"
               },
               {
-                "name": "hbase_bucketcache_ioengine",
-                "value": "offheap"
-              },
-              {
                 "name": "hbase_regionserver_global_memstore_upperLimit",
                 "value": "0.25"
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx-medium-ha.bp
@@ -268,7 +268,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx-micro.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx-micro.bp
@@ -212,7 +212,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.12/cdp-sdx.bp
@@ -208,7 +208,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": ""
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-opdb.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-opdb.bp
@@ -146,10 +146,6 @@
                 "value": "6979321856"
               },
               {
-                "name": "hbase_bucketcache_ioengine",
-                "value": "offheap"
-              },
-              {
                 "name": "hbase_regionserver_global_memstore_upperLimit",
                 "value": "0.25"
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-medium-ha.bp
@@ -268,7 +268,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-micro.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx-micro.bp
@@ -212,7 +212,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.13/cdp-sdx.bp
@@ -212,7 +212,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx-medium-ha.bp
@@ -252,7 +252,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.2/cdp-sdx.bp
@@ -212,7 +212,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx-medium-ha.bp
@@ -252,7 +252,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.6/cdp-sdx.bp
@@ -212,7 +212,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx-medium-ha.bp
@@ -268,7 +268,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.7/cdp-sdx.bp
@@ -212,7 +212,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx-medium-ha.bp
@@ -268,7 +268,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.8/cdp-sdx.bp
@@ -212,7 +212,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-opdb.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-opdb.bp
@@ -146,10 +146,6 @@
                 "value": "6979321856"
               },
               {
-                "name": "hbase_bucketcache_ioengine",
-                "value": "offheap"
-              },
-              {
                 "name": "hbase_regionserver_global_memstore_upperLimit",
                 "value": "0.25"
               },

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx-medium-ha.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx-medium-ha.bp
@@ -268,7 +268,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx.bp
+++ b/core/src/main/resources/defaults/blueprints/7.2.9/cdp-sdx.bp
@@ -212,7 +212,13 @@
           {
             "base": true,
             "refName": "hbase-REGIONSERVER-BASE",
-            "roleType": "REGIONSERVER"
+            "roleType": "REGIONSERVER",
+            "configs": [
+              {
+                "name": "hbase_bucketcache_ioengine",
+                "value": null
+              }
+            ]
           },
           {
             "base": true,

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseVolumeConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseVolumeConfigProvider.java
@@ -6,15 +6,20 @@ import static com.sequenceiq.cloudbreak.template.VolumeUtils.buildEphemeralVolum
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.stereotype.Component;
+
 import com.cloudera.api.swagger.model.ApiClusterTemplateConfig;
 import com.sequenceiq.cloudbreak.cmtemplate.CmHostGroupRoleConfigProvider;
 import com.sequenceiq.cloudbreak.common.type.TemporaryStorage;
 import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 
+@Component
 public class HbaseVolumeConfigProvider implements CmHostGroupRoleConfigProvider {
 
     private static final String BUCKETCACHE_IOENGINE = "hbase_bucketcache_ioengine";
+
+    private static final String BUCKETCACHE_IOENGINE_DEFAULT_VALUE = "offheap";
 
     @Override
     public List<ApiClusterTemplateConfig> getRoleConfigs(String roleType, HostgroupView hostGroupView, TemplatePreparationObject source) {
@@ -23,9 +28,10 @@ public class HbaseVolumeConfigProvider implements CmHostGroupRoleConfigProvider 
                 Integer temporaryStorageVolumeCount = hostGroupView.getTemporaryStorageVolumeCount();
                 if (temporaryStorageVolumeCount != 0) {
                     return List.of(
-                            config(BUCKETCACHE_IOENGINE, "files:" + buildEphemeralVolumePathString(temporaryStorageVolumeCount, "hbase_cache")));
+                            config(BUCKETCACHE_IOENGINE, "file:" + buildEphemeralVolumePathString(1, "hbase_cache")));
                 }
             }
+            return List.of(config(BUCKETCACHE_IOENGINE, BUCKETCACHE_IOENGINE_DEFAULT_VALUE));
         }
         return List.of();
     }

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmHostGroupRoleConfigProviderProcessorTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmHostGroupRoleConfigProviderProcessorTest.java
@@ -266,7 +266,7 @@ public class CmHostGroupRoleConfigProviderProcessorTest {
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = mapRoleConfigs();
         assertEquals(
                 List.of(
-                        config("hbase_bucketcache_ioengine", "files:/hadoopfs/ephfs1/hbase_cache,/hadoopfs/ephfs2/hbase_cache,/hadoopfs/ephfs3/hbase_cache")
+                        config("hbase_bucketcache_ioengine", "file:/hadoopfs/ephfs1/hbase_cache")
                 ),
                 roleConfigs.get("hbase-REGIONSERVER-BASE"));
         assertEquals(
@@ -289,7 +289,11 @@ public class CmHostGroupRoleConfigProviderProcessorTest {
         underTest.process(templateProcessor, templatePreparator);
 
         Map<String, List<ApiClusterTemplateConfig>> roleConfigs = mapRoleConfigs();
-        assertEquals(List.of(), roleConfigs.get("hbase-REGIONSERVER-BASE"));
+        assertEquals(
+                List.of(
+                        config("hbase_bucketcache_ioengine", "offheap")
+                ),
+                roleConfigs.get("hbase-REGIONSERVER-BASE"));
         assertEquals(
                 List.of(
                         config("yarn_nodemanager_local_dirs", "/hadoopfs/fs1/nodemanager,/hadoopfs/fs2/nodemanager"),

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseVolumeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/hbase/HbaseVolumeConfigProviderTest.java
@@ -28,7 +28,7 @@ public class HbaseVolumeConfigProviderTest {
 
         assertEquals(
                 List.of(
-                        config("hbase_bucketcache_ioengine", "files:/hadoopfs/ephfs1/hbase_cache,/hadoopfs/ephfs2/hbase_cache,/hadoopfs/ephfs3/hbase_cache")
+                        config("hbase_bucketcache_ioengine", "file:/hadoopfs/ephfs1/hbase_cache")
                 ),
                 roleConfigs
         );
@@ -41,6 +41,11 @@ public class HbaseVolumeConfigProviderTest {
 
         List<ApiClusterTemplateConfig> roleConfigs = underTest.getRoleConfigs(HbaseRoles.REGIONSERVER, worker, preparatorWithHostGroups(worker));
 
-        assertEquals(List.of(), roleConfigs);
+        assertEquals(
+                List.of(
+                        config("hbase_bucketcache_ioengine", "offheap")
+                ),
+                roleConfigs
+        );
     }
 }


### PR DESCRIPTION
…ider

If the ephemeral volume caching feature is disabled in a cluster the bucketcache config should be set to "offheap" in opdb clusters and should be disbled in datalake clusters. The problem was that if a default value is set for a config in the blueprint the VolumeConfigProvider cannot modify that value (because other way a custom blueprint's value would be also overwritten). To overcome this issue I removed the default value from the blueprints and now the HbaseVolumeConfigProvider sets the value to "offheap" if the feature is disabled. In case of datalakes I added the "" default value in the blueprints to prevent the HbaseVolumeConfigProvider from enabling the bucketcaching. The "" vealue means that the bucketcaching is disabled and that is the expected behaviour for datalakes.

See detailed description in the commit message.