### PR TITLE
CB-15272: Skip custom parcels when removing unused parcels from Cloudera Manager

### DIFF
--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterApi.java
@@ -93,8 +93,9 @@ public interface ClusterApi {
         clusterModificationService().downloadAndDistributeParcels(components, patchUpgrade);
     }
 
-    default ParcelOperationStatus removeUnusedParcels(Set<ClusterComponent> usedParcelComponents) throws CloudbreakException {
-        return clusterModificationService().removeUnusedParcels(usedParcelComponents);
+    default ParcelOperationStatus removeUnusedParcels(Set<ClusterComponent> usedParcelComponents, Set<String> parcelNamesFromImage)
+            throws CloudbreakException {
+        return clusterModificationService().removeUnusedParcels(usedParcelComponents, parcelNamesFromImage);
     }
 
     default void ensureComponentsAreStopped(Map<String, String> components, String hostname) throws CloudbreakException {

--- a/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
+++ b/cluster-api/src/main/java/com/sequenceiq/cloudbreak/cluster/api/ClusterModificationService.java
@@ -45,7 +45,8 @@ public interface ClusterModificationService {
 
     Optional<String> getRoleConfigValueByServiceType(String clusterName, String roleConfigGroup, String serviceType, String configName);
 
-    ParcelOperationStatus removeUnusedParcels(Set<ClusterComponent> usedParcelComponents) throws CloudbreakException;
+    ParcelOperationStatus removeUnusedParcels(Set<ClusterComponent> usedParcelComponents, Set<String> parcelNamesFromImage)
+            throws CloudbreakException;
 
     boolean isServicePresent(String clusterName, String serviceType);
 

--- a/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
+++ b/cluster-cm/src/main/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationService.java
@@ -13,7 +13,6 @@ import static com.sequenceiq.cloudbreak.polling.PollingResult.isExited;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -746,10 +745,10 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
         startAgents();
     }
 
-    @Override
     /**
      * Deploy the client configuration and then start the cluster services.
      */
+    @Override
     public int deployConfigAndStartClusterServices() throws CloudbreakException {
         try {
             LOGGER.info("Deploying configuration and starting services");
@@ -790,20 +789,18 @@ public class ClouderaManagerModificationService implements ClusterModificationSe
     }
 
     @Override
-    public ParcelOperationStatus removeUnusedParcels(Set<ClusterComponent> usedParcelComponents) {
+    public ParcelOperationStatus removeUnusedParcels(Set<ClusterComponent> usedParcelComponents, Set<String> parcelNamesFromImage) {
         ParcelsResourceApi parcelsResourceApi = clouderaManagerApiFactory.getParcelsResourceApi(apiClient);
         ParcelResourceApi parcelResourceApi = clouderaManagerApiFactory.getParcelResourceApi(apiClient);
-        Map<String, ClouderaManagerProduct> cmProducts = new HashMap<>();
-        for (ClusterComponent clusterComponent : usedParcelComponents) {
-            ClouderaManagerProduct product = clusterComponent.getAttributes().getSilent(ClouderaManagerProduct.class);
-            cmProducts.put(product.getName(), product);
-        }
+        Set<String> usedParcelComponentNames = usedParcelComponents.stream()
+                .map(component -> component.getAttributes().getSilent(ClouderaManagerProduct.class).getName())
+                .collect(Collectors.toSet());
         ParcelOperationStatus deactivateStatus = clouderaManagerParcelDecommissionService
-                .deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, stack.getName(), cmProducts);
+                .deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, stack.getName(), usedParcelComponentNames, parcelNamesFromImage);
         ParcelOperationStatus undistributeStatus = clouderaManagerParcelDecommissionService
-                .undistributeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, cmProducts);
+                .undistributeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, usedParcelComponentNames, parcelNamesFromImage);
         ParcelOperationStatus removalStatus = clouderaManagerParcelDecommissionService
-                .removeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, cmProducts);
+                .removeUnusedParcels(apiClient, parcelsResourceApi, parcelResourceApi, stack, usedParcelComponentNames, parcelNamesFromImage);
         ParcelOperationStatus result = removalStatus.merge(deactivateStatus).merge(undistributeStatus);
         LOGGER.info("Result of the parcel removal: {}", result);
         return result;

