### PR TITLE
[RFC] Automatically retry a failed load-based auto-scale event

### DIFF
--- a/autoscale/build.gradle
+++ b/autoscale/build.gradle
@@ -206,6 +206,7 @@ dependencies {
 
     implementation project(':core-api')
     implementation project(':autoscale-api')
+    implementation project(':flow-api')
     implementation project(':common')
     implementation project(':workspace')
     implementation project(':secret-engine')

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/Cluster.java
@@ -88,6 +88,9 @@ public class Cluster implements Monitored, Clustered {
     @Column(name = "lastevaulated")
     private long lastEvaluated;
 
+    @Column(name = "lastretried")
+    private long lastRetried;
+
     @Column(name = "cb_stack_id")
     private long stackId;
 
@@ -262,6 +265,14 @@ public class Cluster implements Monitored, Clustered {
         return lastEvaluated;
     }
 
+    public long getLastRetried() {
+        return lastRetried;
+    }
+
+    public void setLastRetried(long lastRetried) {
+        this.lastRetried = lastRetried;
+    }
+
     public String getStackName() {
         return stackName;
     }
@@ -314,6 +325,33 @@ public class Cluster implements Monitored, Clustered {
 
     public Boolean getAutoscalingEnabled() {
         return autoscalingEnabled;
+    }
+
+    @Override
+    public String toString() {
+        return "Cluster{" +
+                "id=" + id +
+                ", clusterPertain=" + clusterPertain +
+                ", clusterManager=" + clusterManager +
+                ", securityConfig=" + securityConfig +
+                ", state=" + state +
+                ", timeAlerts=" + timeAlerts +
+                ", loadAlerts=" + loadAlerts +
+                ", minSize=" + minSize +
+                ", maxSize=" + maxSize +
+                ", coolDown=" + coolDown +
+                ", stackCrn='" + stackCrn + '\'' +
+                ", stackName='" + stackName + '\'' +
+                ", cloudPlatform='" + cloudPlatform + '\'' +
+                ", stackType=" + stackType +
+                ", lastScalingActivity=" + lastScalingActivity +
+                ", autoscalingEnabled=" + autoscalingEnabled +
+                ", periscopeNodeId='" + periscopeNodeId + '\'' +
+                ", lastEvaluated=" + lastEvaluated +
+                ", lastRetried=" + lastRetried +
+                ", stackId=" + stackId +
+                ", tunnel=" + tunnel +
+                '}';
     }
 }
 

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterScaleStatusMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/ClusterScaleStatusMonitor.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.periscope.monitor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
+import com.sequenceiq.periscope.api.model.ClusterState;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.monitor.evaluator.ClusterScaleStatusEvaluator;
+
+@Component("ClusterScaleStatusMonitor")
+@ConditionalOnProperty(prefix = "periscope.enabledAutoscaleMonitors.cluster-scale-status-monitor", name = "enabled", havingValue = "true")
+public class ClusterScaleStatusMonitor extends ClusterMonitor {
+
+    @Override
+    public String getIdentifier() {
+        return "cluster-scale-status-monitor";
+    }
+
+    @Override
+    public String getTriggerExpression() {
+        return MonitorUpdateRate.EVERY_FIVE_MIN_RATE_CRON;
+    }
+
+    @Override
+    public Class<?> getEvaluatorType(Cluster cluster) {
+        return ClusterScaleStatusEvaluator.class;
+    }
+
+    @Override
+    protected List<Cluster> getMonitored() {
+        return getClusterService().findLoadAlertClusterIdsForPeriscopeNodeId(StackType.WORKLOAD, ClusterState.SUSPENDED, true, getPeriscopeNodeConfig().getId())
+                .stream().map(Cluster::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterScaleStatusEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/ClusterScaleStatusEvaluator.java
@@ -1,0 +1,44 @@
+package com.sequenceiq.periscope.monitor.evaluator;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.periscope.monitor.context.ClusterIdEvaluatorContext;
+import com.sequenceiq.periscope.monitor.context.EvaluatorContext;
+import com.sequenceiq.periscope.monitor.event.ClusterScaleStatusEvent;
+
+@Component("ClusterScaleStatusEvaluator")
+@Scope("prototype")
+public class ClusterScaleStatusEvaluator extends EvaluatorExecutor {
+
+    private static final String EVALUATOR_NAME = ClusterScaleStatusEvaluator.class.getName();
+
+    @Inject
+    private EventPublisher eventPublisher;
+
+    private long clusterId;
+
+    @Override
+    public void setContext(EvaluatorContext context) {
+        clusterId = (long) context.getData();
+    }
+
+    @Override
+    @Nonnull
+    public EvaluatorContext getContext() {
+        return new ClusterIdEvaluatorContext(clusterId);
+    }
+
+    @Override
+    public String getName() {
+        return EVALUATOR_NAME;
+    }
+
+    @Override
+    public void execute() {
+        eventPublisher.publishEvent(new ClusterScaleStatusEvent(clusterId));
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ClusterScaleStatusEvent.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/event/ClusterScaleStatusEvent.java
@@ -1,0 +1,14 @@
+package com.sequenceiq.periscope.monitor.event;
+
+import org.springframework.context.ApplicationEvent;
+
+public class ClusterScaleStatusEvent extends ApplicationEvent {
+
+    public ClusterScaleStatusEvent(long clusterId) {
+        super(clusterId);
+    }
+
+    public long getClusterId() {
+        return (long) source;
+    }
+}

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/CloudbreakCommunicator.java
@@ -16,6 +16,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.AutoscaleStackV
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackV4Response;
 import com.sequenceiq.cloudbreak.client.CloudbreakInternalCrnClient;
+import com.sequenceiq.flow.api.model.RetryableFlowResponse;
 import com.sequenceiq.periscope.aspects.RequestLogging;
 import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.service.AutoscaleRestRequestThreadLocalService;
@@ -52,6 +53,19 @@ public class CloudbreakCommunicator {
 
     public StackStatusV4Response getStackStatusByCrn(String stackCrn) {
         return cloudbreakInternalCrnClient.withInternalCrn().autoscaleEndpoint().getStatusByCrn(stackCrn);
+    }
+
+    public List<RetryableFlowResponse> listRetryableFlows(String name, String accountId) {
+        return requestLogging.logResponseTime(
+                () -> cloudbreakInternalCrnClient.withInternalCrn().distroXV1Endpoint().internalListRetryableFlows(name, accountId),
+                String.format("ListRetryableFlows for cluster name %s", name));
+    }
+
+    public void retryLastFailedScale(String name, String accountId) {
+        requestLogging.logResponseTime(() -> {
+            cloudbreakInternalCrnClient.withInternalCrn().distroXV1Endpoint().internalRetryByNameAndAccountId(name, accountId);
+            return Optional.empty();
+        }, String.format("Retrying last failed scale operation for cluster name %s", name));
     }
 
     public void decommissionInstancesForCluster(Cluster cluster, List<String> decommissionNodeIds) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterScaleStatusHandler.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ClusterScaleStatusHandler.java
@@ -1,0 +1,71 @@
+package com.sequenceiq.periscope.monitor.handler;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.StackStatusV4Response;
+import com.sequenceiq.flow.api.model.RetryableFlowResponse;
+import com.sequenceiq.periscope.domain.Cluster;
+import com.sequenceiq.periscope.monitor.event.ClusterScaleStatusEvent;
+import com.sequenceiq.periscope.service.ClusterService;
+import com.sequenceiq.periscope.utils.LoggingUtils;
+
+@Component
+public class ClusterScaleStatusHandler implements ApplicationListener<ClusterScaleStatusEvent> {
+
+    public static final int MS_IN_A_DAY = 24 * 60 * 60 * 1000;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterScaleStatusHandler.class);
+
+    @Inject
+    private ClusterService clusterService;
+
+    @Inject
+    private CloudbreakCommunicator cloudbreakCommunicator;
+
+    @Override
+    public void onApplicationEvent(ClusterScaleStatusEvent event) {
+        long autoscaleClusterId = event.getClusterId();
+        Cluster cluster = clusterService.findById(autoscaleClusterId);
+        if (cluster == null) {
+            return;
+        }
+        LoggingUtils.buildMdcContext(cluster);
+        StackStatusV4Response statusResponse = cloudbreakCommunicator.getStackStatusByCrn(cluster.getStackCrn());
+        LOGGER.debug("Analysing CB Cluster Status '{}' for Cluster '{}'", statusResponse, cluster.getStackCrn());
+        boolean clusterAvailable = Optional.ofNullable(statusResponse.getStatus()).map(Status::isAvailable).orElse(false)
+                && Optional.ofNullable(statusResponse.getClusterStatus()).map(Status::isAvailable).orElse(false);
+        LOGGER.debug("CB Cluster availability is '{}' for Cluster object '{}'", clusterAvailable, cluster);
+        if (!clusterAvailable) {
+            LOGGER.debug("Checking retriable flows for Cluster '{}'", cluster.getStackCrn());
+            List<RetryableFlowResponse> retryableFlowResponses =
+                    cloudbreakCommunicator.listRetryableFlows(cluster.getStackName(), cluster.getClusterPertain().getTenant());
+            LOGGER.debug("CB Cluster '{}' has retryable flows '{}'", cluster, retryableFlowResponses);
+            if (retryableFlowResponses.isEmpty()) {
+                LOGGER.debug("No retriable operations in cluster '{}'",
+                        cluster.getStackCrn());
+                return;
+            }
+            // Retry the failed scale operation only once a day, unless there are successive scaling activities
+            if (retryableFlowResponses.get(0).getName().contains("scale") &&
+                    cluster.getLastScalingActivity() > cluster.getLastRetried() &&
+                    (System.currentTimeMillis() - cluster.getLastRetried()) > MS_IN_A_DAY) {
+                LOGGER.debug("Retrying failed scale operation in cluster '{}'",
+                        cluster.getStackCrn());
+                cloudbreakCommunicator.retryLastFailedScale(cluster.getStackName(), cluster.getClusterPertain().getTenant());
+                LOGGER.debug("Retried failed scale operation in cluster '{}'",
+                        cluster.getStackCrn());
+                cluster.setLastRetried(System.currentTimeMillis());
+                clusterService.save(cluster);
+            }
+        }
+    }
+}

--- a/autoscale/src/main/resources/application-test.yml
+++ b/autoscale/src/main/resources/application-test.yml
@@ -56,6 +56,8 @@ periscope:
       enabled: false
     cluster-status-monitor:
       enabled: false
+    cluster-scale-status-monitor:
+      enabled: false
 
 cb:
   server:

--- a/autoscale/src/main/resources/application.yml
+++ b/autoscale/src/main/resources/application.yml
@@ -60,6 +60,8 @@ periscope:
       enabled: true
     cluster-status-monitor:
       enabled: true
+    cluster-scale-status-monitor:
+      enabled: true
 
 cb:
   server:

--- a/autoscale/src/main/resources/schema/app/20211122103440_Cluster_status_monitor_last_retry.sql
+++ b/autoscale/src/main/resources/schema/app/20211122103440_Cluster_status_monitor_last_retry.sql
@@ -1,0 +1,9 @@
+-- // CB-12843 Make sure we have PKs on every CB table
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE cluster ADD COLUMN lastretried BIGINT DEFAULT 0;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE cluster DROP COLUMN IF EXISTS lastretried;

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -82,6 +82,7 @@ public class OperationDescriptions {
         public static final String STACK_UPGRADE = "Upgrades a cluster to the latest CM or CDH version";
         public static final String STACK_UPGRADE_INTERNAL = "Upgrades a cluster to the latest CM or CDH version, internal only";
         public static final String LIST_RETRYABLE_FLOWS = "List retryable failed flows";
+        public static final String LIST_RETRYABLE_FLOWS_INTERNAL = "List retryable failed flows (for internal user)";
         public static final String DATABASE_BACKUP = "Performs a backup of the database to a provided location";
         public static final String DATABASE_BACKUP_INTERNAL = "Performs a backup of the database to a provided location, internal only";
         public static final String DATABASE_RESTORE = "Performs a restore of the database from a provided location";

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/doc/DistroXOpDescription.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/doc/DistroXOpDescription.java
@@ -20,6 +20,7 @@ public class DistroXOpDescription {
     public static final String SYNC_BY_NAME = "syncs the stack by name";
     public static final String SYNC_BY_CRN = "syncs the stack by crn";
     public static final String RETRY_BY_NAME = "retries the stack by name";
+    public static final String RETRY_BY_NAME_INTERNAL = "retries the stack by name (for internal user)";
     public static final String RETRY_BY_CRN = "retries the stack by crn";
     public static final String STOP_BY_NAME = "stops the stack by name";
     public static final String STOP_BY_CRN = "stops the stack by crn";

--- a/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/distrox/api/v1/distrox/endpoint/DistroXV1Endpoint.java
@@ -80,6 +80,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recipe.DetachRe
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recipe.UpdateRecipesV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery.RecoveryValidationV4Response;
 import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
+import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.doc.Notes;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions;
 import com.sequenceiq.cloudbreak.jerseyclient.RetryAndMetrics;
@@ -183,6 +184,19 @@ public interface DistroXV1Endpoint {
     @ApiOperation(value = RETRY_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.RETRY_STACK_NOTES,
             nickname = "retryDistroXV1ByName")
     void retryByName(@PathParam("name") String name);
+
+    @GET
+    @Path("name/{name}/retry/internal")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = OperationDescriptions.StackOpDescription.LIST_RETRYABLE_FLOWS_INTERNAL, produces = MediaType.APPLICATION_JSON,
+            notes = Notes.LIST_RETRYABLE_NOTES, nickname = "internalListRetryableFlowsDistroXV1")
+    List<RetryableFlowResponse> internalListRetryableFlows(@PathParam("name") String name, @AccountId @QueryParam("accountId") String accountId);
+
+    @POST
+    @Path("name/{name}/retry/internal")
+    @ApiOperation(value = RETRY_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = Notes.RETRY_STACK_NOTES,
+            nickname = "internalRetryDistroXV1ByNameAndAccountId")
+    void internalRetryByNameAndAccountId(@PathParam("name") String name, @AccountId @QueryParam("accountId") String accountId);
 
     @GET
     @Path("name/{name}/retry")

--- a/flow-api/src/main/java/com/sequenceiq/flow/api/model/RetryableFlowResponse.java
+++ b/flow-api/src/main/java/com/sequenceiq/flow/api/model/RetryableFlowResponse.java
@@ -21,6 +21,9 @@ public class RetryableFlowResponse implements JsonEntity {
         this.failDate = failDate;
     }
 
+    public RetryableFlowResponse() {
+    }
+
     public String getName() {
         return name;
     }


### PR DESCRIPTION
    1. Every 5 mins the scaling status of the load based auto scale enabled clusters is checked.
    2. If there is a failure in scale event then it is retried.
    3. As a side effect also retries manual scale operation failures.
    4. To prevent perpetual retries added a couple of restrictions like one retry per day for a failure which is reset upon successive auto-scaling activity.
