### PR TITLE
CB-13974 Same size instance types for ephemeral tests too

### DIFF
--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -119,7 +119,7 @@ integrationtest:
       volumeCount: 1
       volumeType: gp2
     storageOptimizedInstance:
-      type: m5d.xlarge
+      type: m5d.2xlarge
       rootVolumeSize: 100
       volumeSize: 100
       volumeCount: 1


### PR DESCRIPTION
HIVE Metastore install fails with 'Cannot allocate memory' error,
bumped instance size to 2xlarge, same as for other tests.

