### PR TITLE
CB-14692: Added knox keytab use to backup/restore scripts in order to resolve authentication issues on DataHubs

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/backup_db.sh
@@ -72,6 +72,7 @@ run_kinit() {
   HBASE_KEYTAB=$(find /run/cloudera-scm-agent/process/ -name "*.keytab" -a \( -path "*hbase-REGIONSERVER*" -o -path "*hbase-MASTER*" \) -a -type f | head -n 1)
   SOLR_KEYTAB=$(find /run/cloudera-scm-agent/process/ -name "*.keytab" -path "*solr-SOLR_SERVER*" | head -n 1)
   ATLAS_KEYTAB=$(find /run/cloudera-scm-agent/process/ -name "*.keytab" -path "*atlas-ATLAS_SERVER*" | head -n 1)
+  KNOX_KEYTAB=$(find /run/cloudera-scm-agent/process/ -name "*.keytab" -path "*knox-KNOX_GATEWAY*" | head -n 1)
 
   if kinit_as hdfs "$HDFS_KEYTAB"; then
     doLog "Successful kinit using hdfs principal"
@@ -81,6 +82,8 @@ run_kinit() {
     doLog "Successful kinit using solr principal"
   elif kinit_as atlas "$ATLAS_KEYTAB"; then
     doLog "Successful kinit using atlas principal"
+  elif kinit_as knox "$KNOX_KEYTAB"; then
+    doLog "Successful kinit using knox principal"
   fi
 }
 

--- a/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/postgresql/disaster_recovery/scripts/restore_db.sh
@@ -71,6 +71,7 @@ run_kinit() {
   HBASE_KEYTAB=$(find /run/cloudera-scm-agent/process/ -name "*.keytab" -a \( -path "*hbase-REGIONSERVER*" -o -path "*hbase-MASTER*" \) -a -type f | head -n 1)
   SOLR_KEYTAB=$(find /run/cloudera-scm-agent/process/ -name "*.keytab" -path "*solr-SOLR_SERVER*" | head -n 1)
   ATLAS_KEYTAB=$(find /run/cloudera-scm-agent/process/ -name "*.keytab" -path "*atlas-ATLAS_SERVER*" | head -n 1)
+  KNOX_KEYTAB=$(find /run/cloudera-scm-agent/process/ -name "*.keytab" -path "*knox-KNOX_GATEWAY*" | head -n 1)
 
   if kinit_as hdfs "$HDFS_KEYTAB"; then
     doLog "Successful kinit using hdfs principal"
@@ -80,6 +81,8 @@ run_kinit() {
     doLog "Successful kinit using solr principal"
   elif kinit_as atlas "$ATLAS_KEYTAB"; then
     doLog "Successful kinit using atlas principal"
+  elif kinit_as knox "$KNOX_KEYTAB"; then
+    doLog "Successful kinit using knox principal"
   fi
 }
 


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-14692

Simply added the Knox keytab as a choice to the backup/restore scripts.
Verified that this enables successful database backups on Azure and AWS DataHubs.