### PR TITLE
CB-14084: When DH is started it should reload the database config and reconfigure the services.

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -65,6 +65,10 @@ public interface ClusterApi {
         clusterModificationService().upgradeClusterRuntime(components, patchUpgrade, remoteDataContext);
     }
 
+    default void updateServiceConfig(String serviceType, Map<String, String> config) throws CloudbreakException {
+        clusterModificationService().updateServiceConfig(serviceType, config);
+    }
+
     default void stopCluster(boolean disableKnoxAutorestart) throws CloudbreakException {
         clusterModificationService().stopCluster(disableKnoxAutorestart);
     }

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -39,6 +39,8 @@ public interface ClusterModificationService {
 
     void updateServiceConfigAndRestartService(String serviceName, String configName, String newConfigValue) throws Exception;
 
+    void updateServiceConfig(String serviceName, Map<String, String> config) throws CloudbreakException;
+
     void downloadAndDistributeParcels(Set<ClusterComponent> components, boolean patchUpgrade) throws CloudbreakException;
 
     Optional<String> getRoleConfigValueByServiceType(String clusterName, String roleConfigGroup, String serviceType, String configName);

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -866,9 +866,14 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
 
     @Override
     public void updateServiceConfigAndRestartService(String serviceType, String configName, String newConfigValue) throws Exception {
-        configService.modifyServiceConfigValue(apiClient, stack.getName(), serviceType, configName, newConfigValue);
+        configService.modifyServiceConfig(apiClient, stack.getName(), serviceType, Collections.singletonMap(configName, newConfigValue));
         ClustersResourceApi clustersResourceApi = clouderaManagerApiFactory.getClustersResourceApi(apiClient);
         restartStaleServices(clustersResourceApi, false);
+    }
+
+    @Override
+    public void updateServiceConfig(String serviceName, Map<String, String> config) throws CloudbreakException {
+        configService.modifyServiceConfig(apiClient, stack.getName(), serviceName, config);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/PostgresConfigService.java
@@ -14,6 +14,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
@@ -58,6 +59,11 @@ public class PostgresConfigService {
         if (!postgresConfig.isEmpty()) {
             servicePillar.put(POSTGRESQL_SERVER, new SaltPillarProperties("/postgresql/postgre.sls", singletonMap("postgres", postgresConfig)));
         }
+    }
+
+    public Set<RDSConfig> createRdsConfigIfNeeded(Stack stack, Cluster cluster, DatabaseType databaseType) {
+        return rdsConfigProviderFactory.getRdsConfigProviderForRdsType(databaseType)
+                .createPostgresRdsConfigIfNeeded(stack, cluster);
     }
 
     public Set<RDSConfig> createRdsConfigIfNeeded(Stack stack, Cluster cluster) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/ClusterStartHandler.java
@@ -1,5 +1,9 @@
 package com.sequenceiq.cloudbreak.reactor.handler.cluster;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -7,14 +11,23 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.database.base.DatabaseType;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.core.bootstrap.service.container.postgres.PostgresConfigService;
 import com.sequenceiq.cloudbreak.core.cluster.ClusterBuilderService;
+import com.sequenceiq.cloudbreak.domain.RDSConfig;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartRequest;
 import com.sequenceiq.cloudbreak.reactor.api.event.cluster.ClusterStartResult;
+import com.sequenceiq.cloudbreak.service.CloudbreakException;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.rdsconfig.RedbeamsDbCertificateProvider;
+import com.sequenceiq.cloudbreak.service.sharedservice.DatalakeService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.template.views.RdsView;
 import com.sequenceiq.flow.event.EventSelectorUtil;
 import com.sequenceiq.flow.reactor.api.handler.EventHandler;
 
@@ -25,6 +38,22 @@ import reactor.bus.EventBus;
 public class ClusterStartHandler implements EventHandler<ClusterStartRequest> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterStartHandler.class);
+
+    private static final String HIVE_SERVICE = "HIVE";
+
+    private static final String HIVE_METASTORE_DATABASE_HOST = "hive_metastore_database_host";
+
+    private static final String HIVE_METASTORE_DATABASE_NAME = "hive_metastore_database_name";
+
+    private static final String HIVE_METASTORE_DATABASE_PASSWORD = "hive_metastore_database_password";
+
+    private static final String HIVE_METASTORE_DATABASE_PORT = "hive_metastore_database_port";
+
+    private static final String HIVE_METASTORE_DATABASE_TYPE = "hive_metastore_database_type";
+
+    private static final String HIVE_METASTORE_DATABASE_USER = "hive_metastore_database_user";
+
+    private static final String JDBC_URL_OVERRIDE = "jdbc_url_override";
 
     @Inject
     private ClusterApiConnectors apiConnectors;
@@ -41,6 +70,18 @@ public class ClusterStartHandler implements EventHandler<ClusterStartRequest> {
     @Inject
     private EventBus eventBus;
 
+    @Inject
+    private PostgresConfigService postgresConfigService;
+
+    @Inject
+    private RedbeamsDbCertificateProvider dbCertificateProvider;
+
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private DatalakeService datalakeService;
+
     @Override
     public String selector() {
         return EventSelectorUtil.selector(ClusterStartRequest.class);
@@ -52,12 +93,28 @@ public class ClusterStartHandler implements EventHandler<ClusterStartRequest> {
         ClusterStartResult result;
         try {
             Stack stack = stackService.getByIdWithListsInTransaction(request.getResourceId());
+            Optional<Stack> datalakeStack = datalakeService.getDatalakeStackByDatahubStack(stack);
             int requestId;
-            if (stack.getType() == StackType.WORKLOAD &&
-            entitlementService.isDatalakeLightToMediumMigrationEnabled(ThreadBasedUserCrnProvider.getAccountId())) {
+            // Update the RDC of data lake and update the HMS configuration
+            if (stack.getType() == StackType.WORKLOAD && datalakeStack.isPresent() &&
+                    isDatalakeCreatedAfterDataHub(datalakeStack.get(), stack) &&
+                    entitlementService.isDatalakeLightToMediumMigrationEnabled(ThreadBasedUserCrnProvider.getAccountId())) {
                 LOGGER.info("Triggering update of remote data context");
                 apiConnectors.getConnector(stack).startClusterMgmtServices();
                 clusterBuilderService.configureManagementServices(stack.getId());
+                //Update Hive service configuration
+                Cluster cluster = clusterService.getById(datalakeStack.get().getCluster().getId());
+                Optional<RDSConfig> rdsConfig = postgresConfigService.createRdsConfigIfNeeded(datalakeStack.get(), cluster, DatabaseType.HIVE)
+                        .stream().filter(config -> config.getType().toLowerCase().equals(DatabaseType.HIVE.toString().toLowerCase()))
+                        .findFirst();
+                try {
+                    if (rdsConfig.isEmpty()) {
+                        throw new CloudbreakException("Could not find RDS configuration for Hive");
+                    }
+                    apiConnectors.getConnector(stack).updateServiceConfig(HIVE_SERVICE, getRdsConfigMap(rdsConfig.get()));
+                } catch (CloudbreakException e) {
+                    LOGGER.info("Exception while updating the Data-Hub configuration", e);
+                }
                 requestId = apiConnectors.getConnector(stack).startClusterServices();
             } else {
                 requestId = apiConnectors.getConnector(stack).startCluster();
@@ -67,5 +124,22 @@ public class ClusterStartHandler implements EventHandler<ClusterStartRequest> {
             result = new ClusterStartResult(e.getMessage(), e, request);
         }
         eventBus.notify(result.selector(), new Event<>(event.getHeaders(), result));
+    }
+
+    private Map<String, String> getRdsConfigMap(RDSConfig rdsConfig) {
+        RdsView hiveRdsView = new RdsView(rdsConfig, dbCertificateProvider.getSslCertsFilePath());
+        Map<String, String> configs = new HashMap<String, String>();
+        configs.put(HIVE_METASTORE_DATABASE_HOST, hiveRdsView.getHost());
+        configs.put(HIVE_METASTORE_DATABASE_NAME, hiveRdsView.getDatabaseName());
+        configs.put(HIVE_METASTORE_DATABASE_PASSWORD, hiveRdsView.getConnectionPassword());
+        configs.put(HIVE_METASTORE_DATABASE_PORT, hiveRdsView.getPort());
+        configs.put(HIVE_METASTORE_DATABASE_TYPE, hiveRdsView.getSubprotocol());
+        configs.put(HIVE_METASTORE_DATABASE_USER, hiveRdsView.getConnectionUserName());
+        configs.put(JDBC_URL_OVERRIDE, hiveRdsView.getConnectionURL());
+        return configs;
+    }
+
+    private boolean isDatalakeCreatedAfterDataHub(Stack datalakeStack, Stack dataHubStack) {
+        return datalakeStack.getCreated() > dataHubStack.getCreated();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RdsConfigProviderFactory.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/rdsconfig/RdsConfigProviderFactory.java
@@ -14,7 +14,7 @@ public class RdsConfigProviderFactory {
     @Inject
     private Set<AbstractRdsConfigProvider> rdsConfigProviders;
 
-    private AbstractRdsConfigProvider getRdsConfigProviderForRdsType(DatabaseType type) {
+    public AbstractRdsConfigProvider getRdsConfigProviderForRdsType(DatabaseType type) {
         return rdsConfigProviders.stream().filter(rdsConfigProvider -> rdsConfigProvider.getRdsType() == type).findFirst()
                 .orElseThrow(() -> new UnsupportedOperationException(type.name() + " RdsConfigProvider is not supported!"));
     }


### PR DESCRIPTION
The goal of this change is to fetch the database configuration of a data lake and update the HMS configuration in DH when they are started.

This is needed when a datalake is resized. When a data lake is resized, the backend database is re-created.
