### PR TITLE
CDPSDX-3158: Added GCP to list of supported cloud providers for Datalake-DR.

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/dr/BackupRestoreV4RequestValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/dr/BackupRestoreV4RequestValidator.java
@@ -1,64 +1,80 @@
 package com.sequenceiq.cloudbreak.controller.validation.dr;
 
-import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AWS;
-import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AZURE;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.springframework.stereotype.Component;
+import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AWS;
+import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AZURE;
+import static com.sequenceiq.cloudbreak.common.type.CloudConstants.GCP;
 
 @Component
 public class BackupRestoreV4RequestValidator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackupRestoreV4RequestValidator.class);
 
-    private static final Pattern AWS_PATTERN = Pattern.compile("(^s3[a|n]?$)|(^$)", Pattern.CASE_INSENSITIVE);
+    private static final String[] SUPPORTED_CLOUD_PLATFORMS = {AWS, AZURE, GCP};
 
-    private static final Pattern AZURE_PATTERN = Pattern.compile("(^abfs[s]?$)|(^$)", Pattern.CASE_INSENSITIVE);
+    private static final Map<String, Pattern> CLOUD_PLATFORM_TO_PATTERN = Map.of(
+            AWS, Pattern.compile("^s3[a|n]?$", Pattern.CASE_INSENSITIVE),
+            AZURE, Pattern.compile("^abfs[s]?$", Pattern.CASE_INSENSITIVE),
+            GCP, Pattern.compile("^gs$", Pattern.CASE_INSENSITIVE)
+    );
 
     public ValidationResult validate(Stack stack, String location, String backupId) {
         ValidationResult.ValidationResultBuilder resultBuilder = ValidationResult.builder();
         String cloudPlatform = stack.cloudPlatform();
 
+        String validCloudPlatform = validateCloudPlatformAndReturn(cloudPlatform, resultBuilder);
         if (Strings.isNullOrEmpty(backupId)) {
             resultBuilder.error("Parameter backupId required");
         }
         if (Strings.isNullOrEmpty(location)) {
             resultBuilder.error("Parameter backupLocation required");
         } else {
-            validateCloudLocationScheme(cloudPlatform, location, resultBuilder);
+            validateCloudLocationScheme(validCloudPlatform, location, resultBuilder);
         }
         return resultBuilder.build();
     }
 
