### PR TITLE
CB-14369 image change failure on azure should show image and storage …

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageCopyDetails.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/AzureImageCopyDetails.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.cloud.azure.image;
+
+public class AzureImageCopyDetails {
+
+    private final String imageStorageName;
+
+    private final String imageResourceGroupName;
+
+    private final String imageSource;
+
+    AzureImageCopyDetails(String imageStorageName, String imageResourceGroupName, String imageSource) {
+        this.imageStorageName = imageStorageName;
+        this.imageResourceGroupName = imageResourceGroupName;
+        this.imageSource = imageSource;
+    }
+
+    public String getImageStorageName() {
+        return imageStorageName;
+    }
+
+    public String getImageResourceGroupName() {
+        return imageResourceGroupName;
+    }
+
+    public String getImageSource() {
+        return imageSource;
+    }
+}


### PR DESCRIPTION
…account

On azure, for the vast majority of customers images are still copied to their storage account. Image copy sometimes fails, breaking a provisioning or upgrade.
During upgrade, if image copy fails, it might be beneficial to tell the customer how he can fix the image copy manually, at least which image to copy where.

After the image is copied, retry will not work for a DL, as the last flow state in datalake service to fail was waiting for the flow in cloudbreak - initiation of the flow is a prior, successful step. The flow in cloudbreak is, however, not retried, the customer will thus need to use OS-upgrade.

See detailed description in the commit message.