--- a/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
+++ b/cluster-cm/src/test/java/com/sequenceiq/cloudbreak/cm/ClouderaManagerModificationServiceTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -465,10 +466,10 @@ class ClouderaManagerModificationServiceTest {
     static Object[][] upscaleClusterTestWhenRackIdBatchExecutionFailureDataProvider() {
         return new Object[][] {
                 // testCaseName batchResponseFactory
-                {"response=null", (Supplier<ApiBatchResponse>) () -> null},
-                {"success=null", (Supplier<ApiBatchResponse>) () -> new ApiBatchResponse().success(null).items(List.of())},
-                {"items=null", (Supplier<ApiBatchResponse>) () -> new ApiBatchResponse().success(true).items(null)},
-                {"success=false", (Supplier<ApiBatchResponse>) () -> new ApiBatchResponse().success(false).items(List.of())},
+                { "response=null", (Supplier<ApiBatchResponse>) () -> null },
+                { "success=null", (Supplier<ApiBatchResponse>) () -> new ApiBatchResponse().success(null).items(List.of()) },
+                { "items=null", (Supplier<ApiBatchResponse>) () -> new ApiBatchResponse().success(true).items(null) },
+                { "success=false", (Supplier<ApiBatchResponse>) () -> new ApiBatchResponse().success(false).items(List.of()) },
         };
     }
 
@@ -1060,29 +1061,30 @@ class ClouderaManagerModificationServiceTest {
     @Test
     public void removeUnusedParcels() {
         // GIVEN
+        Set<String> parcelNamesFromImage = new HashSet<>();
         ClouderaManagerProduct cmProduct1 = createClouderaManagerProduct("product1", "version1");
         ClouderaManagerProduct cmProduct2 = createClouderaManagerProduct("product2", "version2");
         Set<ClusterComponent> usedComponents = Set.of(createClusterComponent(cmProduct1), createClusterComponent(cmProduct2));
-        Map<String, ClouderaManagerProduct> productMap = Map.of(cmProduct1.getName(), cmProduct1, cmProduct2.getName(), cmProduct2);
+        Set<String> usedParcelComponentNames = Set.of(cmProduct1.getName(), cmProduct2.getName());
         when(clouderaManagerApiFactory.getParcelsResourceApi(apiClientMock)).thenReturn(parcelsResourceApi);
         when(clouderaManagerApiFactory.getParcelResourceApi(apiClientMock)).thenReturn(parcelResourceApi);
-        when(clouderaManagerParcelDecommissionService.deactivateUnusedParcels(any(), any(), any(), any()))
-                .thenReturn(new ParcelOperationStatus(Map.of("product3", "version3"), Map.of()));
-        when(clouderaManagerParcelDecommissionService.undistributeUnusedParcels(any(), any(), any(), any(), any()))
-                .thenReturn(new ParcelOperationStatus(Map.of("product3", "version3"), Map.of()));
-        when(clouderaManagerParcelDecommissionService.removeUnusedParcels(any(), any(), any(), any(), any()))
-                .thenReturn(new ParcelOperationStatus(Map.of("product3", "version3"), Map.of()));
+        when(clouderaManagerParcelDecommissionService.deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, STACK_NAME, usedParcelComponentNames,
+                parcelNamesFromImage)).thenReturn(new ParcelOperationStatus(Map.of("product3", "version3"), Map.of()));
+        when(clouderaManagerParcelDecommissionService.undistributeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi, stack,
+                usedParcelComponentNames, parcelNamesFromImage)).thenReturn(new ParcelOperationStatus(Map.of("product3", "version3"), Map.of()));
+        when(clouderaManagerParcelDecommissionService.removeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi, stack, usedParcelComponentNames,
+                parcelNamesFromImage)).thenReturn(new ParcelOperationStatus(Map.of("product3", "version3"), Map.of()));
 
         // WHEN
-        ParcelOperationStatus operationStatus = underTest.removeUnusedParcels(usedComponents);
+        ParcelOperationStatus operationStatus = underTest.removeUnusedParcels(usedComponents, parcelNamesFromImage);
 
         // THEN
-        verify(clouderaManagerParcelDecommissionService, times(1)).deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, stack.getName(),
-                productMap);
-        verify(clouderaManagerParcelDecommissionService, times(1)).undistributeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi, stack,
-                productMap);
-        verify(clouderaManagerParcelDecommissionService, times(1)).removeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi,
-                stack, productMap);
+        verify(clouderaManagerParcelDecommissionService).deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, stack.getName(),
+                usedParcelComponentNames, parcelNamesFromImage);
+        verify(clouderaManagerParcelDecommissionService).undistributeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi, stack,
+                usedParcelComponentNames, parcelNamesFromImage);
+        verify(clouderaManagerParcelDecommissionService).removeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi, stack,
+                usedParcelComponentNames, parcelNamesFromImage);
         assertEquals(1, operationStatus.getSuccessful().size());
         assertEquals(0, operationStatus.getFailed().size());
     }
