### PR TITLE
CB-14753 Limit long string fields in telemetry events

### DIFF
--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToClusterShapeConverter.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToClusterShapeConverter.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
@@ -23,6 +24,8 @@ import com.sequenceiq.cloudbreak.structuredevent.event.StructuredSyncEvent;
 public class StructuredEventToClusterShapeConverter {
 
     private static final int DEFAULT_INTEGER_VALUE = -1;
+
+    private static final int MAX_STRING_LENGTH = 3000;
 
     public UsageProto.CDPClusterShape convert(StructuredFlowEvent structuredFlowEvent) {
         UsageProto.CDPClusterShape.Builder cdpClusterShape = UsageProto.CDPClusterShape.newBuilder();
@@ -69,7 +72,10 @@ public class StructuredEventToClusterShapeConverter {
             Collections.sort(hostGroupNodeCount);
             cdpClusterShape.setHostGroupNodeCount(String.join(", ", hostGroupNodeCount));
             cdpClusterShape.setTemporaryStorageUsed(hostGroupTemporaryStorage.contains(TemporaryStorage.EPHEMERAL_VOLUMES.name()));
-            cdpClusterShape.setDefinitionDetails(JsonUtil.writeValueAsStringSilentSafe(stackDetails.getInstanceGroups()));
+            String definitionDetailsJsonString = JsonUtil.writeValueAsStringSilentSafe(stackDetails.getInstanceGroups());
+            if (StringUtils.length(definitionDetailsJsonString) <= MAX_STRING_LENGTH) {
+                cdpClusterShape.setDefinitionDetails(definitionDetailsJsonString);
+            }
         }
 
         return cdpClusterShape;

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToStatusDetailsConverter.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToStatusDetailsConverter.java
@@ -14,7 +14,7 @@ import com.sequenceiq.cloudbreak.structuredevent.event.StructuredSyncEvent;
 @Component
 public class StructuredEventToStatusDetailsConverter {
 
-    private static final int MAX_STRING_LENGTH = 5000;
+    private static final int MAX_STRING_LENGTH = 1500;
 
     public UsageProto.CDPStatusDetails convert(StructuredFlowEvent structuredFlowEvent) {
 

--- a/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToStatusDetailsConverterTest.java
+++ b/structuredevent-service-legacy/src/test/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToStatusDetailsConverterTest.java
@@ -104,19 +104,19 @@ public class StructuredEventToStatusDetailsConverterTest {
         Assertions.assertEquals(StringUtils.repeat("*", 10), flowStatusDetails.getStackStatusReason());
         Assertions.assertEquals(StringUtils.repeat("*", 10), flowStatusDetails.getClusterStatusReason());
 
-        stackDetails.setStatusReason(StringUtils.repeat("*", 5000));
-        clusterDetails.setStatusReason(StringUtils.repeat("*", 5000));
+        stackDetails.setStatusReason(StringUtils.repeat("*", 1500));
+        clusterDetails.setStatusReason(StringUtils.repeat("*", 1500));
         flowStatusDetails = underTest.convert(structuredFlowEvent);
 
-        Assertions.assertEquals(StringUtils.repeat("*", 5000), flowStatusDetails.getStackStatusReason());
-        Assertions.assertEquals(StringUtils.repeat("*", 5000), flowStatusDetails.getClusterStatusReason());
+        Assertions.assertEquals(StringUtils.repeat("*", 1500), flowStatusDetails.getStackStatusReason());
+        Assertions.assertEquals(StringUtils.repeat("*", 1500), flowStatusDetails.getClusterStatusReason());
 
-        stackDetails.setStatusReason(StringUtils.repeat("*", 10000));
-        clusterDetails.setStatusReason(StringUtils.repeat("*", 10000));
+        stackDetails.setStatusReason(StringUtils.repeat("*", 3000));
+        clusterDetails.setStatusReason(StringUtils.repeat("*", 3000));
         flowStatusDetails = underTest.convert(structuredFlowEvent);
 
-        Assertions.assertEquals(StringUtils.repeat("*", 5000), flowStatusDetails.getStackStatusReason());
-        Assertions.assertEquals(StringUtils.repeat("*", 5000), flowStatusDetails.getClusterStatusReason());
+        Assertions.assertEquals(StringUtils.repeat("*", 1500), flowStatusDetails.getStackStatusReason());
+        Assertions.assertEquals(StringUtils.repeat("*", 1500), flowStatusDetails.getClusterStatusReason());
 
     }
 


### PR DESCRIPTION
Trimming stack and cluster status reason strings at 1500 chars and only including instance group detail json strings (definitionDetails) which are maximum of 3000 chars. This way the overall max length of an events stays around 8000 chars so it won't be separated by the log collecting pipeline.