### PR TITLE
Java 11.0.5 have to be used as base docker image because of some TLS issues

### DIFF
--- a/docker-autoscale/Dockerfile
+++ b/docker-autoscale/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.5-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar

--- a/docker-cloudbreak/Dockerfile
+++ b/docker-cloudbreak/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.6-cldr1-jdk-slim-buster
+FROM docker-private.infra.cloudera.com/cloudera_base/cldr-java:11.0.5-cldr1-jdk-slim-buster
 MAINTAINER info@hortonworks.com
 
 # REPO URL to download jar


### PR DESCRIPTION
Java 11.0.5 have to be used as base docker image because of some TLS issues