### PR TITLE
CB-14688: Remove world-readable permissions on cloudbreak webhdfs token

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/post-recipes/scripts/createuserhome.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/post-recipes/scripts/createuserhome.sh
@@ -53,6 +53,7 @@ webhdfs_command()   {
       -X $method --negotiate -u : \
       "$WEBHDFS_URL$path?$query")
     exec {out_fd}>&-
+    chmod 600 $WEBHDFS_COOKIE_JAR
     if [ "$http_code" -ne 200 ]; then
       return $http_code
     fi


### PR DESCRIPTION
Before my change:
```
ls -l /tmp/cloudbreak-webhdfs.cookies
-rw-r--r-- 1 root root 406 Oct 26 19:02 /tmp/cloudbreak-webhdfs.cookies
```
After my change:
```
ls -l /tmp/cloudbreak-webhdfs.cookies
-rw------- 1 root root 406 Nov  2 13:13 /tmp/cloudbreak-webhdfs.cookies
```
