### PR TITLE
CB-13472 - Validate for stopped/unreachable FreeIPA

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/recovery/RecoveryStatus.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/recovery/RecoveryStatus.java
@@ -4,4 +4,12 @@ public enum RecoveryStatus {
 
     RECOVERABLE,
     NON_RECOVERABLE;
+
+    public boolean recoverable() {
+        return RECOVERABLE.equals(this);
+    }
+
+    public boolean nonRecoverable() {
+        return NON_RECOVERABLE.equals(this);
+    }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/recovery/RecoveryValidationV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/recovery/RecoveryValidationV4Response.java
@@ -1,5 +1,10 @@
 package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery;
 
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery.RecoveryStatus.NON_RECOVERABLE;
+import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery.RecoveryStatus.RECOVERABLE;
+
+import java.util.StringJoiner;
+
 public class RecoveryValidationV4Response {
 
     private String reason;
@@ -28,6 +33,25 @@ public class RecoveryValidationV4Response {
 
     public void setStatus(RecoveryStatus status) {
         this.status = status;
+    }
+
+    public RecoveryValidationV4Response merge(RecoveryValidationV4Response other) {
+        boolean nonRecoverable = status.nonRecoverable();
+        boolean otherNonRecoverable = other.getStatus().nonRecoverable();
+        RecoveryStatus mergedState = nonRecoverable || otherNonRecoverable ? NON_RECOVERABLE : RECOVERABLE;
+        String delimiter = mergedState.recoverable() ? " " : " Next issue: ";
+        StringJoiner mergedReason = new StringJoiner(delimiter);
+        if (nonRecoverable) {
+            mergedReason.add(this.reason);
+            if (otherNonRecoverable) {
+                mergedReason.add(other.reason);
+            }
+        } else if (otherNonRecoverable) {
+            mergedReason.add(other.reason);
+        } else {
+            mergedReason.add(this.reason).add(other.reason);
+        }
+        return new RecoveryValidationV4Response(mergedReason.toString().trim(), mergedState);
     }
 
     @Override

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/recovery/RecoveryValidationV4ResponseTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/response/recovery/RecoveryValidationV4ResponseTest.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+public class RecoveryValidationV4ResponseTest {
+
+    private static final String RECOVERABLE_MESSAGE_1 = "recoverable message 1";
+
+    private static final String RECOVERABLE_MESSAGE_2 = "recoverable message 2";
+
+    private static final String NON_RECOVERABLE_MESSAGE_1 = "non-recoverable message 1";
+
+    private static final String NON_RECOVERABLE_MESSAGE_2 = "non-recoverable message 2";
+
+    @Test
+    public void testMergeTwoRecoverableResponses() {
+        RecoveryValidationV4Response baseResponse = new RecoveryValidationV4Response(RECOVERABLE_MESSAGE_1, RecoveryStatus.RECOVERABLE);
+        RecoveryValidationV4Response otherResponse = new RecoveryValidationV4Response(RECOVERABLE_MESSAGE_2, RecoveryStatus.RECOVERABLE);
+        RecoveryValidationV4Response mergedResponse = baseResponse.merge(otherResponse);
+        Assertions.assertEquals("recoverable message 1 recoverable message 2", mergedResponse.getReason());
+        Assertions.assertEquals(RecoveryStatus.RECOVERABLE, mergedResponse.getStatus());
+    }
+
+    @Test
+    public void testMergeTwoNonRecoverableResponses() {
+        RecoveryValidationV4Response baseResponse = new RecoveryValidationV4Response(NON_RECOVERABLE_MESSAGE_1, RecoveryStatus.NON_RECOVERABLE);
+        RecoveryValidationV4Response otherResponse = new RecoveryValidationV4Response(NON_RECOVERABLE_MESSAGE_2, RecoveryStatus.NON_RECOVERABLE);
+        RecoveryValidationV4Response mergedResponse = baseResponse.merge(otherResponse);
+        Assertions.assertEquals("non-recoverable message 1 Next issue: non-recoverable message 2", mergedResponse.getReason());
+        Assertions.assertEquals(RecoveryStatus.NON_RECOVERABLE, mergedResponse.getStatus());
+    }
+
+    @Test
+    public void testMergeRecoverableAndNonRecoverableResponses() {
+        RecoveryValidationV4Response baseResponse = new RecoveryValidationV4Response(RECOVERABLE_MESSAGE_1, RecoveryStatus.RECOVERABLE);
+        RecoveryValidationV4Response otherResponse = new RecoveryValidationV4Response(NON_RECOVERABLE_MESSAGE_1, RecoveryStatus.NON_RECOVERABLE);
+        RecoveryValidationV4Response mergedResponse = baseResponse.merge(otherResponse);
+        Assertions.assertEquals("non-recoverable message 1", mergedResponse.getReason());
+        Assertions.assertEquals(RecoveryStatus.NON_RECOVERABLE, mergedResponse.getStatus());
+    }
+
+    @Test
+    public void testMergeNonrecoverableAndRecoverableResponses() {
+        RecoveryValidationV4Response baseResponse = new RecoveryValidationV4Response(NON_RECOVERABLE_MESSAGE_1, RecoveryStatus.NON_RECOVERABLE);
+        RecoveryValidationV4Response otherResponse = new RecoveryValidationV4Response(RECOVERABLE_MESSAGE_1, RecoveryStatus.RECOVERABLE);
+        RecoveryValidationV4Response mergedResponse = baseResponse.merge(otherResponse);
+        Assertions.assertEquals("non-recoverable message 1", mergedResponse.getReason());
+        Assertions.assertEquals(RecoveryStatus.NON_RECOVERABLE, mergedResponse.getStatus());
+    }
+}

--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxRecoveryEndpoint.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/endpoint/SdxRecoveryEndpoint.java
@@ -26,6 +26,7 @@ import io.swagger.annotations.ApiOperation;
 @Consumes(MediaType.APPLICATION_JSON)
 @Api(value = "/sdx", protocols = "http,https", consumes = MediaType.APPLICATION_JSON)
 public interface SdxRecoveryEndpoint {
+
     @POST
     @Path("{name}/recover")
     @Produces(MediaType.APPLICATION_JSON)

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/FreeipaService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/FreeipaService.java
@@ -2,11 +2,13 @@ package com.sequenceiq.datalake.service;
 
 import javax.inject.Inject;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ServiceUnavailableException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 
@@ -18,7 +20,23 @@ public class FreeipaService {
     @Inject
     private FreeIpaV1Endpoint freeIpaV1Endpoint;
 
-    public DescribeFreeIpaResponse describe(String envCrn) {
+    public void checkFreeipaRunning(String envCrn) {
+        DescribeFreeIpaResponse freeipa = describe(envCrn);
+        if (freeipa != null && freeipa.getAvailabilityStatus() != null) {
+            if (!freeipa.getAvailabilityStatus().isAvailable()) {
+                String message = "Freeipa should be in Available state but currently is " + freeipa.getStatus().name();
+                LOGGER.info(message);
+                throw new BadRequestException(message);
+            }
+        } else {
+            String message = "Freeipa availability cannot be determined currently.";
+            LOGGER.warn(message);
+            throw new ServiceUnavailableException(message);
+        }
+
+    }
+
+    DescribeFreeIpaResponse describe(String envCrn) {
         try {
             return freeIpaV1Endpoint.describe(envCrn);
         } catch (NotFoundException e) {

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/start/SdxStartService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/sdx/start/SdxStartService.java
@@ -1,8 +1,6 @@
 package com.sequenceiq.datalake.service.sdx.start;
 
 import javax.inject.Inject;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
 
@@ -18,13 +16,12 @@ import com.sequenceiq.datalake.entity.DatalakeStatusEnum;
 import com.sequenceiq.datalake.entity.SdxCluster;
 import com.sequenceiq.datalake.flow.SdxReactorFlowManager;
 import com.sequenceiq.datalake.service.FreeipaService;
-import com.sequenceiq.datalake.service.sdx.flowcheck.CloudbreakFlowService;
 import com.sequenceiq.datalake.service.sdx.PollingConfig;
 import com.sequenceiq.datalake.service.sdx.SdxService;
 import com.sequenceiq.datalake.service.sdx.cert.CloudbreakPoller;
+import com.sequenceiq.datalake.service.sdx.flowcheck.CloudbreakFlowService;
 import com.sequenceiq.datalake.service.sdx.status.SdxStatusService;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 
 @Component
 public class SdxStartService {
@@ -57,7 +54,7 @@ public class SdxStartService {
 
     public FlowIdentifier triggerStartIfClusterNotRunning(SdxCluster cluster) {
         MDCBuilder.buildMdcContext(cluster);
-        checkFreeipaRunning(cluster.getEnvCrn());
+        freeipaService.checkFreeipaRunning(cluster.getEnvCrn());
         return sdxReactorFlowManager.triggerSdxStartFlow(cluster);
     }
 
@@ -72,27 +69,15 @@ public class SdxStartService {
             sdxStatusService.setStatusForDatalakeAndNotify(DatalakeStatusEnum.START_IN_PROGRESS, "Datalake start in progress", sdxCluster);
         } catch (NotFoundException e) {
             LOGGER.info("Can not find stack on cloudbreak side {}", sdxCluster.getClusterName());
-        } catch (ClientErrorException e) {
-            String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
-            LOGGER.info("Can not start stack {} from cloudbreak: {}", sdxCluster.getStackId(), errorMessage, e);
-            throw new RuntimeException("Cannot start cluster, error happened during operation: " + errorMessage);
         } catch (WebApplicationException e) {
             String errorMessage = webApplicationExceptionMessageExtractor.getErrorMessage(e);
             LOGGER.info("Can not start stack {} from cloudbreak: {}", sdxCluster.getStackId(), errorMessage, e);
-            throw new RuntimeException("Can not start cluster, error happened during operation: " + errorMessage);
+            throw new RuntimeException("Cannot start cluster, error happened during operation: " + errorMessage);
         }
     }
 
     public void waitCloudbreakCluster(Long sdxId, PollingConfig pollingConfig) {
         SdxCluster sdxCluster = sdxService.getById(sdxId);
         cloudbreakPoller.pollStartUntilAvailable(sdxCluster, pollingConfig);
-    }
-
-    private void checkFreeipaRunning(String envCrn) {
-        DescribeFreeIpaResponse freeipa = freeipaService.describe(envCrn);
-        if (freeipa != null && freeipa.getAvailabilityStatus() != null && !freeipa.getAvailabilityStatus().isAvailable()) {
-            throw new BadRequestException("Freeipa should be in Available state but currently is " + freeipa.getStatus().name());
-        }
-
     }
 }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/FreeipaServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/FreeipaServiceTest.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.datalake.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import javax.ws.rs.ServiceUnavailableException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.FreeIpaV1Endpoint;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
+
+@ExtendWith(MockitoExtension.class)
+class FreeipaServiceTest {
+
+    private static final String ENV_CRN = "crn:cdp:environments:us-west-1:460c0d8f-ae8e-4dce-9cd7-2351762eb9ac:environment:6b2b1600-8ac6-4c26-aa34-dab36f4bd243";
+
+    @Mock
+    private FreeIpaV1Endpoint freeIpaV1Endpoint;
+
+    @InjectMocks
+    private FreeipaService underTest;
+
+    @Test
+    void testCheckFreeipaRunningWhenFreeIpaStoppedThenThrowsException() {
+        DescribeFreeIpaResponse freeipa = new DescribeFreeIpaResponse();
+        freeipa.setStatus(Status.STOPPED);
+        freeipa.setAvailabilityStatus(AvailabilityStatus.UNAVAILABLE);
+
+        when(underTest.describe(ENV_CRN)).thenReturn(freeipa);
+
+        BadRequestException exception = Assertions.assertThrows(BadRequestException.class, () -> underTest.checkFreeipaRunning(ENV_CRN));
+        assertEquals("Freeipa should be in Available state but currently is " + Status.STOPPED, exception.getMessage());
+    }
+
+    @Test
+    void testCheckFreeipaRunningWhenFreeIpaIsNullThenThrowsException() {
+        when(underTest.describe(ENV_CRN)).thenReturn(null);
+
+        ServiceUnavailableException exception = Assertions.assertThrows(ServiceUnavailableException.class, () -> underTest.checkFreeipaRunning(ENV_CRN));
+        assertEquals("Freeipa availability cannot be determined currently.", exception.getMessage());
+    }
+
+    @Test
+    void testCheckFreeipaRunningWhenFreeIpaStatusIsNullThenThrowsException() {
+        DescribeFreeIpaResponse freeipa = new DescribeFreeIpaResponse();
+        when(underTest.describe(ENV_CRN)).thenReturn(freeipa);
+
+        ServiceUnavailableException exception = Assertions.assertThrows(ServiceUnavailableException.class, () -> underTest.checkFreeipaRunning(ENV_CRN));
+        assertEquals("Freeipa availability cannot be determined currently.", exception.getMessage());
+    }
+
+    @Test
+    void testCheckFreeipaRunningWhenFreeIpaAvailableThenPass() {
+        DescribeFreeIpaResponse freeipa = new DescribeFreeIpaResponse();
+        freeipa.setStatus(Status.AVAILABLE);
+        freeipa.setAvailabilityStatus(AvailabilityStatus.AVAILABLE);
+
+        when(underTest.describe(ENV_CRN)).thenReturn(freeipa);
+
+        Assertions.assertDoesNotThrow(() -> underTest.checkFreeipaRunning(ENV_CRN));
+    }
+}

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/recovery/SdxUpgradeRecoveryServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/recovery/SdxUpgradeRecoveryServiceTest.java
@@ -77,7 +77,7 @@ public class SdxUpgradeRecoveryServiceTest {
 
         CloudbreakApiException actual = assertThrows(CloudbreakApiException.class,
                 () -> ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.triggerRecovery(USER_CRN, NameOrCrn.ofName(CLUSTER_NAME), request)));
-        assertEquals("Stack recovery status validation failed on cluster: [dummyCluster]. Message: [web-error]", actual.getMessage());
+        assertEquals("Stack recovery validation failed on cluster: [dummyCluster]. Message: [web-error]", actual.getMessage());
     }
 
     @Test

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxTests.java
@@ -12,6 +12,7 @@ import org.testng.annotations.Test;
 
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.client.ImageCatalogTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.context.Description;
@@ -22,6 +23,7 @@ import com.sequenceiq.it.cloudbreak.dto.ClusterTestDto;
 import com.sequenceiq.it.cloudbreak.dto.ImageSettingsTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxCustomTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
@@ -36,6 +38,9 @@ public class MockSdxTests extends AbstractMockTest {
 
     @Inject
     private SdxTestClient sdxTestClient;
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
 
     @Inject
     private ImageCatalogTestClient imageCatalogTestClient;
@@ -193,10 +198,13 @@ public class MockSdxTests extends AbstractMockTest {
                 .withMock(new EnvironmentNetworkMockParams())
                 .given(EnvironmentTestDto.class)
                 .withNetwork(networkKey)
-                .withCreateFreeIpa(Boolean.FALSE)
+                .withCreateFreeIpa(Boolean.TRUE)
                 .withName(resourcePropertyProvider().getEnvironmentName())
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
                 .given(sdxInternal, SdxInternalTestDto.class)
                 .when(sdxTestClient.createInternal(), key(sdxInternal))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdxInternal))


### PR DESCRIPTION
This commit
 - introduces FreeIPA validation during recovery() and validateRecoverable() calls on CB side
 - refactors FreeIPA validation on SDX side

