### PR TITLE
CB-14523 Do not configure SAN when there is no endpoint for the load-…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProvider.java
@@ -52,6 +52,9 @@ public class LoadBalancerSANProvider {
         if (isNotBlank(lb.getDns())) {
             return Optional.of("DNS:" + lb.getDns());
         }
-        return Optional.of("IP:" + lb.getIp());
+        if (isNotBlank(lb.getIp())) {
+            return Optional.of("IP:" + lb.getIp());
+        }
+        return Optional.empty();
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/san/LoadBalancerSANProviderTest.java
@@ -77,22 +77,30 @@ class LoadBalancerSANProviderTest {
 
     @Test
     void newerVersionHasLoadBalancerWithDNS() {
-        loadBalancerSetUp("foobar.timbuk2.com");
+        loadBalancerSetUp("foobar.timbuk2.com", null);
         assertEquals("DNS:foobar.timbuk2.com", loadBalancerSANProvider.getLoadBalancerSAN(stack).get());
     }
 
     @Test
-    void newerVersionHasLoadBalancerWithoutDNS() {
-        loadBalancerSetUp(null);
+    void newerVersionHasLoadBalancerWithIP() {
+        loadBalancerSetUp(null, "10.10.10.10");
         assertEquals("IP:10.10.10.10", loadBalancerSANProvider.getLoadBalancerSAN(stack).get());
     }
 
-    private void loadBalancerSetUp(String dns) {
+    @Test
+    void newerVersionHasLoadBalancerWithoutDNSOrIP() {
+        loadBalancerSetUp(null, null);
+        assertTrue(loadBalancerSANProvider.getLoadBalancerSAN(stack).isEmpty());
+    }
+
+    private void loadBalancerSetUp(String dns, String ip) {
         LoadBalancer loadBalancer = new LoadBalancer();
         if (dns != null) {
             loadBalancer.setDns("foobar.timbuk2.com");
         }
-        loadBalancer.setIp("10.10.10.10");
+        if (ip != null) {
+            loadBalancer.setIp("10.10.10.10");
+        }
         Set<LoadBalancer> loadBalancers = new HashSet<>();
         loadBalancers.add(loadBalancer);
         when(loadBalancerPersistenceService.findByStackId(ID)).thenReturn(loadBalancers);


### PR DESCRIPTION
…balancer

1. In remote cases where the Azure load-balancer create permission is there but not the read permission it is possible that all of FQDN, DNS, and IP can be null.
2. Not fixing this will lead to a situation where the actual issue will be buried in the CM logs which is (close to) impossible to find.
3. Fixing this also means that the cluster creation will be successful, the load-balancer will be created but not used. This needs to be covered separately in the load-balancer metadata collection logic.
4. Added a unit test to make sure no SAN is generated for this scenario.