### PR TITLE
CB-12777 - add multiAz enablement for freeipa response in environment response

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/FreeIpaResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/FreeIpaResponse.java
@@ -20,6 +20,9 @@ public class FreeIpaResponse implements Serializable {
     @ApiModelProperty(EnvironmentModelDescription.FREEIPA_IMAGE)
     private FreeIpaImageResponse image;
 
+    @ApiModelProperty(value = EnvironmentModelDescription.MULTIAZ_FREEIPA)
+    private boolean enableMultiAz;
+
     public Integer getInstanceCountByGroup() {
         return instanceCountByGroup;
     }
@@ -44,12 +47,21 @@ public class FreeIpaResponse implements Serializable {
         this.image = image;
     }
 
+    public boolean isEnableMultiAz() {
+        return enableMultiAz;
+    }
+
+    public void setEnableMultiAz(boolean enableMultiAz) {
+        this.enableMultiAz = enableMultiAz;
+    }
+
     @Override
     public String toString() {
         return "FreeIpaResponse{" +
                 "instanceCountByGroup=" + instanceCountByGroup +
                 ", aws=" + aws +
                 ", image=" + image +
+                ", enableMultiAz=" + enableMultiAz +
                 '}';
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/FreeIpaConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/FreeIpaConverter.java
@@ -36,6 +36,7 @@ public class FreeIpaConverter {
                     .map(this::convertAws)
                     .ifPresent(response::setAws);
             response.setImage(convertImage(freeIpaCreation.getImageCatalog(), freeIpaCreation.getImageId()));
+            response.setEnableMultiAz(freeIpaCreation.isEnableMultiAz());
             return response;
         }
     }


### PR DESCRIPTION
in the case of SDX response, the related field is already there. For DH it is not relevant since the network setup implicitly tells that whether the cluster is deployed in a multi az way or not.

This pr is a stepping stone to extend the CLI responses as well