### PR TITLE
CB-14374 Azure marketplace: image term read and sign errors are not l…

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/marketplace/AzureImageTermsSignerService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/image/marketplace/AzureImageTermsSignerService.java
@@ -45,7 +45,7 @@ public class AzureImageTermsSignerService {
             return azureImageTerms.getProperties().isAccepted();
         } catch (Exception e) {
             String message = errorMessageBuilder.buildWithReason(e.getMessage());
-            LOGGER.warn(message);
+            LOGGER.warn(message, e);
             throw new CloudConnectorException(message, e);
         }
     }
@@ -75,7 +75,7 @@ public class AzureImageTermsSignerService {
         } catch (Exception e) {
             String message =
                     errorMessageBuilder.buildWithReason(String.format("error when signing vm image terms and conditions, message is '%s'", e.getMessage()));
-            LOGGER.warn(message);
+            LOGGER.warn(message, e);
             throw new CloudConnectorException(message, e);
         }
     }

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/rest/AzureRestOperationsService.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/rest/AzureRestOperationsService.java
@@ -45,8 +45,8 @@ public class AzureRestOperationsService {
             LOGGER.warn(message);
             throw new AzureRestResponseException(message);
         } catch (HttpStatusCodeException e) {
-            String message = String.format("Error during http %s operation", httpMethod.toString());
-            LOGGER.warn(message);
+            String message = String.format("Error during http %s operation: %s", httpMethod.toString(), e.getMessage());
+            LOGGER.warn(message, e);
             throw new AzureRestResponseException(message, e);
         }
     }


### PR DESCRIPTION
…ogged appropriately.

For azure marketplace images CDP has to check if image terms and conditions are accepted. This is done via REST interactions.
It turns out that if an error comes up during a REST operation, the original error is not logged. This needs to be fixed.

See detailed description in the commit message.