### PR TITLE
CB-13376 Add `@Retryable` annotation for CA certificate registration

### DIFF
--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/RootCertRegisterService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/config/RootCertRegisterService.java
@@ -4,6 +4,8 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.exception.NotFoundException;
@@ -11,6 +13,7 @@ import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.freeipa.client.FreeIpaClient;
 import com.sequenceiq.freeipa.client.FreeIpaClientException;
 import com.sequenceiq.freeipa.client.FreeIpaClientExceptionWrapper;
+import com.sequenceiq.freeipa.client.RetryableFreeIpaClientException;
 import com.sequenceiq.freeipa.entity.RootCert;
 import com.sequenceiq.freeipa.entity.Stack;
 import com.sequenceiq.freeipa.service.freeipa.FreeIpaClientFactory;
@@ -36,6 +39,10 @@ public class RootCertRegisterService extends AbstractConfigRegister {
     private RootCertService rootCertService;
 
     @Override
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public void register(Long stackId) {
         try {
             Stack stack = stackService.getStackById(stackId);
@@ -53,6 +60,10 @@ public class RootCertRegisterService extends AbstractConfigRegister {
         return rootCertService.save(rootCert);
     }
 
+    @Retryable(value = RetryableFreeIpaClientException.class,
+            maxAttemptsExpression = RetryableFreeIpaClientException.MAX_RETRIES_EXPRESSION,
+            backoff = @Backoff(delayExpression = RetryableFreeIpaClientException.DELAY_EXPRESSION,
+                    multiplierExpression = RetryableFreeIpaClientException.MULTIPLIER_EXPRESSION))
     public RootCert register(Stack stack) throws FreeIpaClientException {
         return registerInternal(stack);
     }


### PR DESCRIPTION
If the CA cert fetching from FreeIPA fails this annotation would ensure to retry.
This effects the FreeIPA provision as well as CA cert fetching in case it hasn't been stored in the database yet.

See detailed description in the commit message.