### PR TITLE
CB-14740 Fix external test group variables for BasicEnvironmentVirtualGroupTest

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/BasicEnvironmentVirtualGroupTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/BasicEnvironmentVirtualGroupTest.java
@@ -47,16 +47,16 @@ public class BasicEnvironmentVirtualGroupTest extends AbstractE2ETest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BasicEnvironmentVirtualGroupTest.class);
 
-    @Value("${integrationtest.aws.l0.adminGroupName}")
+    @Value("${integrationtest.userGroup.adminGroupName:}")
     private String adminGroupName;
 
-    @Value("${integrationtest.aws.l0.adminGroupCrn}")
+    @Value("${integrationtest.userGroup.adminGroupCrn:}")
     private String adminGroupCrn;
 
-    @Value("${integrationtest.aws.l0.userGroupName}")
+    @Value("${integrationtest.userGroup.userGroupName:}")
     private String userGroupName;
 
-    @Value("${integrationtest.aws.l0.userGroupCrn}")
+    @Value("${integrationtest.userGroup.userGroupCrn:}")
     private String userGroupCrn;
 
     @Inject

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -50,6 +50,11 @@ integrationtest:
     secretkey: nHkdxgZR0BaNHaSYM3ooS6rIlpV5E+k1CIkr+jFId2g=
     crn:
     name:
+  userGroup:
+    adminGroupName: testgroupa
+    adminGroupCrn: "crn:altus:iam:us-west-1:f8e2f110-fc7e-4e46-ae55-381aacc6718c:group:testgroupa/ebc27aff-7d91-4f76-bf98-e81dbbd615e9"
+    userGroupName: testgroupb
+    userGroupCrn: "crn:altus:iam:us-west-1:f8e2f110-fc7e-4e46-ae55-381aacc6718c:group:testgroupb/b983b572-9774-4f8f-8377-861b511442de"
   testsuite:
     pollingInterval: 1000
     threadPoolSize: 8
@@ -125,11 +130,6 @@ integrationtest:
       upgrade:
         imageId: 9c1c8959-86a7-4b7d-af5a-be252f8b395d
         catalog: https://cloudbreak-imagecatalog.s3.us-west-1.amazonaws.com/freeipa-upgrade-test-catalog.json
-    l0:
-      adminGroupName: testgroupa
-      adminGroupCrn: "crn:altus:iam:us-west-1:f8e2f110-fc7e-4e46-ae55-381aacc6718c:group:testgroupa/ebc27aff-7d91-4f76-bf98-e81dbbd615e9"
-      userGroupName: testgroupb
-      userGroupCrn: "crn:altus:iam:us-west-1:f8e2f110-fc7e-4e46-ae55-381aacc6718c:group:testgroupb/b983b572-9774-4f8f-8377-861b511442de"
 
   # azure parameters
   azure:


### PR DESCRIPTION
User groups are provider independent in L0 test cases. So I've moved these variables out from AWS provider related parameters.