### PR TITLE
CB-15334 Add missing goal lists to Cruise Control config provider

### DIFF
--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlGoalConfigs.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlGoalConfigs.java
@@ -2,6 +2,25 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol;
 
 public class CruiseControlGoalConfigs {
 
+    public static final String COMMON_SUPPORTED_GOALS = "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuCapacityGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.PotentialNwOutGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskUsageDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundUsageDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkOutboundUsageDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.CpuUsageDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.TopicReplicaDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderReplicaDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.LeaderBytesInDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.goals.PreferredLeaderElectionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerDiskUsageDistributionGoal," +
+            "com.linkedin.kafka.cruisecontrol.analyzer.kafkaassigner.KafkaAssignerEvenRackAwareGoal";
+
     public static final String COMMON_DEFAULT_GOALS = "com.linkedin.kafka.cruisecontrol.analyzer.goals.ReplicaCapacityGoal," +
             "com.linkedin.kafka.cruisecontrol.analyzer.goals.DiskCapacityGoal," +
             "com.linkedin.kafka.cruisecontrol.analyzer.goals.NetworkInboundCapacityGoal," +

--- a/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProvider.java
+++ b/template-manager-cmtemplate/src/main/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProvider.java
@@ -8,6 +8,7 @@ import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.c
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlGoalConfigs.COMMON_ANOMALY_DETECTION_GOALS;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlGoalConfigs.COMMON_DEFAULT_GOALS;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlGoalConfigs.COMMON_HARD_GOALS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlGoalConfigs.COMMON_SUPPORTED_GOALS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +24,8 @@ import com.sequenceiq.cloudbreak.template.views.HostgroupView;
 
 @Component
 public class CruiseControlRoleConfigProvider implements CmHostGroupRoleConfigProvider {
+
+    private static final String SUPPORTED_GOALS = "goals";
 
     private static final String DEFAULT_GOALS = "default.goals";
 
@@ -106,6 +109,7 @@ public class CruiseControlRoleConfigProvider implements CmHostGroupRoleConfigPro
                     COMMON_ANOMALY_DETECTION_GOALS));
             configs.add(config(DEFAULT_GOALS, "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal," + COMMON_DEFAULT_GOALS));
             configs.add(config(HARD_GOALS, "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal," + COMMON_HARD_GOALS));
+            configs.add(config(SUPPORTED_GOALS, COMMON_SUPPORTED_GOALS));
 
         } else if (isVersionNewerOrEqualThanLimited(cdpVersion, CLOUDERA_STACK_VERSION_7_2_11)) {
             configs.add(config(ANOMALY_DETECTION_GOALS, "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareGoal," +

--- a/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProviderTest.java
+++ b/template-manager-cmtemplate/src/test/java/com/sequenceiq/cloudbreak/cmtemplate/configproviders/cruisecontrol/CruiseControlRoleConfigProviderTest.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.ConfigUtils.config;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlGoalConfigs.COMMON_ANOMALY_DETECTION_GOALS;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlGoalConfigs.COMMON_DEFAULT_GOALS;
+import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlGoalConfigs.COMMON_SUPPORTED_GOALS;
 import static com.sequenceiq.cloudbreak.cmtemplate.configproviders.cruisecontrol.CruiseControlGoalConfigs.COMMON_HARD_GOALS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
@@ -134,7 +135,8 @@ public class CruiseControlRoleConfigProviderTest {
                 config("anomaly.detection.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal," +
                         COMMON_ANOMALY_DETECTION_GOALS),
                 config("default.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal," + COMMON_DEFAULT_GOALS),
-                config("hard.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal," + COMMON_HARD_GOALS)
+                config("hard.goals", "com.linkedin.kafka.cruisecontrol.analyzer.goals.RackAwareDistributionGoal," + COMMON_HARD_GOALS),
+                config("goals", COMMON_SUPPORTED_GOALS)
         );
     }
 }


### PR DESCRIPTION
Starting from CDH>=7.2.14 Cruise Control config provider will set the supported goals list too beside the other goal sets.

When Cruise Control csd is modified in the CM with new goal lists then the Cloudbreak's CC sometimes brake down since there are some missing goal list overrides in the CC config provider. After this change the CM modification won't take affect on the Cloudbreak's CC so the developers will be able to create separate PRs and they won't break any components by modifying another.

Tested:
- with unit tests,
- manually on a provisioned cluster.

See detailed description in the commit message.