### PR TITLE
CB-15138. Cleanup / define APIs for stop-start scaling which can be used

### DIFF
--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/AbstractMonitor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/AbstractMonitor.java
@@ -37,6 +37,8 @@ public abstract class AbstractMonitor<M extends Monitored> implements Monitor<M>
                 EvaluatorContext evaluatorContext = getContext(monitored);
                 evaluatorExecutor.setContext(evaluatorContext);
                 executorServiceWithRegistry.submitIfAbsent(evaluatorExecutor, evaluatorContext.getItemId());
+                // TODO AS-Logging: This needs to log the cluster name as well.
+                // TODO AS-Logging: The size of the queue needs to be logged occasionally.
                 LOGGER.debug("Successfully submitted {} for cluster {}.", evaluatorExecutor.getName(), evaluatorContext.getData());
                 rejectedThreadService.remove(evaluatorContext.getData());
                 monitored.setLastEvaluated(System.currentTimeMillis());

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/EvaluatorExecutor.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/EvaluatorExecutor.java
@@ -29,7 +29,15 @@ public abstract class EvaluatorExecutor implements Runnable {
     public final void run() {
         long itemId = getContext().getItemId();
         try {
+            LOGGER.debug("Running EvaluatorExecutor: {}", this);
+            // TODO AS-Logging: Have the evaluatorExecutors implement toString with relevant context information.
             execute();
+        } catch (Exception e) {
+            LOGGER.warn("Ignoring exception while running EvaluatorExecutor: {}", this, e);
+            // TODO AS-Improvement: The threadpoolexecutor which handles this needs to take care of Exceptions.
+            //  At least log them.
+            // TODO AS-Improvement: Do we need to generate alerts if there are too many failures. This could be a result
+            //  of a temporary problem - so alerting may not work very welll.
         } finally {
             executorServiceWithRegistry.finished(this, itemId);
         }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/evaluator/load/YarnLoadEvaluator.java
@@ -87,11 +87,12 @@ public class YarnLoadEvaluator extends EvaluatorExecutor {
 
     @Override
     protected void execute() {
-        LOGGER.info("ZZZ: YarnLoadEvaluator executing for stackCrn: {}", cluster.getStackCrn());
+        LOGGER.info("ZZZ: YarnLoadEvaluator executing for clusterId: {}", clusterId);
         long start = System.currentTimeMillis();
         String stackCrn = null;
         try {
             cluster = clusterService.findById(clusterId);
+            LOGGER.info("ZZZ: YarnLoadEvaluator executing for clusterId:{}, stackCrn: {}", clusterId, cluster.getStackCrn());
             LoggingUtils.buildMdcContext(cluster);
             stackCrn = cluster.getStackCrn();
             loadAlert = cluster.getLoadAlerts().stream().findFirst().get();
@@ -112,6 +113,12 @@ public class YarnLoadEvaluator extends EvaluatorExecutor {
 
     protected void pollYarnMetricsAndScaleCluster() throws Exception {
         StackV4Response stackV4Response = cloudbreakCommunicator.getByCrn(cluster.getStackCrn());
+        // TODO CB-14929: This needs to be carefully handled. The filter for STOPPED instances, if it does not apply correctl (e.g. nodes
+        //  are in 'Services Starting' state, can result in upscale being skipped, or in some scenarios - unnecessary downscales.
+        //  Sample log for when this happened (downscale by 1 instead of upscale by 5).
+        //  (AS min set to 15, AS max set to 20: 15 nodes RUNNING. 5 nodes in SERVICE_STARTING state - ended up downscaling by 1)
+        //  Sample log: hostFqdnsToInstanceId=20, configMaxNodeCount=0, configMinNodeCount=1, maxAllowedUpScale=0, maxAllowedDownScale=1
+        //  At least protect against such unnecessary downscales.
         Map<String, String> hostFqdnsToInstanceId = stackResponseUtils.getCloudInstanceIdsForHostGroup(stackV4Response, policyHostGroup);
 
         int existingHostGroupSize = hostFqdnsToInstanceId.size();

--- a/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingRequest.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/monitor/handler/ScalingRequest.java
@@ -138,13 +138,12 @@ public class ScalingRequest implements Runnable {
             LOGGER.info("ZZZ: with alternate mechanism");
             UpdateStackV4Request updateStackJson = new UpdateStackV4Request();
             updateStackJson.setWithClusterEvent(true);
-            updateStackJson.setUseStopStartScalingMechanism(true);
             InstanceGroupAdjustmentV4Request instanceGroupAdjustmentJson = new InstanceGroupAdjustmentV4Request();
             instanceGroupAdjustmentJson.setScalingAdjustment(scalingAdjustment);
             instanceGroupAdjustmentJson.setInstanceGroup(hostGroup);
             updateStackJson.setInstanceGroupAdjustment(instanceGroupAdjustmentJson);
 
-            cloudbreakCrnClient.withInternalCrn().autoscaleEndpoint().putStack(stackCrn, cluster.getClusterPertain().getUserId(), updateStackJson);
+            cloudbreakCrnClient.withInternalCrn().autoscaleEndpoint().putStackStartInstances(stackCrn, updateStackJson);
             scalingStatus = ScalingStatus.SUCCESS;
             statusReason = getMessageForCBSuccess();
             metricService.incrementMetricCounter(MetricType.CLUSTER_UPSCALE_SUCCESSFUL);
@@ -175,8 +174,8 @@ public class ScalingRequest implements Runnable {
             hostGroupAdjustmentJson.setWithStackUpdate(true);
             hostGroupAdjustmentJson.setHostGroup(hostGroup);
             hostGroupAdjustmentJson.setValidateNodeCount(false);
-            hostGroupAdjustmentJson.setUserStartStopScalingMechanism(true);
             updateClusterJson.setHostGroupAdjustment(hostGroupAdjustmentJson);
+            // TODO CB-14929: CB-15153 List of nodes not provided. Do we really need to support this? Can Periscope always specify the list of nodes?
             cloudbreakCrnClient.withInternalCrn().autoscaleEndpoint()
                     .putCluster(stackCrn, cluster.getClusterPertain().getUserId(), updateClusterJson);
             scalingStatus = ScalingStatus.SUCCESS;

--- a/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/utils/StackResponseUtils.java
@@ -33,7 +33,8 @@ public class StackResponseUtils {
                 .filter(instanceGroupV4Response -> instanceGroupV4Response.getName().equalsIgnoreCase(hostGroup))
                 .flatMap(instanceGroupV4Response -> instanceGroupV4Response.getMetadata().stream())
                 .filter(instanceMetaData -> instanceMetaData.getDiscoveryFQDN() != null)
-                // TODO CB-14929: the computation of host group counts depends on the scaling mechanism being used. Even for STOPPED instances, this may require additional checks on status of the nodes.
+                // TODO CB-14929: the computation of host group counts depends on the scaling mechanism being used.
+                //  Even for STOPPED instances, this may require additional checks on status of the nodes.
                 .filter(instanceMetaData -> instanceMetaData.getInstanceStatus() != InstanceStatus.STOPPED)
                 .collect(Collectors.toMap(InstanceMetaDataV4Response::getDiscoveryFQDN,
                         InstanceMetaDataV4Response::getInstanceId));

--- a/autoscale/src/main/resources/logback.xml
+++ b/autoscale/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [requestid:%X{requestId:-}]  [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
+                <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [requestid:%X{requestId:-}]  [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] ::: %msg%n</pattern>
             </layout>
         </encoder>
     </appender>
@@ -19,7 +19,7 @@
         </filter>
         <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
             <layout class="com.sequenceiq.cloudbreak.logger.MaskingPatternLayout">
-                <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [requestid:%X{requestId:-}]  [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] %msg%n</pattern>
+                <pattern>%date{ISO8601} [%thread] %method:%line %-5level %logger{5} - [type:%X{resourceType:-springLog}] [crn:%X{resourceCrn:-}] [name:%X{resourceName:-}] [tenant:%X{tenant:-}] [userCrn:%X{userCrn:-}] [requestid:%X{requestId:-}]  [traceId:%X{traceId:-}] [spanId:%X{spanId:-}] ::: %msg%n</pattern>
             </layout>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
@@ -35,7 +35,7 @@
         <appender-ref ref="STDOUT"/>
     </root>
 
-    <logger name="com.sequenceiq" level="${PERISCOPE_LOG_LEVEL:-INFO}" additivity="false">
+    <logger name="com.sequenceiq" level="${PERISCOPE_LOG_LEVEL:-DEBUG}" additivity="false">
         <appender-ref ref="AUTOSCALE_FILE_BASED"/>
         <appender-ref ref="STDOUT"/>
     </logger>
@@ -61,6 +61,10 @@
     </logger>
 
     <logger name="org.hibernate.type.descriptor.sql.BasicBinder">
+        <level value="${PERISCOPE_SQL_LOG_LEVEL:-INFO}"/>
+    </logger>
+
+    <logger name="org.springframework.orm.jpa">
         <level value="${PERISCOPE_SQL_LOG_LEVEL:-INFO}"/>
     </logger>
 

--- a/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingRequestTest.java
+++ b/autoscale/src/test/java/com/sequenceiq/periscope/monitor/handler/ScalingRequestTest.java
@@ -107,6 +107,7 @@ public class ScalingRequestTest {
     @MethodSource("scaleUpNodeCountTesting")
     public void testScaleUpNodeCount(String testCase, int existingClusterNodeCount, int existingHostGroupNodeCount,
             int desiredHostGroupNodeCount, int expectedNodeCount) {
+        // TODO CB-14929: Test needs adjustment based on the scaling strategy being used
         ArgumentCaptor<UpdateStackV4Request> captor = ArgumentCaptor.forClass(UpdateStackV4Request.class);
 
         if (expectedNodeCount > 0) {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/base/ScalingStrategy.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/base/ScalingStrategy.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.base;
+
+// This is intended more for stop-start APIs and future enhancements, and is not propagated/used at the moment
+public enum ScalingStrategy {
+    STOPSTART,
+    STOPSTART_FALLBACK_TO_REGULAR
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/request/UpdateStackV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/autoscales/request/UpdateStackV4Request.java
@@ -24,10 +24,6 @@ public class UpdateStackV4Request implements JsonEntity {
     @ApiModelProperty(StackModelDescription.INSTANCE_GROUP_ADJUSTMENT)
     private InstanceGroupAdjustmentV4Request instanceGroupAdjustment;
 
-    // TODO CB-14929: Cleanup as part of API definition
-    @ApiModelProperty("TODO New propery")
-    private Boolean useStopStartScalingMechanism = Boolean.FALSE;
-
     public StatusRequest getStatus() {
         return status;
     }
@@ -48,14 +44,6 @@ public class UpdateStackV4Request implements JsonEntity {
         this.withClusterEvent = withClusterEvent;
     }
 
-    public Boolean getUseStopStartScalingMechanism() {
-        return useStopStartScalingMechanism;
-    }
-
-    public void setUseStopStartScalingMechanism(Boolean useStopStartScalingMechanism) {
-        this.useStopStartScalingMechanism = useStopStartScalingMechanism;
-    }
-
     public Boolean getWithClusterEvent() {
         return withClusterEvent;
     }
@@ -66,7 +54,6 @@ public class UpdateStackV4Request implements JsonEntity {
                 "status=" + status +
                 ", withClusterEvent=" + withClusterEvent +
                 ", instanceGroupAdjustment=" + instanceGroupAdjustment +
-                ", useStopStartScalingMechanism=" + useStopStartScalingMechanism +
                 '}';
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/HostGroupAdjustmentV4Request.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/stacks/request/HostGroupAdjustmentV4Request.java
@@ -26,10 +26,6 @@ public class HostGroupAdjustmentV4Request implements JsonEntity {
     @ApiModelProperty(HostGroupAdjustmentModelDescription.VALIDATE_NODE_COUNT)
     private Boolean validateNodeCount = Boolean.TRUE;
 
-    // TODO CB-14929: Cleanup as part of API definition
-    @ApiModelProperty("TODO New propery")
-    private Boolean useStopStartScalingMechanism = Boolean.FALSE;
-
     @ApiModelProperty(HostGroupAdjustmentModelDescription.FORCED)
     private Boolean forced;
 
@@ -63,14 +59,6 @@ public class HostGroupAdjustmentV4Request implements JsonEntity {
 
     public void setValidateNodeCount(Boolean validateNodeCount) {
         this.validateNodeCount = validateNodeCount;
-    }
-
-    public Boolean getUseStopStartScalingMechanism() {
-        return useStopStartScalingMechanism;
-    }
-
-    public void setUserStartStopScalingMechanism(Boolean useStopStartScalingMechanism) {
-        this.useStopStartScalingMechanism = useStopStartScalingMechanism;
     }
 
     public void setForced(Boolean forced) {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -556,6 +556,7 @@ public class ModelDescriptions {
         public static final String ADJUSTMENT_TYPE = "scaling adjustment type";
         public static final String THRESHOLD = "scaling threshold";
         public static final String FORCE = "Force remove instance";
+        public static final String SCALING_STRATEGY = "scaling strategy to use while applying the scaling adjustment";
     }
 
     public static class InstanceGroupNetworkScaleModelDescription {

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -30,6 +30,7 @@ public class OperationDescriptions {
         public static final String GET_BY_CRN = "retrieve stack by crn";
         public static final String GET_STATUS_BY_NAME = "retrieve stack status by stack name";
         public static final String PUT_BY_ID = "update stack by id";
+        public static final String PUT_START_INSTANCES_BY_ID = "update stack to start instances by id";
         public static final String PUT_BY_NAME = "update stack by name";
         public static final String GET_STACK_CERT = "retrieves the TLS certificate used by the gateway";
         public static final String GET_ALL = "retrieve all stacks";
@@ -75,6 +76,7 @@ public class OperationDescriptions {
         public static final String POST_STACK_FOR_BLUEPRINT_IN_WORKSPACE = "posts stack for blueprint in workspace";
         public static final String DELETE_INSTANCE_BY_ID_IN_WORKSPACE = "deletes instance from the stack's cluster in workspace";
         public static final String DELETE_MULTIPLE_INSTANCES_BY_ID_IN_WORKSPACE = "deletes multiple instances from the stack's cluster in workspace";
+        public static final String STOP_MULTIPLE_INSTANCES_BY_ID_IN_WORKSPACE = "stop multiple instances from the stack's cluster in workspace";
         public static final String CHECK_IMAGE_IN_WORKSPACE = "checks image in stack by name in workspace";
         public static final String CHECK_IMAGE_IN_WORKSPACE_INTERNAL = "checks image in stack by name in workspace, internal only";
         public static final String GENERATE_HOSTS_INVENTORY = "Generate hosts inventory";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -245,16 +245,6 @@ public class ReactorFlowManager {
         return reactorNotifier.notify(stackId, selector, event);
     }
 
-    public FlowIdentifier triggerStopStartClusterDownscale(Long stackId, HostGroupAdjustmentV4Request hostGroupAdjustment) {
-
-        String selector = FlowChainTriggers.STOPSTART_DOWNSCALE_CHAIN_TRIGGER_EVENT;
-
-        ClusterDownscaleDetails details = new ClusterDownscaleDetails(hostGroupAdjustment.getForced(), false);
-        ClusterAndStackDownscaleTriggerEvent event = new ClusterAndStackDownscaleTriggerEvent(selector, stackId,
-                hostGroupAdjustment.getHostGroup(), hostGroupAdjustment.getScalingAdjustment(), ScalingType.DOWNSCALE_TOGETHER);
-        return reactorNotifier.notify(stackId, selector, event);
-    }
-
     public FlowIdentifier triggerClusterStart(Long stackId) {
         String selector = CLUSTER_START_EVENT.event();
         return reactorNotifier.notify(stackId, selector, new StackEvent(selector, stackId));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/StackCommonService.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.base.ScalingStrategy;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.UpdateStackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.response.CertificateV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
@@ -160,9 +161,17 @@ public class StackCommonService {
     }
 
     public void putInDefaultWorkspace(String crn, UpdateStackV4Request updateRequest) {
+        LOGGER.info("Received putStack on crn: {}, updateRequest: {}", crn, updateRequest);
         Stack stack = stackService.getByCrn(crn);
         MDCBuilder.buildMdcContext(stack);
         put(stack, updateRequest);
+    }
+
+    public void putStartInstancesInDefaultWorkspace(String crn, UpdateStackV4Request updateRequest, ScalingStrategy scalingStrategy) {
+        LOGGER.info("Received putStack on crn: {}, with scalingStrategy: {}, updateRequest: {}", crn, scalingStrategy, updateRequest);
+        Stack stack = stackService.getByCrn(crn);
+        MDCBuilder.buildMdcContext(stack);
+        putStartInstances(stack, updateRequest, scalingStrategy);
     }
 
     public FlowIdentifier putStopInWorkspace(NameOrCrn nameOrCrn, Long workspaceId) {
@@ -201,17 +210,20 @@ public class StackCommonService {
         return syncComponentVersionsFromCm(stack, candidateImageUuids);
     }
 
-    public FlowIdentifier deleteMultipleInstancesInWorkspace(NameOrCrn nameOrCrn, Long workspaceId, Set<String> instanceIds, boolean forced, boolean useAlt) {
+    public FlowIdentifier deleteMultipleInstancesInWorkspace(NameOrCrn nameOrCrn, Long workspaceId, Set<String> instanceIds, boolean forced,
+            ScalingStrategy scalingStrategy) {
         User user = userService.getOrCreate(restRequestThreadLocalService.getCloudbreakUser());
         Optional<Stack> stack = stackService.findStackByNameOrCrnAndWorkspaceId(nameOrCrn, workspaceId);
         if (stack.isEmpty()) {
             throw new BadRequestException("The requested Data Hub does not exist.");
         }
         validateStackIsNotDataLake(stack.orElse(null), instanceIds);
-        return stackOperationService.removeInstances(stack.orElse(null), workspaceId, instanceIds, forced, user, useAlt);
+        return stackOperationService.removeInstances(stack.orElse(null), workspaceId, instanceIds, forced, user, scalingStrategy);
     }
-    public FlowIdentifier deleteMultipleInstancesInWorkspace(NameOrCrn nameOrCrn, Long workspaceId, Set<String> instanceIds, boolean forced) {
-        return deleteMultipleInstancesInWorkspace(nameOrCrn, workspaceId, instanceIds, forced, false);
+
+    public FlowIdentifier deleteMultipleInstancesInWorkspace(NameOrCrn nameOrCrn, Long workspaceId,
+            Set<String> instanceIds, boolean forced) {
+        return deleteMultipleInstancesInWorkspace(nameOrCrn, workspaceId, instanceIds, forced, null);
     }
 
     public FlowIdentifier putStartInWorkspace(NameOrCrn nameOrCrn, Long workspaceId) {
@@ -357,23 +369,31 @@ public class StackCommonService {
         MDCBuilder.buildMdcContext(stack);
         User user = userService.getOrCreate(restRequestThreadLocalService.getCloudbreakUser());
         if (updateRequest.getStatus() != null) {
-            LOGGER.info("ZZZ: Using stackOperationService.updateStatus");
             return stackOperationService.updateStatus(stack.getId(), updateRequest.getStatus(), updateRequest.getWithClusterEvent(), user);
         } else {
-            LOGGER.info("ZZZ: Using scalingAdjustMent stackOperationService.updateNodeCount");
-
-            if (updateRequest.getUseStopStartScalingMechanism()) {
-                LOGGER.info("ZZZ: Using updateNodeCountStopStart");
-                Integer scalingAdjustment = updateRequest.getInstanceGroupAdjustment().getScalingAdjustment();
-                validateHardLimits(scalingAdjustment);
-                return stackOperationService.updateNodeCountStopStart(stack, updateRequest.getInstanceGroupAdjustment(), updateRequest.getWithClusterEvent());
-            } else {
-                LOGGER.info("ZZZ: Using defaultUpdateNodeCount");
-                Integer scalingAdjustment = updateRequest.getInstanceGroupAdjustment().getScalingAdjustment();
-                validateHardLimits(scalingAdjustment);
-                return stackOperationService.updateNodeCount(stack, updateRequest.getInstanceGroupAdjustment(), updateRequest.getWithClusterEvent());
-            }
+            Integer scalingAdjustment = updateRequest.getInstanceGroupAdjustment().getScalingAdjustment();
+            validateHardLimits(scalingAdjustment);
+            return stackOperationService.updateNodeCount(stack, updateRequest.getInstanceGroupAdjustment(), updateRequest.getWithClusterEvent());
         }
+    }
+
+    private FlowIdentifier putStartInstances(Stack stack, UpdateStackV4Request updateRequest, ScalingStrategy scalingStrategy) {
+        MDCBuilder.buildMdcContext(stack);
+        User user = userService.getOrCreate(restRequestThreadLocalService.getCloudbreakUser());
+        if (updateRequest.getStatus() != null) {
+            throw new BadRequestException(String.format("Stack status update is not supported while" +
+                            " attempting to scale-up via instance start. Requested status: '%s' (File a bug)",
+                    updateRequest.getStatus()));
+        }
+        if (scalingStrategy == null) {
+            scalingStrategy = ScalingStrategy.STOPSTART;
+            LOGGER.debug("Scaling strategy is null, and has been set to the default: {}", scalingStrategy);
+        }
+        Integer scalingAdjustment = updateRequest.getInstanceGroupAdjustment().getScalingAdjustment();
+        // TODO CB-14929: This validation needs adjusting since it validates total node count by adding the adjustment.
+        validateHardLimits(scalingAdjustment);
+        return stackOperationService.updateNodeCountStartInstances(stack, updateRequest.getInstanceGroupAdjustment(),
+                updateRequest.getWithClusterEvent(), scalingStrategy);
     }
 
     private void validateHardLimits(Integer scalingAdjustment) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ClusterOperationService.java
@@ -237,35 +237,17 @@ public class ClusterOperationService {
         return volumeSet;
     }
 
-    public FlowIdentifier updateHostsStopStart(Long stackId, HostGroupAdjustmentV4Request hostGroupAdjustment) {
-        LOGGER.info("ZZZ: updateHostsStopStart. stackId:{}, adj: {}", stackId, hostGroupAdjustment);
-        Stack stack = stackService.getById(stackId);
-        Cluster cluster = stack.getCluster();
-        if (cluster == null) {
-            throw new BadRequestException(String.format("There is no cluster installed on stack '%s'.", stack.getName()));
-        }
-
-        clusterService.updateClusterStatusByStackId(stackId, UPDATE_REQUESTED);
-        stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DOWNSCALE_REQUESTED,
-                "Requested node count for downscaling: " + abs(hostGroupAdjustment.getScalingAdjustment()));
-
-        return flowManager.triggerClusterDownscale(stackId, hostGroupAdjustment);
-    }
-
     public FlowIdentifier updateHosts(Long stackId, HostGroupAdjustmentV4Request hostGroupAdjustment) {
         Stack stack = stackService.getById(stackId);
         Cluster cluster = stack.getCluster();
         if (cluster == null) {
             throw new BadRequestException(String.format("There is no cluster installed on stack '%s'.", stack.getName()));
         }
-        // TODO CB-14929: Cleanup this set of changes.
-        // TODO CB-14929: Adjust validations for stop-start
         boolean downscaleRequest = updateHostsValidator.validateRequest(stack, hostGroupAdjustment);
         if (downscaleRequest) {
             clusterService.updateClusterStatusByStackId(stackId, UPDATE_REQUESTED);
             stackUpdater.updateStackStatus(stackId, DetailedStackStatus.DOWNSCALE_REQUESTED,
                     "Requested node count for downscaling: " + abs(hostGroupAdjustment.getScalingAdjustment()));
-
             return flowManager.triggerClusterDownscale(stackId, hostGroupAdjustment);
         } else {
             stackUpdater.updateStackStatus(stackId, DetailedStackStatus.UPSCALE_REQUESTED,

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationService.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.base.ScalingStrategy;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.InstanceGroupAdjustmentV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.StatusRequest;
@@ -111,15 +112,22 @@ public class StackOperationService {
         return flowManager.triggerStackRemoveInstance(stack.getId(), instanceGroupName, metaData.getPrivateId(), forced);
     }
 
-    public FlowIdentifier removeInstances(Stack stack, Long workspaceId, Collection<String> instanceIds, boolean forced, User user, boolean useStopStart) {
-        LOGGER.info("ZZZ: Received delete request for rawInstanceIds: {}", instanceIds);
+    public FlowIdentifier removeInstances(Stack stack, Long workspaceId, Collection<String> instanceIds,
+            boolean forced, User user, ScalingStrategy scalingStrategy) {
+        LOGGER.info("Received removeInstances request with scaling strategy for instanceIds: {}, [{}]", scalingStrategy, instanceIds);
+
+        // TODO CB-14929: How is a null instanceId set / an empty-instanceid set handled by the downstream handlers
+        if (instanceIds == null) {
+            throw new BadRequestException("Downscale request cannot process a 'null' instanceIds collection");
+        }
+
         Map<String, Set<Long>> instanceIdsByHostgroupMap = new HashMap<>();
         for (String instanceId : instanceIds) {
+            // TODO CB-14929: CB-15154 An invalid instanceId should not necessarily fail a downscale-stop operation?
             InstanceMetaData metaData = updateNodeCountValidator.validateInstanceForDownscale(instanceId, stack);
             instanceIdsByHostgroupMap.computeIfAbsent(metaData.getInstanceGroupName(), s -> new LinkedHashSet<>()).add(metaData.getPrivateId());
         }
-        LOGGER.info("ZZZ: removeInstances: instanceIds/hostnames received: {}", instanceIds);
-        LOGGER.info("ZZZ: removeInstances: computedInstanceIds: {}", instanceIdsByHostgroupMap);
+        LOGGER.debug("ZZZ: removeInstances: computedInstanceIds: {}", instanceIdsByHostgroupMap);
         // TODO CB-14929: Validations for start-stop
         if (!forced) {
             for (Map.Entry<String, Set<Long>> entry : instanceIdsByHostgroupMap.entrySet()) {
@@ -130,8 +138,12 @@ public class StackOperationService {
                 updateNodeCountValidator.validateScalingAdjustment(instanceGroupName, scalingAdjustment, stack);
             }
         }
-        if (useStopStart) {
-            LOGGER.info("ZZZ: Triggering stopstart-downscale");
+        if (scalingStrategy != null) {
+            // TODO: CB-14929: CB-15154 stopstart can only support a single hostGroup being specified.
+            // TODO: CB-14929: Should this not be putting the stack into a UpdateInProgress state?, and maybe run inside a transaction? (similar to the upscale)
+            if (instanceIdsByHostgroupMap.size() > 1) {
+                throw new BadRequestException("Downscale via Instance Stop cannot process more than one host group");
+            }
             return flowManager.triggerStopStartStackDownscale(stack.getId(), instanceIdsByHostgroupMap, forced);
         } else {
             return flowManager.triggerStackRemoveInstances(stack.getId(), instanceIdsByHostgroupMap, forced);
@@ -226,12 +238,16 @@ public class StackOperationService {
         }
     }
 
-    public FlowIdentifier updateNodeCountStopStart(Stack stack, InstanceGroupAdjustmentV4Request instanceGroupAdjustmentJson, boolean withClusterEvent) {
-        LOGGER.info("ZZZ: updateNodeCountStopStart");
+    public FlowIdentifier updateNodeCountStartInstances(Stack stack, InstanceGroupAdjustmentV4Request instanceGroupAdjustmentJson,
+            boolean withClusterEvent, ScalingStrategy scalingStrategy) {
 
+        // TODO CB-14929: Post CB-15162 Remove this
         if (instanceGroupAdjustmentJson.getScalingAdjustment() == 0) {
             LOGGER.info("ZZZ: Scaling Adjustment 0. Cancalling existing flows... and continuing");
             flowCancelService.cancelRunningFlows(stack.getId());
+        }
+        if (instanceGroupAdjustmentJson.getScalingAdjustment() < 0) {
+            throw new BadRequestException(String.format("Attempting to downscale via the start instances method. (File a bug)"));
         }
 
         environmentService.checkEnvironmentStatus(stack, EnvironmentStatus.upscalable());
@@ -239,6 +255,7 @@ public class StackOperationService {
             return transactionService.required(() -> {
                 Stack stackWithLists = stackService.getByIdWithLists(stack.getId());
 
+                // TODO CB-14929: Post CB-15162 Remove this
                 if (!stack.isAvailable()) {
                     LOGGER.info("ZZZ: Stack status is not AVAILABLE. Resetting, and cancelling existing flows... it is at: {}", stackWithLists.getStatus());
                     flowCancelService.cancelRunningFlows(stack.getId());
@@ -248,15 +265,19 @@ public class StackOperationService {
                             String.format("fake update"));
                 }
 
+                // TODO CB-14929: validateServiceRoles needs adjusting - it counts NMs, and could be the place where we allow this only for NMs/gateways.
                 updateNodeCountValidator.validateServiceRoles(stackWithLists, instanceGroupAdjustmentJson);
                 updateNodeCountValidator.validateStackStatus(stackWithLists);
                 updateNodeCountValidator.validateInstanceGroup(stackWithLists, instanceGroupAdjustmentJson.getInstanceGroup());
+                // TODO CB-14929: The next 2 validation also needs adjustment. Counts instances - which stop/start will not modify.
                 updateNodeCountValidator.validateScalabilityOfInstanceGroup(stackWithLists, instanceGroupAdjustmentJson);
                 updateNodeCountValidator.validateScalingAdjustment(instanceGroupAdjustmentJson, stackWithLists);
-                // TODO CB-14929: Instead of validating not in RUNNIG state, this validation needs to change to disallow everything except if instances are in STOPPED state.
+                // TODO CB-14929: Instead of validating not in RUNNIG state, this validation needs to change to disallow everything
+                //  except if instances are in STOPPED state.
                 // TODO CB-14929: Overall cleanup of code changes made in this class
                 //updateNodeCountValidator.validateInstanceStatuses(stackWithLists, instanceGroupAdjustmentJson);
-                LOGGER.info("ZZZ: cluster.isAvailable: {}, clusterStatus: {}", stackWithLists.getCluster().isAvailable(), stackWithLists.getCluster().getStatus());
+                LOGGER.info("ZZZ: cluster.isAvailable: {}, clusterStatus: {}", stackWithLists.getCluster().isAvailable(),
+                        stackWithLists.getCluster().getStatus());
                 if (withClusterEvent) {
                     // TODO CB-14929: Figure out valid states for start/stop operations.
 //                    updateNodeCountValidator.validateClusterStatus(stackWithLists);
@@ -264,21 +285,20 @@ public class StackOperationService {
                             instanceGroupAdjustmentJson,
                             stackWithLists,
                             instanceGroupAdjustmentJson.getScalingAdjustment());
+                    // TODO CB-14929: This validations needs to be removed or adjusted. Checks for UNHEALTHY service status.
+                    //  Needs to change to check unhealthy CM / unhealthy RM eventually.
                     updateNodeCountValidator.validataHostMetadataStatuses(stackWithLists, instanceGroupAdjustmentJson);
                 }
-                if (instanceGroupAdjustmentJson.getScalingAdjustment() > 0) {
-                    // TODO CB-14929: When is the DB update performed? Should this be before or after a flow is accepted. The next step sends a trigger.
-                    stackUpdater.updateStackStatus(stackWithLists.getId(), DetailedStackStatus.UPSCALE_REQUESTED,
-                            "Requested node count for upscaling (stopstart): " + instanceGroupAdjustmentJson.getScalingAdjustment());
-                    return flowManager.triggerStopStartStackUpscale(
-                            stackWithLists.getId(),
-                            instanceGroupAdjustmentJson,
-                            withClusterEvent);
-                } else {
-                    stackUpdater.updateStackStatus(stackWithLists.getId(), DetailedStackStatus.DOWNSCALE_REQUESTED,
-                            "Requested node count for downscaling: " + abs(instanceGroupAdjustmentJson.getScalingAdjustment()));
-                    return flowManager.triggerStackDownscale(stackWithLists.getId(), instanceGroupAdjustmentJson);
-                }
+                // TODO CB-14929: Post CB-15162 and add an additional check to ignore upscale requests of size 0 in stackCommonService
+
+                // TODO CB-14929: When should DB status be updated. Should the DetailStackStatus be something other than UPSCALE_REQUESTED.
+                //  i.e. differentiate between an actual upscale and a 'VM pool / start-stop'
+                stackUpdater.updateStackStatus(stackWithLists.getId(), DetailedStackStatus.UPSCALE_REQUESTED,
+                        "Requested node count for upscaling (stopstart): " + instanceGroupAdjustmentJson.getScalingAdjustment());
+                return flowManager.triggerStopStartStackUpscale(
+                        stackWithLists.getId(),
+                        instanceGroupAdjustmentJson,
+                        withClusterEvent);
             });
         } catch (TransactionExecutionException e) {
             if (e.getCause() instanceof BadRequestException) {
@@ -289,7 +309,6 @@ public class StackOperationService {
     }
 
     public FlowIdentifier updateNodeCount(Stack stack, InstanceGroupAdjustmentV4Request instanceGroupAdjustmentJson, boolean withClusterEvent) {
-        LOGGER.info("ZZZ: UpdateNodeCount");
         environmentService.checkEnvironmentStatus(stack, EnvironmentStatus.upscalable());
         try {
             return transactionService.required(() -> {
@@ -309,8 +328,6 @@ public class StackOperationService {
                     updateNodeCountValidator.validataHostMetadataStatuses(stackWithLists, instanceGroupAdjustmentJson);
                 }
                 if (instanceGroupAdjustmentJson.getScalingAdjustment() > 0) {
-                    // TODO CB-14929: When should DB status be updated. Should the DetailStackStatus be something other than UPSCALE_REQUESTED. i.e. differentiate between
-                    //  an actual upscale and a 'VM pool / start-stop'
                     stackUpdater.updateStackStatus(stackWithLists.getId(), DetailedStackStatus.UPSCALE_REQUESTED,
                             "Requested node count for upscaling: " + instanceGroupAdjustmentJson.getScalingAdjustment());
                     return flowManager.triggerStackUpscale(

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/ReactorFlowManagerTest.java
@@ -137,6 +137,8 @@ public class ReactorFlowManagerTest {
         underTest.triggerStackLoadBalancerUpdate(STACK_ID);
         underTest.triggerSyncComponentVersionsFromCm(STACK_ID, Set.of());
         underTest.triggerDatalakeClusterRecovery(STACK_ID);
+        underTest.triggerStopStartStackUpscale(STACK_ID, instanceGroupAdjustment, true);
+        underTest.triggerStopStartStackDownscale(STACK_ID, instanceIdsByHostgroup, false);
 
         int count = 0;
         for (Method method : underTest.getClass().getDeclaredMethods()) {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/StackCommonServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/StackCommonServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -23,15 +24,20 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.base.ScalingStrategy;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.InstanceGroupAdjustmentV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.UpdateStackV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.StackType;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.dto.NameOrCrn;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.base.StatusRequest;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackImageChangeV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.StackScaleV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.network.NetworkScaleV4Request;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.cloud.aws.common.AwsConstants;
+import com.sequenceiq.cloudbreak.common.ScalingHardLimitsService;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
+import com.sequenceiq.cloudbreak.common.user.CloudbreakUser;
 import com.sequenceiq.cloudbreak.controller.validation.network.MultiAzValidator;
 import com.sequenceiq.cloudbreak.converter.v4.stacks.StackScaleV4RequestToUpdateStackV4RequestConverter;
 import com.sequenceiq.cloudbreak.domain.ImageCatalog;
@@ -56,6 +62,8 @@ class StackCommonServiceTest {
     private static final long STACK_ID = 2L;
 
     private static final NameOrCrn STACK_NAME = NameOrCrn.ofName("stackName");
+
+    private static final NameOrCrn STACK_CRN = NameOrCrn.ofCrn("crn:cdp:datahub:us-west-1:9d74eee4-1cad-45d7-b645-7ccf9edbb73d:cluster:6b5a9aa7-223a-4d6a-93ca-27627be773b5");
 
     private static final String SUBNET_ID = "aSubnetId";
 
@@ -88,6 +96,9 @@ class StackCommonServiceTest {
 
     @Mock
     private NodeCountLimitValidator nodeCountLimitValidator;
+
+    @Mock
+    private ScalingHardLimitsService scalingHardLimitsService;
 
     @InjectMocks
     private StackCommonService underTest;
@@ -194,7 +205,44 @@ class StackCommonServiceTest {
 
         underTest.deleteMultipleInstancesInWorkspace(STACK_NAME, WORKSPACE_ID, nodes, true);
 
-        verify(stackOperationService).removeInstances(stack, WORKSPACE_ID, nodes, true, user);
+        verify(stackOperationService).removeInstances(stack, WORKSPACE_ID, nodes, true, user, null);
+    }
+
+    @Test
+    public void testStartInstancesInDefaultWorkspace() {
+        Stack stack = new Stack();
+        stack.setType(StackType.WORKLOAD);
+
+        User user = new User();
+        when(userService.getOrCreate(any())).thenReturn(user);
+        when(stackService.getByCrn(STACK_CRN.getCrn())).thenReturn(stack);
+
+        CloudbreakUser cloudbreakUser = mock(CloudbreakUser.class);
+        when(cloudbreakUser.getUserCrn()).thenReturn("crn:cdp:" + Crn.Service.AUTOSCALE.getName() + ":us-west-1:altus:user:__internal__actor__");
+        when(restRequestThreadLocalService.getCloudbreakUser()).thenReturn(cloudbreakUser);
+
+        UpdateStackV4Request updateStackV4Request = new UpdateStackV4Request();
+        updateStackV4Request.setWithClusterEvent(true);
+        InstanceGroupAdjustmentV4Request instanceGroupAdjustmentV4Request = new InstanceGroupAdjustmentV4Request();
+        instanceGroupAdjustmentV4Request.setInstanceGroup("instanceGroup");
+        instanceGroupAdjustmentV4Request.setScalingAdjustment(5);
+        updateStackV4Request.setInstanceGroupAdjustment(instanceGroupAdjustmentV4Request);
+
+        // Regular flow
+        underTest.putStartInstancesInDefaultWorkspace(STACK_CRN.getCrn(), updateStackV4Request, ScalingStrategy.STOPSTART_FALLBACK_TO_REGULAR);
+        verify(stackOperationService).updateNodeCountStartInstances(stack, updateStackV4Request.getInstanceGroupAdjustment(),
+                true, ScalingStrategy.STOPSTART_FALLBACK_TO_REGULAR);
+
+        // Null scaling strategy
+        underTest.putStartInstancesInDefaultWorkspace(STACK_CRN.getCrn(), updateStackV4Request, null);
+        verify(stackOperationService).updateNodeCountStartInstances(stack, updateStackV4Request.getInstanceGroupAdjustment(),
+                true, ScalingStrategy.STOPSTART);
+
+        // Status is set - Bad Request
+        updateStackV4Request.setStatus(StatusRequest.FULL_SYNC);
+        assertThrows(BadRequestException.class, () -> underTest.putStartInstancesInDefaultWorkspace(STACK_CRN.getCrn(), updateStackV4Request, null));
+
+        // TODO CB-14929: CB-15154 Add validation tests for upscale/downscale limits after the validations are adjusted.
     }
 
     @Test

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackOperationServiceTest.java
@@ -3,12 +3,21 @@ package com.sequenceiq.cloudbreak.service.stack.flow;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.AVAILABLE;
 import static com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus.STOP_REQUESTED;
 import static com.sequenceiq.cloudbreak.event.ResourceEvent.STACK_START_IGNORED;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import org.assertj.core.api.Assertions;
@@ -16,11 +25,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import com.sequenceiq.authorization.service.CommonPermissionCheckingUtils;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.base.ScalingStrategy;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.autoscales.request.InstanceGroupAdjustmentV4Request;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.DetailedStackStatus;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.Status;
@@ -32,11 +43,14 @@ import com.sequenceiq.cloudbreak.domain.StopRestrictionReason;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.StackStatus;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceMetaData;
 import com.sequenceiq.cloudbreak.service.StackUpdater;
 import com.sequenceiq.cloudbreak.service.cluster.flow.ClusterOperationService;
 import com.sequenceiq.cloudbreak.service.datalake.DataLakeStatusCheckerService;
 import com.sequenceiq.cloudbreak.service.environment.EnvironmentService;
 import com.sequenceiq.cloudbreak.service.spot.SpotInstanceUsageCondition;
+import com.sequenceiq.cloudbreak.service.stack.InstanceMetaDataService;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.stack.StackStopRestrictionService;
 import com.sequenceiq.cloudbreak.structuredevent.event.CloudbreakEventService;
@@ -87,6 +101,9 @@ public class StackOperationServiceTest {
 
     @Mock
     private UpdateNodeCountValidator updateNodeCountValidator;
+
+    @Mock
+    private InstanceMetaDataService instanceMetaDataService;
 
     @Test
     public void testStartWhenStackAvailable() {
@@ -242,4 +259,119 @@ public class StackOperationServiceTest {
                 "Requested node count for downscaling: " + 5);
         verify(flowManager).triggerStackDownscale(stack.getId(), downscaleAdjustment);
     }
+
+    @Test
+    public void testUpdateNodeCountStartInstances() throws TransactionService.TransactionExecutionException {
+        Stack stack = new Stack();
+        stack.setId(9876L);
+        stack.setStackStatus(new StackStatus(stack, AVAILABLE));
+        Cluster cluster = new Cluster();
+        cluster.setStatus(Status.AVAILABLE);
+        stack.setCluster(cluster);
+
+        when(stackService.getByIdWithLists(stack.getId())).thenReturn(stack);
+
+        InstanceGroupAdjustmentV4Request upscaleAdjustment = new InstanceGroupAdjustmentV4Request();
+        upscaleAdjustment.setScalingAdjustment(5);
+
+        when(transactionService.required(any(Supplier.class))).thenAnswer(ans -> ((Supplier) ans.getArgument(0)).get());
+
+        // Regular
+        underTest.updateNodeCountStartInstances(stack, upscaleAdjustment, true, ScalingStrategy.STOPSTART);
+        String expectedStatusReason = "Requested node count for upscaling (stopstart): " + upscaleAdjustment.getScalingAdjustment();
+        verify(stackUpdater).updateStackStatus(stack.getId(), DetailedStackStatus.UPSCALE_REQUESTED, expectedStatusReason);
+        verify(flowManager).triggerStopStartStackUpscale(stack.getId(), upscaleAdjustment, true);
+
+        // Somehow invoked with a negative value
+        upscaleAdjustment.setScalingAdjustment(-1);
+        assertThrows(BadRequestException.class,
+                () -> underTest.updateNodeCountStartInstances(stack, upscaleAdjustment, true, ScalingStrategy.STOPSTART));
+
+        // TODO CB-14929: Post CB-15162 Test what happens when the instanceCountAdjustment is 0
+        // TODO CB-14929: Post CB-15154 Potentially additional validation tests
+    }
+
+    @Test
+    public void testRemoveInstances() {
+        Stack stack = new Stack();
+        stack.setId(9876L);
+        stack.setStackStatus(new StackStatus(stack, AVAILABLE));
+        Cluster cluster = new Cluster();
+        cluster.setStatus(Status.AVAILABLE);
+        stack.setCluster(cluster);
+
+        User user = new User();
+
+        Collection<String> instanceIds = new LinkedList<>();
+        InstanceMetaData im1 = createInstanceMetadataForTest(1L, "group1");
+        InstanceMetaData im2 = createInstanceMetadataForTest(2L, "group1");
+        InstanceMetaData im3 = createInstanceMetadataForTest(3L, "group1");
+        instanceIds.add("i1");
+        instanceIds.add("i2");
+        instanceIds.add("i3");
+
+        // This ends up skipping the actual validation that is run here.
+        when(updateNodeCountValidator.validateInstanceForDownscale(im1.getInstanceId(), stack)).thenReturn(im1);
+        when(updateNodeCountValidator.validateInstanceForDownscale(im2.getInstanceId(), stack)).thenReturn(im2);
+        when(updateNodeCountValidator.validateInstanceForDownscale(im3.getInstanceId(), stack)).thenReturn(im3);
+
+        ArgumentCaptor<Map<String, Set<Long>>> capturedInstances;
+        Map<String, Set<Long>> captured;
+
+        // Verify non stop-start invocation
+        capturedInstances = ArgumentCaptor.forClass(Map.class);
+        underTest.removeInstances(stack, 0L, instanceIds, false, user, null);
+        verify(flowManager).triggerStackRemoveInstances(eq(stack.getId()), capturedInstances.capture(), eq(false));
+        captured = capturedInstances.getValue();
+        assertEquals(1, captured.size());
+        assertEquals("group1", captured.keySet().iterator().next());
+        assertEquals(3, captured.entrySet().iterator().next().getValue().size());
+
+        // Verify stop-start invocation
+        reset(flowManager);
+        capturedInstances = ArgumentCaptor.forClass(Map.class);
+        underTest.removeInstances(stack, 0L, instanceIds, false, user, ScalingStrategy.STOPSTART);
+        verify(flowManager).triggerStopStartStackDownscale(eq(stack.getId()), capturedInstances.capture(), eq(false));
+        captured = capturedInstances.getValue();
+        assertEquals(1, captured.size());
+        assertEquals("group1", captured.keySet().iterator().next());
+        assertEquals(3, captured.entrySet().iterator().next().getValue().size());
+
+
+        // No requestIds sent - BadRequest (regular and stopstart)
+        assertThrows(BadRequestException.class,
+                () -> underTest.removeInstances(stack, 0L, null, false, user, null));
+        assertThrows(BadRequestException.class,
+                () -> underTest.removeInstances(stack, 0L, null, false, user, ScalingStrategy.STOPSTART));
+
+        // stopstart supports a single hostGroup only
+        reset(flowManager);
+        InstanceMetaData im4 = createInstanceMetadataForTest(4L, "group2");
+        when(updateNodeCountValidator.validateInstanceForDownscale(im4.getInstanceId(), stack)).thenReturn(im4);
+        instanceIds.add("i4");
+        assertThrows(BadRequestException.class,
+                () -> underTest.removeInstances(stack, 0L, instanceIds, false, user, ScalingStrategy.STOPSTART));
+
+        // regular scaling supports multiple hostgroups
+        reset(flowManager);
+        underTest.removeInstances(stack, 0L, instanceIds, false, user, null);
+        verify(flowManager).triggerStackRemoveInstances(eq(stack.getId()), capturedInstances.capture(), eq(false));
+        captured = capturedInstances.getValue();
+        assertEquals(2, captured.size());
+        assertTrue(captured.containsKey("group1"));
+        assertTrue(captured.containsKey("group2"));
+        assertEquals(3, captured.get("group1").size());
+        assertEquals(1, captured.get("group2").size());
+    }
+
+    private InstanceMetaData createInstanceMetadataForTest(Long privateId, String instanceGroupName) {
+        InstanceMetaData instanceMetaData = new InstanceMetaData();
+        instanceMetaData.setInstanceId("i" + privateId);
+        instanceMetaData.setPrivateId(privateId);
+        InstanceGroup instanceGroup1 = new InstanceGroup();
+        instanceGroup1.setGroupName(instanceGroupName);
+        instanceMetaData.setInstanceGroup(instanceGroup1);
+        return instanceMetaData;
+    }
+
 }


### PR DESCRIPTION
by Periscope / other components.
- Additionally fixes a few unit tests.
- Does not introduce an API for stop without an instanceId set.
- Temporary APIs continue to exist. To be cleaned up later.

See detailed description in the commit message.