### PR TITLE
CB-14899 Cannot upgrade the cluster because the root disk ran out of space

### DIFF
--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -775,9 +775,9 @@ cb:
       sdx.enabled: false
     validation:
       distrox:
-        enabled: false
+        enabled: true
       sdx:
-        enabled: false
+        enabled: true
     permittedServicesForUpgrade: >
         CORE_SETTINGS: 7.2.9,
         CRUISE_CONTROL: 7.2.9,


### PR DESCRIPTION
CB-14899 Cannot upgrade the cluster because the root disk ran out of space

Turn on upgrade validation flow by default.
