### PR TITLE
CB-14540 Base distrox OS upgrade L0 test

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/cluster/DistroXUpgradeTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/cluster/DistroXUpgradeTestDto.java
@@ -43,4 +43,9 @@ public class DistroXUpgradeTestDto extends AbstractSdxTestDto<DistroXUpgradeV1Re
         getRequest().setReplaceVms(replaceVms);
         return this;
     }
+
+    public DistroXUpgradeTestDto withLockComponents(Boolean lockComponents) {
+        getRequest().setLockComponents(lockComponents);
+        return this;
+    }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/KibanaSearchUrl.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/search/KibanaSearchUrl.java
@@ -60,17 +60,23 @@ public class KibanaSearchUrl implements SearchUrl {
 
     private String getAppState() {
         return String.format("(columns:!('@message','@app'," + KEY + "),filters:!(('$state':(store:appState),"
-                        + "meta:(alias:!n,disabled:!f,index:'0ec45520-98e6-11eb-85ad-c5cb99d34f92',key:" + KEY + ",negate:!f,params:!(%s),"
+                        + "meta:(alias:!n,disabled:!f,index:manual-fields,key:" + KEY + ",negate:!f,params:!(%s),"
                         + "type:phrases,value:'%s'),query:(bool:(minimum_should_match:1,should:!(%s"
-                        + "))))),index:'0ec45520-98e6-11eb-85ad-c5cb99d34f92',interval:auto,query:(language:kuery,query:''),sort:!('@timestamp',desc))",
-                getResourceList(), getResourceList(), getResourceQueries());
+                        + "))))),index:manual-fields,interval:auto,query:(language:kuery,query:''),sort:!('@timestamp',desc))",
+                getResourceListParams(), getResourceListValue(), getResourceQueries());
 
     }
 
