### PR TITLE
CB-14924 : Added boolean option for skipping datalake backup during upgrade process.

### DIFF
--- a/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
+++ b/datalake-api/src/main/java/com/sequenceiq/sdx/api/model/SdxUpgradeRequest.java
@@ -17,6 +17,8 @@ public class SdxUpgradeRequest {
 
     private Boolean dryRun;
 
+    private Boolean skipBackup;
+
     private SdxUpgradeShowAvailableImages showAvailableImages;
 
     private SdxUpgradeReplaceVms replaceVms;
@@ -55,6 +57,14 @@ public class SdxUpgradeRequest {
 
     public void setDryRun(Boolean dryRun) {
         this.dryRun = dryRun;
+    }
+
+    public boolean isBackupSkipped() {
+        return Boolean.TRUE.equals(skipBackup);
+    }
+
+    public void setSkipBackup(Boolean skipBackup) {
+        this.skipBackup = skipBackup;
     }
 
     public SdxUpgradeShowAvailableImages getShowAvailableImages() {
@@ -110,6 +120,7 @@ public class SdxUpgradeRequest {
                 ", runtime='" + runtime + '\'' +
                 ", lockComponents=" + lockComponents +
                 ", dryRun=" + dryRun +
+                ", skipBackup=" + skipBackup +
                 ", replaceVms=" + replaceVms +
                 '}';
     }

--- a/datalake/src/test/java/com/sequenceiq/datalake/flow/SdxReactorFlowManagerTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/flow/SdxReactorFlowManagerTest.java
@@ -42,13 +42,9 @@ public class SdxReactorFlowManagerTest {
 
     private static final String BACKUP_LOCATION = "s3a://path/to/backup";
 
-    private static final String LOG_LOCATION = "s3a://path/to/logs";
-
     private static final String IMAGE_ID = "image-id-first";
 
-    private static final String CLOUD_PLATFORM = "Azure";
-
-    private static final SdxUpgradeReplaceVms REPAIR_AFTER_UPGRADE = SdxUpgradeReplaceVms.ENABLED;
+    private static final boolean SKIP_BACKUP = false;
 
     @Mock
     private EntitlementService entitlementService;
@@ -75,7 +71,7 @@ public class SdxReactorFlowManagerTest {
         sdxCluster = getValidSdxCluster();
         BaseFlowEvent baseFlowEvent = new BaseFlowEvent("dontcare", 1L, "crn");
         when(eventFactory.createEventWithErrHandler(anyMap(), any(Acceptable.class)))
-                .thenReturn(new Event<Acceptable>(baseFlowEvent));
+                .thenReturn(new Event(baseFlowEvent));
     }
 
     @Test
@@ -88,8 +84,8 @@ public class SdxReactorFlowManagerTest {
         when(datalakeDrConfig.isConfigured()).thenReturn(true);
         try {
             ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
-                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED));
-        } catch (Exception e) {
+                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP));
+        } catch (Exception ignored) {
         }
         verify(reactor, times(1)).notify(eq(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT), any(Event.class));
 
@@ -98,8 +94,8 @@ public class SdxReactorFlowManagerTest {
         sdxCluster.setCloudStorageFileSystemType(FileSystemType.S3);
         try {
             ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
-                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED));
-        } catch (Exception e) {
+                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP));
+        } catch (Exception ignored) {
         }
         verify(reactor, times(1)).notify(eq(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT), any(Event.class));
     }
@@ -116,8 +112,8 @@ public class SdxReactorFlowManagerTest {
         sdxCluster.setCloudStorageFileSystemType(FileSystemType.ADLS_GEN_2);
         try {
             ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
-                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED));
-        } catch (Exception e) {
+                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP));
+        } catch (Exception ignored) {
         }
         verify(reactor, times(1)).notify(eq(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT), any(Event.class));
     }
@@ -131,8 +127,8 @@ public class SdxReactorFlowManagerTest {
         when(datalakeDrConfig.isConfigured()).thenReturn(true);
         try {
             ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
-                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED));
-        } catch (Exception e) {
+                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP));
+        } catch (Exception ignored) {
         }
         verify(reactor, times(0)).notify(eq(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT), any(Event.class));
 
