### PR TITLE
CB-15257 Start the services before committing the CM Post-patch upgra…

### DIFF
--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -257,6 +257,7 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
             restartMgmtServices();
             if (patchUpgrade) {
                 downloadAndActivateParcels(products, parcelResourceApi, true);
+                startServices();
                 callPostClouderaRuntimeUpgradeCommandIfCMIsNewerThan751(clustersResourceApi);
                 restartServices(clustersResourceApi);
             } else {


### PR DESCRIPTION
…de command

Recently, we introduced a new post-patch upgrade command to update the libraries
on HDFS and it needs the services to be in a running state. However, currently
they are stopped which is fine as the CM command itself will launch the HDFS
service so it can upload the binaries. But on HA template the Namenode start
alone is not enough, it requires other services to be in running state as well
like Zookeper. To fix this we launch all the services before the command is started.

See detailed description in the commit message.