### PR TITLE
CB-14464: Remove the obsoleted logic regarding to DATAHUB/DATALAKE image types

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4CreateImageRequestToCustomImageConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4CreateImageRequestToCustomImageConverter.java
@@ -15,7 +15,7 @@ public class CustomImageCatalogV4CreateImageRequestToCustomImageConverter {
 
     public CustomImage convert(CustomImageCatalogV4CreateImageRequest source) {
         CustomImage result = new CustomImage();
-        result.setImageType(convertImageType(source.getImageType()));
+        result.setImageType(ImageType.valueOf(source.getImageType()));
         result.setBaseParcelUrl(source.getBaseParcelUrl());
         result.setCustomizedImageId(source.getSourceImageId());
         result.setVmImage(getVmImages(source.getVmImages()));
@@ -31,10 +31,5 @@ public class CustomImageCatalogV4CreateImageRequestToCustomImageConverter {
 
             return vmImage;
         }).collect(Collectors.toSet());
-    }
-
-    private ImageType convertImageType(String imageType) {
-        ImageType type = ImageType.valueOf(imageType);
-        return type == ImageType.DATAHUB || type == ImageType.DATALAKE ? ImageType.RUNTIME : type;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4UpdateImageRequestToCustomImageConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4UpdateImageRequestToCustomImageConverter.java
@@ -15,7 +15,7 @@ public class CustomImageCatalogV4UpdateImageRequestToCustomImageConverter {
 
     public CustomImage convert(CustomImageCatalogV4UpdateImageRequest source) {
         CustomImage result = new CustomImage();
-        result.setImageType(source.getImageType() != null ? convertImageType(source.getImageType()) : null);
+        result.setImageType(source.getImageType() != null ? ImageType.valueOf(source.getImageType()) : null);
         result.setBaseParcelUrl(source.getBaseParcelUrl());
         result.setCustomizedImageId(source.getSourceImageId());
         result.setVmImage(source.getVmImages() != null ? getVmImages(source.getVmImages()) : null);
@@ -31,10 +31,5 @@ public class CustomImageCatalogV4UpdateImageRequestToCustomImageConverter {
 
             return vmImage;
         }).collect(Collectors.toSet());
-    }
-
-    private ImageType convertImageType(String imageType) {
-        ImageType type = ImageType.valueOf(imageType);
-        return type == ImageType.DATAHUB || type == ImageType.DATALAKE ? ImageType.RUNTIME : type;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/DefaultImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/DefaultImageCatalogService.java
@@ -61,8 +61,6 @@ public class DefaultImageCatalogService {
                                         FREEIPA_DEFAULT_CATALOG_NAME))),
                         defaultFreeIpaCatalogUrl, FREEIPA_DEFAULT_CATALOG_NAME);
                 break;
-            case DATAHUB:
-            case DATALAKE:
             case RUNTIME:
                 throw new BadRequestException(String.format("Runtime is required in case of '%s' image type", imageType));
             default:
