### PR TITLE
CB-15112 Handle default runtime as optional and use the latest runtime from the default image catalog if empty. Filter advertised and supported runtimes by the available ones

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/ImageCatalogV4Endpoint.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/ImageCatalogV4Endpoint.java
@@ -23,6 +23,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageCat
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageCatalogV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.RuntimeVersionsV4Response;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.doc.ControllerDescription;
 import com.sequenceiq.cloudbreak.doc.OperationDescriptions.ImageCatalogOpDescription;
@@ -183,4 +184,11 @@ public interface ImageCatalogV4Endpoint {
     ImageV4Response getImageFromDefault(@PathParam("workspaceId") Long workspaceId,
             @PathParam("type") String type,
             @PathParam("provider") String provider) throws Exception;
+
+    @GET
+    @Path("default_runtime_versions")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = ImageCatalogOpDescription.GET_DEFAULT_IMAGE_CATALOG_RUNTIME_VERSIONS, produces = MediaType.APPLICATION_JSON,
+            notes = IMAGE_CATALOG_NOTES, nickname = "getRuntimeVersionsFromDefault")
+    RuntimeVersionsV4Response getRuntimeVersionsFromDefault(@PathParam("workspaceId") Long workspaceId) throws Exception;
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/RuntimeVersionsV4Response.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/endpoint/v4/imagecatalog/responses/RuntimeVersionsV4Response.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses;
+
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.annotations.ApiModel;
+
+@ApiModel
+@JsonIgnoreProperties(ignoreUnknown = true)
+@NotNull
+public class RuntimeVersionsV4Response {
+
+    private List<String> runtimeVersions;
+
+    @JsonCreator
+    public RuntimeVersionsV4Response(@JsonProperty("runtimeVersions") List<String> runtimeVersions) {
+        this.runtimeVersions = runtimeVersions;
+    }
+
+    @Override
+    public String toString() {
+        return "RuntimeVersionsV4Response{" +
+                "runtimeVersions=" + runtimeVersions +
+                '}';
+    }
+
+    public List<String> getRuntimeVersions() {
+        return runtimeVersions;
+    }
+}

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/OperationDescriptions.java
@@ -211,6 +211,7 @@ public class OperationDescriptions {
         public static final String DELETE_MULTIPLE_BY_NAME_IN_WORKSPACE = "delete multiple image catalogs by name in workspace";
         public static final String GET_IMAGE_FROM_DEFAULT = "returns an image from the default catalog based on the provided filter";
         public static final String GET_IMAGE_FROM_DEFAULT_BY_ID = "returns an image from the default catalog by id";
+        public static final String GET_DEFAULT_IMAGE_CATALOG_RUNTIME_VERSIONS = "get runtime versions from the default catalog";
     }
 
     public static class CustomImageCatalogOpDescription {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4Controller.java
@@ -36,6 +36,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageCat
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageCatalogV4Responses;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImageV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4Response;
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.RuntimeVersionsV4Response;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.security.internal.AccountId;
 import com.sequenceiq.cloudbreak.auth.security.internal.InitiatorUserCrn;
@@ -255,5 +256,13 @@ public class ImageCatalogV4Controller extends NotificationController implements 
     public ImageV4Response getImageFromDefault(Long workspaceId, String type, String provider) throws Exception {
         StatedImage statedImage = defaultImageCatalogService.getImageFromDefaultCatalog(type, provider);
         return imageToImageV4ResponseConverter.convert(statedImage.getImage());
+    }
+
+    @Override
+    @AccountIdNotNeeded
+    @DisableCheckPermissions
+    public RuntimeVersionsV4Response getRuntimeVersionsFromDefault(Long workspaceId) throws Exception {
+        List<String> runtimeVersions =  imageCatalogService.getRuntimeVersionsFromDefault();
+        return new RuntimeVersionsV4Response(runtimeVersions);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogProvider.java
@@ -6,12 +6,14 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.service.image.catalog.model.ImageCatalogMetaData;
+import com.sequenceiq.cloudbreak.service.image.catalog.model.ImageCatalogWrapper;
 
 @Service
 public class ImageCatalogProvider {
 
     @Inject
-    private CachedImageCatalogProvider cachedImageCatalogProvider;
+    private CachedImageCatalogWrapperProvider cachedImageCatalogWrapperProvider;
 
     public CloudbreakImageCatalogV3 getImageCatalogV3(String catalogUrl) throws CloudbreakImageCatalogException {
         return getImageCatalogV3(catalogUrl, false);
@@ -19,8 +21,14 @@ public class ImageCatalogProvider {
 
     public CloudbreakImageCatalogV3 getImageCatalogV3(String catalogUrl, boolean forceRefresh) throws CloudbreakImageCatalogException {
         if (forceRefresh) {
-            cachedImageCatalogProvider.evictImageCatalogCache(catalogUrl);
+            cachedImageCatalogWrapperProvider.evictImageCatalogCache(catalogUrl);
         }
-        return cachedImageCatalogProvider.getImageCatalogV3(catalogUrl);
+        ImageCatalogWrapper imageCatalogWrapper = cachedImageCatalogWrapperProvider.getImageCatalogWrapper(catalogUrl);
+        return imageCatalogWrapper.getImageCatalog();
+    }
+
+    public ImageCatalogMetaData getImageCatalogMetaData(String catalogUrl) throws CloudbreakImageCatalogException {
+        ImageCatalogWrapper imageCatalogWrapper = cachedImageCatalogWrapperProvider.getImageCatalogWrapper(catalogUrl);
+        return imageCatalogWrapper.getImageCatalogMetaData();
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogService.java
@@ -797,4 +797,9 @@ public class ImageCatalogService extends AbstractWorkspaceAwareResourceService<I
         }
         return statedImage(image.get(), catalogUrl, catalogName);
     }
+
+    public List<String> getRuntimeVersionsFromDefault()
+            throws CloudbreakImageCatalogException {
+        return imageCatalogProvider.getImageCatalogMetaData(defaultCatalogUrl).getRuntimeVersions();
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/ImageCatalogService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/ImageCatalogService.java
@@ -1,15 +1,39 @@
 package com.sequenceiq.cloudbreak.service.image.catalog;
 
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+
+import com.sequenceiq.cloudbreak.cloud.VersionComparator;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.common.type.Versioned;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
 import com.sequenceiq.cloudbreak.service.image.ImageFilter;
 import com.sequenceiq.cloudbreak.service.image.StatedImages;
+import com.sequenceiq.cloudbreak.service.image.catalog.model.ImageCatalogMetaData;
 import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterResult;
 
 interface ImageCatalogService {
+
+    VersionComparator VERSION_COMPARATOR = new VersionComparator();
+
     StatedImages getImages(CloudbreakImageCatalogV3 imageCatalogV3, ImageFilter imageFilter);
 
     void validate(CloudbreakImageCatalogV3 imageCatalogV3) throws CloudbreakImageCatalogException;
 
     ImageFilterResult getImageFilterResult(CloudbreakImageCatalogV3 imageCatalogV3);
+
+    default ImageCatalogMetaData getImageCatalogMetaData(CloudbreakImageCatalogV3 imageCatalogV3) {
+        ImageFilterResult imageFilterResult = getImageFilterResult(imageCatalogV3);
+        List<String> runtimes = imageFilterResult.getAvailableImages().getCdhImages()
+                .stream()
+                .map(Image::getVersion)
+                .distinct()
+                .map(version -> (Versioned) () -> version)
+                .sorted(VERSION_COMPARATOR.reversed())
+                .map(Versioned::getVersion)
+                .collect(toList());
+        return new ImageCatalogMetaData(runtimes);
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/ImageCatalogServiceProxy.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/ImageCatalogServiceProxy.java
@@ -4,6 +4,7 @@ import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
 import com.sequenceiq.cloudbreak.service.image.ImageFilter;
 import com.sequenceiq.cloudbreak.service.image.StatedImages;
+import com.sequenceiq.cloudbreak.service.image.catalog.model.ImageCatalogMetaData;
 import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterResult;
 import org.springframework.stereotype.Component;
 
@@ -31,6 +32,11 @@ public class ImageCatalogServiceProxy implements ImageCatalogService {
     @Override
     public ImageFilterResult getImageFilterResult(CloudbreakImageCatalogV3 imageCatalogV3) {
         return getImageCatalogService(imageCatalogV3).getImageFilterResult(imageCatalogV3);
+    }
+
+    @Override
+    public ImageCatalogMetaData getImageCatalogMetaData(CloudbreakImageCatalogV3 imageCatalogV3) {
+        return getImageCatalogService(imageCatalogV3).getImageCatalogMetaData(imageCatalogV3);
     }
 
     private ImageCatalogService getImageCatalogService(CloudbreakImageCatalogV3 imageCatalogV3) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/model/ImageCatalogMetaData.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/model/ImageCatalogMetaData.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.service.image.catalog.model;
+
+import java.util.List;
+
+public class ImageCatalogMetaData {
+
+    private List<String> runtimeVersions;
+
+    public ImageCatalogMetaData(List<String> runtimeVersions) {
+        this.runtimeVersions = runtimeVersions;
+    }
+
+    public List<String> getRuntimeVersions() {
+        return runtimeVersions;
+    }
+
+    @Override
+    public String toString() {
+        return "ImageCatalogMetaData{" +
+                "runtimeVersions=" + runtimeVersions +
+                '}';
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/model/ImageCatalogWrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/image/catalog/model/ImageCatalogWrapper.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.service.image.catalog.model;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
+
+public class ImageCatalogWrapper {
+
+    private CloudbreakImageCatalogV3 imageCatalog;
+
+    private ImageCatalogMetaData imageCatalogMetaData;
+
+    public ImageCatalogWrapper(CloudbreakImageCatalogV3 imageCatalog, ImageCatalogMetaData imageCatalogMetaData) {
+        this.imageCatalog = imageCatalog;
+        this.imageCatalogMetaData = imageCatalogMetaData;
+    }
+
+    public CloudbreakImageCatalogV3 getImageCatalog() {
+        return imageCatalog;
+    }
+
+    public ImageCatalogMetaData getImageCatalogMetaData() {
+        return imageCatalogMetaData;
+    }
+
+    @Override
+    public String toString() {
+        return "ImageCatalogWrapper{" +
+                "imageCatalog=" + imageCatalog +
+                ", imageCatalogMetaData=" + imageCatalogMetaData +
+                '}';
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/runtimes/SupportedRuntimes.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/runtimes/SupportedRuntimes.java
@@ -1,21 +1,36 @@
 package com.sequenceiq.cloudbreak.service.runtimes;
 
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Strings;
 import com.sequenceiq.cloudbreak.cloud.VersionComparator;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 
 @Component
 public class SupportedRuntimes {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SupportedRuntimes.class);
 
     // Defines what is the latest version what is supported, every former version shall just work
     @Value("${cb.runtimes.latest}")
     private String latestSupportedRuntime;
 
+    @Inject
+    private ImageCatalogService imageCatalogService;
+
     private VersionComparator versionComparator = new VersionComparator();
 
     public boolean isSupported(String runtime) {
+        String latestSupportedRuntime = getLatestSupportedRuntime();
         boolean ret;
         if (Strings.isNullOrEmpty(latestSupportedRuntime)) {
             ret = true;
@@ -23,5 +38,24 @@ public class SupportedRuntimes {
             ret = versionComparator.compare(() -> runtime, () -> latestSupportedRuntime) <= 0;
         }
         return ret;
+    }
+
+    private String getLatestSupportedRuntime() {
+        try {
+            if (Strings.isNullOrEmpty(latestSupportedRuntime)) {
+                List<String> defaultImageCatalogRuntimeVersions = imageCatalogService.getRuntimeVersionsFromDefault();
+                LOGGER.debug("Define latest supported runtime by available runtimes in the default image catalog ('%s').",
+                        String.join(",", defaultImageCatalogRuntimeVersions));
+
+                Optional<String> latestRuntime = defaultImageCatalogRuntimeVersions.stream().findFirst();
+                if (latestRuntime.isEmpty()) {
+                    LOGGER.error("Runtime not found in the default image catalog");
+                }
+                return latestRuntime.orElse(null);
+            }
+        } catch (CloudbreakImageCatalogException ex) {
+            LOGGER.error("Failed to get runtimes from the default image catalog", ex);
+        }
+        return latestSupportedRuntime;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/V4ExistingResourceRestUrlParser.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/structuredevent/rest/urlparsers/V4ExistingResourceRestUrlParser.java
@@ -24,6 +24,7 @@ public class V4ExistingResourceRestUrlParser extends LegacyRestUrlParser {
             + "|blueprints/recommendation"
             + "|blueprints_util/.*"
             + "|image_catalogs/image(s\\b|\\b)"
+            + "|image_catalogs/default_runtime_versions"
             + "|connectors/[a-z_]+"
             + "|recipes/internal"
             + "|file_systems/[a-z_]+)");

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4ControllerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/v4/ImageCatalogV4ControllerTest.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.controller.v4;
+
+
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.RuntimeVersionsV4Response;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
+
+@ExtendWith(MockitoExtension.class)
+public class ImageCatalogV4ControllerTest {
+
+    private static final Long WORKSPACE_ID = 1L;
+
+    @Mock
+    private ImageCatalogService imageCatalogService;
+
+    @InjectMocks
+    private ImageCatalogV4Controller victim;
+
+    @Test
+    public void testGetRuntimeVersionsFromDefault() throws Exception {
+        List<String> expected = List.of("7.2.1", "7.2.2");
+        when(imageCatalogService.getRuntimeVersionsFromDefault()).thenReturn(expected);
+
+        RuntimeVersionsV4Response actual =  victim.getRuntimeVersionsFromDefault(WORKSPACE_ID);
+
+        Assertions.assertEquals(expected, actual.getRuntimeVersions());
+    }
+
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintServiceTest.java
@@ -64,6 +64,7 @@ import com.sequenceiq.cloudbreak.init.blueprint.BlueprintLoaderService;
 import com.sequenceiq.cloudbreak.repository.BlueprintRepository;
 import com.sequenceiq.cloudbreak.repository.BlueprintViewRepository;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.runtimes.SupportedRuntimes;
 import com.sequenceiq.cloudbreak.service.template.ClusterTemplateViewService;
 import com.sequenceiq.cloudbreak.service.user.UserService;
@@ -127,13 +128,18 @@ public class BlueprintServiceTest {
     @Mock
     private ClusterTemplateViewService clusterTemplateViewService;
 
+    @Mock
+    private ImageCatalogService imageCatalogService;
+
     @InjectMocks
     private BlueprintService underTest;
 
     @BeforeEach
     public void setup() {
         CrnTestUtil.mockCrnGenerator(regionAwareCrnGenerator);
-        Whitebox.setInternalState(blueprintListFilters, "supportedRuntimes", new SupportedRuntimes());
+        SupportedRuntimes supportedRuntimes = new SupportedRuntimes();
+        Whitebox.setInternalState(blueprintListFilters, "supportedRuntimes", supportedRuntimes);
+        Whitebox.setInternalState(supportedRuntimes, "imageCatalogService", imageCatalogService);
         lenient().when(legacyRestRequestThreadLocalService.getCloudbreakUser()).thenReturn(cloudbreakUser);
         lenient().when(userService.getOrCreate(cloudbreakUser)).thenReturn(user);
         lenient().when(workspaceService.get(1L, user)).thenReturn(getWorkspace());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CachedImageCatalogWrapperProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/CachedImageCatalogWrapperProviderTest.java
@@ -1,0 +1,316 @@
+package com.sequenceiq.cloudbreak.service.image;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.client.RestClientFactory;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakVersion;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.service.image.catalog.ImageCatalogServiceProxy;
+
+@ExtendWith(MockitoExtension.class)
+public class CachedImageCatalogWrapperProviderTest {
+
+    private static final String CB_IMAGE_CATALOG_V2_JSON = "cb-image-catalog-v2.json";
+
+    private static final String FREEIPA_IMAGE_CATALOG_V3_JSON = "freeipa-image-catalog-v3.json";
+
+    private static final String CB_IMAGE_CATALOG_RC_JSON = "cb-rc-image-catalog.json";
+
+    private static final String CB_IMAGE_CATALOG_NULL_FIELD_JSON = "cb-image-catalog-null-field.json";
+
+    private static final String CB_IMAGE_CATALOG_VALID_JSON = "cb-image-catalog-valid.json";
+
+    private static final String CB_IMAGE_CATALOG_FILTER_NULL_IMAGES_JSON = "cb-image-catalog-filter-null-images.json";
+
+    private static final String CB_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON = "cb-image-catalog-filter-images-null.json";
+
+    private static final String FREEIPA_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON = "freeipa-image-catalog-filter-images-null.json";
+
+    private static final String CB_IMAGE_CATALOG_WITHOUT_BASE_IMAGES = "cb-image-catalog-without-base-images.json";
+
+    private static final String CB_IMAGE_CATALOG_WITHOUT_CDH_IMAGES = "cb-image-catalog-without-cdh-images.json";
+
+    private static final String CB_VERSION = "1.16.5";
+
+    private static final List<String> RC_IMAGE_CATALOG_OS_TYPES = Lists.newArrayList("amazonlinux", "centos7", "amazonlinux2", "sles12", "ubuntu16");
+
+    private static final List<String> CB_AMAZONLINUX_FILTER = Lists.newArrayList("amazonlinux");
+
+    private static final List<String> CB_REDHAT7_FILTER = Lists.newArrayList("redhat7");
+
+    @InjectMocks
+    private CachedImageCatalogWrapperProvider underTest;
+
+    @Mock
+    private Client clientMock;
+
+    @Mock
+    private WebTarget webTargetMock;
+
+    @Mock
+    private Invocation.Builder builderMock;
+
+    @Mock
+    private Response responseMock;
+
+    @Mock
+    private Response.StatusType statusTypeMock;
+
+    @Mock
+    private ImageCatalogServiceProxy imageCatalogServiceProxy;
+
+    @Mock
+    private RestClientFactory restClientFactory;
+
+    @Spy
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testReadImageCatalogFromFile() throws Exception {
+
+        String path = getPath(CB_IMAGE_CATALOG_V2_JSON);
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+
+        CloudbreakImageCatalogV3 catalog = underTest.getImageCatalogWrapper(CB_IMAGE_CATALOG_V2_JSON).getImageCatalog();
+
+        assertNotNull(catalog);
+        Optional<CloudbreakVersion> ver = catalog.getVersions().getCloudbreakVersions().stream().filter(v -> v.getVersions().contains(CB_VERSION)).findFirst();
+        Assertions.assertTrue(ver.isPresent(), "Check that the parsed ImageCatalog contains the desired version of Cloudbreak.");
+        List<String> imageIds = ver.get().getImageIds();
+        assertNotNull(imageIds);
+        Optional<String> imageIdOptional = imageIds.stream().findFirst();
+        Assertions.assertTrue(imageIdOptional.isPresent(), "Check that the parsed ImageCatalog contains image reference for the Cloudbreak version.");
+        String imageId = imageIdOptional.get();
+        boolean baseImageFound = false;
+        if (catalog.getImages().getBaseImages() != null) {
+            baseImageFound = catalog.getImages().getBaseImages().stream().anyMatch(i -> i.getUuid().equals(imageId));
+        }
+        Assertions.assertTrue(baseImageFound, "Check that the parsed ImageCatalog contains image for the Cloudbreak version.");
+    }
+
+    @Test
+    public void testImageCatalogErrorWhenNull() {
+        String path = getPath(CB_IMAGE_CATALOG_NULL_FIELD_JSON);
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+        String errorMessage = getErrorMessage(CB_IMAGE_CATALOG_NULL_FIELD_JSON);
+
+        String expected = "Missing required creator property 'images' (index 0)";
+        Assertions.assertTrue(errorMessage.startsWith(expected), "Check that the 'images' field is missing");
+
+    }
+
+    private String getPath(String catalogUrl) {
+        try {
+            return TestUtil.getFilePath(getClass(), catalogUrl).getParent().toString();
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Catalog JSON cannot be read: %s", catalogUrl), e);
+        }
+    }
+
+    @Test
+    public void testImageCatalogValid() throws CloudbreakImageCatalogException {
+        String path = getPath(CB_IMAGE_CATALOG_VALID_JSON);
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+        underTest.getImageCatalogWrapper(CB_IMAGE_CATALOG_VALID_JSON);
+    }
+
+    @Test
+    public void testImageCatalogFilterNothing() throws CloudbreakImageCatalogException, IOException {
+        String path = getPath(CB_IMAGE_CATALOG_RC_JSON);
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+
+        CloudbreakImageCatalogV3 actualCatalog = underTest.getImageCatalogWrapper(CB_IMAGE_CATALOG_RC_JSON).getImageCatalog();
+
+        List<String> actualOsTypes = getImageCatalogOses(actualCatalog);
+        assertEquals(RC_IMAGE_CATALOG_OS_TYPES, actualOsTypes);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        CloudbreakImageCatalogV3 expectedCatalog =
+                objectMapper.readValue(Paths.get(path, CB_IMAGE_CATALOG_RC_JSON).toFile(), CloudbreakImageCatalogV3.class);
+
+        assertEquals(mapToUuid(expectedCatalog.getImages().getBaseImages()), mapToUuid(actualCatalog.getImages().getBaseImages()));
+        assertEquals(mapToUuid(expectedCatalog.getImages().getCdhImages()), mapToUuid(actualCatalog.getImages().getCdhImages()));
+    }
+
+    private List<String> mapToUuid(List<Image> imageList) {
+        return imageList.stream()
+                .map(Image::getUuid)
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void testCbImageCatalogFilterToAmazonlinux() throws CloudbreakImageCatalogException, IOException {
+        String path = getPath(CB_IMAGE_CATALOG_V2_JSON);
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", CB_AMAZONLINUX_FILTER);
+
+        CloudbreakImageCatalogV3 actualCatalog = underTest.getImageCatalogWrapper(CB_IMAGE_CATALOG_V2_JSON).getImageCatalog();
+
+        List<String> actualOsTypes = getImageCatalogOses(actualCatalog);
+        assertEquals(CB_AMAZONLINUX_FILTER, actualOsTypes);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        CloudbreakImageCatalogV3 expectedCatalog = objectMapper.readValue(Paths.get(path, CB_IMAGE_CATALOG_V2_JSON).toFile(), CloudbreakImageCatalogV3.class);
+
+        assertEquals(mapToUuid(expectedCatalog.getImages().getBaseImages()), mapToUuid(actualCatalog.getImages().getBaseImages()));
+        assertEquals(mapToUuid(Collections.emptyList()), mapToUuid(actualCatalog.getImages().getCdhImages()));
+        assertEquals(1, expectedCatalog.getImages().getCdhImages().size());
+    }
+
+    @Test
+    public void testFreeipaImageCatalogFilterToRedhat7() throws CloudbreakImageCatalogException, IOException {
+        String path = getPath(FREEIPA_IMAGE_CATALOG_V3_JSON);
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", CB_REDHAT7_FILTER);
+
+        CloudbreakImageCatalogV3 actualCatalog = underTest.getImageCatalogWrapper(FREEIPA_IMAGE_CATALOG_V3_JSON).getImageCatalog();
+
+        assertEquals(mapToUuid(Collections.emptyList()), mapToUuid(actualCatalog.getImages().getBaseImages()));
+        assertEquals(mapToUuid(Collections.emptyList()), mapToUuid(actualCatalog.getImages().getCdhImages()));
+        assertEquals(1, actualCatalog.getImages().getFreeIpaImages().size());
+        assertEquals("81851893-8340-411d-afb7-e1b55107fb10", actualCatalog.getImages().getFreeIpaImages().get(0).getUuid());
+    }
+
+    private List<String> getImageCatalogOses(CloudbreakImageCatalogV3 actualCatalog) {
+        return actualCatalog.getImages().getBaseImages().stream()
+                .map(Image::getOs)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    @Test
+    public void testHttpImageCatalogValid() throws CloudbreakImageCatalogException, IOException {
+        String path = getPath(CB_IMAGE_CATALOG_VALID_JSON);
+        String catalogUrl = "http";
+
+        when(restClientFactory.getOrCreateDefault()).thenReturn(clientMock);
+        when(clientMock.target(catalogUrl)).thenReturn(webTargetMock);
+        when(webTargetMock.request()).thenReturn(builderMock);
+        when(builderMock.get()).thenReturn(responseMock);
+        when(responseMock.getStatusInfo()).thenReturn(statusTypeMock);
+        when(statusTypeMock.getFamily()).thenReturn(Response.Status.Family.SUCCESSFUL);
+        when(responseMock.readEntity(String.class)).thenReturn(Files.readString(Paths.get(path, CB_IMAGE_CATALOG_V2_JSON)));
+
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+
+        CloudbreakImageCatalogV3 actualCatalog = underTest.getImageCatalogWrapper(catalogUrl).getImageCatalog();
+
+        CloudbreakImageCatalogV3 expectedCatalog = objectMapper.readValue(Paths.get(path, CB_IMAGE_CATALOG_V2_JSON).toFile(), CloudbreakImageCatalogV3.class);
+
+        assertEquals(mapToUuid(expectedCatalog.getImages().getBaseImages()), mapToUuid(actualCatalog.getImages().getBaseImages()));
+        assertEquals(mapToUuid(expectedCatalog.getImages().getCdhImages()), mapToUuid(actualCatalog.getImages().getCdhImages()));
+
+    }
+
+    @Test
+    public void testHttpImageCatalogNotValidJson() {
+        String path = getPath(CB_IMAGE_CATALOG_VALID_JSON);
+        String catalogUrl = "http";
+
+        when(restClientFactory.getOrCreateDefault()).thenReturn(clientMock);
+        when(clientMock.target(catalogUrl)).thenReturn(webTargetMock);
+        when(webTargetMock.request()).thenReturn(builderMock);
+        when(builderMock.get()).thenReturn(responseMock);
+        when(responseMock.getStatusInfo()).thenReturn(statusTypeMock);
+        when(statusTypeMock.getFamily()).thenReturn(Response.Status.Family.SUCCESSFUL);
+        when(responseMock.readEntity(String.class)).thenReturn("image catalog");
+
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+
+        Assertions.assertThrows(CloudbreakImageCatalogException.class, () -> underTest.getImageCatalogWrapper(catalogUrl));
+    }
+
+    @Test
+    public void testImageCatalogFilterNullImages() throws CloudbreakImageCatalogException {
+        String path = getPath(CB_IMAGE_CATALOG_FILTER_NULL_IMAGES_JSON);
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+
+        CloudbreakImageCatalogV3 imageCatalogV2 = underTest.getImageCatalogWrapper(CB_IMAGE_CATALOG_FILTER_NULL_IMAGES_JSON).getImageCatalog();
+        assertEquals(1L, imageCatalogV2.getImages().getBaseImages().get(0).getImageSetsByProvider().values().size());
+    }
+
+    @Test
+    public void testCbImageCatalogFilterImagesNull() throws CloudbreakImageCatalogException {
+        String path = getPath(CB_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON);
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+
+        Assertions.assertThrows(CloudbreakImageCatalogException.class, () -> underTest.getImageCatalogWrapper(CB_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON));
+    }
+
+    @Test
+    public void testFreeipaImageCatalogFilterImagesNull() throws CloudbreakImageCatalogException {
+        String path = getPath(FREEIPA_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON);
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+
+        Assertions.assertThrows(CloudbreakImageCatalogException.class, () -> underTest.getImageCatalogWrapper(FREEIPA_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON));
+    }
+
+    @Test
+    public void testImageCatalogWithoutBaseImages() throws CloudbreakImageCatalogException {
+        String path = getPath(CB_IMAGE_CATALOG_WITHOUT_BASE_IMAGES);
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+
+        CloudbreakImageCatalogV3 imageCatalogV2 = underTest.getImageCatalogWrapper(CB_IMAGE_CATALOG_WITHOUT_BASE_IMAGES).getImageCatalog();
+        assertNotNull(imageCatalogV2.getImages().getBaseImages());
+    }
+
+    @Test
+    public void testImageCatalogWithoutCdhImages() throws CloudbreakImageCatalogException {
+        String path = getPath(CB_IMAGE_CATALOG_WITHOUT_CDH_IMAGES);
+        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
+        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+
+        CloudbreakImageCatalogV3 imageCatalogV2 = underTest.getImageCatalogWrapper(CB_IMAGE_CATALOG_WITHOUT_CDH_IMAGES).getImageCatalog();
+        assertNotNull(imageCatalogV2.getImages().getCdhImages());
+    }
+
+    private String getErrorMessage(String catalogUrl) {
+        String errorMessage = "";
+        try {
+            underTest.getImageCatalogWrapper(catalogUrl);
+        } catch (CloudbreakImageCatalogException e) {
+            errorMessage = e.getMessage();
+        }
+
+        return errorMessage;
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogProviderTest.java
@@ -1,348 +1,69 @@
 package com.sequenceiq.cloudbreak.service.image;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status.Family;
-import javax.ws.rs.core.Response.StatusType;
-
-import com.sequenceiq.cloudbreak.service.image.catalog.ImageCatalogServiceProxy;
-import org.assertj.core.util.Lists;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sequenceiq.cloudbreak.TestUtil;
-import com.sequenceiq.cloudbreak.client.ConfigKey;
-import com.sequenceiq.cloudbreak.client.RestClientUtil;
 import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
-import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakVersion;
-import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
 import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.service.image.catalog.model.ImageCatalogMetaData;
+import com.sequenceiq.cloudbreak.service.image.catalog.model.ImageCatalogWrapper;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ImageCatalogProviderTest {
 
-    private static final String CB_IMAGE_CATALOG_V2_JSON = "cb-image-catalog-v2.json";
+    private static final String IMAGE_CATALOG_URL = "imageCatalogUrl";
 
-    private static final String FREEIPA_IMAGE_CATALOG_V3_JSON = "freeipa-image-catalog-v3.json";
-
-    private static final String CB_IMAGE_CATALOG_RC_JSON = "cb-rc-image-catalog.json";
-
-    private static final String CB_IMAGE_CATALOG_NULL_FIELD_JSON = "cb-image-catalog-null-field.json";
-
-    private static final String CB_IMAGE_CATALOG_VALID_JSON = "cb-image-catalog-valid.json";
-
-    private static final String CB_IMAGE_CATALOG_FILTER_NULL_IMAGES_JSON = "cb-image-catalog-filter-null-images.json";
-
-    private static final String CB_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON = "cb-image-catalog-filter-images-null.json";
-
-    private static final String FREEIPA_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON = "freeipa-image-catalog-filter-images-null.json";
-
-    private static final String CB_IMAGE_CATALOG_EMPTY_CLOUDBREAK_VERSIONS_JSON = "cb-image-catalog-empty-cloudbreak-versions.json";
-
-    private static final String CB_IMAGE_CATALOG_WITHOUT_BASE_IMAGES = "cb-image-catalog-without-base-images.json";
-
-    private static final String CB_IMAGE_CATALOG_WITHOUT_CDH_IMAGES = "cb-image-catalog-without-cdh-images.json";
-
-    private static final String CB_VERSION = "1.16.5";
-
-    private static final List<String> RC_IMAGE_CATALOG_OS_TYPES = Lists.newArrayList("amazonlinux", "centos7", "amazonlinux2", "sles12", "ubuntu16");
-
-    private static final List<String> CB_AMAZONLINUX_FILTER = Lists.newArrayList("amazonlinux");
-
-    private static final List<String> CB_REDHAT7_FILTER = Lists.newArrayList("redhat7");
-
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
+    @Mock
+    private CachedImageCatalogWrapperProvider cachedImageCatalogWrapperProvider;
 
     @InjectMocks
-    private CachedImageCatalogProvider underTest;
+    private ImageCatalogProvider victim;
 
-    @Mock
-    private Client clientMock;
+    @Test
+    public void shouldReturnImageCatalogWithoutForceRefresh() throws CloudbreakImageCatalogException {
+        ImageCatalogWrapper imageCatalogWrapper = mock(ImageCatalogWrapper.class);
+        CloudbreakImageCatalogV3 imageCatalogV3 = mock(CloudbreakImageCatalogV3.class);
+        when(cachedImageCatalogWrapperProvider.getImageCatalogWrapper(IMAGE_CATALOG_URL)).thenReturn(imageCatalogWrapper);
+        when(imageCatalogWrapper.getImageCatalog()).thenReturn(imageCatalogV3);
 
-    @Mock
-    private WebTarget webTargetMock;
+        CloudbreakImageCatalogV3 actual = victim.getImageCatalogV3(IMAGE_CATALOG_URL);
 
-    @Mock
-    private Builder builderMock;
-
-    @Mock
-    private Response responseMock;
-
-    @Mock
-    private StatusType statusTypeMock;
-
-    @Mock
-    private ImageCatalogServiceProxy imageCatalogServiceProxy;
-
-    @Spy
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
-    private Map<ConfigKey, Client> clientMap = new HashMap<>();
-
-    @Before
-    public void setUp() throws Exception {
-        clientMap.put(new ConfigKey(false, false, false), clientMock);
-
-        Field field = RestClientUtil.class.getDeclaredField("CLIENTS");
-        field.setAccessible(true);
-
-        Field modifiersField = Field.class.getDeclaredField("modifiers");
-        modifiersField.setAccessible(true);
-        modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-
-        field.set(null, clientMap);
+        assertEquals(imageCatalogV3, actual);
+        verifyNoMoreInteractions(cachedImageCatalogWrapperProvider);
     }
 
     @Test
-    public void testReadImageCatalogFromFile() throws Exception {
+    public void shouldReturnImageCatalogWithForceRefresh() throws CloudbreakImageCatalogException {
+        ImageCatalogWrapper imageCatalogWrapper = mock(ImageCatalogWrapper.class);
+        CloudbreakImageCatalogV3 imageCatalogV3 = mock(CloudbreakImageCatalogV3.class);
+        when(cachedImageCatalogWrapperProvider.getImageCatalogWrapper(IMAGE_CATALOG_URL)).thenReturn(imageCatalogWrapper);
+        when(imageCatalogWrapper.getImageCatalog()).thenReturn(imageCatalogV3);
 
-        String path = getPath(CB_IMAGE_CATALOG_V2_JSON);
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
+        CloudbreakImageCatalogV3 actual = victim.getImageCatalogV3(IMAGE_CATALOG_URL, true);
 
-        CloudbreakImageCatalogV3 catalog = underTest.getImageCatalogV3(CB_IMAGE_CATALOG_V2_JSON);
-
-        assertNotNull("Check that the parsed ImageCatalog not null.", catalog);
-        Optional<CloudbreakVersion> ver = catalog.getVersions().getCloudbreakVersions().stream().filter(v -> v.getVersions().contains(CB_VERSION)).findFirst();
-        Assert.assertTrue("Check that the parsed ImageCatalog contains the desired version of Cloudbreak.", ver.isPresent());
-        List<String> imageIds = ver.get().getImageIds();
-        assertNotNull("Check that the parsed ImageCatalog contains the desired version of Cloudbreak with image id(s).", imageIds);
-        Optional<String> imageIdOptional = imageIds.stream().findFirst();
-        Assert.assertTrue("Check that the parsed ImageCatalog contains image reference for the Cloudbreak version.", imageIdOptional.isPresent());
-        String imageId = imageIdOptional.get();
-        boolean baseImageFound = false;
-        if (catalog.getImages().getBaseImages() != null) {
-            baseImageFound = catalog.getImages().getBaseImages().stream().anyMatch(i -> i.getUuid().equals(imageId));
-        }
-        Assert.assertTrue("Check that the parsed ImageCatalog contains image for the Cloudbreak version.", baseImageFound);
+        assertEquals(imageCatalogV3, actual);
+        verify(cachedImageCatalogWrapperProvider).evictImageCatalogCache(IMAGE_CATALOG_URL);
     }
 
     @Test
-    public void testImageCatalogErrorWhenNull() {
-        String path = getPath(CB_IMAGE_CATALOG_NULL_FIELD_JSON);
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
-        String errorMessage = getErrorMessage(CB_IMAGE_CATALOG_NULL_FIELD_JSON);
+    public void shouldReturnImageCatalogMetaData() throws CloudbreakImageCatalogException {
+        ImageCatalogWrapper imageCatalogWrapper = mock(ImageCatalogWrapper.class);
+        ImageCatalogMetaData imageCatalogMetaData = mock(ImageCatalogMetaData.class);
+        when(cachedImageCatalogWrapperProvider.getImageCatalogWrapper(IMAGE_CATALOG_URL)).thenReturn(imageCatalogWrapper);
+        when(imageCatalogWrapper.getImageCatalogMetaData()).thenReturn(imageCatalogMetaData);
 
-        String expected = "Missing required creator property 'images' (index 0)";
-        Assert.assertTrue("Check that the 'images' field is missing", errorMessage.startsWith(expected));
+        ImageCatalogMetaData actual = victim.getImageCatalogMetaData(IMAGE_CATALOG_URL);
 
-    }
-
-    private String getPath(String catalogUrl) {
-        try {
-            return TestUtil.getFilePath(getClass(), catalogUrl).getParent().toString();
-        } catch (Exception e) {
-            throw new RuntimeException(String.format("Catalog JSON cannot be read: %s", catalogUrl), e);
-        }
-    }
-
-    @Test
-    public void testImageCatalogValid() throws CloudbreakImageCatalogException {
-        String path = getPath(CB_IMAGE_CATALOG_VALID_JSON);
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
-        underTest.getImageCatalogV3(CB_IMAGE_CATALOG_VALID_JSON);
-    }
-
-    @Test
-    public void testImageCatalogFilterNothing() throws CloudbreakImageCatalogException, IOException {
-        String path = getPath(CB_IMAGE_CATALOG_RC_JSON);
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
-
-        CloudbreakImageCatalogV3 actualCatalog = underTest.getImageCatalogV3(CB_IMAGE_CATALOG_RC_JSON);
-
-        List<String> actualOsTypes = getImageCatalogOses(actualCatalog);
-        assertEquals(RC_IMAGE_CATALOG_OS_TYPES, actualOsTypes);
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        CloudbreakImageCatalogV3 expectedCatalog =
-                objectMapper.readValue(Paths.get(path, CB_IMAGE_CATALOG_RC_JSON).toFile(), CloudbreakImageCatalogV3.class);
-
-        assertEquals(mapToUuid(expectedCatalog.getImages().getBaseImages()), mapToUuid(actualCatalog.getImages().getBaseImages()));
-        assertEquals(mapToUuid(expectedCatalog.getImages().getCdhImages()), mapToUuid(actualCatalog.getImages().getCdhImages()));
-    }
-
-    private List<String> mapToUuid(List<Image> imageList) {
-        return imageList.stream()
-                .map(Image::getUuid)
-                .collect(Collectors.toList());
-    }
-
-    @Test
-    public void testCbImageCatalogFilterToAmazonlinux() throws CloudbreakImageCatalogException, IOException {
-        String path = getPath(CB_IMAGE_CATALOG_V2_JSON);
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", CB_AMAZONLINUX_FILTER);
-
-        CloudbreakImageCatalogV3 actualCatalog = underTest.getImageCatalogV3(CB_IMAGE_CATALOG_V2_JSON);
-
-        List<String> actualOsTypes = getImageCatalogOses(actualCatalog);
-        assertEquals(CB_AMAZONLINUX_FILTER, actualOsTypes);
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        CloudbreakImageCatalogV3 expectedCatalog = objectMapper.readValue(Paths.get(path, CB_IMAGE_CATALOG_V2_JSON).toFile(), CloudbreakImageCatalogV3.class);
-
-        assertEquals(mapToUuid(expectedCatalog.getImages().getBaseImages()), mapToUuid(actualCatalog.getImages().getBaseImages()));
-        assertEquals(mapToUuid(Collections.emptyList()), mapToUuid(actualCatalog.getImages().getCdhImages()));
-        assertEquals(1, expectedCatalog.getImages().getCdhImages().size());
-    }
-
-    @Test
-    public void testFreeipaImageCatalogFilterToRedhat7() throws CloudbreakImageCatalogException, IOException {
-        String path = getPath(FREEIPA_IMAGE_CATALOG_V3_JSON);
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", CB_REDHAT7_FILTER);
-
-        CloudbreakImageCatalogV3 actualCatalog = underTest.getImageCatalogV3(FREEIPA_IMAGE_CATALOG_V3_JSON);
-
-        assertEquals(mapToUuid(Collections.emptyList()), mapToUuid(actualCatalog.getImages().getBaseImages()));
-        assertEquals(mapToUuid(Collections.emptyList()), mapToUuid(actualCatalog.getImages().getCdhImages()));
-        assertEquals(1, actualCatalog.getImages().getFreeIpaImages().size());
-        assertEquals("81851893-8340-411d-afb7-e1b55107fb10", actualCatalog.getImages().getFreeIpaImages().get(0).getUuid());
-    }
-
-    private List<String> getImageCatalogOses(CloudbreakImageCatalogV3 actualCatalog) {
-        return actualCatalog.getImages().getBaseImages().stream()
-                .map(Image::getOs)
-                .distinct()
-                .collect(Collectors.toList());
-    }
-
-    @Test
-    public void testHttpImageCatalogValid() throws CloudbreakImageCatalogException, IOException {
-        String path = getPath(CB_IMAGE_CATALOG_VALID_JSON);
-        String catalogUrl = "http";
-
-        when(clientMock.target(catalogUrl)).thenReturn(webTargetMock);
-        when(webTargetMock.request()).thenReturn(builderMock);
-        when(builderMock.get()).thenReturn(responseMock);
-        when(responseMock.getStatusInfo()).thenReturn(statusTypeMock);
-        when(statusTypeMock.getFamily()).thenReturn(Family.SUCCESSFUL);
-        when(responseMock.readEntity(String.class)).thenReturn(Files.readString(Paths.get(path, CB_IMAGE_CATALOG_V2_JSON)));
-
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
-
-        CloudbreakImageCatalogV3 actualCatalog = underTest.getImageCatalogV3(catalogUrl);
-
-        CloudbreakImageCatalogV3 expectedCatalog = objectMapper.readValue(Paths.get(path, CB_IMAGE_CATALOG_V2_JSON).toFile(), CloudbreakImageCatalogV3.class);
-
-        assertEquals(mapToUuid(expectedCatalog.getImages().getBaseImages()), mapToUuid(actualCatalog.getImages().getBaseImages()));
-        assertEquals(mapToUuid(expectedCatalog.getImages().getCdhImages()), mapToUuid(actualCatalog.getImages().getCdhImages()));
-
-    }
-
-    @Test(expected = CloudbreakImageCatalogException.class)
-    public void testHttpImageCatalogNotValidJson() throws CloudbreakImageCatalogException {
-        String path = getPath(CB_IMAGE_CATALOG_VALID_JSON);
-        String catalogUrl = "http";
-
-        when(clientMock.target(catalogUrl)).thenReturn(webTargetMock);
-        when(webTargetMock.request()).thenReturn(builderMock);
-        when(builderMock.get()).thenReturn(responseMock);
-        when(responseMock.getStatusInfo()).thenReturn(statusTypeMock);
-        when(statusTypeMock.getFamily()).thenReturn(Family.SUCCESSFUL);
-        when(responseMock.readEntity(String.class)).thenReturn("image catalog");
-
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
-
-        underTest.getImageCatalogV3(catalogUrl);
-    }
-
-    @Test
-    public void testImageCatalogFilterNullImages() throws CloudbreakImageCatalogException {
-        String path = getPath(CB_IMAGE_CATALOG_FILTER_NULL_IMAGES_JSON);
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
-
-        CloudbreakImageCatalogV3 imageCatalogV2 = underTest.getImageCatalogV3(CB_IMAGE_CATALOG_FILTER_NULL_IMAGES_JSON);
-        assertEquals(1L, imageCatalogV2.getImages().getBaseImages().get(0).getImageSetsByProvider().values().size());
-    }
-
-    @Test
-    public void testCbImageCatalogFilterImagesNull() throws CloudbreakImageCatalogException {
-        String path = getPath(CB_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON);
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
-
-        thrown.expectMessage("Base and CDH images are empty or every items equals NULL");
-        thrown.expect(CloudbreakImageCatalogException.class);
-
-        underTest.getImageCatalogV3(CB_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON);
-    }
-
-    @Test
-    public void testFreeipaImageCatalogFilterImagesNull() throws CloudbreakImageCatalogException {
-        String path = getPath(FREEIPA_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON);
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
-
-        thrown.expectMessage("Freeipa images are empty or every items equals NULL");
-        thrown.expect(CloudbreakImageCatalogException.class);
-
-        underTest.getImageCatalogV3(FREEIPA_IMAGE_CATALOG_FILTER_IMAGES_NULL_JSON);
-    }
-
-    @Test
-    public void testImageCatalogWithoutBaseImages() throws CloudbreakImageCatalogException {
-        String path = getPath(CB_IMAGE_CATALOG_WITHOUT_BASE_IMAGES);
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
-
-        CloudbreakImageCatalogV3 imageCatalogV2 = underTest.getImageCatalogV3(CB_IMAGE_CATALOG_WITHOUT_BASE_IMAGES);
-        assertNotNull(imageCatalogV2.getImages().getBaseImages());
-    }
-
-    @Test
-    public void testImageCatalogWithoutCdhImages() throws CloudbreakImageCatalogException {
-        String path = getPath(CB_IMAGE_CATALOG_WITHOUT_CDH_IMAGES);
-        ReflectionTestUtils.setField(underTest, "etcConfigDir", path);
-        ReflectionTestUtils.setField(underTest, "enabledLinuxTypes", Collections.emptyList());
-
-        CloudbreakImageCatalogV3 imageCatalogV2 = underTest.getImageCatalogV3(CB_IMAGE_CATALOG_WITHOUT_CDH_IMAGES);
-        assertNotNull(imageCatalogV2.getImages().getCdhImages());
-    }
-
-    private String getErrorMessage(String catalogUrl) {
-        String errorMessage = "";
-        try {
-            underTest.getImageCatalogV3(catalogUrl);
-        } catch (CloudbreakImageCatalogException e) {
-            errorMessage = e.getMessage();
-        }
-
-        return errorMessage;
+        assertEquals(imageCatalogMetaData, actual);
+        verifyNoMoreInteractions(cachedImageCatalogWrapperProvider);
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/ImageCatalogServiceTest.java
@@ -81,6 +81,7 @@ import com.sequenceiq.cloudbreak.service.image.catalog.AdvertisedImageProvider;
 import com.sequenceiq.cloudbreak.service.image.catalog.ImageCatalogServiceProxy;
 import com.sequenceiq.cloudbreak.service.image.catalog.VersionBasedImageCatalogService;
 import com.sequenceiq.cloudbreak.service.image.catalog.VersionBasedImageProvider;
+import com.sequenceiq.cloudbreak.service.image.catalog.model.ImageCatalogMetaData;
 import com.sequenceiq.cloudbreak.service.stack.StackService;
 import com.sequenceiq.cloudbreak.service.user.UserProfileHandler;
 import com.sequenceiq.cloudbreak.service.user.UserProfileService;
@@ -900,6 +901,19 @@ public class ImageCatalogServiceTest {
         assertEquals(4, actual.size());
         assertTrue(actual.contains(imageCatalogs.stream().filter(catalog -> catalog.getName().equals("default")).findFirst().get()));
         assertTrue(actual.contains(imageCatalogs.stream().filter(catalog -> catalog.getName().equals(CUSTOM_CATALOG_NAME)).findFirst().get()));
+    }
+
+    @Test
+    public void testGetRuntimeVersionsFromDefault() throws CloudbreakImageCatalogException {
+        List<String> expected = List.of("7.2.1");
+        ImageCatalogMetaData imageCatalogMetaData = mock(ImageCatalogMetaData.class);
+
+        when(imageCatalogProvider.getImageCatalogMetaData(DEFAULT_CATALOG_URL)).thenReturn(imageCatalogMetaData);
+        when(imageCatalogMetaData.getRuntimeVersions()).thenReturn(expected);
+
+        List<String> actual = underTest.getRuntimeVersionsFromDefault();
+
+        assertEquals(expected, actual);
     }
 
     private void setupImageCatalogProvider(String catalogUrl, String catalogFile) throws IOException, CloudbreakImageCatalogException {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/image/catalog/ImageCatalogServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/image/catalog/ImageCatalogServiceTest.java
@@ -1,0 +1,91 @@
+package com.sequenceiq.cloudbreak.service.image.catalog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.testcontainers.shaded.org.apache.commons.lang.NotImplementedException;
+
+import com.sequenceiq.cloudbreak.cloud.model.catalog.CloudbreakImageCatalogV3;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Image;
+import com.sequenceiq.cloudbreak.cloud.model.catalog.Images;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.service.image.ImageFilter;
+import com.sequenceiq.cloudbreak.service.image.StatedImages;
+import com.sequenceiq.cloudbreak.service.image.catalog.model.ImageCatalogMetaData;
+import com.sequenceiq.cloudbreak.service.upgrade.image.ImageFilterResult;
+
+@ExtendWith(MockitoExtension.class)
+public class ImageCatalogServiceTest {
+
+    private static final String RUNTIME_721 = "7.2.1";
+
+    private static final String RUNTIME_722 = "7.2.2";
+
+    private static final String RUNTIME_7210 = "7.2.10";
+
+    private ImageCatalogService victim;
+
+    @Mock
+    private CloudbreakImageCatalogV3 imageCatalogV3;
+
+    @BeforeEach
+    public void initTests() {
+        Image runtimeImage721 = mock(Image.class);
+        Image runtimeImage722 = mock(Image.class);
+        Image runtimeImage7210 = mock(Image.class);
+        imageCatalogV3 = mock(CloudbreakImageCatalogV3.class);
+
+        when(runtimeImage721.getVersion()).thenReturn(RUNTIME_721);
+        when(runtimeImage722.getVersion()).thenReturn(RUNTIME_722);
+        when(runtimeImage7210.getVersion()).thenReturn(RUNTIME_7210);
+
+        Images images = new Images(List.of(), List.of(runtimeImage722, runtimeImage7210, runtimeImage721, runtimeImage721), List.of(), Set.of());
+        ImageFilterResult imageFilterResult = new ImageFilterResult(images, null);
+
+        victim = new TestImplementation(imageCatalogV3, imageFilterResult);
+    }
+
+    @Test
+    public void testGetImageMetaDataContainsDistinctListOfVersionsInReversedOrder() {
+        ImageCatalogMetaData imageCatalogMetaData = victim.getImageCatalogMetaData(imageCatalogV3);
+
+        assertEquals(List.of(RUNTIME_7210, RUNTIME_722, RUNTIME_721), imageCatalogMetaData.getRuntimeVersions());
+    }
+
+    private static class TestImplementation implements ImageCatalogService {
+
+        private CloudbreakImageCatalogV3 imageCatalogV3;
+
+        private ImageFilterResult imageFilterResult;
+
+        TestImplementation(CloudbreakImageCatalogV3 imageCatalogV3, ImageFilterResult imageFilterResult) {
+            this.imageCatalogV3 = imageCatalogV3;
+            this.imageFilterResult = imageFilterResult;
+        }
+
+        @Override
+        public StatedImages getImages(CloudbreakImageCatalogV3 imageCatalogV3, ImageFilter imageFilter) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public void validate(CloudbreakImageCatalogV3 imageCatalogV3) throws CloudbreakImageCatalogException {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public ImageFilterResult getImageFilterResult(CloudbreakImageCatalogV3 imageCatalogV3) {
+            assertEquals(this.imageCatalogV3, imageCatalogV3);
+            return imageFilterResult;
+        }
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/runtimes/SupportedRuntimesTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/runtimes/SupportedRuntimesTest.java
@@ -1,21 +1,36 @@
 package com.sequenceiq.cloudbreak.service.runtimes;
 
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.powermock.reflect.Whitebox;
+
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SupportedRuntimesTest {
 
+    private static final String RUNTIME_700 = "7.0.0";
+
+    private static final String RUNTIME_710 = "7.1.0";
+
+    private static final String RUNTIME_720 = "7.2.0";
+
+    private static final String RUNTIME_7210 = "7.2.10";
+
+    @InjectMocks
     private SupportedRuntimes underTest;
 
-    @Before
-    public void setUp() {
-        underTest = new SupportedRuntimes();
-    }
+    @Mock
+    private ImageCatalogService imageCatalogService;
 
     @Test
     public void testAllowEverything() {
@@ -24,9 +39,9 @@ public class SupportedRuntimesTest {
 
     @Test
     public void testSupported() {
-        Whitebox.setInternalState(underTest, "latestSupportedRuntime", "7.1.0");
+        Whitebox.setInternalState(underTest, "latestSupportedRuntime", RUNTIME_710);
         // Older or equal versions shall be supported
-        Assert.assertTrue(underTest.isSupported("7.1.0"));
+        Assert.assertTrue(underTest.isSupported(RUNTIME_710));
         Assert.assertTrue(underTest.isSupported("7.1.0.0"));
         Assert.assertTrue(underTest.isSupported("7.0.99.0"));
         Assert.assertTrue(underTest.isSupported("7"));
@@ -35,16 +50,58 @@ public class SupportedRuntimesTest {
 
     @Test
     public void testNotSupported() {
-        Whitebox.setInternalState(underTest, "latestSupportedRuntime", "7.1.0");
+        Whitebox.setInternalState(underTest, "latestSupportedRuntime", RUNTIME_710);
         // Newer versions shall not be supported
-        Assert.assertFalse(underTest.isSupported("7.2.0"));
+        Assert.assertFalse(underTest.isSupported(RUNTIME_720));
     }
 
     @Test
     public void testInvalidVersions() {
-        Whitebox.setInternalState(underTest, "latestSupportedRuntime", "7.1.0");
+        Whitebox.setInternalState(underTest, "latestSupportedRuntime", RUNTIME_710);
         // Invalid versions shall not be supported, but at least they shall not throw exception
         Assert.assertFalse(underTest.isSupported("blah"));
         Assert.assertFalse(underTest.isSupported("8"));
+    }
+
+    @Test
+    public void testSupportedByFirstDefaultImageCatalogRuntime() throws CloudbreakImageCatalogException {
+        Whitebox.setInternalState(underTest, "latestSupportedRuntime", "");
+        when(imageCatalogService.getRuntimeVersionsFromDefault()).thenReturn(List.of(RUNTIME_7210, RUNTIME_700));
+
+        Assert.assertTrue(underTest.isSupported(RUNTIME_710));
+        Assert.assertTrue(underTest.isSupported(RUNTIME_720));
+    }
+
+    @Test
+    public void testNotSupportedByFirstDefaultImageCatalogRuntime() throws CloudbreakImageCatalogException {
+        Whitebox.setInternalState(underTest, "latestSupportedRuntime", "");
+        when(imageCatalogService.getRuntimeVersionsFromDefault()).thenReturn(List.of(RUNTIME_700, RUNTIME_7210));
+
+        Assert.assertFalse(underTest.isSupported(RUNTIME_710));
+        Assert.assertFalse(underTest.isSupported(RUNTIME_720));
+    }
+
+    @Test
+    public void testNotSupportedByDefaultImageCatalogRuntimes() throws CloudbreakImageCatalogException {
+        Whitebox.setInternalState(underTest, "latestSupportedRuntime", "");
+        when(imageCatalogService.getRuntimeVersionsFromDefault()).thenReturn(List.of(RUNTIME_710));
+
+        Assert.assertFalse(underTest.isSupported(RUNTIME_720));
+    }
+
+    @Test
+    public void testSupportInCaseOfEmptyImageCatalogResponse() throws CloudbreakImageCatalogException {
+        Whitebox.setInternalState(underTest, "latestSupportedRuntime", "");
+        when(imageCatalogService.getRuntimeVersionsFromDefault()).thenReturn(List.of());
+
+        Assert.assertTrue(underTest.isSupported(RUNTIME_720));
+    }
+
+    @Test
+    public void testSupportInCaseOfImageCatalogException() throws CloudbreakImageCatalogException {
+        Whitebox.setInternalState(underTest, "latestSupportedRuntime", "");
+        when(imageCatalogService.getRuntimeVersionsFromDefault()).thenThrow(new CloudbreakImageCatalogException(""));
+
+        Assert.assertTrue(underTest.isSupported(RUNTIME_720));
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateServiceFilterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/template/ClusterTemplateServiceFilterTest.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -21,13 +22,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.powermock.reflect.Whitebox;
 
 import com.sequenceiq.cloudbreak.api.endpoint.v4.clustertemplate.responses.ClusterTemplateViewV4Response;
 import com.sequenceiq.cloudbreak.api.endpoint.v4.common.ResourceStatus;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.common.service.TransactionService;
 import com.sequenceiq.cloudbreak.converter.v4.clustertemplate.ClusterTemplateViewToClusterTemplateViewV4ResponseConverter;
+import com.sequenceiq.cloudbreak.core.CloudbreakImageCatalogException;
 import com.sequenceiq.cloudbreak.domain.view.ClusterTemplateView;
+import com.sequenceiq.cloudbreak.service.image.ImageCatalogService;
 import com.sequenceiq.cloudbreak.service.runtimes.SupportedRuntimes;
 import com.sequenceiq.distrox.v1.distrox.service.EnvironmentServiceDecorator;
 
@@ -66,10 +70,18 @@ class ClusterTemplateServiceFilterTest {
     private SupportedRuntimes supportedRuntimes;
 
     @Mock
+    private ImageCatalogService imageCatalogService;
+
+    @Mock
     private ClusterTemplateViewToClusterTemplateViewV4ResponseConverter clusterTemplateViewToClusterTemplateViewV4ResponseConverter;
 
     @InjectMocks
     private ClusterTemplateService underTest;
+
+    @BeforeEach
+    public void initTests() throws CloudbreakImageCatalogException {
+        Whitebox.setInternalState(supportedRuntimes, "imageCatalogService", imageCatalogService);
+    }
 
     // @formatter:off
     // CHECKSTYLE:OFF
@@ -102,7 +114,7 @@ class ClusterTemplateServiceFilterTest {
     }
 
     @Test
-    void testIfGettingUsableTemplateWhenTemplateIsDefaultThenTrueShouldCome() {
+    void testIfGettingUsableTemplateWhenTemplateIsDefaultThenTrueShouldCome() throws CloudbreakImageCatalogException {
         ClusterTemplateViewV4Response templateViewV4Response = new ClusterTemplateViewV4Response();
         templateViewV4Response.setStatus(ResourceStatus.DEFAULT);
 

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/imagecatalog/ImageCatalogService.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/imagecatalog/ImageCatalogService.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.datalake.service.imagecatalog;
 
+import java.util.List;
 import java.util.Optional;
 
 import javax.inject.Inject;
@@ -18,6 +19,7 @@ import com.sequenceiq.cloudbreak.api.endpoint.v4.imagecatalog.responses.ImagesV4
 import com.sequenceiq.cloudbreak.api.endpoint.v4.stacks.request.image.ImageSettingsV4Request;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.client.CloudbreakInternalCrnClient;
+import com.sequenceiq.cloudbreak.common.exception.CloudbreakServiceException;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
 import com.sequenceiq.datalake.service.sdx.SdxService;
 
@@ -89,6 +91,16 @@ public class ImageCatalogService implements ResourcePropertyProvider {
         } catch (javax.ws.rs.NotFoundException e) {
             LOGGER.info("Sdx cluster not found on CB side", e);
             return null;
+        }
+    }
+
+    public List<String> getDefaultImageCatalogRuntimeVersions(Long workspaceId) {
+        ImageCatalogV4Endpoint imageCatalogV4Endpoint = cloudbreakInternalCrnClient.withInternalCrn().imageCatalogV4Endpoint();
+        try {
+            return imageCatalogV4Endpoint.getRuntimeVersionsFromDefault(workspaceId).getRuntimeVersions();
+        } catch (Exception ex) {
+            LOGGER.error("Failed to get runtime versions from default image catalog.", ex);
+            throw new CloudbreakServiceException(ex);
         }
     }
 }

--- a/datalake/src/test/java/com/sequenceiq/datalake/configuration/CDPConfigServiceTest.java
+++ b/datalake/src/test/java/com/sequenceiq/datalake/configuration/CDPConfigServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -31,6 +32,7 @@ import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.EntitlementService;
 import com.sequenceiq.cloudbreak.auth.altus.model.Entitlement;
 import com.sequenceiq.cloudbreak.common.mappable.CloudPlatform;
+import com.sequenceiq.datalake.service.imagecatalog.ImageCatalogService;
 import com.sequenceiq.datalake.service.sdx.CDPConfigKey;
 import com.sequenceiq.sdx.api.model.AdvertisedRuntime;
 import com.sequenceiq.sdx.api.model.SdxClusterShape;
@@ -38,6 +40,18 @@ import com.sequenceiq.sdx.api.model.SdxClusterShape;
 @ExtendWith(MockitoExtension.class)
 class CDPConfigServiceTest {
     private static final String USER_CRN = "crn:altus:iam:us-west-1:test-aws:user:cloudbreak@hortonworks.com";
+
+    private static final String RUNTIME_710 = "7.1.0";
+
+    private static final String RUNTIME_722 = "7.2.2";
+
+    private static final String RUNTIME_726 = "7.2.6";
+
+    private static final String RUNTIME_729 = "7.2.9";
+
+    private static final String RUNTIME_7212 = "7.2.12";
+
+    private static final String RUNTIME_7213 = "7.2.13";
 
     @Spy
     private Set<String> advertisedRuntimes;
@@ -51,18 +65,22 @@ class CDPConfigServiceTest {
     @Mock
     private EntitlementService entitlementService;
 
+    @Mock
+    private ImageCatalogService imageCatalogService;
+
     @BeforeEach
     public void setupAll() {
         lenient().when(entitlementService.isEntitledFor(anyString(), eq(Entitlement.CDP_DATA_LAKE_MEDIUM_DUTY_WITH_PROFILER))).thenReturn(Boolean.TRUE);
+        ReflectionTestUtils.setField(cdpConfigService, "defaultRuntime", RUNTIME_710);
     }
 
     private static Object[][] testResourceTemplateDataProvider() {
         return new Object[][]{
                 //testCaseName     templatePath     expectedVersion     expectedProvider    expectedEntitlement     expectedSdxClusterShape
                 {"testResourceTemplate - with Entitlement", "resources/duties/7.2.13/aws/cdp_data_lake_medium_duty_with_profiler/medium_duty_ha.json",
-                        "7.2.13", "aws", "/cdp_data_lake_medium_duty_with_profiler", "medium_duty_ha"},
+                        RUNTIME_7213, "aws", "/cdp_data_lake_medium_duty_with_profiler", "medium_duty_ha"},
                 {"testResourceTemplate - without Entitlement", "resources/duties/7.2.13/aws/medium_duty_ha.json",
-                        "7.2.13", "aws", null, "medium_duty_ha"}
+                        RUNTIME_7213, "aws", null, "medium_duty_ha"}
         };
     }
 
@@ -83,22 +101,22 @@ class CDPConfigServiceTest {
         ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> {
             when(supportedRuntimes.isEmpty()).thenReturn(true);
             cdpConfigService.initCdpStackRequests();
-            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-            assertTrue(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.2.13"))
+            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, RUNTIME_710)));
+            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, RUNTIME_710)));
+            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+            assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, RUNTIME_710)));
+            assertTrue(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, RUNTIME_7213))
                     .getCluster().getBlueprintName().contains("Profiler"));
-            assertFalse(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.2.12"))
+            assertFalse(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, RUNTIME_7212))
                     .getCluster().getBlueprintName().contains("Profiler"));
-            assertFalse(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.2.13"))
+            assertFalse(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, RUNTIME_7213))
                     .getCluster().getBlueprintName().contains("Profiler"));
             lenient().when(entitlementService.isEntitledFor(anyString(), eq(Entitlement.CDP_DATA_LAKE_MEDIUM_DUTY_WITH_PROFILER))).thenReturn(Boolean.FALSE);
-            assertFalse(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, "7.2.13"))
+            assertFalse(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.MEDIUM_DUTY_HA, RUNTIME_7213))
                     .getCluster().getBlueprintName().contains("Profiler"));
         });
     }
@@ -107,16 +125,16 @@ class CDPConfigServiceTest {
     void cdpEnableStackRequests() {
         when(supportedRuntimes.isEmpty()).thenReturn(false);
         when(supportedRuntimes.contains(Mockito.anyString())).thenReturn(true);
-        when(supportedRuntimes.contains("7.2.12")).thenReturn(false);
+        when(supportedRuntimes.contains(RUNTIME_7212)).thenReturn(false);
         cdpConfigService.initCdpStackRequests();
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
+        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+        assertNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, RUNTIME_710)));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, RUNTIME_710)));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, RUNTIME_710)));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, RUNTIME_710)));
     }
 
     @Test
@@ -124,30 +142,48 @@ class CDPConfigServiceTest {
         when(supportedRuntimes.isEmpty()).thenReturn(false);
         when(supportedRuntimes.contains(Mockito.anyString())).thenReturn(true);
         cdpConfigService.initCdpStackRequests();
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.2.12")));
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
-        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, "7.1.0")));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, RUNTIME_7212)));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AWS, SdxClusterShape.LIGHT_DUTY, RUNTIME_710)));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.AZURE, SdxClusterShape.LIGHT_DUTY, RUNTIME_710)));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.YARN, SdxClusterShape.LIGHT_DUTY, RUNTIME_710)));
+        assertNotNull(cdpConfigService.getConfigForKey(new CDPConfigKey(CloudPlatform.MOCK, SdxClusterShape.LIGHT_DUTY, RUNTIME_710)));
     }
 
     @Test
     void testEmptyAdvertisedRuntimes() {
-        ReflectionTestUtils.setField(cdpConfigService, "defaultRuntime", "7.1.0");
-
         when(supportedRuntimes.isEmpty()).thenReturn(false);
         when(supportedRuntimes.contains(Mockito.anyString())).thenReturn(false);
-        when(supportedRuntimes.contains("7.2.12")).thenReturn(true);
-        when(supportedRuntimes.contains("7.1.0")).thenReturn(true);
+        when(supportedRuntimes.contains(RUNTIME_7212)).thenReturn(true);
+        when(supportedRuntimes.contains(RUNTIME_710)).thenReturn(true);
 
         when(advertisedRuntimes.isEmpty()).thenReturn(true);
 
         cdpConfigService.initCdpStackRequests();
 
-        List<AdvertisedRuntime> expected = List.of(rt("7.2.12", false), rt("7.1.0", true));
+        List<AdvertisedRuntime> expected = List.of(rt(RUNTIME_7212, false), rt(RUNTIME_710, true));
+        List<AdvertisedRuntime> actual = cdpConfigService.getAdvertisedRuntimes(null);
+
+        assertArrayEquals(expected.toArray(), actual.toArray());
+    }
+
+    @Test
+    void testEmptyDefaultRuntimeAndEmptyAdvertisedRuntimes() {
+        ReflectionTestUtils.setField(cdpConfigService, "defaultRuntime", null);
+
+        when(imageCatalogService.getDefaultImageCatalogRuntimeVersions(any())).thenReturn(List.of(RUNTIME_7212, RUNTIME_729));
+        when(supportedRuntimes.isEmpty()).thenReturn(false);
+        when(supportedRuntimes.contains(Mockito.anyString())).thenReturn(false);
+        when(supportedRuntimes.contains(RUNTIME_7212)).thenReturn(true);
+        when(supportedRuntimes.contains(RUNTIME_710)).thenReturn(true);
+
+        when(advertisedRuntimes.isEmpty()).thenReturn(true);
+
+        cdpConfigService.initCdpStackRequests();
+
+        List<AdvertisedRuntime> expected = List.of(rt(RUNTIME_7212, true));
         List<AdvertisedRuntime> actual = cdpConfigService.getAdvertisedRuntimes(null);
 
         assertArrayEquals(expected.toArray(), actual.toArray());
@@ -155,45 +191,76 @@ class CDPConfigServiceTest {
 
     @Test
     void testFilteredDlVersions() {
-        List<String> supportedVersions = List.of("7.2.6", "7.2.12");
+        List<String> supportedVersions = List.of(RUNTIME_7212, RUNTIME_726);
         mockSupportedRuntimes(supportedVersions);
         cdpConfigService.initCdpStackRequests();
         assertArrayEquals(supportedVersions.toArray(), cdpConfigService.getDatalakeVersions("").toArray());
     }
 
     @Test
-    void testFilteredDlVersionsForGcp() {
-        List<String> supportedVersions = List.of("7.2.6", "7.2.2");
+    void testFilteredDlVersionsEmptyDefault() {
+        ReflectionTestUtils.setField(cdpConfigService, "defaultRuntime", null);
+
+        when(imageCatalogService.getDefaultImageCatalogRuntimeVersions(any())).thenReturn(List.of(RUNTIME_7212, RUNTIME_726));
+
+        List<String> supportedVersions = List.of(RUNTIME_7212, RUNTIME_726, RUNTIME_722);
         mockSupportedRuntimes(supportedVersions);
         cdpConfigService.initCdpStackRequests();
-        List<String> gcpSupportedVersions = List.of("7.2.6");
+        assertArrayEquals(List.of(RUNTIME_7212, RUNTIME_726).toArray(), cdpConfigService.getDatalakeVersions("").toArray());
+    }
+
+    @Test
+    void testFilteredDlVersionsForGcp() {
+        List<String> supportedVersions = List.of(RUNTIME_726, RUNTIME_722);
+        mockSupportedRuntimes(supportedVersions);
+        cdpConfigService.initCdpStackRequests();
+        List<String> gcpSupportedVersions = List.of(RUNTIME_726);
         assertArrayEquals("Templates are only available from 7.2.6",
                 gcpSupportedVersions.toArray(), cdpConfigService.getDatalakeVersions("GCP").toArray());
     }
 
     @Test
     void testFilteredDlVersionsForAws() {
-        List<String> supportedVersions = List.of("7.2.6", "7.2.12");
+        List<String> supportedVersions = List.of(RUNTIME_726, RUNTIME_7212);
         mockSupportedRuntimes(supportedVersions);
         cdpConfigService.initCdpStackRequests();
-        List<String> gcpSupportedVersions = List.of("7.2.6", "7.2.12");
+        List<String> gcpSupportedVersions = List.of(RUNTIME_7212, RUNTIME_726);
         assertArrayEquals(gcpSupportedVersions.toArray(), cdpConfigService.getDatalakeVersions("AWS").toArray());
     }
 
     @Test
     void testAdvertisedRuntimes() {
-        ReflectionTestUtils.setField(cdpConfigService, "defaultRuntime", "7.1.0");
-
-        List<String> supportedVersions = List.of("7.1.0", "7.2.12");
+        List<String> supportedVersions = List.of(RUNTIME_710, RUNTIME_7212);
         mockSupportedRuntimes(supportedVersions);
 
         when(advertisedRuntimes.isEmpty()).thenReturn(false);
-        when(advertisedRuntimes.contains("7.2.12")).thenReturn(false);
-        when(advertisedRuntimes.contains("7.1.0")).thenReturn(true);
+        when(advertisedRuntimes.contains(RUNTIME_7212)).thenReturn(false);
+        when(advertisedRuntimes.contains(RUNTIME_710)).thenReturn(true);
 
         cdpConfigService.initCdpStackRequests();
 
-        List<AdvertisedRuntime> expected = List.of(rt("7.1.0", true));
+        List<AdvertisedRuntime> expected = List.of(rt(RUNTIME_710, true));
+        List<AdvertisedRuntime> actual = cdpConfigService.getAdvertisedRuntimes(null);
+
+        assertArrayEquals(expected.toArray(), actual.toArray());
+    }
+
+    @Test
+    void testAdvertisedRuntimesWithEmptyDefault() {
+        ReflectionTestUtils.setField(cdpConfigService, "defaultRuntime", null);
+
+        when(imageCatalogService.getDefaultImageCatalogRuntimeVersions(any())).thenReturn(List.of(RUNTIME_7212, RUNTIME_729));
+
+        List<String> supportedVersions = List.of(RUNTIME_710, RUNTIME_729, RUNTIME_7212);
+        mockSupportedRuntimes(supportedVersions);
+
+        when(advertisedRuntimes.isEmpty()).thenReturn(false);
+        when(advertisedRuntimes.contains(RUNTIME_7212)).thenReturn(true);
+        when(advertisedRuntimes.contains(RUNTIME_729)).thenReturn(true);
+
+        cdpConfigService.initCdpStackRequests();
+
+        List<AdvertisedRuntime> expected = List.of(rt(RUNTIME_7212, true), rt(RUNTIME_729, false));
         List<AdvertisedRuntime> actual = cdpConfigService.getAdvertisedRuntimes(null);
 
         assertArrayEquals(expected.toArray(), actual.toArray());
@@ -201,17 +268,17 @@ class CDPConfigServiceTest {
 
     @Test
     void testAdvertisedRuntimesForGcp() {
-        ReflectionTestUtils.setField(cdpConfigService, "defaultRuntime", "7.2.6");
+        ReflectionTestUtils.setField(cdpConfigService, "defaultRuntime", RUNTIME_726);
 
-        List<String> supportedVersions = List.of("7.2.6", "7.2.2");
+        List<String> supportedVersions = List.of(RUNTIME_726, RUNTIME_722);
         mockSupportedRuntimes(supportedVersions);
 
-        List<String> advertisedVersions = List.of("7.2.6");
+        List<String> advertisedVersions = List.of(RUNTIME_726);
         mockAdvertisedRuntimes(advertisedVersions);
 
         cdpConfigService.initCdpStackRequests();
 
-        List<AdvertisedRuntime> expected = List.of(rt("7.2.6", true));
+        List<AdvertisedRuntime> expected = List.of(rt(RUNTIME_726, true));
         List<AdvertisedRuntime> actual = cdpConfigService.getAdvertisedRuntimes("GCP");
 
         assertArrayEquals(expected.toArray(), actual.toArray());


### PR DESCRIPTION
See detailed description in the commit message.