### PR TITLE
CB-14893 CB-14893 [e2e] The repair tests with stopped instances is fa…

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/e2e/sdx/SdxRepairTests.java
@@ -107,8 +107,8 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances();
 
-        repair(sdxTestDto, sdx, MASTER.getName());
-        repair(sdxTestDto, sdx, IDBROKER.getName());
+        repair(sdxTestDto, sdx, MASTER.getName(), Set.of(SdxClusterStatusResponse.CLUSTER_UNREACHABLE));
+        repair(sdxTestDto, sdx, IDBROKER.getName(), Set.of(SdxClusterStatusResponse.NODE_FAILURE));
 
         sdxTestDto
                 .then((tc, testDto, client) -> {
@@ -171,7 +171,7 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
 
     }
 
-    private void repair(SdxTestDto sdxTestDto, String sdx, String hostgroupName) {
+    private void repair(SdxTestDto sdxTestDto, String sdx, String hostgroupName, Set<SdxClusterStatusResponse> ignoredFailedStatuses) {
         List<String> expectedVolumeIds = new ArrayList<>();
         List<String> actualVolumeIds = new ArrayList<>();
 
@@ -184,8 +184,7 @@ public class SdxRepairTests extends PreconditionSdxE2ETest {
                 })
                 .awaitForHostGroups(List.of(hostgroupName), InstanceStatus.STOPPED)
                 .when(sdxTestClient.repair(hostgroupName), key(sdx))
-                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, Set.of(SdxClusterStatusResponse.CLUSTER_UNREACHABLE),
-                        key(sdx).withWaitForFlow(Boolean.FALSE))
+                .await(SdxClusterStatusResponse.REPAIR_IN_PROGRESS, ignoredFailedStatuses, key(sdx).withWaitForFlow(Boolean.FALSE))
                 .await(SdxClusterStatusResponse.RUNNING, key(sdx))
                 .awaitForHealthyInstances()
                 .then((tc, testDto, client) -> {


### PR DESCRIPTION
…iling, 2nd change.

The reason of the failure: when an instance is stopped on the cloudprovider but the CM is reachable, then the core syncer maps this to cluster state NODE_FAILURE, and also sets the corresponding instancemetadata to STOPPED. The SDX syncer in response maps this to NODE_FAILURE as well. In the test this is a failure state, leading to an immediate termination of the test.
The NODE_FAILURE state is, however, expected in this test, so as a remedy it is added to the failed states that should be ignored.

See detailed description in the commit message.