### PR TITLE
CB-14570 New endpoint on FreeIPA service to trigger CCM upgrade flow

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -20,8 +20,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
+import com.sequenceiq.cloudbreak.validation.ValidCrn;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
 import com.sequenceiq.flow.api.model.RetryableFlowResponse;
 import com.sequenceiq.freeipa.api.FreeIpaApi;
@@ -100,8 +102,8 @@ public interface FreeIpaV1Endpoint {
     @GET
     @Path("internal/all")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = FreeIpaOperationDescriptions.INTERNAL_GET_ALL_BY_ENVID, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
-            nickname = "internalGetAllFreeIpaByEnvironmentV1")
+    @ApiOperation(value = FreeIpaOperationDescriptions.INTERNAL_GET_ALL_BY_ENVID_AND_ACCOUNTID, produces = MediaType.APPLICATION_JSON,
+            notes = FreeIpaNotes.FREEIPA_NOTES, nickname = "internalGetAllFreeIpaByEnvironmentV1")
     List<DescribeFreeIpaResponse> describeAllInternal(
             @QueryParam("environment") String environmentCrn,
             @QueryParam("accountId") @AccountId String accountId);
@@ -247,4 +249,12 @@ public interface FreeIpaV1Endpoint {
     @ApiOperation(value = FreeIpaOperationDescriptions.GENERATE_IMAGE_CATALOG, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "generateImageCatalog")
     GenerateImageCatalogResponse generateImageCatalog(@QueryParam("environment") @NotEmpty String environmentCrn);
+
+    @PUT
+    @Path("/internal/upgrade_ccm")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = FreeIpaOperationDescriptions.INTERNAL_UPGRADE_CCM_BY_ENVID, produces = MediaType.APPLICATION_JSON,
+            notes = FreeIpaNotes.FREEIPA_NOTES, nickname = "internalUpgradeCcmByEnvironmentV1")
+    OperationStatus upgradeCcmInternal(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @QueryParam("environment") @NotEmpty String environmentCrn,
+            @ValidCrn(resource = CrnResourceDescriptor.USER) @QueryParam("initiatorUserCrn") @NotEmpty String initiatorUserCrn);
 }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -1,17 +1,17 @@
 package com.sequenceiq.freeipa.api.v1.freeipa.stack.doc;
 
 public final class FreeIpaOperationDescriptions {
-    public static final String CREATE = "Create FreeIpa stack";
+    public static final String CREATE = "Create FreeIPA stack";
     public static final String REGISTER_CHILD_ENVIRONMENT = "Register a child environment";
     public static final String DEREGISTER_CHILD_ENVIRONMENT = "Deregister a child environment";
-    public static final String GET_BY_ENVID = "Get FreeIPA stack by envid";
-    public static final String GET_ALL_BY_ENVID = "Get all FreeIPA stacks by envid";
-    public static final String INTERNAL_GET_ALL_BY_ENVID = "Get all FreeIPA stacks by envid";
-    public static final String INTERNAL_GET_BY_ENVID_AND_ACCOUNTID = "Get FreeIPA stack by envid and account id";
+    public static final String GET_BY_ENVID = "Get FreeIPA stack by environment CRN";
+    public static final String GET_ALL_BY_ENVID = "Get all FreeIPA stacks by environment CRN";
+    public static final String INTERNAL_GET_ALL_BY_ENVID_AND_ACCOUNTID = "Get all FreeIPA stacks by environment CRN and account ID using the internal actor";
+    public static final String INTERNAL_GET_BY_ENVID_AND_ACCOUNTID = "Get FreeIPA stack by environment CRN and account ID using the internal actor";
     public static final String LIST_BY_ACCOUNT = "List all FreeIPA stacks by account";
     public static final String INTERNAL_LIST_BY_ACCOUNT = "List all FreeIPA stacks by account using the internal actor";
-    public static final String GET_ROOTCERTIFICATE_BY_ENVID = "Get FreeIPA root certificate by envid";
-    public static final String DELETE_BY_ENVID = "Delete FreeIPA stack by envid";
+    public static final String GET_ROOTCERTIFICATE_BY_ENVID = "Get FreeIPA root certificate by environment CRN";
+    public static final String DELETE_BY_ENVID = "Delete FreeIPA stack by environment CRN";
     public static final String CLEANUP = "Cleans out users, hosts and related DNS entries";
     public static final String INTERNAL_CLEANUP = "Cleans out users, hosts and related DNS entries using internal actor";
     public static final String START = "Start all FreeIPA stacks that attached to the given environment CRN";
@@ -31,6 +31,8 @@ public final class FreeIpaOperationDescriptions {
     public static final String LIST_RETRYABLE_FLOWS = "List retryable failed flows";
     public static final String CHANGE_IMAGE_CATALOG = "Changes the image catalog used for creating instances";
     public static final String GENERATE_IMAGE_CATALOG = "Generates an image catalog that only contains the currently used image for creating instances";
+    public static final String INTERNAL_UPGRADE_CCM_BY_ENVID =
+            "Initiates the CCM tunnel type upgrade to the latest available version for FreeIPA stack by environment CRN using the internal actor";
 
     private FreeIpaOperationDescriptions() {
     }

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/model/OperationType.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/operation/model/OperationType.java
@@ -11,7 +11,8 @@ public enum OperationType {
     DOWNSCALE,
     UPSCALE,
     BIND_USER_CREATE,
-    UPGRADE;
+    UPGRADE,
+    UPGRADE_CCM;
 
     public static OperationType fromSyncOperationType(SyncOperationType syncOperationType) {
         switch (syncOperationType) {

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -26,11 +26,13 @@ import com.sequenceiq.authorization.annotation.RequestObject;
 import com.sequenceiq.authorization.annotation.ResourceCrn;
 import com.sequenceiq.authorization.resource.AuthorizationResourceAction;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.auth.security.internal.InitiatorUserCrn;
 import com.sequenceiq.cloudbreak.auth.security.internal.TenantAwareParam;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.structuredevent.rest.annotation.AccountEntityType;
+import com.sequenceiq.cloudbreak.validation.ValidCrn;
 import com.sequenceiq.cloudbreak.validation.ValidationResult;
 import com.sequenceiq.cloudbreak.validation.ValidationResult.State;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
@@ -74,6 +76,7 @@ import com.sequenceiq.freeipa.service.stack.FreeIpaListService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaStackHealthDetailsService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaStartService;
 import com.sequenceiq.freeipa.service.stack.FreeIpaStopService;
+import com.sequenceiq.freeipa.service.stack.FreeIpaUpgradeCcmService;
 import com.sequenceiq.freeipa.service.stack.RepairInstancesService;
 import com.sequenceiq.freeipa.util.CrnService;
 
@@ -148,6 +151,9 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
 
     @Inject
     private ImageCatalogGeneratorService imageCatalogGeneratorService;
+
+    @Inject
+    private FreeIpaUpgradeCcmService upgradeCcmService;
 
     @Override
     @CheckPermissionByRequestProperty(path = "environmentCrn", type = CRN, action = EDIT_ENVIRONMENT)
@@ -355,4 +361,14 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
         String accountId = crnService.getCurrentAccountId();
         return imageCatalogGeneratorService.generate(environmentCrn, accountId);
     }
+
+    @Override
+    @InternalOnly
+    public OperationStatus upgradeCcmInternal(
+            @ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT) @ResourceCrn @NotEmpty String environmentCrn,
+            @ValidCrn(resource = CrnResourceDescriptor.USER) @InitiatorUserCrn @NotEmpty String initiatorUserCrn) {
+        String accountId = crnService.getCurrentAccountId();
+        return upgradeCcmService.upgradeCcm(environmentCrn, accountId);
+    }
+
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmOperationAcceptor.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmOperationAcceptor.java
@@ -1,0 +1,56 @@
+package com.sequenceiq.freeipa.flow.stack.upgrade.ccm;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.repository.OperationRepository;
+import com.sequenceiq.freeipa.service.freeipa.user.AcceptResult;
+import com.sequenceiq.freeipa.service.operation.OperationAcceptor;
+
+@Component
+public class UpgradeCcmOperationAcceptor extends OperationAcceptor {
+
+    protected UpgradeCcmOperationAcceptor(OperationRepository operationRepository) {
+        super(operationRepository);
+    }
+
+    @Override
+    public AcceptResult accept(Operation operation) {
+        Optional<AcceptResult> validationResult = validateOperation(operation);
+        if (validationResult.isPresent()) {
+            return validationResult.get();
+        } else {
+            boolean runningForSameStack = hasRunningOperationForSameStack(operation);
+            if (runningForSameStack) {
+                return AcceptResult.reject("There is already a running Cluster Connectivity Manager upgrade for FreeIPA stack");
+            } else {
+                return AcceptResult.accept();
+            }
+        }
+    }
+
+    private Optional<AcceptResult> validateOperation(Operation operation) {
+        if (operation.getEnvironmentList() == null || operation.getEnvironmentList().size() != 1) {
+            return Optional.of(AcceptResult.reject("Cluster Connectivity Manager upgrade must be invoked for a single environment!"));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private boolean hasRunningOperationForSameStack(Operation operation) {
+        List<Operation> runningOperations = getOperationRepository().findRunningByAccountIdAndType(operation.getAccountId(), selector());
+        return runningOperations.stream()
+                .filter(op -> !op.getId().equals(operation.getId()))
+                .anyMatch(op -> op.getEnvironmentList().contains(operation.getEnvironmentList().get(0)));
+    }
+
+    @Override
+    protected OperationType selector() {
+        return OperationType.UPGRADE_CCM;
+    }
+
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStartService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStartService.java
@@ -36,8 +36,8 @@ public class FreeIpaStartService {
         MDCBuilder.addAccountId(accountId);
         List<Stack> stacks = stackService.findAllByEnvironmentCrnAndAccountId(environmentCrn, accountId);
         if (stacks.isEmpty()) {
-            LOGGER.debug("No FreeIpa found in environment");
-            throw new NotFoundException("No FreeIpa found in environment");
+            LOGGER.debug("No FreeIPA found in environment");
+            throw new NotFoundException("No FreeIPA found in environment");
         }
         stacks.stream()
                 .filter(s -> s.getStackStatus().getStatus().isStartable())
@@ -47,7 +47,8 @@ public class FreeIpaStartService {
     private void triggerStackStart(Stack stack) {
         MDCBuilder.buildMdcContext(stack);
         LOGGER.debug("Trigger start event, new status: {}", START_REQUESTED);
-        stackUpdater.updateStackStatus(stack, START_REQUESTED, "Started of stack infrastructure has been requested.");
+        stackUpdater.updateStackStatus(stack, START_REQUESTED, "Starting of stack infrastructure has been requested.");
         flowManager.notify(STACK_START_EVENT.event(), new StackEvent(STACK_START_EVENT.event(), stack.getId()));
     }
+
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStopService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaStopService.java
@@ -37,8 +37,8 @@ public class FreeIpaStopService {
         MDCBuilder.addAccountId(accountId);
         List<Stack> stacks = stackService.findAllByEnvironmentCrnAndAccountId(environmentCrn, accountId);
         if (stacks.isEmpty()) {
-            LOGGER.info("No FreeIpa found in environment");
-            throw new NotFoundException("No FreeIpa found in environment");
+            LOGGER.info("No FreeIPA found in environment");
+            throw new NotFoundException("No FreeIPA found in environment");
         }
 
         stacks.stream()
@@ -62,10 +62,11 @@ public class FreeIpaStopService {
             LOGGER.debug("Stack stop is ignored");
             result = false;
         } else if (!stack.isAvailable() && !stack.isStopFailed()) {
-            LOGGER.debug("Cannot update the status of stack '%s' to STOPPED, because it isn't in AVAILABLE state.");
+            LOGGER.debug("Cannot update the status of stack '{}' to STOPPED, because it isn't in AVAILABLE state.", stack.getName());
             throw new BadRequestException(
                     String.format("Cannot update the status of stack '%s' to STOPPED, because it isn't in AVAILABLE state.", stack.getName()));
         }
         return result;
     }
+
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaUpgradeCcmService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/FreeIpaUpgradeCcmService.java
@@ -1,0 +1,82 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.converter.operation.OperationToOperationStatusConverter;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+
+@Service
+public class FreeIpaUpgradeCcmService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaUpgradeCcmService.class);
+
+    private final FreeIpaFlowManager flowManager;
+
+    private final StackService stackService;
+
+    private final StackUpdater stackUpdater;
+
+    private final OperationService operationService;
+
+    private final OperationToOperationStatusConverter operationConverter;
+
+    public FreeIpaUpgradeCcmService(FreeIpaFlowManager flowManager, StackService stackService, StackUpdater stackUpdater, OperationService operationService,
+            OperationToOperationStatusConverter operationConverter) {
+        this.flowManager = flowManager;
+        this.stackService = stackService;
+        this.stackUpdater = stackUpdater;
+        this.operationService = operationService;
+        this.operationConverter = operationConverter;
+    }
+
+    public OperationStatus upgradeCcm(String environmentCrn, String accountId) {
+        MDCBuilder.addEnvCrn(environmentCrn);
+        MDCBuilder.addAccountId(accountId);
+        Stack stack = stackService.getByEnvironmentCrnAndAccountIdWithLists(environmentCrn, accountId);
+        MDCBuilder.buildMdcContext(stack);
+        validateCcmUpgrade(stack);
+
+        LOGGER.info("Start 'UPGRADE_CCM' operation");
+        Operation operation = operationService.startOperation(accountId, OperationType.UPGRADE_CCM, List.of(stack.getEnvironmentCrn()), List.of());
+        if (OperationState.RUNNING == operation.getStatus()) {
+            return operationConverter.convert(triggerCcmUpgradeFlow(accountId, operation));
+        } else {
+            LOGGER.info("Operation isn't in RUNNING state: {}", operation);
+            return operationConverter.convert(operation);
+        }
+    }
+
+    private void validateCcmUpgrade(Stack stack) {
+        if (!stack.isAvailable()) {
+            throw new BadRequestException(
+                String.format("FreeIPA stack '%s' must be AVAILABLE to start Cluster Connectivity Manager upgrade.", stack.getName()));
+        }
+    }
+
+    private Operation triggerCcmUpgradeFlow(String accountId, Operation operation) {
+        try {
+            LOGGER.info("Starting CCM upgrade flow");
+            // TODO log & update stack status (if needed), then send event to FreeIpaFlowManager; see CB-14571
+            // TODO what to do with the FlowIdentifier?
+            LOGGER.info("Started CCM upgrade flow");
+            return operation;
+        } catch (Exception e) {
+            LOGGER.error("Couldn't start CCM upgrade flow", e);
+            return operationService.failOperation(accountId, operation.getOperationId(),
+                    "Couldn't start Cluster Connectivity Manager upgrade flow: " + e.getMessage());
+        }
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmOperationAcceptorTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/flow/stack/upgrade/ccm/UpgradeCcmOperationAcceptorTest.java
@@ -1,0 +1,119 @@
+package com.sequenceiq.freeipa.flow.stack.upgrade.ccm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.repository.OperationRepository;
+import com.sequenceiq.freeipa.service.freeipa.user.AcceptResult;
+
+@ExtendWith(MockitoExtension.class)
+class UpgradeCcmOperationAcceptorTest {
+
+    private static final long ID_1 = 1L;
+
+    private static final long ID_2 = 2L;
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    private static final String ENVIRONMENT_CRN_1 = "environmentCrn1";
+
+    private static final String ENVIRONMENT_CRN_2 = "environmentCrn2";
+
+    @Mock
+    private OperationRepository operationRepository;
+
+    @InjectMocks
+    private UpgradeCcmOperationAcceptor underTest;
+
+    @Test
+    void selectorTest() {
+        assertThat(underTest.selector()).isEqualTo(OperationType.UPGRADE_CCM);
+    }
+
+    static Object[][] acceptTestWhenValidationFailureDataProvider() {
+        return new Object[][]{
+                // testCaseName environmentList
+                {"environmentList=null", null},
+                {"environmentList=()", List.of()},
+                {"environmentList=(ENVIRONMENT_CRN_1, ENVIRONMENT_CRN_2)", List.of(ENVIRONMENT_CRN_1, ENVIRONMENT_CRN_2)},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("acceptTestWhenValidationFailureDataProvider")
+    void acceptTestWhenValidationFailure(String testCaseName, List<String> environmentList) {
+        Operation operation = createOperation(ID_1, environmentList);
+
+        AcceptResult result = underTest.accept(operation);
+
+        assertThat(result).isNotNull();
+        assertThat(result.isAccepted()).isFalse();
+
+        Optional<String> rejectionMessage = result.getRejectionMessage();
+        assertThat(rejectionMessage).isNotNull();
+        assertThat(rejectionMessage).isPresent();
+        assertThat(rejectionMessage.get()).isEqualTo("Cluster Connectivity Manager upgrade must be invoked for a single environment!");
+    }
+
+    @Test
+    void acceptTestWhenHasRunningOperationForSameStack() {
+        Operation operation = createOperation(ID_1, List.of(ENVIRONMENT_CRN_1));
+        when(operationRepository.findRunningByAccountIdAndType(ACCOUNT_ID, OperationType.UPGRADE_CCM))
+                .thenReturn(List.of(createOperation(ID_2, List.of(ENVIRONMENT_CRN_1))));
+
+        AcceptResult result = underTest.accept(operation);
+
+        assertThat(result).isNotNull();
+        assertThat(result.isAccepted()).isFalse();
+
+        Optional<String> rejectionMessage = result.getRejectionMessage();
+        assertThat(rejectionMessage).isNotNull();
+        assertThat(rejectionMessage).isPresent();
+        assertThat(rejectionMessage.get()).isEqualTo("There is already a running Cluster Connectivity Manager upgrade for FreeIPA stack");
+    }
+
+    static Object[][] acceptTestWhenSuccessDataProvider() {
+        return new Object[][]{
+                // testCaseName runningOperations
+                {"runningOperations=()", List.of()},
+                {"runningOperations=((ID_1, ENVIRONMENT_CRN_1))", List.of(createOperation(ID_1, List.of(ENVIRONMENT_CRN_1)))},
+                {"runningOperations=((ID_2, ENVIRONMENT_CRN_2))", List.of(createOperation(ID_2, List.of(ENVIRONMENT_CRN_2)))},
+                {"runningOperations=((ID_1, ENVIRONMENT_CRN_1), (ID_2, ENVIRONMENT_CRN_2))", List.of(createOperation(ID_1, List.of(ENVIRONMENT_CRN_1)),
+                        createOperation(ID_2, List.of(ENVIRONMENT_CRN_2)))},
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("acceptTestWhenSuccessDataProvider")
+    void acceptTestWhenSuccess(String testCaseName, List<Operation> runningOperations) {
+        Operation operation = createOperation(ID_1, List.of(ENVIRONMENT_CRN_1));
+        when(operationRepository.findRunningByAccountIdAndType(ACCOUNT_ID, OperationType.UPGRADE_CCM)).thenReturn(runningOperations);
+
+        AcceptResult result = underTest.accept(operation);
+
+        assertThat(result).isNotNull();
+        assertThat(result.isAccepted()).isTrue();
+    }
+
+    private static Operation createOperation(long id, List<String> environmentList) {
+        Operation operation = new Operation();
+        operation.setId(id);
+        operation.setAccountId(ACCOUNT_ID);
+        operation.setEnvironmentList(environmentList);
+        return operation;
+    }
+
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaUpgradeCcmServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/FreeIpaUpgradeCcmServiceTest.java
@@ -1,0 +1,121 @@
+package com.sequenceiq.freeipa.service.stack;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationState;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
+import com.sequenceiq.freeipa.api.v1.operation.model.OperationType;
+import com.sequenceiq.freeipa.converter.operation.OperationToOperationStatusConverter;
+import com.sequenceiq.freeipa.entity.Operation;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.StackStatus;
+import com.sequenceiq.freeipa.service.freeipa.flow.FreeIpaFlowManager;
+import com.sequenceiq.freeipa.service.operation.OperationService;
+
+@ExtendWith(MockitoExtension.class)
+class FreeIpaUpgradeCcmServiceTest {
+
+    private static final String STACK_NAME = "stackName";
+
+    private static final String ENVIRONMENT_CRN = "environmentCrn";
+
+    private static final String ACCOUNT_ID = "accountId";
+
+    @Mock
+    private FreeIpaFlowManager flowManager;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private StackUpdater stackUpdater;
+
+    @Mock
+    private OperationService operationService;
+
+    @Mock
+    private OperationToOperationStatusConverter operationConverter;
+
+    @InjectMocks
+    private FreeIpaUpgradeCcmService underTest;
+
+    private OperationStatus operationStatus;
+
+    @BeforeEach
+    void setUp() {
+        operationStatus = new OperationStatus();
+    }
+
+    @Test
+    void upgradeCcmTestWhenAvailableAndOperationRunning() {
+        Stack stack = createStack(Status.AVAILABLE);
+        when(stackService.getByEnvironmentCrnAndAccountIdWithLists(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(stack);
+        Operation operation = createOperation(OperationState.RUNNING);
+        when(operationService.startOperation(ACCOUNT_ID, OperationType.UPGRADE_CCM, List.of(ENVIRONMENT_CRN), List.of())).thenReturn(operation);
+        when(operationConverter.convert(operation)).thenReturn(operationStatus);
+
+        OperationStatus result = underTest.upgradeCcm(ENVIRONMENT_CRN, ACCOUNT_ID);
+
+        assertThat(result).isSameAs(operationStatus);
+        // TODO verify that flow has been triggered successfully; see CB-14571
+    }
+
+    // TODO add test for AvailableAndOperationRunningAndFlowStartFailure; see CB-14571
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(value = OperationState.class, names = {"RUNNING"}, mode = EnumSource.Mode.EXCLUDE)
+    void upgradeCcmTestWhenAvailableAndOperationNotRunning(OperationState operationState) {
+        Stack stack = createStack(Status.AVAILABLE);
+        when(stackService.getByEnvironmentCrnAndAccountIdWithLists(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(stack);
+        Operation operation = createOperation(operationState);
+        when(operationService.startOperation(ACCOUNT_ID, OperationType.UPGRADE_CCM, List.of(ENVIRONMENT_CRN), List.of())).thenReturn(operation);
+        when(operationConverter.convert(operation)).thenReturn(operationStatus);
+
+        OperationStatus result = underTest.upgradeCcm(ENVIRONMENT_CRN, ACCOUNT_ID);
+
+        assertThat(result).isSameAs(operationStatus);
+        // TODO verify that flow has not been triggered; see CB-14571
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @EnumSource(value = Status.class, names = {"AVAILABLE"}, mode = EnumSource.Mode.EXCLUDE)
+    void upgradeCcmTestWhenNotAvailable(Status status) {
+        Stack stack = createStack(status);
+        when(stackService.getByEnvironmentCrnAndAccountIdWithLists(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(stack);
+
+        BadRequestException badRequestException = assertThrows(BadRequestException.class, () -> underTest.upgradeCcm(ENVIRONMENT_CRN, ACCOUNT_ID));
+        assertThat(badRequestException).hasMessage("FreeIPA stack 'stackName' must be AVAILABLE to start Cluster Connectivity Manager upgrade.");
+    }
+
+    private Stack createStack(Status status) {
+        Stack stack = new Stack();
+        stack.setEnvironmentCrn(ENVIRONMENT_CRN);
+        stack.setName(STACK_NAME);
+        StackStatus stackStatus = new StackStatus();
+        stack.setStackStatus(stackStatus);
+        stackStatus.setStatus(status);
+        return stack;
+    }
+
+    private Operation createOperation(OperationState operationState) {
+        Operation operation = new Operation();
+        operation.setStatus(operationState);
+        return operation;
+    }
+
+}


### PR DESCRIPTION
* Add new operation `PUT` `/v1/freeipa/internal/upgrade_ccm` (nickname `internalUpgradeCcmByEnvironmentV1`) to `FreeIpaV1Endpoint`. This is an internal-only endpoint that triggers the CCM upgrade workflow for the FreeIPA cluster associated with a given environment. The stack must be `AVAILABLE` for the invocation to succeed.
  * Returns an `OperationStatus`.
  * The underlying `FreeIpaUpgradeCcmService` is only a skeleton; the actual flow trigger and stack status update will be added later (see [CB-14571](https://jira.cloudera.com/browse/CB-14571)).
* Testing:
  * UT.
  * `freeipa` service Swagger UI & `curl` in local CB.