### PR TITLE
DISTX-683 Store secret custom configurations info in the vault

### DIFF
--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/EntityTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/EntityTest.java
@@ -11,19 +11,22 @@ import org.junit.Test;
 import org.reflections.Reflections;
 
 import com.sequenceiq.cloudbreak.service.secret.SecretValue;
+import com.sequenceiq.cloudbreak.service.secret.domain.AccountIdAwareResource;
 import com.sequenceiq.cloudbreak.workspace.model.TenantAwareResource;
 
 public class EntityTest {
     @Test
-    public void testIfClassesWithSecretFieldsAreInheritedFromTenantOrWorkspaceAwareResources() {
+    public void testIfClassesWithSecretFieldsAreInheritedFromTenantOrWorkspaceOrAccountIdAwareResources() {
         Reflections reflections = new Reflections("com.sequenceiq");
         Set<Class<?>> entityClasses = reflections.getTypesAnnotatedWith(Entity.class);
         Set<Class<?>> wrongClasses = entityClasses.stream()
                 .filter(cls -> FieldUtils.getFieldsWithAnnotation(cls, SecretValue.class).length > 0)
                 .filter(cls -> !TenantAwareResource.class.isAssignableFrom(cls))
+                .filter(cls -> !AccountIdAwareResource.class.isAssignableFrom(cls))
                 .collect(Collectors.toSet());
         Assert.assertTrue(
-                String.format("Classes with Secret fields should be inherited from TenantAwareResource or WorkspaceAwareResoruce. Wrong classes: %s",
+                String.format("Classes with Secret fields should be inherited from TenantAwareResource, WorkspaceAwareResource " +
+                                "or AccountIdAwareResource. Wrong classes: %s",
                         wrongClasses.stream().map(Class::getName).collect(Collectors.joining(", "))), wrongClasses.isEmpty());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/customconfigs/CustomConfigurationsViewProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/customconfigs/CustomConfigurationsViewProvider.java
@@ -23,7 +23,9 @@ public class CustomConfigurationsViewProvider {
     }
 
     public CustomConfigurationPropertyView getCustomConfigurationPropertyView(@Nonnull CustomConfigurationProperty customConfigurationProperty) {
-        return new CustomConfigurationPropertyView(customConfigurationProperty.getName(), customConfigurationProperty.getValue(),
-                customConfigurationProperty.getRoleType(), customConfigurationProperty.getServiceType());
+        return new CustomConfigurationPropertyView(customConfigurationProperty.getName(),
+                customConfigurationProperty.getValue(),
+                customConfigurationProperty.getRoleType(),
+                customConfigurationProperty.getServiceType());
     }
 }

--- a/core/src/main/resources/schema/app/20211210124157_DISTX-683_Add_secretvalue_column_to_customconfiguration_properties_table.sql
+++ b/core/src/main/resources/schema/app/20211210124157_DISTX-683_Add_secretvalue_column_to_customconfiguration_properties_table.sql
@@ -1,0 +1,15 @@
+-- // DISTX-683 Add secretvalue column to customconfiguration_properties table
+-- Migration SQL that makes the change goes here.
+ALTER TABLE customconfigurations_properties ADD COLUMN IF NOT EXISTS secretvalue text;
+ALTER TABLE customconfigurations_properties ALTER COLUMN secretvalue SET DEFAULT '{}';
+UPDATE customconfigurations_properties SET secretvalue = '{}' WHERE secretvalue IS NULL;
+ALTER TABLE customconfigurations_properties ALTER COLUMN secretvalue SET NOT NULL;
+ALTER TABLE customconfigurations_properties ALTER COLUMN "value" DROP NOT NULL;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE customconfigurations_properties DROP COLUMN IF EXISTS secretvalue;
+UPDATE customconfigurations_properties SET "value" = '' WHERE "value" IS NULL;
+ALTER TABLE customconfigurations_properties ALTER COLUMN "value" SET NOT NULL;
+

--- a/custom-configurations/build.gradle
+++ b/custom-configurations/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   implementation project(':common')
   implementation project(':auth-connector')
   implementation project(':authorization-common')
+  implementation project(':secret-engine')
   implementation project(':custom-configurations-api')
 
   implementation group: 'org.springframework.data',        name: 'spring-data-jpa',              version: springDataJpaFrameworkVersion
@@ -21,6 +22,7 @@ dependencies {
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: springBootVersion
   testImplementation group: 'org.junit.jupiter',        name: 'junit-jupiter-api',        version: junitJupiterVersion
   testImplementation group: 'org.mockito',              name: 'mockito-core',             version: mockitoVersion
+  testImplementation group: 'org.apache.commons',       name: 'commons-collections4',     version: commonsCollections4Version
   testRuntimeOnly    group: 'org.junit.jupiter',        name: 'junit-jupiter-engine'
 }
 

--- a/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationPropertyConverter.java
+++ b/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationPropertyConverter.java
@@ -1,24 +1,23 @@
 package com.sequenceiq.cloudbreak.converter;
 
+import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.model.CustomConfigurationPropertyParameters;
 import com.sequenceiq.cloudbreak.domain.CustomConfigurationProperty;
 
+@Component
 public class CustomConfigurationPropertyConverter {
 
-    private CustomConfigurationPropertyConverter() {
-    }
-
-    public static CustomConfigurationProperty convertFrom(CustomConfigurationPropertyParameters source) {
+    public CustomConfigurationProperty convertFromRequestJson(CustomConfigurationPropertyParameters source) {
         CustomConfigurationProperty customConfigurationProperty = new CustomConfigurationProperty();
         customConfigurationProperty.setName(source.getName());
-        customConfigurationProperty.setValue(source.getValue());
+        customConfigurationProperty.setSecretValue(source.getValue());
         customConfigurationProperty.setRoleType(source.getRoleType());
         customConfigurationProperty.setServiceType(source.getServiceType());
         return customConfigurationProperty;
     }
 
-    public static CustomConfigurationPropertyParameters convertTo(CustomConfigurationProperty source) {
+    public CustomConfigurationPropertyParameters convertToResponseJson(CustomConfigurationProperty source) {
         CustomConfigurationPropertyParameters response = new CustomConfigurationPropertyParameters();
         response.setName(source.getName());
         response.setValue(source.getValue());

--- a/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationsToCustomConfigurationsV4ResponseConverter.java
+++ b/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationsToCustomConfigurationsV4ResponseConverter.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.converter;
 
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.responses.CustomConfigurationsV4Response;
@@ -10,12 +12,18 @@ import com.sequenceiq.cloudbreak.domain.CustomConfigurations;
 @Component
 public class CustomConfigurationsToCustomConfigurationsV4ResponseConverter {
 
+    @Inject
+    private CustomConfigurationPropertyConverter customConfigurationPropertyConverter;
+
     public CustomConfigurationsV4Response convert(CustomConfigurations source) {
         CustomConfigurationsV4Response response = new CustomConfigurationsV4Response();
         response.setName(source.getName());
         response.setCreated(source.getCreated());
         response.setCrn(source.getCrn());
-        response.setConfigurations(source.getConfigurations().stream().map(CustomConfigurationPropertyConverter::convertTo).collect(Collectors.toSet()));
+        response.setConfigurations(source.getConfigurations()
+                .stream()
+                .map(c -> customConfigurationPropertyConverter.convertToResponseJson(c))
+                .collect(Collectors.toSet()));
         response.setAccount(source.getAccount());
         response.setRuntimeVersion(source.getRuntimeVersion());
         return response;

--- a/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationsV4RequestToCustomConfigurationsConverter.java
+++ b/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationsV4RequestToCustomConfigurationsConverter.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.converter;
 
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.requests.CustomConfigurationsV4Request;
@@ -10,10 +12,13 @@ import com.sequenceiq.cloudbreak.domain.CustomConfigurations;
 @Component
 public class CustomConfigurationsV4RequestToCustomConfigurationsConverter {
 
+    @Inject
+    private CustomConfigurationPropertyConverter customConfigurationPropertyConverter;
+
     public CustomConfigurations convert(CustomConfigurationsV4Request source) {
         CustomConfigurations customConfigurations = new CustomConfigurations();
         customConfigurations.setName(source.getName());
-        customConfigurations.setConfigurations(source.getConfigurations().stream().map(CustomConfigurationPropertyConverter::convertFrom)
+        customConfigurations.setConfigurations(source.getConfigurations().stream().map(c -> customConfigurationPropertyConverter.convertFromRequestJson(c))
                 .collect(Collectors.toSet()));
         customConfigurations.setRuntimeVersion(source.getRuntimeVersion());
         return customConfigurations;

--- a/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/domain/CustomConfigurationProperty.java
+++ b/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/domain/CustomConfigurationProperty.java
@@ -1,9 +1,12 @@
 package com.sequenceiq.cloudbreak.domain;
 
-import java.io.Serializable;
-import java.util.Objects;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
+import java.io.Serializable;
+
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -13,10 +16,14 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sequenceiq.cloudbreak.service.secret.SecretValue;
+import com.sequenceiq.cloudbreak.service.secret.domain.AccountIdAwareResource;
+import com.sequenceiq.cloudbreak.service.secret.domain.Secret;
+import com.sequenceiq.cloudbreak.service.secret.domain.SecretToString;
 
 @Entity
 @Table(name = "customconfigurations_properties")
-public class CustomConfigurationProperty implements Serializable {
+public class CustomConfigurationProperty implements Serializable, AccountIdAwareResource {
 
     @Id
     @SequenceGenerator(name = "custom_config_property_generator", sequenceName = "custom_configuration_property_id_seq", allocationSize = 1)
@@ -29,18 +36,23 @@ public class CustomConfigurationProperty implements Serializable {
     @Column(nullable = false)
     private String value;
 
+    @Column(nullable = false)
+    @Convert(converter = SecretToString.class)
+    @SecretValue
+    private Secret secretValue = Secret.EMPTY;
+
     @Column
     private String roleType;
 
     @Column(nullable = false)
     private String serviceType;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.ALL)
     private CustomConfigurations customConfigurations;
 
     public CustomConfigurationProperty(String name, String value, String roleType, String serviceType) {
         this.name = name;
-        this.value = value;
+        this.secretValue = new Secret(value);
         this.roleType = roleType;
         this.serviceType = serviceType;
     }
@@ -65,8 +77,20 @@ public class CustomConfigurationProperty implements Serializable {
         this.name = name;
     }
 
+    public String getSecretValue() {
+        return secretValue.getRaw();
+    }
+
+    public void setSecretValue(String secretValue) {
+        this.secretValue = new Secret(secretValue);
+    }
+
+    public String getSecret() {
+        return secretValue.getSecret();
+    }
+
     public String getValue() {
-        return value;
+        return isNullOrEmpty(value) ? getSecretValue() : value;
     }
 
     public void setValue(String value) {
@@ -98,31 +122,17 @@ public class CustomConfigurationProperty implements Serializable {
     }
 
     @Override
+    public String getAccountId() {
+        return getCustomConfigs().getAccount();
+    }
+
+    @Override
     public String toString() {
-        return "CustomConfigProperty{" +
+        return "CustomConfigurationProperty{" +
                 "id=" + id +
                 ", name='" + name + '\'' +
-                ", value='" + value + '\'' +
                 ", roleType='" + roleType + '\'' +
                 ", serviceType='" + serviceType + '\'' +
                 '}';
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof CustomConfigurationProperty)) {
-            return false;
-        }
-        CustomConfigurationProperty property = (CustomConfigurationProperty) o;
-        return getName().equals(property.getName()) && getValue().equals(property.getValue()) &&
-                Objects.equals(getRoleType(), property.getRoleType()) && getServiceType().equals(property.getServiceType());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getName(), getValue(), getRoleType(), getServiceType());
     }
 }

--- a/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/repository/CustomConfigurationPropertyRepository.java
+++ b/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/repository/CustomConfigurationPropertyRepository.java
@@ -1,0 +1,13 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import javax.transaction.Transactional;
+
+import org.springframework.data.repository.CrudRepository;
+
+import com.sequenceiq.cloudbreak.domain.CustomConfigurationProperty;
+import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
+
+@EntityType(entityClass = CustomConfigurationProperty.class)
+@Transactional(Transactional.TxType.REQUIRED)
+public interface CustomConfigurationPropertyRepository extends CrudRepository<CustomConfigurationProperty, Long> {
+}

--- a/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/repository/CustomConfigurationsRepository.java
+++ b/custom-configurations/src/main/java/com/sequenceiq/cloudbreak/repository/CustomConfigurationsRepository.java
@@ -6,8 +6,8 @@ import java.util.Optional;
 
 import javax.transaction.Transactional;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 
 import com.sequenceiq.authorization.service.model.projection.ResourceCrnAndNameView;
@@ -16,7 +16,7 @@ import com.sequenceiq.cloudbreak.workspace.repository.EntityType;
 
 @EntityType(entityClass = CustomConfigurations.class)
 @Transactional(Transactional.TxType.REQUIRED)
-public interface CustomConfigurationsRepository extends JpaRepository<CustomConfigurations, Long> {
+public interface CustomConfigurationsRepository extends CrudRepository<CustomConfigurations, Long> {
 
     @Query("SELECT c FROM CustomConfigurations c LEFT JOIN FETCH c.configurations WHERE c.name = :customConfigsName AND c.account = :accountId")
     Optional<CustomConfigurations> findByNameAndAccountId(@Param("customConfigsName") String customConfigsName, @Param("accountId") String accountId);

--- a/custom-configurations/src/test/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationPropertyConverterTest.java
+++ b/custom-configurations/src/test/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationPropertyConverterTest.java
@@ -1,0 +1,59 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.cloudbreak.api.model.CustomConfigurationPropertyParameters;
+import com.sequenceiq.cloudbreak.domain.CustomConfigurationProperty;
+
+class CustomConfigurationPropertyConverterTest {
+
+    private static final String TEST_PROPERTY_NAME = "propertyName";
+
+    private static final String TEST_PROPERTY_VALUE = "propertyValue";
+
+    private static final String TEST_ROLE = "roleType";
+
+    private static final String TEST_SERVICE = "serviceType";
+
+    private CustomConfigurationPropertyConverter underTest;
+
+    @BeforeEach
+    void setUp() {
+        underTest = new CustomConfigurationPropertyConverter();
+    }
+
+    @Test
+    void testConvertFromCustomConfigurationPropertyParameters() {
+        CustomConfigurationPropertyParameters property = new CustomConfigurationPropertyParameters();
+        property.setName(TEST_PROPERTY_NAME);
+        property.setValue(TEST_PROPERTY_VALUE);
+        property.setRoleType(TEST_ROLE);
+        property.setServiceType(TEST_SERVICE);
+
+        CustomConfigurationProperty result = underTest.convertFromRequestJson(property);
+
+        assertEquals(TEST_PROPERTY_NAME, result.getName());
+        assertEquals(TEST_PROPERTY_VALUE, result.getValue());
+        assertEquals(TEST_ROLE, result.getRoleType());
+        assertEquals(TEST_SERVICE, result.getServiceType());
+    }
+
+    @Test
+    void testConvertToCustomConfigurationPropertyParameters() {
+        CustomConfigurationProperty property = new CustomConfigurationProperty();
+        property.setName(TEST_PROPERTY_NAME);
+        property.setSecretValue(TEST_PROPERTY_VALUE);
+        property.setRoleType(TEST_ROLE);
+        property.setServiceType(TEST_SERVICE);
+
+        CustomConfigurationPropertyParameters result = underTest.convertToResponseJson(property);
+
+        assertEquals(TEST_PROPERTY_NAME, result.getName());
+        assertEquals(TEST_PROPERTY_VALUE, result.getValue());
+        assertEquals(TEST_ROLE, result.getRoleType());
+        assertEquals(TEST_SERVICE, result.getServiceType());
+    }
+}

--- a/custom-configurations/src/test/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationsToCustomConfigurationsV4ResponseConverterTest.java
+++ b/custom-configurations/src/test/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationsToCustomConfigurationsV4ResponseConverterTest.java
@@ -2,13 +2,22 @@ package com.sequenceiq.cloudbreak.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
+import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
+import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.responses.CustomConfigurationsV4Response;
 import com.sequenceiq.cloudbreak.api.model.CustomConfigurationPropertyParameters;
 import com.sequenceiq.cloudbreak.domain.CustomConfigurationProperty;
@@ -16,11 +25,16 @@ import com.sequenceiq.cloudbreak.domain.CustomConfigurations;
 
 class CustomConfigurationsToCustomConfigurationsV4ResponseConverterTest {
 
+    @Mock
+    private CustomConfigurationPropertyConverter customConfigurationPropertyConverter;
+
+    @InjectMocks
     private CustomConfigurationsToCustomConfigurationsV4ResponseConverter underTest;
 
-    private CustomConfigurations customConfigurations = new CustomConfigurations("test",
+    private final CustomConfigurations customConfigurations = new CustomConfigurations("test",
             "crn:cdp:resource:us-west-1:tenant:customconfigs:c7da2918-dd14-49ed-9b43-33ff55bd6309",
-            Set.of(new CustomConfigurationProperty("property1", "value1", "role1", "service1")),
+            Set.of(new CustomConfigurationProperty("property1", "value1", "role1", "service1"),
+                    new CustomConfigurationProperty("property2", "value2", null, "service2")),
             "7.2.8",
             "accid",
             System.currentTimeMillis()
@@ -28,18 +42,25 @@ class CustomConfigurationsToCustomConfigurationsV4ResponseConverterTest {
 
     @BeforeEach
     void setUp() {
-        underTest = new CustomConfigurationsToCustomConfigurationsV4ResponseConverter();
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test
     void testConvert() {
         customConfigurations.setAccount("testAccount");
+        when(customConfigurationPropertyConverter.convertToResponseJson(any(CustomConfigurationProperty.class))).thenCallRealMethod();
+
         CustomConfigurationsV4Response response = underTest.convert(customConfigurations);
+
         assertEquals(customConfigurations.getName(), response.getName());
-        assertEquals(customConfigurations.getConfigurations(), response.getConfigurations()
-                .stream()
-                .map(CustomConfigurationPropertyConverter::convertFrom)
-                .collect(Collectors.toSet()));
+        assertTrue(CollectionUtils.isEqualCollection(Sets.newHashSet("property1", "property2"),
+                collectNames(response.getConfigurations())));
+        assertTrue(CollectionUtils.isEqualCollection(Sets.newHashSet("value1", "value2"),
+                collectValues(response.getConfigurations())));
+        assertTrue(CollectionUtils.isEqualCollection(Sets.newHashSet("role1", null),
+                collectRoles(response.getConfigurations())));
+        assertTrue(CollectionUtils.isEqualCollection(Sets.newHashSet("service2", "service1"),
+                collectServices(response.getConfigurations())));
         assertEquals(customConfigurations.getRuntimeVersion(), response.getRuntimeVersion());
         assertEquals(customConfigurations.getCrn(), response.getCrn());
         assertEquals(customConfigurations.getAccount(), response.getAccount());
@@ -55,9 +76,25 @@ class CustomConfigurationsToCustomConfigurationsV4ResponseConverterTest {
     @Test
     void testConvertResponseContainsCorrectCustomConfigsProperties() {
         Set<CustomConfigurationPropertyParameters> properties = customConfigurations.getConfigurations().stream()
-                .map(CustomConfigurationPropertyConverter::convertTo).collect(Collectors.toSet());
+                .map(c -> customConfigurationPropertyConverter.convertToResponseJson(c)).collect(Collectors.toSet());
         CustomConfigurationsV4Response response = underTest.convert(customConfigurations);
         Set<CustomConfigurationPropertyParameters> result = response.getConfigurations();
         assertEquals(properties, result);
+    }
+
+    private Set<String> collectNames(Collection<CustomConfigurationPropertyParameters> properties) {
+        return properties.stream().map(CustomConfigurationPropertyParameters::getName).collect(Collectors.toSet());
+    }
+
+    private Set<String> collectValues(Collection<CustomConfigurationPropertyParameters> properties) {
+        return properties.stream().map(CustomConfigurationPropertyParameters::getValue).collect(Collectors.toSet());
+    }
+
+    private Set<String> collectServices(Collection<CustomConfigurationPropertyParameters> properties) {
+        return properties.stream().map(CustomConfigurationPropertyParameters::getServiceType).collect(Collectors.toSet());
+    }
+
+    private Set<String> collectRoles(Collection<CustomConfigurationPropertyParameters> properties) {
+        return properties.stream().map(CustomConfigurationPropertyParameters::getRoleType).collect(Collectors.toSet());
     }
 }

--- a/custom-configurations/src/test/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationsV4RequestToCustomConfigurationsConverterTest.java
+++ b/custom-configurations/src/test/java/com/sequenceiq/cloudbreak/converter/CustomConfigurationsV4RequestToCustomConfigurationsConverterTest.java
@@ -1,6 +1,8 @@
 package com.sequenceiq.cloudbreak.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -8,24 +10,34 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
 import com.sequenceiq.cloudbreak.api.endpoint.v4.requests.CustomConfigurationsV4Request;
 import com.sequenceiq.cloudbreak.api.model.CustomConfigurationPropertyParameters;
+import com.sequenceiq.cloudbreak.domain.CustomConfigurationProperty;
 import com.sequenceiq.cloudbreak.domain.CustomConfigurations;
 
 class CustomConfigurationsV4RequestToCustomConfigurationsConverterTest {
 
+    @Mock
+    private CustomConfigurationPropertyConverter customConfigurationPropertyConverter;
+
+    @InjectMocks
     private CustomConfigurationsV4RequestToCustomConfigurationsConverter underTest;
 
-    private CustomConfigurationsV4Request request = new CustomConfigurationsV4Request();
+    private final CustomConfigurationsV4Request request = new CustomConfigurationsV4Request();
+
+    private final  CustomConfigurationPropertyParameters property = new CustomConfigurationPropertyParameters();
 
     @BeforeEach
     void setUp() {
-        underTest = new CustomConfigurationsV4RequestToCustomConfigurationsConverter();
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test
     void testConvert() {
-        CustomConfigurationPropertyParameters property = new CustomConfigurationPropertyParameters();
         property.setName("property1");
         property.setValue("value1");
         property.setRoleType("role1");
@@ -33,11 +45,16 @@ class CustomConfigurationsV4RequestToCustomConfigurationsConverterTest {
         request.setName("test");
         request.setConfigurations(Set.of(property));
         request.setRuntimeVersion("7.2.8");
+        when(customConfigurationPropertyConverter.convertFromRequestJson(any(CustomConfigurationPropertyParameters.class)))
+                .thenReturn(new CustomConfigurationProperty("property1", "value1", "role1", "service1"));
+        when(customConfigurationPropertyConverter.convertToResponseJson(any(CustomConfigurationProperty.class))).thenReturn(property);
+
         CustomConfigurations result = underTest.convert(request);
+
         assertEquals(request.getName(), result.getName());
         assertEquals(request.getConfigurations(), result.getConfigurations()
                 .stream()
-                .map(CustomConfigurationPropertyConverter::convertTo)
+                .map(c -> customConfigurationPropertyConverter.convertToResponseJson(c))
                 .collect(Collectors.toSet()));
         assertEquals(request.getRuntimeVersion(), result.getRuntimeVersion());
     }


### PR DESCRIPTION
### Changes
- Using the annotation `SecretValue`, Custom Configuration values are now being stored in the vault.
- This involves schema changes to make the `CustomConfigurationProperty` entity to be workspace aware.
- The changes are in line with 'Approach 2' as listed in the referenced one pager. 
<img width="1792" alt="Screenshot 2021-11-10 at 2 13 27 PM" src="https://user-images.githubusercontent.com/30623280/141079676-e4c607c7-de3e-4e99-afff-8e0923b12987.png">

### References
- [DISTX 683 One Pager](https://docs.google.com/document/d/1cLtRwLWpXM-keDz_dR0yYTQSZqFTpr4PgWezbSiLRD4/edit?usp=sharing)
- [DISTX-683](jira.cloudera.com/browse/DISTX-683)
- [Design doc](https://docs.google.com/document/d/1jat_7jDNNRr5TagYEP7lG4r_UzBejHieCD-BEM9-jTE/edit?usp=sharing)

See detailed description in the commit message.