### PR TITLE
CB-14839 test actual compress-results.sh

### DIFF
--- a/integration-test/scripts/compress-results.sh
+++ b/integration-test/scripts/compress-results.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-status_code=0
-
 compress_if_exists () {
   sourceDir=$1
   targetArchive=$2
@@ -11,12 +9,19 @@ compress_if_exists () {
   else
     du -h $sourceDir
     echo "Compressing $sourceDir directory"
-    GZIP=-9 tar -cvzf "$targetArchive" "$sourceDir" #&& rm -R "$sourceDir"
+    #special error handling is needed since logs might still be flushed even after docker container stop is issued
+    #tar gz file changed as we read it ignore
+    set +e
+    GZIP=-9 tar -cvzf "$targetArchive" "$sourceDir"
+    exitcode=$?
+    if [ "$exitcode" != "1" ] && [ "$exitcode" != "0" ]; then
+        exit $exitcode
+    fi
+    rm -R "$sourceDir"
+    set -e
     du -h "$targetArchive"
   fi
 }
-
-set -ex
 
 start=`date +%s`
 echo -e "\n\033[0;92m+++ INTEGRATION TEST RESULTS COMPRESS STARTED +++\n";


### PR DESCRIPTION
- please check integration-test build results, it now has compressed logs and suite logs
- ~1 magnitude less disk space, so we can increase build result retention 10 fold, but we should start catious
- will apply same post build step to e2e tests

``` 
[0;92m+++ INTEGRATION TEST RESULTS COMPRESSED SUCCESSFULLY AND TOOK 41 SECONDS+++
```

![image](https://user-images.githubusercontent.com/3493960/141993942-bbe9df83-16be-47e8-b39f-7044494f44a8.png)
