### PR TITLE
CB-15352. Fix date/step based progress calculation (that shows 99%).

### DIFF
--- a/flow/src/main/java/com/sequenceiq/flow/converter/OperationDetailsPopulator.java
+++ b/flow/src/main/java/com/sequenceiq/flow/converter/OperationDetailsPopulator.java
@@ -86,9 +86,9 @@ public class OperationDetailsPopulator {
                 source.setProgressStatus(calculateProgress(source.getOperations()));
             } else {
                 source.setProgressStatus(OperationProgressStatus.RUNNING);
-            }
-            if (progressFromHistory != null && progressFromHistory != DEFAULT_PROGRESS) {
-                source.setProgress(progressFromHistory);
+                if (progressFromHistory != null && progressFromHistory != DEFAULT_PROGRESS && fullProgress > progressFromHistory) {
+                    source.setProgress(progressFromHistory);
+                }
             }
         } else {
             source.setProgress(DEFAULT_PROGRESS);

--- a/flow/src/test/java/com/sequenceiq/flow/converter/OperationDetailsPopulatorTest.java
+++ b/flow/src/test/java/com/sequenceiq/flow/converter/OperationDetailsPopulatorTest.java
@@ -28,6 +28,8 @@ public class OperationDetailsPopulatorTest {
 
     private static final int MAX_PROGRESS = 100;
 
+    private static final int IN_PROGRESS_FROM_HISTORY = 65;
+
     private static final int IN_PROGRESS = 66;
 
     private static final String DUMMY_CLASS = "Sample";
@@ -74,7 +76,7 @@ public class OperationDetailsPopulatorTest {
         // WHEN
         OperationView operationView = underTest.createOperationView(operationFlowsView, OperationResource.ENVIRONMENT);
         // THEN
-        assertEquals(IN_PROGRESS, operationView.getProgress());
+        assertEquals(IN_PROGRESS_FROM_HISTORY, operationView.getProgress());
         assertEquals(OperationProgressStatus.RUNNING, operationView.getProgressStatus());
     }
 
@@ -97,6 +99,7 @@ public class OperationDetailsPopulatorTest {
         return OperationFlowsView.Builder.newBuilder()
                 .withOperationType(operationType)
                 .withFlowTypeProgressMap(flowProgressResponseMap)
+                .withProgressFromHistory(IN_PROGRESS_FROM_HISTORY)
                 .withTypeOrderList(List.of(DUMMY_CLASS))
                 .build();
     }

--- a/redbeams/src/main/java/com/sequenceiq/redbeams/service/operation/OperationService.java
+++ b/redbeams/src/main/java/com/sequenceiq/redbeams/service/operation/OperationService.java
@@ -25,7 +25,9 @@ public class OperationService {
     public OperationView getOperationProgressByResourceCrn(String resourceCrn, boolean detailed) {
         OperationView response = new OperationView();
         Optional<OperationFlowsView> operationFlowsViewOpt = flowService.getLastFlowOperationByResourceCrn(resourceCrn);
-        operationFlowsViewOpt.ifPresent(operationFlowsView -> operationDetailsPopulator.createOperationView(operationFlowsView, OperationResource.REMOTEDB));
+        if (operationFlowsViewOpt.isPresent()) {
+            return operationDetailsPopulator.createOperationView(operationFlowsViewOpt.get(), OperationResource.REMOTEDB);
+        }
         return response;
     }
 }


### PR DESCRIPTION
details:
- if the operation is available in the flow stats table, it always overrides the step based progress with the time based progress.
- expectation: if the time based progress show higher value than the step based, use the step based

See detailed description in the commit message.