### PR TITLE
CB-14704 Handle Oozie HA datahub with load balancer disabled

### DIFF
--- a/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLoadBalancerLaunchService.java
+++ b/cloud-aws-cloudformation/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/connector/resource/AwsLoadBalancerLaunchService.java
@@ -48,6 +48,7 @@ import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.notification.PersistenceNotifier;
 import com.sequenceiq.common.api.type.CommonStatus;
+import com.sequenceiq.common.api.type.LoadBalancerType;
 
 @Service
 public class AwsLoadBalancerLaunchService {
@@ -86,7 +87,8 @@ public class AwsLoadBalancerLaunchService {
         List<CloudLoadBalancer> cloudLoadBalancers = stack.getLoadBalancers();
         String cFStackName = cfStackUtil.getCfStackName(ac);
         if (!cloudLoadBalancers.isEmpty()) {
-            LOGGER.debug("Creating load balancers of types " + cloudLoadBalancers.stream().map(CloudLoadBalancer::getType));
+            LOGGER.debug("Creating load balancers of types " + cloudLoadBalancers.stream().map(CloudLoadBalancer::getType)
+                    .map(LoadBalancerType::name).collect(Collectors.joining(",")));
 
             AwsCredentialView credentialView = new AwsCredentialView(ac.getCloudCredential());
             String regionName = ac.getCloudContext().getLocation().getRegion().value();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/LoadBalancerConfigService.java
@@ -209,6 +209,11 @@ public class LoadBalancerConfigService {
         boolean azureLoadBalancerDisabled = CloudPlatform.AZURE.toString().equalsIgnoreCase(stack.getCloudPlatform()) &&
                 getLoadBalancerSku(source) == LoadBalancerSku.NONE;
         if (azureLoadBalancerDisabled) {
+            Optional<TargetGroup> oozieTargetGroup = setupOozieHATargetGroup(stack, true);
+            if (oozieTargetGroup.isPresent()) {
+                throw new CloudbreakServiceException("Unsupported setup: Load balancers are disabled, but Oozie HA is configured. " +
+                        "Either enable Azure load balancers, or use a non-HA Oozie setup.");
+            }
             LOGGER.debug("Azure load balancers have been explicitly disabled.");
             return Collections.emptySet();
         }


### PR DESCRIPTION
Throws a CloudbreakServiceException during initial stack creation if an Oozie HA template is used,
but the load balancer is explicitly disabled. Tested with unit tests.