@@ -141,8 +137,8 @@ public class SdxReactorFlowManagerTest {
         sdxCluster.setCloudStorageFileSystemType(FileSystemType.ADLS_GEN_2);
         try {
             ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
-                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED));
-        } catch (Exception e) {
+                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP));
+        } catch (Exception ignored) {
         }
         verify(reactor, times(0)).notify(eq(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT), any(Event.class));
 
@@ -151,8 +147,8 @@ public class SdxReactorFlowManagerTest {
         sdxCluster.setCloudStorageFileSystemType(FileSystemType.GCS);
         try {
             ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
-                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED));
-        } catch (Exception e) {
+                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP));
+        } catch (Exception ignored) {
         }
         verify(reactor, times(0)).notify(eq(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT), any(Event.class));
     }
@@ -164,8 +160,8 @@ public class SdxReactorFlowManagerTest {
         sdxCluster.setCloudStorageFileSystemType(FileSystemType.S3);
         try {
             ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
-                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED));
-        } catch (Exception e) {
+                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP));
+        } catch (Exception ignored) {
         }
         verify(reactor, times(0)).notify(eq(DatalakeUpgradeFlowChainStartEvent.DATALAKE_UPGRADE_FLOW_CHAIN_EVENT), any(Event.class));
     }
@@ -178,7 +174,8 @@ public class SdxReactorFlowManagerTest {
         when(environmentClientService.getBackupLocation(ENV_CRN)).thenThrow(new BadRequestException("No backup location"));
         when(entitlementService.isDatalakeBackupOnUpgradeEnabled(any())).thenReturn(true);
         when(datalakeDrConfig.isConfigured()).thenReturn(true);
-        ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED));
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP));
     }
 
     @Test
@@ -189,8 +186,21 @@ public class SdxReactorFlowManagerTest {
         when(entitlementService.isDatalakeBackupOnUpgradeEnabled(any())).thenReturn(false);
         try {
             ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
-                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED));
-        } catch (Exception e) {
+                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP));
+        } catch (Exception ignored) {
+        }
+        verify(reactor, times(1)).notify(eq(DATALAKE_UPGRADE_EVENT.event()), any(Event.class));
+    }
+
+    @Test
+    public void testSdxUpgradeRequestBackupNotRequested() {
+        sdxCluster = getValidSdxCluster("7.2.10");
+        sdxCluster.setRangerRazEnabled(false);
+        sdxCluster.setCloudStorageFileSystemType(FileSystemType.S3);
+        try {
+            ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                    underTest.triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.DISABLED, true));
+        } catch (Exception ignored) {
         }
         verify(reactor, times(1)).notify(eq(DATALAKE_UPGRADE_EVENT.event()), any(Event.class));
     }

--- a/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/service/upgrade/SdxRuntimeUpgradeServiceTest.java
@@ -35,8 +35,8 @@ import com.sequenceiq.cloudbreak.auth.ClouderaManagerLicenseProvider;
 import com.sequenceiq.cloudbreak.auth.JsonCMLicense;
 import com.sequenceiq.cloudbreak.auth.PaywallAccessChecker;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
 import com.sequenceiq.cloudbreak.client.RestClientFactory;
 import com.sequenceiq.cloudbreak.common.exception.BadRequestException;
 import com.sequenceiq.cloudbreak.message.CloudbreakMessagesService;
@@ -76,6 +76,8 @@ public class SdxRuntimeUpgradeServiceTest {
     private static final String V_7_0_2 = "7.0.2";
 
     private static final SdxUpgradeReplaceVms REPAIR_AFTER_UPGRADE = SdxUpgradeReplaceVms.ENABLED;
+
+    private static final boolean SKIP_BACKUP = false;
 
     @Mock
     private StackV4Endpoint stackV4Endpoint;
@@ -236,8 +238,8 @@ public class SdxRuntimeUpgradeServiceTest {
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest, ACCOUNT_ID));
 
-        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE);
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE);
+        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE, SKIP_BACKUP);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE, SKIP_BACKUP);
     }
 
     @Test
