### PR TITLE
CDPSDX-3198: resize data lake provisioning fails with external database

### DIFF
--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/api/endpoint/v4/databaseserver/DatabaseServerV4Endpoint.java
@@ -101,6 +101,14 @@ public interface DatabaseServerV4Endpoint {
     );
 
     @POST
+    @Path("updateclustercrn")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = DatabaseServerOpDescription.UPDATE_CLUSTER_CRN,  notes = DatabaseServerNotes.UPDATE_CLUSTER_CRN,
+            consumes = MediaType.APPLICATION_JSON, nickname = "updateClusterCrn")
+    void updateClusterCrn(@QueryParam("environmentCrn") String environmentCrn, @QueryParam("currentClusterCrn") String currentClusterCrn,
+            @QueryParam("newClusterCrn") String newClusterCrn, @QueryParam("initiatorUserCrn") String initiatorUserCrn);
+
+    @POST
     @Path("internal/managed")
     @Consumes(MediaType.APPLICATION_JSON)
     @ApiOperation(value = DatabaseServerOpDescription.CREATE_INTERNAL, notes = DatabaseServerNotes.CREATE,

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/Notes.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/Notes.java
@@ -53,6 +53,8 @@ public final class Notes {
                 "Gets information on a database server by cluster CRN";
         public static final String CREATE =
             "Creates a new database server. The database server starts out with only default databases.";
+        public static final String UPDATE_CLUSTER_CRN =
+                "Updates the cluster crn associated with the database";
         public static final String RELEASE =
             "Releases management of a service-managed database server. Resource tracking information is discarded, "
             + " but the server remains registered as user-managed.";

--- a/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
+++ b/redbeams-api/src/main/java/com/sequenceiq/redbeams/doc/OperationDescriptions.java
@@ -27,6 +27,7 @@ public final class OperationDescriptions {
         public static final String GET_BY_CLUSTER_CRN = "get a database server by cluster CRN";
         public static final String CREATE = "create and register a database server in a cloud provider";
         public static final String CREATE_INTERNAL = "create and register a database server in a cloud provider with internal actor";
+        public static final String UPDATE_CLUSTER_CRN = "Update the cluster crn associated with the database";
         public static final String RELEASE = "release management of a service-managed database server";
         public static final String REGISTER = "register a database server";
         public static final String DELETE_BY_CRN = "terminate and/or deregister a database server by CRN";

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4Controller.java
@@ -48,6 +48,7 @@ import com.sequenceiq.redbeams.converter.v4.databaseserver.DatabaseServerConfigT
 import com.sequenceiq.redbeams.converter.v4.databaseserver.DatabaseServerV4RequestToDatabaseServerConfigConverter;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.redbeams.exception.NotFoundException;
 import com.sequenceiq.redbeams.service.dbserverconfig.DatabaseServerConfigService;
 import com.sequenceiq.redbeams.service.stack.RedbeamsCreationService;
 import com.sequenceiq.redbeams.service.stack.RedbeamsStartService;
@@ -125,6 +126,16 @@ public class DatabaseServerV4Controller implements DatabaseServerV4Endpoint {
         DBStack dbStack = dbStackConverter.convert(request, ThreadBasedUserCrnProvider.getUserCrn());
         DBStack savedDBStack = redbeamsCreationService.launchDatabaseServer(dbStack, request.getClusterCrn());
         return dbStackToDatabaseServerStatusV4ResponseConverter.convert(savedDBStack);
+    }
+
+    @Override
+    @InternalOnly
+    public void updateClusterCrn(String environmentCrn, String currentClusterCrn, String newClusterCrn, @InitiatorUserCrn String initiatorUserCrn) {
+        DatabaseServerConfig databaseServerConfig = databaseServerConfigService.findByEnvironmentCrnAndClusterCrn(environmentCrn, currentClusterCrn)
+                .orElseThrow(() -> new NotFoundException(String.format("No %s found with cluster CRN '%s' in environment '%s'",
+                        DatabaseServerConfig.class.getSimpleName(), currentClusterCrn, environmentCrn)));
+        databaseServerConfig.setClusterCrn(newClusterCrn);
+        databaseServerConfigService.update(databaseServerConfig);
     }
 
     @Override

--- a/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
+++ b/redbeams/src/test/java/com/sequenceiq/redbeams/controller/v4/databaseserver/DatabaseServerV4ControllerTest.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -32,6 +33,7 @@ import com.sequenceiq.redbeams.converter.v4.databaseserver.DatabaseServerConfigT
 import com.sequenceiq.redbeams.converter.v4.databaseserver.DatabaseServerV4RequestToDatabaseServerConfigConverter;
 import com.sequenceiq.redbeams.domain.DatabaseServerConfig;
 import com.sequenceiq.redbeams.domain.stack.DBStack;
+import com.sequenceiq.redbeams.exception.NotFoundException;
 import com.sequenceiq.redbeams.service.dbserverconfig.DatabaseServerConfigService;
 import com.sequenceiq.redbeams.service.stack.RedbeamsCreationService;
 import com.sequenceiq.redbeams.service.stack.RedbeamsStartService;
@@ -52,15 +54,22 @@ public class DatabaseServerV4ControllerTest {
             .setResource("resource2")
             .build();
 
+    private static final Crn USERCRN = CrnTestUtil.getDatabaseServerCrnBuilder()
+            .setAccountId("account")
+            .setResource("user")
+            .build();
+
+    private static final String USER_CRN = USERCRN.toString();
+
     private static final String SERVER_CRN_2 = CRN_2.toString();
 
     private static final String SERVER_NAME = "myserver";
 
     private static final String ENVIRONMENT_CRN = "myenv";
 
-    private static final String USER_CRN = "userCrn";
-
     private static final String CLUSTER_CRN = "clusterCrn";
+
+    private static final String CLUSTER_CRN1 = "clusterCrn1";
 
     @InjectMocks
     private DatabaseServerV4Controller underTest;
@@ -162,6 +171,20 @@ public class DatabaseServerV4ControllerTest {
         DatabaseServerV4Response response = underTest.getByName(ENVIRONMENT_CRN, SERVER_NAME);
 
         assertEquals(serverResponse.getId().longValue(), response.getId().longValue());
+    }
+
+    @Test
+    public void testUpdateClusterCrn() {
+        when(service.findByEnvironmentCrnAndClusterCrn(ENVIRONMENT_CRN, CLUSTER_CRN)).thenReturn(Optional.of(server));
+        underTest.updateClusterCrn(ENVIRONMENT_CRN, CLUSTER_CRN, CLUSTER_CRN1, USER_CRN);
+
+        when(service.findByEnvironmentCrnAndClusterCrn(ENVIRONMENT_CRN, CLUSTER_CRN)).thenThrow(new NotFoundException("Not found"));
+        try {
+            underTest.updateClusterCrn(ENVIRONMENT_CRN, CLUSTER_CRN, CLUSTER_CRN1, USER_CRN);
+            Assert.fail("NotFoundException should have been thrown");
+        } catch (NotFoundException notFoundException) {
+
+        }
     }
 
     @Test


### PR DESCRIPTION
**Behavior Observed:**

Database creation for new resized DL, never completed. It always timed out.

**Issue-1:**
One of the steps performed while detaching the data lake is updating the CRN of the cluster with the newly created CRN so that the new datalake that is being created can use the same CRN as the original one.

When this is done, the cluster CRN saved in DatabaseServerConfig should be updated otherwise, there will be issues while creating a new database using the same cluster CRN.

**Issue-2:**
When RedbeamsCreationService.launchDatabaseServer is invoked to create a new database while resizing, it returned an already existing database that was in a stopped state. Polling task that is created to poll the status of creation never completes as the database status would not change to one of the expected states.


Changes made would address both issues.