### PR TITLE
CB-8981 We should move files like /var/log/init-services-db-executed to another place

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/EmbeddedDatabaseConfigProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/container/postgres/EmbeddedDatabaseConfigProvider.java
@@ -18,15 +18,21 @@ public class EmbeddedDatabaseConfigProvider {
 
     public static final String POSTGRES_LOG_DIRECTORY_KEY = "postgres_log_directory";
 
+    public static final String POSTGRES_SCRIPTS_EXECUTED_DIRECTORY_KEY = "postgres_scripts_executed_directory";
+
     public static final String POSTGRES_DATA_ON_ATTACHED_DISK_KEY = "postgres_data_on_attached_disk";
 
     public static final String POSTGRES_SUBDIRECTORY_ON_ATTACHED_DISK = "pgsql";
 
     public static final String POSTGRES_LOG_SUBDIRECTORY_ON_ATTACHED_DISK = "pgsql/log";
 
+    public static final String POSTGRES_SCRIPTS_EXECUTED_SUBDIRECTORY_ON_ATTACHED_DISK = "pgsql/scripts";
+
     public static final String POSTGRES_DEFAULT_DIRECTORY = "/var/lib/pgsql";
 
     public static final String POSTGRES_DEFAULT_LOG_DIRECTORY = "/var/log";
+
+    public static final String POSTGRES_DEFAULT_SCRIPTS_EXECUTED_DIRECTORY = "/opt/salt/scripts";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EmbeddedDatabaseConfigProvider.class);
 
@@ -43,6 +49,7 @@ public class EmbeddedDatabaseConfigProvider {
             result = Map.of(
                     POSTGRES_DIRECTORY_KEY, POSTGRES_DEFAULT_DIRECTORY,
                     POSTGRES_LOG_DIRECTORY_KEY, POSTGRES_DEFAULT_LOG_DIRECTORY,
+                    POSTGRES_SCRIPTS_EXECUTED_DIRECTORY_KEY, POSTGRES_DEFAULT_SCRIPTS_EXECUTED_DIRECTORY,
                     POSTGRES_DATA_ON_ATTACHED_DISK_KEY, false);
         }
         LOGGER.debug("Embedded Postgres sql server pillar parameters: {}", result);
@@ -51,8 +58,9 @@ public class EmbeddedDatabaseConfigProvider {
 
     private Map<String, Object> createEmbeddedDbOnAttachedDiskConfig() {
         return Map.of(
-            POSTGRES_DIRECTORY_KEY, VolumeUtils.DATABASE_VOLUME + "/" + POSTGRES_SUBDIRECTORY_ON_ATTACHED_DISK,
-            POSTGRES_LOG_DIRECTORY_KEY, VolumeUtils.DATABASE_VOLUME + "/" + POSTGRES_LOG_SUBDIRECTORY_ON_ATTACHED_DISK,
-            POSTGRES_DATA_ON_ATTACHED_DISK_KEY, true);
+                POSTGRES_DIRECTORY_KEY, VolumeUtils.DATABASE_VOLUME + "/" + POSTGRES_SUBDIRECTORY_ON_ATTACHED_DISK,
+                POSTGRES_LOG_DIRECTORY_KEY, VolumeUtils.DATABASE_VOLUME + "/" + POSTGRES_LOG_SUBDIRECTORY_ON_ATTACHED_DISK,
+                POSTGRES_SCRIPTS_EXECUTED_DIRECTORY_KEY, VolumeUtils.DATABASE_VOLUME + "/" + POSTGRES_SCRIPTS_EXECUTED_SUBDIRECTORY_ON_ATTACHED_DISK,
+                POSTGRES_DATA_ON_ATTACHED_DISK_KEY, true);
     }
 }


### PR DESCRIPTION
CB-8981 We should move files like /var/log/init-services-db-executed to another place

Cluster creation:
* In case of external db:
** init-services-db-remote-executed file will be created in /opt/salt/scripts directory
* In case of embedded db on attached disk:
** pgsql_listen_address_configured, pgsql_max_connections_configured will be created in /dbfs/pgsql/scripts directory
** init-services-db-executed will be created in /dbfs/pgsql/scripts directory
* In case of embedded db on root disk:
** pgsql_listen_address_configured, pgsql_max_connections_configured will be created in /opts/salt/scripts directory
** init-services-db-executed will be created in /dbfs/pgsql/scripts directory

In case of old cluster upgrade (Salt update) the above mentioned files will be moved to the right place from /var/log

Tests:
* New DL creation with embedded db and with external db
* New DH creation with embedded db on attached disk and on root disk
* Upgrade old style DL with external db
* Upgrade old style DH with embedded db on attached disk and on root disk