@@ -260,9 +262,9 @@ public class SdxRuntimeUpgradeServiceTest {
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerUpgradeByCrn(USER_CRN, STACK_CRN, null, ACCOUNT_ID));
 
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, SdxUpgradeReplaceVms.DISABLED);
-        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, SdxUpgradeReplaceVms.ENABLED);
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.ENABLED);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP);
+        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, SdxUpgradeReplaceVms.ENABLED, SKIP_BACKUP);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.ENABLED, SKIP_BACKUP);
     }
 
     @Test
@@ -288,9 +290,9 @@ public class SdxRuntimeUpgradeServiceTest {
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerUpgradeByCrn(USER_CRN, STACK_CRN, null, ACCOUNT_ID));
 
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, SdxUpgradeReplaceVms.DISABLED);
-        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, SdxUpgradeReplaceVms.ENABLED);
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.ENABLED);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, SdxUpgradeReplaceVms.DISABLED, SKIP_BACKUP);
+        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, SdxUpgradeReplaceVms.ENABLED, SKIP_BACKUP);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, SdxUpgradeReplaceVms.ENABLED, SKIP_BACKUP);
     }
 
     @Test
@@ -436,8 +438,8 @@ public class SdxRuntimeUpgradeServiceTest {
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
                 underTest.triggerUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest, ACCOUNT_ID));
 
-        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE);
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE);
+        verify(sdxReactorFlowManager, times(1)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE, SKIP_BACKUP);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE, SKIP_BACKUP);
     }
 
     @Test
@@ -477,8 +479,8 @@ public class SdxRuntimeUpgradeServiceTest {
             assertEquals(errorMessage, e.getMessage());
         }
 
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE);
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE, SKIP_BACKUP);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE, SKIP_BACKUP);
     }
 
     @Test
@@ -517,8 +519,8 @@ public class SdxRuntimeUpgradeServiceTest {
             assertEquals(errorMessage, e.getMessage());
         }
 
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE);
-        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID_LAST, REPAIR_AFTER_UPGRADE, SKIP_BACKUP);
+        verify(sdxReactorFlowManager, times(0)).triggerDatalakeRuntimeUpgradeFlow(sdxCluster, IMAGE_ID, REPAIR_AFTER_UPGRADE, SKIP_BACKUP);
     }
 
     @Test
@@ -604,10 +606,10 @@ public class SdxRuntimeUpgradeServiceTest {
         ArgumentCaptor<UpgradeV4Response> upgradeV4ResponseCaptor = ArgumentCaptor.forClass(UpgradeV4Response.class);
         when(sdxUpgradeClusterConverter.upgradeResponseToSdxUpgradeResponse(upgradeV4ResponseCaptor.capture())).thenReturn(expectedResponse);
 
-        SdxUpgradeResponse actualRespone = underTest.checkForUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest, ACCOUNT_ID);
+        SdxUpgradeResponse actualResponse = underTest.checkForUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest, ACCOUNT_ID);
 
         UpgradeV4Response capturedUpgradeV4Response = upgradeV4ResponseCaptor.getValue();
-        assertEquals(actualRespone, expectedResponse);
+        assertEquals(actualResponse, expectedResponse);
         assertTrue(capturedUpgradeV4Response.getReason().contains("No information about current image, cannot filter patch upgrade candidates based on it"));
         assertTrue(capturedUpgradeV4Response.getUpgradeCandidates().isEmpty());
     }