@@ -78,8 +76,6 @@ public class DefaultImageCatalogService {
         switch (imageType) {
             case FREEIPA:
                 throw new BadRequestException(String.format("Runtime is not supported in case of '%s' image type", imageType));
-            case DATAHUB:
-            case DATALAKE:
             case RUNTIME:
                 ImageCatalog imageCatalog = getCloudbreakDefaultImageCatalog();
                 ImageFilter imageFilter = new ImageFilter(imageCatalog, Set.of(provider), null, false, null, runtime);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
@@ -352,8 +352,8 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
 
     private StatedImages getStatedImagesFromCustomImageCatalog(ImageCatalog imageCatalog, Set<String> providers) throws CloudbreakImageCatalogException {
         try {
-            List<Image> cbImages = getImages(Set.of(ImageType.DATALAKE, ImageType.DATAHUB, ImageType.RUNTIME), imageCatalog, providers);
-            List<Image> freeIpaImages = getImages(Set.of(ImageType.FREEIPA), imageCatalog, providers);
+            List<Image> cbImages = getImages(ImageType.RUNTIME, imageCatalog, providers);
+            List<Image> freeIpaImages = getImages(ImageType.FREEIPA, imageCatalog, providers);
             return statedImages(new Images(null, cbImages, freeIpaImages,
                     Set.of(cbVersion)), imageCatalog.getImageCatalogUrl(), imageCatalog.getName());
         } catch (CloudbreakImageNotFoundException ex) {
@@ -361,11 +361,11 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
         }
     }
 
-    private List<Image> getImages(Set<ImageType> imageTypes, ImageCatalog imageCatalog, Set<String> providers)
+    private List<Image> getImages(ImageType imageType, ImageCatalog imageCatalog, Set<String> providers)
             throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
         List<Image> images = new ArrayList<>();
         for (CustomImage customImage : imageCatalog.getCustomImages()) {
-            if (imageTypes.contains(customImage.getImageType())) {
+            if (imageType == customImage.getImageType()) {
                 StatedImage sourceImage = getSourceImageByImageType(customImage);
                 Optional<String> provider = sourceImage.getImage().getImageSetsByProvider().keySet().stream().findFirst();
                 provider.ifPresent(p -> {
@@ -777,8 +777,6 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
         switch (customImage.getImageType()) {
             case FREEIPA:
                 return getImageByUrl(defaultFreeIpaCatalogUrl, FREEIPA_DEFAULT_CATALOG_NAME, customImage.getCustomizedImageId());
-            case DATAHUB:
-            case DATALAKE:
             case RUNTIME:
                 return getImage(customImage.getCustomizedImageId());
             default:

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest.java
@@ -21,10 +21,6 @@ public class CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest {
 
     private static final String VALID_IMAGE_TYPE = "RUNTIME";
 
-    private static final String DEPRECATED_IMAGE_TYPE1 = "DATALAKE";
-
-    private static final String DEPRECATED_IMAGE_TYPE2 = "DATAHUB";
-
     private static final String INVALID_IMAGE_TYPE = "invalid image type";
 
     private static final String REGION = "region";
@@ -44,44 +40,6 @@ public class CustomImageCatalogV4CreateImageRequestToCustomImageConverterTest {
         source.setSourceImageId(SOURCE_IMAGE_ID);
         source.setBaseParcelUrl(BASE_PARCEL_URL);
         source.setImageType(VALID_IMAGE_TYPE);
-        source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
-
-        CustomImage result = victim.convert(source);
-        assertEquals(SOURCE_IMAGE_ID, result.getCustomizedImageId());
-        assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
-        assertEquals(ImageType.RUNTIME, result.getImageType());
-        assertEquals(1, result.getVmImage().size());
-
-        VmImage vmImage = result.getVmImage().stream().findFirst().get();
-        assertEquals(REGION, vmImage.getRegion());
-        assertEquals(IMAGE_REFERENCE, vmImage.getImageReference());
-    }
-
-    @Test
-    public void shouldConvertDatalakeImageType() {
-        CustomImageCatalogV4CreateImageRequest source = new CustomImageCatalogV4CreateImageRequest();
-        source.setSourceImageId(SOURCE_IMAGE_ID);
-        source.setBaseParcelUrl(BASE_PARCEL_URL);
-        source.setImageType(DEPRECATED_IMAGE_TYPE1);
-        source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
-
-        CustomImage result = victim.convert(source);
-        assertEquals(SOURCE_IMAGE_ID, result.getCustomizedImageId());
-        assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
-        assertEquals(ImageType.RUNTIME, result.getImageType());
-        assertEquals(1, result.getVmImage().size());
-
-        VmImage vmImage = result.getVmImage().stream().findFirst().get();
-        assertEquals(REGION, vmImage.getRegion());
-        assertEquals(IMAGE_REFERENCE, vmImage.getImageReference());
-    }
-
-    @Test
-    public void shouldConvertDatahubImageType() {
-        CustomImageCatalogV4CreateImageRequest source = new CustomImageCatalogV4CreateImageRequest();
-        source.setSourceImageId(SOURCE_IMAGE_ID);
-        source.setBaseParcelUrl(BASE_PARCEL_URL);
-        source.setImageType(DEPRECATED_IMAGE_TYPE2);
         source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
 
         CustomImage result = victim.convert(source);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/v4/customimage/CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest.java
@@ -22,10 +22,6 @@ public class CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest {
 
     private static final String VALID_IMAGE_TYPE = "RUNTIME";
 
-    private static final String DEPRECATED_IMAGE_TYPE1 = "DATALAKE";
-
-    private static final String DEPRECATED_IMAGE_TYPE2 = "DATAHUB";
-
     private static final String INVALID_IMAGE_TYPE = "invalid image type";
 
     private static final String REGION = "region";
@@ -45,44 +41,6 @@ public class CustomImageCatalogV4UpdateImageRequestToCustomImageConverterTest {
         source.setSourceImageId(SOURCE_IMAGE_ID);
         source.setBaseParcelUrl(BASE_PARCEL_URL);
         source.setImageType(VALID_IMAGE_TYPE);
-        source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
-
-        CustomImage result = victim.convert(source);
-        assertEquals(SOURCE_IMAGE_ID, result.getCustomizedImageId());
-        assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
-        assertEquals(ImageType.RUNTIME, result.getImageType());
-        assertEquals(1, result.getVmImage().size());
-
-        VmImage vmImage = result.getVmImage().stream().findFirst().get();
-        assertEquals(REGION, vmImage.getRegion());
-        assertEquals(IMAGE_REFERENCE, vmImage.getImageReference());
-    }
-
-    @Test
-    public void shouldConvertDatalakeImageType() {
-        CustomImageCatalogV4UpdateImageRequest source = new CustomImageCatalogV4UpdateImageRequest();
-        source.setSourceImageId(SOURCE_IMAGE_ID);
-        source.setBaseParcelUrl(BASE_PARCEL_URL);
-        source.setImageType(DEPRECATED_IMAGE_TYPE1);
-        source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
-
-        CustomImage result = victim.convert(source);
-        assertEquals(SOURCE_IMAGE_ID, result.getCustomizedImageId());
-        assertEquals(BASE_PARCEL_URL, result.getBaseParcelUrl());
-        assertEquals(ImageType.RUNTIME, result.getImageType());
-        assertEquals(1, result.getVmImage().size());
-
-        VmImage vmImage = result.getVmImage().stream().findFirst().get();
-        assertEquals(REGION, vmImage.getRegion());
-        assertEquals(IMAGE_REFERENCE, vmImage.getImageReference());
-    }
-
-    @Test
-    public void shouldConvertDatahubImageType() {
-        CustomImageCatalogV4UpdateImageRequest source = new CustomImageCatalogV4UpdateImageRequest();
-        source.setSourceImageId(SOURCE_IMAGE_ID);
-        source.setBaseParcelUrl(BASE_PARCEL_URL);
-        source.setImageType(DEPRECATED_IMAGE_TYPE2);
         source.setVmImages(Collections.singleton(getVmImageRequest(REGION, IMAGE_REFERENCE)));
 
         CustomImage result = victim.convert(source);


### PR DESCRIPTION
This task is the second step to refine the datalake and datahub operations based on the  CB-14390. This must be done in this order due to backward compatibility. Actually, in this step we should remove the business logic corresponding to the datahub/datalake enumerations, however, it is important that the proper enumeration values cannot be deleted.