### PR TITLE
CB-14893 [e2e] The repair tests were failing, some of them constantly.

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakClient.java
@@ -78,7 +78,7 @@ public class CloudbreakClient extends MicroserviceClient<com.sequenceiq.cloudbre
 
     @Override
     public <E extends Enum<E>, T extends WaitObject> T waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext) {
+            TestContext testContext, Set<E> ignoredFailedStatuses) {
         Map<String, Status> map = new HashMap<>();
         desiredStatuses.forEach((key, v) -> map.put(key, (Status) v));
         return (T) new CloudbreakWaitObject(this, name, map, testContext.getActingUserCrn().getAccountId());

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/EnvironmentClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/EnvironmentClient.java
@@ -52,7 +52,7 @@ public class EnvironmentClient extends MicroserviceClient<com.sequenceiq.environ
 
     @Override
     public <E extends Enum<E>, T extends WaitObject> T waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext) {
+            TestContext testContext, Set<E> ignoredFailedStatuses) {
         return (T) new EnvironmentWaitObject(this, entity.getName(), entity.getCrn(), (EnvironmentStatus) desiredStatuses.get("status"));
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/FreeIpaClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/FreeIpaClient.java
@@ -58,7 +58,7 @@ public class FreeIpaClient extends MicroserviceClient<com.sequenceiq.freeipa.api
 
     @Override
     public <E extends Enum<E>, W extends WaitObject> W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext) {
+            TestContext testContext, Set<E> ignoredFailedStatuses) {
         if (entity instanceof FreeIpaUserSyncTestDto) {
             FreeIpaUserSyncTestDto freeIpaSyncTestDto = (FreeIpaUserSyncTestDto) entity;
             if (freeIpaSyncTestDto.getOperationId() == null) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/MicroserviceClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/MicroserviceClient.java
@@ -46,7 +46,7 @@ public abstract class MicroserviceClient<C, I> extends Entity {
     }
 
     public abstract <E extends Enum<E>, W extends WaitObject> W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext);
+            TestContext testContext, Set<E> ignoredFailedStatuses);
 
     public abstract C getDefaultClient();
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RedbeamsClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/RedbeamsClient.java
@@ -49,7 +49,7 @@ public class RedbeamsClient extends MicroserviceClient<com.sequenceiq.redbeams.c
 
     @Override
     public <E extends Enum<E>, W extends WaitObject> W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext) {
+            TestContext testContext, Set<E> ignoredFailedStatuses) {
         return (W) new RedbeamsWaitObject(this, entity.getCrn(), (Status) desiredStatuses.get("status"));
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SdxClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SdxClient.java
@@ -38,8 +38,9 @@ public class SdxClient extends MicroserviceClient<SdxServiceApiKeyEndpoints, Voi
 
     @Override
     public <E extends Enum<E>, W extends WaitObject> W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext) {
-        return (W) new DatalakeWaitObject(this, entity.getName(), (SdxClusterStatusResponse) desiredStatuses.get("status"));
+            TestContext testContext, Set<E> ignoredFailedStatuses) {
+        return (W) new DatalakeWaitObject(this, entity.getName(), (SdxClusterStatusResponse) desiredStatuses.get("status"),
+                (Set<SdxClusterStatusResponse>) ignoredFailedStatuses);
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/UmsClient.java
@@ -46,7 +46,7 @@ public class UmsClient extends MicroserviceClient<GrpcUmsClient, Void> {
 
     @Override
     public <E extends Enum<E>, W extends WaitObject> W waitObject(CloudbreakTestDto entity, String name, Map<String, E> desiredStatuses,
-            TestContext testContext) {
+            TestContext testContext, Set<E> ignoredFailedStatuses) {
         throw new TestFailException("Wait object does not support by ums client");
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -7,11 +7,13 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -947,6 +949,11 @@ public abstract class TestContext implements ApplicationContextAware {
 
     public <T extends CloudbreakTestDto, E extends Enum<E>> T await(T entity, Map<String, E> desiredStatuses, RunningParameter runningParameter,
             Duration pollingInterval) {
+        return await(entity, desiredStatuses, new HashSet<>(), runningParameter, pollingInterval);
+    }
+
+    public <T extends CloudbreakTestDto, E extends Enum<E>> T await(T entity, Map<String, E> desiredStatuses, Set<E> ignoredFailedStatuses,
+            RunningParameter runningParameter, Duration pollingInterval) {
         checkShutdown();
         if (!getExceptionMap().isEmpty() && runningParameter.isSkipOnFail()) {
             Log.await(LOGGER, String.format("Cloudbreak await should be skipped because of previous error. await [%s]", desiredStatuses));
@@ -968,7 +975,7 @@ public abstract class TestContext implements ApplicationContextAware {
             LOGGER.info("Resource Crn is not available for: {}", awaitEntity.getName());
         }
 
-        resourceAwait.await(awaitEntity, desiredStatuses, getTestContext(), runningParameter, pollingInterval, maxRetry);
+        resourceAwait.await(awaitEntity, desiredStatuses, ignoredFailedStatuses, getTestContext(), runningParameter, pollingInterval, maxRetry);
         return entity;
     }
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/dto/sdx/SdxTestDto.java
@@ -153,6 +153,11 @@ public class SdxTestDto extends AbstractSdxTestDto<SdxClusterRequest, SdxCluster
         return getTestContext().await(this, Map.of("status", status), runningParameter);
     }
 
+    public SdxTestDto await(SdxClusterStatusResponse status, Set<SdxClusterStatusResponse> ignoredFailedStatuses, RunningParameter runningParameter) {
+        TestContext testContext = getTestContext();
+        return getTestContext().await(this, Map.of("status", status), ignoredFailedStatuses, runningParameter, testContext.getPollingDurationInMills());
+    }
+
     public SdxTestDto await(SdxClusterStatusResponse status, RunningParameter runningParameter, Duration pollingInterval) {
         return getTestContext().await(this, Map.of("status", status), runningParameter, pollingInterval);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
@@ -6,6 +6,7 @@ import static com.sequenceiq.it.cloudbreak.context.RunningParameter.key;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import javax.inject.Inject;
 
@@ -72,7 +73,8 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                 })
                 .awaitForDeletedInstancesOnProvider()
                 .when(sdxTestClient.repair(MASTER.getName(), IDBROKER.getName()), key(sdx))
-                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, key(sdx).withWaitForFlow(false))
+                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, Set.of(SdxClusterStatusResponse.CLUSTER_UNREACHABLE),
+                        key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances()
                 .then((tc, testDto, client) -> {
@@ -154,7 +156,8 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                 })
                 .awaitForHostGroups(List.of("gateway", "idbroker"), InstanceStatus.DELETED_ON_PROVIDER_SIDE)
                 .when(sdxTestClient.repair("gateway", "idbroker"), key(sdx))
-                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, key(sdx).withWaitForFlow(false))
+                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, Set.of(SdxClusterStatusResponse.CLUSTER_UNREACHABLE),
+                        key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances()
                 .then((tc, testDto, client) -> {
@@ -181,7 +184,8 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                 })
                 .awaitForHostGroups(List.of(hostgroupName), InstanceStatus.STOPPED)
                 .when(sdxTestClient.repair(hostgroupName), key(sdx))
-                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, key(sdx).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, Set.of(SdxClusterStatusResponse.CLUSTER_UNREACHABLE),
+                        key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances()
                 .then((tc, testDto, client) -> {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ResourceAwait.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/ResourceAwait.java
@@ -2,6 +2,7 @@ package com.sequenceiq.it.cloudbreak.util.wait.service;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,8 +20,8 @@ public class ResourceAwait {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceAwait.class);
 
-    public <E extends Enum<E>> CloudbreakTestDto await(CloudbreakTestDto entity, Map<String, E> desiredStatuses, TestContext testContext,
-            RunningParameter runningParameter, Duration pollingInterval, int maxRetry) {
+    public <E extends Enum<E>> CloudbreakTestDto await(CloudbreakTestDto entity, Map<String, E> desiredStatuses, Set<E> ignoredFailedStatuses,
+            TestContext testContext, RunningParameter runningParameter, Duration pollingInterval, int maxRetry) {
         try {
             if (entity == null) {
                 throw new RuntimeException("Cloudbreak key has been provided but no result in resource map!");
@@ -29,7 +30,7 @@ public class ResourceAwait {
             MicroserviceClient client = testContext.getMicroserviceClient(entity.getClass(), testContext.setActingUser(runningParameter)
                     .getAccessKey());
             String name = entity.getName();
-            WaitObject waitObject = client.waitObject(entity, name, desiredStatuses, testContext);
+            WaitObject waitObject = client.waitObject(entity, name, desiredStatuses, testContext, ignoredFailedStatuses);
             if (waitObject.isDeletionCheck()) {
                 client.waiterService().waitObject(new WaitTerminationChecker<>(), waitObject, testContext, pollingInterval, maxRetry, 1);
             } else if (waitObject.isFailedCheck()) {

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitObject.java
@@ -26,6 +26,8 @@ public interface WaitObject {
 
     boolean isDeleted();
 
+    boolean isFailedButIgnored();
+
     boolean isFailed();
 
     boolean isDeletionInProgress();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/WaitOperationChecker.java
@@ -30,13 +30,21 @@ public class WaitOperationChecker<T extends WaitObject> extends ExceptionChecker
             return true;
         }
         if (waitObject.isFailed()) {
+            handleFailedState(waitObject, name, actualStatuses);
+        }
+
+        return waitObject.isInDesiredStatus();
+    }
+
+    private void handleFailedState(T waitObject, String name, Map<String, String> actualStatuses) {
+        if (waitObject.isFailedButIgnored()) {
+            LOGGER.info("Cluster '{}' is in a failed state but the test will ignore it (status:'{}').", name, actualStatuses);
+        } else {
             Map<String, String> actualStatusReasons = waitObject.actualStatusReason();
             LOGGER.error("Cluster '{}' is in failed state (status:'{}'), waiting is cancelled.", name, actualStatuses);
             throw new TestFailException(String.format("Cluster '%s' is in failed state. Status: '%s' statusReason: '%s'",
                     name, actualStatuses, actualStatusReasons));
         }
-
-        return waitObject.isInDesiredStatus();
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/cloudbreak/CloudbreakWaitObject.java
@@ -83,6 +83,11 @@ public class CloudbreakWaitObject implements WaitObject {
     }
 
     @Override
+    public boolean isFailedButIgnored() {
+        return false;
+    }
+
+    @Override
     public boolean isDeletionInProgress() {
         List<Status> deleteInProgressStatuses = List.of(PRE_DELETE_IN_PROGRESS, DELETE_IN_PROGRESS, EXTERNAL_DATABASE_DELETION_IN_PROGRESS);
         return !ListUtils.retainAll(deleteInProgressStatuses, actualStatusesEnumValues()).isEmpty();

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/datalake/DatalakeWaitObject.java
@@ -35,12 +35,15 @@ public class DatalakeWaitObject implements WaitObject {
 
     private final SdxClusterStatusResponse desiredStatus;
 
+    private final Set<SdxClusterStatusResponse> ignoredFailedStatuses;
+
     private SdxClusterResponse sdxResponse;
 
-    public DatalakeWaitObject(SdxClient client, String name, SdxClusterStatusResponse desiredStatus) {
+    public DatalakeWaitObject(SdxClient client, String name, SdxClusterStatusResponse desiredStatus, Set<SdxClusterStatusResponse> ignoredFailedStatuses) {
         this.client = client;
         this.name = name;
         this.desiredStatus = desiredStatus;
+        this.ignoredFailedStatuses = ignoredFailedStatuses;
     }
 
     public SdxEndpoint getEndpoint() {
@@ -84,6 +87,11 @@ public class DatalakeWaitObject implements WaitObject {
     @Override
     public boolean isDeleted() {
         return sdxResponse.getStatus().equals(DELETED);
+    }
+
+    @Override
+    public boolean isFailedButIgnored() {
+        return ignoredFailedStatuses.contains(sdxResponse.getStatus());
     }
 
     @Override

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/environment/EnvironmentWaitObject.java
@@ -83,6 +83,11 @@ public class EnvironmentWaitObject implements WaitObject {
     }
 
     @Override
+    public boolean isFailedButIgnored() {
+        return false;
+    }
+
+    @Override
     public boolean isFailed() {
         return environment.getEnvironmentStatus().isFailed();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/FreeIpaWaitObject.java
@@ -87,6 +87,11 @@ public class FreeIpaWaitObject implements WaitObject {
     }
 
     @Override
+    public boolean isFailedButIgnored() {
+        return false;
+    }
+
+    @Override
     public boolean isFailed() {
         return freeIpa.getStatus().isFailed();
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/instance/FreeIpaInstanceWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/freeipa/instance/FreeIpaInstanceWaitObject.java
@@ -86,6 +86,11 @@ public class FreeIpaInstanceWaitObject implements WaitObject {
     }
 
     @Override
+    public boolean isFailedButIgnored() {
+        return false;
+    }
+
+    @Override
     public boolean isDeleteFailed() {
         return getInstanceStatuses().values().stream().anyMatch(FAILED::equals);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/instance/InstanceWaitObject.java
@@ -91,6 +91,11 @@ public class InstanceWaitObject implements WaitObject {
     }
 
     @Override
+    public boolean isFailedButIgnored() {
+        return false;
+    }
+
+    @Override
     public boolean isDeleteFailed() {
         return getInstanceStatuses().values().stream().anyMatch(DECOMMISSION_FAILED::equals);
     }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/redbeams/RedbeamsWaitObject.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/util/wait/service/redbeams/RedbeamsWaitObject.java
@@ -84,6 +84,11 @@ public class RedbeamsWaitObject implements WaitObject {
     }
 
     @Override
+    public boolean isFailedButIgnored() {
+        return false;
+    }
+
+    @Override
     public boolean isFailed() {
         Set<Status> failedStatuses = Set.of(UPDATE_FAILED, CREATE_FAILED, ENABLE_SECURITY_FAILED, DELETE_FAILED, START_FAILED, STOP_FAILED);
         return failedStatuses.contains(redbeams.getStatus());


### PR DESCRIPTION
The reason of the failure: when an instance is stopped on the cloudprovider and the CM is not reachable, then SDX syncer maps this to CLUSTER_UNREACHABLE. In the test this is a failure state, leading to an immediate termination of the test.

In this PR the await is further customized: it not only waits for a status, but the test writer can set up some tests to ignore some of the failure states. This is only fully implemented for SDX.

See detailed description in the commit message.