### PR TITLE
CB-14361 Schedule long sync when data lake is deleted on provider side

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/statuschecker/StatusCheckerConfig.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/statuschecker/StatusCheckerConfig.java
@@ -15,12 +15,19 @@ public class StatusCheckerConfig {
     @Value("${statuschecker.intervalsec:180}")
     private int intervalInSeconds;
 
+    @Value("${statuschecker.longintervalsec:7200}")
+    private int longIntervalInSeconds;
+
     @Value("${statuschecker.enabled:true}")
     private boolean autoSyncEnabled;
 
     @PostConstruct
     void logEnablement() {
-        LOGGER.info("Auto sync is {}", autoSyncEnabled ? "enabled" : "disabled");
+        if (autoSyncEnabled) {
+            LOGGER.info("Auto sync is enabled. Short sync period is {} sec. Long sync period is {} sec.", intervalInSeconds, longIntervalInSeconds);
+        } else {
+            LOGGER.info("Auto sync is disabled.");
+        }
     }
 
     public boolean isAutoSyncEnabled() {
@@ -29,5 +36,9 @@ public class StatusCheckerConfig {
 
     public int getIntervalInSeconds() {
         return intervalInSeconds;
+    }
+
+    public int getLongIntervalInSeconds() {
+        return longIntervalInSeconds;
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
@@ -125,7 +126,7 @@ public class StackStatusCheckerJobTest {
     public void init() {
         Tracer tracer = Mockito.mock(Tracer.class);
         underTest = new StackStatusCheckerJob(tracer);
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         when(flowLogService.isOtherFlowRunning(anyLong())).thenReturn(Boolean.FALSE);
         underTest.setLocalId("1");
         underTest.setRemoteResourceCrn("remote:crn");
@@ -141,6 +142,7 @@ public class StackStatusCheckerJobTest {
         stack.setCreator(user);
 
         when(stackService.get(anyLong())).thenReturn(stack);
+        when(jobExecutionContext.getMergedJobDataMap()).thenReturn(new JobDataMap());
     }
 
     @After

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusIntegrationTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -160,6 +161,7 @@ class StackStatusIntegrationTest {
         setUpStack();
         setUpClusterApi();
         when(environmentClientService.getByCrnAsInternal(anyString())).thenReturn(environment);
+        when(jobExecutionContext.getMergedJobDataMap()).thenReturn(new JobDataMap());
     }
 
     private void setUpRunningInstances() {


### PR DESCRIPTION
Schedule long sync when data lake is deleted on provider side. This avoids unscheduling the sync job if for example azure returns empty node list. If the cluster becomes available it reschedules the short sync jobs.

Refactored sdx status syncer to work based on stack status rather than sdx status. Previously it was implemented like a state machine but it missed certain transitions (for example if the user stops all instances and then deletes data lake nodes from the provider the data lake state would remain in stopped). Current implementation takes CB stack status as the source of truth.