@@ -1090,29 +1092,32 @@ class ClouderaManagerModificationServiceTest {
     @Test
     public void removeUnusedParcelsWhenSomeParcelOperationsFail() {
         // GIVEN
+        Set<String> parcelNamesFromImage = new HashSet<>();
         ClouderaManagerProduct cmProduct1 = createClouderaManagerProduct("product1", "version1");
         ClouderaManagerProduct cmProduct2 = createClouderaManagerProduct("product2", "version2");
         Set<ClusterComponent> usedComponents = Set.of(createClusterComponent(cmProduct1), createClusterComponent(cmProduct2));
-        Map<String, ClouderaManagerProduct> productMap = Map.of(cmProduct1.getName(), cmProduct1, cmProduct2.getName(), cmProduct2);
+        Set<String> usedParcelComponentNames = Set.of(cmProduct1.getName(), cmProduct2.getName());
         when(clouderaManagerApiFactory.getParcelsResourceApi(apiClientMock)).thenReturn(parcelsResourceApi);
         when(clouderaManagerApiFactory.getParcelResourceApi(apiClientMock)).thenReturn(parcelResourceApi);
-        when(clouderaManagerParcelDecommissionService.deactivateUnusedParcels(any(), any(), any(), any()))
-                .thenReturn(new ParcelOperationStatus(Map.of("spark3", "version3", "product5", "version5"), Map.of("product4", "version4")));
-        when(clouderaManagerParcelDecommissionService.undistributeUnusedParcels(any(), any(), any(), any(), any()))
-                .thenReturn(new ParcelOperationStatus(Map.of("product5", "version5"), Map.of("spark3", "version3")));
-        when(clouderaManagerParcelDecommissionService.removeUnusedParcels(any(), any(), any(), any(), any()))
-                .thenReturn(new ParcelOperationStatus(Map.of("product5", "version5"), Map.of()));
+        when(clouderaManagerParcelDecommissionService.deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, STACK_NAME, usedParcelComponentNames,
+                parcelNamesFromImage))
+                        .thenReturn(new ParcelOperationStatus(Map.of("spark3", "version3", "product5", "version5"), Map.of("product4", "version4")));
+        when(clouderaManagerParcelDecommissionService.undistributeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi, stack,
+                usedParcelComponentNames, parcelNamesFromImage))
+                        .thenReturn(new ParcelOperationStatus(Map.of("product5", "version5"), Map.of("spark3", "version3")));
+        when(clouderaManagerParcelDecommissionService.removeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi, stack, usedParcelComponentNames,
+                parcelNamesFromImage)).thenReturn(new ParcelOperationStatus(Map.of("product5", "version5"), Map.of()));
 
         // WHEN
-        ParcelOperationStatus operationStatus = underTest.removeUnusedParcels(usedComponents);
+        ParcelOperationStatus operationStatus = underTest.removeUnusedParcels(usedComponents, parcelNamesFromImage);
 
         // THEN
         verify(clouderaManagerParcelDecommissionService, times(1)).deactivateUnusedParcels(parcelsResourceApi, parcelResourceApi, stack.getName(),
-                productMap);
+                usedParcelComponentNames, parcelNamesFromImage);
         verify(clouderaManagerParcelDecommissionService, times(1)).undistributeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi, stack,
-                productMap);
-        verify(clouderaManagerParcelDecommissionService, times(1)).removeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi,
-                stack, productMap);
+                usedParcelComponentNames, parcelNamesFromImage);
+        verify(clouderaManagerParcelDecommissionService, times(1)).removeUnusedParcels(apiClientMock, parcelsResourceApi, parcelResourceApi, stack,
+                usedParcelComponentNames, parcelNamesFromImage);
         assertEquals(1, operationStatus.getSuccessful().size());
         assertEquals("version5", operationStatus.getSuccessful().get("product5"));
         assertEquals(2, operationStatus.getFailed().size());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/parcel/ParcelServiceTest.java
@@ -1,7 +1,8 @@
 package com.sequenceiq.cloudbreak.service.parcel;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
@@ -11,21 +12,33 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.cloud.model.ClouderaManagerProduct;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.cluster.api.ClusterApi;
 import com.sequenceiq.cloudbreak.cluster.model.ParcelOperationStatus;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageNotFoundException;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.ClusterComponent;
 import com.sequenceiq.cloudbreak.service.CloudbreakException;
