### PR TITLE
CB-15183 Don't send event about command failure/timeout when there is…

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandCheckerTask.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/polling/task/AbstractClouderaManagerCommandCheckerTask.java
@@ -58,13 +58,17 @@ public abstract class AbstractClouderaManagerCommandCheckerTask<T extends Cloude
 
     @Override
     public void sendFailureEvent(T pollerObject) {
-        getClusterEventService().fireClusterManagerEvent(pollerObject.getStack(),
-                ResourceEvent.CLUSTER_CM_COMMAND_FAILED, getCommandName(), Optional.of(pollerObject.getId()));
+        if (pollerObject.getId() != null) {
+            getClusterEventService().fireClusterManagerEvent(pollerObject.getStack(),
+                    ResourceEvent.CLUSTER_CM_COMMAND_FAILED, getCommandName(), Optional.of(pollerObject.getId()));
+        }
     }
 
     @Override
     public void sendTimeoutEvent(T pollerObject) {
-        getClusterEventService().fireClusterManagerEvent(pollerObject.getStack(),
-                ResourceEvent.CLUSTER_CM_COMMAND_TIMEOUT, getCommandName(), Optional.of(pollerObject.getId()));
+        if (pollerObject.getId() != null) {
+            getClusterEventService().fireClusterManagerEvent(pollerObject.getStack(),
+                    ResourceEvent.CLUSTER_CM_COMMAND_TIMEOUT, getCommandName(), Optional.of(pollerObject.getId()));
+        }
     }
 }


### PR DESCRIPTION
… no commandId. This fixes th NPE during event sending.

See detailed description in the commit message.