@@ -638,10 +640,10 @@ public class SdxRuntimeUpgradeServiceTest {
         ArgumentCaptor<UpgradeV4Response> upgradeV4ResponseCaptor = ArgumentCaptor.forClass(UpgradeV4Response.class);
         when(sdxUpgradeClusterConverter.upgradeResponseToSdxUpgradeResponse(upgradeV4ResponseCaptor.capture())).thenReturn(expectedResponse);
 
-        SdxUpgradeResponse actualRespone = underTest.checkForUpgradeByCrn(USER_CRN, STACK_CRN, new SdxUpgradeRequest(), ACCOUNT_ID);
+        SdxUpgradeResponse actualResponse = underTest.checkForUpgradeByCrn(USER_CRN, STACK_CRN, new SdxUpgradeRequest(), ACCOUNT_ID);
 
         UpgradeV4Response capturedUpgradeV4Response = upgradeV4ResponseCaptor.getValue();
-        assertEquals(expectedResponse, actualRespone);
+        assertEquals(expectedResponse, actualResponse);
         assertTrue(StringUtils.isEmpty(capturedUpgradeV4Response.getReason()));
         assertEquals(1, capturedUpgradeV4Response.getUpgradeCandidates().size());
         assertEquals(MATCHING_TARGET_RUNTIME, capturedUpgradeV4Response.getUpgradeCandidates().get(0).getComponentVersions().getCdp());
@@ -673,10 +675,10 @@ public class SdxRuntimeUpgradeServiceTest {
         ArgumentCaptor<UpgradeV4Response> upgradeV4ResponseCaptor = ArgumentCaptor.forClass(UpgradeV4Response.class);
         when(sdxUpgradeClusterConverter.upgradeResponseToSdxUpgradeResponse(upgradeV4ResponseCaptor.capture())).thenReturn(expectedResponse);
 
-        SdxUpgradeResponse actualRespone = underTest.checkForUpgradeByCrn(USER_CRN, STACK_CRN, new SdxUpgradeRequest(), ACCOUNT_ID);
+        SdxUpgradeResponse actualResponse = underTest.checkForUpgradeByCrn(USER_CRN, STACK_CRN, new SdxUpgradeRequest(), ACCOUNT_ID);
 
         UpgradeV4Response capturedUpgradeV4Response = upgradeV4ResponseCaptor.getValue();
-        assertEquals(expectedResponse, actualRespone);
+        assertEquals(expectedResponse, actualResponse);
         assertEquals(0, capturedUpgradeV4Response.getUpgradeCandidates().size());
     }
 
@@ -708,10 +710,10 @@ public class SdxRuntimeUpgradeServiceTest {
         ArgumentCaptor<UpgradeV4Response> upgradeV4ResponseCaptor = ArgumentCaptor.forClass(UpgradeV4Response.class);
         when(sdxUpgradeClusterConverter.upgradeResponseToSdxUpgradeResponse(upgradeV4ResponseCaptor.capture())).thenReturn(expectedResponse);
 
-        SdxUpgradeResponse actualRespone = underTest.checkForUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest, ACCOUNT_ID);
+        SdxUpgradeResponse actualResponse = underTest.checkForUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest, ACCOUNT_ID);
 
         UpgradeV4Response capturedUpgradeV4Response = upgradeV4ResponseCaptor.getValue();
-        assertEquals(expectedResponse, actualRespone);
+        assertEquals(expectedResponse, actualResponse);
         assertEquals(0, capturedUpgradeV4Response.getUpgradeCandidates().size());
         assertTrue(capturedUpgradeV4Response.getReason().contains("it is not possible to upgrade from [7.0.2] to [7.2.0] runtime"));
     }
@@ -744,10 +746,10 @@ public class SdxRuntimeUpgradeServiceTest {
         ArgumentCaptor<UpgradeV4Response> upgradeV4ResponseCaptor = ArgumentCaptor.forClass(UpgradeV4Response.class);
         when(sdxUpgradeClusterConverter.upgradeResponseToSdxUpgradeResponse(upgradeV4ResponseCaptor.capture())).thenReturn(expectedResponse);
 
-        SdxUpgradeResponse actualRespone = underTest.checkForUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest, ACCOUNT_ID);
+        SdxUpgradeResponse actualResponse = underTest.checkForUpgradeByCrn(USER_CRN, STACK_CRN, sdxUpgradeRequest, ACCOUNT_ID);
 
         UpgradeV4Response capturedUpgradeV4Response = upgradeV4ResponseCaptor.getValue();
-        assertEquals(expectedResponse, actualRespone);
+        assertEquals(expectedResponse, actualResponse);
         assertEquals(0, capturedUpgradeV4Response.getUpgradeCandidates().size());
         assertTrue(capturedUpgradeV4Response.getReason().contains("The version of target runtime has to be the same as the current one"));
     }


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-14924

Just added a new field in the request which is checked by the flow trigger. I also had to modify the tests, and did some slight cleanup of the classes I worked in.

This has not been tested, I will do that locally soon, but wanted eyes on the change.