### PR TITLE
CB-15260: DES not deleted on Azure cloud if encryption key is wrong

### DIFF
--- a/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
+++ b/cloud-azure/src/main/java/com/sequenceiq/cloudbreak/cloud/azure/client/AzureClient.java
@@ -57,6 +57,7 @@ import com.microsoft.azure.management.graphrbac.RoleAssignment;
 import com.microsoft.azure.management.graphrbac.RoleAssignments;
 import com.microsoft.azure.management.graphrbac.implementation.RoleAssignmentInner;
 import com.microsoft.azure.management.keyvault.KeyPermissions;
+import com.microsoft.azure.management.keyvault.Vault;
 import com.microsoft.azure.management.marketplaceordering.v2015_06_01.AgreementTerms;
 import com.microsoft.azure.management.marketplaceordering.v2015_06_01.implementation.MarketplaceOrderingManager;
 import com.microsoft.azure.management.msi.Identity;
@@ -103,8 +104,8 @@ import com.microsoft.azure.storage.blob.CopyState;
 import com.microsoft.azure.storage.blob.ListBlobItem;
 import com.sequenceiq.cloudbreak.client.ProviderAuthenticationFailedException;
 import com.sequenceiq.cloudbreak.cloud.azure.AzureDiskType;
-import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarketplaceImage;
 import com.sequenceiq.cloudbreak.cloud.azure.AzurePrivateDnsZoneServiceEnum;
+import com.sequenceiq.cloudbreak.cloud.azure.image.marketplace.AzureMarketplaceImage;
 import com.sequenceiq.cloudbreak.cloud.azure.status.AzureStatusMapper;
 import com.sequenceiq.cloudbreak.cloud.azure.util.AzureAuthExceptionHandler;
 import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
