### PR TITLE
CB-14839 suites_log and integcb/logs should be compress to save space

### DIFF
--- a/integration-test/Makefile
+++ b/integration-test/Makefile
@@ -59,6 +59,9 @@ docker-compose:
 check-results:
 	./scripts/check-results.sh
 
+compress-results:
+	./scripts/compress-results.sh
+
 stop-containers:
 	./scripts/stop-containers.sh
 

--- a/integration-test/scripts/compress-results.sh
+++ b/integration-test/scripts/compress-results.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+status_code=0
+
+compress_if_exists () {
+  sourceDir=$1
+  targetArchive=$2
+
+  if [[ ! -d $sourceDir ]]; then
+    echo "Source dir '$sourceDir' does not exists, skipping compress"
+  else
+    du -h $sourceDir
+    echo "Compressing $sourceDir directory"
+    GZIP=-9 tar -cvzf "$targetArchive" "$sourceDir" #&& rm -R "$sourceDir"
+    du -h "$targetArchive"
+  fi
+}
+
+set -ex
+
+start=`date +%s`
+echo -e "\n\033[0;92m+++ INTEGRATION TEST RESULTS COMPRESS STARTED +++\n";
+
+# Check integration test results
+compress_if_exists suites_log suites.tar.gz
+compress_if_exists integcb/logs integcb-logs.tar.gz
+
+end=`date +%s`
+echo -e "\n\033[0;92m+++ INTEGRATION TEST RESULTS COMPRESSED SUCCESSFULLY AND TOOK $((end-start)) SECONDS+++\n";


### PR DESCRIPTION
- to have longer test result retention time
- originally wanted this to be included as the last step of test execution but if we want to compress app logs, we need to wait for container stop, otherwise we'll get this:
```
tar: integcb/logs/cloudbreak/cloudbreak.log: file changed as we read it
make: *** [compress-results] Error 1
Build step 'Conditional steps (multiple)' marked build as failure
```