-    private void validateCloudLocationScheme(String cloudPlatform, String location, ValidationResult.ValidationResultBuilder resultBuilder) {
+    private String validateCloudPlatformAndReturn(String cloudPlatform, ValidationResult.ValidationResultBuilder resultBuilder) {
+        String validCloudPlatform = Arrays.stream(SUPPORTED_CLOUD_PLATFORMS).filter(cloudPlatform::equalsIgnoreCase)
+                .findFirst().orElse(null);
+
+        if (validCloudPlatform == null) {
+            resultBuilder.error("Cloud platform \"" + cloudPlatform + "\" not supported for backup/restore");
+        }
+
+        return validCloudPlatform;
+    }
+
+    private void validateCloudLocationScheme(String validCloudPlatform, String location, ValidationResult.ValidationResultBuilder resultBuilder) {
         try {
             URI uri = new URI(location);
-            if (!Strings.isNullOrEmpty(uri.getScheme()) &&
-                    uri.getScheme().equalsIgnoreCase("hdfs")) {
+            if (Strings.isNullOrEmpty(uri.getScheme())) {
+                LOGGER.warn("Using a null or empty URI scheme for backup location");
                 return;
             }
-            if (AWS.equalsIgnoreCase(cloudPlatform)) {
-                if (uri.getScheme() != null) {
-                    Matcher matcher = AWS_PATTERN.matcher(uri.getScheme());
-                    if (!matcher.find()) {
-                        resultBuilder.error("Incorrect URL scheme for AWS cloud platform: " + location);
-                    }
-                }
-            } else if (AZURE.equalsIgnoreCase(cloudPlatform)) {
-                if (uri.getScheme() != null) {
-                    Matcher matcher = AZURE_PATTERN.matcher(uri.getScheme());
-                    if (!matcher.find()) {
-                        resultBuilder.error("Incorrect URL scheme for Azure cloud platform: " + location);
-                    }
+            if (uri.getScheme().equalsIgnoreCase("hdfs")) {
+                return;
+            }
+            if (validCloudPlatform != null) {
+                Matcher matcher = CLOUD_PLATFORM_TO_PATTERN.get(validCloudPlatform).matcher(uri.getScheme());
+                if (!matcher.find()) {
+                    resultBuilder.error("Incorrect scheme \"" + uri.getScheme() + "\" for cloud platform \"" + validCloudPlatform + "\"");
                 }
             } else {
-                resultBuilder.error("Cloud platform " + cloudPlatform + " not supported for backup/restore");
+                resultBuilder.error("Unsupported cloud platform, can't validate scheme");
             }
         } catch (URISyntaxException e) {
             resultBuilder.error("Unable to parse URI for location: " + location);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGenerator.java
@@ -2,6 +2,7 @@ package com.sequenceiq.cloudbreak.reactor.handler.cluster.dr;
 
 import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AWS;
 import static com.sequenceiq.cloudbreak.common.type.CloudConstants.AZURE;
+import static com.sequenceiq.cloudbreak.common.type.CloudConstants.GCP;
 import static java.util.Collections.singletonMap;
 
 import java.net.URI;
@@ -59,6 +60,8 @@ public class BackupRestoreSaltConfigGenerator {
             fullLocation = "s3a://" + uri.getSchemeSpecificPart().replaceAll("^/+", "");
         } else if (AZURE.equalsIgnoreCase(cloudPlatform)) {
             fullLocation = "abfs://" + uri.getSchemeSpecificPart().replaceAll("^/+", "");
+        } else if (GCP.equalsIgnoreCase(cloudPlatform)) {
+            fullLocation = "gs://" + uri.getSchemeSpecificPart().replaceAll("^/+", "");
         } else {
             throw new UnsupportedOperationException("Cloud platform not supported for backup/restore: " + cloudPlatform);
         }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/reactor/handler/cluster/dr/BackupRestoreSaltConfigGeneratorTest.java
@@ -134,4 +134,34 @@ public class BackupRestoreSaltConfigGeneratorTest {
 
         assertEquals(location + "/"  + BACKUP_ID + DATABASE_BACKUP_POSTFIX, disasterRecoveryKeyValuePairs.get(OBJECT_STORAGE_URL_KEY));
     }
+
+    @Test
+    public void testObjectStorageUrlIsPrefixedWithGSForGCPCloudplatform() throws URISyntaxException {
+        String cloudPlatform = "gcp";
+        String location = "/test/backups";
+        Stack placeholderStack = new Stack();
+        placeholderStack.setCloudPlatform(cloudPlatform);
+
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
+
+        Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
+        Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
+
+        assertEquals("gs://test/backups/backupId_database_backup", disasterRecoveryKeyValuePairs.get(OBJECT_STORAGE_URL_KEY));
+    }
+
+    @Test
+    public void testGSSchemeIsPassedThroughUnchanged() throws Exception {
+        String cloudPlatform = "gcp";
+        String location = "gs://eng-sdx-daily-datalake/bderriso-provo/data/backup01";
+        Stack placeholderStack = new Stack();
+        placeholderStack.setCloudPlatform(cloudPlatform);
+
+        SaltConfig saltConfig = saltConfigGenerator.createSaltConfig(location, BACKUP_ID, RANGER_ADMIN_GROUP, true, placeholderStack);
+
+        Map<String, Object> disasterRecoveryProperties = saltConfig.getServicePillarConfig().get("disaster-recovery").getProperties();
+        Map<String, String> disasterRecoveryKeyValuePairs = (Map<String, String>) disasterRecoveryProperties.get(DISASTER_RECOVERY_KEY);
+
+        assertEquals(location + "/"  + BACKUP_ID + DATABASE_BACKUP_POSTFIX, disasterRecoveryKeyValuePairs.get(OBJECT_STORAGE_URL_KEY));
+    }
 }


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CDPSDX-3158

Main objective of this change is to add GCP to the supported cloud providers for backup/restore. I also went ahead and changed some of the current logic for validating the URI scheme of the cloud platform to make it cleaner, albeit at the cost of a little worse performance so feel free to let me know if it's worth changing back. 

Thanks!