@@ -981,6 +982,14 @@ public class AzureClient {
             DiskEncryptionSetInner desIn = createDiskEncryptionSetInner(sourceVaultId, encryptionKeyUrl, location, tags);
             DiskEncryptionSetsInner dSetsIn = computeManager.inner().diskEncryptionSets();
             return dSetsIn.createOrUpdate(resourceGroupName, diskEncryptionSetName, desIn);
+        });
+    }
+
+    public boolean keyVaultExists(String resourceGroupName, String vaultName) {
+        return handleAuthException(() -> {
+            Vault keyVault = azure.vaults()
+                    .getByResourceGroup(resourceGroupName, vaultName);
+            return keyVault != null;
         });
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/ResourceEncryptionDeleteHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/deletion/handler/ResourceEncryptionDeleteHandler.java
@@ -60,12 +60,12 @@ public class ResourceEncryptionDeleteHandler extends EventSenderAwareHandler<Env
         try {
             environmentService.findEnvironmentById(environmentDto.getId()).ifPresent(environment -> {
                 if (AZURE.name().equalsIgnoreCase(environmentDto.getCloudPlatform())) {
-                    String diskEncryptionSetId = Optional.ofNullable(environmentDto.getParameters())
+                    String encryptionKeyUrl = Optional.ofNullable(environmentDto.getParameters())
                             .map(ParametersDto::getAzureParametersDto)
                             .map(AzureParametersDto::getAzureResourceEncryptionParametersDto)
-                            .map(AzureResourceEncryptionParametersDto::getDiskEncryptionSetId)
+                            .map(AzureResourceEncryptionParametersDto::getEncryptionKeyUrl)
                             .orElse(null);
-                    if (StringUtils.isNotEmpty(diskEncryptionSetId) &&
+                    if (StringUtils.isNotEmpty(encryptionKeyUrl) &&
                             (environment.getStatus() != EnvironmentStatus.ENVIRONMENT_ENCRYPTION_RESOURCES_DELETED)) {
                         deleteEncryptionResources(environmentDto, environment);
                     } else {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
@@ -44,6 +44,7 @@ import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameters.dao.domain.AwsParameters;
 import com.sequenceiq.environment.parameters.dao.domain.AzureParameters;
 import com.sequenceiq.environment.parameters.dao.domain.BaseParameters;
+import com.sequenceiq.environment.parameters.dao.repository.AzureParametersRepository;
 import com.sequenceiq.environment.parameters.service.ParametersService;
 
 @Service
@@ -69,10 +70,13 @@ public class EnvironmentModificationService {
 
     private final EnvironmentEncryptionService environmentEncryptionService;
 
+    private final AzureParametersRepository azureParametersRepository;
+
     public EnvironmentModificationService(EnvironmentDtoConverter environmentDtoConverter, EnvironmentService environmentService,
             CredentialService credentialService, NetworkService networkService, AuthenticationDtoConverter authenticationDtoConverter,
             ParametersService parametersService, EnvironmentFlowValidatorService environmentFlowValidatorService,
-            EnvironmentResourceService environmentResourceService, EnvironmentEncryptionService environmentEncryptionService) {
+            EnvironmentResourceService environmentResourceService, EnvironmentEncryptionService environmentEncryptionService,
+            AzureParametersRepository azureParametersRepository) {
         this.environmentDtoConverter = environmentDtoConverter;
         this.environmentService = environmentService;
         this.credentialService = credentialService;
@@ -82,6 +86,7 @@ public class EnvironmentModificationService {
         this.environmentFlowValidatorService = environmentFlowValidatorService;
         this.environmentResourceService = environmentResourceService;
         this.environmentEncryptionService = environmentEncryptionService;
+        this.azureParametersRepository = azureParametersRepository;
     }
 
     public EnvironmentDto editByName(String environmentName, EnvironmentEditDto editDto) {
@@ -183,6 +188,7 @@ public class EnvironmentModificationService {
                 CreatedDiskEncryptionSet createdDiskEncryptionSet = environmentEncryptionService.createEncryptionResources(
                         environmentDtoConverter.environmentToDto(environment));
                 azureParameters.setDiskEncryptionSetId(createdDiskEncryptionSet.getDiskEncryptionSetId());
+                azureParametersRepository.save(azureParameters);
             } catch (Exception e) {
                 throw new BadRequestException(e);
             }
@@ -190,8 +196,7 @@ public class EnvironmentModificationService {
         } else {
             throw new BadRequestException(validateKey.getFormattedErrors());
         }
-        Environment saved = environmentService.save(environment);
-        return environmentDtoConverter.environmentToDto(saved);
+        return environmentDtoConverter.environmentToDto(environment);
     }
 
     private EnvironmentDto changeTelemetryFeatures(EnvironmentFeatures features, Environment environment) {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentModificationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentModificationServiceTest.java
@@ -59,6 +59,7 @@ import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameters.dao.domain.AwsParameters;
 import com.sequenceiq.environment.parameters.dao.domain.AzureParameters;
 import com.sequenceiq.environment.parameters.dao.domain.BaseParameters;
+import com.sequenceiq.environment.parameters.dao.repository.AzureParametersRepository;
 import com.sequenceiq.environment.parameters.service.ParametersService;
 
 @ExtendWith(SpringExtension.class)
@@ -96,6 +97,9 @@ class EnvironmentModificationServiceTest {
 
     @MockBean
     private EnvironmentEncryptionService environmentEncryptionService;
+
+    @MockBean
+    private AzureParametersRepository azureParametersRepository;
 
     @Mock
     private EnvironmentValidatorService validatorService;
@@ -652,10 +656,10 @@ class EnvironmentModificationServiceTest {
         environmentModificationServiceUnderTest.updateAzureResourceEncryptionParametersByEnvironmentName(ACCOUNT_ID,
                 ENVIRONMENT_NAME, updateAzureResourceEncryptionDto);
 
-        ArgumentCaptor<Environment> environmentArgumentCaptor = ArgumentCaptor.forClass(Environment.class);
-        verify(environmentService).save(environmentArgumentCaptor.capture());
-        assertEquals("dummyKeyUrl", ((AzureParameters) environmentArgumentCaptor.getValue().getParameters()).getEncryptionKeyUrl());
-        assertEquals("dummyResourceGroupName", ((AzureParameters) environmentArgumentCaptor.getValue().getParameters()).getEncryptionKeyResourceGroupName());
+        ArgumentCaptor<AzureParameters> azureParametersArgumentCaptor = ArgumentCaptor.forClass(AzureParameters.class);
+        verify(azureParametersRepository).save(azureParametersArgumentCaptor.capture());
+        assertEquals("dummyKeyUrl", azureParametersArgumentCaptor.getValue().getEncryptionKeyUrl());
+        assertEquals("dummyResourceGroupName", azureParametersArgumentCaptor.getValue().getEncryptionKeyResourceGroupName());
     }
 
     @Test
@@ -681,10 +685,10 @@ class EnvironmentModificationServiceTest {
         environmentModificationServiceUnderTest.updateAzureResourceEncryptionParametersByEnvironmentCrn(ACCOUNT_ID,
                 ENVIRONMENT_NAME, updateAzureResourceEncryptionDto);
 
-        ArgumentCaptor<Environment> environmentArgumentCaptor = ArgumentCaptor.forClass(Environment.class);
-        verify(environmentService).save(environmentArgumentCaptor.capture());
-        assertEquals("dummyKeyUrl", ((AzureParameters) environmentArgumentCaptor.getValue().getParameters()).getEncryptionKeyUrl());
-        assertEquals("dummyResourceGroupName", ((AzureParameters) environmentArgumentCaptor.getValue().getParameters()).getEncryptionKeyResourceGroupName());
+        ArgumentCaptor<AzureParameters> azureParametersArgumentCaptor = ArgumentCaptor.forClass(AzureParameters.class);
+        verify(azureParametersRepository).save(azureParametersArgumentCaptor.capture());
+        assertEquals("dummyKeyUrl", azureParametersArgumentCaptor.getValue().getEncryptionKeyUrl());
+        assertEquals("dummyResourceGroupName", azureParametersArgumentCaptor.getValue().getEncryptionKeyResourceGroupName());
 
     }
 


### PR DESCRIPTION
CB-15260: DES not deleted on Azure cloud if encryption key is wrong

This PR fixes following issues- 
1. Checks the existence of encryptionKeyUrl to delete the encryption resources. 
2. Saves azureEncryptionParameters correctly while adding the encryption resources for existing environments. "environmentService.save(environment)" was not able to save the encryptionKeyUrl as it is a secret. As a r
esult, saving it using AzureParameters entity.
3. Checks for the existence of keyVault before creating the disk encryption set. A check has been added before removing the disk encryption set's access policy from keyVault - to handle the case where keyVault is deleted/access changed but environment still exists. Without this existence check it would through an NPE.


Tests -
1. Updated the existing test.
2. Tested the updation of encryptionKeyUrl for existing environment with both wrong key and correct key.

```
juhig@MacBook-Pro thunderhead % ./clients/cdpcli/cdp.sh environments update-azure-encryption-resources \
    --environment testcmk \
    --encryption-key-url 'https://juhig.vault.azure.net/keys/juhig-key/c648437323ad45e59041fa1d5e9307d7' \
    --encryption-key-resource-group-name 'juhig'
2021-12-03 16:24:45,234 - MainThread - cdpcli.clidriver - WARNING - You are running an INTERNAL release of the CDP CLI, which has different capabilities from the standard public release. Find the public release at: https://pypi.org/project/cdpcli/

An error occurred: {&quot;message&quot;:&quot;vaultName \&quot;juhig\&quot; either does not exists or user does not have permissions to access it. Kindly check if the vault &amp; encryption key exists and correct encryption key url is specified.&quot;,&quot;payload&quot;:null} (Status Code: 400; Error Code: INVALID_ARGUMENT; Service: environments; Operation: updateAzureEncryptionResources; Request ID: 426a7b76-de9d-49f1-84f7-c9b5e76a47e3;)```
