### PR TITLE
CB-14572 Add TunnelType to FreeIPA response

### DIFF
--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -86,8 +86,8 @@ public class EnvironmentModelDescription {
     public static final String DEFAULT_SECURITY_GROUPS = "Security groups where all other hosts are placed. Comma separated list.";
     public static final String SECURITY_CIDR = "CIDR range which is allowed for inbound traffic. Either IPv4 or IPv6 is allowed.";
 
-    public static final String TUNNEL = "Configuration that the connection going directly or with cluster proxy or with ccm and cluster proxy.";
-    public static final String OVERRIDE_TUNNEL = "Flag that marks that the request was intented to set the tunnel version by hand and it will not be " +
+    public static final String TUNNEL = "Configuration that the connection going directly or with cluster proxy or with CCM and cluster proxy.";
+    public static final String OVERRIDE_TUNNEL = "Flag that marks that the request was intended to set the tunnel version by hand and it will not be " +
             "overwritten by Cloudbreak";
 
     public static final String LOG_CLOUD_STORAGE = "Cloud storage configuration for this environment. Service logs will be stored in the defined location.";

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/FreeIpaApi.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/FreeIpaApi.java
@@ -1,10 +1,21 @@
 package com.sequenceiq.freeipa.api;
 
+import io.swagger.annotations.ApiKeyAuthDefinition;
+import io.swagger.annotations.SecurityDefinition;
+import io.swagger.annotations.SwaggerDefinition;
+
+@SwaggerDefinition(securityDefinition = @SecurityDefinition(
+        apiKeyAuthDefinitions = {
+                @ApiKeyAuthDefinition(key = FreeIpaApi.CRN_HEADER_API_KEY, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, name = "x-cdp-actor-crn")
+        }))
 public class FreeIpaApi {
 
     public static final String API_ROOT_CONTEXT = "/api";
 
+    public static final String CRN_HEADER_API_KEY = "crnHeader";
+
     private FreeIpaApi() {
     }
+
 }
 

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -24,6 +24,7 @@ import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.RetryableFlowResponse;
+import com.sequenceiq.freeipa.api.FreeIpaApi;
 import com.sequenceiq.freeipa.api.v1.freeipa.cleanup.CleanupRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaNotes;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaOperationDescriptions;
@@ -43,11 +44,15 @@ import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.Authorization;
 
 @RetryAndMetrics
 @Path("/v1/freeipa")
 @Consumes(MediaType.APPLICATION_JSON)
-@Api(value = "/v1/freeipa", protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
+@Api(value = "/v1/freeipa",
+        protocols = "http,https",
+        authorizations = {@Authorization(value = FreeIpaApi.CRN_HEADER_API_KEY)},
+        consumes = MediaType.APPLICATION_JSON)
 public interface FreeIpaV1Endpoint {
     @POST
     @Path("")

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaModelDescriptions.java
@@ -5,7 +5,7 @@ public class FreeIpaModelDescriptions {
     public static final String REGION = "region of the freeipa stack";
     public static final String AVAILABILITY_ZONE = "availability zone of the freeipa stack";
     public static final String PLACEMENT_SETTINGS = "placement configuration parameters for a cluster (e.g. 'region', 'availabilityZone')";
-    public static final String INSTANCE_GROUPS = "collection of instance groupst";
+    public static final String INSTANCE_GROUPS = "collection of instance groups";
     public static final String AUTHENTICATION = "freeipa stack related authentication";
     public static final String NETWORK = "freeipa stack related network";
     public static final String IMAGE_SETTINGS = "settings for custom images";
@@ -17,7 +17,7 @@ public class FreeIpaModelDescriptions {
     public static final String FREEIPA_APPLICATION_VERSION = "version of the application provisioned FreeIPA";
     public static final String CLOUD_PLATFORM = "Cloud Platform for FreeIPA";
     public static final String USE_CCM = "whether to use CCM for communicating with the freeipa instance";
-    public static final String TUNNEL = "Configuration that the connection going directly or with cluster proxy or with ccm and cluster proxy.";
+    public static final String TUNNEL = "Configuration that the connection going directly or with cluster proxy or with CCM and cluster proxy.";
     public static final String VARIANT = "Configuration of cloud platform variant.";
     public static final String TAGS = "Tags for freeipa server.";
     public static final String USERSYNC_STATUS_DETAILS = "user sync status details for the environment";
@@ -44,9 +44,9 @@ public class FreeIpaModelDescriptions {
     }
 
     public static class InstanceMetaDataModelDescription {
-        public static final String PRIVATE_IP = "private ip of the insctance";
-        public static final String PUBLIC_IP = "public ip of the instance";
-        public static final String INSTANCE_ID = "id of the instance";
+        public static final String PRIVATE_IP = "private IP of the instance";
+        public static final String PUBLIC_IP = "public IP of the instance";
+        public static final String INSTANCE_ID = "ID of the instance";
         public static final String DISCOVERY_FQDN = "the fully qualified domain name of the node in the service discovery cluster";
     }
 
@@ -63,8 +63,8 @@ public class FreeIpaModelDescriptions {
 
     public static class SecurityGroupModelDescription {
         public static final String SECURITY_RULES = "list of security rules that relates to the security group";
-        public static final String SECURITY_GROUP_ID = "Exisiting security group id";
-        public static final String SECURITY_GROUP_IDS = "Exisiting security group ids";
+        public static final String SECURITY_GROUP_ID = "Existing security group ID";
+        public static final String SECURITY_GROUP_IDS = "Existing security group IDs";
     }
 
     public static class SecurityRuleModelDescription {
@@ -92,7 +92,7 @@ public class FreeIpaModelDescriptions {
         public static final String GCP_PARAMETERS = "provider specific parameters of the specified network";
         public static final String OPENSTACK_PARAMETERS_DEPRECATED = "provider specific parameters of the specified network";
         public static final String OUTBOUND_INTERNET_TRAFFIC = "A flag to enable or disable the outbound internet traffic from the instances.";
-        public static final String NETWORK_CIDRS = "the network cidrs which have to be reacheable from the instances";
+        public static final String NETWORK_CIDRS = "the network CIDRs which have to be reachable from the instances";
     }
 
     public static class FreeIpaServerSettingsModelDescriptions {

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/describe/DescribeFreeIpaResponse.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/describe/DescribeFreeIpaResponse.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sequenceiq.common.api.cloudstorage.CloudStorageResponse;
 import com.sequenceiq.common.api.telemetry.response.TelemetryResponse;
+import com.sequenceiq.common.api.type.Tunnel;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.doc.FreeIpaModelDescriptions;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
@@ -42,6 +43,9 @@ public class DescribeFreeIpaResponse {
     @NotNull
     @ApiModelProperty(FreeIpaModelDescriptions.PLACEMENT_SETTINGS)
     private PlacementResponse placement;
+
+    @ApiModelProperty(value = FreeIpaModelDescriptions.TUNNEL)
+    private Tunnel tunnel;
 
     @NotNull
     @Valid
@@ -119,6 +123,14 @@ public class DescribeFreeIpaResponse {
 
     public void setPlacement(PlacementResponse placement) {
         this.placement = placement;
+    }
+
+    public Tunnel getTunnel() {
+        return tunnel;
+    }
+
+    public void setTunnel(Tunnel tunnel) {
+        this.tunnel = tunnel;
     }
 
     public List<InstanceGroupResponse> getInstanceGroups() {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/EndpointConfig.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/configuration/EndpointConfig.java
@@ -54,6 +54,9 @@ public class EndpointConfig extends ResourceConfig {
     @Value("${freeipa.structuredevent.rest.enabled:false}")
     private Boolean auditEnabled;
 
+    @Value("${server.servlet.context-path:}")
+    private String contextPath;
+
     @Inject
     private List<ExceptionMapper<?>> exceptionMappers;
 
@@ -78,10 +81,10 @@ public class EndpointConfig extends ResourceConfig {
     private void registerSwagger() {
         BeanConfig swaggerConfig = new BeanConfig();
         swaggerConfig.setTitle("FreeIPA API");
-        swaggerConfig.setDescription("");
+        swaggerConfig.setDescription("API for working with FreeIPA clusters");
         swaggerConfig.setVersion(applicationVersion);
         swaggerConfig.setSchemes(new String[]{"http", "https"});
-        swaggerConfig.setBasePath(FreeIpaApi.API_ROOT_CONTEXT);
+        swaggerConfig.setBasePath(contextPath + FreeIpaApi.API_ROOT_CONTEXT);
         swaggerConfig.setLicenseUrl("https://github.com/sequenceiq/cloudbreak/blob/master/LICENSE");
         swaggerConfig.setResourcePackage("com.sequenceiq.freeipa.api,com.sequenceiq.flow.api,com.sequenceiq.authorization," +
                 "com.sequenceiq.cloudbreak.structuredevent.rest.endpoint");

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToDescribeFreeIpaResponseConverter.java
@@ -75,16 +75,17 @@ public class StackToDescribeFreeIpaResponseConverter {
         Optional.ofNullable(image).ifPresent(i -> describeFreeIpaResponse.setImage(imageSettingsResponseConverter.convert(i)));
         Optional.ofNullable(freeIpa).ifPresent(f -> describeFreeIpaResponse.setFreeIpa(freeIpaServerResponseConverter.convert(f)));
         describeFreeIpaResponse.setNetwork(networkResponseConverter.convert(stack));
-        describeFreeIpaResponse.setPlacement(convert(stack));
+        describeFreeIpaResponse.setPlacement(convertToPlacementResponse(stack));
+        describeFreeIpaResponse.setTunnel(stack.getTunnel());
         describeFreeIpaResponse.setInstanceGroups(instanceGroupConverter.convert(stack.getInstanceGroups()));
         describeFreeIpaResponse.setAvailabilityStatus(stackToAvailabilityStatusConverter.convert(stack));
         describeFreeIpaResponse.setStatus(stack.getStackStatus().getStatus());
         describeFreeIpaResponse.setStatusString(stack.getStackStatus().getStatusString());
         describeFreeIpaResponse.setStatusReason(stack.getStackStatus().getStatusReason());
         decorateFreeIpaServerResponseWithIps(describeFreeIpaResponse.getFreeIpa(), describeFreeIpaResponse.getInstanceGroups());
-        decoreateFreeIpaServerResponseWithLoadBalancedHost(stack, describeFreeIpaResponse.getFreeIpa(), freeIpa);
+        decorateFreeIpaServerResponseWithLoadBalancedHost(stack, describeFreeIpaResponse.getFreeIpa(), freeIpa);
         describeFreeIpaResponse.setAppVersion(stack.getAppVersion());
-        decorateWithCloudStorgeAndTelemetry(stack, describeFreeIpaResponse);
+        decorateWithCloudStorageAndTelemetry(stack, describeFreeIpaResponse);
         Optional.ofNullable(userSyncStatus).ifPresent(u -> describeFreeIpaResponse.setUserSyncStatus(userSyncStatusConverter.convert(u)));
         return describeFreeIpaResponse;
     }
@@ -99,7 +100,7 @@ public class StackToDescribeFreeIpaResponseConverter {
         }
     }
 
-    private void decorateWithCloudStorgeAndTelemetry(Stack stack, DescribeFreeIpaResponse response) {
+    private void decorateWithCloudStorageAndTelemetry(Stack stack, DescribeFreeIpaResponse response) {
         TelemetryResponse telemetryResponse = telemetryConverter.convert(stack.getTelemetry());
         if (telemetryResponse != null) {
             response.setTelemetry(telemetryResponse);
@@ -115,17 +116,18 @@ public class StackToDescribeFreeIpaResponseConverter {
         }
     }
 
-    private void decoreateFreeIpaServerResponseWithLoadBalancedHost(Stack stack, FreeIpaServerResponse freeIpaServerResponse, FreeIpa freeIpa) {
+    private void decorateFreeIpaServerResponseWithLoadBalancedHost(Stack stack, FreeIpaServerResponse freeIpaServerResponse, FreeIpa freeIpa) {
         if (Objects.nonNull(freeIpaServerResponse) && balancedDnsAvailabilityChecker.isBalancedDnsAvailable(stack)) {
             freeIpaServerResponse.setFreeIpaHost(FreeIpaDomainUtils.getFreeIpaFqdn(freeIpa.getDomain()));
             freeIpaServerResponse.setFreeIpaPort(stack.getGatewayport());
         }
     }
 
-    private PlacementResponse convert(Stack source) {
+    private PlacementResponse convertToPlacementResponse(Stack source) {
         PlacementResponse placementResponse = new PlacementResponse();
         placementResponse.setAvailabilityZone(source.getAvailabilityZone());
         placementResponse.setRegion(source.getRegion());
         return placementResponse;
     }
+
 }

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/RedbeamsApi.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/RedbeamsApi.java
@@ -6,7 +6,7 @@ import io.swagger.annotations.SwaggerDefinition;
 
 @SwaggerDefinition(securityDefinition = @SecurityDefinition(
     apiKeyAuthDefinitions = {
-        @ApiKeyAuthDefinition(key = "crnHeader", in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, name = "x-cdp-actor-crn")
+        @ApiKeyAuthDefinition(key = RedbeamsApi.CRN_HEADER_API_KEY, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, name = "x-cdp-actor-crn")
     }))
 public class RedbeamsApi {
 


### PR DESCRIPTION
* Add new property `DescribeFreeIpaResponse.tunnel` (`freeipa-api`). It is copied as-is from `Stack.tunnel` (`freeipa`).
* `freeipa` Swagger fixes:
  * Add API description.
  * Correct base path so that Swagger UI becomes usable.
  * Add `ApiKeyAuthDefinition` to `FreeIpaApi` (`freeipa`) so that user authn information can be entered in Swagger UI. (Solution has been adapted from `redbeams`.) This extra header is currently only enabled for `FreeIpaV1Endpoint`.
* Fix spelling errors in several places.
* Testing:
  * UT.
  * `freeipa` Swagger UI in local CB.