### PR TITLE
CB-13205:Edit/Update the existing CMK on an environment

### DIFF
--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/info/model/RightV4.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/info/model/RightV4.java
@@ -26,6 +26,7 @@ public enum RightV4 {
     CHANGE_CRED(AuthorizationResourceAction.CHANGE_CREDENTIAL),
     DH_CREATE(AuthorizationResourceAction.ENVIRONMENT_CREATE_DATAHUB),
     UPDATE_AZURE_ENCRYPTION_RESOURCES(AuthorizationResourceAction.UPDATE_AZURE_ENCRYPTION_RESOURCES),
+    UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS(AuthorizationResourceAction.UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS),
     // dh level
     DH_START(AuthorizationResourceAction.START_DATAHUB),
     DH_STOP(AuthorizationResourceAction.STOP_DATAHUB),

--- a/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
+++ b/authorization-common-api/src/main/java/com/sequenceiq/authorization/resource/AuthorizationResourceAction.java
@@ -95,6 +95,7 @@ public enum AuthorizationResourceAction {
     LIST_ASSIGNED_ROLES("iam/listAssignedResourceRoles", null),
     STRUCTURED_EVENTS_READ("structured_events/read", AuthorizationResourceType.STRUCTURED_EVENT),
     UPDATE_AZURE_ENCRYPTION_RESOURCES("environments/updateAzureEncryptionResources", AuthorizationResourceType.ENVIRONMENT),
+    UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS("environments/updateAwsDiskEncryptionParameters", AuthorizationResourceType.ENVIRONMENT),
     ENVIRONMENT_CHANGE_FREEIPA_IMAGE("environments/changeFreeipaImageCatalog", AuthorizationResourceType.ENVIRONMENT),
     // deprecated actions, please do not use them
     ENVIRONMENT_READ("environments/read", AuthorizationResourceType.ENVIRONMENT),

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentOpDescription.java
@@ -35,6 +35,8 @@ public class EnvironmentOpDescription {
     public static final String GET_OPERATION = "Get flow operation progress details for resource by resource crn";
     public static final String UPDATE_AZURE_ENCRYPTION_RESOURCES_BY_NAME = "Updates the Customer managed key of the Azure environment of a given name.";
     public static final String UPDATE_AZURE_ENCRYPTION_RESOURCES_BY_CRN = "Updates the Customer managed key of the Azure environment of a given CRN.";
+    public static final String UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS_BY_NAME = "Updates the Customer managed key of the AWS environment of a given name.";
+    public static final String UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS_BY_CRN = "Updates the Customer managed key of the AWS environment of a given CRN.";
     public static final String UPGRADE_CCM = "Initiates the CCM tunnel type upgrade to the latest available version";
 
     private EnvironmentOpDescription() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/endpoint/EnvironmentEndpoint.java
@@ -33,6 +33,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentCl
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentEditRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLoadBalancerUpdateRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.aws.UpdateAwsDiskEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.UpdateAzureResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
@@ -124,6 +125,15 @@ public interface EnvironmentEndpoint {
             @Valid UpdateAzureResourceEncryptionParametersRequest request);
 
     @PUT
+    @Path("/name/{name}/update_aws_disk_encryption_parameters")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS_BY_NAME,
+            produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+        nickname = "UpdateAwsDiskEncryptionParametersV1ByName")
+    DetailedEnvironmentResponse updateAwsDiskEncryptionParametersByEnvironmentName(@PathParam("name") String environmentName,
+            @Valid UpdateAwsDiskEncryptionParametersRequest request);
+
+    @PUT
     @Path("/name/{name}/change_telemetry_features")
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = EnvironmentOpDescription.CHANGE_TELEMETRY_FEATURES_BY_NAME, produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
@@ -185,6 +195,15 @@ public interface EnvironmentEndpoint {
             nickname = "UpdateAzureResourceEncryptionParametersV1ByCrn")
     DetailedEnvironmentResponse updateAzureResourceEncryptionParametersByEnvironmentCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
     @PathParam("crn") String crn, @Valid UpdateAzureResourceEncryptionParametersRequest request);
+
+    @PUT
+    @Path("/crn/{crn}/update_aws_disk_encryption_parameters")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = EnvironmentOpDescription.UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS_BY_CRN,
+            produces = MediaType.APPLICATION_JSON, notes = ENVIRONMENT_NOTES,
+        nickname = "updateAwsDiskEncryptionParametersV1ByCrn")
+    DetailedEnvironmentResponse updateAwsDiskEncryptionParametersByEnvironmentCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+    @PathParam("crn") String crn, @Valid UpdateAwsDiskEncryptionParametersRequest request);
 
     @PUT
     @Path("/crn/{crn}/change_telemetry_features")

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/aws/UpdateAwsDiskEncryptionParametersRequest.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/request/aws/UpdateAwsDiskEncryptionParametersRequest.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.environment.api.v1.environment.model.request.aws;
+
+import java.io.Serializable;
+
+import com.sequenceiq.environment.api.doc.environment.EnvironmentModelDescription;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(value = "UpdateAwsDiskEncryptionParametersV1Request")
+public class UpdateAwsDiskEncryptionParametersRequest implements Serializable {
+
+    @ApiModelProperty(EnvironmentModelDescription.AWS_DISK_ENCRYPTION_PARAMETERS)
+    private AwsDiskEncryptionParameters awsDiskEncryptionParameters;
+
+    public AwsDiskEncryptionParameters getAwsDiskEncryptionParameters() {
+        return awsDiskEncryptionParameters;
+    }
+
+    public void setAwsDiskEncryptionParameters(AwsDiskEncryptionParameters awsDiskEncryptionParameters) {
+        this.awsDiskEncryptionParameters = awsDiskEncryptionParameters;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateAwsDiskEncryptionParametersRequest{" +
+                "AwsDiskEncryptionParameters='" + awsDiskEncryptionParameters + '\'' +
+                '}';
+    }
+
+    public static class Builder {
+        private AwsDiskEncryptionParameters awsDiskEncryptionParameters;
+
+        private Builder() {
+        }
+
+        public Builder withAwsDiskEncryptionParameters(AwsDiskEncryptionParameters awsDiskEncryptionParameters) {
+            this.awsDiskEncryptionParameters = awsDiskEncryptionParameters;
+            return this;
+        }
+
+        public UpdateAwsDiskEncryptionParametersRequest build() {
+            UpdateAwsDiskEncryptionParametersRequest updateAwsDiskEncryptionParametersRequest = new UpdateAwsDiskEncryptionParametersRequest();
+            updateAwsDiskEncryptionParametersRequest.setAwsDiskEncryptionParameters(awsDiskEncryptionParameters);
+            return updateAwsDiskEncryptionParametersRequest;
+        }
+    }
+}

--- a/environment-api/src/test/java/com/sequenceiq/environment/api/v1/environment/model/request/aws/UpdateAwsDiskEncryptionParametersRequestTest.java
+++ b/environment-api/src/test/java/com/sequenceiq/environment/api/v1/environment/model/request/aws/UpdateAwsDiskEncryptionParametersRequestTest.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.environment.api.v1.environment.model.request.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class UpdateAwsDiskEncryptionParametersRequestTest {
+    private static final String ENCRYPTION_KEY_ARN = "encryptionKeyArn";
+
+    @Test
+    void builderTest() {
+        AwsDiskEncryptionParameters awsDiskEncryptionParameters = AwsDiskEncryptionParameters.builder().
+                withEncryptionKeyArn(ENCRYPTION_KEY_ARN).build();
+        UpdateAwsDiskEncryptionParametersRequest underTest = UpdateAwsDiskEncryptionParametersRequest.builder().
+                withAwsDiskEncryptionParameters(awsDiskEncryptionParameters).build();
+        assertThat(underTest.getAwsDiskEncryptionParameters()).isEqualTo(awsDiskEncryptionParameters);
+        assertThat(underTest.getAwsDiskEncryptionParameters().getEncryptionKeyArn()).isEqualTo(ENCRYPTION_KEY_ARN);
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/UpdateAwsDiskEncryptionParametersDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/UpdateAwsDiskEncryptionParametersDto.java
@@ -1,0 +1,43 @@
+package com.sequenceiq.environment.environment.dto;
+
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
+
+public class UpdateAwsDiskEncryptionParametersDto {
+
+    private AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto;
+
+    public AwsDiskEncryptionParametersDto getAwsDiskEncryptionParametersDto() {
+        return awsDiskEncryptionParametersDto;
+    }
+
+    public void setAwsDiskEncryptionParametersDto(AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto) {
+        this.awsDiskEncryptionParametersDto = awsDiskEncryptionParametersDto;
+    }
+
+    public static UpdateAwsDiskEncryptionParametersDto.Builder builder() {
+        return new UpdateAwsDiskEncryptionParametersDto.Builder();
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateAwsDiskEncryptionParametersDto{" +
+                "AwsDiskEncryptionParametersDto='" + awsDiskEncryptionParametersDto + '\'' +
+                '}';
+    }
+
+    public static final class Builder {
+
+        private AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto;
+
+        public Builder withAwsDiskEncryptionParametersDto(AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto) {
+            this.awsDiskEncryptionParametersDto = awsDiskEncryptionParametersDto;
+            return this;
+        }
+
+        public UpdateAwsDiskEncryptionParametersDto build() {
+            UpdateAwsDiskEncryptionParametersDto updateAwsDiskEncryptionParametersDto = new UpdateAwsDiskEncryptionParametersDto();
+            updateAwsDiskEncryptionParametersDto.setAwsDiskEncryptionParametersDto(awsDiskEncryptionParametersDto);
+            return updateAwsDiskEncryptionParametersDto;
+        }
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentCreationService.java
@@ -193,8 +193,15 @@ public class EnvironmentCreationService {
             validationBuilder.merge(validatorService.validateEncryptionKey(creationDto));
         }
         if (AWS.name().equalsIgnoreCase(creationDto.getCloudPlatform())) {
-            validationBuilder.merge(validatorService.validateEncryptionKeyArn(creationDto));
+            String encryptionKeyArn = Optional.ofNullable(creationDto.getParameters())
+                    .map(paramsDto -> paramsDto.getAwsParametersDto())
+                    .map(awsParamsDto -> awsParamsDto.getAwsDiskEncryptionParametersDto())
+                    .map(awsREparamsDto -> awsREparamsDto.getEncryptionKeyArn()).orElse(null);
+            if (encryptionKeyArn != null) {
+                validationBuilder.merge(validatorService.validateEncryptionKeyArn(encryptionKeyArn, creationDto.getAccountId()));
+            }
         }
+
         ValidationResult parentChildValidation = validatorService.validateParentChildRelation(environment, creationDto.getParentEnvironmentName());
         validationBuilder.merge(parentChildValidation);
         EnvironmentTelemetry environmentTelemetry = creationDto.getTelemetry();

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/EnvironmentModificationService.java
@@ -21,6 +21,7 @@ import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.environment.credential.service.CredentialService;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.domain.EnvironmentAuthentication;
+import com.sequenceiq.environment.environment.domain.EnvironmentViewConverter;
 import com.sequenceiq.environment.environment.domain.ExperimentalFeatures;
 import com.sequenceiq.environment.environment.dto.AuthenticationDto;
 import com.sequenceiq.environment.environment.dto.AuthenticationDtoConverter;
@@ -30,6 +31,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentDtoConverter;
 import com.sequenceiq.environment.environment.dto.EnvironmentEditDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentValidationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
+import com.sequenceiq.environment.environment.dto.UpdateAwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.environment.dto.UpdateAzureResourceEncryptionDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
@@ -39,11 +41,13 @@ import com.sequenceiq.environment.environment.validation.EnvironmentValidatorSer
 import com.sequenceiq.environment.environment.validation.ValidationType;
 import com.sequenceiq.environment.network.NetworkService;
 import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameters.dao.domain.AwsParameters;
 import com.sequenceiq.environment.parameters.dao.domain.AzureParameters;
 import com.sequenceiq.environment.parameters.dao.domain.BaseParameters;
+import com.sequenceiq.environment.parameters.dao.repository.AwsParametersRepository;
 import com.sequenceiq.environment.parameters.dao.repository.AzureParametersRepository;
 import com.sequenceiq.environment.parameters.service.ParametersService;
 
@@ -70,12 +74,17 @@ public class EnvironmentModificationService {
 
     private final EnvironmentEncryptionService environmentEncryptionService;
 
+    private final EnvironmentViewConverter environmentViewConverter;
+
+    private final AwsParametersRepository awsParametersRepository;
+
     private final AzureParametersRepository azureParametersRepository;
 
     public EnvironmentModificationService(EnvironmentDtoConverter environmentDtoConverter, EnvironmentService environmentService,
             CredentialService credentialService, NetworkService networkService, AuthenticationDtoConverter authenticationDtoConverter,
             ParametersService parametersService, EnvironmentFlowValidatorService environmentFlowValidatorService,
             EnvironmentResourceService environmentResourceService, EnvironmentEncryptionService environmentEncryptionService,
+            EnvironmentViewConverter environmentViewConverter, AwsParametersRepository awsParametersRepository,
             AzureParametersRepository azureParametersRepository) {
         this.environmentDtoConverter = environmentDtoConverter;
         this.environmentService = environmentService;
@@ -86,6 +95,8 @@ public class EnvironmentModificationService {
         this.environmentFlowValidatorService = environmentFlowValidatorService;
         this.environmentResourceService = environmentResourceService;
         this.environmentEncryptionService = environmentEncryptionService;
+        this.environmentViewConverter = environmentViewConverter;
+        this.awsParametersRepository = awsParametersRepository;
         this.azureParametersRepository = azureParametersRepository;
     }
 
@@ -132,6 +143,21 @@ public class EnvironmentModificationService {
         return updateAzureResourceEncryptionParameters(accountId, crn, dto.getAzureResourceEncryptionParametersDto(), environment);
     }
 
+    public EnvironmentDto updateAwsDiskEncryptionParametersByEnvironmentName(String accountId, String environmentName,
+            UpdateAwsDiskEncryptionParametersDto dto) {
+        Environment environment = environmentService
+                .findByNameAndAccountIdAndArchivedIsFalse(environmentName, accountId)
+                .orElseThrow(() -> new NotFoundException(String.format("No environment found with name '%s'", environmentName)));
+        return updateAwsDiskEncryptionParameters(accountId, environmentName, dto.getAwsDiskEncryptionParametersDto(), environment);
+    }
+
+    public EnvironmentDto updateAwsDiskEncryptionParametersByEnvironmentCrn(String accountId, String crn, UpdateAwsDiskEncryptionParametersDto dto) {
+        Environment environment = environmentService
+                .findByResourceCrnAndAccountIdAndArchivedIsFalse(crn, accountId)
+                .orElseThrow(() -> new NotFoundException(String.format("No environment found with CRN '%s'", crn)));
+        return updateAwsDiskEncryptionParameters(accountId, crn, dto.getAwsDiskEncryptionParametersDto(), environment);
+    }
+
     public EnvironmentDto changeTelemetryFeaturesByEnvironmentName(String accountId, String environmentName,
             EnvironmentFeatures features) {
         Environment environment = environmentService
@@ -174,6 +200,38 @@ public class EnvironmentModificationService {
         Environment saved = environmentService.save(environment);
         return environmentDtoConverter.environmentToDto(saved);
     }
+
+    private EnvironmentDto updateAwsDiskEncryptionParameters(String accountId, String environmentNameOrCrn, AwsDiskEncryptionParametersDto dto,
+            Environment environment) {
+            if (dto.getEncryptionKeyArn() != null) {
+                ValidationResult validateKey = environmentService.getValidatorService().validateEncryptionKeyArn(dto.getEncryptionKeyArn(),
+                        accountId);
+                if (!validateKey.hasError()) {
+                    if (environment.getParameters() == null) {
+                        AwsParameters awsParameters = new AwsParameters();
+                        awsParameters.setEncryptionKeyArn(dto.getEncryptionKeyArn());
+                        awsParameters.setAccountId(accountId);
+                        awsParameters.setId(environment.getId());
+                        awsParameters.setName(environment.getName());
+                        awsParameters.setEnvironment(environmentViewConverter.convert(environment));
+                        environment.setParameters(awsParameters);
+                    } else {
+                        AwsParameters awsParameters = (AwsParameters) environment.getParameters();
+                        if (awsParameters.getEncryptionKeyArn() == null) {
+                            awsParameters.setEncryptionKeyArn(dto.getEncryptionKeyArn());
+                        } else {
+                            throw new BadRequestException("The environment already has an encryption key set and could not be updated");
+                        }
+                    }
+                    LOGGER.debug("Successfully updated the encryption key ARN for the environment {}.", environmentNameOrCrn);
+                } else {
+                    throw new BadRequestException(validateKey.getFormattedErrors());
+                }
+                AwsParameters awsParameters = (AwsParameters) environment.getParameters();
+                awsParametersRepository.save(awsParameters);
+            }
+            return environmentDtoConverter.environmentToDto(environment);
+        }
 
     private EnvironmentDto updateAzureResourceEncryptionParameters(String accountId, String environmentName, AzureResourceEncryptionParametersDto dto,
             Environment environment) {

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/EnvironmentController.java
@@ -50,6 +50,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentCl
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentEditRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentLoadBalancerUpdateRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.EnvironmentRequest;
+import com.sequenceiq.environment.api.v1.environment.model.request.aws.UpdateAwsDiskEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.UpdateAzureResourceEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
 import com.sequenceiq.environment.api.v1.environment.model.response.EnvironmentCrnResponse;
@@ -65,6 +66,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentCreationDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentEditDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
+import com.sequenceiq.environment.environment.dto.UpdateAwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.environment.dto.UpdateAzureResourceEncryptionDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.environment.service.EnvironmentCreationService;
@@ -329,6 +331,26 @@ public class EnvironmentController implements EnvironmentEndpoint {
         String accountId = ThreadBasedUserCrnProvider.getAccountId();
         UpdateAzureResourceEncryptionDto dto = environmentApiConverter.convertUpdateAzureResourceEncryptionDto(request);
         EnvironmentDto result = environmentModificationService.updateAzureResourceEncryptionParametersByEnvironmentName(accountId, environmentName, dto);
+        return environmentResponseConverter.dtoToDetailedResponse(result);
+    }
+
+    @Override
+    @CheckPermissionByResourceCrn(action = AuthorizationResourceAction.UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS)
+    public DetailedEnvironmentResponse updateAwsDiskEncryptionParametersByEnvironmentCrn(@ValidCrn(resource = CrnResourceDescriptor.ENVIRONMENT)
+    @ResourceCrn String crn, @RequestObject @Valid UpdateAwsDiskEncryptionParametersRequest request) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        UpdateAwsDiskEncryptionParametersDto dto = environmentApiConverter.convertUpdateAwsDiskEncryptionParametersDto(request);
+        EnvironmentDto result = environmentModificationService.updateAwsDiskEncryptionParametersByEnvironmentCrn(accountId, crn, dto);
+        return environmentResponseConverter.dtoToDetailedResponse(result);
+    }
+
+    @Override
+    @CheckPermissionByResourceName(action = AuthorizationResourceAction.UPDATE_AWS_DISK_ENCRYPTION_PARAMETERS)
+    public DetailedEnvironmentResponse updateAwsDiskEncryptionParametersByEnvironmentName(@ResourceName String environmentName,
+            @RequestObject @Valid UpdateAwsDiskEncryptionParametersRequest request) {
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        UpdateAwsDiskEncryptionParametersDto dto = environmentApiConverter.convertUpdateAwsDiskEncryptionParametersDto(request);
+        EnvironmentDto result = environmentModificationService.updateAwsDiskEncryptionParametersByEnvironmentName(accountId, environmentName, dto);
         return environmentResponseConverter.dtoToDetailedResponse(result);
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverter.java
@@ -37,6 +37,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsDiskEn
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.S3GuardRequestParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.aws.UpdateAwsDiskEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
@@ -56,6 +57,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentEditDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
 import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
+import com.sequenceiq.environment.environment.dto.UpdateAwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.environment.dto.UpdateAzureResourceEncryptionDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.network.dto.NetworkDto;
@@ -234,7 +236,9 @@ public class EnvironmentApiConverter {
     private AwsDiskEncryptionParametersDto awsDiskEncryptionParametersToAwsDiskEncryptionParametersDto(
             AwsDiskEncryptionParameters awsDiskEncryptionParameters) {
         AwsDiskEncryptionParametersDto.Builder awsDiskEncryptionParametersDto = AwsDiskEncryptionParametersDto.builder()
-                .withEncryptionKeyArn(awsDiskEncryptionParameters.getEncryptionKeyArn());
+                .withEncryptionKeyArn(Optional.ofNullable(awsDiskEncryptionParameters)
+                        .map(AwsDiskEncryptionParameters::getEncryptionKeyArn)
+                        .orElse(null));
         return awsDiskEncryptionParametersDto.build();
     }
 
@@ -392,6 +396,13 @@ public class EnvironmentApiConverter {
         return UpdateAzureResourceEncryptionDto.builder()
                 .withAzureResourceEncryptionParametersDto(
                         azureResourceEncryptionParametersToAzureEncryptionParametersDto(request.getAzureResourceEncryptionParameters()))
+                .build();
+    }
+
+    public UpdateAwsDiskEncryptionParametersDto convertUpdateAwsDiskEncryptionParametersDto(UpdateAwsDiskEncryptionParametersRequest request) {
+        return UpdateAwsDiskEncryptionParametersDto.builder()
+                .withAwsDiskEncryptionParametersDto(
+                        awsDiskEncryptionParametersToAwsDiskEncryptionParametersDto(request.getAwsDiskEncryptionParameters()))
                 .build();
     }
 

--- a/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorService.java
@@ -290,24 +290,16 @@ public class EnvironmentValidatorService {
         return resultBuilder.build();
     }
 
-    public ValidationResult validateEncryptionKeyArn(EnvironmentCreationDto creationDto) {
+    public ValidationResult validateEncryptionKeyArn(String encryptionKeyArn, String accountId) {
         ValidationResultBuilder resultBuilder = ValidationResult.builder();
-        if (AWS.name().equalsIgnoreCase(creationDto.getCloudPlatform())) {
-            String encryptionKeyArn = Optional.ofNullable(creationDto.getParameters())
-                    .map(paramsDto -> paramsDto.getAwsParametersDto())
-                    .map(awsParametersDto -> awsParametersDto.getAwsDiskEncryptionParametersDto())
-                    .map(awsREparamsDto -> awsREparamsDto.getEncryptionKeyArn()).orElse(null);
-            if (StringUtils.isNotEmpty(encryptionKeyArn)) {
-                if (!entitlementService.isAWSDiskEncryptionWithCMKEnabled(creationDto.getAccountId())) {
-                    resultBuilder.error(String.format("You specified encryptionKeyArn to use Server Side Encryption for " +
-                            "AWS Managed disks with CMK, "
-                            + "but that feature is currently disabled. Get 'CDP_CB_AWS_DISK_ENCRYPTION_WITH_CMK' " +
-                            "enabled for your account to use SSE with CMK."));
-                } else {
-                    ValidationResult validationResult = encryptionKeyArnValidator.validateEncryptionKeyArn(encryptionKeyArn);
-                    resultBuilder.merge(validationResult);
-                }
-            }
+        if (!entitlementService.isAWSDiskEncryptionWithCMKEnabled(accountId)) {
+            resultBuilder.error(String.format("You specified encryptionKeyArn to use Server Side Encryption for " +
+                    "AWS Managed disks with CMK, "
+                    + "but that feature is currently disabled. Get 'CDP_CB_AWS_DISK_ENCRYPTION_WITH_CMK' " +
+                    "enabled for your account to use SSE with CMK."));
+        } else {
+            ValidationResult validationResult = encryptionKeyArnValidator.validateEncryptionKeyArn(encryptionKeyArn);
+            resultBuilder.merge(validationResult);
         }
         return resultBuilder.build();
     }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/dto/UpdateAwsDiskEncryptionParametersDtoTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/dto/UpdateAwsDiskEncryptionParametersDtoTest.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.environment.environment.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
+
+public class UpdateAwsDiskEncryptionParametersDtoTest {
+
+    @Test
+    void builderTest() {
+        AwsDiskEncryptionParametersDto awsDiskEncryptionParametersDto = AwsDiskEncryptionParametersDto.builder()
+                                                                        .withEncryptionKeyArn("dummyEncryptionKeyArn").build();
+        UpdateAwsDiskEncryptionParametersDto underTest = UpdateAwsDiskEncryptionParametersDto.builder()
+                                                        .withAwsDiskEncryptionParametersDto(awsDiskEncryptionParametersDto).build();
+        assertThat(underTest.getAwsDiskEncryptionParametersDto()).isEqualTo(awsDiskEncryptionParametersDto);
+    }
+}

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentCreationServiceTest.java
@@ -55,6 +55,7 @@ import com.sequenceiq.environment.environment.validation.EnvironmentValidatorSer
 import com.sequenceiq.environment.network.CloudNetworkService;
 import com.sequenceiq.environment.network.NetworkService;
 import com.sequenceiq.environment.network.service.LoadBalancerEntitlementService;
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
@@ -505,6 +506,13 @@ class EnvironmentCreationServiceTest {
                 .withCreator(CRN)
                 .withAccountId(ACCOUNT_ID)
                 .withAuthentication(AuthenticationDto.builder().build())
+                .withParameters(ParametersDto.builder()
+                        .withAwsParameters(AwsParametersDto.builder()
+                                .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
+                                        .withEncryptionKeyArn("dummy-key-arn")
+                                        .build())
+                                .build())
+                        .build())
                 .build();
         final Environment environment = new Environment();
         environment.setName(ENVIRONMENT_NAME);
@@ -515,7 +523,7 @@ class EnvironmentCreationServiceTest {
 
         ValidationResultBuilder validationResultBuilder = new ValidationResultBuilder();
         validationResultBuilder.error("error");
-        when(validatorService.validateEncryptionKeyArn(any())).thenReturn(validationResultBuilder.build());
+        when(validatorService.validateEncryptionKeyArn(any(), any())).thenReturn(validationResultBuilder.build());
 
         when(environmentService.isNameOccupied(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(false);
         when(environmentDtoConverter.creationDtoToEnvironment(eq(environmentCreationDto))).thenReturn(environment);

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentModificationServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/EnvironmentModificationServiceTest.java
@@ -36,6 +36,7 @@ import com.sequenceiq.environment.credential.domain.Credential;
 import com.sequenceiq.environment.credential.service.CredentialService;
 import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.domain.EnvironmentAuthentication;
+import com.sequenceiq.environment.environment.domain.EnvironmentViewConverter;
 import com.sequenceiq.environment.environment.dto.AuthenticationDto;
 import com.sequenceiq.environment.environment.dto.AuthenticationDtoConverter;
 import com.sequenceiq.environment.environment.dto.EnvironmentChangeCredentialDto;
@@ -43,6 +44,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.dto.EnvironmentDtoConverter;
 import com.sequenceiq.environment.environment.dto.EnvironmentEditDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
+import com.sequenceiq.environment.environment.dto.UpdateAwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.environment.dto.UpdateAzureResourceEncryptionDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentFeatures;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
@@ -53,12 +55,14 @@ import com.sequenceiq.environment.environment.validation.EnvironmentValidatorSer
 import com.sequenceiq.environment.network.NetworkService;
 import com.sequenceiq.environment.network.dao.domain.AwsNetwork;
 import com.sequenceiq.environment.network.dto.NetworkDto;
+import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.AzureResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
 import com.sequenceiq.environment.parameters.dao.domain.AwsParameters;
 import com.sequenceiq.environment.parameters.dao.domain.AzureParameters;
 import com.sequenceiq.environment.parameters.dao.domain.BaseParameters;
+import com.sequenceiq.environment.parameters.dao.repository.AwsParametersRepository;
 import com.sequenceiq.environment.parameters.dao.repository.AzureParametersRepository;
 import com.sequenceiq.environment.parameters.service.ParametersService;
 
@@ -109,6 +113,12 @@ class EnvironmentModificationServiceTest {
 
     @Mock
     private ValidationResult validationResult;
+
+    @MockBean
+    private EnvironmentViewConverter environmentViewConverter;
+
+    @MockBean
+    private AwsParametersRepository awsParametersRepository;
 
     @Test
     void editByName() {
@@ -631,6 +641,68 @@ class EnvironmentModificationServiceTest {
         verify(environmentService).save(any());
         assertFalse(environment.getTelemetry().getFeatures().getCloudStorageLogging().isEnabled());
         assertTrue(environment.getTelemetry().getFeatures().getClusterLogsCollection().isEnabled());
+    }
+
+    @Test
+    void testUpdateAwsDiskEncryptionParametersByEnvironmentName() {
+        UpdateAwsDiskEncryptionParametersDto updateAwsDiskEncryptionParametersDto = UpdateAwsDiskEncryptionParametersDto.builder()
+                .withAwsDiskEncryptionParametersDto(AwsDiskEncryptionParametersDto.builder()
+                        .withEncryptionKeyArn("dummyKeyArn")
+                        .build())
+                .build();
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+                .withParameters(ParametersDto.builder()
+                        .withAwsParameters(AwsParametersDto.builder()
+                                .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
+                                        .withEncryptionKeyArn("dummyKeyArn")
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+        Environment env = new Environment();
+        env.setParameters(new AwsParameters());
+        when(environmentService.getValidatorService()).thenReturn(validatorService);
+        when(environmentService
+                .findByNameAndAccountIdAndArchivedIsFalse(eq(ENVIRONMENT_NAME), eq(ACCOUNT_ID))).thenReturn(Optional.of(env));
+        when(validatorService.validateEncryptionKeyArn(any(String.class), any(String.class))).thenReturn(ValidationResult.builder().build());
+        when(environmentDtoConverter.environmentToDto(env)).thenReturn(environmentDto);
+        EnvironmentDto envDto = environmentModificationServiceUnderTest.updateAwsDiskEncryptionParametersByEnvironmentName(ACCOUNT_ID,
+                ENVIRONMENT_NAME, updateAwsDiskEncryptionParametersDto);
+        assertEquals(envDto.getParameters().getAwsParametersDto().getAwsDiskEncryptionParametersDto().getEncryptionKeyArn(), "dummyKeyArn");
+        ArgumentCaptor<AwsParameters> awsParametersArgumentCaptor = ArgumentCaptor.forClass(AwsParameters.class);
+        verify(awsParametersRepository).save(awsParametersArgumentCaptor.capture());
+        assertEquals("dummyKeyArn", awsParametersArgumentCaptor.getValue().getEncryptionKeyArn());
+    }
+
+    @Test
+    void testUpdateAwsDiskEncryptionParametersByEnvironmentCrn() {
+        UpdateAwsDiskEncryptionParametersDto updateAwsDiskEncryptionParametersDto = UpdateAwsDiskEncryptionParametersDto.builder()
+                .withAwsDiskEncryptionParametersDto(AwsDiskEncryptionParametersDto.builder()
+                        .withEncryptionKeyArn("dummyKeyArn")
+                        .build())
+                .build();
+        EnvironmentDto environmentDto = EnvironmentDto.builder()
+                .withParameters(ParametersDto.builder()
+                        .withAwsParameters(AwsParametersDto.builder()
+                                .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
+                                        .withEncryptionKeyArn("dummyKeyArn")
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+        Environment env = new Environment();
+        env.setParameters(new AwsParameters());
+        when(environmentService.getValidatorService()).thenReturn(validatorService);
+        when(environmentService
+                .findByResourceCrnAndAccountIdAndArchivedIsFalse(eq(CRN), eq(ACCOUNT_ID))).thenReturn(Optional.of(env));
+        when(validatorService.validateEncryptionKeyArn(any(String.class), any(String.class))).thenReturn(ValidationResult.builder().build());
+        when(environmentDtoConverter.environmentToDto(env)).thenReturn(environmentDto);
+        EnvironmentDto envDto = environmentModificationServiceUnderTest.updateAwsDiskEncryptionParametersByEnvironmentCrn(ACCOUNT_ID,
+                CRN, updateAwsDiskEncryptionParametersDto);
+        assertEquals(envDto.getParameters().getAwsParametersDto().getAwsDiskEncryptionParametersDto().getEncryptionKeyArn(), "dummyKeyArn");
+        ArgumentCaptor<AwsParameters> awsParametersArgumentCaptor = ArgumentCaptor.forClass(AwsParameters.class);
+        verify(awsParametersRepository).save(awsParametersArgumentCaptor.capture());
+        assertEquals("dummyKeyArn", awsParametersArgumentCaptor.getValue().getEncryptionKeyArn());
     }
 
     @Test

--- a/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentApiConverterTest.java
@@ -49,6 +49,7 @@ import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsEnviro
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.AwsFreeIpaSpotParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.aws.S3GuardRequestParameters;
+import com.sequenceiq.environment.api.v1.environment.model.request.aws.UpdateAwsDiskEncryptionParametersRequest;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureEnvironmentParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceEncryptionParameters;
 import com.sequenceiq.environment.api.v1.environment.model.request.azure.AzureResourceGroup;
@@ -67,6 +68,7 @@ import com.sequenceiq.environment.environment.dto.EnvironmentLoadBalancerDto;
 import com.sequenceiq.environment.environment.dto.FreeIpaCreationDto;
 import com.sequenceiq.environment.environment.dto.LocationDto;
 import com.sequenceiq.environment.environment.dto.SecurityAccessDto;
+import com.sequenceiq.environment.environment.dto.UpdateAwsDiskEncryptionParametersDto;
 import com.sequenceiq.environment.environment.dto.UpdateAzureResourceEncryptionDto;
 import com.sequenceiq.environment.environment.dto.telemetry.EnvironmentTelemetry;
 import com.sequenceiq.environment.network.dto.NetworkDto;
@@ -87,6 +89,8 @@ public class EnvironmentApiConverterTest {
     private static final String KEY_URL = "dummy-key-url";
 
     private static final String KEY_URL_RESOURCE_GROUP = "dummy-key-url";
+
+    private static final String ENCRYPTION_KEY_ARN = "dummy-key-arn";
 
     @InjectMocks
     private EnvironmentApiConverter underTest;
@@ -313,7 +317,7 @@ public class EnvironmentApiConverterTest {
         when(networkRequestToDtoConverter.convert(request.getNetwork())).thenReturn(networkDto);
 
         EnvironmentCreationDto actual = testInitCreationDto(request);
-        assertEquals("dummy-key-arn",
+        assertEquals(ENCRYPTION_KEY_ARN,
                 actual.getParameters().getAwsParametersDto().getAwsDiskEncryptionParametersDto().getEncryptionKeyArn());
     }
 
@@ -397,6 +401,17 @@ public class EnvironmentApiConverterTest {
 
         assertEquals(KEY_URL, actual.getAzureResourceEncryptionParametersDto().getEncryptionKeyUrl());
         assertEquals(KEY_URL_RESOURCE_GROUP, actual.getAzureResourceEncryptionParametersDto().getEncryptionKeyResourceGroupName());
+    }
+
+    @Test
+    void testConvertUpdateAwsDiskEncryptionParametersDto() {
+        UpdateAwsDiskEncryptionParametersRequest request = UpdateAwsDiskEncryptionParametersRequest.builder()
+                .withAwsDiskEncryptionParameters(AwsDiskEncryptionParameters.builder()
+                        .withEncryptionKeyArn(ENCRYPTION_KEY_ARN)
+                        .build())
+                .build();
+        UpdateAwsDiskEncryptionParametersDto actual = underTest.convertUpdateAwsDiskEncryptionParametersDto(request);
+        assertEquals(ENCRYPTION_KEY_ARN, actual.getAwsDiskEncryptionParametersDto().getEncryptionKeyArn());
     }
 
     private void assertLocation(LocationRequest request, LocationDto actual) {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/validation/EnvironmentValidatorServiceTest.java
@@ -47,8 +47,6 @@ import com.sequenceiq.environment.environment.validation.validators.EncryptionKe
 import com.sequenceiq.environment.environment.validation.validators.NetworkCreationValidator;
 import com.sequenceiq.environment.environment.validation.validators.PublicKeyValidator;
 import com.sequenceiq.environment.environment.validation.validators.TagValidator;
-import com.sequenceiq.environment.parameter.dto.AwsDiskEncryptionParametersDto;
-import com.sequenceiq.environment.parameter.dto.AwsParametersDto;
 import com.sequenceiq.environment.parameter.dto.GcpParametersDto;
 import com.sequenceiq.environment.parameter.dto.GcpResourceEncryptionParametersDto;
 import com.sequenceiq.environment.parameter.dto.ParametersDto;
@@ -384,51 +382,20 @@ class EnvironmentValidatorServiceTest {
 
     @Test
     void shouldFailIfEncryptionKeyArnSpecifiedAndEntitlementDisabled() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("AWS")
-                .withParameters(ParametersDto.builder()
-                    .withAwsParameters(AwsParametersDto.builder()
-                        .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
-                            .withEncryptionKeyArn("dummy-key-arn")
-                        .build())
-                    .build())
-                .build())
-            .build();
+        String encryptionKeyArn = "dummy-key-arn";
         when(entitlementService.isAWSDiskEncryptionWithCMKEnabled(any())).thenReturn(false);
-        ValidationResult validationResult = underTest.validateEncryptionKeyArn(creationDto);
+        ValidationResult validationResult = underTest.validateEncryptionKeyArn(encryptionKeyArn, ACCOUNT_ID);
         assertTrue(validationResult.hasError());
     }
 
     @Test
-    void testToValidateEncryptionKeyArnNotSpecified() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("AWS")
-                .build();
-        ValidationResult validationResult = underTest.validateEncryptionKeyArn(creationDto);
-        assertFalse(validationResult.hasError());
-    }
-
-    @Test
     void testValidateEncryptionKeyArnSpecifiedAndEntitlementEnabled() {
-        EnvironmentCreationDto creationDto = EnvironmentCreationDto.builder()
-                .withAccountId(ACCOUNT_ID)
-                .withCloudPlatform("AWS")
-                .withParameters(ParametersDto.builder()
-                        .withAwsParameters(AwsParametersDto.builder()
-                                .withAwsDiskEncryptionParameters(AwsDiskEncryptionParametersDto.builder()
-                                        .withEncryptionKeyArn("dummy-key-arn")
-                                        .build())
-                                .build())
-                        .build())
-                .build();
+        String encryptionKeyArn = "dummy-key-arn";
         ValidationResult.ValidationResultBuilder validationResultBuilder = new ValidationResult.ValidationResultBuilder();
         when(encryptionKeyArnValidator.validateEncryptionKeyArn(any())).thenReturn(validationResultBuilder.build());
         when(entitlementService.isAWSDiskEncryptionWithCMKEnabled(any())).thenReturn(true);
-        ValidationResult validationResult = underTest.validateEncryptionKeyArn(creationDto);
+        ValidationResult validationResult = underTest.validateEncryptionKeyArn(encryptionKeyArn, ACCOUNT_ID);
         assertFalse(validationResult.hasError());
-
     }
 
     @Test

--- a/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AwsDiskEncryptionParametersDto.java
+++ b/structuredevent-model/src/main/java/com/sequenceiq/environment/parameter/dto/AwsDiskEncryptionParametersDto.java
@@ -18,7 +18,7 @@ public class AwsDiskEncryptionParametersDto {
 
     @Override
     public String toString() {
-        return "AzureResourceEncryptionParametersDto{" +
+        return "AwsDiskEncryptionParametersDto{" +
                 "encryptionKeyArn=" + encryptionKeyArn +
                 '}';
     }


### PR DESCRIPTION
Tested this change by creating an environment without passing encryption paramater/CMK during creation and post creation ran the below CLI on the enviornment:

/Users/satyabolnedi/master/thunderhead/clients/cdpcli/cdp.sh environments update-aws-disk-encryption-parameters --environment satya-testabc2 --encryption-key-arn "dummykey"  --profile local

and verified that the encryption key arn is updated to DB in enviornment_parameters table and also post that created Datalake and Datahubs on the environment and verified that the respective disks and External RDS created post the updation are encrypted with the new key passed from CLI.

I will update the Thunderhead PR with the respective Cb build post merging this change. Thunderhead Draft PR created : https://github.infra.cloudera.com/thunderhead/thunderhead/pull/6665/files