### PR TITLE
CB-14558 in case of datalake resize we rename the stack CRN to be able...

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/sharedservice/DatalakeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/sharedservice/DatalakeService.java
@@ -60,7 +60,7 @@ public class DatalakeService {
         SharedServiceV4Response sharedServiceResponse = new SharedServiceV4Response();
         if (cluster.getStack().getDatalakeCrn() != null) {
             LOGGER.debug("Add shared service response by datalakeCrn");
-            Stack datalakeStack = stackService.getByCrn(cluster.getStack().getDatalakeCrn());
+            Stack datalakeStack = stackService.getByCrnOrElseNull(cluster.getStack().getDatalakeCrn());
             if (datalakeStack != null) {
                 sharedServiceResponse.setSharedClusterId(datalakeStack.getId());
                 sharedServiceResponse.setSharedClusterName(datalakeStack.getName());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -282,6 +282,14 @@ public class StackService implements ResourceIdProvider, ResourcePropertyProvide
         }
     }
 
+    public Stack getByCrnOrElseNull(String crn) {
+        try {
+            return transactionService.required(() -> stackRepository.findByResourceCrn(crn).orElse(null));
+        } catch (TransactionExecutionException e) {
+            throw new TransactionRuntimeExecutionException(e);
+        }
+    }
+
     public Stack getByCrn(String crn) {
         try {
             return transactionService.required(() -> stackRepository.findByResourceCrn(crn).orElseThrow(notFound("Stack", crn)));


### PR DESCRIPTION
… to create a new resized stack with the original CRN. But if a distrox is attached the original CRN is linked in every attached distrox (datalakecrn field in stack entity). In case of distrox list we try to fill shared info to distrox, it means we try to find datalake with the CRN saved to datalakecrn field. This call throws 404 and distrox list fails with 404. I just create a new method to stackService to get datalake stack by crn and if it can not find then we return null. It results we don't fill shared service response in this case.