### PR TITLE
CB-13832: Add metrics on services installed on Datahub cluster

### DIFF
--- a/structuredevent-service-legacy/build.gradle
+++ b/structuredevent-service-legacy/build.gradle
@@ -15,6 +15,7 @@ jar {
 
 dependencies {
     implementation group: 'org.springframework.kafka',          name: 'spring-kafka',                version: '2.6.4'
+    implementation group: 'org.skyscreamer',          name: 'jsonassert',                version: '1.5.0'
 
     implementation project(':structuredevent-model')
     implementation project(':workspace')

--- a/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToClusterShapeConverter.java
+++ b/structuredevent-service-legacy/src/main/java/com/sequenceiq/cloudbreak/structuredevent/service/telemetry/converter/StructuredEventToClusterShapeConverter.java
@@ -9,6 +9,11 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.cloudera.thunderhead.service.common.usage.UsageProto;
@@ -26,6 +31,8 @@ public class StructuredEventToClusterShapeConverter {
     private static final int DEFAULT_INTEGER_VALUE = -1;
 
     private static final int MAX_STRING_LENGTH = 3000;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StructuredEventToClusterShapeConverter.class);
 
     public UsageProto.CDPClusterShape convert(StructuredFlowEvent structuredFlowEvent) {
         UsageProto.CDPClusterShape.Builder cdpClusterShape = UsageProto.CDPClusterShape.newBuilder();
@@ -56,6 +63,9 @@ public class StructuredEventToClusterShapeConverter {
 
         if (blueprintDetails != null) {
             cdpClusterShape.setClusterTemplateName(defaultIfEmpty(blueprintDetails.getName(), ""));
+            if (blueprintDetails.getBlueprintJson() != null) {
+                cdpClusterShape.setClusterTemplateDetails(defaultIfEmpty(getClusterTemplateDetails(blueprintDetails.getBlueprintJson()), ""));
+            }
         }
 
         if (stackDetails != null) {
@@ -79,5 +89,23 @@ public class StructuredEventToClusterShapeConverter {
         }
 
         return cdpClusterShape;
+    }
+
+    private String getClusterTemplateDetails(String blueprintJson) {
+        JSONObject templateDetails = new JSONObject();
+        try {
+            JSONObject services = new JSONObject();
+            templateDetails.put("services", services);
+            if (!blueprintJson.isEmpty()) {
+                JSONArray jsonArray = new JSONObject(blueprintJson).getJSONArray("services");
+                for (int i = 0; i < jsonArray.length(); i++) {
+                    services.put(jsonArray.getJSONObject(i).getString("serviceType"), 1);
+                }
+            }
+        } catch (JSONException e) {
+            LOGGER.debug("Failed to fetch services from cluster template {}", blueprintJson);
+        } finally {
+            return templateDetails.toString();
+        }
     }
 }

--- a/usage-collection/src/main/proto/usage.proto
+++ b/usage-collection/src/main/proto/usage.proto
@@ -1095,6 +1095,8 @@ message CDPClusterShape {
   string definitionDetails = 4;
   // Indicating whether Temporary Storage is used in the cluster
   bool temporaryStorageUsed = 5;
+  // Cluster template details in JSON format
+  string clusterTemplateDetails = 6;
 }
 
 message CDPVersionDetails {


### PR DESCRIPTION
CB-13832: Add metrics on services installed on Datahub cluster
This PR adds cluster template details - services installed on datahub cluster - to CDPClusterShape to make it available to EDH metrics.

<img width="988" alt="Screenshot 2021-11-29 at 7 46 50 PM" src="https://user-images.githubusercontent.com/32215750/143898707-19125a36-141b-478b-936b-0cd0383eceb8.png">
