### PR TITLE
CB-15242 aws cloud storage validation is not working if a condition r…

### DIFF
--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsObjectStorageConnector.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/AwsObjectStorageConnector.java
@@ -98,6 +98,7 @@ public class AwsObjectStorageConnector implements ObjectStorageConnector {
         } else {
             response = ObjectStorageValidateResponse.builder()
                     .withStatus(ResponseStatus.OK)
+                    .withError(validationResult.getFormattedWarnings())
                     .build();
         }
         return response;

--- a/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AbstractAwsSimulatePolicyValidator.java
+++ b/cloud-aws-common/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/common/validator/AbstractAwsSimulatePolicyValidator.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.cloud.aws.common.validator;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.springframework.util.CollectionUtils;
+
+import com.amazonaws.services.identitymanagement.model.EvaluationResult;
+import com.amazonaws.services.identitymanagement.model.Role;
+
+public abstract class AbstractAwsSimulatePolicyValidator {
+
+    SortedSet<String> getFailedActions(Role role, List<EvaluationResult> evaluationResults) {
+        return evaluationResults.stream()
+                .filter(this::isEvaluationFailed)
+                .map(evaluationResult -> String.format("%s:%s:%s", role.getArn(),
+                        evaluationResult.getEvalActionName(), evaluationResult.getEvalResourceName()))
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    SortedSet<String> getWarnings(Role role, List<EvaluationResult> evaluationResults) {
+        return evaluationResults.stream()
+                .filter(this::isEvaluationWarning)
+                .map(evaluationResult -> String.format("missing context values: %s",
+                        String.join(",", new HashSet<>(evaluationResult.getMissingContextValues()))))
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+
+    private boolean isEvaluationFailed(EvaluationResult evaluationResult) {
+        return evaluationResult.getEvalDecision().toLowerCase().contains("deny")
+                && CollectionUtils.isEmpty(evaluationResult.getMissingContextValues());
+    }
+
+    private boolean isEvaluationWarning(EvaluationResult evaluationResult) {
+        return evaluationResult.getEvalDecision().toLowerCase().contains("deny")
+                && !CollectionUtils.isEmpty(evaluationResult.getMissingContextValues());
+    }
+}

--- a/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
+++ b/datalake/src/main/java/com/sequenceiq/datalake/service/validation/cloudstorage/CloudStorageValidator.java
@@ -7,6 +7,7 @@ import static com.sequenceiq.environment.api.v1.environment.model.request.azure.
 import java.util.EnumSet;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -83,6 +84,8 @@ public class CloudStorageValidator {
 
             if (ResponseStatus.ERROR.equals(response.getStatus())) {
                 validationResultBuilder.error(response.getError());
+            } else if (StringUtils.isNotBlank(response.getError())) {
+                validationResultBuilder.warning(response.getError());
             }
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/EnvironmentValidationHandler.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/EnvironmentValidationHandler.java
@@ -2,6 +2,7 @@ package com.sequenceiq.environment.environment.flow.creation.handler;
 
 import static com.sequenceiq.environment.environment.flow.creation.event.EnvCreationHandlerSelectors.VALIDATE_ENVIRONMENT_EVENT;
 import static com.sequenceiq.environment.environment.flow.creation.event.EnvCreationStateSelectors.START_NETWORK_CREATION_EVENT;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.Set;
 
@@ -123,6 +124,10 @@ public class EnvironmentValidationHandler extends EventSenderAwareHandler<Enviro
         }
         if (response != null && ResponseStatus.ERROR.equals(response.getStatus())) {
             throw new EnvironmentServiceException(response.getError());
+        }
+        if (response != null && ResponseStatus.OK.equals(response.getStatus()) && isNotBlank(response.getError())) {
+            eventSenderService.sendEventAndNotification(environmentDto, ThreadBasedUserCrnProvider.getUserCrn(),
+                    ResourceEvent.ENVIRONMENT_VALIDATION_FAILED_AND_SKIPPED, Set.of(response.getError()));
         }
     }
 


### PR DESCRIPTION
…estricts the regions

If the aws policies contains any condition and the validation doesn't provide a context value for this, the policy simulation will fail but it will contain references to the missing context value. 
The solution in this pull request is that in case of missing context value cb will generate a notification about it and let the cluster provision proceed.