### PR TITLE
CB-14466: Remove the obsoleted DATAHUB/DATALAKE enum values

### DIFF
--- a/common-model/src/main/java/com/sequenceiq/common/api/type/ImageType.java
+++ b/common-model/src/main/java/com/sequenceiq/common/api/type/ImageType.java
@@ -2,8 +2,6 @@ package com.sequenceiq.common.api.type;
 
 public enum ImageType {
     FREEIPA,
-    DATAHUB,
-    DATALAKE,
     RUNTIME,
     UNKNOWN
 }


### PR DESCRIPTION
No we can can remove the proper DATAHUB and DATALAKE enumeration values, instead of these the RUNTIME value has been provided previously. Follow up task of CB-14464.