### PR TITLE
CB-14348: Add FreeIPA rebuild API

### DIFF
--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/FreeIpaV1Endpoint.java
@@ -38,6 +38,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.imagecatalog.ChangeImag
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.imagecatalog.GenerateImageCatalogResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.reboot.RebootInstancesRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.rebuild.RebuildRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.repair.RepairInstancesRequest;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 
@@ -118,6 +119,13 @@ public interface FreeIpaV1Endpoint {
     @ApiOperation(value = FreeIpaOperationDescriptions.REPAIR, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
             nickname = "repairV1")
     OperationStatus repairInstances(@Valid RepairInstancesRequest request) throws Exception;
+
+    @POST
+    @Path("rebuild")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = FreeIpaOperationDescriptions.REBUILD, produces = MediaType.APPLICATION_JSON, notes = FreeIpaNotes.FREEIPA_NOTES,
+            nickname = "rebuildV1")
+    DescribeFreeIpaResponse rebuild(@Valid RebuildRequest request) throws Exception;
 
     @GET
     @Path("ca.crt")

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/doc/FreeIpaOperationDescriptions.java
@@ -19,6 +19,7 @@ public final class FreeIpaOperationDescriptions {
     public static final String HEALTH = "Provides a detailed health of the FreeIPA stack";
     public static final String REBOOT = "Reboot one or more instances";
     public static final String REPAIR = "Repair one or more instances";
+    public static final String REBUILD = "Rebuild the FreeIPA cluster";
     public static final String BIND_USER_CREATE = "Creates kerberos and ldap bind users for cluster";
     public static final String UPDATE_SALT = "Update salt states on FreeIPA instances";
     public static final String CHANGE_IMAGE = "Changes the image used for creating instances";

--- a/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/rebuild/RebuildRequest.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/freeipa/api/v1/freeipa/stack/model/rebuild/RebuildRequest.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.freeipa.api.v1.freeipa.stack.model.rebuild;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sequenceiq.cloudbreak.auth.crn.CrnResourceDescriptor;
+import com.sequenceiq.cloudbreak.validation.ValidCrn;
+import com.sequenceiq.service.api.doc.ModelDescriptions;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+@ApiModel("RebuildV1Request")
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RebuildRequest {
+    @ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+    @NotEmpty
+    @ApiModelProperty(value = ModelDescriptions.ENVIRONMENT_CRN, required = true)
+    private String environmentCrn;
+
+    @NotNull
+    @ApiModelProperty(value = ModelDescriptions.REBUILD_SOURCE_CRN, required = true)
+    private String sourceCrn;
+
+    public String getEnvironmentCrn() {
+        return environmentCrn;
+    }
+
+    public void setEnvironmentCrn(String environmentCrn) {
+        this.environmentCrn = environmentCrn;
+    }
+
+    public String getSourceCrn() {
+        return sourceCrn;
+    }
+
+    public void setSourceCrn(String sourceCrn) {
+        this.sourceCrn = sourceCrn;
+    }
+
+    @Override
+    public String toString() {
+        return "RebuildRequest{" +
+                "environmentCrn='" + environmentCrn + '\'' +
+                ", sourceCrn='" + sourceCrn + '\'' +
+                '}';
+    }
+}

--- a/freeipa-api/src/main/java/com/sequenceiq/service/api/doc/ModelDescriptions.java
+++ b/freeipa-api/src/main/java/com/sequenceiq/service/api/doc/ModelDescriptions.java
@@ -23,6 +23,7 @@ public class ModelDescriptions {
     public static final String USERS = "Users to check for.";
     public static final String GROUP = "Group to check for.";
     public static final String RESULT = "Result of the check.";
+    public static final String REBUILD_SOURCE_CRN = "CRN of the FreeIPA to use as the source for rebuilding.";
 
     private ModelDescriptions() {
     }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/controller/FreeIpaV1Controller.java
@@ -48,6 +48,7 @@ import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.imagecatalog.ChangeImag
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.imagecatalog.GenerateImageCatalogResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.list.ListFreeIpaResponse;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.reboot.RebootInstancesRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.rebuild.RebuildRequest;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.repair.RepairInstancesRequest;
 import com.sequenceiq.freeipa.api.v1.operation.model.OperationStatus;
 import com.sequenceiq.freeipa.authorization.FreeIpaFiltering;
@@ -256,6 +257,13 @@ public class FreeIpaV1Controller implements FreeIpaV1Endpoint {
     public OperationStatus repairInstances(@RequestObject @Valid RepairInstancesRequest request) {
         String accountId = crnService.getCurrentAccountId();
         return repairInstancesService.repairInstances(accountId, request);
+    }
+
+    @Override
+    @CheckPermissionByRequestProperty(path = "environmentCrn", type = CRN, action = REPAIR_FREEIPA)
+    public DescribeFreeIpaResponse rebuild(@RequestObject @Valid RebuildRequest request) {
+        String accountId = crnService.getCurrentAccountId();
+        return repairInstancesService.rebuild(accountId, request);
     }
 
     @Override

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToCreateFreeIpaRequestConverter.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/converter/stack/StackToCreateFreeIpaRequestConverter.java
@@ -1,0 +1,393 @@
+package com.sequenceiq.freeipa.converter.stack;
+
+import com.google.common.collect.Maps;
+import com.sequenceiq.cloudbreak.cloud.model.StackTags;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.common.network.NetworkConstants;
+import com.sequenceiq.common.api.backup.request.BackupRequest;
+import com.sequenceiq.common.api.telemetry.model.Features;
+import com.sequenceiq.common.api.telemetry.model.Logging;
+import com.sequenceiq.common.api.telemetry.model.Telemetry;
+import com.sequenceiq.common.api.telemetry.model.WorkloadAnalytics;
+import com.sequenceiq.common.api.telemetry.request.FeaturesRequest;
+import com.sequenceiq.common.api.telemetry.request.LoggingRequest;
+import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
+import com.sequenceiq.common.api.telemetry.request.WorkloadAnalyticsRequest;
+import com.sequenceiq.freeipa.api.model.Backup;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupNetworkRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceTemplateRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.VolumeRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.aws.AwsInstanceTemplateParameters;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.aws.AwsInstanceTemplateSpotParameters;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.aws.InstanceGroupAwsNetworkParameters;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.region.PlacementRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.security.SecurityGroupRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.security.SecurityRuleRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.security.StackAuthenticationRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaRequest;
+import com.sequenceiq.freeipa.entity.FreeIpa;
+import com.sequenceiq.freeipa.entity.ImageEntity;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceGroupNetwork;
+import com.sequenceiq.freeipa.entity.Network;
+import com.sequenceiq.freeipa.entity.SecurityGroup;
+import com.sequenceiq.freeipa.entity.SecurityRule;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.StackAuthentication;
+import com.sequenceiq.freeipa.entity.Template;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+public class StackToCreateFreeIpaRequestConverter implements Converter<Stack, CreateFreeIpaRequest> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StackToCreateFreeIpaRequestConverter.class);
+
+    private static final String DELETED_NAME_DELIMETER = "_";
+
+    private static final String PATH_DELIMETER = "/";
+
+    private static final String CLUSTER_BACKUP_PREFIX = "cluster-backups";
+
+    private static final String CLUSTER_LOG_PREFIX = "cluster-logs";
+
+    private static final String CLUSTER_TYPE = "freeipa";
+
+    private static final String AZURE_BLOB_STORAGE_SCHEMA = "https";
+
+    private static final String ORIGINAL_AZURE_BLOB_STORAGE_SCHEMA = "abfs://";
+
+    @Inject
+    private FreeIpaService freeIpaService;
+
+    @Override
+    public CreateFreeIpaRequest convert(Stack source) {
+        CreateFreeIpaRequest request = new CreateFreeIpaRequest();
+
+        request.setEnvironmentCrn(source.getEnvironmentCrn());
+        request.setName(getName(source));
+        request.setPlacement(getPlacementRequest(source));
+        request.setInstanceGroups(source.getInstanceGroups().stream().map(this::getInstanceGroupRequst).collect(Collectors.toList()));
+        request.setAuthentication(getStackAuthenticationRequest(source.getStackAuthentication()));
+        request.setNetwork(getNetworkRequest(source.getNetwork()));
+        request.setImage(getImageSettingsRequest(source.getImage()));
+        request.setFreeIpa(getFreeIpaServerRequest(source));
+        request.setGatewayPort(source.getGatewayport());
+        request.setTelemetry(getTelemetry(source));
+        request.setBackup(getBackup(source));
+        request.setTags(getTags(source.getTags()));
+        request.setUseCcm(source.getUseCcm());
+        request.setTunnel(source.getTunnel());
+        request.setVariant(source.getPlatformvariant());
+
+        return request;
+    }
+
+    private String getName(Stack stack) {
+        String name = stack.getName();
+        if (stack.isDeleteCompleted()) {
+            int lastDelimeterIndex = name.lastIndexOf(DELETED_NAME_DELIMETER);
+            if (lastDelimeterIndex != -1) {
+                name = name.substring(0, lastDelimeterIndex);
+            }
+        }
+        return name;
+    }
+
+    private PlacementRequest getPlacementRequest(Stack stack) {
+        PlacementRequest placementRequest = new PlacementRequest();
+        placementRequest.setRegion(stack.getRegion());
+        placementRequest.setAvailabilityZone(stack.getAvailabilityZone());
+        return placementRequest;
+    }
+
+    private InstanceGroupRequest getInstanceGroupRequst(InstanceGroup instanceGroup) {
+        InstanceGroupRequest request = new InstanceGroupRequest();
+        request.setInstanceTemplateRequest(getInstanceTemplateRequest(instanceGroup.getTemplate()));
+        request.setName(instanceGroup.getGroupName());
+        request.setNetwork(getInststanceGroupNetworkRequest(instanceGroup.getInstanceGroupNetwork()));
+        request.setNodeCount(instanceGroup.getNodeCount());
+        request.setSecurityGroup(getSecurityGroupRequest(instanceGroup.getSecurityGroup()));
+        request.setType(instanceGroup.getInstanceGroupType());
+        return request;
+    }
+
+    private InstanceTemplateRequest getInstanceTemplateRequest(Template template) {
+        InstanceTemplateRequest request = null;
+        if (template != null) {
+            request = new InstanceTemplateRequest();
+            request.setInstanceType(template.getInstanceType());
+            Integer spotPercentage = template.getAttributes().getValue(AwsInstanceTemplate.EC2_SPOT_PERCENTAGE);
+            Double maxPrice = template.getAttributes().getValue(AwsInstanceTemplate.EC2_SPOT_MAX_PRICE);
+            if (spotPercentage != null) {
+                AwsInstanceTemplateParameters aws = new AwsInstanceTemplateParameters();
+                AwsInstanceTemplateSpotParameters spot = new AwsInstanceTemplateSpotParameters();
+                spot.setPercentage(spotPercentage);
+                if (maxPrice != null) {
+                    spot.setMaxPrice(maxPrice);
+                }
+                aws.setSpot(spot);
+                request.setAws(aws);
+            }
+            VolumeRequest volumeRequest = new VolumeRequest();
+            volumeRequest.setType(template.getVolumeType());
+            volumeRequest.setCount(template.getVolumeCount());
+            volumeRequest.setSize(template.getVolumeSize());
+            request.setAttachedVolumes(Optional.of(volumeRequest)
+                    .filter(v -> v.getCount() != null && v.getCount() > 0 &&
+                            v.getSize() != null && v.getSize() > 0)
+                            .stream().collect(Collectors.toSet()));
+        }
+        return request;
+    }
+
+    private InstanceGroupNetworkRequest getInststanceGroupNetworkRequest(InstanceGroupNetwork instanceGroupNetwork) {
+        InstanceGroupNetworkRequest request = null;
+        if (instanceGroupNetwork != null) {
+            request = new InstanceGroupNetworkRequest();
+            List<String> subnetIds = instanceGroupNetwork.getAttributes().getValue(NetworkConstants.SUBNET_IDS);
+            if (subnetIds != null) {
+                InstanceGroupAwsNetworkParameters aws = new InstanceGroupAwsNetworkParameters();
+                aws.setSubnetIds(subnetIds);
+                request.setAws(aws);
+            }
+        }
+        return request;
+    }
+
+    private SecurityGroupRequest getSecurityGroupRequest(SecurityGroup securityGroup) {
+        SecurityGroupRequest request = null;
+        if (securityGroup != null) {
+            request = new SecurityGroupRequest();
+            request.setSecurityGroupIds(securityGroup.getSecurityGroupIds());
+            request.setSecurityRules(securityGroup.getSecurityRules().stream().map(this::getSecurityRuleRequest).collect(Collectors.toList()));
+        }
+        return request;
+    }
+
+    private SecurityRuleRequest getSecurityRuleRequest(SecurityRule securityRule) {
+        SecurityRuleRequest request = null;
+        if (securityRule != null) {
+            request = new SecurityRuleRequest();
+            request.setModifiable(securityRule.isModifiable());
+            request.setPorts(Arrays.stream(securityRule.getPorts()).collect(Collectors.toList()));
+            request.setProtocol(securityRule.getProtocol());
+            request.setSubnet(securityRule.getCidr());
+        }
+        return request;
+    }
+
+    private StackAuthenticationRequest getStackAuthenticationRequest(StackAuthentication stackAuthentication) {
+        StackAuthenticationRequest request = null;
+        if (stackAuthentication != null) {
+            request = new StackAuthenticationRequest();
+            request.setLoginUserName(stackAuthentication.getLoginUserName());
+            request.setPublicKey(stackAuthentication.getPublicKey());
+            request.setPublicKeyId(stackAuthentication.getPublicKeyId());
+        }
+        return request;
+    }
+
+    private NetworkRequest getNetworkRequest(Network network) {
+        NetworkRequest request = null;
+        if (network != null) {
+            request = new NetworkRequest();
+            Optional<CloudPlatform> cloudPlatform = Optional.ofNullable(network.cloudPlatform())
+                    .or(() -> Optional.ofNullable(network.getAttributes().getValue(NetworkConstants.CLOUD_PLATFORM)))
+                    .map(CloudPlatform::valueOf);
+            request.setNetworkCidrs(network.getNetworkCidrs());
+            request.setOutboundInternetTraffic(network.getOutboundInternetTraffic());
+            if (cloudPlatform.isPresent()) {
+                request.setCloudPlatform(cloudPlatform.get());
+                switch (cloudPlatform.get()) {
+                    case AWS:
+                        request.createAws().parse(network.getAttributes().getMap());
+                        break;
+                    case AZURE:
+                        request.createAzure().parse(network.getAttributes().getMap());
+                        break;
+                    case GCP:
+                        request.createGcp().parse(network.getAttributes().getMap());
+                        break;
+                    case MOCK:
+                        request.createMock().parse(network.getAttributes().getMap());
+                        break;
+                    case YARN:
+                        request.createYarn().parse(network.getAttributes().getMap());
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+        return request;
+    }
+
+    private ImageSettingsRequest getImageSettingsRequest(ImageEntity image) {
+        ImageSettingsRequest request = null;
+        if (image != null) {
+            request = new ImageSettingsRequest();
+            request.setCatalog(image.getImageCatalogUrl());
+            request.setId(image.getImageId());
+            request.setOs(image.getOs());
+        }
+        return request;
+    }
+
+    private FreeIpaServerRequest getFreeIpaServerRequest(Stack stack) {
+        FreeIpaServerRequest request = new FreeIpaServerRequest();
+        FreeIpa freeIpa = freeIpaService.findByStack(stack);
+        if (freeIpa != null) {
+            request.setAdminGroupName(freeIpa.getAdminGroupName());
+            request.setAdminPassword(freeIpa.getAdminPassword());
+            request.setDomain(freeIpa.getDomain());
+            request.setHostname(freeIpa.getHostname());
+        }
+        return request;
+    }
+
+    private TelemetryRequest getTelemetry(Stack stack) {
+        TelemetryRequest request = null;
+        Telemetry telemetry = stack.getTelemetry();
+        if (telemetry != null) {
+            request = new TelemetryRequest();
+            request.setFluentAttributes(telemetry.getFluentAttributes());
+            request.setLogging(getLoggingRequest(telemetry.getLogging()));
+            request.setFeatures(getFeaturesRequest(telemetry.getFeatures()));
+            request.setWorkloadAnalytics(getWorkloadAnalyticsRequest(telemetry.getWorkloadAnalytics()));
+        }
+        return request;
+    }
+
+    private LoggingRequest getLoggingRequest(Logging logging) {
+        LoggingRequest request = null;
+        if (logging != null) {
+            request = new LoggingRequest();
+            request.setStorageLocation(getLoggingLocation(logging.getStorageLocation()));
+            request.setS3(logging.getS3());
+            request.setAdlsGen2(logging.getAdlsGen2());
+            request.setGcs(logging.getGcs());
+            request.setCloudwatch(logging.getCloudwatch());
+        }
+        return request;
+    }
+
+    private FeaturesRequest getFeaturesRequest(Features features) {
+        FeaturesRequest request = null;
+        if (features != null) {
+            request = new FeaturesRequest();
+            request.setClusterLogsCollection(features.getClusterLogsCollection());
+            request.setMonitoring(features.getMonitoring());
+            request.setCloudStorageLogging(features.getCloudStorageLogging());
+            request.setWorkloadAnalytics(features.getWorkloadAnalytics());
+        }
+        return request;
+    }
+
+    private WorkloadAnalyticsRequest getWorkloadAnalyticsRequest(WorkloadAnalytics workloadAnalytics) {
+        WorkloadAnalyticsRequest request = null;
+        if (workloadAnalytics != null) {
+            request = new WorkloadAnalyticsRequest();
+            request.setAttributes(workloadAnalytics.getAttributes());
+        }
+        return request;
+    }
+
+    private BackupRequest getBackup(Stack stack) {
+        BackupRequest request = null;
+        Backup backup = stack.getBackup();
+        if (backup != null) {
+            request = new BackupRequest();
+            request.setStorageLocation(getBackupLocation(stack, backup.getStorageLocation()));
+            request.setS3(backup.getS3());
+            request.setAdlsGen2(backup.getAdlsGen2());
+            request.setGcs(backup.getGcs());
+            // NOT STORED request.setCloudwatch();
+        }
+        return request;
+    }
+
+    private Map<String, String> getTags(Json tags) {
+        Map<String, String> userDefined = Maps.newHashMap();
+        if (tags != null) {
+            try {
+                StackTags stackTag = tags.get(StackTags.class);
+                userDefined.putAll(stackTag.getUserDefinedTags());
+            } catch (IOException e) {
+                LOGGER.info("Exception during converting user defined tags.", e);
+            }
+        }
+        return userDefined;
+    }
+
+    private String getLoggingLocation(String location) {
+        return getLocation(location, CLUSTER_LOG_PREFIX);
+    }
+
+    String getBackupLocation(Stack stack, String location) {
+        String originalLocation = getLocation(location, CLUSTER_BACKUP_PREFIX);
+
+        // During provisioning, the URL for Azure is converted from abfs/abfss to https, this conversion needs to be reversed.
+        // Example: convert https://storage1.dfs.core.windows.net/logs-fs into abfs://logs-fs@storage1.dfs.core.windows.net
+        try {
+            if (CloudPlatform.AZURE.equalsIgnoreCase(stack.getCloudPlatform()) && originalLocation != null) {
+                URI uri = new URI(originalLocation);
+                if (AZURE_BLOB_STORAGE_SCHEMA.equals(uri.getScheme())) {
+                    String uriPath = uri.getPath();
+                    int firstSeparator = uriPath.indexOf(PATH_DELIMETER);
+                    if (firstSeparator != -1) {
+                        int secondSeparator = uriPath.indexOf(PATH_DELIMETER, firstSeparator + 1);
+                        String bucketName;
+                        String bucketPath = "";
+                        if (secondSeparator == -1) {
+                            bucketName = uriPath.substring(firstSeparator + 1);
+                        } else {
+                            bucketName = uriPath.substring(firstSeparator + 1, secondSeparator);
+                            bucketPath = uriPath.substring(secondSeparator);
+                        }
+                        originalLocation = String.format("%s%s@%s%s", ORIGINAL_AZURE_BLOB_STORAGE_SCHEMA, bucketName, uri.getHost(), bucketPath);
+                    }
+                }
+            }
+        } catch (URISyntaxException e) {
+            LOGGER.error("URI syntax error");
+        }
+        return originalLocation;
+    }
+
+    /**
+     * The storage location has the following appended /PREFIX/CLUSTER_TYPE/CLUSTER_IDENTIFIER appended. This must be
+     * removed in order to get the original path.
+     */
+    private String getLocation(String location, String prefix) {
+        if (location != null) {
+            String searchString = Paths.get(prefix, CLUSTER_TYPE).toString();
+            int index = location.lastIndexOf(searchString) - PATH_DELIMETER.length();
+            if (index > -1) {
+                location = location.substring(0, index);
+            }
+        }
+        return location;
+    }
+}

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/events/FreeIpaCustomCrnOrNameProvider.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/events/FreeIpaCustomCrnOrNameProvider.java
@@ -17,6 +17,6 @@ public class FreeIpaCustomCrnOrNameProvider extends AbstractCustomCrnOrNameProvi
 
     @Override
     protected List<? extends AccountAwareResource> getResource(String environmentCrn, String accountId) {
-        return List.of(stackService.getByEnvironmentCrnAndAccountIdEvenIfTerminated(environmentCrn, accountId));
+        return stackService.getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(environmentCrn, accountId);
     }
 }

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/ChildEnvironmentRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/ChildEnvironmentRepository.java
@@ -15,8 +15,21 @@ import com.sequenceiq.freeipa.entity.Stack;
 @Transactional(Transactional.TxType.REQUIRED)
 public interface ChildEnvironmentRepository extends CrudRepository<ChildEnvironment, Long> {
 
-    @Query("SELECT c.stack FROM ChildEnvironment c WHERE c.environmentCrn = :childEnvironmentCrn AND c.stack.accountId = :accountId")
+    @Query("SELECT c.stack FROM ChildEnvironment c WHERE c.environmentCrn = :childEnvironmentCrn AND c.stack.accountId = :accountId AND c.stack.terminated = -1")
     Optional<Stack> findParentStackByChildEnvironmentCrn(@Param("childEnvironmentCrn") String childEnvironmentCrn, @Param("accountId") String accountId);
+
+    @Query("SELECT c.stack FROM ChildEnvironment c LEFT JOIN FETCH c.stack.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData "
+            + "WHERE c.environmentCrn = :childEnvironmentCrn AND c.stack.accountId = :accountId")
+    List<Stack> findMultipleParentByEnvirnmentCrnWthListsEvenIfTerminated(
+            @Param("childEnvironmentCrn") String childEnvironmentCrn,
+            @Param("accountId") String accountId);
+
+    @Query("SELECT c.stack FROM ChildEnvironment c LEFT JOIN FETCH c.stack.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData "
+            + "WHERE c.environmentCrn = :childEnvironmentCrn AND c.stack.accountId = :accountId AND c.stack.resourceCrn = :resourceCrn")
+    Optional<Stack> findParentByEnvirnmentCrnAndCrnWthListsEvenIfTerminated(
+            @Param("childEnvironmentCrn") String childEnvironmentCrn,
+            @Param("accountId") String accountId,
+            @Param("resourceCrn") String resourceCrn);
 
     @Query("SELECT c FROM ChildEnvironment c "
             + "WHERE c.environmentCrn = :childEnvironmentCrn AND c.stack.environmentCrn = :parentEnvironmentCrn AND c.stack.accountId = :accountId")

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/repository/StackRepository.java
@@ -32,6 +32,15 @@ public interface StackRepository extends AccountAwareResourceRepository<Stack, L
     @Query("SELECT s FROM Stack s LEFT JOIN FETCH s.instanceGroups ig LEFT JOIN FETCH ig.instanceMetaData WHERE s.id= :id ")
     Optional<Stack> findOneWithLists(@Param("id") Long id);
 
+    @Query("SELECT s FROM Stack s "
+            + "LEFT JOIN FETCH s.instanceGroups ig "
+            + "LEFT JOIN FETCH ig.instanceMetaData "
+            + "WHERE s.accountId = :accountId AND s.environmentCrn = :environmentCrn AND s.resourceCrn = :resourceCrn ")
+    Optional<Stack> findByAccountIdEnvironmentCrnAndCrnWithListsEvenIfTerminated(
+            @Param("environmentCrn") String environmentCrn,
+            @Param("accountId") String accountId,
+            @Param("resourceCrn") String resourceCrn);
+
     @Query("SELECT s FROM Stack s WHERE s.accountId = :accountId AND s.environmentCrn = :environmentCrn AND s.name = :name AND s.terminated = -1")
     Optional<Stack> findByAccountIdEnvironmentCrnAndName(
             @Param("accountId") String accountId,
@@ -48,7 +57,7 @@ public interface StackRepository extends AccountAwareResourceRepository<Stack, L
     Optional<Stack> findByEnvironmentCrnAndAccountId(@Param("environmentCrn") String environmentCrn, @Param("accountId") String accountId);
 
     @Query("SELECT s FROM Stack s WHERE s.accountId = :accountId AND s.environmentCrn = :environmentCrn")
-    Optional<Stack> findByEnvironmentCrnAndAccountIdEvenIfTerminated(@Param("environmentCrn") String environmentCrn, @Param("accountId") String accountId);
+    List<Stack> findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(@Param("environmentCrn") String environmentCrn, @Param("accountId") String accountId);
 
     @Query("SELECT s FROM Stack s LEFT JOIN ChildEnvironment c ON c.stack.id = s.id WHERE s.accountId = :accountId "
             + "AND (s.environmentCrn IN :environmentCrns OR c.environmentCrn IN :environmentCrns) AND s.terminated = -1")

--- a/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ChildEnvironmentService.java
+++ b/freeipa/src/main/java/com/sequenceiq/freeipa/service/stack/ChildEnvironmentService.java
@@ -36,6 +36,14 @@ public class ChildEnvironmentService {
         return repository.findParentStackByChildEnvironmentCrn(environmentCrn, accountId);
     }
 
+    public List<Stack> findMultipleParentStackByChildEnvironmentCrnWithListsEvenIfTerminated(String environmentCrn, String accountId) {
+        return repository.findMultipleParentByEnvirnmentCrnWthListsEvenIfTerminated(environmentCrn, accountId);
+    }
+
+    public Optional<Stack> findParentStackByChildEnvironmentCrnAndCrnWithListsEvenIfTerminated(String environmentCrn, String accountId, String crn) {
+        return repository.findParentByEnvirnmentCrnAndCrnWthListsEvenIfTerminated(environmentCrn, accountId, crn);
+    }
+
     public List<ChildEnvironment> findChildEnvironments(Stack stack, String accountId) {
         return repository.findByStackId(stack.getId(), accountId);
     }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/controller/FreeIpaV1ControllerTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.rebuild.RebuildRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -236,5 +237,14 @@ class FreeIpaV1ControllerTest {
         underTest.generateImageCatalog(ENVIRONMENT_CRN);
 
         verify(imageCatalogGeneratorService).generate(ENVIRONMENT_CRN, ACCOUNT_ID);
+    }
+
+    @Test
+    void rebuild() {
+        when(crnService.getCurrentAccountId()).thenReturn(ACCOUNT_ID);
+        RebuildRequest request = new RebuildRequest();
+
+        underTest.rebuild(request);
+        verify(repairInstancesService, times(1)).rebuild(crnService.getCurrentAccountId(), request);
     }
 }

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToCreateFreeIpaRequestConverterTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/converter/stack/StackToCreateFreeIpaRequestConverterTest.java
@@ -1,0 +1,398 @@
+package com.sequenceiq.freeipa.converter.stack;
+
+import com.sequenceiq.cloudbreak.cloud.model.StackTags;
+import com.sequenceiq.cloudbreak.cloud.model.instance.AwsInstanceTemplate;
+import com.sequenceiq.cloudbreak.common.json.Json;
+import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.cloudbreak.common.network.NetworkConstants;
+import com.sequenceiq.common.api.backup.request.BackupRequest;
+import com.sequenceiq.common.api.cloudstorage.old.AdlsGen2CloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.GcsCloudStorageV1Parameters;
+import com.sequenceiq.common.api.cloudstorage.old.S3CloudStorageV1Parameters;
+import com.sequenceiq.common.api.telemetry.model.CloudwatchParams;
+import com.sequenceiq.common.api.telemetry.model.Features;
+import com.sequenceiq.common.api.telemetry.model.Logging;
+import com.sequenceiq.common.api.telemetry.model.Telemetry;
+import com.sequenceiq.common.api.telemetry.model.WorkloadAnalytics;
+import com.sequenceiq.common.api.telemetry.request.TelemetryRequest;
+import com.sequenceiq.common.api.type.FeatureSetting;
+import com.sequenceiq.common.api.type.OutboundInternetTraffic;
+import com.sequenceiq.common.api.type.Tunnel;
+import com.sequenceiq.freeipa.api.model.Backup;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.DetailedStackStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.image.ImageSettingsRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceGroupType;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.InstanceTemplateRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.instance.VolumeRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.network.NetworkRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.region.PlacementRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.security.SecurityRuleRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.security.StackAuthenticationRequest;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.create.CreateFreeIpaRequest;
+import com.sequenceiq.freeipa.entity.FreeIpa;
+import com.sequenceiq.freeipa.entity.ImageEntity;
+import com.sequenceiq.freeipa.entity.InstanceGroup;
+import com.sequenceiq.freeipa.entity.InstanceGroupNetwork;
+import com.sequenceiq.freeipa.entity.Network;
+import com.sequenceiq.freeipa.entity.SecurityGroup;
+import com.sequenceiq.freeipa.entity.SecurityRule;
+import com.sequenceiq.freeipa.entity.Stack;
+import com.sequenceiq.freeipa.entity.StackAuthentication;
+import com.sequenceiq.freeipa.entity.StackStatus;
+import com.sequenceiq.freeipa.entity.Template;
+import com.sequenceiq.freeipa.service.freeipa.FreeIpaService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class StackToCreateFreeIpaRequestConverterTest {
+
+    private static final String ENVIRONMENT_CRN = "test:environment:crn";
+
+    private static final String NAME = "freeipa-name";
+
+    private static final String REGION = "region";
+
+    private static final String AVAILIBILTYY_ZONE = "az";
+
+    private static final String INSTANCE_GROUP_NAME = "ig.name";
+
+    private static final String INSTANCE_TYPE = "instance.type";
+
+    private static final String VOLUME_TYPE = "volume.type";
+
+    private static final String PORT = "8080";
+
+    private static final String PROTOCOL = "tcp";
+
+    private static final String CIDR = "0.0.0.0/0";
+
+    private static final String LOGIN_NAME = "login";
+
+    private static final String PUBLIC_KEY = "public.key";
+
+    private static final String PUBLIC_KEY_ID = "public.key.id";
+
+    private static final String CLOUD_PLATFORM = "AWS";
+
+    private static final String VPC_ID = "vpc.id";
+
+    private static final String SUBNET_ID = "subnet.id";
+
+    private static final String IMAGE_CATALOG_URL = "image.catalog.url";
+
+    private static final String IMAGE_ID = "image.id";
+
+    private static final String IMAGE_OS = "image.os";
+
+    private static final String ADMIN_GROUP_NAME = "admin";
+
+    private static final String ADMIN_PASSWORD = "password";
+
+    private static final String DOMAIN = "cloudera.site";
+
+    private static final String HOSTNAME = "ipaserver";
+
+    private static final String STORAGE_LOCATION =
+            "s3a://logs-bucket/subdir/cluster-logs/freeipa/cluster-name-freeipa_16A5F400-405C-4AE8-A540-6942D9CF844C";
+
+    private static final String STORAGE_LOCATION_REQUEST = "s3a://logs-bucket/subdir";
+
+    private static final String BACKUP_STORAGE_LOCATION =
+            "s3a://backup-bucket/subdir/cluster-backups/freeipa/cluster-name-freeipa_16A5F400-405C-4AE8-A540-6942D9CF844C";
+
+    private static final String BACKUP_STORAGE_LOCATION_REQUEST = "s3a://backup-bucket/subdir";
+
+    private static final List<String> SUBNET_IDS = List.of("subnet-1");
+
+    private static final Set<String> SECURITY_GROUP_IDS = Set.of("security.group.1");
+
+    private static final Map<String, String> USER_DEFINED_TAGS = Map.of("user.tags", "value1");
+
+    private static final Map<String, String> APPLICATION_TAGS = Map.of("application.tags", "value2");
+
+    private static final Map<String, String> DEFAULT_TAGS = Map.of("default.tags", "value3");
+
+    private static final Long TERMINATION_TIME = 1638023474891L;
+
+    private static final Integer VOLUMNE_COUNT = 1;
+
+    private static final Integer VOLUMNE_SIZE = 2;
+
+    private static final Integer NODE_COUNT = 3;
+
+    private static final Integer GATEWAY_PORT = 4;
+
+    private static final Integer EC2_SPOT_PERCENTAGE = 0;
+
+    private static final Double EC2_SPOT_MAX_PRICE = 0.0d;
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    @InjectMocks
+    private StackToCreateFreeIpaRequestConverter underTest;
+
+    @Mock
+    private FreeIpaService freeIpaService;
+
+    @Test
+    void testConvert() {
+        // Initialize
+        Stack stack = new Stack();
+        stack.setEnvironmentCrn(ENVIRONMENT_CRN);
+        stack.setName(NAME + "_" + TERMINATION_TIME);
+        stack.setRegion(REGION);
+        stack.setAvailabilityZone(AVAILIBILTYY_ZONE);
+        stack.setGatewayport(GATEWAY_PORT);
+        stack.setUseCcm(true);
+        stack.setTunnel(Tunnel.CCMV2);
+        stack.setPlatformvariant(CLOUD_PLATFORM);
+
+        StackStatus stackStatus = new StackStatus();
+        stackStatus.setStack(stack);
+        stackStatus.setDetailedStackStatus(DetailedStackStatus.DELETE_COMPLETED);
+        stackStatus.setStatus(Status.DELETE_COMPLETED);
+        stack.setStackStatus(stackStatus);
+
+        InstanceGroup ig = new InstanceGroup();
+        ig.setGroupName(INSTANCE_GROUP_NAME);
+        Template template = new Template();
+        template.setInstanceType(INSTANCE_TYPE);
+        template.setAttributes(new Json(Map.of(
+                AwsInstanceTemplate.EC2_SPOT_PERCENTAGE, EC2_SPOT_PERCENTAGE,
+                AwsInstanceTemplate.EC2_SPOT_MAX_PRICE, EC2_SPOT_MAX_PRICE)));
+        template.setVolumeType(VOLUME_TYPE);
+        template.setVolumeCount(VOLUMNE_COUNT);
+        template.setVolumeSize(VOLUMNE_SIZE);
+        ig.setTemplate(template);
+        InstanceGroupNetwork igNetwork = new InstanceGroupNetwork();
+        igNetwork.setAttributes(new Json(Map.of(
+                NetworkConstants.SUBNET_IDS, SUBNET_IDS
+        )));
+        ig.setInstanceGroupNetwork(igNetwork);
+        ig.setNodeCount(NODE_COUNT);
+        SecurityGroup sg = new SecurityGroup();
+        sg.setSecurityGroupIds(SECURITY_GROUP_IDS);
+        SecurityRule sr = new SecurityRule();
+        sr.setModifiable(true);
+        sr.setPorts(PORT);
+        sr.setProtocol(PROTOCOL);
+        sr.setCidr(CIDR);
+        sg.setSecurityRules(Set.of(sr));
+        ig.setSecurityGroup(sg);
+        ig.setInstanceGroupType(InstanceGroupType.MASTER);
+        stack.setInstanceGroups(Set.of(ig));
+
+        StackAuthentication stackAuthentication = new StackAuthentication();
+        stackAuthentication.setLoginUserName(LOGIN_NAME);
+        stackAuthentication.setPublicKey(PUBLIC_KEY);
+        stackAuthentication.setPublicKeyId(PUBLIC_KEY_ID);
+        stack.setStackAuthentication(stackAuthentication);
+
+        Network network = new Network();
+        network.setNetworkCidrs(List.of(CIDR));
+        network.setOutboundInternetTraffic(OutboundInternetTraffic.ENABLED);
+        network.setAttributes(new Json(Map.of(
+                "vpcId", VPC_ID,
+                "subnetId", SUBNET_ID
+        )));
+        network.setCloudPlatform(CLOUD_PLATFORM);
+        stack.setNetwork(network);
+
+        ImageEntity image = new ImageEntity();
+        image.setImageCatalogUrl(IMAGE_CATALOG_URL);
+        image.setImageId(IMAGE_ID);
+        image.setOs(IMAGE_OS);
+        stack.setImage(image);
+
+        FreeIpa freeIpa = new FreeIpa();
+        freeIpa.setAdminGroupName(ADMIN_GROUP_NAME);
+        freeIpa.setAdminPassword(ADMIN_PASSWORD);
+        freeIpa.setDomain(DOMAIN);
+        freeIpa.setHostname(HOSTNAME);
+
+        Telemetry telemetry = new Telemetry();
+        Map<String, Object> fluentAttributes = Map.of("fluent", "attributes");
+        telemetry.setFluentAttributes(fluentAttributes);
+        Logging logging = new Logging();
+        logging.setStorageLocation(STORAGE_LOCATION);
+        S3CloudStorageV1Parameters s3Storage = new S3CloudStorageV1Parameters();
+        logging.setS3(s3Storage);
+        AdlsGen2CloudStorageV1Parameters adlsStorage = new AdlsGen2CloudStorageV1Parameters();
+        logging.setAdlsGen2(adlsStorage);
+        GcsCloudStorageV1Parameters gcsStorage = new GcsCloudStorageV1Parameters();
+        logging.setGcs(gcsStorage);
+        CloudwatchParams cloudwatchParamsStorage = new CloudwatchParams();
+        logging.setCloudwatch(cloudwatchParamsStorage);
+        telemetry.setLogging(logging);
+        Features features = new Features();
+        features.setClusterLogsCollection(new FeatureSetting());
+        features.setMonitoring(new FeatureSetting());
+        features.setCloudStorageLogging(new FeatureSetting());
+        features.setWorkloadAnalytics(new FeatureSetting());
+        telemetry.setFeatures(features);
+        WorkloadAnalytics workloadAnalytics = new WorkloadAnalytics();
+        workloadAnalytics.setAttributes(Map.of());
+        telemetry.setWorkloadAnalytics(workloadAnalytics);
+        stack.setTelemetry(telemetry);
+
+        Backup backup = new Backup();
+        backup.setStorageLocation(BACKUP_STORAGE_LOCATION);
+        S3CloudStorageV1Parameters s3BackupLocation = new S3CloudStorageV1Parameters();
+        backup.setS3(s3BackupLocation);
+        AdlsGen2CloudStorageV1Parameters adlsBackupLocation = new AdlsGen2CloudStorageV1Parameters();
+        backup.setAdlsGen2(adlsBackupLocation);
+        GcsCloudStorageV1Parameters gcsBackupLocation = new GcsCloudStorageV1Parameters();
+        backup.setGcs(gcsBackupLocation);
+        stack.setBackup(backup);
+
+        StackTags tags = new StackTags(USER_DEFINED_TAGS, APPLICATION_TAGS, DEFAULT_TAGS);
+        stack.setTags(new Json(tags));
+
+
+        when(freeIpaService.findByStack(stack)).thenReturn(freeIpa);
+
+
+        // Convert
+        CreateFreeIpaRequest request = underTest.convert(stack);
+
+
+        // Validate
+        assertNotNull(request);
+        assertEquals(ENVIRONMENT_CRN, request.getEnvironmentCrn());
+        assertEquals(NAME, request.getName());
+        assertEquals(GATEWAY_PORT, request.getGatewayPort());
+        assertTrue(request.getUseCcm());
+        assertEquals(Tunnel.CCMV2, request.getTunnel());
+        assertEquals(CLOUD_PLATFORM, request.getVariant());
+
+        PlacementRequest placementRequest = request.getPlacement();
+        assertNotNull(placementRequest);
+        assertEquals(REGION, placementRequest.getRegion());
+        assertEquals(AVAILIBILTYY_ZONE, placementRequest.getAvailabilityZone());
+
+        assertEquals(1, request.getInstanceGroups().size());
+        InstanceGroupRequest igRequest = request.getInstanceGroups().get(0);
+        assertEquals(INSTANCE_GROUP_NAME, igRequest.getName());
+        InstanceTemplateRequest templateRequest = igRequest.getInstanceTemplate();
+        assertNotNull(templateRequest);
+        assertEquals(INSTANCE_TYPE, templateRequest.getInstanceType());
+        assertNotNull(templateRequest.getAws());
+        assertNotNull(templateRequest.getAws().getSpot());
+        assertEquals(EC2_SPOT_PERCENTAGE, templateRequest.getAws().getSpot().getPercentage());
+        assertEquals(EC2_SPOT_MAX_PRICE, templateRequest.getAws().getSpot().getMaxPrice());
+        List<VolumeRequest> volumeRequests = templateRequest.getAttachedVolumes().stream().collect(Collectors.toList());
+        assertEquals(1, volumeRequests.size());
+        assertEquals(VOLUME_TYPE, volumeRequests.get(0).getType());
+        assertEquals(VOLUMNE_COUNT, volumeRequests.get(0).getCount());
+        assertEquals(VOLUMNE_SIZE, volumeRequests.get(0).getSize());
+        assertNotNull(igRequest.getNetwork());
+        assertNotNull(igRequest.getNetwork().getAws());
+        assertEquals(SUBNET_IDS, igRequest.getNetwork().getAws().getSubnetIds());
+        assertEquals(NODE_COUNT, ig.getNodeCount());
+        assertNotNull(igRequest.getSecurityGroup());
+        assertEquals(SECURITY_GROUP_IDS, igRequest.getSecurityGroup().getSecurityGroupIds());
+        List<SecurityRuleRequest> srRequst = igRequest.getSecurityGroup().getSecurityRules();
+        assertEquals(1, srRequst.size());
+        assertTrue(srRequst.get(0).isModifiable());
+        assertEquals(List.of(PORT), srRequst.get(0).getPorts());
+        assertEquals(PROTOCOL, srRequst.get(0).getProtocol());
+        assertEquals(CIDR, srRequst.get(0).getSubnet());
+        assertEquals(InstanceGroupType.MASTER, ig.getInstanceGroupType());
+
+        StackAuthenticationRequest stackAuthenticationRequest = request.getAuthentication();
+        assertNotNull(stackAuthenticationRequest);
+        assertEquals(LOGIN_NAME, stackAuthenticationRequest.getLoginUserName());
+        assertEquals(PUBLIC_KEY, stackAuthenticationRequest.getPublicKey());
+        assertEquals(PUBLIC_KEY_ID, stackAuthenticationRequest.getPublicKeyId());
+
+        NetworkRequest networkRequest = request.getNetwork();
+        assertNotNull(networkRequest);
+        assertEquals(CloudPlatform.AWS, networkRequest.getCloudPlatform());
+        assertEquals(List.of(CIDR), networkRequest.getNetworkCidrs());
+        assertEquals(OutboundInternetTraffic.ENABLED, networkRequest.getOutboundInternetTraffic());
+        assertNotNull(networkRequest.getAws());
+        assertNull(networkRequest.getAzure());
+        assertNull(networkRequest.getGcp());
+        assertNull(networkRequest.getMock());
+        assertNull(networkRequest.getYarn());
+        assertEquals(CloudPlatform.AWS, networkRequest.getAws().getCloudPlatform());
+        assertEquals(VPC_ID, networkRequest.getAws().getVpcId());
+        assertEquals(SUBNET_ID, networkRequest.getAws().getSubnetId());
+
+        ImageSettingsRequest imageSettingsRequest = request.getImage();
+        assertNotNull(imageSettingsRequest);
+        assertEquals(IMAGE_ID, imageSettingsRequest.getId());
+        assertEquals(IMAGE_CATALOG_URL, imageSettingsRequest.getCatalog());
+        assertEquals(IMAGE_OS, imageSettingsRequest.getOs());
+
+        FreeIpaServerRequest freeIpaServerRequest = request.getFreeIpa();
+        assertNotNull(freeIpaServerRequest);
+        assertEquals(ADMIN_GROUP_NAME, freeIpaServerRequest.getAdminGroupName());
+        assertEquals(ADMIN_PASSWORD, freeIpaServerRequest.getAdminPassword());
+        assertEquals(DOMAIN, freeIpaServerRequest.getDomain());
+        assertEquals(HOSTNAME, freeIpaServerRequest.getHostname());
+
+        TelemetryRequest telemetryRequest = request.getTelemetry();
+        assertNotNull(telemetryRequest);
+        assertEquals(fluentAttributes, telemetryRequest.getFluentAttributes());
+        assertNotNull(telemetryRequest.getLogging());
+        assertEquals(STORAGE_LOCATION_REQUEST, telemetryRequest.getLogging().getStorageLocation());
+        assertEquals(s3Storage, telemetryRequest.getLogging().getS3());
+        assertEquals(adlsStorage, telemetryRequest.getLogging().getAdlsGen2());
+        assertEquals(gcsStorage, telemetryRequest.getLogging().getGcs());
+        assertNotNull(telemetryRequest.getLogging().getCloudwatch());
+        assertNotNull(telemetryRequest.getFeatures());
+        assertNotNull(telemetryRequest.getFeatures().getClusterLogsCollection());
+        assertNotNull(telemetryRequest.getFeatures().getMonitoring());
+        assertNotNull(telemetryRequest.getFeatures().getCloudStorageLogging());
+        assertNotNull(telemetryRequest.getFeatures().getWorkloadAnalytics());
+        assertNotNull(telemetryRequest.getWorkloadAnalytics());
+        assertEquals(Map.of(), telemetryRequest.getWorkloadAnalytics().getAttributes());
+
+        BackupRequest backupRequest = request.getBackup();
+        assertNotNull(backupRequest);
+        assertEquals(BACKUP_STORAGE_LOCATION_REQUEST, backupRequest.getStorageLocation());
+        assertEquals(s3BackupLocation, backupRequest.getS3());
+        assertEquals(adlsBackupLocation, backupRequest.getAdlsGen2());
+        assertEquals(gcsBackupLocation, backupRequest.getGcs());
+
+        assertEquals(USER_DEFINED_TAGS, request.getTags());
+    }
+
+    @Test
+    void getBackupLocationTest() {
+        Stack stack = new Stack();
+        stack.setCloudPlatform("AZURE");
+        assertEquals("abfs://logs-fs@storage1.dfs.core.windows.net",
+                underTest.getBackupLocation(stack, "https://storage1.dfs.core.windows.net/logs-fs"));
+        assertEquals("abfs://logs-fs@storage1.dfs.core.windows.net/foo/bar",
+                underTest.getBackupLocation(stack, "https://storage1.dfs.core.windows.net/logs-fs/foo/bar"));
+        assertEquals("abfs://logs-fs@storage1.dfs.core.windows.net",
+                underTest.getBackupLocation(stack, "abfs://logs-fs@storage1.dfs.core.windows.net"));
+        assertEquals("abfs://logs-fs@storage1.dfs.core.windows.net/foo/bar",
+                underTest.getBackupLocation(stack, "abfs://logs-fs@storage1.dfs.core.windows.net/foo/bar"));
+        assertEquals("abfss://logs-fs@storage1.dfs.core.windows.net",
+                underTest.getBackupLocation(stack, "abfss://logs-fs@storage1.dfs.core.windows.net"));
+        assertEquals("abfss://logs-fs@storage1.dfs.core.windows.net/foo/bar",
+                underTest.getBackupLocation(stack, "abfss://logs-fs@storage1.dfs.core.windows.net/foo/bar"));
+    }
+}

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/events/FreeIpaCustomCrnOrNameProviderTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/events/FreeIpaCustomCrnOrNameProviderTest.java
@@ -4,6 +4,7 @@ import static com.sequenceiq.cloudbreak.structuredevent.rest.urlparser.CDPRestUr
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
@@ -70,7 +71,7 @@ public class FreeIpaCustomCrnOrNameProviderTest {
         stack.setResourceCrn("stackCrn");
         stack.setId(2922L);
 
-        when(stackService.getByEnvironmentCrnAndAccountIdEvenIfTerminated("env-crn", "acc")).thenReturn(stack);
+        when(stackService.getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated("env-crn", "acc")).thenReturn(List.of(stack));
 
         Map<String, String> restParams = new HashMap<>();
         Map<String, String> expected = ThreadBasedUserCrnProvider.doAs(userCrn, () -> underTest.provide(restCallDetails, null, restParams, "name", "crn"));

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/ChildEnvironmentServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/ChildEnvironmentServiceTest.java
@@ -2,9 +2,11 @@ package com.sequenceiq.freeipa.service.stack;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
@@ -28,6 +30,8 @@ class ChildEnvironmentServiceTest {
     private static final String ENVIRONMENT_CRN = "test:environment:crn";
 
     private static final String CHILD_ENVIRONMENT_CRN = "test:childenv:crn";
+
+    private static final String FREEIPA_CRN = "test:freeipa:crn";
 
     private static final String ACCOUNT_ID = "account:id";
 
@@ -56,6 +60,26 @@ class ChildEnvironmentServiceTest {
         boolean result = underTest.isChildEnvironment(ENVIRONMENT_CRN, ACCOUNT_ID);
 
         assertTrue(result);
+    }
+
+    @Test
+    void findMultipleParentStackByChildEnvironmentCrnWithListsEvenIfTerminated() {
+        List<Stack> stackList = List.of(new Stack());
+        when(repository.findMultipleParentByEnvirnmentCrnWthListsEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(stackList);
+
+        List<Stack> result = underTest.findMultipleParentStackByChildEnvironmentCrnWithListsEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID);
+
+        assertEquals(stackList, result);
+    }
+
+    @Test
+    void findParentStackByChildEnvironmentCrnAndCrnWithListsEvenIfTerminated() {
+        Optional<Stack> stack = Optional.of(new Stack());
+        when(repository.findParentByEnvirnmentCrnAndCrnWthListsEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID, FREEIPA_CRN)).thenReturn(stack);
+
+        Optional<Stack> result = underTest.findParentStackByChildEnvironmentCrnAndCrnWithListsEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID, FREEIPA_CRN);
+
+        assertEquals(stack, result);
     }
 
     @Test

--- a/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/StackServiceTest.java
+++ b/freeipa/src/test/java/com/sequenceiq/freeipa/service/stack/StackServiceTest.java
@@ -31,6 +31,8 @@ class StackServiceTest {
 
     private static final String CHILD_ENVIRONMENT_CRN = "test:environment:child-crn";
 
+    private static final String FREEIPA_CRN = "test:freeipa:crn";
+
     private static final Long STACK_ID = 1L;
 
     private static final String STACK_NAME = "stack-name";
@@ -172,6 +174,39 @@ class StackServiceTest {
     void findAllWithDetailedStackStatuses() {
         when(stackRepository.findAllWithDetailedStackStatuses(Mockito.eq(List.of(DetailedStackStatus.AVAILABLE)))).thenReturn(List.of(stack));
         List<Stack> results = underTest.findAllWithDetailedStackStatuses(List.of(DetailedStackStatus.AVAILABLE));
+
+        assertEquals(List.of(stack), results);
+    }
+
+    @Test
+    void findByCrnAndAccountIdWithListsEvenIfTerminated() {
+        when(stackRepository.findByAccountIdEnvironmentCrnAndCrnWithListsEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID, FREEIPA_CRN))
+                .thenReturn(Optional.of(stack));
+        Optional<Stack> results = underTest.findByCrnAndAccountIdWithListsEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID, FREEIPA_CRN);
+
+        assertEquals(Optional.of(stack), results);
+    }
+
+    @Test
+    void getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated() {
+        when(stackRepository.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(List.of(stack));
+        List<Stack> results = underTest.getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID);
+
+        assertEquals(List.of(stack), results);
+    }
+
+    @Test
+    void getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminatedThrowsWhenCrnDoesNotExist() {
+        when(stackRepository.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(List.of());
+        NotFoundException notFoundException =
+                assertThrows(NotFoundException.class, () -> underTest.getMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID));
+        assertEquals("FreeIPA stack by environment [" + ENVIRONMENT_CRN + "] not found", notFoundException.getMessage());
+    }
+
+    @Test
+    void findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated() {
+        when(stackRepository.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID)).thenReturn(List.of(stack));
+        List<Stack> results = underTest.findMultipleByEnvironmentCrnAndAccountIdEvenIfTerminated(ENVIRONMENT_CRN, ACCOUNT_ID);
 
         assertEquals(List.of(stack), results);
     }


### PR DESCRIPTION
Create an API in the FreeIPA management service for rebuilding a
FreeIPA cluster. Rebuilding creates a new cluster in an environment
with the same configuration of the original source FreeIPA cluster so
that a backup can be restored but this does not restore the backed up
data.

Several internal APIs and database repositories now support a list of
FreeIPA clusters rather than a single cluster. This allows the old
cluster information to be used for the restoration. During cluster
deletion, some cluster information that was previously deleted from
the database is now kept. This is needed in order to fully reconstruct
the original FreeIPA creation request.

This was tested in a local deployment of cloudbreak on 2.49 and 2.50
in Azure and AWS. Unit tests were also added.

See detailed description in the commit message.