### PR TITLE
CB-14640: Fix yarn_nodemanager_log_dirs to be ephemeral volumes if present

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnVolumeConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnVolumeConfigProvider.java
@@ -35,14 +35,17 @@ public class YarnVolumeConfigProvider implements CmHostGroupRoleConfigProvider {
                     }
                 }
                 String localDirsVolumePath;
+                String logDirsVolumePath;
                 if (hostGroupView != null && hostGroupView.getTemporaryStorage() == TemporaryStorage.EPHEMERAL_VOLUMES && temporaryStorageVolumeCount != 0) {
                     localDirsVolumePath = buildEphemeralVolumePathString(temporaryStorageVolumeCount, "nodemanager");
+                    logDirsVolumePath = buildEphemeralVolumePathString(temporaryStorageVolumeCount, "nodemanager/log");
                 } else {
                     localDirsVolumePath = buildVolumePathStringZeroVolumeHandled(volumeCount, "nodemanager");
+                    logDirsVolumePath = buildVolumePathStringZeroVolumeHandled(volumeCount, "nodemanager/log");
                 }
                 return List.of(
                         config(NODE_LOCAL_DIRS, localDirsVolumePath),
-                        config(NODE_LOG_DIRS, buildVolumePathStringZeroVolumeHandled(volumeCount, "nodemanager/log"))
+                        config(NODE_LOG_DIRS, logDirsVolumePath)
                 );
             default:
                 return List.of();

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmHostGroupRoleConfigProviderProcessorTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/CmHostGroupRoleConfigProviderProcessorTest.java
@@ -272,7 +272,8 @@ public class CmHostGroupRoleConfigProviderProcessorTest {
         assertEquals(
                 List.of(
                         config("yarn_nodemanager_local_dirs", "/hadoopfs/ephfs1/nodemanager,/hadoopfs/ephfs2/nodemanager,/hadoopfs/ephfs3/nodemanager"),
-                        config("yarn_nodemanager_log_dirs", "/hadoopfs/fs1/nodemanager/log,/hadoopfs/fs2/nodemanager/log")
+                        config("yarn_nodemanager_log_dirs", "/hadoopfs/ephfs1/nodemanager/log,/hadoopfs/ephfs2/nodemanager/log," +
+                                "/hadoopfs/ephfs3/nodemanager/log")
                 ),
                 roleConfigs.get("yarn-NODEMANAGER-BASE")
         );

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnVolumeConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/yarn/YarnVolumeConfigProviderTest.java
@@ -60,7 +60,8 @@ class YarnVolumeConfigProviderTest {
         assertEquals(
                 List.of(
                         config("yarn_nodemanager_local_dirs", "/hadoopfs/ephfs1/nodemanager,/hadoopfs/ephfs2/nodemanager,/hadoopfs/ephfs3/nodemanager"),
-                        config("yarn_nodemanager_log_dirs", "/hadoopfs/fs1/nodemanager/log,/hadoopfs/fs2/nodemanager/log")
+                        config("yarn_nodemanager_log_dirs", "/hadoopfs/ephfs1/nodemanager/log,/hadoopfs/ephfs2/nodemanager/log," +
+                                "/hadoopfs/ephfs3/nodemanager/log")
                 ),
                 roleConfigs
         );


### PR DESCRIPTION
CB-14640: Fix yarn_nodemanager_log_dirs to be ephemeral volumes if present
If Instance has ephemeral volumes which are mounted, temporary data like `yarn_nodemanager_local_dirs` and `yarn_nodemanager_log_dirs` should use ephemeral volumes.
