### PR TITLE
CB-14574 Add API endpoints to detect the presence of Ranger Raz. This…

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -47,6 +47,8 @@ public interface ClusterModificationService {
 
     ParcelOperationStatus removeUnusedParcels(Set<ClusterComponent> usedParcelComponents) throws CloudbreakException;
 
+    boolean isServicePresent(String clusterName, String serviceType);
+
     default void stopComponents(Map<String, String> components, String hostname) {
         throw new UnsupportedOperationException("Interface not implemented.");
     }

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -880,4 +880,17 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
     public Optional<String> getRoleConfigValueByServiceType(String clusterName, String roleConfigGroup, String serviceType, String configName) {
         return configService.getRoleConfigValueByServiceType(apiClient, clusterName, roleConfigGroup, serviceType, configName);
     }
+
+    @Override
+    public boolean isServicePresent(String clusterName, String serviceType) {
+        boolean servicePresent = false;
+        try {
+            servicePresent = readServices(stack)
+                    .stream()
+                    .anyMatch(service -> serviceType.equalsIgnoreCase(service.getType()));
+        } catch (ApiException e) {
+            LOGGER.debug("Failed to determine if {} service is present in cluster {}.", serviceType, stack.getCluster().getId());
+        }
+        return servicePresent;
+    }
 }

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
@@ -5,7 +5,9 @@ import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUD
 import static com.sequenceiq.cloudbreak.cmtemplate.CMRepositoryVersionUtil.CLOUDERAMANAGER_VERSION_7_5_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -1115,6 +1117,17 @@ class ClouderaManagerModificationServiceTest {
         assertEquals(2, operationStatus.getFailed().size());
         assertEquals("version3", operationStatus.getFailed().get("spark3"));
         assertEquals("version4", operationStatus.getFailed().get("product4"));
+    }
+
+    @Test
+    void testIsServicePresent() throws ApiException {
+        stack.getCluster().setName("test-cluster-name");
+        List<ApiService> services = List.of(new ApiService().type("RANGER_RAZ"), new ApiService().type("ATLAS"), new ApiService().type("HDFS"));
+        when(clouderaManagerApiFactory.getServicesResourceApi(apiClientMock)).thenReturn(servicesResourceApi);
+        when(servicesResourceApi.readServices(anyString(), anyString())).thenReturn(new ApiServiceList().items(services));
+
+        assertTrue(underTest.isServicePresent(stack.getCluster().getName(), "RANGER_RAZ"));
+        assertFalse(underTest.isServicePresent(stack.getCluster().getName(), "NON EXISTENT"));
     }
 
     private ClusterComponent createClusterComponent(ClouderaManagerProduct clouderaManagerProduct) {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/StackV4Endpoint.java
@@ -24,6 +24,7 @@ import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescrip
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.DELETE_WITH_KERBEROS_IN_WORKSPACE;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.DETACH_RECIPE_IN_WORKSPACE;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.DETACH_RECIPE_IN_WORKSPACE_INTERNAL;
+import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.RANGER_RAZ_ENABLED;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.GENERATE_HOSTS_INVENTORY;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.GET_BY_CRN_IN_WORKSPACE;
 import static com.sequenceiq.cloudbreak.doc.OperationDescriptions.StackOpDescription.GET_BY_NAME_IN_WORKSPACE;
@@ -86,6 +87,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.UpdateRec
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.CertificatesRotationV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.GeneratedBlueprintV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.RangerRazEnabledV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackViewV4Responses;
@@ -536,4 +538,11 @@ public interface StackV4Endpoint {
     @ApiOperation(value = CHANGE_IMAGE_CATALOG, nickname = "changeImageCatalogInternal")
     void changeImageCatalogInternal(@PathParam("workspaceId") Long workspaceId, @PathParam("name") String name,
             @QueryParam("initiatorUserCrn") String initiatorUserCrn, @Valid @NotNull ChangeImageCatalogV4Request changeImageCatalogRequest);
+
+    @GET
+    @Path("internal/{crn}/ranger_raz_enabled")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = RANGER_RAZ_ENABLED, produces = MediaType.APPLICATION_JSON, nickname = "rangerRazEnabled")
+    RangerRazEnabledV4Response rangerRazEnabledInternal(@PathParam("workspaceId") Long workspaceId, @PathParam("crn") String crn,
+            @QueryParam("initiatorUserCrn") String initiatorUserCrn);
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/RangerRazEnabledV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/RangerRazEnabledV4Response.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response;
+
+public class RangerRazEnabledV4Response {
+
+    private boolean rangerRazEnabled;
+
+    public RangerRazEnabledV4Response() {
+    }
+
+    public RangerRazEnabledV4Response(boolean rangerRazEnabled) {
+        this.rangerRazEnabled = rangerRazEnabled;
+    }
+
+    public boolean isRangerRazEnabled() {
+        return rangerRazEnabled;
+    }
+
+    public void setRangerRazEnabled(boolean rangerRazEnabled) {
+        this.rangerRazEnabled = rangerRazEnabled;
+    }
+
+    @Override
+    public String toString() {
+        return "RangerRazEnabledV4Response{" +
+                "rangerRazEnabled=" + rangerRazEnabled +
+                '}';
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -91,6 +91,7 @@ public class OperationDescriptions {
         public static final String UPDATE_LOAD_BALANCERS = "Updates an existing cluster with load balancers, including adding the Endpoint Gateway " +
             "if it's enabled.";
         public static final String CHANGE_IMAGE_CATALOG = "Changes image catalog of the cluster";
+        public static final String RANGER_RAZ_ENABLED = "Determines if Ranger Raz is present in the cluster.";
     }
 
     public static class ClusterOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/StackV4Controller.java
@@ -34,6 +34,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.DetachRec
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.recipe.UpdateRecipesV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.tags.upgrade.UpgradeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.CertificatesRotationV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.RangerRazEnabledV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recipe.DetachRecipeV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery.RecoveryV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.GeneratedBlueprintV4Response;
@@ -456,5 +457,11 @@ public class StackV4Controller extends NotificationController implements StackV4
             ChangeImageCatalogV4Request changeImageCatalogRequest) {
         stackOperations.changeImageCatalog(NameOrCrn.ofName(name), restRequestThreadLocalService.getRequestedWorkspaceId(),
                 changeImageCatalogRequest.getImageCatalog());
+    }
+
+    @Override
+    @InternalOnly
+    public RangerRazEnabledV4Response rangerRazEnabledInternal(Long workspaceId, String crn, @InitiatorUserCrn String initiatorUserCrn) {
+        return new RangerRazEnabledV4Response(stackOperationService.rangerRazEnabled(restRequestThreadLocalService.getRequestedWorkspaceId(), crn));
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -84,6 +84,8 @@ public class ClusterService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterService.class);
 
+    private static final String RANGER_RAZ = "RANGER_RAZ";
+
     @Inject
     private StackService stackService;
 
@@ -396,6 +398,15 @@ public class ClusterService {
             LOGGER.info("Update cert expiration state from {} to {}", cluster.getCertExpirationState(), VALID);
             repository.updateCertExpirationState(cluster.getId(), VALID);
         }
+    }
+
+    public boolean isRangerRazEnabledOnCluster(Stack stack) {
+        Cluster cluster = stack.getCluster();
+        ClusterApi clusterApi = clusterApiConnectors.getConnector(stack);
+        if (!clusterApi.clusterStatusService().isClusterManagerRunning()) {
+            throw new BadRequestException(String.format("Cloudera Manager is not running for cluster: %s", cluster.getName()));
+        }
+        return clusterApi.clusterModificationService().isServicePresent(cluster.getName(), RANGER_RAZ);
     }
 
     public Cluster prepareCluster(Collection<HostGroup> hostGroups, Blueprint blueprint, Stack stack, Cluster cluster) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -303,6 +303,11 @@ public class StackOperationService {
         return result;
     }
 
+    public boolean rangerRazEnabled(Long workspaceId, String crn) {
+        Stack stack = stackService.getByCrnInWorkspace(crn, workspaceId);
+        return clusterService.isRangerRazEnabledOnCluster(stack);
+    }
+
     private boolean isStackStartable(Stack stack) {
         return stack.isStopped() || stack.isStartFailed();
     }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/StackV4ControllerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/StackV4ControllerTest.java
@@ -47,4 +47,14 @@ class StackV4ControllerTest {
 
         verify(stackOperations).changeImageCatalog(NameOrCrn.ofName(stackName), WORKSPACE_ID, imageCatalog);
     }
+
+    @Test
+    void rangerRazEnabledTest() {
+        when(restRequestThreadLocalService.getRequestedWorkspaceId()).thenReturn(WORKSPACE_ID);
+        String stackCrn = "test-crn";
+
+        underTest.rangerRazEnabledInternal(WORKSPACE_ID, stackCrn, USER_CRN);
+
+        verify(stackOperationService).rangerRazEnabled(WORKSPACE_ID, stackCrn);
+    }
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxEndpoint.java
@@ -231,6 +231,18 @@ public interface SdxEndpoint {
     @ApiOperation(value = ROTATE_CERTIFICATES, nickname = "rotateAutoTlsCertificatesByCrn")
     FlowIdentifier rotateAutoTlsCertificatesByCrn(@PathParam("crn") String crn, @Valid CertificatesRotationV4Request rotateCertificateRequest);
 
+    @PUT
+    @Path("/crn/{crn}/enable_ranger_raz")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Set the rangerRazEnabled flag of the cluster if Raz is installed manually", nickname = "enableRangerRazByCrn")
+    void enableRangerRazByCrn(@PathParam("crn") String crn);
+
+    @PUT
+    @Path("/name/{name}/enable_ranger_raz")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Set the rangerRazEnabled flag of the cluster if Raz is installed manually", nickname = "enableRangerRazByName")
+    void enableRangerRazByName(@PathParam("name") String name);
+
     @POST
     @Path("{name}/custom_image")
     @Produces(MediaType.APPLICATION_JSON)

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxController.java
@@ -336,6 +336,18 @@ public class SdxController implements SdxEndpoint {
     }
 
     @Override
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.START_DATALAKE)
+    public void enableRangerRazByCrn(@ResourceCrn String crn) {
+        sdxService.updateRangerRazEnabled(getSdxClusterByCrn(crn));
+    }
+
+    @Override
+    @CheckPermissionByResourceName(action = AuthorizationResourceAction.START_DATALAKE)
+    public void enableRangerRazByName(@ResourceName String name) {
+        sdxService.updateRangerRazEnabled(getSdxClusterByName(name));
+    }
+
+    @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.ROTATE_CERT_DATALAKE)
     public FlowIdentifier rotateAutoTlsCertificatesByName(@ResourceName String name, @Valid CertificatesRotationV4Request rotateCertificateRequest) {
         SdxCluster sdxCluster = getSdxClusterByName(name);

--- a/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/controller/sdx/SdxControllerTest.java
@@ -123,6 +123,26 @@ class SdxControllerTest {
         verify(sdxImageCatalogChangeService).changeImageCatalog(sdxCluster, request.getImageCatalog());
     }
 
+    @Test
+    void enableRangerRazByCrnTest() {
+        SdxCluster sdxCluster = getValidSdxCluster();
+        when(sdxService.getByCrn(anyString(), anyString())).thenReturn(sdxCluster);
+
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> sdxController.enableRangerRazByCrn(sdxCluster.getCrn()));
+
+        verify(sdxService).updateRangerRazEnabled(sdxCluster);
+    }
+
+    @Test
+    void enableRangerRazByNameTest() {
+        SdxCluster sdxCluster = getValidSdxCluster();
+        when(sdxService.getByNameInAccount(anyString(), anyString())).thenReturn(sdxCluster);
+
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> sdxController.enableRangerRazByName(sdxCluster.getName()));
+
+        verify(sdxService).updateRangerRazEnabled(sdxCluster);
+    }
+
     private SdxCluster getValidSdxCluster() {
         SdxCluster sdxCluster = new SdxCluster();
         sdxCluster.setClusterName("test-sdx-cluster");


### PR DESCRIPTION
… will be invoked by the CDPCLI.
### Overview
- New API endpoints are added to Sdx to set the rangerRazEnabled flag for the datalake. 
- These endpoints will be invoked by the CDPCLI

### Example CDPCLI command
`cdp datalake enable-ranger-raz --datalake-name my-dl --profile dev`
The result can be verified via the output of `cdp datalake describe-datalake --datalake-name my-dl --profile dev`

See detailed description in the commit message.