### PR TITLE
CB-9902 Increase the default node count for the compute group to 1 fo…

### DIFF
--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-ha.json
@@ -65,7 +65,7 @@
           },
           "instanceType": "e2-standard-16"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering-spark3.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.10/gcp/dataengineering.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/gcp/dataengineering-ha.json
@@ -66,7 +66,7 @@
           },
           "instanceType": "e2-standard-16"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/gcp/dataengineering-spark3.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.11/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.11/gcp/dataengineering.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.12/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.12/gcp/dataengineering-ha.json
@@ -66,7 +66,7 @@
           },
           "instanceType": "e2-standard-16"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.12/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.12/gcp/dataengineering-spark3.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.12/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.12/gcp/dataengineering.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.13/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.13/gcp/dataengineering-ha.json
@@ -67,7 +67,7 @@
           },
           "instanceType": "e2-standard-16"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.13/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.13/gcp/dataengineering-spark3.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.13/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.13/gcp/dataengineering.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.6/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.6/gcp/dataengineering.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering-ha.json
@@ -56,7 +56,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering-spark3.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.7/gcp/dataengineering.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-ha.json
@@ -65,7 +65,7 @@
           },
           "instanceType": "e2-standard-16"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering-spark3.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.8/gcp/dataengineering.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-ha.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-ha.json
@@ -65,7 +65,7 @@
           },
           "instanceType": "e2-standard-16"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-spark3.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering-spark3.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },

--- a/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering.json
+++ b/core/src/main/resources/defaults/clustertemplates/7.2.9/gcp/dataengineering.json
@@ -37,7 +37,7 @@
           ],
           "instanceType": "e2-standard-8"
         },
-        "nodeCount": 0,
+        "nodeCount": 1,
         "type": "CORE",
         "recoveryMode": "MANUAL"
       },


### PR DESCRIPTION
…r the GCP DE cluster shapes.

This is a workaround for OPSAPS-54928, where starting a compute group
with 0 nodes causes upscaled nodes belonging to this group to be
misconfigured, and not consume available resources (8GB for NMs).
This workaround exists for AWS and Azure but there is no reason to not
do it in GCP too.
