### PR TITLE
CB-14703 Backport CB-14012 to 2.48

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaData.java
@@ -283,6 +283,10 @@ public class InstanceMetaData implements ProvisionEntity {
         return publicIp;
     }
 
+    public String getIpWrapper(boolean preferPrivateIp) {
+        return preferPrivateIp ? privateIp : getPublicIpWrapper();
+    }
+
     public InstanceMetadataType getInstanceMetadataType() {
         return instanceMetadataType;
     }

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaDataTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/stack/instance/InstanceMetaDataTest.java
@@ -1,0 +1,36 @@
+package com.sequenceiq.cloudbreak.domain.stack.instance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class InstanceMetaDataTest {
+
+    private static final String PRIVATE_IP = "10.20.30.40";
+
+    private static final String PUBLIC_IP = "1.2.3.4";
+
+    static Object[][] getIpWrapperDataProvider() {
+        return new Object[][]{
+                // testCaseName publicIp preferPrivateIp expectedResult
+                {"publicIp=null, preferPrivateIp=false", null, false, PRIVATE_IP},
+                {"publicIp=PUBLIC_IP, preferPrivateIp=false", PUBLIC_IP, false, PUBLIC_IP},
+                {"publicIp=null, preferPrivateIp=true", null, true, PRIVATE_IP},
+                {"publicIp=PUBLIC_IP, preferPrivateIp=true", PUBLIC_IP, true, PRIVATE_IP},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getIpWrapperDataProvider")
+    void getIpWrapperTest(String testCaseName, String publicIp, boolean preferPrivateIp, String expectedResult) {
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setPrivateIp(PRIVATE_IP);
+        instanceMetaData.setPublicIp(publicIp);
+
+        String result = instanceMetaData.getIpWrapper(preferPrivateIp);
+
+        assertThat(result).isEqualTo(expectedResult);
+    }
+
+}


### PR DESCRIPTION
* Up to now, Cluster Proxy registrations used either public or private IPs, depending on the source subnet, even if CCM was active. This has been changed to always pick the VM private IP when any variant of CCM is employed.
  * Applies to both FreeIPA and DL / DH stacks, and all kinds of Cluster Proxy service, tunnel and CCMv2 endpoint entries.
  * The former FreeIPA logic was checking for `stack.getSecurityConfig().isUsePrivateIpToTls()` to decide if the private IP was preferable. That condition is a legacy remnant from 2.9 CB and, thus, not applicable to CDP deployments (where it will
    always evaluate to `false`).
* `InstanceMetaData` (`core-model`): Added a helper, `getIpWrapper(boolean)`, that returns either the private IP or the result of `getPublicIpWrapper()`, depending on the `boolean` argument.
* Testing:
  * Added new UT & adapted existing ones.
  * Manual verification in local CB.

(cherry picked from commit 5dc2a68870c3b1159927616271c720d2bc62cff1)