### PR TITLE
CB-14656 Fix unbound service restart of existing stacks

### DIFF
--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/model/JobResourceAdapter.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/model/JobResourceAdapter.java
@@ -3,10 +3,15 @@ package com.sequenceiq.cloudbreak.quartz.model;
 import java.util.Optional;
 
 import org.quartz.Job;
+import org.quartz.JobDataMap;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.repository.CrudRepository;
 
 public abstract class JobResourceAdapter<T> {
+
+    public static final String LOCAL_ID = "localId";
+
+    public static final String REMOTE_RESOURCE_CRN = "remoteResourceCrn";
 
     private T resource;
 
@@ -33,12 +38,19 @@ public abstract class JobResourceAdapter<T> {
     public abstract String getRemoteResourceId();
 
     private Optional<T> find(Long id, ApplicationContext context) {
-        CrudRepository repo = context.getBean(getRepositoryClassForResource());
-        return (Optional<T>) repo.findById(id);
+        CrudRepository<T, Long> repo = context.getBean(getRepositoryClassForResource());
+        return repo.findById(id);
     }
 
     public abstract Class<? extends Job> getJobClassForResource();
 
-    public abstract Class<? extends CrudRepository> getRepositoryClassForResource();
+    public abstract Class<? extends CrudRepository<T, Long>> getRepositoryClassForResource();
+
+    public JobDataMap toJobDataMap() {
+        JobDataMap jobDataMap = new JobDataMap();
+        jobDataMap.put(LOCAL_ID, getLocalId());
+        jobDataMap.put(REMOTE_RESOURCE_CRN, getRemoteResourceId());
+        return jobDataMap;
+    }
 
 }

--- a/common/src/main/java/com/sequenceiq/cloudbreak/quartz/statuschecker/ResourceCheckerJobListener.java
+++ b/common/src/main/java/com/sequenceiq/cloudbreak/quartz/statuschecker/ResourceCheckerJobListener.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.quartz.statuschecker;
 
+import static com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter.REMOTE_RESOURCE_CRN;
+
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -12,8 +14,6 @@ import org.springframework.stereotype.Component;
 public class ResourceCheckerJobListener extends JobListenerSupport {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceCheckerJobListener.class);
-
-    private static final String REMOTE_RESOURCE_CRN = "remoteResourceCrn";
 
     @Override
     public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/Status.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/common/Status.java
@@ -207,4 +207,20 @@ public enum Status {
         return Sets.immutableEnumSet(STOPPED, DELETE_COMPLETED,
                 CREATE_FAILED, DELETE_FAILED, DELETED_ON_PROVIDER_SIDE);
     }
+
+    public static EnumSet<Status> getUnschedulableStatuses() {
+        return EnumSet.of(
+                Status.CREATE_FAILED,
+                Status.PRE_DELETE_IN_PROGRESS,
+                Status.DELETE_IN_PROGRESS,
+                Status.DELETE_FAILED,
+                Status.DELETE_COMPLETED,
+                Status.EXTERNAL_DATABASE_CREATION_FAILED,
+                Status.EXTERNAL_DATABASE_DELETION_IN_PROGRESS,
+                Status.EXTERNAL_DATABASE_DELETION_FINISHED,
+                Status.EXTERNAL_DATABASE_DELETION_FAILED,
+                Status.LOAD_BALANCER_UPDATE_FINISHED,
+                Status.LOAD_BALANCER_UPDATE_FAILED
+        );
+    }
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/StackPatchTypeConverter.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/converter/StackPatchTypeConverter.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.cloudbreak.domain.converter;
+
+import com.sequenceiq.cloudbreak.converter.DefaultEnumConverter;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
+
+public class StackPatchTypeConverter extends DefaultEnumConverter<StackPatchType>  {
+
+    @Override
+    public StackPatchType getDefault() {
+        return StackPatchType.UNKNOWN;
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/Stack.java
@@ -600,6 +600,12 @@ public class Stack implements ProvisionEntity, WorkspaceAwareResource {
         return metaData.orElse(null);
     }
 
+    public Optional<InstanceMetaData> getClusterManagerServer() {
+        return getInstanceMetaDataAsList().stream()
+                .filter(InstanceMetaData::getClusterManagerServer)
+                .findFirst();
+    }
+
     public Optional<InstanceGroup> getGatewayHostGroup() {
         return instanceGroups.stream()
                 .filter(ig -> InstanceGroupType.GATEWAY.equals(ig.getInstanceGroupType()))

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackPatch.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackPatch.java
@@ -1,0 +1,83 @@
+package com.sequenceiq.cloudbreak.domain.stack;
+
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+import com.sequenceiq.cloudbreak.domain.ProvisionEntity;
+import com.sequenceiq.cloudbreak.domain.converter.StackPatchTypeConverter;
+
+@Entity
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"stack_id", "type"}))
+public class StackPatch implements ProvisionEntity  {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO, generator = "stackpatch_generator")
+    @SequenceGenerator(name = "stackpatch_generator", sequenceName = "stackpatch_id_seq", allocationSize = 1)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Stack stack;
+
+    @Convert(converter = StackPatchTypeConverter.class)
+    private StackPatchType type;
+
+    private Long created = System.currentTimeMillis();
+
+    public StackPatch() {
+    }
+
+    public StackPatch(Stack stack, StackPatchType type) {
+        this.stack = stack;
+        this.type = type;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Stack getStack() {
+        return stack;
+    }
+
+    public void setStack(Stack stack) {
+        this.stack = stack;
+    }
+
+    public StackPatchType getType() {
+        return type;
+    }
+
+    public void setType(StackPatchType type) {
+        this.type = type;
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public void setCreated(Long created) {
+        this.created = created;
+    }
+
+    @Override
+    public String toString() {
+        return "StackPatch{" +
+                "id=" + id +
+                ", type=" + type +
+                ", created=" + created +
+                '}';
+    }
+
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackPatchType.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/stack/StackPatchType.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.domain.stack;
+
+public enum StackPatchType {
+    UNBOUND_RESTART,
+    UNKNOWN
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/AbstractStackJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/AbstractStackJobInitializer.java
@@ -1,0 +1,34 @@
+package com.sequenceiq.cloudbreak.job;
+
+import java.util.stream.Stream;
+
+import javax.inject.Inject;
+
+import com.sequenceiq.cloudbreak.domain.projection.StackTtlView;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+public abstract class AbstractStackJobInitializer implements JobInitializer {
+
+    @Inject
+    private StackService stackService;
+
+    protected Stream<Stack> getAliveStacksStream() {
+        return stackService.getAllAlive().stream()
+                .map(this::convertToStack);
+    }
+
+    protected Stream<Stack> getAliveAndNotDeleteInProgressStacksStream() {
+        return getAliveStacksStream()
+                .filter(s -> !s.isStackInDeletionOrFailedPhase());
+    }
+
+    private Stack convertToStack(StackTtlView view) {
+        Stack result = new Stack();
+        result.setId(view.getId());
+        result.setResourceCrn(view.getCrn());
+        result.setStackStatus(view.getStatus());
+        return result;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackJobAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackJobAdapter.java
@@ -2,11 +2,10 @@ package com.sequenceiq.cloudbreak.job;
 
 import org.quartz.Job;
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.repository.StackRepository;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
+import com.sequenceiq.cloudbreak.repository.StackRepository;
 
 public class StackJobAdapter extends JobResourceAdapter<Stack> {
 
@@ -34,7 +33,7 @@ public class StackJobAdapter extends JobResourceAdapter<Stack> {
     }
 
     @Override
-    public Class<? extends CrudRepository> getRepositoryClassForResource() {
+    public Class<StackRepository> getRepositoryClassForResource() {
         return StackRepository.class;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackJobInitializer.java
@@ -4,34 +4,17 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.domain.projection.StackTtlView;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
 import com.sequenceiq.cloudbreak.quartz.statuschecker.service.StatusCheckerJobService;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
 
 @Component
-public class StackJobInitializer implements JobInitializer {
+public class StackJobInitializer extends AbstractStackJobInitializer {
 
     @Inject
     private StatusCheckerJobService jobService;
 
-    @Inject
-    private StackService stackService;
-
     @Override
     public void initJobs() {
-        stackService.getAllAlive().stream()
-                .map(this::convertToStack)
-                .filter(s -> !s.isStackInDeletionOrFailedPhase())
+        getAliveAndNotDeleteInProgressStacksStream()
                 .forEach(s -> jobService.schedule(new StackJobAdapter(s)));
-    }
-
-    private Stack convertToStack(StackTtlView view) {
-        Stack result = new Stack();
-        result.setId(view.getId());
-        result.setResourceCrn(view.getCrn());
-        result.setStackStatus(view.getStatus());
-        return result;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJob.java
@@ -120,7 +120,7 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
             measure(() -> {
                 Stack stack = stackService.get(getStackId());
                 Status stackStatus = stack.getStatus();
-                if (unschedulableStates().contains(stackStatus)) {
+                if (Status.getUnschedulableStatuses().contains(stackStatus)) {
                     LOGGER.debug("Stack sync will be unscheduled, stack state is {}", stackStatus);
                     jobService.unschedule(getLocalId());
                 } else if (shouldSwitchToLongSyncJob(stackStatus, context)) {
@@ -161,23 +161,6 @@ public class StackStatusCheckerJob extends StatusCheckerJob {
 
     private Set<Status> longSyncableStates() {
         return EnumSet.of(Status.DELETED_ON_PROVIDER_SIDE);
-    }
-
-    @VisibleForTesting
-    Set<Status> unschedulableStates() {
-        return EnumSet.of(
-                Status.CREATE_FAILED,
-                Status.PRE_DELETE_IN_PROGRESS,
-                Status.DELETE_IN_PROGRESS,
-                Status.DELETE_FAILED,
-                Status.DELETE_COMPLETED,
-                Status.EXTERNAL_DATABASE_CREATION_FAILED,
-                Status.EXTERNAL_DATABASE_DELETION_IN_PROGRESS,
-                Status.EXTERNAL_DATABASE_DELETION_FINISHED,
-                Status.EXTERNAL_DATABASE_DELETION_FAILED,
-                Status.LOAD_BALANCER_UPDATE_FINISHED,
-                Status.LOAD_BALANCER_UPDATE_FAILED
-        );
     }
 
     @VisibleForTesting

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusCheckerJobInitializer.java
@@ -4,33 +4,17 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.domain.projection.StackTtlView;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.job.AbstractStackJobInitializer;
 
 @Component
-public class NodeStatusCheckerJobInitializer implements JobInitializer {
-
-    @Inject
-    private StackService stackService;
+public class NodeStatusCheckerJobInitializer extends AbstractStackJobInitializer {
 
     @Inject
     private NodeStatusCheckerJobService nodeStatusCheckerJobService;
 
     @Override
     public void initJobs() {
-        stackService.getAllAlive().stream()
-                .map(this::convertToStack)
-                .filter(s -> !s.isStackInDeletionOrFailedPhase())
+        getAliveAndNotDeleteInProgressStacksStream()
                 .forEach(s -> nodeStatusCheckerJobService.schedule(new NodeStatusJobAdapter(s)));
-    }
-
-    private Stack convertToStack(StackTtlView view) {
-        Stack result = new Stack();
-        result.setId(view.getId());
-        result.setResourceCrn(view.getCrn());
-        result.setStackStatus(view.getStatus());
-        return result;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusJobAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/nodestatus/NodeStatusJobAdapter.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.job.nodestatus;
 
 import org.quartz.Job;
-import org.springframework.data.repository.CrudRepository;
 
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
@@ -29,7 +28,7 @@ public class NodeStatusJobAdapter extends JobResourceAdapter<Stack> {
     }
 
     @Override
-    public Class<? extends CrudRepository> getRepositoryClassForResource() {
+    public Class<StackRepository> getRepositoryClassForResource() {
         return StackRepository.class;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherConfig.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.job.stackpatcher;
+
+import javax.annotation.PostConstruct;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExistingStackPatcherConfig {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExistingStackPatcherConfig.class);
+
+    @Value("${existingstackpatcher.intervalhours}")
+    private int intervalInHours;
+
+    @Value("${existingstackpatcher.enabled}")
+    private boolean existingStackPatcherEnabled;
+
+    @PostConstruct
+    void logEnablement() {
+        LOGGER.info("Existing stack patcher is {}", existingStackPatcherEnabled ? "enabled" : "disabled");
+    }
+
+    public boolean isExistingStackPatcherEnabled() {
+        return existingStackPatcherEnabled;
+    }
+
+    public int getIntervalInHours() {
+        return intervalInHours;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJob.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJob.java
@@ -1,0 +1,102 @@
+package com.sequenceiq.cloudbreak.job.stackpatcher;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
+import com.sequenceiq.cloudbreak.domain.view.StackView;
+import com.sequenceiq.cloudbreak.quartz.statuschecker.job.StatusCheckerJob;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.stack.StackViewService;
+import com.sequenceiq.cloudbreak.service.stackpatch.ExistingStackPatchApplyException;
+import com.sequenceiq.cloudbreak.service.stackpatch.ExistingStackPatchService;
+
+import io.opentracing.Tracer;
+
+@DisallowConcurrentExecution
+@Component
+public class ExistingStackPatcherJob extends StatusCheckerJob {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExistingStackPatcherJob.class);
+
+    @Inject
+    private StackViewService stackViewService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private ExistingStackPatcherJobService jobService;
+
+    @Inject
+    private Collection<ExistingStackPatchService> existingStackPatchServices;
+
+    public ExistingStackPatcherJob(Tracer tracer) {
+        super(tracer, "Existing Stack Patcher Job");
+    }
+
+    @Override
+    protected Object getMdcContextObject() {
+        return stackViewService.findById(getStackId()).orElseGet(StackView::new);
+    }
+
+    @Override
+    protected void executeTracedJob(JobExecutionContext context) throws JobExecutionException {
+        Stack stack = stackService.getByIdWithListsInTransaction(getStackId());
+        Status stackStatus = stack.getStatus();
+        if (!Status.getUnschedulableStatuses().contains(stackStatus)) {
+            applyStackPatches(stack);
+        } else {
+            LOGGER.debug("Existing stack fixing will be unscheduled, because stack {} state is {}", stack.getResourceCrn(), stackStatus);
+        }
+        jobService.unschedule(context.getJobDetail().getKey());
+    }
+
+    private void applyStackPatches(Stack stack) throws JobExecutionException {
+        Map<StackPatchType, Exception> errors = new HashMap<>();
+        for (ExistingStackPatchService existingStackPatchService : existingStackPatchServices) {
+            if (!existingStackPatchService.isStackAlreadyFixed(stack)) {
+                try {
+                    applyStackPatch(stack, existingStackPatchService);
+                } catch (ExistingStackPatchApplyException e) {
+                    LOGGER.error("Failed to patch stack: {} for {}", stack.getResourceCrn(), existingStackPatchService.getStackFixType(), e);
+                    errors.put(existingStackPatchService.getStackFixType(), e);
+                }
+            } else {
+                LOGGER.debug("Stack {} was already patched for {}", stack.getResourceCrn(), existingStackPatchService.getStackFixType());
+            }
+        }
+        if (errors.isEmpty()) {
+            LOGGER.info("All patches finished for stack {}", stack.getResourceCrn());
+        } else {
+            throw new JobExecutionException(String.format("Failed to patch stack %s, errors: %s", stack.getResourceCrn(), errors));
+        }
+    }
+
+    private void applyStackPatch(Stack stack, ExistingStackPatchService existingStackPatchService) throws ExistingStackPatchApplyException {
+        StackPatchType stackPatchType = existingStackPatchService.getStackFixType();
+        if (existingStackPatchService.isAffected(stack)) {
+            LOGGER.debug("Stack {} needs patch for {}", stack.getResourceCrn(), stackPatchType);
+            existingStackPatchService.apply(stack);
+            LOGGER.info("Stack {} was patched successfully for {}", stack.getResourceCrn(), stackPatchType);
+        } else {
+            LOGGER.debug("Stack {} is not affected by {}", stack.getResourceCrn(), stackPatchType);
+        }
+    }
+
+    private Long getStackId() {
+        return Long.valueOf(getLocalId());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobAdapter.java
@@ -1,4 +1,4 @@
-package com.sequenceiq.cloudbreak.structuredevent.job;
+package com.sequenceiq.cloudbreak.job.stackpatcher;
 
 import org.quartz.Job;
 import org.springframework.context.ApplicationContext;
@@ -7,13 +7,13 @@ import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
 
-public class StructuredSynchronizerJobAdapter extends JobResourceAdapter<Stack> {
+public class ExistingStackPatcherJobAdapter extends JobResourceAdapter<Stack> {
 
-    public StructuredSynchronizerJobAdapter(Long id, ApplicationContext context) {
+    public ExistingStackPatcherJobAdapter(Long id, ApplicationContext context) {
         super(id, context);
     }
 
-    public StructuredSynchronizerJobAdapter(Stack resource) {
+    public ExistingStackPatcherJobAdapter(Stack resource) {
         super(resource);
     }
 
@@ -29,7 +29,7 @@ public class StructuredSynchronizerJobAdapter extends JobResourceAdapter<Stack> 
 
     @Override
     public Class<? extends Job> getJobClassForResource() {
-        return StructuredSynchronizerJob.class;
+        return ExistingStackPatcherJob.class;
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobInitializer.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.job.stackpatcher;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.job.AbstractStackJobInitializer;
+
+@Component
+public class ExistingStackPatcherJobInitializer extends AbstractStackJobInitializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExistingStackPatcherJobInitializer.class);
+
+    @Inject
+    private ExistingStackPatcherConfig config;
+
+    @Inject
+    private ExistingStackPatcherJobService jobService;
+
+    @Override
+    public void initJobs() {
+        if (config.isExistingStackPatcherEnabled()) {
+            LOGGER.info("Scheduling stack patcher jobs");
+            getAliveAndNotDeleteInProgressStacksStream()
+                    .forEach(s -> jobService.schedule(new ExistingStackPatcherJobAdapter(s)));
+        } else {
+            LOGGER.info("Skipping scheduling stack patcher jobs, as they are disabled");
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobService.java
@@ -1,0 +1,96 @@
+package com.sequenceiq.cloudbreak.job.stackpatcher;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.impl.matchers.GroupMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ExistingStackPatcherJobService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExistingStackPatcherJobService.class);
+
+    private static final String JOB_GROUP = "existing-stack-patcher-jobs";
+
+    private static final String TRIGGER_GROUP = "existing-stack-patcher-triggers";
+
+    private static final Random RANDOM = new SecureRandom();
+
+    @Inject
+    private ExistingStackPatcherConfig properties;
+
+    @Inject
+    private Scheduler scheduler;
+
+    public void schedule(ExistingStackPatcherJobAdapter resource) {
+        JobDetail jobDetail = buildJobDetail(resource);
+        JobKey jobKey = jobDetail.getKey();
+        Trigger trigger = buildJobTrigger(jobDetail);
+        try {
+            if (scheduler.getJobDetail(jobKey) != null) {
+                unschedule(jobKey);
+            }
+            LOGGER.debug("Scheduling stack patcher job for stack {}", resource.getRemoteResourceId());
+            scheduler.scheduleJob(jobDetail, trigger);
+        } catch (SchedulerException e) {
+            LOGGER.error(String.format("Error during scheduling stack patcher job: %s", jobDetail), e);
+        }
+    }
+
+    public void unschedule(JobKey jobKey) {
+        try {
+            if (scheduler.getJobDetail(jobKey) != null) {
+                scheduler.deleteJob(jobKey);
+            }
+            if (scheduler.getJobKeys(GroupMatcher.groupEquals(JOB_GROUP)).isEmpty()) {
+                LOGGER.info("All existing stacks have been patched, hooray!");
+            }
+        } catch (SchedulerException e) {
+            LOGGER.error(String.format("Error during unscheduling quartz job: %s", jobKey), e);
+        }
+    }
+
+    private JobDetail buildJobDetail(ExistingStackPatcherJobAdapter resource) {
+        return JobBuilder.newJob(ExistingStackPatcherJob.class)
+                .withIdentity(resource.getLocalId(), JOB_GROUP)
+                .withDescription("Patching existing stack: " + resource.getRemoteResourceId())
+                .usingJobData(resource.toJobDataMap())
+                .storeDurably()
+                .build();
+    }
+
+    private Trigger buildJobTrigger(JobDetail jobDetail) {
+        return TriggerBuilder.newTrigger()
+                .forJob(jobDetail)
+                .withIdentity(jobDetail.getKey().getName(), TRIGGER_GROUP)
+                .withDescription("Trigger for patching existing stack")
+                .startAt(delayedFirstStart())
+                .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                        .withIntervalInHours(properties.getIntervalInHours())
+                        .repeatForever()
+                        .withMisfireHandlingInstructionNextWithExistingCount())
+                .build();
+    }
+
+    private Date delayedFirstStart() {
+        int delayInMinutes = RANDOM.nextInt((int) TimeUnit.HOURS.toMinutes(properties.getIntervalInHours()));
+        return Date.from(ZonedDateTime.now().toInstant().plus(Duration.ofMinutes(delayInMinutes)));
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackPatchRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackPatchRepository.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+
+@EntityType(entityClass = StackPatch.class)
+@Transactional(Transactional.TxType.REQUIRED)
+public interface StackPatchRepository extends JpaRepository<StackPatch, Long> {
+
+    Optional<StackPatch> findByStackAndType(Stack stack, StackPatchType stackPatchType);
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/InstanceMetadataUpdater.java
@@ -37,7 +37,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
-import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceMetadataType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.Image;
 import com.sequenceiq.cloudbreak.common.json.Json;
@@ -75,8 +74,7 @@ public class InstanceMetadataUpdater {
 
     public void updatePackageVersionsOnAllInstances(Long stackId) throws Exception {
         Stack stack = getStackForFreshInstanceStatuses(stackId);
-        Boolean enableKnox = stack.getCluster().getGateway() != null;
-        GatewayConfig gatewayConfig = getGatewayConfig(stack, enableKnox);
+        GatewayConfig gatewayConfig = gatewayConfigService.getPrimaryGatewayConfig(stack);
 
         Map<String, Map<String, String>> packageVersionsByNameByHost = getPackageVersionByNameByHost(gatewayConfig, hostOrchestrator);
 
@@ -97,16 +95,6 @@ public class InstanceMetadataUpdater {
 
     private Stack getStackForFreshInstanceStatuses(Long stackId) {
         return stackService.getByIdWithListsInTransaction(stackId);
-    }
-
-    private GatewayConfig getGatewayConfig(Stack stack, Boolean enableKnox) {
-        GatewayConfig gatewayConfig = null;
-        for (InstanceMetaData gateway : stack.getNotTerminatedGatewayInstanceMetadata()) {
-            if (InstanceMetadataType.GATEWAY_PRIMARY.equals(gateway.getInstanceMetadataType())) {
-                gatewayConfig = gatewayConfigService.getGatewayConfig(stack, gateway, enableKnox);
-            }
-        }
-        return gatewayConfig;
     }
 
     private List<String> updateInstanceMetaDataIfVersionQueryFailed(Map<String, Map<String, String>> packageVersionsByNameByHost,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaClientService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaClientService.java
@@ -13,6 +13,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.auth.crn.InternalCrnBuilder;
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.exception.WebApplicationExceptionMessageExtractor;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
@@ -49,6 +51,10 @@ public class FreeipaClientService {
 
     public Optional<DescribeFreeIpaResponse> findByEnvironmentCrn(String environmentCrn) {
         try {
+            if (InternalCrnBuilder.isInternalCrn(ThreadBasedUserCrnProvider.getUserCrn())) {
+                String accountId = Crn.fromString(environmentCrn).getAccountId();
+                return Optional.ofNullable(freeIpaV1Endpoint.describeInternal(environmentCrn, accountId));
+            }
             return Optional.ofNullable(freeIpaV1Endpoint.describe(environmentCrn));
         } catch (NotFoundException e) {
             LOGGER.info("FreeIPA is not found for env: {}", environmentCrn, e);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/ExistingStackPatchApplyException.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/ExistingStackPatchApplyException.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.cloudbreak.service.stackpatch;
+
+public class ExistingStackPatchApplyException extends Exception {
+
+    public ExistingStackPatchApplyException(String message) {
+        super(message);
+    }
+
+    public ExistingStackPatchApplyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/ExistingStackPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/ExistingStackPatchService.java
@@ -1,0 +1,78 @@
+package com.sequenceiq.cloudbreak.service.stackpatch;
+
+import static com.sequenceiq.cloudbreak.util.Benchmark.checkedMeasure;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
+import com.sequenceiq.cloudbreak.repository.StackPatchRepository;
+import com.sequenceiq.flow.core.FlowLogService;
+import com.sequenceiq.flow.domain.FlowLog;
+import com.sequenceiq.flow.service.FlowRetryService;
+
+public abstract class ExistingStackPatchService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExistingStackPatchService.class);
+
+    @Inject
+    private StackPatchRepository stackPatchRepository;
+
+    @Inject
+    private FlowLogService flowLogService;
+
+    @Inject
+    private FlowRetryService flowRetryService;
+
+    public boolean isStackAlreadyFixed(Stack stack) {
+        return stackPatchRepository.findByStackAndType(stack, getStackFixType()).isPresent();
+    }
+
+    public void apply(Stack stack) throws ExistingStackPatchApplyException {
+        if (flowLogService.isOtherFlowRunning(stack.getId())) {
+            String message = String.format("Another flow is running for stack %s, skipping patch apply to let the flow finish", stack.getResourceCrn());
+            throw new ExistingStackPatchApplyException(message);
+        } else {
+            Optional<FlowLog> lastRetryableFailedFlow = flowRetryService.getLastRetryableFailedFlow(stack.getId());
+            if (lastRetryableFailedFlow.isEmpty()) {
+                try {
+                    LOGGER.info("Starting stack {} patching for {}", stack.getResourceCrn(), getStackFixType());
+                    checkedMeasure(() -> doApply(stack), LOGGER, "Existing stack patching took {} ms for stack {} and patch {}.",
+                            stack.getResourceCrn(), getStackFixType());
+                    LOGGER.info("Stack {} was patched successfully for {}", stack.getResourceCrn(), getStackFixType());
+                    stackPatchRepository.save(new StackPatch(stack, getStackFixType()));
+                } catch (ExistingStackPatchApplyException e) {
+                    throw e;
+                } catch (Exception e) {
+                    String message = String.format("Something unexpected went wrong with stack %s while applying patch %s",
+                            stack.getResourceCrn(), getStackFixType());
+                    throw new ExistingStackPatchApplyException(message, e);
+                }
+            } else {
+                String message = String.format("Stack %s has a retryable failed flow, skipping patch apply to preserve possible retry", stack.getResourceCrn());
+                throw new ExistingStackPatchApplyException(message);
+            }
+        }
+    }
+
+    /**
+     * @return The StackFixType that is fixed by running the service implementation's doApply
+     */
+    public abstract StackPatchType getStackFixType();
+
+    /**
+     * @return Is the stack affected by the {@link StackPatchType}
+     */
+    public abstract boolean isAffected(Stack stack);
+
+    /**
+     * Apply the fix of {@link StackPatchType} for the affected stack
+     */
+    abstract void doApply(Stack stack) throws ExistingStackPatchApplyException;
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/UnboundRestartPatchService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stackpatch/UnboundRestartPatchService.java
@@ -1,0 +1,104 @@
+package com.sequenceiq.cloudbreak.service.stackpatch;
+
+import static com.sequenceiq.cloudbreak.domain.stack.StackPatchType.UNBOUND_RESTART;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.dyngr.Polling;
+import com.dyngr.core.AttemptResult;
+import com.dyngr.core.AttemptResults;
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
+import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
+import com.sequenceiq.cloudbreak.service.cluster.flow.ClusterOperationService;
+import com.sequenceiq.cloudbreak.service.stack.StackImageService;
+import com.sequenceiq.flow.api.model.FlowCheckResponse;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.flow.service.FlowService;
+
+@Service
+public class UnboundRestartPatchService extends ExistingStackPatchService {
+
+    private static final String AFFECTED_STACK_VERSION = "7.2.11";
+
+    private static final Set<String> AFFECTED_IMAGE_IDS = Set.of(
+            "26cd5a65-cd5c-457d-8d48-9caf1a486516",
+            "19cf97b8-56d8-4be9-b317-998eea99d884",
+            "c24acec3-9110-4474-9082-3620deac0910"
+    );
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UnboundRestartPatchService.class);
+
+    @Inject
+    private StackImageService stackImageService;
+
+    @Inject
+    private ClusterOperationService clusterOperationService;
+
+    @Inject
+    private FlowService flowService;
+
+    @Override
+    public StackPatchType getStackFixType() {
+        return UNBOUND_RESTART;
+    }
+
+    @Override
+    public boolean isAffected(Stack stack) {
+        try {
+            boolean affected = false;
+            if (AFFECTED_STACK_VERSION.equals(stack.getStackVersion())) {
+                Image image = stackImageService.getCurrentImage(stack);
+                affected = AFFECTED_IMAGE_IDS.contains(image.getImageId());
+                LOGGER.debug("Stack {} with version {} and image {} is {} by unbound service restart bug",
+                        stack.getResourceCrn(), stack.getStackVersion(), image.getImageId(), affected ? "affected" : "not affected");
+            } else {
+                LOGGER.debug("Stack {} with version {} is not affected by unbound service restart bug", stack.getResourceCrn(), stack.getStackVersion());
+            }
+            return affected;
+        } catch (CloudbreakImageNotFoundException e) {
+            LOGGER.warn("Image not found for stack " + stack.getResourceCrn(), e);
+            throw new CloudbreakRuntimeException("Image not found for stack " + stack.getResourceCrn(), e);
+        }
+    }
+
+    @Override
+    void doApply(Stack stack) throws ExistingStackPatchApplyException {
+        if (isCmServerReachable(stack)) {
+            FlowIdentifier flowIdentifier = ThreadBasedUserCrnProvider.doAsInternalActor(() -> clusterOperationService.updateSalt(stack));
+            Boolean success = Polling.waitPeriodly(1, TimeUnit.MINUTES)
+                    .run(() -> pollFlowState(flowIdentifier));
+            if (!success) {
+                throw new ExistingStackPatchApplyException("Failed to update salt for stack " + stack.getResourceCrn());
+            }
+        } else {
+            LOGGER.info("Salt update cannot run, because CM server is unreachable of stack: {}", stack.getResourceCrn());
+            throw new ExistingStackPatchApplyException("Salt update cannot run, because CM server is unreachable of stack: " + stack.getResourceCrn());
+        }
+    }
+
+    private boolean isCmServerReachable(Stack stack) throws ExistingStackPatchApplyException {
+        return stack.getClusterManagerServer()
+                .orElseThrow(() -> new ExistingStackPatchApplyException("Could not find CM server for stack: " + stack.getResourceCrn()))
+                .isReachable();
+    }
+
+    private AttemptResult<Boolean> pollFlowState(FlowIdentifier flowIdentifier) {
+        FlowCheckResponse flowState = flowService.getFlowState(flowIdentifier.getPollableId());
+        LOGGER.debug("Salt update polling has active flow: {}, with latest fail: {}",
+                flowState.getHasActiveFlow(), flowState.getLatestFlowFinalizedAndFailed());
+        return flowState.getHasActiveFlow()
+                ? AttemptResults.justContinue()
+                : AttemptResults.finishWith(!flowState.getLatestFlowFinalizedAndFailed());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobInitializer.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/job/StructuredSynchronizerJobInitializer.java
@@ -4,32 +4,17 @@ import javax.inject.Inject;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.domain.projection.StackTtlView;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.cloudbreak.quartz.model.JobInitializer;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.job.AbstractStackJobInitializer;
 
 @Component
-public class StructuredSynchronizerJobInitializer implements JobInitializer {
+public class StructuredSynchronizerJobInitializer extends AbstractStackJobInitializer {
 
     @Inject
     private StructuredSynchronizerJobService jobService;
 
-    @Inject
-    private StackService stackService;
-
     @Override
     public void initJobs() {
-        stackService.getAllAlive().stream()
-                .map(this::convertToStack)
+        getAliveStacksStream()
                 .forEach(s -> jobService.scheduleWithDelay(new StructuredSynchronizerJobAdapter(s)));
-    }
-
-    private Stack convertToStack(StackTtlView view) {
-        Stack result = new Stack();
-        result.setId(view.getId());
-        result.setResourceCrn(view.getCrn());
-        result.setStackStatus(view.getStatus());
-        return result;
     }
 }

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -836,3 +836,7 @@ notification:
 crn:
   partition: cdp
   region: us-west-1
+
+existingstackpatcher:
+  intervalhours: 1
+  enabled: true

--- a/core/src/main/resources/schema/app/20211103115000_CB-14656_create_stackpatch_table.sql
+++ b/core/src/main/resources/schema/app/20211103115000_CB-14656_create_stackpatch_table.sql
@@ -1,0 +1,26 @@
+-- // CB-14656
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE IF NOT EXISTS stackpatch
+(
+    id              bigint NOT NULL,
+    type            CHARACTER VARYING(255) NOT NULL,
+    created         int8 NOT NULL,
+    stack_id        bigint NOT NULL,
+    PRIMARY KEY (id)
+);
+
+ALTER TABLE ONLY stackpatch ADD CONSTRAINT fk_stackpatch_stack_id FOREIGN KEY (stack_id) REFERENCES stack(id);
+
+ALTER TABLE ONLY stackpatch ADD CONSTRAINT uk_stackpatch_stack_type UNIQUE (stack_id, type);
+
+CREATE INDEX IF NOT EXISTS stackpatch_type_stack ON stackpatch(stack_id, type);
+
+CREATE SEQUENCE IF NOT EXISTS stackpatch_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP TABLE IF EXISTS stackpatch;
+
+DROP SEQUENCE IF EXISTS stackpatch_id_seq;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/StackStatusCheckerJobTest.java
@@ -197,7 +197,7 @@ public class StackStatusCheckerJobTest {
 
     @Test
     public void testHandledAllStatesSeparately() {
-        Set<Status> unshedulableStates = underTest.unschedulableStates();
+        Set<Status> unshedulableStates = Status.getUnschedulableStatuses();
         Set<Status> ignoredStates = underTest.ignoredStates();
         Set<Status> syncableStates = underTest.syncableStates();
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/job/stackpatcher/ExistingStackPatcherJobTest.java
@@ -1,0 +1,178 @@
+package com.sequenceiq.cloudbreak.job.stackpatcher;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.springframework.util.ReflectionUtils;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
+import com.sequenceiq.cloudbreak.service.stackpatch.ExistingStackPatchApplyException;
+import com.sequenceiq.cloudbreak.service.stackpatch.ExistingStackPatchService;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+@ExtendWith(MockitoExtension.class)
+class ExistingStackPatcherJobTest {
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private ExistingStackPatcherJobService jobService;
+
+    @Mock
+    private ExistingStackPatchService existingStackPatchService;
+
+    @InjectMocks
+    private ExistingStackPatcherJob underTest;
+
+    @Captor
+    private ArgumentCaptor<JobKey> jobKeyArgumentCaptor;
+
+    @Mock
+    private JobExecutionContext context;
+
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() {
+        stack = new Stack();
+        stack.setId(123L);
+        stack.setResourceCrn("stack-crn");
+        setStackStatus(Status.AVAILABLE);
+
+        MockitoAnnotations.openMocks(this);
+
+        when(stackService.getByIdWithListsInTransaction(stack.getId())).thenReturn(stack);
+
+        underTest.setLocalId(stack.getId().toString());
+        underTest.setRemoteResourceCrn(stack.getResourceCrn());
+
+        setStackFixServices();
+
+        JobDetail jobDetail = mock(JobDetail.class);
+        lenient().when(jobDetail.getKey()).thenReturn(JobKey.jobKey(stack.getId().toString()));
+        lenient().when(context.getJobDetail()).thenReturn(jobDetail);
+    }
+
+    @Test
+    void shouldUnscheduleWhenStackIsInFailedOrDeletedStatus() throws JobExecutionException, ExistingStackPatchApplyException {
+        setStackStatus(Status.CREATE_FAILED);
+
+        underTest.executeTracedJob(context);
+
+        verifyUnschedule();
+        verify(existingStackPatchService, never()).apply(stack);
+    }
+
+    @Test
+    void shouldNotApplyWhenStackIsAlreadyFixed() throws JobExecutionException, ExistingStackPatchApplyException {
+        when(existingStackPatchService.isStackAlreadyFixed(stack)).thenReturn(true);
+
+        underTest.executeTracedJob(context);
+
+        verifyUnschedule();
+        verify(existingStackPatchService, never()).apply(stack);
+    }
+
+    @Test
+    void shouldNotApplyWhenStackIsNotAffected() throws JobExecutionException, ExistingStackPatchApplyException {
+        when(existingStackPatchService.isAffected(stack)).thenReturn(false);
+
+        underTest.executeTracedJob(context);
+
+        verifyUnschedule();
+        verify(existingStackPatchService, never()).apply(stack);
+    }
+
+    @Test
+    void shouldApplyWhenStackIsAffected() throws JobExecutionException, ExistingStackPatchApplyException {
+        when(existingStackPatchService.isAffected(stack)).thenReturn(true);
+
+        underTest.executeTracedJob(context);
+
+        verifyUnschedule();
+        verify(existingStackPatchService).apply(stack);
+    }
+
+    @Test
+    void shouldNotUnscheduleWhenApplyFails() throws ExistingStackPatchApplyException {
+        when(existingStackPatchService.isAffected(stack)).thenReturn(true);
+        doThrow(ExistingStackPatchApplyException.class).when(existingStackPatchService).apply(stack);
+
+        Assertions.assertThatThrownBy(() -> underTest.executeTracedJob(context))
+                .isInstanceOf(JobExecutionException.class)
+                .hasMessageStartingWith("Failed to patch stack");
+
+        verify(jobService, never()).unschedule(any());
+    }
+
+    @Test
+    void shouldNotUnscheduleWhenOneApplyFailsAndOneSucceeds() throws ExistingStackPatchApplyException {
+        ExistingStackPatchService failingExistingStackPatchService = mock(ExistingStackPatchService.class);
+        when(failingExistingStackPatchService.isAffected(stack)).thenReturn(true);
+        doThrow(ExistingStackPatchApplyException.class).when(failingExistingStackPatchService).apply(stack);
+        setStackFixServices(failingExistingStackPatchService);
+
+        when(existingStackPatchService.isAffected(stack)).thenReturn(true);
+
+        Assertions.assertThatThrownBy(() -> underTest.executeTracedJob(context))
+                .isInstanceOf(JobExecutionException.class)
+                .hasMessageStartingWith("Failed to patch stack");
+
+        verify(jobService, never()).unschedule(any());
+    }
+
+    private void setStackStatus(Status status) {
+        StackStatus stackStatus = new StackStatus();
+        stackStatus.setStatus(status);
+        stack.setStackStatus(stackStatus);
+    }
+
+    /**
+     * workaround for collection injection
+     */
+    private void setStackFixServices(ExistingStackPatchService... additionalServices) {
+        try {
+            Field existingStackPatchServicesField = ExistingStackPatcherJob.class.getDeclaredField("existingStackPatchServices");
+            ReflectionUtils.makeAccessible(existingStackPatchServicesField);
+            Set<ExistingStackPatchService> existingStackPatchServices = new HashSet<>();
+            existingStackPatchServices.add(existingStackPatchService);
+            existingStackPatchServices.addAll(Set.of(additionalServices));
+            ReflectionUtils.setField(existingStackPatchServicesField, underTest, existingStackPatchServices);
+        } catch (NoSuchFieldException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void verifyUnschedule() {
+        verify(jobService).unschedule(jobKeyArgumentCaptor.capture());
+        Assertions.assertThat(jobKeyArgumentCaptor.getValue())
+                .returns(underTest.getLocalId(), JobKey::getName);
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/InstanceMetadataUpdaterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ambari/InstanceMetadataUpdaterTest.java
@@ -3,7 +3,6 @@ package com.sequenceiq.cloudbreak.service.cluster.ambari;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus.SERVICES_UNHEALTHY;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -74,7 +73,7 @@ public class InstanceMetadataUpdaterTest {
     @Before
     public void setUp() throws CloudbreakException, JsonProcessingException, CloudbreakOrchestratorFailedException {
         MockitoAnnotations.initMocks(this);
-        when(gatewayConfigService.getGatewayConfig(any(Stack.class), any(InstanceMetaData.class), anyBoolean())).thenReturn(gatewayConfig);
+        when(gatewayConfigService.getPrimaryGatewayConfig(any(Stack.class))).thenReturn(gatewayConfig);
 
         InstanceMetadataUpdater.Package packageByName = new InstanceMetadataUpdater.Package();
         packageByName.setName("packageByName");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/ExistingStackPatchServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/ExistingStackPatchServiceTest.java
@@ -1,0 +1,146 @@
+package com.sequenceiq.cloudbreak.service.stackpatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatch;
+import com.sequenceiq.cloudbreak.domain.stack.StackPatchType;
+import com.sequenceiq.cloudbreak.repository.StackPatchRepository;
+import com.sequenceiq.flow.core.FlowLogService;
+import com.sequenceiq.flow.domain.FlowLog;
+import com.sequenceiq.flow.service.FlowRetryService;
+
+@ExtendWith(MockitoExtension.class)
+class ExistingStackPatchServiceTest {
+
+    @Mock
+    private StackPatchRepository stackPatchRepository;
+
+    @Mock
+    private FlowLogService flowLogService;
+
+    @Mock
+    private FlowRetryService flowRetryService;
+
+    @InjectMocks
+    private NoopExistingStackPatchService underTest;
+
+    @InjectMocks
+    private ThrowExceptionExistingStackPatchService alsoUnderTest;
+
+    @Captor
+    private ArgumentCaptor<StackPatch> stackFixArgumentCaptor;
+
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() {
+        stack = new Stack();
+        stack.setId(123L);
+        stack.setResourceCrn("stack-crn");
+    }
+
+    @Test
+    void isStackAlreadyFixedFalse() {
+        when(stackPatchRepository.findByStackAndType(stack, StackPatchType.UNKNOWN)).thenReturn(Optional.empty());
+
+        boolean result = underTest.isStackAlreadyFixed(stack);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isStackAlreadyFixedTrue() {
+        when(stackPatchRepository.findByStackAndType(stack, StackPatchType.UNKNOWN)).thenReturn(Optional.of(new StackPatch()));
+
+        boolean result = underTest.isStackAlreadyFixed(stack);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void applyShouldFailWhenFlowIsRunning() {
+        when(flowLogService.isOtherFlowRunning(stack.getId())).thenReturn(true);
+
+        assertThatThrownBy(() -> underTest.apply(stack))
+                .hasMessage("Another flow is running for stack %s, skipping patch apply to let the flow finish", stack.getResourceCrn());
+    }
+
+    @Test
+    void applyShouldFailWhenLastFlowRetryable() {
+        when(flowRetryService.getLastRetryableFailedFlow(stack.getId())).thenReturn(Optional.of(new FlowLog()));
+
+        assertThatThrownBy(() -> underTest.apply(stack))
+                .hasMessage("Stack %s has a retryable failed flow, skipping patch apply to preserve possible retry", stack.getResourceCrn());
+    }
+
+    @Test
+    void shouldSaveStackFixWhenApplyIsSuccessful() throws ExistingStackPatchApplyException {
+        underTest.apply(stack);
+
+        verify(stackPatchRepository).save(stackFixArgumentCaptor.capture());
+        StackPatch stackPatch = stackFixArgumentCaptor.getValue();
+        assertThat(stackPatch)
+                .returns(stack, StackPatch::getStack)
+                .returns(StackPatchType.UNKNOWN, StackPatch::getType);
+    }
+
+    @Test
+    void shouldTranslateUnexpectedExceptionType() throws ExistingStackPatchApplyException {
+        assertThatThrownBy(() -> alsoUnderTest.apply(stack))
+                .isInstanceOf(ExistingStackPatchApplyException.class)
+                .hasMessage("Something unexpected went wrong with stack %s while applying patch %s",
+                        stack.getResourceCrn(), StackPatchType.UNKNOWN);
+    }
+
+    static class NoopExistingStackPatchService extends ExistingStackPatchService {
+
+        @Override
+        public StackPatchType getStackFixType() {
+            return StackPatchType.UNKNOWN;
+        }
+
+        @Override
+        public boolean isAffected(Stack stack) {
+            return false;
+        }
+
+        @Override
+        void doApply(Stack stack) {
+            // do nothing
+        }
+    }
+
+    static class ThrowExceptionExistingStackPatchService extends ExistingStackPatchService {
+
+        @Override
+        public StackPatchType getStackFixType() {
+            return StackPatchType.UNKNOWN;
+        }
+
+        @Override
+        public boolean isAffected(Stack stack) {
+            return false;
+        }
+
+        @Override
+        void doApply(Stack stack) {
+            throw new RuntimeException("Unexpected exception");
+        }
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/UnboundRestartPatchServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stackpatch/UnboundRestartPatchServiceTest.java
@@ -1,0 +1,148 @@
+package com.sequenceiq.cloudbreak.service.stackpatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.cloud.model.Image;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
+import com.sequenceiq.cloudbreak.domain.stack.Stack;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
+import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
+import com.sequenceiq.cloudbreak.repository.StackPatchRepository;
+import com.sequenceiq.cloudbreak.service.cluster.flow.ClusterOperationService;
+import com.sequenceiq.cloudbreak.service.stack.StackImageService;
+import com.sequenceiq.flow.api.model.FlowCheckResponse;
+import com.sequenceiq.flow.api.model.FlowIdentifier;
+import com.sequenceiq.flow.api.model.FlowType;
+import com.sequenceiq.flow.core.FlowLogService;
+import com.sequenceiq.flow.service.FlowService;
+
+@ExtendWith(MockitoExtension.class)
+class UnboundRestartPatchServiceTest {
+
+    private static final String POLLABLE_ID = "pollable-id";
+
+    @Mock
+    private StackPatchRepository stackPatchRepository;
+
+    @Mock
+    private FlowLogService flowLogService;
+
+    @Mock
+    private StackImageService stackImageService;
+
+    @Mock
+    private ClusterOperationService clusterOperationService;
+
+    @Mock
+    private FlowService flowService;
+
+    @InjectMocks
+    private UnboundRestartPatchService underTest;
+
+    private Stack stack;
+
+    @BeforeEach
+    void setUp() {
+        stack = new Stack();
+        stack.setId(123L);
+        stack.setResourceCrn("stack-crn");
+
+        setCmServerReachability(true);
+    }
+
+    @Test
+    void unaffectedStackVersionNotAffected() {
+        stack.setStackVersion("7.2.12");
+
+        boolean result = underTest.isAffected(stack);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void affectedStackVersionButUnaffectedImageIdIsNotAffected() throws CloudbreakImageNotFoundException {
+        stack.setStackVersion("7.2.11");
+        setStackImageId("123456");
+
+        boolean result = underTest.isAffected(stack);
+
+        assertThat(result).isFalse();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"26cd5a65-cd5c-457d-8d48-9caf1a486516", "19cf97b8-56d8-4be9-b317-998eea99d884", "c24acec3-9110-4474-9082-3620deac0910"})
+    void affectedImageIsAffected(String imageId) throws CloudbreakImageNotFoundException {
+        stack.setStackVersion("7.2.11");
+        setStackImageId(imageId);
+
+        boolean result = underTest.isAffected(stack);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void unreachableCmServerFailsToApply() {
+        setCmServerReachability(false);
+
+        assertThatThrownBy(() -> underTest.doApply(stack))
+                .isInstanceOf(ExistingStackPatchApplyException.class)
+                .hasMessageStartingWith("Salt update cannot run, because CM server is unreachable of stack");
+    }
+
+    @Test
+    void failedFlowState() {
+        when(clusterOperationService.updateSalt(stack)).thenReturn(new FlowIdentifier(FlowType.FLOW, POLLABLE_ID));
+        setFlowState(true, true);
+
+        assertThatThrownBy(() -> underTest.doApply(stack))
+                .isInstanceOf(ExistingStackPatchApplyException.class)
+                .hasMessageStartingWith("Failed to update salt for stack");
+    }
+
+    @Test
+    void allHostsSucceedToApply() throws CloudbreakOrchestratorFailedException, ExistingStackPatchApplyException {
+        when(clusterOperationService.updateSalt(stack)).thenReturn(new FlowIdentifier(FlowType.FLOW, POLLABLE_ID));
+        setFlowState(true, false);
+
+        underTest.doApply(stack);
+    }
+
+    private void setCmServerReachability(boolean reachable) {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setClusterManagerServer(true);
+        instanceMetaData.setInstanceStatus(reachable ? InstanceStatus.SERVICES_RUNNING : InstanceStatus.ORCHESTRATION_FAILED);
+        instanceGroup.setInstanceMetaData(Set.of(instanceMetaData));
+        stack.setInstanceGroups(Set.of(instanceGroup));
+    }
+
+    private void setStackImageId(String id) throws CloudbreakImageNotFoundException {
+        Image image = mock(Image.class);
+        when(image.getImageId()).thenReturn(id);
+        when(stackImageService.getCurrentImage(stack)).thenReturn(image);
+    }
+
+    private void setFlowState(boolean finished, boolean failed) {
+        FlowCheckResponse flowCheckResponse = new FlowCheckResponse();
+        flowCheckResponse.setHasActiveFlow(!finished);
+        flowCheckResponse.setLatestFlowFinalizedAndFailed(failed);
+        when(flowService.getFlowState(POLLABLE_ID)).thenReturn(flowCheckResponse);
+    }
+
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/job/SdxClusterJobAdapter.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/job/SdxClusterJobAdapter.java
@@ -2,11 +2,10 @@ package com.sequenceiq.datalake.job;
 
 import org.quartz.Job;
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.repository.CrudRepository;
 
+import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.repository.SdxClusterRepository;
-import com.sequenceiq.cloudbreak.quartz.model.JobResourceAdapter;
 
 public class SdxClusterJobAdapter extends JobResourceAdapter<SdxCluster> {
 
@@ -34,7 +33,7 @@ public class SdxClusterJobAdapter extends JobResourceAdapter<SdxCluster> {
     }
 
     @Override
-    public Class<? extends CrudRepository> getRepositoryClassForResource() {
+    public Class<SdxClusterRepository> getRepositoryClassForResource() {
         return SdxClusterRepository.class;
     }
 }

--- a/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/core/FlowLogService.java
@@ -60,6 +60,8 @@ public interface FlowLogService {
 
     List<FlowLog> findAllByResourceIdOrderByCreatedDesc(Long id);
 
+    Optional<FlowLog> getLastFlowLog(Long resourceId);
+
     List<FlowLog> findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(Long id);
 
     int purgeFinalizedFlowLogs();

--- a/flow/src/main/java/com/sequenceiq/flow/domain/RetryableState.java
+++ b/flow/src/main/java/com/sequenceiq/flow/domain/RetryableState.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.flow.domain;
+
+public enum RetryableState {
+    FLOW_PENDING,
+    LAST_NOT_FAILED_OR_NOT_RETRYABLE,
+    NO_SUCCESSFUL_STATE,
+    RETRYABLE;
+
+    public boolean isRetryable() {
+        return RETRYABLE.equals(this);
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/domain/RetryableStateResponse.java
+++ b/flow/src/main/java/com/sequenceiq/flow/domain/RetryableStateResponse.java
@@ -1,0 +1,55 @@
+package com.sequenceiq.flow.domain;
+
+public class RetryableStateResponse {
+
+    private RetryableState state;
+
+    private String lastKnownStateMessage;
+
+    private String name;
+
+    private FlowLog lastSuccessfulStateFlowLog;
+
+    public RetryableState getState() {
+        return state;
+    }
+
+    public String getLastKnownStateMessage() {
+        return lastKnownStateMessage;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public FlowLog getLastSuccessfulStateFlowLog() {
+        return lastSuccessfulStateFlowLog;
+    }
+
+    public static RetryableStateResponse flowPending() {
+        RetryableStateResponse response = new RetryableStateResponse();
+        response.state = RetryableState.FLOW_PENDING;
+        return response;
+    }
+
+    public static RetryableStateResponse lastFlowNotFailedOrNotRetryable(String lastKnownStateMessage) {
+        RetryableStateResponse response = new RetryableStateResponse();
+        response.state = RetryableState.LAST_NOT_FAILED_OR_NOT_RETRYABLE;
+        response.lastKnownStateMessage = lastKnownStateMessage;
+        return response;
+    }
+
+    public static RetryableStateResponse retryable(String name, FlowLog lastSuccessfulStateFlowLog) {
+        RetryableStateResponse response = new RetryableStateResponse();
+        response.state = RetryableState.RETRYABLE;
+        response.name = name;
+        response.lastSuccessfulStateFlowLog = lastSuccessfulStateFlowLog;
+        return response;
+    }
+
+    public static RetryableStateResponse noSuccessfulState() {
+        RetryableStateResponse response = new RetryableStateResponse();
+        response.state = RetryableState.NO_SUCCESSFUL_STATE;
+        return response;
+    }
+}

--- a/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
+++ b/flow/src/main/java/com/sequenceiq/flow/service/flowlog/FlowLogDBService.java
@@ -274,6 +274,11 @@ public class FlowLogDBService implements FlowLogService {
     }
 
     @Override
+    public Optional<FlowLog> getLastFlowLog(Long resourceId) {
+        return flowLogRepository.findFirstByResourceIdOrderByCreatedDesc(resourceId);
+    }
+
+    @Override
     public List<FlowLog> findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(Long id) {
         return flowLogRepository.findAllByResourceIdAndFinalizedIsFalseOrderByCreatedDesc(id);
     }

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/host/HostOrchestrator.java
@@ -68,6 +68,9 @@ public interface HostOrchestrator extends HostRecipeExecutor {
 
     Map<String, String> runCommandOnAllHosts(GatewayConfig gateway, String command) throws CloudbreakOrchestratorFailedException;
 
+    Map<String, String> replacePatternInFileOnAllHosts(GatewayConfig gatewayConfig, String file, String pattern, String replace)
+            throws CloudbreakOrchestratorFailedException;
+
     Map<String, JsonNode> getGrainOnAllHosts(GatewayConfig gateway, String grain) throws CloudbreakOrchestratorFailedException;
 
     Map<String, String> getMembers(GatewayConfig gatewayConfig, List<String> privateIps) throws CloudbreakOrchestratorException;

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -820,6 +820,17 @@ public class SaltOrchestrator implements HostOrchestrator {
     }
 
     @Override
+    public Map<String, String> replacePatternInFileOnAllHosts(GatewayConfig gatewayConfig, String file, String pattern, String replace)
+            throws CloudbreakOrchestratorFailedException {
+        try (SaltConnector saltConnector = saltService.createSaltConnector(gatewayConfig)) {
+            return SaltStates.replacePatternInFile(retry, saltConnector, file, pattern, replace);
+        } catch (RuntimeException e) {
+            LOGGER.warn("Error occurred during file replace execution in file '{}' while replacing pattern '{}' with '{}'", file, pattern, replace, e);
+            throw new CloudbreakOrchestratorFailedException(e.getMessage(), e);
+        }
+    }
+
+    @Override
     public void uploadRecipes(List<GatewayConfig> allGatewayConfigs, Map<String, List<RecipeModel>> recipes, ExitCriteriaModel exitModel)
             throws CloudbreakOrchestratorFailedException {
         GatewayConfig primaryGateway = saltService.getPrimaryGatewayConfig(allGatewayConfigs);

--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/states/SaltStates.java
@@ -330,6 +330,21 @@ public class SaltStates {
         });
     }
 
+    public static Map<String, String> replacePatternInFile(Retry retry, SaltConnector sc, String file, String pattern, String replace) {
+        return retry.testWith2SecDelayMax15Times(() -> {
+            try {
+                String[] args = new String[]{file, String.format("pattern='%s'", pattern), String.format("repl='%s'", replace)};
+                CommandExecutionResponse resp = measure(() -> sc.run(Glob.ALL, "file.replace", LOCAL, CommandExecutionResponse.class, args), LOGGER,
+                        "Command run took {}ms for file.replace with args [{}]", (Object) args);
+                List<Map<String, String>> result = resp.getResult();
+                return CollectionUtils.isEmpty(result) ? new HashMap<>() : result.get(0);
+            } catch (RuntimeException e) {
+                LOGGER.error("Salt run command failed", e);
+                throw new Retry.ActionFailedException("Salt run command failed");
+            }
+        });
+    }
+
     public static Map<String, String> runCommandOnHosts(Retry retry, SaltConnector sc, Target<String> target, String command) {
         return retry.testWith2SecDelayMax15Times(() -> {
             try {

--- a/orchestrator-salt/src/main/resources/salt/salt/unbound/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/unbound/init.sls
@@ -1,6 +1,12 @@
 {%- from 'metadata/settings.sls' import metadata with context %}
 {%- from 'nodes/settings.sls' import host with context %}
 
+faulty_7_2_11_images_unbound_restart_patch:
+  file.replace:
+    - name: "/etc/dhcp/dhclient-enter-hooks"
+    - pattern: "systemctl restart unbound"
+    - repl: "pkill -u unbound -SIGHUP unbound"
+
 /etc/unbound/conf.d/00-cluster.conf:
   file.managed:
     - makedirs: True


### PR DESCRIPTION
The faulty unbound service restart (systemctl restart unbound) that was burned to 7.2.11 images caused issues on multiple stacks. Hotfix images were created containing the correct unbound service restart (pkill -u unbound -SIGHUP unbound), and the purpose of this commit is to fix the stacks created with the faulty images.
Implementation details:
- Create a new salt state that fixes the command, that will be applied to new stacks: faulty_7_2_11_images_unbound_restart_patch
- Introduce a new quartz job that runs for existing stacks: ExistingStackPatcherJob
- Trigger a full salt update on the affected stacks to upload and apply the new salt file to existing stacks: UnboundRestartPatchService