### PR TITLE
CB-14935 Configure RackAwareDistributionGoal instead of RackAwareGoal…

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/CMRepositoryVersionUtil.java
@@ -56,6 +56,8 @@ public class CMRepositoryVersionUtil {
 
     public static final Versioned CLOUDERA_STACK_VERSION_7_2_12 = () -> "7.2.12";
 
+    public static final Versioned CLOUDERA_STACK_VERSION_7_2_14 = () -> "7.2.14";
+
     public static final Versioned CFM_VERSION_2_0_0_0 = () -> "2.0.0.0";
 
     public static final Versioned CFM_VERSION_2_2_3_0 = () -> "2.2.3.0";

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlGoalConfigs.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlGoalConfigs.java
@@ -1,0 +1,26 @@
+package com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol;
+
+public class CruiseControlGoalConfigs {
+
+    public static final String COMMON_DEFAULT_GOALS = "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal";
+
+    public static final String COMMON_HARD_GOALS = "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal";
+
+    public static final String COMMON_ANOMALY_DETECTION_GOALS = "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal";
+
+    private CruiseControlGoalConfigs() { }
+}

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProviderTest.java
@@ -1,6 +1,9 @@
 package com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol;
 
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlGoalConfigs.COMMON_ANOMALY_DETECTION_GOALS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlGoalConfigs.COMMON_DEFAULT_GOALS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlGoalConfigs.COMMON_HARD_GOALS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
@@ -38,10 +41,34 @@ public class CruiseControlRoleConfigProviderTest {
     }
 
     @Test
-    void testRoleConfigWithCdpVersionIsHigherThan7211() {
+    void testRoleConfigWithCdpVersionIs7212() {
         cdpMainVersionIs("7.2.12");
         HostgroupView hostGroup = new HostgroupView("test group");
         assertEquals(createExpectedConfigWithStackVersionAtLeast7211(),
+                provider.getRoleConfigs(CruiseControlRoles.CRUISE_CONTROL_SERVER, hostGroup, getTemplatePreparationObject(hostGroup)));
+    }
+
+    @Test
+    void testRoleConfigWithCdpVersionIs7213() {
+        cdpMainVersionIs("7.2.13");
+        HostgroupView hostGroup = new HostgroupView("test group");
+        assertEquals(createExpectedConfigWithStackVersionAtLeast7211(),
+                provider.getRoleConfigs(CruiseControlRoles.CRUISE_CONTROL_SERVER, hostGroup, getTemplatePreparationObject(hostGroup)));
+    }
+
+    @Test
+    void testRoleConfigWithCdpVersionIs7214() {
+        cdpMainVersionIs("7.2.14");
+        HostgroupView hostGroup = new HostgroupView("test group");
+        assertEquals(createExpectedConfigWithStackVersionAtLeast7214(),
+                provider.getRoleConfigs(CruiseControlRoles.CRUISE_CONTROL_SERVER, hostGroup, getTemplatePreparationObject(hostGroup)));
+    }
+
+    @Test
+    void testRoleConfigWithCdpVersionIs7215() {
+        cdpMainVersionIs("7.2.15");
+        HostgroupView hostGroup = new HostgroupView("test group");
+        assertEquals(createExpectedConfigWithStackVersionAtLeast7214(),
                 provider.getRoleConfigs(CruiseControlRoles.CRUISE_CONTROL_SERVER, hostGroup, getTemplatePreparationObject(hostGroup)));
     }
 
@@ -79,29 +106,35 @@ public class CruiseControlRoleConfigProviderTest {
                 config("network.inbound.capacity.threshold", "0.85"),
                 config("network.outbound.capacity.threshold", "0.85"),
                 config("leader.replica.count.balance.threshold", "1.5"),
-                config("anomaly.detection.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal"),
-                config("default.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal"),
-                config("hard.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
-                        "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal"),
                 config("auth_method", "Trusted Proxy"),
-                config("trusted.proxy.spnego.fallback.enabled", "true")
+                config("trusted.proxy.spnego.fallback.enabled", "true"),
+                config("anomaly.detection.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +
+                        COMMON_ANOMALY_DETECTION_GOALS),
+                config("default.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," + COMMON_DEFAULT_GOALS),
+                config("hard.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," + COMMON_HARD_GOALS)
         );
     }
 
+    private List<ApiClusterTemplateConfig> createExpectedConfigWithStackVersionAtLeast7214() {
+        return List.of(config("self.healing.enabled", "true"),
+                config("anomaly.notifier.class", "com.linkedin.kafka.cruisecontrol.detector.notifier.SelfHealingNotifier"),
+                config("metric.anomaly.finder.class", "com.cloudera.kafka.cruisecontrol.detector.EmptyBrokerAnomalyFinder"),
+                config("cpu.balance.threshold", "1.5"),
+                config("disk.balance.threshold", "1.5"),
+                config("network.inbound.balance.threshold", "1.5"),
+                config("network.outbound.balance.threshold", "1.5"),
+                config("replica.count.balance.threshold", "1.5"),
+                config("disk.capacity.threshold", "0.85"),
+                config("cpu.capacity.threshold", "0.75"),
+                config("network.inbound.capacity.threshold", "0.85"),
+                config("network.outbound.capacity.threshold", "0.85"),
+                config("leader.replica.count.balance.threshold", "1.5"),
+                config("auth_method", "Trusted Proxy"),
+                config("trusted.proxy.spnego.fallback.enabled", "true"),
+                config("anomaly.detection.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal," +
+                        COMMON_ANOMALY_DETECTION_GOALS),
+                config("default.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal," + COMMON_DEFAULT_GOALS),
+                config("hard.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal," + COMMON_HARD_GOALS)
+        );
+    }
 }


### PR DESCRIPTION
… for Cruise Control in Cloudbreak

Starting from CDH>=7.2.14 RackAwareGoal has to be changed to RackAwareDistriutionGoal. This commit changes the mentioned goal and also the Cruise Control configuration provider was refactored to better support goal changes.

Tested: Unit test + Manually on provisioned cluster
