### PR TITLE
CB-14398 - Add a RecoveryService to choose between Upgrade and Resize recoveries.

### DIFF
--- a/datalake-dr-connector/README.md
+++ b/datalake-dr-connector/README.md
@@ -1,0 +1,2 @@
+# `datalake-dr-connector`
+Provides a gRPC client for interacting with the `datalake-dr-service` module.

--- a/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxRecoveryController.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/controller/sdx/SdxRecoveryController.java
@@ -13,7 +13,7 @@ import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
-import com.sequenceiq.datalake.service.upgrade.recovery.SdxUpgradeRecoveryService;
+import com.sequenceiq.datalake.service.recovery.RecoveryService;
 import com.sequenceiq.sdx.api.endpoint.SdxRecoveryEndpoint;
 import com.sequenceiq.sdx.api.model.SdxRecoverableResponse;
 import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
@@ -23,13 +23,13 @@ import com.sequenceiq.sdx.api.model.SdxRecoveryResponse;
 public class SdxRecoveryController implements SdxRecoveryEndpoint {
 
     @Inject
-    private SdxUpgradeRecoveryService sdxUpgradeRecoveryService;
+    private RecoveryService recoveryService;
 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.RECOVER_DATALAKE)
     public SdxRecoveryResponse recoverClusterByName(@ResourceName String name, @Valid SdxRecoveryRequest recoverSdxClusterRequest) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        return sdxUpgradeRecoveryService.triggerRecovery(userCrn, NameOrCrn.ofName(name), recoverSdxClusterRequest);
+        return recoveryService.triggerRecovery(userCrn, NameOrCrn.ofName(name), recoverSdxClusterRequest);
     }
 
     @Override
@@ -37,20 +37,20 @@ public class SdxRecoveryController implements SdxRecoveryEndpoint {
     public SdxRecoveryResponse recoverClusterByCrn(@ResourceCrn @TenantAwareParam String crn,
             @Valid SdxRecoveryRequest recoverSdxClusterRequest) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        return sdxUpgradeRecoveryService.triggerRecovery(userCrn, NameOrCrn.ofCrn(crn), recoverSdxClusterRequest);
+        return recoveryService.triggerRecovery(userCrn, NameOrCrn.ofCrn(crn), recoverSdxClusterRequest);
     }
 
     @Override
     @CheckPermissionByResourceName(action = AuthorizationResourceAction.RECOVER_DATALAKE)
     public SdxRecoverableResponse getClusterRecoverableByName(@ResourceName String name) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        return sdxUpgradeRecoveryService.validateRecovery(userCrn, NameOrCrn.ofName(name));
