### PR TITLE
CB-13906. Include sar outputs (plain text) and nginx report in diagno…

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/BaseDiagnosticsCollectionRequest.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/diagnostics/BaseDiagnosticsCollectionRequest.java
@@ -53,6 +53,12 @@ public class BaseDiagnosticsCollectionRequest {
     @ApiModelProperty(DiagnosticsModelDescription.INCLUDE_SALT_LOGS)
     private Boolean includeSaltLogs = Boolean.FALSE;
 
+    @ApiModelProperty(DiagnosticsModelDescription.INCLUDE_SAR_OUTPUT)
+    private Boolean includeSarOutput = Boolean.FALSE;
+
+    @ApiModelProperty(DiagnosticsModelDescription.INCLUDE_NGINX_REPORT)
+    private Boolean includeNginxReport = Boolean.FALSE;
+
     @ApiModelProperty(DiagnosticsModelDescription.UPDATE_PACKAGE)
     private Boolean updatePackage = Boolean.FALSE;
 
@@ -143,6 +149,22 @@ public class BaseDiagnosticsCollectionRequest {
 
     public void setIncludeSaltLogs(Boolean includeSaltLogs) {
         this.includeSaltLogs = includeSaltLogs;
+    }
+
+    public Boolean getIncludeSarOutput() {
+        return includeSarOutput;
+    }
+
+    public void setIncludeSarOutput(Boolean includeSarOutput) {
+        this.includeSarOutput = includeSarOutput;
+    }
+
+    public Boolean getIncludeNginxReport() {
+        return includeNginxReport;
+    }
+
+    public void setIncludeNginxReport(Boolean includeNginxReport) {
+        this.includeNginxReport = includeNginxReport;
     }
 
     public Boolean getUpdatePackage() {

--- a/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/telemetry/doc/DiagnosticsModelDescription.java
@@ -15,6 +15,8 @@ public class DiagnosticsModelDescription {
             "hosts that are included the specific host groups";
     public static final String ADDITIONAL_LOGS = "Additional log path and label pairs that will be sent in the diagnostics collection";
     public static final String INCLUDE_SALT_LOGS = "Include salt logs in the diagnostic collections";
+    public static final String INCLUDE_SAR_OUTPUT = "Include sar outputs in the diagnostics collections";
+    public static final String INCLUDE_NGINX_REPORT = "Include nginx html reports in the diagnostics collections";
     public static final String UPDATE_PACKAGE = "Upgrade or install required telemetry cli tool on the nodes (works only with network)";
     public static final String SKIP_VALIDATION = "Skip cloud storage write operation testing or databus connection " +
             "check (depends on the destination) during init stage.";

--- a/common-model/src/main/java/com/sequenceiq/common/model/diagnostics/DiagnosticParameters.java
+++ b/common-model/src/main/java/com/sequenceiq/common/model/diagnostics/DiagnosticParameters.java
@@ -49,6 +49,10 @@ public class DiagnosticParameters {
 
     private Boolean includeSaltLogs = Boolean.FALSE;
 
+    private Boolean includeSarOutput = Boolean.FALSE;
+
+    private Boolean includeNginxReport = Boolean.FALSE;
+
     private Boolean updatePackage = Boolean.FALSE;
 
     private Boolean skipValidation = Boolean.FALSE;
@@ -96,6 +100,8 @@ public class DiagnosticParameters {
         parameters.put(HOSTS_FILTER, Optional.ofNullable(hosts).orElse(null));
         parameters.put(EXCLUDE_HOSTS_FILTER, Optional.ofNullable(excludeHosts).orElse(null));
         parameters.put("includeSaltLogs", Optional.ofNullable(includeSaltLogs).orElse(false));
+        parameters.put("includeSarOutput", Optional.ofNullable(includeSarOutput).orElse(false));
+        parameters.put("includeNginxReport", Optional.ofNullable(includeNginxReport).orElse(false));
         parameters.put("updatePackage", Optional.ofNullable(updatePackage).orElse(false));
         parameters.put("skipValidation", Optional.ofNullable(skipValidation).orElse(false));
         parameters.put("skipUnresponsiveHosts", Optional.ofNullable(skipUnresponsiveHosts).orElse(false));
@@ -169,6 +175,14 @@ public class DiagnosticParameters {
 
     public void setIncludeSaltLogs(Boolean includeSaltLogs) {
         this.includeSaltLogs = includeSaltLogs;
+    }
+
+    public void setIncludeSarOutput(Boolean includeSarOutput) {
+        this.includeSarOutput = includeSarOutput;
+    }
+
+    public void setIncludeNginxReport(Boolean includeNginxReport) {
+        this.includeNginxReport = includeNginxReport;
     }
 
     public void setUpdatePackage(Boolean updatePackage) {
@@ -273,6 +287,14 @@ public class DiagnosticParameters {
 
     public Boolean getIncludeSaltLogs() {
         return includeSaltLogs;
+    }
+
+    public Boolean getIncludeSarOutput() {
+        return includeSarOutput;
+    }
+
+    public Boolean getIncludeNginxReport() {
+        return includeNginxReport;
     }
 
     public Boolean getUpdatePackage() {
@@ -438,6 +460,16 @@ public class DiagnosticParameters {
 
         public DiagnosticParametersBuilder withIncludeSaltLogs(Boolean includeSaltLogs) {
             diagnosticParameters.setIncludeSaltLogs(includeSaltLogs);
+            return this;
+        }
+
+        public DiagnosticParametersBuilder withIncludeSarOutput(Boolean includeSarOutput) {
+            diagnosticParameters.setIncludeSarOutput(includeSarOutput);
+            return this;
+        }
+
+        public DiagnosticParametersBuilder withIncludeNginxReport(Boolean includeNginxReport) {
+            diagnosticParameters.setIncludeNginxReport(includeNginxReport);
             return this;
         }
 

--- a/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/DiagnosticsDataToParameterConverter.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/telemetry/converter/DiagnosticsDataToParameterConverter.java
@@ -45,6 +45,8 @@ public class DiagnosticsDataToParameterConverter {
                 .withHosts(Optional.ofNullable(request.getHosts()).orElse(new HashSet<>()))
                 .withExcludeHosts(Optional.ofNullable(request.getExcludeHosts()).orElse(new HashSet<>()))
                 .withIncludeSaltLogs(request.getIncludeSaltLogs())
+                .withIncludeSarOutput(request.getIncludeSarOutput())
+                .withIncludeNginxReport(request.getIncludeNginxReport())
                 .withUpdatePackage(request.getUpdatePackage())
                 .withSkipValidation(request.getSkipValidation())
                 .withSkipWorkspaceCleanupOnStartup(request.getSkipWorkspaceCleanupOnStartup())

--- a/datalake/src/main/java/com/sequenceiq/datalake/converter/DiagnosticsParamsConverter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/converter/DiagnosticsParamsConverter.java
@@ -50,6 +50,10 @@ public class DiagnosticsParamsConverter {
 
     private static final String PARAMS_INCLUDE_SALT_LOGS = "includeSaltLogs";
 
+    private static final String PARAMS_INCLUDE_SAR_OUTPUT = "includeSarOutput";
+
+    private static final String PARAMS_INCLUDE_NGINX_REPORT = "includeNginxReport";
+
     private static final String PARAMS_UPDATE_PACKAGE = "updatePackage";
 
     private static final String PARAMS_SKIP_VALIDATION = "skipValidation";
@@ -76,6 +80,8 @@ public class DiagnosticsParamsConverter {
         props.put(PARAMS_END_TIME, request.getEndTime());
         props.put(PARAMS_ADDITIONAL_LOGS, request.getAdditionalLogs());
         props.put(PARAMS_INCLUDE_SALT_LOGS, request.getIncludeSaltLogs());
+        props.put(PARAMS_INCLUDE_SAR_OUTPUT, request.getIncludeSarOutput());
+        props.put(PARAMS_INCLUDE_NGINX_REPORT, request.getIncludeNginxReport());
         props.put(PARAMS_UPDATE_PACKAGE, request.getUpdatePackage());
         props.put(PARAMS_SKIP_VALIDATION, request.getSkipValidation());
         props.put(PARAMS_SKIP_WORKSPACE_CLEANUP_ON_STARTUP, request.getSkipWorkspaceCleanupOnStartup());
@@ -98,6 +104,8 @@ public class DiagnosticsParamsConverter {
         request.setStartTime((Date) Optional.ofNullable(props.get(PARAMS_START_TIME)).orElse(null));
         request.setEndTime((Date) Optional.ofNullable(props.get(PARAMS_END_TIME)).orElse(null));
         request.setIncludeSaltLogs((Boolean) Optional.ofNullable(props.get(PARAMS_INCLUDE_SALT_LOGS)).orElse(false));
+        request.setIncludeSarOutput((Boolean) Optional.ofNullable(props.get(PARAMS_INCLUDE_SAR_OUTPUT)).orElse(false));
+        request.setIncludeNginxReport((Boolean) Optional.ofNullable(props.get(PARAMS_INCLUDE_NGINX_REPORT)).orElse(false));
         request.setUpdatePackage((Boolean) Optional.ofNullable(props.get(PARAMS_UPDATE_PACKAGE)).orElse(false));
         request.setSkipValidation((Boolean) Optional.ofNullable(props.get(PARAMS_SKIP_VALIDATION)).orElse(false));
         request.setSkipUnresponsiveHosts((Boolean) Optional.ofNullable(props.get(PARAMS_SKIP_UNRESPONSIVE_HOSTS)).orElse(false));

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/settings.sls
@@ -16,6 +16,16 @@
 {% set end_time = salt['pillar.get']('filecollector:endTime') %}
 {% set label_filter = salt['pillar.get']('filecollector:labelFilter') %}
 {% set include_salt_logs = salt['pillar.get']('filecollector:includeSaltLogs') %}
+{% if salt['pillar.get']('filecollector:includeSarOutput') and salt['pkg.version']('sysstat') %}
+  {% set include_sar_output = True %}
+{% else %}
+  {% set include_sar_output = False %}
+{% endif %}
+{% if salt['pillar.get']('filecollector:includeNginxReport') and salt['pkg.version']('goaccess') %}
+  {% set include_nginx_report = True %}
+{% else %}
+  {% set include_nginx_report = False %}
+{% endif %}
 {% set update_package = salt['pillar.get']('filecollector:updatePackage') %}
 {% set skip_test_cloud_storage = salt['pillar.get']('filecollector:skipTestCloudStorage') %}
 {% set additional_logs = salt['pillar.get']('filecollector:additionalLogs') %}
@@ -127,6 +137,8 @@
     "labelFilter": label_filter,
     "additionalLogs": additional_logs,
     "includeSaltLogs": include_salt_logs,
+    "includeSarOutput": include_sar_output,
+    "includeNginxReport": include_nginx_report,
     "updatePackage": update_package,
     "skipValidation": skip_validation,
     "skipWorkspaceCleanupOnStartup": skip_workspace_cleanup_on_startup,

--- a/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/filecollector.yaml.j2
+++ b/orchestrator-salt/src/main/resources/salt-common/salt/filecollector/template/filecollector.yaml.j2
@@ -64,6 +64,12 @@ collector:
       useFullPath: false
       folderPrefix: report
       mandatory: true
+    - path: /var/lib/cdp-nodestatus/report/salt_keys_report.json
+      label: nodestatus_salt_keys
+      skipAnonymization: true
+      useFullPath: false
+      folderPrefix: report
+      mandatory: true
     - path: /etc/nginx/nginx.conf
       label: nginx_conf
       skipAnonymization: true
@@ -80,7 +86,19 @@ collector:
       skipLabelFromPath: true
       skipAnonymization: true
       useFullPath: false
-      folderPrefix: doctor{% if destination in ["CLOUD_STORAGE", "LOCAL"] %}
+      folderPrefix: doctor{% if filecollector.includeSarOutput %}
+    - path: /tmp/sar_output/*.txt
+      label: sar
+      skipLabelFromPath: true
+      skipAnonymization: true
+      useFullPath: false
+      folderPrefix: sar{% endif %}{% if destination in ["CLOUD_STORAGE", "LOCAL", "SUPPORT"] %}{% if filecollector.includeNginxReport %}
+    - path: /tmp/nginx_report.html
+      label: nginx_report
+      skipLabelFromPath: true
+      skipAnonymization: true
+      useFullPath: false
+      folderPrefix: report{% endif %}
     - path: /tmp/cdp_report.html
       label: report
       skipLabelFromPath: true


### PR DESCRIPTION
…stics bundle.

details:
- add new parameter for diagnostics request to create/include sar output: includeSarOutput
- add new parameter for diagnostics request to create/include nginx report: includeNginxReport
- salt state changes to generaate goaccess + syststat data
- also include salt keys report in the bundle
- update filecollector configuration to include report htmls (nodestatus + nginx report) by using support destinations as well

See detailed description in the commit message.