### PR TITLE
CB-11073 - [E2E] Node failure testing during upgrade

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/DetailedStackStatus.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/DetailedStackStatus.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.common;
 
+import java.util.List;
+
 public enum DetailedStackStatus {
     UNKNOWN(null),
     // Provision statuses
@@ -84,6 +86,7 @@ public enum DetailedStackStatus {
     NODE_FAILURE(Status.NODE_FAILURE),
     CLUSTER_UPGRADE_INIT_FAILED(Status.AVAILABLE),
     CLUSTER_MANAGER_UPGRADE_FAILED(Status.AVAILABLE),
+    CLUSTER_UPGRADE_STARTED(Status.UPDATE_IN_PROGRESS),
     CLUSTER_UPGRADE_FAILED(Status.AVAILABLE),
     CLUSTER_UPGRADE_FINISHED(Status.AVAILABLE),
     STACK_IMAGE_UPDATE_FAILED(Status.UPDATE_FAILED),
@@ -116,5 +119,14 @@ public enum DetailedStackStatus {
 
     public Status getStatus() {
         return status;
+    }
+
+    public static List<DetailedStackStatus> getUpgradeFailureStatuses() {
+        return List.of(
+                DetailedStackStatus.CLUSTER_UPGRADE_FAILED,
+                DetailedStackStatus.CLUSTER_MANAGER_UPGRADE_FAILED,
+                DetailedStackStatus.CLUSTER_MANAGER_NOT_RESPONDING,
+                DetailedStackStatus.NODE_FAILURE,
+                DetailedStackStatus.CLUSTER_UPGRADE_INIT_FAILED);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeService.java
@@ -47,6 +47,7 @@ public class ClusterUpgradeService {
     public void initUpgradeCluster(long stackId, StatedImage targetImage) {
         flowMessageService.fireEventAndLog(stackId, Status.UPDATE_IN_PROGRESS.name(), DATALAKE_UPGRADE, targetImage.getImage().getUuid());
         clusterService.updateClusterStatusByStackId(stackId, Status.UPDATE_IN_PROGRESS);
+        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.CLUSTER_UPGRADE_STARTED, "Cluster upgrade has been started.");
     }
 
     public void upgradeClusterManager(long stackId) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/provision/ClusterCreationActions.java
@@ -660,10 +660,11 @@ public class ClusterCreationActions {
     @Bean(name = "CLUSTER_CREATION_FAILED_STATE")
     public Action<?, ?> clusterCreationFailedAction() {
         return new AbstractStackFailureAction<ClusterCreationState, ClusterCreationEvent>() {
+
             @Override
             protected void doExecute(StackFailureContext context, StackFailureEvent payload, Map<Object, Object> variables) {
                 LOGGER.error("Cluster creation failed with exception", payload.getException());
-                clusterCreationService.handleClusterCreationFailure(context.getStackView(), payload.getException());
+                clusterCreationService.handleClusterCreationFailure(context.getStackView(), payload.getException(), context.getProvisionType());
                 getMetricService().incrementMetricCounter(MetricType.CLUSTER_CREATION_FAILED, context.getStackView(), payload.getException());
                 sendEvent(context);
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/AbstractStackFailureAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/AbstractStackFailureAction.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack;
 
+import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.action.AbstractStackCreationAction.PROVISION_TYPE;
+
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import javax.inject.Inject;
@@ -8,6 +11,7 @@ import javax.inject.Inject;
 import org.springframework.statemachine.StateContext;
 
 import com.sequenceiq.cloudbreak.core.flow2.AbstractStackAction;
+import com.sequenceiq.cloudbreak.reactor.api.event.stack.ProvisionType;
 import com.sequenceiq.flow.core.Flow;
 import com.sequenceiq.flow.core.FlowEvent;
 import com.sequenceiq.flow.core.FlowParameters;
@@ -34,7 +38,9 @@ public abstract class AbstractStackFailureAction<S extends FlowState, E extends 
         StackView stack = stackService.getViewByIdWithoutAuth(payload.getResourceId());
         MDCBuilder.buildMdcContext(stack);
         flow.setFlowFailed(payload.getException());
-        return new StackFailureContext(flowParameters, stack);
+        Map<Object, Object> variables = stateContext.getExtendedState().getVariables();
+        ProvisionType provisionType = (ProvisionType) variables.getOrDefault(PROVISION_TYPE, ProvisionType.REGULAR);
+        return new StackFailureContext(flowParameters, stack, provisionType);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/StackFailureContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/StackFailureContext.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack;
 
+import com.sequenceiq.cloudbreak.reactor.api.event.stack.ProvisionType;
 import com.sequenceiq.flow.core.CommonContext;
 import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.flow.core.FlowParameters;
@@ -8,13 +9,25 @@ public class StackFailureContext extends CommonContext {
 
     private final StackView stackView;
 
+    private final ProvisionType provisionType;
+
     public StackFailureContext(FlowParameters flowParameters, StackView stackView) {
         super(flowParameters);
         this.stackView = stackView;
+        this.provisionType = ProvisionType.REGULAR;
+    }
+
+    public StackFailureContext(FlowParameters flowParameters, StackView stackView, ProvisionType provisionType) {
+        super(flowParameters);
+        this.stackView = stackView;
+        this.provisionType = provisionType;
     }
 
     public StackView getStackView() {
         return stackView;
     }
 
+    public ProvisionType getProvisionType() {
+        return provisionType;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackStatusRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackStatusRepository.java
@@ -17,6 +17,6 @@ public interface StackStatusRepository extends CrudRepository<StackStatus, Long>
 
     Optional<StackStatus> findFirstByStackIdOrderByCreatedDesc(long stackId);
 
-    List<StackStatus> findAllByStackIdOrderByCreatedDesc(long stackId);
+    List<StackStatus> findAllByStackIdOrderByCreatedAsc(long stackId);
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackstatus/StackStatusService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackstatus/StackStatusService.java
@@ -21,7 +21,7 @@ public class StackStatusService {
     }
 
     public List<StackStatus> findAllStackStatusesById(long stackId) {
-        return repository.findAllByStackIdOrderByCreatedDesc(stackId);
+        return repository.findAllByStackIdOrderByCreatedAsc(stackId);
     }
 
 }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRecoveryResponse.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxRecoveryResponse.java
@@ -6,6 +6,9 @@ public class SdxRecoveryResponse {
 
     private FlowIdentifier flowIdentifier;
 
+    public SdxRecoveryResponse() {
+    }
+
     public SdxRecoveryResponse(FlowIdentifier flowIdentifier) {
         this.flowIdentifier = flowIdentifier;
     }

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxClient.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxClient.java
@@ -11,6 +11,7 @@ import com.sequenceiq.sdx.api.endpoint.ProgressEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxBackupEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxInternalEndpoint;
+import com.sequenceiq.sdx.api.endpoint.SdxRecoveryEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxRestoreEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxUpgradeEndpoint;
 
@@ -21,6 +22,8 @@ public interface SdxClient {
     SdxEndpoint sdxEndpoint();
 
     SdxUpgradeEndpoint sdxUpgradeEndpoint();
+
+    SdxRecoveryEndpoint sdxRecoveryEndpoint();
 
     FlowEndpoint flowEndpoint();
 

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxServiceApiKeyEndpoints.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxServiceApiKeyEndpoints.java
@@ -14,6 +14,7 @@ import com.sequenceiq.sdx.api.endpoint.ProgressEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxBackupEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxInternalEndpoint;
+import com.sequenceiq.sdx.api.endpoint.SdxRecoveryEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxRestoreEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxUpgradeEndpoint;
 
@@ -36,6 +37,11 @@ public class SdxServiceApiKeyEndpoints extends AbstractKeyBasedServiceEndpoint i
     @Override
     public SdxUpgradeEndpoint sdxUpgradeEndpoint() {
         return getEndpoint(SdxUpgradeEndpoint.class);
+    }
+
+    @Override
+    public SdxRecoveryEndpoint sdxRecoveryEndpoint() {
+        return getEndpoint(SdxRecoveryEndpoint.class);
     }
 
     @Override

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxServiceCrnEndpoints.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/client/SdxServiceCrnEndpoints.java
@@ -14,6 +14,7 @@ import com.sequenceiq.sdx.api.endpoint.ProgressEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxBackupEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxInternalEndpoint;
+import com.sequenceiq.sdx.api.endpoint.SdxRecoveryEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxRestoreEndpoint;
 import com.sequenceiq.sdx.api.endpoint.SdxUpgradeEndpoint;
 
@@ -36,6 +37,11 @@ public class SdxServiceCrnEndpoints extends AbstractUserCrnServiceEndpoint imple
     @Override
     public SdxUpgradeEndpoint sdxUpgradeEndpoint() {
         return getEndpoint(SdxUpgradeEndpoint.class);
+    }
+
+    @Override
+    public SdxRecoveryEndpoint sdxRecoveryEndpoint() {
+        return getEndpoint(SdxRecoveryEndpoint.class);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRecoveryAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRecoveryAction.java
@@ -1,0 +1,38 @@
+package com.sequenceiq.it.cloudbreak.action.sdx;
+
+import java.util.Collections;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
+import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
+import com.sequenceiq.sdx.api.model.SdxRecoveryResponse;
+
+public class SdxRecoveryAction implements Action<SdxTestDto, SdxClient> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxRecoveryAction.class);
+
+    @Override
+    public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
+        SdxRecoveryRequest recoveryRequest = testDto.getSdxRecoveryRequest();
+
+        Log.when(LOGGER, " SDX endpoint: %s" + client.getDefaultClient().sdxEndpoint() + ", SDX's environment: " + testDto.getRequest().getEnvironment());
+        Log.whenJson(LOGGER, " SDX recovery request: ", recoveryRequest);
+        SdxRecoveryResponse recoveryResponse = client.getDefaultClient()
+                .sdxRecoveryEndpoint()
+                .recoverClusterByName(testDto.getName(), recoveryRequest);
+        testDto.setFlow("SDX recovery", recoveryResponse.getFlowIdentifier());
+        SdxClusterDetailResponse detailedResponse = client.getDefaultClient()
+                .sdxEndpoint()
+                .getDetail(testDto.getName(), Collections.emptySet());
+        testDto.setResponse(detailedResponse);
+        Log.whenJson(LOGGER, " SDX recovery response: ", detailedResponse);
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/SdxTestClient.java
@@ -24,6 +24,7 @@ import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteCustomAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxForceDeleteInternalAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxListAction;
+import com.sequenceiq.it.cloudbreak.action.sdx.SdxRecoveryAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshCustomAction;
 import com.sequenceiq.it.cloudbreak.action.sdx.SdxRefreshInternalAction;
@@ -133,6 +134,10 @@ public class SdxTestClient {
 
     public Action<SdxTestDto, SdxClient> upgrade() {
         return new SdxUpgradeAction();
+    }
+
+    public Action<SdxTestDto, SdxClient> recover() {
+        return new SdxRecoveryAction();
     }
 
     public Action<SdxInternalTestDto, SdxClient> resize() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxRecoveryTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxRecoveryTestDto.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.it.cloudbreak.dto.sdx;
+
+import com.sequenceiq.it.cloudbreak.Prototype;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
+import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
+import com.sequenceiq.sdx.api.model.SdxRecoveryResponse;
+import com.sequenceiq.sdx.api.model.SdxRecoveryType;
+
+@Prototype
+public class SdxRecoveryTestDto extends AbstractSdxTestDto<SdxRecoveryRequest, SdxRecoveryResponse, SdxRecoveryTestDto> {
+
+    public SdxRecoveryTestDto(SdxRecoveryRequest request, TestContext testContext) {
+        super(request, testContext);
+    }
+
+    public SdxRecoveryTestDto(TestContext testContext) {
+        super(new SdxRecoveryRequest(), testContext);
+    }
+
+    public SdxRecoveryTestDto() {
+        super(SdxRecoveryTestDto.class.getSimpleName().toUpperCase());
+    }
+
+    @Override
+    public SdxRecoveryTestDto valid() {
+        return withRecoveryType(SdxRecoveryType.RECOVER_WITHOUT_DATA);
+    }
+
+    public SdxRecoveryTestDto withRecoveryType(SdxRecoveryType type) {
+        getRequest().setType(type);
+        return this;
+    }
+
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -56,6 +56,7 @@ import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 import com.sequenceiq.sdx.api.model.SdxDatabaseRequest;
 import com.sequenceiq.sdx.api.model.SdxRecipe;
+import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
 import com.sequenceiq.sdx.api.model.SdxRepairRequest;
 import com.sequenceiq.sdx.api.model.SdxUpgradeRequest;
 
@@ -158,6 +159,10 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
 
     public SdxTestDto awaitForFlow() {
         return awaitForFlow(emptyRunningParameter());
+    }
+
+    public SdxTestDto awaitForFlowFail() {
+        return awaitForFlow(emptyRunningParameter().withWaitForFlowFail());
     }
 
     @Override
@@ -351,6 +356,14 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
             throw new IllegalArgumentException("SDX Upgrade does not exist!");
         }
         return upgrade.getRequest();
+    }
+
+    public SdxRecoveryRequest getSdxRecoveryRequest() {
+        SdxRecoveryTestDto recovery = given(SdxRecoveryTestDto.class);
+        if (recovery == null) {
+            throw new IllegalArgumentException("SDX Recovery does not exist!");
+        }
+        return recovery.getRequest();
     }
 
     public SdxClusterResizeRequest getSdxResizeRequest() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/SdxBackupRestoreTest.java
@@ -83,19 +83,19 @@ public class SdxBackupRestoreTest extends PreconditionSdxE2ETest {
     }
 
     private SdxInternalTestDto validateDatalakeStatus(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) {
-        String statuReason = client.getDefaultClient()
+        String statusReason = client.getDefaultClient()
                 .sdxEndpoint()
                 .getDetailByCrn(testDto.getCrn(), Collections.emptySet())
                 .getStatusReason();
-        if (statuReason.contains("Datalake backup failed")) {
-            LOGGER.error(String.format(" Sdx '%s' backup has been failed: '%s' ", testDto.getName(), statuReason));
-            throw new TestFailException(String.format(" Sdx '%s' backup has been failed: '%s' ", testDto.getName(), statuReason));
-        } else if (statuReason.contains("Datalake restore failed")) {
-            LOGGER.error(String.format(" Sdx '%s' restore has been failed: '%s' ", testDto.getName(), statuReason));
-            throw new TestFailException(String.format(" Sdx '%s' restore has been failed: '%s' ", testDto.getName(), statuReason));
+        if (statusReason.contains("Datalake backup failed")) {
+            LOGGER.error(String.format(" Sdx '%s' backup has been failed: '%s' ", testDto.getName(), statusReason));
+            throw new TestFailException(String.format(" Sdx '%s' backup has been failed: '%s' ", testDto.getName(), statusReason));
+        } else if (statusReason.contains("Datalake restore failed")) {
+            LOGGER.error(String.format(" Sdx '%s' restore has been failed: '%s' ", testDto.getName(), statusReason));
+            throw new TestFailException(String.format(" Sdx '%s' restore has been failed: '%s' ", testDto.getName(), statusReason));
         } else {
-            LOGGER.info(String.format(" Sdx '%s' backup/restore has been done with '%s'. ", testDto.getName(), statuReason));
-            Log.then(LOGGER, format(" Sdx '%s' backup/restore has been done with '%s'. ", testDto.getName(), statuReason));
+            LOGGER.info(String.format(" Sdx '%s' backup/restore has been done with '%s'. ", testDto.getName(), statusReason));
+            Log.then(LOGGER, format(" Sdx '%s' backup/restore has been done with '%s'. ", testDto.getName(), statusReason));
         }
         return testDto;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRecoveryTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRecoveryTests.java
@@ -1,0 +1,118 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.sdx;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.emptyRunningParameter;
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+import static java.lang.String.format;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.image.StackImageV4Response;
+import com.sequenceiq.it.cloudbreak.SdxClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
+import com.sequenceiq.it.cloudbreak.log.Log;
+import com.sequenceiq.it.cloudbreak.util.SdxUtil;
+import com.sequenceiq.it.cloudbreak.util.spot.UseSpotInstances;
+import com.sequenceiq.it.cloudbreak.util.ssh.action.SshJClientActions;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+
+public class SdxRecoveryTests extends PreconditionSdxE2ETest {
+
+    private static final String INJECT_UPGRADE_FAILURE_CMD =
+            "sudo sh -c \"echo -e '\\n127.0.0.1 cloudera-build-us-west-1.vpc.cloudera.com' >> /etc/hosts\"";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SdxRecoveryTests.class);
+
+    @Inject
+    private SshJClientActions sshJClientActions;
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private SdxUtil sdxUtil;
+
+    @Inject
+    private CommonClusterManagerProperties commonClusterManagerProperties;
+
+    @Test(dataProvider = TEST_CONTEXT)
+    @UseSpotInstances
+    @Description(
+            given = "there is a running Cloudbreak and an SDX cluster in available state, "
+                    + "upgrade is called on the SDX cluster then failure point inserted to make the upgrade fail",
+            when = "recovery called on the SDX cluster",
+            then = "SDX recovery should be successful, the cluster should be up and running, the image should be the same, stack CRN should be retained"
+    )
+    public void testSDXUpgradeRecovery(TestContext testContext) {
+        String sdx = resourcePropertyProvider().getName();
+        AtomicReference<String> originalImageId = new AtomicReference<>();
+        AtomicReference<String> originalCrn = new AtomicReference<>();
+
+        testContext
+                .given(sdx, SdxTestDto.class)
+                .withCloudStorage()
+                .withRuntimeVersion(commonClusterManagerProperties.getUpgrade().getCurrentRuntimeVersion())
+                .when(sdxTestClient.create(), key(sdx))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdx))
+                .awaitForHealthyInstances()
+                .then((tc, testDto, client) -> getOriginalImageIdAndStackCrn(originalImageId, originalCrn, testDto, client))
+                .when(sdxTestClient.upgrade(), key(sdx))
+                .await(SdxClusterStatusResponse.DATALAKE_UPGRADE_IN_PROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
+                .then((tc, testDto, client) -> executeCommandToCauseUpgradeFailure(testDto, client))
+                .awaitForFlowFail()
+                .when(sdxTestClient.recover(), key(sdx))
+                .awaitForFlow(emptyRunningParameter().withWaitForFlowSuccess())
+                .then((tc, dto, client) -> validateStackCrn(originalCrn, dto))
+                .then((tc, dto, client) -> validateImageId(originalImageId, dto))
+                .validate();
+    }
+
+    private SdxTestDto getOriginalImageIdAndStackCrn(AtomicReference<String> originalImageId,
+            AtomicReference<String> originalCrn, SdxTestDto testDto, SdxClient client) {
+        originalImageId.set(sdxUtil.getImageId(testDto, client));
+        originalCrn.set(testDto.getCrn());
+        return testDto;
+    }
+
+    private SdxTestDto executeCommandToCauseUpgradeFailure(SdxTestDto testDto, SdxClient client) {
+        Map<String, Pair<Integer, String>> hostsAppenderCmdResultByIpsMap = sshJClientActions.executeSshCommand(getInstanceGroups(testDto, client),
+                List.of(HostGroupType.MASTER.getName(), HostGroupType.IDBROKER.getName()), INJECT_UPGRADE_FAILURE_CMD, false);
+        LOGGER.debug("SSH hosts file edit result: " + hostsAppenderCmdResultByIpsMap);
+        return testDto;
+    }
+
+    private SdxTestDto validateStackCrn(AtomicReference<String> originalCrn, SdxTestDto dto) {
+        String newCrn = dto.getResponse().getStackV4Response().getCrn();
+        Log.log(LOGGER, format(" Stack new crn: %s ", newCrn));
+        if (!newCrn.equals(originalCrn.get())) {
+            throw new TestFailException(" The stack CRN has changed to: " + newCrn + " instead of: " + originalCrn.get());
+        }
+        return dto;
+    }
+
+    private SdxTestDto validateImageId(AtomicReference<String> originalImageId, SdxTestDto dto) {
+        StackImageV4Response image = dto.getResponse().getStackV4Response().getImage();
+        Log.log(LOGGER, format(" Image Catalog Name: %s ", image.getCatalogName()));
+        Log.log(LOGGER, format(" Image Catalog URL: %s ", image.getCatalogUrl()));
+        Log.log(LOGGER, format(" Image ID: %s ", image.getId()));
+
+        if (!image.getId().equals(originalImageId.get())) {
+            throw new TestFailException(" The selected image ID is: " + image.getId() + " instead of: " + originalImageId.get());
+        }
+        return dto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxUpgradeTests.java
@@ -25,6 +25,7 @@ import com.sequenceiq.sdx.api.model.SdxClusterShape;
 import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
 
 public class SdxUpgradeTests extends PreconditionSdxE2ETest {
+
     @Inject
     private SdxTestClient sdxTestClient;
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxUtil.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/SdxUtil.java
@@ -8,18 +8,28 @@ import org.springframework.stereotype.Component;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.instancegroup.InstanceGroupV4Response;
 import com.sequenceiq.it.cloudbreak.SdxClient;
 import com.sequenceiq.it.cloudbreak.dto.AbstractSdxTestDto;
+import com.sequenceiq.sdx.api.model.SdxClusterDetailResponse;
 
 @Component
 public class SdxUtil {
 
     public List<String> getInstanceIds(AbstractSdxTestDto testDto, SdxClient sdxClient, String hostGroupName) {
-        List<InstanceGroupV4Response> instanceGroups = sdxClient.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), new HashSet<>())
+        List<InstanceGroupV4Response> instanceGroups = getSdxClusterDetailResponse(testDto, sdxClient)
                 .getStackV4Response().getInstanceGroups();
         return InstanceUtil.getInstanceIds(instanceGroups, hostGroupName);
     }
 
     public String getShape(AbstractSdxTestDto testDto, SdxClient sdxClient) {
-        return sdxClient.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), new HashSet<>())
+        return getSdxClusterDetailResponse(testDto, sdxClient)
                 .getClusterShape().name();
+    }
+
+    public String getImageId(AbstractSdxTestDto testDto, SdxClient sdxClient) {
+        return getSdxClusterDetailResponse(testDto, sdxClient)
+                .getStackV4Response().getImage().getId();
+    }
+
+    private SdxClusterDetailResponse getSdxClusterDetailResponse(AbstractSdxTestDto testDto, SdxClient sdxClient) {
+        return sdxClient.getDefaultClient().sdxEndpoint().getDetail(testDto.getName(), new HashSet<>());
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/azure/azurevm/action/AzureClientActions.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.PowerState;
 import com.microsoft.azure.management.compute.VirtualMachine;
+import com.microsoft.azure.management.compute.VirtualMachineDataDisk;
 import com.microsoft.azure.management.resources.fluentcore.arm.models.HasId;
-import com.sequenceiq.it.cloudbreak.ResourcePropertyProvider;
 import com.sequenceiq.it.cloudbreak.log.Log;
 import com.sequenceiq.it.cloudbreak.util.azure.AzureInstanceActionExecutor;
 import com.sequenceiq.it.cloudbreak.util.azure.AzureInstanceActionResult;
@@ -27,10 +27,8 @@ import rx.schedulers.Schedulers;
 
 @Component
 public class AzureClientActions {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AzureClientActions.class);
 
-    @Inject
-    private ResourcePropertyProvider resourcePropertyProvider;
+    private static final Logger LOGGER = LoggerFactory.getLogger(AzureClientActions.class);
 
     @Inject
     private Azure azure;
@@ -40,7 +38,10 @@ public class AzureClientActions {
         instanceIds.forEach(id -> {
             String resourceGroup = getResourceGroupName(clusterName, id);
             VirtualMachine vm = azure.virtualMachines().getByResourceGroup(resourceGroup, id);
-            diskIds.addAll(vm.dataDisks().values().stream().map(HasId::id).collect(Collectors.toList()));
+            Map<Integer, VirtualMachineDataDisk> dataDiskMap = vm.dataDisks();
+            if (dataDiskMap != null && !dataDiskMap.isEmpty()) {
+                diskIds.addAll(dataDiskMap.values().stream().map(HasId::id).collect(Collectors.toList()));
+            }
         });
         return diskIds;
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshJClientActions.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/ssh/action/SshJClientActions.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -274,8 +275,7 @@ public class SshJClientActions extends SshJClient {
             Pair<Integer, String> cmdOut = execute(sshClient, fileListCommand);
             Log.log(LOGGER, format(" Command exit status '%s' and result '%s'. ", cmdOut.getKey(), cmdOut.getValue()));
 
-            List<String> cmdOutputValues = List.of(cmdOut.getValue().split("[\\r\\n\\t]"))
-                    .stream().filter(Objects::nonNull).collect(Collectors.toList());
+            List<String> cmdOutputValues = Stream.of(cmdOut.getValue().split("[\\r\\n\\t]")).filter(Objects::nonNull).collect(Collectors.toList());
             boolean fileFound = cmdOutputValues.stream()
                     .anyMatch(outputValue -> outputValue.strip().startsWith("/"));
             String foundFilePath = cmdOutputValues.stream()

--- a/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-longrunning-e2e-tests.yaml
@@ -3,6 +3,7 @@ tests:
   - name: "aws-longrunning-e2e-tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.AwsDistroXEphemeralTemporaryStorageStopStartTest

--- a/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
@@ -3,6 +3,7 @@ tests:
   - name: "azure-longrunning-e2e-tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests

--- a/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/gcp-longrunning-e2e-tests.yaml
@@ -4,3 +4,4 @@ tests:
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecoveryTests

--- a/integration-test/src/main/resources/testsuites/e2e/sdx-recovery-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/sdx-recovery-tests.yaml
@@ -1,0 +1,5 @@
+name: "sdx-recovery-tests"
+tests:
+  - name: "sdx_e2e_recovery_tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecoveryTests


### PR DESCRIPTION
- Long running E2E test that performs a failed upgrade then a successful recovery
- includes a fix of UPGRADE_FAILED statuses necessary for recovery validation
