### PR TITLE
CB-13472 - Validate for stopped/unreachable FreeIPA

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeFreeIpaStatusValidationHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeFreeIpaStatusValidationHandler.java
@@ -2,8 +2,6 @@ package com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation
 
 import static com.sequenceiq.cloudbreak.core.flow2.cluster.datalake.upgrade.validation.event.ClusterUpgradeValidationHandlerSelectors.VALIDATE_FREEIPA_STATUS_EVENT;
 
-import java.util.Set;
-
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
@@ -20,7 +18,6 @@ import com.sequenceiq.cloudbreak.service.freeipa.FreeipaService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.reactor.api.handler.ExceptionCatcherEventHandler;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 
 import reactor.bus.Event;
 
@@ -41,7 +38,7 @@ public class ClusterUpgradeFreeIpaStatusValidationHandler extends ExceptionCatch
         ClusterUpgradeFreeIpaStatusValidationEvent request = event.getData();
         Long stackId = request.getResourceId();
         String environmentCrn = getStack(stackId).getEnvironmentCrn();
-        if (!freeipaService.freeipaStatusInDesiredState(environmentCrn, Set.of(Status.AVAILABLE))) {
+        if (!freeipaService.checkFreeipaRunning(environmentCrn)) {
             String message = "Upgrade cannot be performed because the FreeIPA isn't available. Please check the FreeIPA state and try again.";
             LOGGER.info("FreeIPA status validation failed with: {}", message);
             return new ClusterUpgradeValidationFailureEvent(stackId, new UpgradeValidationFailedException(message));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairService.java
@@ -65,7 +65,6 @@ import com.sequenceiq.common.api.type.InstanceGroupType;
 import com.sequenceiq.common.model.AwsDiskType;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 import com.sequenceiq.redbeams.api.endpoint.v4.databaseserver.responses.DatabaseServerV4Response;
 
 @Service
@@ -164,7 +163,7 @@ public class ClusterRepairService {
         boolean reattach = !deleteVolumes;
         Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> repairStartResult;
         List<String> stoppedInstanceIds = getStoppedNotSelectedInstanceIds(stack, repairMode, selectedParts);
-        if (!freeipaService.freeipaStatusInDesiredState(stack, Set.of(Status.AVAILABLE))) {
+        if (!freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn())) {
             repairStartResult = Result.error(RepairValidation
                     .of("Action cannot be performed because the FreeIPA isn't available. Please check the FreeIPA state."));
         } else if (!environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaService.java
@@ -1,17 +1,16 @@
 package com.sequenceiq.cloudbreak.service.freeipa;
 
-import java.util.Set;
-
 import javax.inject.Inject;
-import javax.ws.rs.NotFoundException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
-import com.sequenceiq.cloudbreak.domain.stack.Stack;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
 
 @Service
@@ -22,25 +21,26 @@ public class FreeipaService {
     @Inject
     private FreeipaClientService freeipaClientService;
 
-    public boolean freeipaStatusInDesiredState(Stack stack, Set<Status> desiredStatuses) {
-        return freeipaStatusInDesiredState(stack.getEnvironmentCrn(), desiredStatuses);
+    @Retryable(value = CloudbreakServiceException.class, maxAttempts = 3, backoff = @Backoff(delay = 200))
+    public boolean checkFreeipaRunning(String envCrn) {
+        DescribeFreeIpaResponse freeipa = freeipaClientService.getByEnvironmentCrn(envCrn);
+        if (freeipa == null || freeipa.getAvailabilityStatus() == null || freeipa.getAvailabilityStatus() == AvailabilityStatus.UNKNOWN) {
+            String message = "Freeipa availability cannot be determined currently.";
+            LOGGER.info(message);
+            throw new CloudbreakServiceException(message);
+        } else if (!freeipa.getAvailabilityStatus().isAvailable()) {
+            String message = "Freeipa should be in Available state but currently is " + freeipa.getStatus().name();
+            LOGGER.info(message);
+            return false;
+        } else {
+            return true;
+        }
     }
 
-    public boolean freeipaStatusInDesiredState(String envCrn, Set<Status> desiredStatuses) {
-        boolean ret = false;
-        if (envCrn != null) {
-            try {
-                DescribeFreeIpaResponse freeIpaResponse = freeipaClientService.getByEnvironmentCrn(envCrn);
-                ret = desiredStatuses.contains(freeIpaResponse.getStatus());
-            } catch (CloudbreakServiceException e) {
-                if (e.getCause() instanceof NotFoundException) {
-                    LOGGER.debug("Cannot check the freeipa status: {}", e.getMessage(), e);
-                    ret = true;
-                } else {
-                    LOGGER.debug("Unkonwn error during freeipa status check", e);
-                }
-            }
-        }
-        return ret;
+    @Recover
+    public boolean recoverCheckFreeipaRunning(CloudbreakServiceException e, String envCrn) {
+        String message = String.format("Freeipa availability trials exhausted for %s, defaulting to FreeIPA non-available", envCrn);
+        LOGGER.warn(message, e);
+        return false;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterRecoveryService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterRecoveryService.java
@@ -6,7 +6,6 @@ import static com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.response.recovery
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -29,7 +28,6 @@ import com.sequenceiq.cloudbreak.service.freeipa.FreeipaService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stackstatus.StackStatusService;
 import com.sequenceiq.flow.api.model.FlowIdentifier;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 
 @Service
 public class ClusterRecoveryService {
@@ -57,7 +55,7 @@ public class ClusterRecoveryService {
 
     public RecoveryValidationV4Response validateRecovery(Long workspaceId, NameOrCrn stackNameOrCrn) {
         Stack stack = stackService.getByNameOrCrnInWorkspace(stackNameOrCrn, workspaceId);
-        return validateFreeIpaStatus(stack).merge(validateStackStatus(stack));
+        return validateFreeIpaStatus(stack.getEnvironmentCrn()).merge(validateStackStatus(stack));
     }
 
     private RecoveryValidationV4Response validateStackStatus(Stack stack) {
@@ -100,8 +98,8 @@ public class ClusterRecoveryService {
         return new RecoveryValidationV4Response(reason, status);
     }
 
-    private RecoveryValidationV4Response validateFreeIpaStatus(Stack stack) {
-        boolean freeIpaAvailable = freeipaService.freeipaStatusInDesiredState(stack, Set.of(Status.AVAILABLE));
+    private RecoveryValidationV4Response validateFreeIpaStatus(String envCrn) {
+        boolean freeIpaAvailable = freeipaService.checkFreeipaRunning(envCrn);
         String reason = "";
         RecoveryStatus status;
         if (!freeIpaAvailable) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeFreeIpaStatusValidationHandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/cluster/datalake/upgrade/validation/handler/ClusterUpgradeFreeIpaStatusValidationHandlerTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Set;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,7 +20,6 @@ import com.sequenceiq.cloudbreak.domain.view.StackView;
 import com.sequenceiq.cloudbreak.service.freeipa.FreeipaService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.flow.reactor.api.handler.HandlerEvent;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ClusterUpgradeFreeIpaStatusValidationHandlerTest {
@@ -52,24 +49,24 @@ public class ClusterUpgradeFreeIpaStatusValidationHandlerTest {
     @Test
     public void testFreeIpaValidationReturnsNotAvailableThenThrowError() {
 
-        when(freeipaService.freeipaStatusInDesiredState(ENV_CRN, Set.of(Status.AVAILABLE))).thenReturn(false);
+        when(freeipaService.checkFreeipaRunning(ENV_CRN)).thenReturn(false);
 
         Selectable nextFlowStepSelector = underTest.doAccept(getHandlerEvent());
 
         assertEquals(FAILED_CLUSTER_UPGRADE_VALIDATION_EVENT.selector(), nextFlowStepSelector.selector());
-        verify(freeipaService).freeipaStatusInDesiredState(ENV_CRN, Set.of(Status.AVAILABLE));
+        verify(freeipaService).checkFreeipaRunning(ENV_CRN);
         verify(stackService).getViewByIdWithoutAuth(STACK_ID);
     }
 
     @Test
     public void testFreeIpaValidationReturnsAvailableThenPass() {
 
-        when(freeipaService.freeipaStatusInDesiredState(ENV_CRN, Set.of(Status.AVAILABLE))).thenReturn(true);
+        when(freeipaService.checkFreeipaRunning(ENV_CRN)).thenReturn(true);
 
         Selectable nextFlowStepSelector = underTest.doAccept(getHandlerEvent());
 
         assertEquals(FINISH_CLUSTER_UPGRADE_FREEIPA_STATUS_VALIDATION_EVENT.selector(), nextFlowStepSelector.selector());
-        verify(freeipaService).freeipaStatusInDesiredState(ENV_CRN, Set.of(Status.AVAILABLE));
+        verify(freeipaService).checkFreeipaRunning(ENV_CRN);
         verify(stackService).getViewByIdWithoutAuth(STACK_ID);
     }
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/ClusterRepairServiceTest.java
@@ -96,6 +96,8 @@ public class ClusterRepairServiceTest {
 
     private static final String STACK_CRN = "STACK_CRN";
 
+    private static final String ENV_CRN = "ENV_CRN";
+
     private static final long CLUSTER_ID = 1;
 
     @Mock
@@ -163,6 +165,7 @@ public class ClusterRepairServiceTest {
         stack.setResourceCrn(STACK_CRN);
         stack.setCluster(cluster);
         stack.setPlatformVariant("AWS");
+        stack.setEnvironmentCrn(ENV_CRN);
         StackStatus stackStatus = new StackStatus();
         stackStatus.setStatus(Status.AVAILABLE);
         stack.setStackStatus(stackStatus);
@@ -184,7 +187,7 @@ public class ClusterRepairServiceTest {
         when(stackUpdater.updateStackStatus(1L, DetailedStackStatus.REPAIR_IN_PROGRESS)).thenReturn(stack);
         when(stackService.getByIdWithListsInTransaction(1L)).thenReturn(stack);
         when(stack.getInstanceMetaDataAsList()).thenReturn(List.of(host1));
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -208,7 +211,7 @@ public class ClusterRepairServiceTest {
         when(stack.getInstanceMetaDataAsList()).thenReturn(List.of(host1));
         when(stack.getInstanceGroups()).thenReturn(Set.of(host1.getInstanceGroup()));
         when(stack.getTunnel()).thenReturn(Tunnel.CLUSTER_PROXY);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -230,7 +233,7 @@ public class ClusterRepairServiceTest {
 
         when(hostGroupService.getByCluster(eq(1L))).thenReturn(Set.of(hostGroup1));
         when(stackService.getByIdWithListsInTransaction(1L)).thenReturn(stack);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
         DatabaseServerV4Response databaseServerV4Response = new DatabaseServerV4Response();
@@ -258,7 +261,7 @@ public class ClusterRepairServiceTest {
         when(image.isPrewarmed()).thenReturn(true);
         when(imageCatalogService.getImage(any(), any(), any())).thenReturn(StatedImage.statedImage(image, "catalogUrl", "catalogName"));
         when(clusterDBValidationService.isGatewayRepairEnabled(cluster)).thenReturn(true);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -283,7 +286,7 @@ public class ClusterRepairServiceTest {
         when(image.isPrewarmed()).thenReturn(false);
         when(imageCatalogService.getImage(any(), any(), any())).thenReturn(StatedImage.statedImage(image, "catalogUrl", "catalogName"));
         when(clusterDBValidationService.isGatewayRepairEnabled(cluster)).thenReturn(true);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -308,7 +311,7 @@ public class ClusterRepairServiceTest {
         when(image.isPrewarmed()).thenReturn(true);
         when(imageCatalogService.getImage(any(), any(), any())).thenReturn(StatedImage.statedImage(image, "catalogUrl", "catalogName"));
         when(clusterDBValidationService.isGatewayRepairEnabled(cluster)).thenReturn(false);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -329,7 +332,7 @@ public class ClusterRepairServiceTest {
         hostGroup1.setInstanceGroup(instanceGroup);
 
         when(hostGroupService.getByCluster(eq(1L))).thenReturn(Set.of(hostGroup1));
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -372,7 +375,7 @@ public class ClusterRepairServiceTest {
         when(hostGroupService.getByCluster(eq(1L))).thenReturn(Set.of(hostGroup1));
         when(stackService.getByIdWithListsInTransaction(1L)).thenReturn(stack);
         when(stack.getInstanceMetaDataAsList()).thenReturn(List.of(host1));
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -393,7 +396,7 @@ public class ClusterRepairServiceTest {
         DatabaseServerV4Response databaseServerV4Response = new DatabaseServerV4Response();
         databaseServerV4Response.setStatus(STOPPED);
         when(redbeamsClientService.getByCrn(eq("dbCrn"))).thenReturn(databaseServerV4Response);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -422,7 +425,7 @@ public class ClusterRepairServiceTest {
 
         when(stackService.getByIdWithListsInTransaction(1L)).thenReturn(stack);
         when(stack.getInstanceMetaDataAsList()).thenReturn(List.of(host1, host2));
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -444,7 +447,7 @@ public class ClusterRepairServiceTest {
     @Test
     public void testValidateRepairWhenFreeIpaNotAvailable() {
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(false);
 
         Result<Map<HostGroupName, Set<InstanceMetaData>>, RepairValidation> actual =
@@ -458,7 +461,7 @@ public class ClusterRepairServiceTest {
     @Test
     public void testValidateRepairWhenEnvNotAvailable() {
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(false);
 
@@ -473,7 +476,7 @@ public class ClusterRepairServiceTest {
     @Test
     public void testValidateRepairWhenOneGWUnhealthyAndNotSelected() {
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -505,7 +508,7 @@ public class ClusterRepairServiceTest {
     @Test
     public void testValidateRepairWhenTwoGWUnhealthyAndNotSelected() {
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -537,7 +540,7 @@ public class ClusterRepairServiceTest {
     @Test
     public void testValidateRepairWhenNoUnhealthyGWAndNotSelected() {
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
         HostGroup hostGroup1 = new HostGroup();
@@ -573,7 +576,7 @@ public class ClusterRepairServiceTest {
     @Test
     public void testValidateRepairWhenReattachSupported() {
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 
@@ -597,7 +600,7 @@ public class ClusterRepairServiceTest {
     @Test
     public void testValidateRepairWhenReattachNotSupported() {
         when(stackService.getByIdWithListsInTransaction(STACK_ID)).thenReturn(stack);
-        when(freeipaService.freeipaStatusInDesiredState(stack, Set.of(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)))
+        when(freeipaService.checkFreeipaRunning(stack.getEnvironmentCrn()))
                 .thenReturn(true);
         when(environmentService.environmentStatusInDesiredState(stack, Set.of(EnvironmentStatus.AVAILABLE))).thenReturn(true);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/freeipa/FreeipaServiceTest.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.cloudbreak.service.freeipa;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.AvailabilityStatus;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
+import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.describe.DescribeFreeIpaResponse;
+
+@ExtendWith(MockitoExtension.class)
+class FreeipaServiceTest {
+
+    private static final String ENV_CRN =
+            "crn:cdp:environments:us-west-1:460c0d8f-ae8e-4dce-9cd7-2351762eb9ac:environment:6b2b1600-8ac6-4c26-aa34-dab36f4bd243";
+
+    @Mock
+    private FreeipaClientService freeipaClientService;
+
+    @InjectMocks
+    private FreeipaService underTest;
+
+    @ParameterizedTest
+    @EnumSource(value = Status.class)
+    void testCheckFreeipaRunningWhenFreeIpaStoppedThenReturnsFalse(Status status) {
+        DescribeFreeIpaResponse freeipa = new DescribeFreeIpaResponse();
+        freeipa.setStatus(status);
+        freeipa.setAvailabilityStatus(AvailabilityStatus.UNAVAILABLE);
+
+        when(freeipaClientService.getByEnvironmentCrn(ENV_CRN)).thenReturn(freeipa);
+
+        boolean freeipaRunning = underTest.checkFreeipaRunning(ENV_CRN);
+        assertFalse(freeipaRunning);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Status.class)
+    void testCheckFreeipaRunningWhenFreeIpaUnknownThenThrowsException(Status status) {
+        DescribeFreeIpaResponse freeipa = new DescribeFreeIpaResponse();
+        freeipa.setStatus(status);
+        freeipa.setAvailabilityStatus(AvailabilityStatus.UNKNOWN);
+
+        when(freeipaClientService.getByEnvironmentCrn(ENV_CRN)).thenReturn(freeipa);
+
+        CloudbreakServiceException exception = Assertions.assertThrows(CloudbreakServiceException.class, () -> underTest.checkFreeipaRunning(ENV_CRN));
+        assertEquals("Freeipa availability cannot be determined currently.", exception.getMessage());
+    }
+
+    @Test
+    void testCheckFreeipaRunningWhenFreeIpaIsNullThenThrowsException() {
+        when(freeipaClientService.getByEnvironmentCrn(ENV_CRN)).thenReturn(null);
+
+        CloudbreakServiceException exception = Assertions.assertThrows(CloudbreakServiceException.class, () -> underTest.checkFreeipaRunning(ENV_CRN));
+        assertEquals("Freeipa availability cannot be determined currently.", exception.getMessage());
+    }
+
+    @Test
+    void testCheckFreeipaRunningWhenFreeIpaStatusIsNullThenThrowsException() {
+        DescribeFreeIpaResponse freeipa = new DescribeFreeIpaResponse();
+        when(freeipaClientService.getByEnvironmentCrn(ENV_CRN)).thenReturn(freeipa);
+
+        CloudbreakServiceException exception = Assertions.assertThrows(CloudbreakServiceException.class, () -> underTest.checkFreeipaRunning(ENV_CRN));
+        assertEquals("Freeipa availability cannot be determined currently.", exception.getMessage());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Status.class)
+    void testCheckFreeipaRunningWhenFreeIpaAvailableThenPass(Status status) {
+        DescribeFreeIpaResponse freeipa = new DescribeFreeIpaResponse();
+        freeipa.setStatus(status);
+        freeipa.setAvailabilityStatus(AvailabilityStatus.AVAILABLE);
+
+        when(freeipaClientService.getByEnvironmentCrn(ENV_CRN)).thenReturn(freeipa);
+
+        Assertions.assertDoesNotThrow(() -> underTest.checkFreeipaRunning(ENV_CRN));
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterRecoveryServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/upgrade/ClusterRecoveryServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -26,7 +25,6 @@ import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.service.freeipa.FreeipaService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stackstatus.StackStatusService;
-import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status;
 
 @RunWith(Parameterized.class)
 public class ClusterRecoveryServiceTest {
@@ -72,7 +70,7 @@ public class ClusterRecoveryServiceTest {
 
         when(stackService.getByNameOrCrnInWorkspace(stackNameOrCrn, WORKSPACE_ID)).thenReturn(STACK);
         when(stackStatusService.findAllStackStatusesById(STACK.getId())).thenReturn(stackStatusList);
-        when(freeipaService.freeipaStatusInDesiredState(STACK, Set.of(Status.AVAILABLE))).thenReturn(freeIpaStatus);
+        when(freeipaService.checkFreeipaRunning(STACK.getEnvironmentCrn())).thenReturn(freeIpaStatus);
 
         RecoveryValidationV4Response response = underTest.validateRecovery(WORKSPACE_ID, stackNameOrCrn);
 

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRepairTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxRepairTests.java
@@ -17,6 +17,7 @@ import org.testng.annotations.Test;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.customdomain.CustomDomainSettingsV4Request;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
 import com.sequenceiq.it.cloudbreak.cloud.HostGroupType;
 import com.sequenceiq.it.cloudbreak.context.Description;
@@ -24,6 +25,7 @@ import com.sequenceiq.it.cloudbreak.context.MockedTestContext;
 import com.sequenceiq.it.cloudbreak.context.TestContext;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.mock.Method;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.util.SdxUtil;
@@ -44,6 +46,9 @@ public class MockSdxRepairTests extends AbstractMockTest {
 
     @Inject
     private SdxUtil sdxUtil;
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
 
     protected void setupTest(TestContext testContext) {
         createDefaultUser(testContext);
@@ -99,10 +104,13 @@ public class MockSdxRepairTests extends AbstractMockTest {
                 .withMock(new EnvironmentNetworkMockParams())
                 .given(EnvironmentTestDto.class)
                 .withNetwork(networkKey)
-                .withCreateFreeIpa(Boolean.FALSE)
+                .withCreateFreeIpa(Boolean.TRUE)
                 .withName(resourcePropertyProvider().getEnvironmentName())
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
                 .given(sdxInternal, SdxInternalTestDto.class)
                 .withDatabase(sdxDatabaseRequest)
                 .withCustomDomain(customDomain)
@@ -163,10 +171,13 @@ public class MockSdxRepairTests extends AbstractMockTest {
                 .withMock(new EnvironmentNetworkMockParams())
                 .given(EnvironmentTestDto.class)
                 .withNetwork(networkKey)
-                .withCreateFreeIpa(Boolean.FALSE)
+                .withCreateFreeIpa(Boolean.TRUE)
                 .withName(resourcePropertyProvider().getEnvironmentName())
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
                 .given(sdxInternal, SdxInternalTestDto.class)
                 .withDatabase(sdxDatabaseRequest)
                 .withCustomDomain(customDomain)

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/testcase/mock/MockSdxUpgradeTests.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.auth.crn.TestCrnGenerator;
 import com.sequenceiq.environment.api.v1.environment.model.EnvironmentNetworkMockParams;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentStatus;
 import com.sequenceiq.it.cloudbreak.assertion.datalake.SdxUpgradeTestAssertion;
+import com.sequenceiq.it.cloudbreak.client.FreeIpaTestClient;
 import com.sequenceiq.it.cloudbreak.client.ImageCatalogTestClient;
 import com.sequenceiq.it.cloudbreak.client.RedbeamsDatabaseServerTestClient;
 import com.sequenceiq.it.cloudbreak.client.SdxTestClient;
@@ -28,6 +29,7 @@ import com.sequenceiq.it.cloudbreak.dto.VolumeV4TestDto;
 import com.sequenceiq.it.cloudbreak.dto.database.RedbeamsDatabaseServerTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentNetworkTestDto;
 import com.sequenceiq.it.cloudbreak.dto.environment.EnvironmentTestDto;
+import com.sequenceiq.it.cloudbreak.dto.freeipa.FreeIpaTestDto;
 import com.sequenceiq.it.cloudbreak.dto.imagecatalog.ImageCatalogTestDto;
 import com.sequenceiq.it.cloudbreak.dto.sdx.SdxInternalTestDto;
 import com.sequenceiq.it.cloudbreak.dto.stack.StackTestDto;
@@ -44,6 +46,9 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
 
     @Inject
     private SdxTestClient sdxTestClient;
+
+    @Inject
+    private FreeIpaTestClient freeIpaTestClient;
 
     protected void setupTest(TestContext testContext) {
         createDefaultUser(testContext);
@@ -70,10 +75,13 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
                 .withMock(new EnvironmentNetworkMockParams())
                 .given(EnvironmentTestDto.class)
                 .withNetwork(networkKey)
-                .withCreateFreeIpa(Boolean.FALSE)
+                .withCreateFreeIpa(Boolean.TRUE)
                 .withName(resourcePropertyProvider().getEnvironmentName())
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
                 .given(cluster, ClusterTestDto.class)
                 .given(imageSettings, ImageSettingsTestDto.class)
                 .withImageId("aaa778fc-7f17-4535-9021-515351df3691")
@@ -117,10 +125,13 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
                 .withMock(new EnvironmentNetworkMockParams())
                 .given(EnvironmentTestDto.class)
                 .withNetwork(networkKey)
-                .withCreateFreeIpa(Boolean.FALSE)
+                .withCreateFreeIpa(Boolean.TRUE)
                 .withName(resourcePropertyProvider().getEnvironmentName())
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
                 .given(RedbeamsDatabaseServerTestDto.class)
                 .withEnvironmentCrn(testContext.get(EnvironmentTestDto.class).getResponse().getCrn())
                 .withClusterCrn(clusterCrn)
@@ -164,11 +175,14 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
                 .withMock(new EnvironmentNetworkMockParams())
                 .given(EnvironmentTestDto.class)
                 .withNetwork(networkKey)
-                .withCreateFreeIpa(Boolean.FALSE)
+                .withCreateFreeIpa(Boolean.TRUE)
                 .withName(resourcePropertyProvider().getEnvironmentName())
                 .withBackup("location/of/the/backup")
                 .when(getEnvironmentTestClient().create())
                 .await(EnvironmentStatus.AVAILABLE)
+                .given(FreeIpaTestDto.class)
+                .when(freeIpaTestClient.create())
+                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
                 .given(cluster, ClusterTestDto.class)
                 .given(imageSettings, ImageSettingsTestDto.class)
                 .withImageId("aaa778fc-7f17-4535-9021-515351df3691")
@@ -204,11 +218,14 @@ public class MockSdxUpgradeTests extends AbstractMockTest {
 //                .withMock(new EnvironmentNetworkMockParams())
 //                .given(EnvironmentTestDto.class)
 //                .withNetwork(networkKey)
-//                .withCreateFreeIpa(Boolean.FALSE)
+//                .withCreateFreeIpa(Boolean.TRUE)
 //                .withName(resourcePropertyProvider().getEnvironmentName())
 //                .withBackup("location/of/the/backup")
 //                .when(getEnvironmentTestClient().create())
 //                .await(EnvironmentStatus.AVAILABLE)
+//                .given(FreeIpaTestDto.class)
+//                .when(freeIpaTestClient.create())
+//                .await(com.sequenceiq.freeipa.api.v1.freeipa.stack.model.common.Status.AVAILABLE)
 //                .given(cluster, ClusterTestDto.class)
 //                .given(imageSettings, ImageSettingsTestDto.class)
 //                .withImageId("aaa778fc-7f17-4535-9021-515351df3691")


### PR DESCRIPTION
This commit
- refactors FreeIpaService to use `freeipa.getAvailabilityStatus().isAvailable()` instead of former status which is not indicative in all cases.