+import com.sequenceiq.cloudbreak.service.CloudbreakRuntimeException;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterApiConnectors;
+import com.sequenceiq.cloudbreak.service.image.ImageService;
+import com.sequenceiq.cloudbreak.service.image.StatedImage;
 import com.sequenceiq.cloudbreak.service.upgrade.ClusterComponentUpdater;
 
 @ExtendWith(MockitoExtension.class)
 public class ParcelServiceTest {
 
     private static final long CLUSTER_ID = 2L;
+
+    private static final long STACK_ID = 1L;
+
+    private static final String PARCEL_NAME = "parcel1";
 
     @Mock
     private ClusterApiConnectors clusterApiConnectors;
@@ -36,28 +49,59 @@ public class ParcelServiceTest {
     @Mock
     private ClusterApi clusterApi;
 
+    @Mock
+    private ImageService imageService;
+
+    @Mock
+    private ClouderaManagerProductTransformer clouderaManagerProductTransformer;
+
     @InjectMocks
     private ParcelService underTest;
 
     @Test
-    void testRemoveUnusedComponents() throws CloudbreakException {
+    void testRemoveUnusedComponents() throws CloudbreakException, CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
         Stack stack = createStack();
         Set<ClusterComponent> clusterComponentsByBlueprint = Collections.emptySet();
+        Image currentImage = Mockito.mock(Image.class);
+        Set<ClouderaManagerProduct> products = Set.of(new ClouderaManagerProduct().withName(PARCEL_NAME));
+        ParcelOperationStatus removalStatus = new ParcelOperationStatus();
+
+        when(imageService.getCurrentImage(STACK_ID)).thenReturn(StatedImage.statedImage(currentImage, null, null));
+        when(clouderaManagerProductTransformer.transform(currentImage, false, true)).thenReturn(products);
         when(clusterApiConnectors.getConnector(stack)).thenReturn(clusterApi);
-        when(clusterApi.removeUnusedParcels(any())).thenReturn(new ParcelOperationStatus());
+        when(clusterApi.removeUnusedParcels(clusterComponentsByBlueprint, Set.of(PARCEL_NAME))).thenReturn(removalStatus);
 
         underTest.removeUnusedParcelComponents(stack, clusterComponentsByBlueprint);
 
+        verify(imageService).getCurrentImage(STACK_ID);
+        verify(clouderaManagerProductTransformer).transform(currentImage, false, true);
         verify(clusterApiConnectors).getConnector(stack);
-        verify(clusterApi).removeUnusedParcels(clusterComponentsByBlueprint);
-        verify(clusterComponentUpdater).removeUnusedCdhProductsFromClusterComponents(stack.getCluster().getId(), clusterComponentsByBlueprint,
-                new ParcelOperationStatus());
+        verify(clusterApi).removeUnusedParcels(clusterComponentsByBlueprint, Set.of(PARCEL_NAME));
+        verify(clusterComponentUpdater).removeUnusedCdhProductsFromClusterComponents(stack.getCluster().getId(), clusterComponentsByBlueprint, removalStatus);
+    }
+
+    @Test
+    void testRemoveUnusedComponentsShouldCallParcelRemovalWithEmptyProductListWhenTheCurrentImageIsNotFound()
+            throws CloudbreakImageNotFoundException, CloudbreakImageCatalogException {
+        Stack stack = createStack();
+        Set<ClusterComponent> clusterComponentsByBlueprint = Collections.emptySet();
+
+        when(imageService.getCurrentImage(STACK_ID)).thenThrow(new CloudbreakImageCatalogException("Image not found"));
+
+        assertThrows(CloudbreakRuntimeException.class, () -> underTest.removeUnusedParcelComponents(stack, clusterComponentsByBlueprint));
+
+        verify(imageService).getCurrentImage(STACK_ID);
+        verifyNoInteractions(clusterApiConnectors);
+        verifyNoInteractions(clusterComponentUpdater);
+        verifyNoInteractions(clusterApi);
+        verifyNoInteractions(clouderaManagerProductTransformer);
     }
 
     private Stack createStack() {
         Stack stack = new Stack();
         Cluster cluster = new Cluster();
         cluster.setId(CLUSTER_ID);
+        stack.setId(STACK_ID);
         stack.setCluster(cluster);
         return stack;
     }


### PR DESCRIPTION
### Problem
When we try to remove unused parcels from the CM server, the used components will be figured out from the blueprint. Therefore, if a custom parcel is not present in the blueprint, it will be deleted.

### Solution
Based on the current image we're collecting the possible prewarm parcels. If a parcel in the CM server is not present in the prewarm parcel list we're skipping to remove it. 