### PR TITLE
CB-14522 Add Kafka Connect endpoint to Knox

### DIFF
--- a/core-api/src/main/resources/definitions/exposed-services.json
+++ b/core-api/src/main/resources/definitions/exposed-services.json
@@ -450,6 +450,21 @@
       "minVersion": "7.2.11"
     },
     {
+      "name": "KAFKA_CONNECT_API",
+      "displayName": "Kafka Connect",
+      "serviceName": "KAFKA_CONNECT",
+      "knoxService": "KAFKA_CONNECT",
+      "knoxUrl": "/kafka-connect/",
+      "ssoSupported": true,
+      "port": 28083,
+      "tlsPort": 28085,
+      "apiOnly": true,
+      "apiIncluded": true,
+      "visibleForDatalake": true,
+      "visibleForDatahub": true,
+      "minVersion": "7.2.14"
+    },
+    {
       "name": "IMPALA",
       "displayName": "Impala",
       "serviceName": "IMPALAD",

--- a/core-api/src/test/java/com/sequenceiq/cloudbreak/api/service/ExposedServiceCollectorTest.java
+++ b/core-api/src/test/java/com/sequenceiq/cloudbreak/api/service/ExposedServiceCollectorTest.java
@@ -31,6 +31,8 @@ class ExposedServiceCollectorTest {
 
     private static final Optional<String> CDH_7_2_11 = Optional.of("7.2.11");
 
+    private static final Optional<String> CDH_7_2_14 = Optional.of("7.2.14");
+
     @InjectMocks
     private ExposedServiceCollector underTest;
 
@@ -103,6 +105,7 @@ class ExposedServiceCollectorTest {
                 "IMPALAD",
                 "IMPALA_DEBUG_UI",
                 "JOBHISTORY",
+                "KAFKA_CONNECT",
                 "KUDU_MASTER",
                 "LIVY_SERVER",
                 "LIVY_SERVER_FOR_SPARK3",
@@ -153,6 +156,7 @@ class ExposedServiceCollectorTest {
                 "JOBHISTORYUI",
                 "JOBTRACKER",
                 "RESOURCEMANAGERAPI",
+                "KAFKA_CONNECT",
                 "KUDUUI",
                 "LIVYSERVER1",
                 "LIVYSERVER_API",
@@ -241,7 +245,7 @@ class ExposedServiceCollectorTest {
     @Test
     void getNonTLSServicePorts() {
         underTest.init();
-        assertThat(underTest.getAllServicePorts(CDH_7_2_11, false)).containsOnly(
+        assertThat(underTest.getAllServicePorts(CDH_7_2_14, false)).containsOnly(
                 Map.entry("ATLAS", 21000),
                 Map.entry("ATLAS_API", 21000),
                 Map.entry("AVATICA", 8765),
@@ -260,6 +264,7 @@ class ExposedServiceCollectorTest {
                 Map.entry("JOBHISTORYUI", 19888),
                 Map.entry("JOBTRACKER", 8032),
                 Map.entry("RESOURCEMANAGERAPI", 8032),
+                Map.entry("KAFKA_CONNECT", 28083),
                 Map.entry("KUDUUI", 8051),
                 Map.entry("LIVYSERVER1", 8998),
                 Map.entry("LIVYSERVER_API", 8998),
@@ -347,7 +352,7 @@ class ExposedServiceCollectorTest {
     @Test
     void getTLSServicePorts() {
         underTest.init();
-        assertThat(underTest.getAllServicePorts(CDH_7_2_11, true)).containsOnly(
+        assertThat(underTest.getAllServicePorts(CDH_7_2_14, true)).containsOnly(
                 Map.entry("ATLAS", 31443),
                 Map.entry("ATLAS_API", 31443),
                 Map.entry("AVATICA", 8765),
@@ -366,6 +371,7 @@ class ExposedServiceCollectorTest {
                 Map.entry("JOBHISTORYUI", 19890),
                 Map.entry("JOBTRACKER", 8032),
                 Map.entry("RESOURCEMANAGERAPI", 8032),
+                Map.entry("KAFKA_CONNECT", 28085),
                 Map.entry("KUDUUI", 8051),
                 Map.entry("LIVYSERVER1", 8998),
                 Map.entry("LIVYSERVER_API", 8998),

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_api.xml.j2
@@ -155,6 +155,10 @@
                  <name>{{ aclsauthz_prefix ~ "cruise-control.acl" }}</name>
                  <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
+            <param>
+                 <name>{{ aclsauthz_prefix ~ "kafka_connect.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+            </param>
         </provider>
 {%- endif %}
 
@@ -297,6 +301,12 @@
             {% if 'CRUISE-CONTROL' in exposed and 'CRUISE_CONTROL_SERVER' in salt['pillar.get']('gateway:location') -%}
             <param>
                 <name>CRUISE-CONTROL</name>
+                <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+            </param>
+            {%- endif %}
+            {% if 'KAFKA_CONNECT' in exposed and 'KAFKA_CONNECT' in salt['pillar.get']('gateway:location') -%}
+            <param>
+                <name>KAFKA_CONNECT</name>
                 <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
             </param>
             {%- endif %}
@@ -576,6 +586,16 @@
     {%- endif %}
     {%- endif %}
 
+    {% if 'KAFKA_CONNECT' in salt['pillar.get']('gateway:location') -%}
+    {% if 'KAFKA_CONNECT' in exposed -%}
+    <service>
+        <role>KAFKA_CONNECT</role>
+        {% for hostloc in salt['pillar.get']('gateway:location')['KAFKA_CONNECT'] -%}
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['KAFKA_CONNECT'] }}</url>
+        {%- endfor %}
+    </service>
+    {%- endif %}
+    {%- endif %}
 
     {% if 'PHOENIX_QUERY_SERVER' in salt['pillar.get']('gateway:location') -%}
     {% if 'AVATICA' in exposed -%}

--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/config/cm/topology_token.xml.j2
@@ -139,6 +139,10 @@
                  <name>{{ aclsauthz_prefix ~ "ssb-mve-api.acl" }}</name>
                  <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
             </param>
+            <param>
+                 <name>{{ aclsauthz_prefix ~ "kafka_connect.acl" }}</name>
+                 <value>*;{{ salt['pillar.get']('gateway:envAccessGroup') }};*</value>
+            </param>
         </provider>
 {%- endif %}
 
@@ -259,6 +263,12 @@
                <name>LIVYFORSPARK3API</name>
                <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
              </param>
+            {%- endif %}
+            {% if 'KAFKA_CONNECT' in exposed and 'KAFKA_CONNECT' in salt['pillar.get']('gateway:location') -%}
+            <param>
+                <name>KAFKA_CONNECT</name>
+                <value>enabled=true;maxFailoverAttempts=3;failoverSleep=1000</value>
+            </param>
             {%- endif %}
         </provider>
     </gateway>
@@ -509,6 +519,17 @@
             <name>replayBufferSize</name>
             <value>512</value>
         </param>
+    </service>
+    {%- endif %}
+    {%- endif %}
+
+    {% if 'KAFKA_CONNECT' in salt['pillar.get']('gateway:location') -%}
+    {% if 'KAFKA_CONNECT' in exposed -%}
+    <service>
+        <role>KAFKA_CONNECT</role>
+        {% for hostloc in salt['pillar.get']('gateway:location')['KAFKA_CONNECT'] -%}
+        <url>{{ protocol }}://{{ hostloc }}:{{ ports['KAFKA_CONNECT'] }}</url>
+        {%- endfor %}
     </service>
     {%- endif %}
     {%- endif %}


### PR DESCRIPTION
Starting from CDH>=7.2.14 Kafka Connect will be a part of Cloudbreak. This commit add the Kafka Connect endpoint to Knox.

Tested:
- with unit tests,
- manually on a provisioned cluster.

See detailed description in the commit message.