### PR TITLE
CB-14427 : Added Hue and schema registry to disaster recovery pgpass file.

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/.pgpass
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/.pgpass
@@ -7,4 +7,6 @@
 {{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:profiler_agent:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
 {{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:profiler_metric:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
 {{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:oozie:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
+{{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:hue:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
+{{ pillar['postgres']['clouderamanager']['remote_db_url'] }}:{{ pillar['postgres']['clouderamanager']['remote_db_port'] }}:schema_registry:{{ pillar['postgres']['clouderamanager']['remote_admin'] }}:{{ pillar['postgres']['clouderamanager']['remote_admin_pw'] }}
 {% endif %}


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-14427

This change serves to fully enable backup/restore of the specific databases required by the QE team. Specifically, the only additions needed were for Hue and Schema Registry.