+        return recoveryService.validateRecovery(userCrn, NameOrCrn.ofName(name));
     }
 
     @Override
     @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.RECOVER_DATALAKE)
     public SdxRecoverableResponse getClusterRecoverableByCrn(@ResourceCrn @TenantAwareParam String crn) {
         String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        return sdxUpgradeRecoveryService.validateRecovery(userCrn, NameOrCrn.ofCrn(crn));
+        return recoveryService.validateRecovery(userCrn, NameOrCrn.ofCrn(crn));
     }
 }

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/recovery/RecoveryService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/recovery/RecoveryService.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.datalake.service.recovery;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.datalake.service.resize.recovery.ResizeRecoveryService;
+import com.sequenceiq.datalake.service.upgrade.recovery.SdxUpgradeRecoveryService;
+import com.sequenceiq.sdx.api.model.SdxRecoverableResponse;
+import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
+import com.sequenceiq.sdx.api.model.SdxRecoveryResponse;
+
+@Service
+/**
+ * Recovers an SDX cluster from a failure during Resize or Upgrade.
+ *
+ * Chooses the appropriate recovery action to take based on the state of the SDX cluster.
+ * <ul>
+ *     <li>{@Code SdxUpgradeRecoveryService}</li>
+ *     <li>{@Code ResizeRecoveryService}</li>
+ * </ul>
+ */
+public class RecoveryService {
+    @Inject
+    private SdxUpgradeRecoveryService sdxUpgradeRecoveryService;
+
+    @Inject
+    private ResizeRecoveryService resizeRecoveryService;
+
+    // todo: refactor this to return a flow identifier
+    public SdxRecoveryResponse triggerRecovery(String crn, NameOrCrn nameOrCrn, SdxRecoveryRequest sdxRecoveryRequest) {
+        if (resizeRecoveryService.canRecover()) {
+            return resizeRecoveryService.triggerRecovery();
+        } else {
+            return sdxUpgradeRecoveryService.triggerRecovery(crn, nameOrCrn, sdxRecoveryRequest);
+        }
+    }
+
+    public SdxRecoverableResponse validateRecovery(String crn, NameOrCrn nameOrCrn) {
+        if (resizeRecoveryService.canRecover()) {
+            return resizeRecoveryService.validateRecovery();
+        } else {
+            return sdxUpgradeRecoveryService.validateRecovery(crn, nameOrCrn);
+        }
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/resize/recovery/ResizeRecoveryService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/resize/recovery/ResizeRecoveryService.java
@@ -1,0 +1,47 @@
+package com.sequenceiq.datalake.service.resize.recovery;
+
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.sdx.api.model.SdxRecoverableResponse;
+import com.sequenceiq.sdx.api.model.SdxRecoveryResponse;
+
+@Service
+/**
+ * Provides entrypoint for recovery of failed SDX resize.
+ *
+ * The main entry point is {@code triggerRecovery}, which starts a cloudbreak Flow to recover the Data Lake.
+ * To ensure a Resize recovery is appropriate, use one of {@code canRecover} or {@code validateRecovery}.
+ */
+public class ResizeRecoveryService {
+
+    /**
+     * Determines if it's possible to run a <em>Resize</em> recovery, returning a simple boolean indicator
+     * @return true if resize recovery is possible.
+     */
+    public boolean canRecover() {
+        return false;
+    }
+
+    /**
+     * Determines if it's possible to run a <em>Resize</em> recovery, returning a detailed validation message.
+     *
+     * This is distinguished from {@code canRecover} by including a detailed validation message, usable as a web response.
+     * @return detailed validation message, as a web response
+     */
+    public SdxRecoverableResponse validateRecovery() {
+        // todo: implement me
+        throw new BadRequestException("SDX Resize Recovery is not yet implemented");
+    }
+
+    /**
+     * Checks if recovery is possible, then performs the resize recovery if appropriate.
+     * @return a response containing information for the triggered recovery Flow.
+     */
+    public SdxRecoveryResponse triggerRecovery() {
+        validateRecovery();
+        // todo: implement me
+        return null;
+    }
+
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/recovery/RecoveryServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/recovery/RecoveryServiceTest.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.datalake.service.recovery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery.RecoveryStatus;
+import com.sequenceiq.datalake.service.resize.recovery.ResizeRecoveryService;
+import com.sequenceiq.datalake.service.upgrade.recovery.SdxUpgradeRecoveryService;
+import com.sequenceiq.sdx.api.model.SdxRecoverableResponse;
+import com.sequenceiq.sdx.api.model.SdxRecoveryRequest;
+import com.sequenceiq.sdx.api.model.SdxRecoveryResponse;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RecoveryServiceTest {
+
+    public static final String USER_CRN = "userCrn";
+
+    public static final String RESOURCE_CRN = "resourceCrn";
+
+    public static final NameOrCrn NAME_OR_CRN = NameOrCrn.ofCrn(RESOURCE_CRN);
+
+    @Mock
+    private SdxUpgradeRecoveryService mockSdxUpgradeRecoveryService;
+
+    @Mock
+    private ResizeRecoveryService mockResizeRecoveryService;
+
+    @InjectMocks
+    private RecoveryService recoveryService;
+
+    @Test
+    public void testRecoveryServiceCanRecoverFromUpgradeFailureByClusterName() {
+        SdxRecoveryRequest request = new SdxRecoveryRequest();
+        SdxRecoveryResponse response = new SdxRecoveryResponse();
+        when(mockSdxUpgradeRecoveryService.triggerRecovery(USER_CRN, NAME_OR_CRN, request)).thenReturn(response);
+
+        SdxRecoveryResponse result = recoveryService.triggerRecovery(USER_CRN, NAME_OR_CRN, request);
+
+        // Basically, just check that we pass through
+        Mockito.verify(mockSdxUpgradeRecoveryService).triggerRecovery(USER_CRN, NAME_OR_CRN, request);
+        assertNotNull(result);
+        assertEquals(response, result);
+    }
+
+    @Test
+    public void testRecoveryServiceCanValidateUpgradeFailureByClusterName() {
+        SdxRecoverableResponse response = new SdxRecoverableResponse("Some reason", RecoveryStatus.RECOVERABLE);
+        when(mockSdxUpgradeRecoveryService.validateRecovery(USER_CRN, NAME_OR_CRN)).thenReturn(response);
+
+        SdxRecoverableResponse result = recoveryService.validateRecovery(USER_CRN, NAME_OR_CRN);
+
+        // Basically, just check that we pass through
+        Mockito.verify(mockSdxUpgradeRecoveryService).validateRecovery(USER_CRN, NAME_OR_CRN);
+        assertNotNull(result);
+        assertEquals(response, result);
+    }
+
+    @Test
+    public void testRecoveryServiceCanSwitchToResizeRecovery() {
+        SdxRecoveryRequest request = new SdxRecoveryRequest();
+        SdxRecoveryResponse response = new SdxRecoveryResponse();
+        when(mockResizeRecoveryService.triggerRecovery()).thenReturn(response);
+        when(mockResizeRecoveryService.canRecover()).thenReturn(true);
+
+        SdxRecoveryResponse result = recoveryService.triggerRecovery(USER_CRN, NAME_OR_CRN, request);
+
+        // Basically, just check that we pass through to the Resize Recovery Service
+        Mockito.verifyNoInteractions(mockSdxUpgradeRecoveryService);
+        Mockito.verify(mockResizeRecoveryService).canRecover();
+        Mockito.verify(mockResizeRecoveryService).triggerRecovery();
+        assertNotNull(result);
+        assertEquals(response, result);
+    }
+
+    @Test
+    public void testRecoveryServiceCanValidateResizeRecovery() {
+        SdxRecoverableResponse resizeRecoverableResponse = new SdxRecoverableResponse("Resize recovery is allowed.", RecoveryStatus.RECOVERABLE);
+        when(mockResizeRecoveryService.validateRecovery()).thenReturn(resizeRecoverableResponse);
+        when(mockResizeRecoveryService.canRecover()).thenReturn(true);
+
+        SdxRecoverableResponse result = recoveryService.validateRecovery(USER_CRN, NAME_OR_CRN);
+
+        // Basically, just check that we pass through
+        Mockito.verify(mockResizeRecoveryService).validateRecovery();
+        assertNotNull(result);
+        assertEquals(resizeRecoverableResponse, result);
+    }
+}


### PR DESCRIPTION
Closes [CB-14398](https://jira.cloudera.com/browse/CB-14398).

Adds a RecoveryService which chooses one of Resize or Upgrade recovery.

Change the recovery controller to call into the Recovery Service.

This is small PR, additional changes are forthcoming, depending on results of design doc review.