### PR TITLE
Revert "CB-13810: Validate the existence of key url provided by user for Azure cmk"

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResources.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResources.java
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.microsoft.azure.keyvault.models.KeyBundle;
 import com.microsoft.azure.management.compute.implementation.DiskEncryptionSetInner;
 import com.microsoft.azure.management.resources.ResourceGroup;
 import com.sequenceiq.cloudbreak.cloud.EncryptionResources;
@@ -81,20 +80,18 @@ public class AzureEncryptionResources implements EncryptionResources {
     @Override
     public CreatedDiskEncryptionSet createDiskEncryptionSet(DiskEncryptionSetCreationRequest diskEncryptionSetCreationRequest) {
         try {
-            String encryptionKeyUrl = diskEncryptionSetCreationRequest.getEncryptionKeyUrl();
+            String vaultName;
             AuthenticatedContext authenticatedContext = azureClientService.createAuthenticatedContext(diskEncryptionSetCreationRequest.getCloudContext(),
                     diskEncryptionSetCreationRequest.getCloudCredential());
             AzureClient azureClient = authenticatedContext.getParameter(AzureClient.class);
 
-            String vaultName;
-            Matcher matcher = ENCRYPTION_KEY_URL_VAULT_NAME.matcher(encryptionKeyUrl);
+            Matcher matcher = ENCRYPTION_KEY_URL_VAULT_NAME.matcher(diskEncryptionSetCreationRequest.getEncryptionKeyUrl());
             if (matcher.matches()) {
                 vaultName = matcher.group(1);
             } else {
                 throw new IllegalArgumentException("vaultName cannot be fetched from encryptionKeyUrl. encryptionKeyUrl should be of format - " +
                         "'https://<vaultName>.vault.azure.net/keys/<keyName>/<keyVersion>'");
             }
-
             boolean singleResourceGroup = Boolean.TRUE;
             String vaultResourceGroupName = diskEncryptionSetCreationRequest.getEncryptionKeyResourceGroupName();
             String desResourceGroupName = diskEncryptionSetCreationRequest.getDiskEncryptionSetResourceGroupName();
@@ -108,18 +105,6 @@ public class AzureEncryptionResources implements EncryptionResources {
                 desResourceGroupName = azureUtils.generateResourceGroupNameByNameAndId(
                         String.format("%s-CDP_DES-", diskEncryptionSetCreationRequest.getCloudContext().getName()),
                         diskEncryptionSetCreationRequest.getId());
-            }
-
-            KeyBundle key = azureClient.checkEncryptionKeyExistenceOnCloud(encryptionKeyUrl, vaultName, vaultResourceGroupName);
-            if (key != null && key.attributes() != null) {
-                if (!key.attributes().enabled()) {
-                    throw new IllegalArgumentException(String.format("keyName %s is not enabled to be used for encryption. " +
-                            "Please 'enable' the key using Azure portal.", key.keyIdentifier().name()));
-                }
-            } else {
-                throw new IllegalArgumentException(String.format("Key specified with keyUrl '%s' - either does not exist or " +
-                                "insufficient permissions to access it. Please ensure that the key exists and user has 'List' permissions on the keyVault %s",
-                        encryptionKeyUrl, vaultName));
             }
 
             String sourceVaultId = String.format("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.KeyVault/vaults/%s",

--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -31,7 +31,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.microsoft.azure.CloudException;
 import com.microsoft.azure.PagedList;
-import com.microsoft.azure.keyvault.models.KeyBundle;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.compute.AvailabilitySet;
 import com.microsoft.azure.management.compute.CachingTypes;
@@ -104,8 +103,8 @@ import com.microsoft.azure.storage.blob.CopyState;
 import com.microsoft.azure.storage.blob.ListBlobItem;
 import com.sequenceiq.cloudbreak.client.ProviderAuthenticationFailedException;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType;
-import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
 import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarketplaceImage;
+import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
 import com.sequenceiq.cloudbreak.cloud.azure.status.AzureStatusMapper;
 import com.sequenceiq.cloudbreak.cloud.azure.util.AzureAuthExceptionHandler;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
@@ -1022,12 +1021,4 @@ public class AzureClient {
         return azureClientCredentials.getAccesToken();
     }
 
-    public KeyBundle checkEncryptionKeyExistenceOnCloud(String encryptionKeyUrl, String keyVaultName, String keyVaultResourceGroupName) {
-        return handleAuthException(() -> {
-            return azure.vaults()
-                    .getByResourceGroup(keyVaultResourceGroupName, keyVaultName)
-                    .client()
-                    .getKey(encryptionKeyUrl);
-        });
-    }
 }

--- a/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResourcesTest.java
+++ b/cloud-azure/src/test/java/com/sequenceiq/cloudbreak/cloud/azure/AzureEncryptionResourcesTest.java
@@ -37,9 +37,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.microsoft.azure.keyvault.models.KeyAttributes;
-import com.microsoft.azure.keyvault.models.KeyBundle;
-import com.microsoft.azure.keyvault.webkey.JsonWebKey;
 import com.microsoft.azure.management.compute.DiskEncryptionSetIdentityType;
 import com.microsoft.azure.management.compute.DiskEncryptionSetType;
 import com.microsoft.azure.management.compute.EncryptionSetIdentity;
@@ -219,54 +216,11 @@ public class AzureEncryptionResourcesTest {
     }
 
     @Test
-    public void testCreateDiskEncryptionSetShouldCheckEncryptionKeyExistenceOnCloudAndThrowExistenceError() {
-        DiskEncryptionSetCreationRequest requestedSet = new DiskEncryptionSetCreationRequest.Builder()
-                .withId("uniqueId")
-                .withCloudCredential(cloudCredential)
-                .withCloudContext(cloudContext)
-                .withDiskEncryptionSetResourceGroupName("dummyResourceGroup")
-                .withTags(new HashMap<>())
-                .withEncryptionKeyUrl("https://dummyVaultName.vault.azure.net/wrongKey")
-                .build();
-        when(azureClientService.createAuthenticatedContext(cloudContext, cloudCredential)).thenReturn(authenticatedContext);
-        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
-        initExceptionConversion();
-
-        verifyException(IllegalArgumentException.class, () -> underTest.createDiskEncryptionSet(requestedSet),
-                "Key specified with keyUrl 'https://dummyVaultName.vault.azure.net/wrongKey' - either does not exist or insufficient" +
-                        " permissions to access it. Please ensure that the key exists and user has 'List' permissions on the keyVault dummyVaultName");
-    }
-
-    @Test
-    public void testCreateDiskEncryptionSetShouldCheckEncryptionKeyExistenceOnCloudAndThrowEnabledError() {
-        DiskEncryptionSetCreationRequest requestedSet = new DiskEncryptionSetCreationRequest.Builder()
-                .withId("uniqueId")
-                .withCloudCredential(cloudCredential)
-                .withCloudContext(cloudContext)
-                .withDiskEncryptionSetResourceGroupName("dummyResourceGroup")
-                .withEncryptionKeyResourceGroupName("dummyResourceGroup")
-                .withTags(new HashMap<>())
-                .withEncryptionKeyUrl("https://dummyVaultName.vault.azure.net/keys/dummyKeyName/dummyKeyVersion")
-                .build();
-        when(azureClientService.createAuthenticatedContext(cloudContext, cloudCredential)).thenReturn(authenticatedContext);
-        when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
-        when(azureClient.checkEncryptionKeyExistenceOnCloud(any(String.class), any(String.class), any(String.class)))
-                .thenReturn(new KeyBundle()
-                        .withAttributes((KeyAttributes) new KeyAttributes().withEnabled(Boolean.FALSE))
-                        .withKey(new JsonWebKey().withKid("https://dummyVaultName.vault.azure.net/keys/dummyKeyName/dummyKeyVersion")));
-        initExceptionConversion();
-
-        verifyException(IllegalArgumentException.class, () -> underTest.createDiskEncryptionSet(requestedSet),
-                "keyName dummyKeyName is not enabled to be used for encryption. Please 'enable' the key using Azure portal.");
-    }
-
-    @Test
     public void testCreateDiskEncryptionSetShouldMakeCloudCallAndThrowException() {
         DiskEncryptionSetCreationRequest requestedSet = new DiskEncryptionSetCreationRequest.Builder()
                 .withId("uniqueId")
                 .withCloudCredential(cloudCredential)
                 .withCloudContext(cloudContext)
-                .withEncryptionKeyResourceGroupName("dummyResourceGroup")
                 .withDiskEncryptionSetResourceGroupName("dummyResourceGroup")
                 .withTags(new HashMap<>())
                 .withEncryptionKeyUrl("https://dummyVaultName.vault.azure.net/keys/dummyKeyName/dummyKeyVersion")
@@ -276,8 +230,6 @@ public class AzureEncryptionResourcesTest {
         when(azureUtils.generateDesNameByNameAndId("envName-DES-", "uniqueId")).thenReturn("dummyEnvName-DES-uniqueId");
         when(azureClientService.createAuthenticatedContext(cloudContext, cloudCredential)).thenReturn(authenticatedContext);
         when(authenticatedContext.getParameter(AzureClient.class)).thenReturn(azureClient);
-        when(azureClient.checkEncryptionKeyExistenceOnCloud(any(String.class), any(String.class), any(String.class)))
-                .thenReturn(new KeyBundle().withAttributes((KeyAttributes) new KeyAttributes().withEnabled(Boolean.TRUE)));
         initExceptionConversion();
         when(azureClient.getCurrentSubscription()).thenReturn(subscription);
 
@@ -311,8 +263,6 @@ public class AzureEncryptionResourcesTest {
                 .withTags(new HashMap<>());
         ReflectionTestUtils.setField(des, "id", DES_RESOURCE_ID);
         Subscription subscription = mock(Subscription.class);
-        when(azureClient.checkEncryptionKeyExistenceOnCloud(any(String.class), any(String.class), any(String.class)))
-                .thenReturn(new KeyBundle().withAttributes((KeyAttributes) new KeyAttributes().withEnabled(Boolean.TRUE)));
         when(persistenceNotifier.notifyAllocation(any(CloudResource.class), eq(cloudContext))).thenReturn(new ResourcePersisted());
         when(subscription.subscriptionId()).thenReturn("dummySubscriptionId");
         when(azureUtils.generateDesNameByNameAndId(any(String.class), any(String.class))).thenReturn("dummyEnvName-DES-uniqueId");
@@ -403,8 +353,6 @@ public class AzureEncryptionResourcesTest {
                 .withTags(new HashMap<>());
         ReflectionTestUtils.setField(desAfterPolling, "id", DES_RESOURCE_ID);
         Subscription subscription = mock(Subscription.class);
-        when(azureClient.checkEncryptionKeyExistenceOnCloud(any(String.class), any(String.class), any(String.class)))
-                .thenReturn(new KeyBundle().withAttributes((KeyAttributes) new KeyAttributes().withEnabled(Boolean.TRUE)));
         when(persistenceNotifier.notifyAllocation(any(CloudResource.class), eq(cloudContext))).thenReturn(new ResourcePersisted());
         when(subscription.subscriptionId()).thenReturn("dummySubscriptionId");
         when(azureUtils.generateDesNameByNameAndId(any(String.class), any(String.class))).thenReturn("dummyEnvName-DES-uniqueId");
@@ -454,8 +402,6 @@ public class AzureEncryptionResourcesTest {
                 .withTags(new HashMap<>());
         ReflectionTestUtils.setField(des, "id", DES_RESOURCE_ID);
         Subscription subscription = mock(Subscription.class);
-        when(azureClient.checkEncryptionKeyExistenceOnCloud(any(String.class), any(String.class), any(String.class)))
-                .thenReturn(new KeyBundle().withAttributes((KeyAttributes) new KeyAttributes().withEnabled(Boolean.TRUE)));
         when(persistenceNotifier.notifyAllocation(any(CloudResource.class), eq(cloudContext))).thenReturn(new ResourcePersisted());
         when(subscription.subscriptionId()).thenReturn("dummySubscriptionId");
         when(azureUtils.generateDesNameByNameAndId(any(String.class), any(String.class))).thenReturn("dummyEnvName-DES-uniqueId");
@@ -503,8 +449,6 @@ public class AzureEncryptionResourcesTest {
                 .withTags(new HashMap<>());
         ReflectionTestUtils.setField(des, "id", DES_RESOURCE_ID);
         Subscription subscription = mock(Subscription.class);
-        when(azureClient.checkEncryptionKeyExistenceOnCloud(any(String.class), any(String.class), any(String.class)))
-                .thenReturn(new KeyBundle().withAttributes((KeyAttributes) new KeyAttributes().withEnabled(Boolean.TRUE)));
         when(persistenceNotifier.notifyAllocation(any(CloudResource.class), eq(cloudContext))).thenReturn(new ResourcePersisted());
         when(subscription.subscriptionId()).thenReturn("dummySubscriptionId");
         when(azureUtils.generateDesNameByNameAndId(any(String.class), any(String.class))).thenReturn("dummyEnvName-DES-uniqueId");
@@ -552,8 +496,6 @@ public class AzureEncryptionResourcesTest {
                 .withTags(new HashMap<>());
         ReflectionTestUtils.setField(des, "id", DES_RESOURCE_ID);
         Subscription subscription = mock(Subscription.class);
-        when(azureClient.checkEncryptionKeyExistenceOnCloud(any(String.class), any(String.class), any(String.class)))
-                .thenReturn(new KeyBundle().withAttributes((KeyAttributes) new KeyAttributes().withEnabled(Boolean.TRUE)));
         when(persistenceNotifier.notifyAllocation(any(CloudResource.class), eq(cloudContext))).thenReturn(new ResourcePersisted());
         when(subscription.subscriptionId()).thenReturn("dummySubscriptionId");
         when(azureUtils.generateDesNameByNameAndId(any(String.class), any(String.class))).thenReturn("dummyEnvName-DES-uniqueId");
@@ -620,8 +562,6 @@ public class AzureEncryptionResourcesTest {
         ResourceGroup resourceGroup = mock(ResourceGroup.class);
         ReflectionTestUtils.setField(des, "id", DES_RESOURCE_ID);
         Subscription subscription = mock(Subscription.class);
-        when(azureClient.checkEncryptionKeyExistenceOnCloud(any(String.class), any(String.class), any(String.class)))
-                .thenReturn(new KeyBundle().withAttributes((KeyAttributes) new KeyAttributes().withEnabled(Boolean.TRUE)));
         when(persistenceNotifier.notifyAllocation(any(CloudResource.class), eq(cloudContext))).thenReturn(new ResourcePersisted());
         when(subscription.subscriptionId()).thenReturn("dummySubscriptionId");
         when(azureUtils.generateDesNameByNameAndId(any(String.class), any(String.class))).thenReturn("dummyEnvName-DES-uniqueId");


### PR DESCRIPTION
CB-14873: Environment provisioning for Azure CMK environments is failing without additional access policies 

Revert "CB-13810: Validate the existence of key url provided by user for Azure cmk"
This reverts commit c90356f966cb9737ff1373aafbc2311213ec88ca.

CB-13810 added a validation to check the existence of encryption key in KeyVault. It requires "get" access policy on the credential app which is used to create azure environment. If customer's keyVault is behind firewall the CDP_CIDRs needs to be whitelisted. As customer is not ok in whitelisting public-IPs to their firewalls, this changes is being reverted.