### PR TITLE
CB-14681 DH upgrade retry event says "Upgrade Datalake cluster"

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/ClusterUpgradeFlowConfig.java
@@ -79,7 +79,7 @@ public class ClusterUpgradeFlowConfig extends AbstractFlowConfiguration<ClusterU
 
     @Override
     public String getDisplayName() {
-        return "Upgrade Datalake cluster";
+        return "Upgrade cluster";
     }
 
     @Override


### PR DESCRIPTION
A common flow in both DL and DH upgrade had Datalake in its name.

See detailed description in the commit message.