### PR TITLE
CB-14825 Increase wait timeouts for SDX backup and restore

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupAction.java
@@ -2,8 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.sdx;
 
 import static java.lang.String.format;
 
+import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +33,7 @@ public class SdxBackupAction implements Action<SdxTestDto, SdxClient> {
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
-        sleep(2, sdxName);
+        testContext.waitingFor(Duration.ofMinutes(5), "Waiting for CM services to be synchronized has been interrupted");
 
         Log.when(LOGGER, format(" SDX '%s' backup has been started to '%s' by name '%s'... ", sdxName, backupLocation, backupName));
         Log.whenJson(LOGGER, " SDX backup request: ", testDto.getRequest());
@@ -48,13 +48,5 @@ public class SdxBackupAction implements Action<SdxTestDto, SdxClient> {
         testDto.setResponse(detailedResponse);
         Log.whenJson(LOGGER, " SDX response after backup: ", client.getDefaultClient().sdxEndpoint().get(sdxName));
         return testDto;
-    }
-
-    private void sleep(long sleepMinutes, String sdxName) {
-        try {
-            TimeUnit.MINUTES.sleep(sleepMinutes);
-        } catch (InterruptedException ignored) {
-            LOGGER.warn("Waiting for CM services to be synchronized has been interrupted, cause:", ignored);
-        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxBackupInternalAction.java
@@ -2,8 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.sdx;
 
 import static java.lang.String.format;
 
+import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +33,7 @@ public class SdxBackupInternalAction implements Action<SdxInternalTestDto, SdxCl
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
-        sleep(2, sdxName);
+        testContext.waitingFor(Duration.ofMinutes(5), "Waiting for CM services to be synchronized has been interrupted");
 
         Log.when(LOGGER, format(" Internal SDX '%s' backup has been started to '%s' by name '%s'... ", sdxName, backupLocation, backupName));
         Log.whenJson(LOGGER, " Internal SDX backup request: ", testDto.getRequest());
@@ -48,13 +48,5 @@ public class SdxBackupInternalAction implements Action<SdxInternalTestDto, SdxCl
         testDto.setResponse(detailedResponse);
         Log.whenJson(LOGGER, " Internal SDX response after backup: ", client.getDefaultClient().sdxEndpoint().get(sdxName));
         return testDto;
-    }
-
-    private void sleep(long sleepMinutes, String sdxName) {
-        try {
-            TimeUnit.MINUTES.sleep(sleepMinutes);
-        } catch (InterruptedException ignored) {
-            LOGGER.warn("Waiting for CM services to be synchronized has been interrupted, cause:", ignored);
-        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRestoreInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxRestoreInternalAction.java
@@ -2,8 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.sdx;
 
 import static java.lang.String.format;
 
+import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,7 +33,7 @@ public class SdxRestoreInternalAction implements Action<SdxInternalTestDto, SdxC
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
-        sleep(2, sdxName);
+        testContext.waitingFor(Duration.ofMinutes(5), "Waiting for CM services to be synchronized has been interrupted");
 
         Log.when(LOGGER, format(" Internal SDX '%s' restore has been started to '%s' ", sdxName, backupLocation));
         Log.whenJson(LOGGER, " Internal SDX restore request: ", testDto.getRequest());
@@ -48,13 +48,5 @@ public class SdxRestoreInternalAction implements Action<SdxInternalTestDto, SdxC
         testDto.setResponse(detailedResponse);
         Log.whenJson(LOGGER, " Internal SDX response after restore: ", client.getDefaultClient().sdxEndpoint().get(sdxName));
         return testDto;
-    }
-
-    private void sleep(long sleepMinutes, String sdxName) {
-        try {
-            TimeUnit.MINUTES.sleep(sleepMinutes);
-        } catch (InterruptedException ignored) {
-            LOGGER.warn("Waiting for CM services to be synchronized has been interrupted, cause:", ignored);
-        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncAction.java
@@ -2,8 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.sdx;
 
 import static java.lang.String.format;
 
+import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +23,7 @@ public class SdxSyncAction implements Action<SdxTestDto, SdxClient> {
     public SdxTestDto action(TestContext testContext, SdxTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
-        sleep(1, sdxName);
+        testContext.waitingFor(Duration.ofMinutes(4), "Waiting for CM services to be synchronized has been interrupted");
 
         Log.when(LOGGER, format(" SDX '%s' sync has been started... ", sdxName));
         Log.whenJson(LOGGER, " SDX sync request: ", testDto.getRequest());
@@ -38,13 +38,5 @@ public class SdxSyncAction implements Action<SdxTestDto, SdxClient> {
         Log.whenJson(LOGGER, " SDX response after sync: ", client.getDefaultClient().sdxEndpoint().get(sdxName));
 
         return testDto;
-    }
-
-    private void sleep(long sleepMinutes, String sdxName) {
-        try {
-            TimeUnit.MINUTES.sleep(sleepMinutes);
-        } catch (InterruptedException ignored) {
-            LOGGER.warn("Waiting for CM services to be synchronized has been interrupted, cause:", ignored);
-        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncInternalAction.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/action/sdx/SdxSyncInternalAction.java
@@ -2,8 +2,8 @@ package com.sequenceiq.it.cloudbreak.action.sdx;
 
 import static java.lang.String.format;
 
+import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +23,7 @@ public class SdxSyncInternalAction implements Action<SdxInternalTestDto, SdxClie
     public SdxInternalTestDto action(TestContext testContext, SdxInternalTestDto testDto, SdxClient client) throws Exception {
         String sdxName = testDto.getName();
 
-        sleep(1, sdxName);
+        testContext.waitingFor(Duration.ofMinutes(4), "Waiting for CM services to be synchronized has been interrupted");
 
         Log.when(LOGGER, format(" Internal SDX '%s' sync has been started... ", sdxName));
         Log.whenJson(LOGGER, " Internal SDX sync request: ", testDto.getRequest());
@@ -38,13 +38,5 @@ public class SdxSyncInternalAction implements Action<SdxInternalTestDto, SdxClie
         Log.whenJson(LOGGER, " Internal SDX response after sync: ", client.getDefaultClient().sdxEndpoint().get(sdxName));
 
         return testDto;
-    }
-
-    private void sleep(long sleepMinutes, String sdxName) {
-        try {
-            TimeUnit.MINUTES.sleep(sleepMinutes);
-        } catch (InterruptedException ignored) {
-            LOGGER.warn("Waiting for CM services to be synchronized has been interrupted, cause:", ignored);
-        }
     }
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/context/TestContext.java
@@ -1235,6 +1235,17 @@ public abstract class TestContext implements ApplicationContextAware {
         return cloudProvider;
     }
 
+    public void waitingFor(Duration duration, String interruptedMessage) {
+        Duration waitDuration = duration == null ? Duration.ofMinutes(0) : duration;
+        String intrMessage = interruptedMessage == null ? "Waiting has been interrupted:" : interruptedMessage;
+        try {
+            Thread.sleep(waitDuration.toMillis());
+            LOGGER.info("Wait '{}' duration has been done.", duration.toString());
+        } catch (InterruptedException e) {
+            LOGGER.warn(StringUtils.join(intrMessage, e));
+        }
+    }
+
     @Override
     public String toString() {
         return getClass().getSimpleName() + "{clients: " + clients + ", entities: " + resourceNames + "}";


### PR DESCRIPTION
Our [MOW-Dev API E2E projects](http://ci-cloudbreak.eng.hortonworks.com/job/mow-dev-e2e/) are failing, because of [CB-14825 Datalake backup flow has been finalized with failed status](https://jira.cloudera.com/browse/CB-14825).

While this issue is going to be investigated then fix, I'm increased the CM service wait timeout as a possible workaround. We had similar solution previously at [CB-13322 Data Lake database backup request failed: 409, Could not connect to Solr OR ATLAS_ENTITY_AUDIT_EVENTS_TABLE: HBase failure: Failed to take snapshot](https://jira.cloudera.com/browse/CB-13322)