### PR TITLE
CB-14250 - Finalise stack status validation for recovery - minor corr…

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/event/ResourceEvent.java
@@ -230,6 +230,7 @@ public enum ResourceEvent {
     CLUSTER_BUILDING("cluster.building"),
     CLUSTER_RESET("cluster.reset"),
     CLUSTER_BUILT("cluster.built"),
+    RECOVERY_FINISHED("recovery.finished"),
     CLUSTER_DELETE_FAILED("ambari.cluster.delete.failed"),
     CLUSTER_DELETE_STARTED("cluster.termination.started"),
     CLUSTER_CHANGING_CREDENTIAL("cluster.changing.credential"),

--- a/common/src/main/resources/messages/messages.properties
+++ b/common/src/main/resources/messages/messages.properties
@@ -71,6 +71,7 @@ cluster.starting=Starting cluster
 cluster.dns.update.finished=DNS entries have been updated for the cluster
 cluster.building=Installing CDP services
 cluster.built=CDP services have been installed
+recovery.finished=Cluster recovery has been completed
 ambari.cluster.created=Cloudera Manager cluster created
 cluster.started=Cluster has been started
 cluster.stopping=Stopping cluster

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/recovery/RecoveryValidationV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/recovery/RecoveryValidationV4Response.java
@@ -4,14 +4,14 @@ public class RecoveryValidationV4Response {
 
     private String reason;
 
-    private RecoveryStatus recoveryStatus;
+    private RecoveryStatus status;
 
     public RecoveryValidationV4Response() {
     }
 
-    public RecoveryValidationV4Response(String reason, RecoveryStatus recoveryStatus) {
+    public RecoveryValidationV4Response(String reason, RecoveryStatus status) {
         this.reason = reason;
-        this.recoveryStatus = recoveryStatus;
+        this.status = status;
     }
 
     public String getReason() {
@@ -22,19 +22,19 @@ public class RecoveryValidationV4Response {
         this.reason = reason;
     }
 
-    public RecoveryStatus getRecoveryStatus() {
-        return recoveryStatus;
+    public RecoveryStatus getStatus() {
+        return status;
     }
 
-    public void setRecoveryStatus(RecoveryStatus recoveryStatus) {
-        this.recoveryStatus = recoveryStatus;
+    public void setStatus(RecoveryStatus status) {
+        this.status = status;
     }
 
     @Override
     public String toString() {
         return "RecoveryValidationV4Response{" +
                 "reason='" + reason + '\'' +
-                ", recoveryStatus=" + recoveryStatus +
+                ", status=" + status +
                 '}';
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
@@ -643,7 +643,7 @@ public class ClusterCreationActions {
         return new AbstractClusterCreationAction<>(ClusterProxyGatewayRegistrationSuccess.class) {
             @Override
             protected void doExecute(ClusterCreationViewContext context, ClusterProxyGatewayRegistrationSuccess payload, Map<Object, Object> variables) {
-                clusterCreationService.clusterInstallationFinished(context.getStack());
+                clusterCreationService.clusterInstallationFinished(context.getStack(), context.getProvisionType());
                 jobService.schedule(context.getStackId(), StackJobAdapter.class);
                 syncJobService.schedule(context.getStackId(), StructuredSynchronizerJobAdapter.class);
                 getMetricService().incrementMetricCounter(MetricType.CLUSTER_CREATION_SUCCESSFUL, context.getStack());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterRecoveryServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterRecoveryServiceTest.java
@@ -66,7 +66,7 @@ public class ClusterRecoveryServiceTest {
 
         RecoveryValidationV4Response response = underTest.validateRecovery(WORKSPACE_ID, stackNameOrCrn);
 
-        Assertions.assertEquals(expectedRecoveryStatus, response.getRecoveryStatus());
+        Assertions.assertEquals(expectedRecoveryStatus, response.getStatus());
         Assertions.assertEquals(expectedMessage, response.getReason());
     }
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/recovery/SdxUpgradeRecoveryService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/upgrade/recovery/SdxUpgradeRecoveryService.java
@@ -76,7 +76,7 @@ public class SdxUpgradeRecoveryService {
             String initiatorUserCrn = ThreadBasedUserCrnProvider.getUserCrn();
             RecoveryValidationV4Response response = ThreadBasedUserCrnProvider.doAsInternalActor(() ->
                     stackV4Endpoint.getClusterRecoverableByNameInternal(0L, sdxCluster.getClusterName(), initiatorUserCrn));
-            return new SdxRecoverableResponse(response.getReason(), response.getRecoveryStatus());
+            return new SdxRecoverableResponse(response.getReason(), response.getStatus());
         } catch (WebApplicationException e) {
             String exceptionMessage = exceptionMessageExtractor.getErrorMessage(e);
             String message = String.format("Stack recovery status validation failed on cluster: [%s]. Message: [%s]",


### PR DESCRIPTION
…ections

- model `status` field is named uniformly in both SDX and DistroX endpoints
- Recovery success triggers a stack update indicating RECOVERY_FINISHED

