### PR TITLE
CB-12973 based on azure support recommendation we 

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureVirtualMachineService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureVirtualMachineService.java
@@ -44,7 +44,7 @@ public class AzureVirtualMachineService {
     @Inject
     private AzureResourceGroupMetadataProvider azureResourceGroupMetadataProvider;
 
-    @Retryable(backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 10000), maxAttempts = 10)
+    @Retryable(backoff = @Backoff(delay = 1000, multiplier = 2, maxDelay = 10000), maxAttempts = 60)
     public Map<String, VirtualMachine> getVirtualMachinesByName(AzureClient azureClient, String resourceGroup, Collection<String> privateInstanceIds) {
         LOGGER.debug("Starting to retrieve vm metadata from Azure for {} for ids: {}", resourceGroup, privateInstanceIds);
         PagedList<VirtualMachine> virtualMachines = azureClient.getVirtualMachines(resourceGroup);


### PR DESCRIPTION
increase the retry cycle to ~10 mins for fetching the VMs as the issues is getting more frequent once again.