-    private String getResourceList() {
+    private String getResourceListParams() {
         List<String> list = searchables.stream().map(Searchable::getSearchId).collect(Collectors.toList());
 
         return String.join(",", list);
+    }
+
+    private String getResourceListValue() {
+        List<String> list = searchables.stream().map(Searchable::getSearchId).collect(Collectors.toList());
+
+        return String.join(",%20", list);
     }
 
     private String getResourceQueries() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/DistroXOSUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion/DistroXOSUpgradeTests.java
@@ -1,0 +1,139 @@
+package com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion;
+
+import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
+
+import javax.inject.Inject;
+
+import org.testng.annotations.Ignore;
+import org.testng.annotations.Test;
+
+import com.sequenceiq.distrox.api.v1.distrox.model.upgrade.DistroXUpgradeReplaceVms;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
+import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
+import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
+import com.sequenceiq.it.cloudbreak.context.Description;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.DistroXUpgradeTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxTestDto;
+import com.sequenceiq.it.cloudbreak.dto.sdx.SdxUpgradeTestDto;
+import com.sequenceiq.it.cloudbreak.testcase.e2e.AbstractE2ETest;
+import com.sequenceiq.sdx.api.model.SdxClusterStatusResponse;
+import com.sequenceiq.sdx.api.model.SdxUpgradeReplaceVms;
+
+public class DistroXOSUpgradeTests extends AbstractE2ETest {
+
+    @Inject
+    private SdxTestClient sdxTestClient;
+
+    @Inject
+    private DistroXTestClient distroXTestClient;
+
+    @Inject
+    private CommonClusterManagerProperties commonClusterManagerProperties;
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
+
+    @Override
+    protected void setupTest(TestContext testContext) {
+        testContext.getCloudProvider().getCloudFunctionality().cloudStorageInitialize();
+        createDefaultUser(testContext);
+        initializeDefaultBlueprints(testContext);
+        createDefaultCredential(testContext);
+        createEnvironmentWithFreeIpa(testContext);
+    }
+
+    @Ignore("This test case should be re-enabled in case of OPSAPS-62124 has been resolved at MOW-Dev")
+    @Test(dataProvider = TEST_CONTEXT, description = "We need to wait the OPSAPS-62124 to be resolved")
+    @Description(
+            given = "there is a running environment with freeIPA in available state",
+            when = "SDX (light duty) and base DistroX (5 nodes with master, compute and workers) should be created successfully",
+            and = "SDX then DistroX runtime upgrade done successfully after that OS upgrade called on DistroX",
+            then = "DistroX upgrade should be successful, the cluster should be up and running")
+    public void testBaseDistroXOSUpgrade(TestContext testContext) {
+        String sdxName = resourcePropertyProvider().getName();
+        String distroXName = resourcePropertyProvider().getName();
+        String currentRuntimeVersion = commonClusterManagerProperties.getUpgrade().getDistroXUpgradeCurrentVersion();
+        String targetRuntimeVersion = commonClusterManagerProperties.getUpgrade().getDistroXUpgradeTargetVersion();
+
+        testContext
+                .given(sdxName, SdxTestDto.class)
+                    .withCloudStorage()
+                    .withRuntimeVersion(currentRuntimeVersion)
+                .when(sdxTestClient.create(), key(sdxName))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxName))
+                .awaitForHealthyInstances()
+                .validate();
+
+        testContext
+                .given(distroXName, DistroXTestDto.class)
+                    .withTemplate(String.format(commonClusterManagerProperties.getInternalDistroXBlueprintType(), currentRuntimeVersion))
+                .when(distroXTestClient.create(), key(distroXName))
+                .await(STACK_AVAILABLE, key(distroXName))
+                .awaitForHealthyInstances()
+                .validate();
+
+        testContext
+                .given(distroXName, DistroXTestDto.class)
+                .when(distroXTestClient.stop(), key(distroXName))
+                .await(STACK_STOPPED, key(distroXName))
+                .validate();
+        testContext
+                .given(SdxUpgradeTestDto.class)
+                    .withReplaceVms(SdxUpgradeReplaceVms.ENABLED)
+                    .withRuntime(targetRuntimeVersion)
+                .given(sdxName, SdxTestDto.class)
+                .when(sdxTestClient.upgrade(), key(sdxName))
+                .await(SdxClusterStatusResponse.DATALAKE_UPGRADE_IN_PROGRESS, key(sdxName).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxName))
+                .awaitForHealthyInstances()
+                .validate();
+
+        testContext
+                .given(distroXName, DistroXTestDto.class)
+                .when(distroXTestClient.start(), key(distroXName))
+                .await(STACK_AVAILABLE, key(distroXName))
+                .validate();
+        testContext
+                .given(DistroXUpgradeTestDto.class)
+                    .withRuntime(targetRuntimeVersion)
+                .given(distroXName, DistroXTestDto.class)
+                .when(distroXTestClient.upgrade(), key(distroXName))
+                .await(STACK_AVAILABLE, key(distroXName))
+                .awaitForHealthyInstances()
+                .validate();
+        testContext
+                .given(DistroXUpgradeTestDto.class)
+                    .withLockComponents(Boolean.TRUE)
+                    .withRuntime(null)
+                    .withReplaceVms(DistroXUpgradeReplaceVms.ENABLED)
+                .given(distroXName, DistroXTestDto.class)
+                .when(distroXTestClient.upgrade(), key(distroXName))
+                .await(STACK_AVAILABLE, key(distroXName))
+                .awaitForHealthyInstances()
+                .validate();
+
+        testContext
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.describe())
+                .await(Status.AVAILABLE)
+                .awaitForHealthyInstances()
+                .validate();
+        testContext
+                .given(sdxName, SdxTestDto.class)
+                .when(sdxTestClient.describe(), key(sdxName))
+                .await(SdxClusterStatusResponse.RUNNING, key(sdxName))
+                .awaitForHealthyInstances()
+                .validate();
+        testContext
+                .given(distroXName, DistroXTestDto.class)
+                .when(distroXTestClient.get(), key(distroXName))
+                .await(STACK_AVAILABLE, key(distroXName))
+                .awaitForHealthyInstances()
+                .validate();
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakWaitObject.java
@@ -13,10 +13,13 @@ import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.EXTERNAL_D
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.EXTERNAL_DATABASE_START_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.EXTERNAL_DATABASE_STOP_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.LOAD_BALANCER_UPDATE_FAILED;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.NODE_FAILURE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.PRE_DELETE_IN_PROGRESS;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.RECOVERY_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.RESTORE_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.START_FAILED;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.STOP_FAILED;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UNREACHABLE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status.UPDATE_FAILED;
 
 import java.util.ArrayList;
