### PR TITLE
CB-15240 Always create new instances during repair and do not reuse o…

### DIFF
--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActionsTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleActionsTest.java
@@ -64,9 +64,6 @@ class StackUpscaleActionsTest {
     private InstanceMetaDataService instanceMetaDataService;
 
     @Mock
-    private StackScalabilityCondition stackScalabilityCondition;
-
-    @Mock
     private StackUpscaleService stackUpscaleService;
 
     @Mock
@@ -139,7 +136,7 @@ class StackUpscaleActionsTest {
         StackScaleTriggerEvent payload = new StackScaleTriggerEvent(SELECTOR, STACK_ID, INSTANCE_GROUP_NAME, ADJUSTMENT,
                 adjustmentTypeWithThreshold);
 
-        when(stackScalabilityCondition.isScalable(stack, INSTANCE_GROUP_NAME)).thenReturn(true);
+        when(stackUpscaleService.getInstanceCountToCreate(stack, INSTANCE_GROUP_NAME, ADJUSTMENT, false)).thenReturn(ADJUSTMENT);
 
         Stack updatedStack = mock(Stack.class);
         when(instanceMetaDataService.saveInstanceAndGetUpdatedStack(stack, 3, INSTANCE_GROUP_NAME, false, context.getHostNames(), false,
@@ -175,7 +172,7 @@ class StackUpscaleActionsTest {
         StackScaleTriggerEvent payload = new StackScaleTriggerEvent(SELECTOR, STACK_ID, INSTANCE_GROUP_NAME, ADJUSTMENT,
                 adjustmentTypeWithThreshold);
 
-        when(stackScalabilityCondition.isScalable(stack, INSTANCE_GROUP_NAME)).thenReturn(false);
+        when(stackUpscaleService.getInstanceCountToCreate(stack, INSTANCE_GROUP_NAME, ADJUSTMENT, false)).thenReturn(ADJUSTMENT_ZERO);
 
         List<CloudResourceStatus> resourceStatuses = List.of(cloudResourceStatus);
         when(resourceService.getAllAsCloudResourceStatus(STACK_ID)).thenReturn(resourceStatuses);
@@ -212,7 +209,7 @@ class StackUpscaleActionsTest {
         StackScaleTriggerEvent payload = new StackScaleTriggerEvent(SELECTOR, STACK_ID, INSTANCE_GROUP_NAME, ADJUSTMENT_ZERO,
                 adjustmentTypeWithThreshold);
 
-        when(stackScalabilityCondition.isScalable(stack, INSTANCE_GROUP_NAME)).thenReturn(true);
+        when(stackUpscaleService.getInstanceCountToCreate(stack, INSTANCE_GROUP_NAME, ADJUSTMENT_ZERO, false)).thenReturn(ADJUSTMENT_ZERO);
 
         List<CloudResourceStatus> resourceStatuses = List.of(cloudResourceStatus);
         when(resourceService.getAllAsCloudResourceStatus(STACK_ID)).thenReturn(resourceStatuses);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/stack/upscale/StackUpscaleServiceTest.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.core.flow2.stack.upscale;
+
+import static com.sequenceiq.cloudbreak.TestUtil.instanceMetaData;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.InstanceStatus;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
+
+@ExtendWith(MockitoExtension.class)
+class StackUpscaleServiceTest {
+
+    @Mock
+    private StackScalabilityCondition stackScalabilityCondition;
+
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
+
+    @InjectMocks
+    private StackUpscaleService underTest;
+
+    @Test
+    public void testGetInstanceCountToCreateWhenRepair() {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        when(stackScalabilityCondition.isScalable(any(), eq("worker"))).thenReturn(Boolean.TRUE);
+        when(instanceMetaDataService.unusedInstancesInInstanceGroupByName(eq(1L), eq("worker")))
+                .thenReturn(Set.of(instanceMetaData(1L, 1L, InstanceStatus.CREATED, false, instanceGroup),
+                        instanceMetaData(2L, 1L, InstanceStatus.CREATED, false, instanceGroup)));
+
+        int instanceCountToCreate = underTest.getInstanceCountToCreate(TestUtil.stack(), "worker", 3, true);
+        assertEquals(3, instanceCountToCreate);
+    }
+
+    @Test
+    public void testGetInstanceCountToCreateWhenUpscale() {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        when(stackScalabilityCondition.isScalable(any(), eq("worker"))).thenReturn(Boolean.TRUE);
+        when(instanceMetaDataService.unusedInstancesInInstanceGroupByName(eq(1L), eq("worker")))
+                .thenReturn(Set.of(instanceMetaData(1L, 1L, InstanceStatus.CREATED, false, instanceGroup),
+                        instanceMetaData(2L, 1L, InstanceStatus.CREATED, false, instanceGroup)));
+
+        int instanceCountToCreate = underTest.getInstanceCountToCreate(TestUtil.stack(), "worker", 3, false);
+        assertEquals(1, instanceCountToCreate);
+    }
+
+    @Test
+    public void testGetInstanceCountToCreateWhenStackIsNotScalable() {
+        InstanceGroup instanceGroup = new InstanceGroup();
+        when(stackScalabilityCondition.isScalable(any(), eq("worker"))).thenReturn(Boolean.FALSE);
+        when(instanceMetaDataService.unusedInstancesInInstanceGroupByName(eq(1L), eq("worker")))
+                .thenReturn(Set.of(instanceMetaData(1L, 1L, InstanceStatus.CREATED, false, instanceGroup),
+                        instanceMetaData(2L, 1L, InstanceStatus.CREATED, false, instanceGroup)));
+
+        int instanceCountToCreate = underTest.getInstanceCountToCreate(TestUtil.stack(), "worker", 3, false);
+        assertEquals(0, instanceCountToCreate);
+    }
+}


### PR DESCRIPTION
…ld instances left in CREATED status

After a failed repair (upscale), instances may remain in CREATED status.
The next repair will always create new instances, and will not skip important steps required in case of a repair (e.g.: set the hostname of the instance).

See detailed description in the commit message.