### PR TITLE
CB-14758 Added tests:

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/service/AwsResourceNameService.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/service/AwsResourceNameService.java
@@ -128,7 +128,7 @@ public class AwsResourceNameService extends CloudbreakResourceNameService {
         name = normalize(stackName);
         name = adjustPartLength(name);
         name = appendPart(name, stackId);
-        name = appendPart(name, "ClusterNodeSecurityGroup");
+        name = appendPart(name, "SecurityGroup");
         name = appendPart(name, StringUtils.capitalize(normalize(instanceGroupName)));
         name = adjustBaseLength(name, maxResourceNameLength);
 

--- a/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilderTest.java
+++ b/cloud-aws-native/src/test/java/com/sequenceiq/cloudbreak/cloud/aws/resource/instance/AwsNativeInstanceResourceBuilderTest.java
@@ -113,6 +113,7 @@ public class AwsNativeInstanceResourceBuilderTest {
                 .name("name")
                 .type(ResourceType.AWS_INSTANCE)
                 .status(CommonStatus.CREATED)
+                .group("groupName")
                 .params(emptyMap())
                 .build();
 
@@ -121,6 +122,7 @@ public class AwsNativeInstanceResourceBuilderTest {
                 .type(ResourceType.AWS_SECURITY_GROUP)
                 .status(CommonStatus.CREATED)
                 .reference("sg-id")
+                .group("groupName")
                 .params(emptyMap())
                 .build();
 
@@ -197,6 +199,7 @@ public class AwsNativeInstanceResourceBuilderTest {
                 .name("name")
                 .type(ResourceType.AWS_INSTANCE)
                 .status(CommonStatus.CREATED)
+                .group("groupName")
                 .params(emptyMap())
                 .build();
 
@@ -205,6 +208,7 @@ public class AwsNativeInstanceResourceBuilderTest {
                 .type(ResourceType.AWS_SECURITY_GROUP)
                 .status(CommonStatus.CREATED)
                 .reference("sg-id")
+                .group("groupName")
                 .params(emptyMap())
                 .build();
 

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/compute/GcpInstanceResourceBuilder.java
@@ -233,7 +233,6 @@ public class GcpInstanceResourceBuilder extends AbstractGcpComputeBuilder {
         String projectId = context.getProjectId();
         String zone = context.getLocation().getAvailabilityZone().value();
 
-        //upscale will give us all groups here
         List<CloudResource> instanceGroupResources = filterGroupFromName(filterResourcesByType(context.getGroupResources(group.getName()),
                 ResourceType.GCP_INSTANCE_GROUP), group.getName());
 

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/context/ResourceBuilderContext.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/context/ResourceBuilderContext.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
 
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
@@ -72,7 +73,7 @@ public class ResourceBuilderContext extends DynamicModel {
 
     public synchronized void addGroupResources(String groupName, Collection<CloudResource> resources) {
         List<CloudResource> list = groupResources.computeIfAbsent(groupName, k -> new ArrayList<>());
-        list.addAll(resources);
+        list.addAll(resources.stream().filter(cloudResource -> groupName.equals(cloudResource.getGroup())).collect(Collectors.toList()));
     }
 
     public synchronized void addComputeResources(Long index, Collection<CloudResource> resources) {

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/group/GroupResourceService.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/group/GroupResourceService.java
@@ -66,6 +66,7 @@ public class GroupResourceService {
                 try {
                     CloudResource buildableResource = builder.create(context, auth, group, network);
                     if (buildableResource != null) {
+                        buildableResource = CloudResource.builder().cloudResource(buildableResource).group(group.getName()).build();
                         createResource(auth, buildableResource);
                         CloudResource resource = builder.build(context, auth, group, network, group.getSecurity(), buildableResource);
                         updateResource(auth, resource);

--- a/core/src/main/resources/schema/app/20211105113320_CB-14758_update_AWS_security_group_resources_to_have_instance_group_name_reference_based_on_resource_name.sql
+++ b/core/src/main/resources/schema/app/20211105113320_CB-14758_update_AWS_security_group_resources_to_have_instance_group_name_reference_based_on_resource_name.sql
@@ -1,0 +1,9 @@
+-- // CB-14758 update AWS security group resources to have instance group name reference based on resource name
+-- Migration SQL that makes the change goes here.
+
+UPDATE resource SET instancegroup = lower(substring(resourcename from '[a-zA-Z0-9]*$')) where resourcetype = 'AWS_SECURITY_GROUP' AND instancegroup is NULL;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXCreateAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/DistroXCreateAction.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.it.cloudbreak.action.v1.distrox;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -8,6 +9,7 @@ import com.sequenceiq.it.cloudbreak.CloudbreakClient;
 import com.sequenceiq.it.cloudbreak.action.Action;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.log.Log;
 
 public class DistroXCreateAction implements Action<DistroXTestDto, CloudbreakClient> {
@@ -16,6 +18,10 @@ public class DistroXCreateAction implements Action<DistroXTestDto, CloudbreakCli
 
     @Override
     public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
+        if (StringUtils.isEmpty(testDto.getRequest().getEnvironmentName())) {
+            Log.when(LOGGER, " Env name cannot be null ");
+            throw new TestFailException("Env name cannot be null");
+        }
         Log.whenJson(LOGGER, " Distrox create request: ", testDto.getRequest());
         StackV4Response stackV4Response = client.getDefaultClient()
                         .distroXV1Endpoint()

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/FetchPreferredSubnetForInstanceNetworkIfMultiAzEnabledAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/v1/distrox/FetchPreferredSubnetForInstanceNetworkIfMultiAzEnabledAction.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.it.cloudbreak.action.v1.distrox;
+
+import java.util.ArrayList;
+
+import com.sequenceiq.distrox.api.v1.distrox.model.network.InstanceGroupNetworkV1Request;
+import com.sequenceiq.distrox.api.v1.distrox.model.network.aws.InstanceGroupAwsNetworkV1Parameters;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+import com.sequenceiq.it.cloudbreak.CloudbreakClient;
+import com.sequenceiq.it.cloudbreak.EnvironmentClient;
+import com.sequenceiq.it.cloudbreak.action.Action;
+import com.sequenceiq.it.cloudbreak.context.TestContext;
+import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
+
+public class FetchPreferredSubnetForInstanceNetworkIfMultiAzEnabledAction implements Action<DistroXTestDto, CloudbreakClient> {
+
+    @Override
+    public DistroXTestDto action(TestContext testContext, DistroXTestDto testDto, CloudbreakClient client) throws Exception {
+        if ("AWS_NATIVE".equals(testDto.getRequest().getVariant())) {
+            EnvironmentClient envClient = testContext.getMicroserviceClient(EnvironmentClient.class);
+            DetailedEnvironmentResponse envResponse = envClient.getDefaultClient()
+                    .environmentV1Endpoint()
+                    .getByName(testDto.getRequest().getEnvironmentName());
+            InstanceGroupNetworkV1Request instanceGroupNetworkV1Request = new InstanceGroupNetworkV1Request();
+            InstanceGroupAwsNetworkV1Parameters awsNetworkV1Parameters = new InstanceGroupAwsNetworkV1Parameters();
+            awsNetworkV1Parameters.setSubnetIds(new ArrayList<>(envResponse.getNetwork().getPreferedSubnetIds()));
+            instanceGroupNetworkV1Request.setAws(awsNetworkV1Parameters);
+            testDto.getRequest().getInstanceGroups().forEach(s -> s.setNetwork(instanceGroupNetworkV1Request));
+        }
+        return testDto;
+    }
+}

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/distrox/AvailabilityZoneAssertion.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/assertion/distrox/AvailabilityZoneAssertion.java
@@ -24,6 +24,7 @@ public class AvailabilityZoneAssertion implements Assertion<DistroXTestDto, Clou
             return testDto;
         }
         List<InstanceGroupV4Response> instanceGroups = testDto.getResponse().getInstanceGroups();
+        checkAwsNativeVariantIfMultiAzEnabled(testContext, testDto);
         instanceGroups.stream().forEach(instanceGroup -> {
             if (instanceGroup.getAvailabilityZones() == null || instanceGroup.getAvailabilityZones().size() <= 1) {
                 return;
@@ -40,6 +41,13 @@ public class AvailabilityZoneAssertion implements Assertion<DistroXTestDto, Clou
             }
         });
         return testDto;
+    }
+
+    private void checkAwsNativeVariantIfMultiAzEnabled(TestContext testContext, DistroXTestDto testDto) {
+        if ("AWS_NATIVE".equals(testContext.getCloudProvider().getVariant()) &&
+                !testContext.getCloudProvider().getVariant().equals(testDto.getResponse().getVariant())) {
+            throw new TestFailException("The Multi-AZ enabled but the stack variant is not AWS_NATIVE: " + testDto.getResponse().getVariant());
+        }
     }
 
     private boolean allAvailabilityZoneHasNearlyTheSameInstanceCount(Map<String, Integer> instanceNoByAvailabilityZone, int max) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/client/DistroXTestClient.java
@@ -22,6 +22,7 @@ import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXShowBlueprintAction
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXStartAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXStopAction;
 import com.sequenceiq.it.cloudbreak.action.v1.distrox.DistroXUpgradeAction;
+import com.sequenceiq.it.cloudbreak.action.v1.distrox.FetchPreferredSubnetForInstanceNetworkIfMultiAzEnabledAction;
 import com.sequenceiq.it.cloudbreak.action.v4.util.RenewDistroXCertificateAction;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
 import com.sequenceiq.it.cloudbreak.dto.distrox.DistroXTestDto;
@@ -33,6 +34,10 @@ public class DistroXTestClient {
 
     public Action<DistroXTestDto, CloudbreakClient> create() {
         return new DistroXCreateAction();
+    }
+
+    public Action<DistroXTestDto, CloudbreakClient> fetchPreferredSubnetForInstanceNetworkIfMultiAzEnabled() {
+        return new FetchPreferredSubnetForInstanceNetworkIfMultiAzEnabledAction();
     }
 
     public Action<DistroXTestDto, CloudbreakClient> createInternal() {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDto.java
@@ -47,7 +47,6 @@ import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.CloudbreakTestDto;
 import com.sequenceiq.it.cloudbreak.dto.clustertemplate.ClusterTemplateTestDto;
 import com.sequenceiq.it.cloudbreak.dto.distrox.cluster.DistroXUpgradeTestDto;
-import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
 import com.sequenceiq.it.cloudbreak.exception.TestFailException;
 import com.sequenceiq.it.cloudbreak.search.Searchable;
 import com.sequenceiq.it.cloudbreak.util.AuditUtil;
@@ -78,7 +77,7 @@ public class DistroXTestDto extends DistroXTestDtoBase<DistroXTestDto> implement
 
     @Override
     public DistroXTestDtoBase<DistroXTestDto> valid() {
-        return super.valid().withEnvironment(EnvironmentTestDto.class);
+        return super.valid().withEnvironment();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/distrox/DistroXTestDtoBase.java
@@ -43,19 +43,17 @@ public class DistroXTestDtoBase<T extends DistroXTestDtoBase> extends AbstractCl
         return this;
     }
 
-    public DistroXTestDtoBase<T> withEnvironment(Class<EnvironmentTestDto> environmentKey) {
+    public DistroXTestDtoBase<T> withEnvironment() {
         return withEnvironmentKey(EnvironmentTestDto.class.getSimpleName());
     }
 
     public DistroXTestDtoBase<T> withEnvironmentKey(String environmentKey) {
         EnvironmentTestDto env = getTestContext().get(environmentKey);
-        if (env == null) {
-            throw new IllegalArgumentException("Env is null with given key: " + environmentKey);
+        DistroXTestDtoBase<T> ret = this;
+        if (env != null && env.getResponse() != null) {
+            ret = withEnvironmentName(env.getResponse().getName());
         }
-        if (env.getResponse() == null) {
-            throw new IllegalArgumentException("Env response is null with given key: " + environmentKey);
-        }
-        return withEnvironmentName(env.getResponse().getName());
+        return ret;
     }
 
     public DistroXTestDtoBase<T> withName(String name) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXRepairTests.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.it.cloudbreak.assertion.distrox.AvailabilityZoneAssertion;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
@@ -54,9 +55,11 @@ public class DistroXRepairTests extends AbstractE2ETest {
 
         testContext
                 .given(distrox, DistroXTestDto.class)
+                .when(distroXTestClient.fetchPreferredSubnetForInstanceNetworkIfMultiAzEnabled())
                 .when(distroXTestClient.create(), key(distrox))
                 .await(STACK_AVAILABLE)
                 .awaitForHealthyInstances()
+                .then(new AvailabilityZoneAssertion())
                 .then((tc, testDto, client) -> {
                     CloudFunctionality cloudFunctionality = tc.getCloudProvider().getCloudFunctionality();
                     List<String> instancesToDelete = distroxUtil.getInstanceIds(testDto, client, MASTER.getName());
@@ -68,6 +71,7 @@ public class DistroXRepairTests extends AbstractE2ETest {
                 .when(distroXTestClient.repair(MASTER), key(distrox))
                 .await(STACK_AVAILABLE, key(distrox))
                 .awaitForHealthyInstances()
+                .then(new AvailabilityZoneAssertion())
                 .then((tc, testDto, client) -> {
                     CloudFunctionality cloudFunctionality = tc.getCloudProvider().getCloudFunctionality();
                     List<String> instanceIds = distroxUtil.getInstanceIds(testDto, client, MASTER.getName());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/distrox/DistroXUpgradeTests.java
@@ -6,6 +6,7 @@ import javax.inject.Inject;
 
 import org.testng.annotations.Test;
 
+import com.sequenceiq.it.cloudbreak.assertion.distrox.AvailabilityZoneAssertion;
 import com.sequenceiq.it.cloudbreak.client.DistroXTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.v4.CommonClusterManagerProperties;
@@ -60,9 +61,11 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
         testContext
                 .given(distroXName, DistroXTestDto.class)
                 .withTemplate(String.format(commonClusterManagerProperties.getInternalDistroXBlueprintType(), currentRuntimeVersion))
+                .when(distroXTestClient.fetchPreferredSubnetForInstanceNetworkIfMultiAzEnabled())
                 .when(distroXTestClient.create(), key(distroXName))
                 .await(STACK_AVAILABLE)
                 .awaitForHealthyInstances()
+                .then(new AvailabilityZoneAssertion())
                 .validate();
         testContext
                 .given(distroXName, DistroXTestDto.class)
@@ -91,6 +94,7 @@ public class DistroXUpgradeTests extends AbstractE2ETest {
                 .when(distroXTestClient.upgrade(), key(distroXName))
                 .await(STACK_AVAILABLE, key(distroXName))
                 .awaitForHealthyInstances()
+                .then(new AvailabilityZoneAssertion())
                 .validate();
     }
 }

--- a/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests-for-native.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/aws-e2e-tests-for-native.yaml
@@ -1,6 +1,8 @@
 name: "aws-e2e-tests"
 tests:
-  - name: "aws_e2e_tests"
+  - name: "aws_native_e2e_tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXEncryptedVolumeTest
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXRepairTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.imagevalidation.PrewarmImageValidatorE2ETest


### PR DESCRIPTION
* native upgrade
* native repair
Some minor fixes the AWS_NATIVE resource builders.
Environment name check moved into the create action instead of the TestDto's valid method in the IT. This was neccessary because we cannot prepare properly the distrox object. In this case I wnat to use an existing env with name, but I cannot set because the env was required in prepare time instad of the execution

See detailed description in the commit message.