### PR TITLE
CB-14656 Fix unbound service restart of existing stacks

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/StackFixTypeConverter.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/StackFixTypeConverter.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.cloudbreak.domain.converter;
+
+import com.sequenceiq.cloudbreak.converter.DefaultEnumConverter;
+import com.sequenceiq.cloudbreak.domain.stack.StackFix.StackFixType;
+
+public class StackFixTypeConverter extends DefaultEnumConverter<StackFixType>  {
+
+    @Override
+    public StackFixType getDefault() {
+        return StackFixType.UNKNOWN;
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackFix.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackFix.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.cloudbreak.domain.stack;
+
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
+import com.sequenceiq.cloudbreak.domain.converter.StackFixTypeConverter;
+
+@Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"stack_id", "type"}))
+public class StackFix implements ProvisionEntity  {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "stackfix_generator")
+    @SequenceGenerator(name = "stackfix_generator", sequenceName = "stackfix_id_seq", allocationSize = 1)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Stack stack;
+
+    @Convert(converter = StackFixTypeConverter.class)
+    private StackFixType type;
+
+    private Long created = System.currentTimeMillis();
+
+    public StackFix() {
+    }
+
+    public StackFix(Stack stack, StackFixType type) {
+        this.stack = stack;
+        this.type = type;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Stack getStack() {
+        return stack;
+    }
+
+    public void setStack(Stack stack) {
+        this.stack = stack;
+    }
+
+    public StackFixType getType() {
+        return type;
+    }
+
+    public void setType(StackFixType type) {
+        this.type = type;
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public void setCreated(Long created) {
+        this.created = created;
+    }
+
+    @Override
+    public String toString() {
+        return "StackFix{" +
+                "id=" + id +
+                ", type=" + type +
+                ", created=" + created +
+                '}';
+    }
+
+    public enum StackFixType {
+        UNBOUND_RESTART,
+        UNKNOWN
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerConfig.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.job.existingstackfix;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExistingStackFixerConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExistingStackFixerConfig.class);
+
+    @Value("${existingstackfixer.intervalhours:1}")
+    private int intervalInHours;
+
+    @Value("${existingstackfixer.enabled:true}")
+    private boolean existingStackFixerEnabled;
+
+    @PostConstruct
+    void logEnablement() {
+        LOGGER.info("Existing stack fixer is {}", existingStackFixerEnabled ? "enabled" : "disabled");
+    }
+
+    public boolean isExistingStackFixerEnabled() {
+        return existingStackFixerEnabled;
+    }
+
+    public int getIntervalInHours() {
+        return intervalInHours;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerJob.java
@@ -1,0 +1,115 @@
+package com.sequenceiq.cloudbreak.job.existingstackfix;
+
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackFix.StackFixType;
+import com.sequenceiq.cloudbreak.domain.view.StackView;
+import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
+import com.sequenceiq.cloudbreak.service.existingstackfix.ExistingStackFixService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.stack.StackViewService;
+
+import io.opentracing.Tracer;
+
+@DisallowConcurrentExecution
+@Component
+public class ExistingStackFixerJob extends StatusCheckerJob {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExistingStackFixerJob.class);
+
+    @Inject
+    private StackViewService stackViewService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private ExistingStackFixerJobService jobService;
+
+    @Inject
+    private Collection<ExistingStackFixService> existingStackFixServices;
+
+    public ExistingStackFixerJob(Tracer tracer) {
+        super(tracer, "Existing Stack Fixer Job");
+    }
+
+    @Override
+    protected Object getMdcContextObject() {
+        return stackViewService.findById(getStackId()).orElseGet(StackView::new);
+    }
+
+    @Override
+    protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
+        Stack stack = stackService.getByIdWithListsInTransaction(getStackId());
+
+        Status stackStatus = stack.getStatus();
+        if (failedOrInDeleteStatuses().contains(stackStatus)) {
+            LOGGER.debug("Existing stack fixing will be unscheduled, stack {} state is {}", stack.getResourceCrn(), stackStatus);
+            jobService.unschedule(getLocalId());
+            return;
+        }
+
+        Map<StackFixType, Exception> errors = new HashMap<>();
+        for (ExistingStackFixService existingStackFixService : existingStackFixServices) {
+            StackFixType stackFixType = existingStackFixService.getStackFixType();
+            if (existingStackFixService.isStackAlreadyFixed(stack)) {
+                LOGGER.debug("Stack {} was already fixed for {}", stack.getResourceCrn(), stackFixType);
+                continue;
+            }
+            try {
+                if (!existingStackFixService.isAffected(stack)) {
+                    LOGGER.debug("Stack {} is not affected by {}", stack.getResourceCrn(), stackFixType);
+                    continue;
+                }
+                LOGGER.debug("Stack {} needs fix for {}", stack.getResourceCrn(), stackFixType);
+                existingStackFixService.apply(stack);
+                LOGGER.info("Stack {} was fixed successfully for {}", stack.getResourceCrn(), stackFixType);
+            } catch (Exception e) {
+                LOGGER.error("Failed to fix stack: {} for {}", stack.getResourceCrn(), stackFixType, e);
+                errors.put(stackFixType, e);
+            }
+        }
+        if (!errors.isEmpty()) {
+            throw new JobExecutionException(String.format("Failed to fix stack %s, errors: %s", stack.getResourceCrn(), errors));
+        }
+        LOGGER.info("All fixes finished for stack {}", stack.getResourceCrn());
+        jobService.unschedule(getLocalId());
+    }
+
+    @VisibleForTesting
+    Set<Status> failedOrInDeleteStatuses() {
+        return EnumSet.of(
+                Status.CREATE_FAILED,
+                Status.PRE_DELETE_IN_PROGRESS,
+                Status.DELETE_IN_PROGRESS,
+                Status.DELETE_FAILED,
+                Status.DELETE_COMPLETED,
+                Status.EXTERNAL_DATABASE_CREATION_FAILED,
+                Status.EXTERNAL_DATABASE_DELETION_IN_PROGRESS,
+                Status.EXTERNAL_DATABASE_DELETION_FINISHED,
+                Status.EXTERNAL_DATABASE_DELETION_FAILED,
+                Status.LOAD_BALANCER_UPDATE_FINISHED,
+                Status.LOAD_BALANCER_UPDATE_FAILED
+        );
+    }
+
+    private Long getStackId() {
+        return Long.valueOf(getLocalId());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerJobAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerJobAdapter.java
@@ -1,0 +1,40 @@
+package com.sequenceiq.cloudbreak.job.existingstackfix;
+
+import org.quartz.Job;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.repository.CrudRepository;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+import com.sequenceiq.cloudbreak.repository.StackRepository;
+
+public class ExistingStackFixerJobAdapter extends JobResourceAdapter<Stack> {
+
+    public ExistingStackFixerJobAdapter(Long id, ApplicationContext context) {
+        super(id, context);
+    }
+
+    public ExistingStackFixerJobAdapter(Stack resource) {
+        super(resource);
+    }
+
+    @Override
+    public String getLocalId() {
+        return String.valueOf(getResource().getId());
+    }
+
+    @Override
+    public String getRemoteResourceId() {
+        return getResource().getResourceCrn();
+    }
+
+    @Override
+    public Class<? extends Job> getJobClassForResource() {
+        return ExistingStackFixerJob.class;
+    }
+
+    @Override
+    public Class<? extends CrudRepository> getRepositoryClassForResource() {
+        return StackRepository.class;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerJobInitializer.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.job.existingstackfix;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.domain.projection.StackTtlView;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@Component
+public class ExistingStackFixerJobInitializer implements JobInitializer {
+
+    @Inject
+    private ExistingStackFixerConfig config;
+
+    @Inject
+    private ExistingStackFixerJobService jobService;
+
+    @Inject
+    private StackService stackService;
+
+    @Override
+    public void initJobs() {
+        if (!config.isExistingStackFixerEnabled()) {
+            return;
+        }
+        stackService.getAllAlive().stream()
+                .map(this::convertToStack)
+                .filter(s -> !s.isStackInDeletionOrFailedPhase())
+                .forEach(s -> jobService.schedule(new ExistingStackFixerJobAdapter(s)));
+    }
+
+    private Stack convertToStack(StackTtlView view) {
+        Stack result = new Stack();
+        result.setId(view.getId());
+        result.setResourceCrn(view.getCrn());
+        result.setStackStatus(view.getStatus());
+        return result;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerJobService.java
@@ -1,0 +1,89 @@
+package com.sequenceiq.cloudbreak.job.existingstackfix;
+
+import javax.inject.Inject;
+
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.impl.matchers.GroupMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ExistingStackFixerJobService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExistingStackFixerJobService.class);
+
+    private static final String JOB_GROUP = "existing-stack-fixer-jobs";
+
+    private static final String TRIGGER_GROUP = "existing-stack-fixer-triggers";
+
+    private static final String LOCAL_ID = "localId";
+
+    private static final String REMOTE_RESOURCE_CRN = "remoteResourceCrn";
+
+    @Inject
+    private ExistingStackFixerConfig properties;
+
+    @Inject
+    private Scheduler scheduler;
+
+    public void schedule(ExistingStackFixerJobAdapter resource) {
+        String localId = resource.getLocalId();
+        JobDetail jobDetail = buildJobDetail(localId, resource.getRemoteResourceId());
+        Trigger trigger = buildJobTrigger(jobDetail);
+        try {
+            if (scheduler.getJobDetail(JobKey.jobKey(localId, JOB_GROUP)) != null) {
+                unschedule(localId);
+            }
+            scheduler.scheduleJob(jobDetail, trigger);
+        } catch (SchedulerException e) {
+            LOGGER.error(String.format("Error during scheduling quartz job: %s", jobDetail), e);
+        }
+    }
+
+    public void unschedule(String id) {
+        JobKey jobKey = JobKey.jobKey(id, JOB_GROUP);
+        try {
+            if (scheduler.getJobDetail(jobKey) != null) {
+                scheduler.deleteJob(jobKey);
+            }
+            if (scheduler.getJobKeys(GroupMatcher.groupEquals(JOB_GROUP)).isEmpty()) {
+                LOGGER.info("All existing stacks have been fixed, hooray!");
+            }
+        } catch (SchedulerException e) {
+            LOGGER.error(String.format("Error during unscheduling quartz job: %s", jobKey), e);
+        }
+    }
+
+    private JobDetail buildJobDetail(String stackId, String crn) {
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put(LOCAL_ID, stackId);
+        jobDataMap.put(REMOTE_RESOURCE_CRN, crn);
+        return JobBuilder.newJob(ExistingStackFixerJob.class)
+                .withIdentity(stackId, JOB_GROUP)
+                .withDescription("Fixing existing stack: " + crn)
+                .usingJobData(jobDataMap)
+                .storeDurably()
+                .build();
+    }
+
+    private Trigger buildJobTrigger(JobDetail jobDetail) {
+        return TriggerBuilder.newTrigger()
+                .forJob(jobDetail)
+                .withIdentity(jobDetail.getKey().getName(), TRIGGER_GROUP)
+                .withDescription("Trigger for fixing existing stack")
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                        .withIntervalInHours(properties.getIntervalInHours())
+                        .repeatForever()
+                        .withMisfireHandlingInstructionNextWithRemainingCount())
+                .build();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackFixRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackFixRepository.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackFix;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+
+@EntityType(entityClass = StackFix.class)
+@Transactional(Transactional.TxType.REQUIRED)
+public interface StackFixRepository extends JpaRepository<StackFix, Long> {
+
+    Optional<StackFix> findByStackAndType(Stack stack, StackFix.StackFixType stackFixType);
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/GatewayConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/GatewayConfigProvider.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.service.cluster;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
+import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+
+@Component
+public class GatewayConfigProvider {
+
+    @Inject
+    private GatewayConfigService gatewayConfigService;
+
+    public GatewayConfig getGatewayConfig(Stack stack) {
+        Boolean enableKnox = stack.getCluster().getGateway() != null;
+        GatewayConfig gatewayConfig = null;
+        for (InstanceMetaData gateway : stack.getNotTerminatedGatewayInstanceMetadata()) {
+            if (InstanceMetadataType.GATEWAY_PRIMARY.equals(gateway.getInstanceMetadataType())) {
+                gatewayConfig = gatewayConfigService.getGatewayConfig(stack, gateway, enableKnox);
+            }
+        }
+        return gatewayConfig;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/existingstackfix/ExistingStackFixService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/existingstackfix/ExistingStackFixService.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.cloudbreak.service.existingstackfix;
+
+import static com.sequenceiq.cloudbreak.util.Benchmark.measure;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackFix;
+import com.sequenceiq.cloudbreak.domain.stack.StackFix.StackFixType;
+import com.sequenceiq.cloudbreak.repository.StackFixRepository;
+import com.sequenceiq.flow.core.FlowLogService;
+
+public abstract class ExistingStackFixService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExistingStackFixService.class);
+
+    @Inject
+    private StackFixRepository stackFixRepository;
+
+    @Inject
+    private FlowLogService flowLogService;
+
+    public boolean isStackAlreadyFixed(Stack stack) {
+        return stackFixRepository.findByStackAndType(stack, getStackFixType()).isPresent();
+    }
+
+    public void apply(Stack stack) {
+        if (flowLogService.isOtherFlowRunning(stack.getId())) {
+            throw new IllegalStateException("Another flow is running for stack " + stack.getResourceCrn());
+        }
+
+        measure(() -> doApply(stack), LOGGER, "Existing stack fixing {} took {} ms for stack: {}.", getStackFixType(), stack.getResourceCrn());
+
+        LOGGER.info("Stack {} was fixed successfully for {}", stack.getResourceCrn(), getStackFixType());
+        stackFixRepository.save(new StackFix(stack, getStackFixType()));
+    }
+
+    /**
+     * @return The StackFixType that is fixed by running the service implementation's doApply
+     */
+    public abstract StackFixType getStackFixType();
+
+    /**
+     * @return Is the stack affected by the {@link StackFixType}
+     */
+    public abstract boolean isAffected(Stack stack);
+
+    /**
+     * Apply the fix of {@link StackFixType} for the affected stack
+     */
+    abstract void doApply(Stack stack);
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/existingstackfix/UnboundRestartFixService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/existingstackfix/UnboundRestartFixService.java
@@ -1,0 +1,97 @@
+package com.sequenceiq.cloudbreak.service.existingstackfix;
+
+import static com.sequenceiq.cloudbreak.domain.stack.StackFix.StackFixType.UNBOUND_RESTART;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackFix;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.service.cluster.GatewayConfigProvider;
+import com.sequenceiq.cloudbreak.service.stack.StackImageService;
+
+@Service
+public class UnboundRestartFixService extends ExistingStackFixService {
+
+    static final String AFFECTED_STACK_VERSION = "7.2.11";
+
+    static final Set<String> AFFECTED_IMAGE_IDS = Set.of(
+            "26cd5a65-cd5c-457d-8d48-9caf1a486516",
+            "19cf97b8-56d8-4be9-b317-998eea99d884",
+            "c24acec3-9110-4474-9082-3620deac0910"
+    );
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnboundRestartFixService.class);
+
+    @Inject
+    private StackImageService stackImageService;
+
+    @Inject
+    private GatewayConfigProvider gatewayConfigProvider;
+
+    @Inject
+    private HostOrchestrator hostOrchestrator;
+
+    @Override
+    public StackFix.StackFixType getStackFixType() {
+        return UNBOUND_RESTART;
+    }
+
+    @Override
+    public boolean isAffected(Stack stack) {
+        if (!AFFECTED_STACK_VERSION.equals(stack.getStackVersion())) {
+            return false;
+        }
+        try {
+            Image image = stackImageService.getCurrentImage(stack);
+            return AFFECTED_IMAGE_IDS.contains(image.getImageId());
+        } catch (CloudbreakImageNotFoundException e) {
+            throw new IllegalStateException("Image not found for stack " + stack.getResourceCrn(), e);
+        }
+    }
+
+    @Override
+    void doApply(Stack stack) {
+        if (!isCmServerReachable(stack)) {
+            LOGGER.info("UnboundRestartFixService cannot run, because CM server is unreachable of stack: {}", stack.getResourceCrn());
+            throw new RuntimeException("CM server is unreachable for stack: " + stack.getResourceCrn());
+        }
+        try {
+            Map<String, String> hostResponses = hostOrchestrator.replacePatternInFileOnAllHosts(gatewayConfigProvider.getGatewayConfig(stack),
+                    "/etc/dhcp/dhclient-enter-hooks", "systemctl restart unbound", "pkill -u unbound -SIGHUP unbound");
+            LOGGER.debug("Replace unbound service restart responses for stack {}: {}", stack.getResourceCrn(), hostResponses);
+            List<String> failedHosts = hostResponses.entrySet().stream()
+                    .filter(entry -> StringUtils.equalsAny(entry.getValue(), "false", "null", null))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toList());
+            if (!failedHosts.isEmpty()) {
+                throw new RuntimeException(String.format("Host(s) of stack %s had an invalid response: %s", stack.getResourceCrn(), failedHosts));
+            }
+        } catch (CloudbreakOrchestratorFailedException e) {
+            throw new RuntimeException("Failed to replace unbound service restart on all hosts", e);
+        }
+    }
+
+    private boolean isCmServerReachable(Stack stack) {
+        return stack.getInstanceGroups().stream()
+                .flatMap(ig -> ig.getInstanceMetaDataSet().stream())
+                .filter(InstanceMetaData::getClusterManagerServer)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Could not find CM server for stack: " + stack.getResourceCrn()))
+                .isReachable();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaClientService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaClientService.java
@@ -13,6 +13,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.auth.crn.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
@@ -49,6 +51,10 @@ public class FreeipaClientService {
 
     public Optional<DescribeFreeIpaResponse> findByEnvironmentCrn(String environmentCrn) {
         try {
+            if (InternalCrnBuilder.isInternalCrn(ThreadBasedUserCrnProvider.getUserCrn())) {
+                String accountId = Crn.fromString(environmentCrn).getAccountId();
+                return Optional.ofNullable(freeIpaV1Endpoint.describeInternal(environmentCrn, accountId));
+            }
             return Optional.ofNullable(freeIpaV1Endpoint.describe(environmentCrn));
         } catch (NotFoundException e) {
             LOGGER.info("FreeIPA is not found for env: {}", environmentCrn, e);

--- a/core/src/main/resources/schema/app/20211103115000_CB-14656_create_stackfix_table.sql
+++ b/core/src/main/resources/schema/app/20211103115000_CB-14656_create_stackfix_table.sql
@@ -1,0 +1,22 @@
+-- // CB-14656
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE IF NOT EXISTS stackfix
+(
+    id              bigint NOT NULL,
+    type            CHARACTER VARYING(255) NOT NULL,
+    created         int8 NOT NULL,
+    stack_id        bigint NOT NULL,
+    PRIMARY KEY (id)
+);
+
+ALTER TABLE ONLY stackfix ADD CONSTRAINT fk_stackfix_stack_id FOREIGN KEY (stack_id) REFERENCES stack(id);
+
+CREATE SEQUENCE IF NOT EXISTS stackfix_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP TABLE IF EXISTS stackfix;
+
+DROP SEQUENCE IF EXISTS stackfix_id_seq;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/existingstackfix/ExistingStackFixerJobTest.java
@@ -1,0 +1,154 @@
+package com.sequenceiq.cloudbreak.job.existingstackfix;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobExecutionException;
+import org.springframework.util.ReflectionUtils;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
+import com.sequenceiq.cloudbreak.service.existingstackfix.ExistingStackFixService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class ExistingStackFixerJobTest {
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private ExistingStackFixerJobService jobService;
+
+    @Mock
+    private ExistingStackFixService existingStackFixService;
+
+    @InjectMocks
+    private ExistingStackFixerJob underTest;
+
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException {
+        stack = new Stack();
+        stack.setId(123L);
+        stack.setResourceCrn("stack-crn");
+        setStackStatus(Status.AVAILABLE);
+
+        MockitoAnnotations.openMocks(this);
+
+        when(stackService.getByIdWithListsInTransaction(stack.getId())).thenReturn(stack);
+
+        underTest.setLocalId(stack.getId().toString());
+        underTest.setRemoteResourceCrn(stack.getResourceCrn());
+
+        setStackFixServices();
+    }
+
+    @Test
+    void shouldUnscheduleWhenStackIsInFailedOrDeletedStatus() throws JobExecutionException {
+        setStackStatus(Status.CREATE_FAILED);
+
+        underTest.executeTracedJob(null);
+
+        verify(jobService).unschedule(underTest.getLocalId());
+        verify(existingStackFixService, never()).apply(stack);
+    }
+
+    @Test
+    void shouldNotApplyWhenStackIsAlreadyFixed() throws JobExecutionException {
+        when(existingStackFixService.isStackAlreadyFixed(stack)).thenReturn(true);
+
+        underTest.executeTracedJob(null);
+
+        verify(jobService).unschedule(underTest.getLocalId());
+        verify(existingStackFixService, never()).apply(stack);
+    }
+
+    @Test
+    void shouldNotApplyWhenStackIsNotAffected() throws JobExecutionException {
+        when(existingStackFixService.isAffected(stack)).thenReturn(false);
+
+        underTest.executeTracedJob(null);
+
+        verify(jobService).unschedule(underTest.getLocalId());
+        verify(existingStackFixService, never()).apply(stack);
+    }
+
+    @Test
+    void shouldApplyWhenStackIsAffected() throws JobExecutionException {
+        when(existingStackFixService.isAffected(stack)).thenReturn(true);
+
+        underTest.executeTracedJob(null);
+
+        verify(jobService).unschedule(underTest.getLocalId());
+        verify(existingStackFixService).apply(stack);
+    }
+
+    @Test
+    void shouldNotUnscheduleWhenApplyFails() {
+        when(existingStackFixService.isAffected(stack)).thenReturn(true);
+        doThrow(RuntimeException.class).when(existingStackFixService).apply(stack);
+
+        Assertions.assertThatThrownBy(() -> underTest.executeTracedJob(null))
+                .isInstanceOf(JobExecutionException.class)
+                .hasMessageStartingWith("Failed to fix stack");
+
+        verify(jobService, never()).unschedule(underTest.getLocalId());
+    }
+
+    @Test
+    void shouldNotUnscheduleWhenOneApplyFailsAndOneSucceeds() {
+        ExistingStackFixService failingExistingStackFixService = mock(ExistingStackFixService.class);
+        when(failingExistingStackFixService.isAffected(stack)).thenReturn(true);
+        doThrow(RuntimeException.class).when(failingExistingStackFixService).apply(stack);
+        setStackFixServices(failingExistingStackFixService);
+
+        when(existingStackFixService.isAffected(stack)).thenReturn(true);
+
+        Assertions.assertThatThrownBy(() -> underTest.executeTracedJob(null))
+                .isInstanceOf(JobExecutionException.class)
+                .hasMessageStartingWith("Failed to fix stack");
+
+        verify(jobService, never()).unschedule(underTest.getLocalId());
+    }
+
+    private void setStackStatus(Status status) {
+        StackStatus stackStatus = new StackStatus();
+        stackStatus.setStatus(status);
+        stack.setStackStatus(stackStatus);
+    }
+
+    /**
+     * workaround for collection injection
+     */
+    private void setStackFixServices(ExistingStackFixService... additionalServices) {
+        try {
+            Field existingStackFixServicesField = ExistingStackFixerJob.class.getDeclaredField("existingStackFixServices");
+            ReflectionUtils.makeAccessible(existingStackFixServicesField);
+            Set<ExistingStackFixService> existingStackFixServices = new HashSet<>();
+            existingStackFixServices.add(existingStackFixService);
+            existingStackFixServices.addAll(Set.of(additionalServices));
+            ReflectionUtils.setField(existingStackFixServicesField, underTest, existingStackFixServices);
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/InstanceMetadataUpdaterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/InstanceMetadataUpdaterTest.java
@@ -3,7 +3,6 @@ package com.sequenceiq.cloudbreak.service.cluster.ambari;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.SERVICES_UNHEALTHY;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -41,7 +40,7 @@ import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFa
 import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
-import com.sequenceiq.cloudbreak.service.GatewayConfigService;
+import com.sequenceiq.cloudbreak.service.cluster.GatewayConfigProvider;
 import com.sequenceiq.cloudbreak.service.cluster.InstanceMetadataUpdater;
 import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
@@ -51,7 +50,7 @@ import com.sequenceiq.common.api.type.InstanceGroupType;
 public class InstanceMetadataUpdaterTest {
 
     @Mock
-    private GatewayConfigService gatewayConfigService;
+    private GatewayConfigProvider gatewayConfigProvider;
 
     @Mock
     private InstanceMetaDataService instanceMetaDataService;
@@ -74,7 +73,7 @@ public class InstanceMetadataUpdaterTest {
     @Before
     public void setUp() throws CloudbreakException, JsonProcessingException, CloudbreakOrchestratorFailedException {
         MockitoAnnotations.initMocks(this);
-        when(gatewayConfigService.getGatewayConfig(any(Stack.class), any(InstanceMetaData.class), anyBoolean())).thenReturn(gatewayConfig);
+        when(gatewayConfigProvider.getGatewayConfig(any(Stack.class))).thenReturn(gatewayConfig);
 
         InstanceMetadataUpdater.Package packageByName = new InstanceMetadataUpdater.Package();
         packageByName.setName("packageByName");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/existingstackfix/ExistingStackFixServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/existingstackfix/ExistingStackFixServiceTest.java
@@ -1,0 +1,104 @@
+package com.sequenceiq.cloudbreak.service.existingstackfix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackFix;
+import com.sequenceiq.cloudbreak.domain.stack.StackFix.StackFixType;
+import com.sequenceiq.cloudbreak.repository.StackFixRepository;
+import com.sequenceiq.flow.core.FlowLogService;
+
+@ExtendWith(MockitoExtension.class)
+class ExistingStackFixServiceTest {
+
+    @Mock
+    private StackFixRepository stackFixRepository;
+
+    @Mock
+    private FlowLogService flowLogService;
+
+    @InjectMocks
+    private NoopExistingStackFixService underTest;
+
+    @Captor
+    private ArgumentCaptor<StackFix> stackFixArgumentCaptor;
+
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() {
+        stack = new Stack();
+        stack.setId(123L);
+        stack.setResourceCrn("stack-crn");
+    }
+
+    @Test
+    void isStackAlreadyFixedFalse() {
+        when(stackFixRepository.findByStackAndType(stack, StackFixType.UNKNOWN)).thenReturn(Optional.empty());
+
+        boolean result = underTest.isStackAlreadyFixed(stack);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isStackAlreadyFixedTrue() {
+        when(stackFixRepository.findByStackAndType(stack, StackFixType.UNKNOWN)).thenReturn(Optional.of(new StackFix()));
+
+        boolean result = underTest.isStackAlreadyFixed(stack);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void applyShouldFailWhenFlowIsRunning() {
+        when(flowLogService.isOtherFlowRunning(stack.getId())).thenReturn(true);
+
+        assertThatThrownBy(() -> underTest.apply(stack))
+                .hasMessage("Another flow is running for stack stack-crn");
+    }
+
+    @Test
+    void shouldSaveStackFixWhenApplyIsSuccessful() {
+        underTest.apply(stack);
+
+        verify(stackFixRepository).save(stackFixArgumentCaptor.capture());
+        StackFix stackFix = stackFixArgumentCaptor.getValue();
+        assertThat(stackFix)
+                .returns(stack, StackFix::getStack)
+                .returns(StackFixType.UNKNOWN, StackFix::getType);
+    }
+
+    static class NoopExistingStackFixService extends ExistingStackFixService {
+
+        @Override
+        public StackFixType getStackFixType() {
+            return StackFixType.UNKNOWN;
+        }
+
+        @Override
+        public boolean isAffected(Stack stack) {
+            return false;
+        }
+
+        @Override
+        void doApply(Stack stack) {
+            // do nothing
+        }
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/existingstackfix/UnboundRestartFixServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/existingstackfix/UnboundRestartFixServiceTest.java
@@ -1,0 +1,141 @@
+package com.sequenceiq.cloudbreak.service.existingstackfix;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.orchestrator.host.HostOrchestrator;
+import com.sequenceiq.cloudbreak.repository.StackFixRepository;
+import com.sequenceiq.cloudbreak.service.cluster.GatewayConfigProvider;
+import com.sequenceiq.cloudbreak.service.stack.StackImageService;
+import com.sequenceiq.flow.core.FlowLogService;
+
+@ExtendWith(MockitoExtension.class)
+class UnboundRestartFixServiceTest {
+
+    @Mock
+    private StackFixRepository stackFixRepository;
+
+    @Mock
+    private FlowLogService flowLogService;
+
+    @Mock
+    private StackImageService stackImageService;
+
+    @Mock
+    private GatewayConfigProvider gatewayConfigProvider;
+
+    @Mock
+    private HostOrchestrator hostOrchestrator;
+
+    @InjectMocks
+    private UnboundRestartFixService underTest;
+
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() {
+        stack = new Stack();
+        stack.setId(123L);
+        stack.setResourceCrn("stack-crn");
+
+        setCmServerReachability(true);
+    }
+
+    @Test
+    void unaffectedStackVersionNotAffected() {
+        stack.setStackVersion("7.2.12");
+
+        boolean result = underTest.isAffected(stack);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void affectedStackVersionButUnaffectedImageIdIsNotAffected() throws CloudbreakImageNotFoundException {
+        stack.setStackVersion(UnboundRestartFixService.AFFECTED_STACK_VERSION);
+        setStackImageId("123456");
+
+        boolean result = underTest.isAffected(stack);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void affectedImageIsAffected() throws CloudbreakImageNotFoundException {
+        stack.setStackVersion(UnboundRestartFixService.AFFECTED_STACK_VERSION);
+        setStackImageId(UnboundRestartFixService.AFFECTED_IMAGE_IDS.stream().findFirst().get());
+
+        boolean result = underTest.isAffected(stack);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void unreachableCmServerFailsToApply() {
+        setCmServerReachability(false);
+
+        assertThatThrownBy(() -> underTest.doApply(stack))
+                .hasMessageStartingWith("CM server is unreachable for stack");
+    }
+
+    @Test
+    void failedHostsFailsToApply() throws CloudbreakOrchestratorFailedException {
+        when(hostOrchestrator.replacePatternInFileOnAllHosts(any(), any(), any(), any())).thenReturn(
+                Map.of("host1", "false", "host2", "null"));
+
+        assertThatThrownBy(() -> underTest.doApply(stack))
+                .hasMessageStartingWith("Host(s) of stack stack-crn had an invalid response");
+    }
+
+    @Test
+    void orchestratorExceptionTranslates() throws CloudbreakOrchestratorFailedException {
+        doThrow(new CloudbreakOrchestratorFailedException("oops")).when(hostOrchestrator).replacePatternInFileOnAllHosts(any(), any(), any(), any());
+
+        assertThatThrownBy(() -> underTest.doApply(stack))
+                .hasMessage("Failed to replace unbound service restart on all hosts");
+    }
+
+    @Test
+    void allHostsSucceedToApply() throws CloudbreakOrchestratorFailedException {
+        when(hostOrchestrator.replacePatternInFileOnAllHosts(any(), any(), any(), any())).thenReturn(Map.of("host", "success"));
+
+        underTest.doApply(stack);
+    }
+
+    private void setCmServerReachability(boolean reachable) {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setClusterManagerServer(true);
+        instanceMetaData.setInstanceStatus(reachable ? InstanceStatus.SERVICES_RUNNING : InstanceStatus.ORCHESTRATION_FAILED);
+        instanceGroup.setInstanceMetaData(Set.of(instanceMetaData));
+        stack.setInstanceGroups(Set.of(instanceGroup));
+    }
+
+    private void setStackImageId(String id) throws CloudbreakImageNotFoundException {
+        Image image = mock(Image.class);
+        when(image.getImageId()).thenReturn(id);
+        when(stackImageService.getCurrentImage(stack)).thenReturn(image);
+    }
+
+}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -68,6 +68,9 @@ public interface HostOrchestrator extends HostRecipeExecutor {
 
     Map<String, String> runCommandOnAllHosts(GatewayConfig gateway, String command) throws CloudbreakOrchestratorFailedException;
 
+    Map<String, String> replacePatternInFileOnAllHosts(GatewayConfig gatewayConfig, String file, String pattern, String replace)
+            throws CloudbreakOrchestratorFailedException;
+
     Map<String, JsonNode> getGrainOnAllHosts(GatewayConfig gateway, String grain) throws CloudbreakOrchestratorFailedException;
 
     Map<String, String> getMembers(GatewayConfig gatewayConfig, List<String> privateIps) throws CloudbreakOrchestratorException;

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -820,6 +820,17 @@ public class SaltOrchestrator implements HostOrchestrator {
     }
 
     @Override
+    public Map<String, String> replacePatternInFileOnAllHosts(GatewayConfig gatewayConfig, String file, String pattern, String replace)
+            throws CloudbreakOrchestratorFailedException {
+        try (SaltConnector saltConnector = saltService.createSaltConnector(gatewayConfig)) {
+            return SaltStates.replacePatternInFile(retry, saltConnector, file, pattern, replace);
+        } catch (RuntimeException e) {
+            LOGGER.info("Error occurred during file replace execution in file '{}' while replacing pattern '{}' with '{}'", file, pattern, replace, e);
+            throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
+        }
+    }
+
+    @Override
     public void uploadRecipes(List<GatewayConfig> allGatewayConfigs, Map<String, List<RecipeModel>> recipes, ExitCriteriaModel exitModel)
             throws CloudbreakOrchestratorFailedException {
         GatewayConfig primaryGateway = saltService.getPrimaryGatewayConfig(allGatewayConfigs);

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
@@ -330,6 +330,21 @@ public class SaltStates {
         });
     }
 
+    public static Map<String, String> replacePatternInFile(Retry retry, SaltConnector sc, String file, String pattern, String replace) {
+        return retry.testWith2SecDelayMax15Times(() -> {
+            try {
+                String[] args = new String[]{file, String.format("pattern='%s'", pattern), String.format("repl='%s'", replace)};
+                CommandExecutionResponse resp = measure(() -> sc.run(Glob.ALL, "file.replace", LOCAL, CommandExecutionResponse.class, args), LOGGER,
+                        "Command run took {}ms for file.replace with args [{}]", (Object) args);
+                List<Map<String, String>> result = resp.getResult();
+                return CollectionUtils.isEmpty(result) ? new HashMap<>() : result.get(0);
+            } catch (RuntimeException e) {
+                LOGGER.error("Salt run command failed", e);
+                throw new Retry.ActionFailedException("Salt run command failed");
+            }
+        });
+    }
+
     public static Map<String, String> runCommandOnHosts(Retry retry, SaltConnector sc, Target<String> target, String command) {
         return retry.testWith2SecDelayMax15Times(() -> {
             try {

--- a/orchestrator-salt/src/main/resources/salt/salt/bugfix/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/bugfix/init.sls
@@ -1,0 +1,5 @@
+restart_unbound_fix:
+  file.replace:
+    - name: "/etc/dhcp/dhclient-enter-hooks"
+    - pattern: "systemctl restart unbound"
+    - repl: "pkill -u unbound -SIGHUP unbound"

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -13,6 +13,7 @@ base:
     - logrotate
     - ntp
     - postgresql.root-certs
+    - bugfix
 
   'G@roles:ad_member and G@os_family:RedHat':
     - match: compound


### PR DESCRIPTION
Introduce a new quartz job that runs for existing stacks, applying fixes.
The first fix implemented is a salt command to replace the faulty unbound service restart on the stacks that use one of the affected images.