### PR TITLE
CB-15245:Fix NPE in create-aws-cluster when encryption type set to null

### DIFF
--- a/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
+++ b/core/src/main/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverter.java
@@ -56,7 +56,7 @@ public class InstanceTemplateParameterConverter {
     private AwsEncryptionV4Parameters convert(AwsEncryptionV1Parameters source, DetailedEnvironmentResponse environment) {
         AwsEncryptionV4Parameters response = new AwsEncryptionV4Parameters();
         EncryptionType dataHubEncryptionKeyType = source.getType();
-        if (dataHubEncryptionKeyType.equals(EncryptionType.CUSTOM)) {
+        if (EncryptionType.CUSTOM.equals(dataHubEncryptionKeyType)) {
             response.setKey(source.getKey());
             response.setType(source.getType());
         } else {

--- a/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/distrox/v1/distrox/converter/InstanceTemplateParameterConverterTest.java
@@ -199,6 +199,19 @@ class InstanceTemplateParameterConverterTest {
     }
 
     @Test
+    void testWhenDatahubEncryptionTypeSetToNull() {
+        AwsInstanceTemplateV1Parameters source = new AwsInstanceTemplateV1Parameters();
+        source.setEncryption(encryption(null, null));
+        DetailedEnvironmentResponse environment = createDetailedEnvironmentResponseForAwsEncryption(true, false, null);
+        AwsInstanceTemplateV4Parameters awsInstanceTemplateV4Parameters = underTest.convert(source, environment);
+        assertThat(awsInstanceTemplateV4Parameters).isNotNull();
+        AwsEncryptionV4Parameters encryption = awsInstanceTemplateV4Parameters.getEncryption();
+        assertThat(encryption).isNotNull();
+        assertThat(encryption.getType()).isNull();
+        assertThat(encryption.getKey()).isNull();
+    }
+
+    @Test
     void convertTestAwsInstanceTemplateV1ParametersToAwsInstanceTemplateV4ParametersWhenBasicFields() {
         AwsInstanceTemplateV1Parameters source = new AwsInstanceTemplateV1Parameters();
 


### PR DESCRIPTION
Tested this with a custom template where encryption type is set to null and DH creation success.