### PR TITLE
CB-14974 Pass DL backup path to CM

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/ranger/RangerCloudStorageServiceConfigProvider.java
@@ -11,7 +11,6 @@ import static com.sequenceiq.common.model.CloudStorageCdpService.RANGER_AUDIT;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
@@ -28,6 +27,8 @@ import com.sequenceiq.cloudbreak.template.TemplatePreparationObject;
 @Component
 public class RangerCloudStorageServiceConfigProvider implements CmTemplateComponentConfigProvider {
 
+    public static final String DEFAULT_BACKUP_DIR = "default.backup.location";
+
     private static final String RANGER_HDFS_AUDIT_URL = "ranger_plugin_hdfs_audit_url";
 
     private static final String HIVE_METASTORE_DIR =  "hive.metastore.warehouse.dir";
@@ -39,6 +40,8 @@ public class RangerCloudStorageServiceConfigProvider implements CmTemplateCompon
     private static final String CLOUD_STORAGE_PATHS = "cloud_storage_paths";
 
     private static final String HBASE_ROOT_DIR = "hbase.rootdir";
+
+    private static final String BACKUP_LOCATION = "BACKUP_LOCATION";
 
     @Override
     public List<ApiClusterTemplateConfig> getServiceConfigs(CmTemplateProcessor templateProcessor, TemplatePreparationObject templatePreparationObject) {
@@ -63,7 +66,10 @@ public class RangerCloudStorageServiceConfigProvider implements CmTemplateCompon
             ConfigUtils.getStorageLocationForServiceProperty(templatePreparationObject, HBASE_ROOT_DIR)
                     .ifPresent(location -> cloudPaths.add(HBASE_ROOT.name() + "=" + location.getValue()));
 
-            String cloudPath = cloudPaths.stream().collect(Collectors.joining(","));
+            ConfigUtils.getStorageLocationForServiceProperty(templatePreparationObject, DEFAULT_BACKUP_DIR)
+                    .ifPresent(location -> cloudPaths.add(BACKUP_LOCATION + "=" + location.getValue()));
+
+            String cloudPath = String.join(",", cloudPaths);
             return List.of(getRangerAuditConfig(templateProcessor, templatePreparationObject), config(CLOUD_STORAGE_PATHS, cloudPath));
         } else {
             return List.of(getRangerAuditConfig(templateProcessor, templatePreparationObject));

--- a/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/filesystem/StorageLocationView.java
+++ b/template-manager-core/src/main/java/com/sequenceiq/cloudbreak/template/filesystem/StorageLocationView.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.template.filesystem;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import com.sequenceiq.cloudbreak.domain.StorageLocation;
 
@@ -30,4 +31,22 @@ public class StorageLocationView implements Serializable {
         return value;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StorageLocationView that = (StorageLocationView) o;
+        return Objects.equals(configFile, that.configFile)
+                && Objects.equals(property, that.property)
+                && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(configFile, property, value);
+    }
 }


### PR DESCRIPTION
If the default backup location is set for an environment, pass that to Ranger in the cloud_storage_paths
field as "BACKUP_LOCATION=\<backup location>". This information will be used to construct the RAZ
backup/restore data lake policy.

Tested via unit tests and in local CB.

![Screenshot from 2021-11-19 14-31-20](https://user-images.githubusercontent.com/49536206/142903857-27cfb844-6c07-451c-bf2e-c5f0edaf95a9.png)

I added this logic outside of the settings in the cm-cloud-storage-location-specification.json because there is no specific CM service setting associated with the backup location, so there is no reason to provide information about it outside of the property name and value.