### PR TITLE
CB-14624 Cluster definition uniqueness across the env instead of work…

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/ClusterTemplate.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/cluster/ClusterTemplate.java
@@ -27,7 +27,7 @@ import com.sequenceiq.cloudbreak.workspace.model.Workspace;
 import com.sequenceiq.cloudbreak.workspace.model.WorkspaceAwareResource;
 
 @Entity
-@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"workspace_id", "name"}))
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"workspace_id", "name", "resourceCrn"}))
 public class ClusterTemplate implements WorkspaceAwareResource, Serializable {
 
     @Id

--- a/core/src/main/resources/schema/app/20211025144933_CB-14624_unique_constraint_to_cluster_template_crn.sql
+++ b/core/src/main/resources/schema/app/20211025144933_CB-14624_unique_constraint_to_cluster_template_crn.sql
@@ -1,0 +1,7 @@
+-- // CB-1859 set crn to stack
+-- Migration SQL that makes the change goes here.
+ALTER TABLE clustertemplate ADD CONSTRAINT clustertemplate_crn_uq UNIQUE (resourceCrn);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE clustertemplate DROP constraint clustertemplate_crn_uq;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateServiceTest.java
@@ -1,0 +1,120 @@
+package com.sequenceiq.cloudbreak.service.template;
+
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterTemplate;
+import com.sequenceiq.cloudbreak.repository.cluster.ClusterTemplateRepository;
+import com.sequenceiq.cloudbreak.service.environment.EnvironmentClientService;
+import com.sequenceiq.cloudbreak.workspace.model.Workspace;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class ClusterTemplateServiceTest {
+
+    @InjectMocks
+    private ClusterTemplateService underTest;
+
+    @Mock
+    private ClusterTemplateRepository clusterTemplateRepository;
+
+    @Mock
+    private EnvironmentClientService environmentClientService;
+
+    @Mock
+    private Workspace workspace;
+
+    @Test
+    public void testCheckDuplicationWhenExistedResourceEnvNullWithoutException() {
+        String name = "new-name";
+        ClusterTemplate newOne = new ClusterTemplate();
+        newOne.setName(name);
+        newOne.setStatus(ResourceStatus.USER_MANAGED);
+        newOne.setWorkspace(workspace);
+        Stack stack = new Stack();
+        stack.setEnvironmentCrn("envCrn");
+        newOne.setStackTemplate(stack);
+
+        ClusterTemplate existed = new ClusterTemplate();
+        existed.setStackTemplate(new Stack());
+
+        when(clusterTemplateRepository.findByNameAndWorkspace(name, workspace)).thenReturn(Optional.of(existed));
+
+        underTest.checkDuplication(newOne);
+    }
+
+    @Test
+    public void testCheckDuplicationWhenNewResourceEnvNullWithoutException() {
+        String name = "new-name";
+        ClusterTemplate newOne = new ClusterTemplate();
+        newOne.setName(name);
+        newOne.setStatus(ResourceStatus.USER_MANAGED);
+        newOne.setWorkspace(workspace);
+        Stack stack = new Stack();
+        newOne.setStackTemplate(stack);
+
+        ClusterTemplate existed = new ClusterTemplate();
+        Stack existedStack = new Stack();
+        existedStack.setEnvironmentCrn("envCrn");
+        existed.setStackTemplate(existedStack);
+
+        when(clusterTemplateRepository.findByNameAndWorkspace(name, workspace)).thenReturn(Optional.of(existed));
+
+        underTest.checkDuplication(newOne);
+    }
+
+    @Test
+    public void testCheckDuplicationWhenEnvCrnisSame() {
+        String name = "new-name";
+        ClusterTemplate newOne = new ClusterTemplate();
+        newOne.setName(name);
+        newOne.setStatus(ResourceStatus.USER_MANAGED);
+        newOne.setWorkspace(workspace);
+        Stack stack = new Stack();
+        stack.setEnvironmentCrn("envCrn");
+        newOne.setStackTemplate(stack);
+
+        ClusterTemplate existed = new ClusterTemplate();
+        Stack existedStack = new Stack();
+        existedStack.setEnvironmentCrn("envCrn");
+        existed.setStackTemplate(existedStack);
+
+        DetailedEnvironmentResponse envResponse = new DetailedEnvironmentResponse();
+        envResponse.setName("envName");
+
+        when(clusterTemplateRepository.findByNameAndWorkspace(name, workspace)).thenReturn(Optional.of(existed));
+        when(environmentClientService.getByCrn("envCrn")).thenReturn(envResponse);
+
+        DuplicateClusterTemplateException actual = Assertions.assertThrows(DuplicateClusterTemplateException.class, () -> underTest.checkDuplication(newOne));
+        Assertions.assertEquals("Cluster definition already exists with name 'new-name' for the environment of 'envName'", actual.getMessage());
+    }
+
+    @Test
+    public void testCheckDuplicationWhenExistedResourceEnvAndNewOneenvCrnNull() {
+        String name = "new-name";
+        ClusterTemplate newOne = new ClusterTemplate();
+        newOne.setName(name);
+        newOne.setStatus(ResourceStatus.USER_MANAGED);
+        newOne.setWorkspace(workspace);
+        Stack stack = new Stack();
+        newOne.setStackTemplate(stack);
+
+        ClusterTemplate existed = new ClusterTemplate();
+        existed.setStackTemplate(new Stack());
+
+        when(clusterTemplateRepository.findByNameAndWorkspace(name, workspace)).thenReturn(Optional.of(existed));
+
+        DuplicateClusterTemplateException actual = Assertions.assertThrows(DuplicateClusterTemplateException.class, () -> underTest.checkDuplication(newOne));
+        Assertions.assertEquals("The default cluster definition could not be created with the same name", actual.getMessage());
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/ClusterTemplateTest.java
@@ -298,7 +298,7 @@ public class ClusterTemplateTest extends AbstractMockTest {
     )
     public void testCreateAgainClusterTemplate(MockedTestContext testContext) {
         String generatedKey = resourcePropertyProvider().getName();
-
+        String envName = testContext.get(EnvironmentTestDto.class).getName();
         testContext
                 .given("placementSettings", PlacementSettingsTestDto.class)
                 .withRegion(MockCloudProvider.LONDON)
@@ -308,7 +308,8 @@ public class ClusterTemplateTest extends AbstractMockTest {
                 .given(ClusterTemplateTestDto.class)
                 .withName(resourcePropertyProvider().getName())
                 .when(clusterTemplateTestClient.createV4(), RunningParameter.key(generatedKey))
-                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class, expectedMessage("^clustertemplate already exists with name.*"))
+                .whenException(clusterTemplateTestClient.createV4(), BadRequestException.class, expectedMessage("^Cluster definition already exists with " +
+                        "name.*" + envName))
                 .validate();
     }
 


### PR DESCRIPTION
…space. Check the cluster definition name and the related stack's env crn.

* if the new and old one's env crn is null -> exception (they are default template)
* if the env crn is the same -> exception (they are in the same env)
* if the new or the old one's env crn is null -> ok

See detailed description in the commit message.