### PR TITLE
CB-14558 Datalake deletion stuck, force delete does not work

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/sharedservice/DatalakeService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/sharedservice/DatalakeService.java
@@ -73,12 +73,14 @@ public class DatalakeService {
         SharedServiceV4Response sharedServiceResponse = new SharedServiceV4Response();
         if (!Strings.isNullOrEmpty(stack.getDatalakeCrn())) {
             LOGGER.debug("Checking datalake through the datalakeCrn.");
-            Stack datalakeStack = stackService.getByCrn(stack.getDatalakeCrn());
+            Stack datalakeStack = stackService.getByCrnOrElseNull(stack.getDatalakeCrn());
             if (datalakeStack != null) {
                 LOGGER.debug("Datalake (stack id {}, name {}) has been found for stack: {}",
                         datalakeStack.getId(), datalakeStack.getName(), stack.getResourceCrn());
                 sharedServiceResponse.setSharedClusterName(datalakeStack.getName());
                 sharedServiceResponse.setSharedClusterId(datalakeStack.getId());
+            } else {
+                LOGGER.debug("Unable to find datalake with CRN {}", stack.getDatalakeCrn());
             }
         }
         stackResponse.setSharedService(sharedServiceResponse);
@@ -86,7 +88,7 @@ public class DatalakeService {
 
     public Optional<Stack> getDatalakeStackByDatahubStack(Stack datahubStack) {
         if (!Strings.isNullOrEmpty(datahubStack.getDatalakeCrn())) {
-            return Optional.of(stackService.getByCrn(datahubStack.getDatalakeCrn()));
+            return Optional.ofNullable(stackService.getByCrnOrElseNull(datahubStack.getDatalakeCrn()));
         }
         LOGGER.info("There is no datalake has been set for the cluster.");
         return Optional.empty();
@@ -135,7 +137,7 @@ public class DatalakeService {
                 if (Strings.isNullOrEmpty(stack.getDatalakeCrn())) {
                     break;
                 }
-                Stack datalakeStack = stackService.getByCrn(stack.getDatalakeCrn());
+                Stack datalakeStack = stackService.getByCrnOrElseNull(stack.getDatalakeCrn());
                 if (datalakeStack == null) {
                     break;
                 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/sharedservice/DatalakeServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/sharedservice/DatalakeServiceTest.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.service.sharedservice;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
@@ -71,11 +73,28 @@ public class DatalakeServiceTest {
 
     @Test
     public void testAddSharedServiceResponseWhenDatalakeCrnIsNotNull() {
+        Stack resultStack = new Stack();
+        resultStack.setName("teststack");
+        resultStack.setId(1L);
+        lenient().when(stackService.getByCrnOrElseNull(anyString())).thenReturn(resultStack);
         Stack source = new Stack();
         source.setDatalakeCrn("crn");
         StackV4Response x = new StackV4Response();
         underTest.addSharedServiceResponse(source, x);
-        verify(stackService, times(1)).getByCrn("crn");
+        verify(stackService, times(1)).getByCrnOrElseNull("crn");
+        assertEquals(1L, x.getSharedService().getSharedClusterId());
+        assertEquals("teststack", x.getSharedService().getSharedClusterName());
+    }
+
+    @Test
+    public void testAddSharedServiceResponseWhenDatalakeCrnIsNotNullAndDatalakeIsMissing() {
+        Stack source = new Stack();
+        source.setDatalakeCrn("crn");
+        StackV4Response x = new StackV4Response();
+        underTest.addSharedServiceResponse(source, x);
+        verify(stackService, times(1)).getByCrnOrElseNull("crn");
+        assertNull(x.getSharedService().getSharedClusterId());
+        assertNull(x.getSharedService().getSharedClusterName());
     }
 
     @Test
@@ -84,7 +103,7 @@ public class DatalakeServiceTest {
         source.setDatalakeCrn(null);
         StackV4Response x = new StackV4Response();
         underTest.addSharedServiceResponse(source, x);
-        verify(stackService, never()).getByCrn("crn");
+        verify(stackService, never()).getByCrnOrElseNull("crn");
     }
 
     @Test
@@ -97,10 +116,23 @@ public class DatalakeServiceTest {
 
     @Test
     public void testGetDatalakeStackByDatahubStackWhereDatalakeCrnIsNotNull() {
+        Stack resultStack = new Stack();
+        resultStack.setName("teststack");
+        lenient().when(stackService.getByCrnOrElseNull(anyString())).thenReturn(resultStack);
         Stack stack = new Stack();
         stack.setDatalakeCrn("crn");
-        underTest.getDatalakeStackByDatahubStack(stack);
-        verify(stackService, times(1)).getByCrn("crn");
+        Optional<Stack> datalake = underTest.getDatalakeStackByDatahubStack(stack);
+        verify(stackService, times(1)).getByCrnOrElseNull("crn");
+        assert datalake.isPresent();
+    }
+
+    @Test
+    public void testGetDatalakeStackByDatahubStackWhereDatalakeCrnIsNotNullAndDatalakeIsMissing() {
+        Stack stack = new Stack();
+        stack.setDatalakeCrn("crn");
+        Optional<Stack> datalake = underTest.getDatalakeStackByDatahubStack(stack);
+        verify(stackService, times(1)).getByCrnOrElseNull("crn");
+        assert datalake.isEmpty();
     }
 
     @Test
@@ -155,7 +187,7 @@ public class DatalakeServiceTest {
 
         SharedServiceConfigsView res = underTest.createSharedServiceConfigsView(stack);
 
-        verify(stackService, times(1)).getByCrn("crn");
+        verify(stackService, times(1)).getByCrnOrElseNull("crn");
         Assertions.assertFalse(res.isDatalakeCluster());
 
     }
@@ -169,7 +201,7 @@ public class DatalakeServiceTest {
 
         SharedServiceConfigsView res = underTest.createSharedServiceConfigsView(stack);
 
-        verify(stackService, times(0)).getByCrn("crn");
+        verify(stackService, times(0)).getByCrnOrElseNull("crn");
         Assertions.assertTrue(res.isDatalakeCluster());
     }
 
@@ -182,7 +214,7 @@ public class DatalakeServiceTest {
 
         SharedServiceConfigsView res = underTest.createSharedServiceConfigsView(stack);
 
-        verify(stackService, times(0)).getByCrn("crn");
+        verify(stackService, times(0)).getByCrnOrElseNull("crn");
         Assertions.assertFalse(res.isDatalakeCluster());
     }
 


### PR DESCRIPTION
For any call to `stackService.getByCrn` where subsequent code can handle the case that the returned
datalake is 'null', replace that call with `stackService.getByCrnOrElseNull`. This will eliminate
the errors deleting a datahub when the attached datalake cannot be found.

Tested with unit tests and by manually create a DL+DH, then removing the DL CRN from the database so
it could not be found. Verified the DH, DL, and env could all be successfully deleted.

See detailed description in the commit message.