@@ -106,9 +109,9 @@ public class CloudbreakWaitObject implements WaitObject {
 
     @Override
     public boolean isFailed() {
-        List<Status> failedStatuses = List.of(UPDATE_FAILED, BACKUP_FAILED, RESTORE_FAILED, CREATE_FAILED, ENABLE_SECURITY_FAILED, DELETE_FAILED,
-                START_FAILED, STOP_FAILED, EXTERNAL_DATABASE_CREATION_FAILED, EXTERNAL_DATABASE_DELETION_FAILED, EXTERNAL_DATABASE_START_FAILED,
-                EXTERNAL_DATABASE_STOP_FAILED, LOAD_BALANCER_UPDATE_FAILED);
+        List<Status> failedStatuses = List.of(UPDATE_FAILED, BACKUP_FAILED, RESTORE_FAILED, RECOVERY_FAILED, CREATE_FAILED, ENABLE_SECURITY_FAILED,
+                DELETE_FAILED, START_FAILED, STOP_FAILED, UNREACHABLE, NODE_FAILURE, EXTERNAL_DATABASE_CREATION_FAILED, EXTERNAL_DATABASE_DELETION_FAILED,
+                EXTERNAL_DATABASE_START_FAILED, EXTERNAL_DATABASE_STOP_FAILED, LOAD_BALANCER_UPDATE_FAILED);
         return !ListUtils.retainAll(failedStatuses, actualStatusesEnumValues()).isEmpty();
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeWaitObject.java
@@ -1,12 +1,16 @@
 package com.sequenceiq.it.cloudbreak.util.wait.service.datalake;
 
+import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.CERT_RENEWAL_FAILED;
 import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.CERT_ROTATION_FAILED;
+import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.CLUSTER_UNREACHABLE;
+import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.DATALAKE_RECOVERY_FAILED;
 import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.DATALAKE_RESTORE_FAILED;
 import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.DATALAKE_UPGRADE_FAILED;
 import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.DELETED;
 import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.DELETE_FAILED;
 import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.DELETE_REQUESTED;
 import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.EXTERNAL_DATABASE_DELETION_IN_PROGRESS;
+import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.NODE_FAILURE;
 import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.PROVISIONING_FAILED;
 import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.REPAIR_FAILED;
 import static com.sequenceiq.sdx.api.model.SdxClusterStatusResponse.STACK_DELETION_IN_PROGRESS;
@@ -85,7 +89,8 @@ public class DatalakeWaitObject implements WaitObject {
     @Override
     public boolean isFailed() {
         Set<SdxClusterStatusResponse> failedStatuses = Set.of(PROVISIONING_FAILED, REPAIR_FAILED, DATALAKE_UPGRADE_FAILED,
-                DELETE_FAILED, START_FAILED, STOP_FAILED, SYNC_FAILED, CERT_ROTATION_FAILED, DATALAKE_RESTORE_FAILED);
+                DATALAKE_RECOVERY_FAILED, DELETE_FAILED, START_FAILED, STOP_FAILED, CLUSTER_UNREACHABLE, NODE_FAILURE, SYNC_FAILED,
+                CERT_ROTATION_FAILED, CERT_RENEWAL_FAILED, DATALAKE_RESTORE_FAILED);
         return failedStatuses.contains(sdxResponse.getStatus());
     }
 

--- a/integration-test/src/main/resources/testsuites/e2e/l0promotion/distrox-os-upgrade-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/l0promotion/distrox-os-upgrade-tests.yaml
@@ -1,0 +1,5 @@
+name: "distrox-os-upgrade-tests"
+tests:
+  - name: "distrox_os_upgrade_tests"
+    classes:
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.l0promotion.DistroXOSUpgradeTests


### PR DESCRIPTION
Create new data hub (distrox) OS upgrade L0 test(s) at [Cloudbreak API test project](https://github.com/hortonworks/cloudbreak/tree/master/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/l0promotion).

Test duration must be take into consideration:
- base (1:master, 1:compute, 3:workers) test takes more than 3 hours
- 50 workers test takes around 4 hours
- 200 workers test takes around 7 hours

So I was implemented the base case for the test project.

**NOTE:**
- We need to wait the [OPSAPS-62124](https://jira.cloudera.com/browse/OPSAPS-62124) to be resolved
- In the future if we would like to run this automated test on a daily basis, we need to create a separate `Longrunning` Jenkins job for this. This can be part of a follow up JIRA.