### PR TITLE
CB-14833 Enable Oozie HA testing in YCloud

### DIFF
--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/component/YarnLoadBalancerComponentFactoryService.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/component/YarnLoadBalancerComponentFactoryService.java
@@ -36,6 +36,8 @@ public class YarnLoadBalancerComponentFactoryService {
      */
     private final String loadBalancerImageName = "docker-sandbox.infra.cloudera.com/cloudbreak/yarn-loadbalancer:2021-03-23-12-02-09";
 
+    private final String loadBalancerImageNameForDEHA = "docker-sandbox.infra.cloudera.com/cloudbreak/yarn-loadbalancer:2021-11-24-16-14-09";
+
     private final int loadBalancerNumCPUs = 1;
 
     /**
@@ -57,6 +59,9 @@ public class YarnLoadBalancerComponentFactoryService {
     public List<YarnComponent> create(CloudStack cloudStack, List<String> gatewayIPs, String applicationName) {
         LOGGER.debug("Creating the loadbalancer components for application " + applicationName + " with gatewayIPs: " + gatewayIPs.toString() + ".");
         Artifact artifact = createLoadBalancerArtifact();
+        if (checkDeHa(cloudStack)) {
+            artifact.setId(loadBalancerImageNameForDEHA);
+        }
         Resource resource = createLoadBalancerResource();
         String launchCommand = createLoadBalancerLaunchCommand(cloudStack);
         Configuration configuration = createLoadBalancerConfiguration(gatewayIPs);
@@ -70,6 +75,10 @@ public class YarnLoadBalancerComponentFactoryService {
 
         LOGGER.debug("Finished creating the Yarn load balancer components for application " + applicationName + ".");
         return loadBalancerComponents;
+    }
+
+    public boolean checkDeHa(CloudStack cloudStack) {
+        return cloudStack.getGroups().stream().anyMatch(x -> "masterx".equalsIgnoreCase(x.getName()));
     }
 
     /**

--- a/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/launch/YarnLoadBalancerLaunchService.java
+++ b/cloud-yarn/src/main/java/com/sequenceiq/cloudbreak/cloud/yarn/loadbalancer/service/launch/YarnLoadBalancerLaunchService.java
@@ -100,9 +100,14 @@ public class YarnLoadBalancerLaunchService {
         Set<String> gatewayGroupNames = getGatewayGroupNames(cloudStack);
 
         List<String> gatewayIPs = Lists.newArrayList();
+        boolean deHaCluster = componentFactory.checkDeHa(cloudStack);
         foundContainers.forEach(container -> {
             if (gatewayGroupNames.contains(container.getComponentName())) {
-                gatewayIPs.add(container.getIp() + ":443");
+                if (deHaCluster) {
+                    gatewayIPs.add(container.getIp());
+                } else {
+                    gatewayIPs.add(container.getIp() + ":443");
+                }
             }
         });
         LOGGER.info("Successfully found the following gateway IPs for the load balancer: " + gatewayIPs + ".");


### PR DESCRIPTION
1. The new image is built and published.
2. Once it is tested in mow-dev new image will be published which will be common for DE HA and other clusters like Datalake.
3. During that time the special handling of DE HA will be removed.
4. This is the fastest way to roll out this feature without disrupting the L0 and other testing that depends on this load-balancer.

See detailed description in the commit message.