### PR TITLE
Revert "CB-15109 - [e2e] AZURE SDX upgrade recovery test failure"

### DIFF
--- a/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
+++ b/integration-test/src/main/resources/testsuites/e2e/azure-longrunning-e2e-tests.yaml
@@ -3,8 +3,7 @@ tests:
   - name: "azure-longrunning-e2e-tests"
     classes:
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxUpgradeTests
-#      TODO: re-enable if stabilized
-#      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecoveryTests
+      - name: com.sequenceiq.it.cloudbreak.testcase.e2e.sdx.SdxRecoveryTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.environment.EnvironmentStopStartTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.distrox.DistroXUpgradeTests
       - name: com.sequenceiq.it.cloudbreak.testcase.e2e.freeipa.FreeIpaUpgradeTests


### PR DESCRIPTION
As the fix for E2E test (https://github.com/hortonworks/cloudbreak/pull/11815/commits/c972e293c9e5128882605399073c24432e66e3f3) is merged to master the test  can be re-enabled.

This reverts commit 82640202e726793bd8069fca27bc82a63dab541d.
