### PR TITLE
CB-14678 use PEM's "generateManagedDomainNames" endpoint for domain name generation and store it on environment level

### DIFF
--- a/cluster-dns-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/publicendpointmanagement/PublicEndpointManagementGrpc.java
+++ b/cluster-dns-connector/src/generated/main/grpc/com/cloudera/thunderhead/service/publicendpointmanagement/PublicEndpointManagementGrpc.java
@@ -267,6 +267,37 @@ public final class PublicEndpointManagementGrpc {
     return getPollCertificateSigningMethod;
   }
 
+  private static volatile io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest,
+      com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse> getRevokeCertificateMethod;
+
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "RevokeCertificate",
+      requestType = com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.class,
+      responseType = com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
+  public static io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest,
+      com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse> getRevokeCertificateMethod() {
+    io.grpc.MethodDescriptor<com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest, com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse> getRevokeCertificateMethod;
+    if ((getRevokeCertificateMethod = PublicEndpointManagementGrpc.getRevokeCertificateMethod) == null) {
+      synchronized (PublicEndpointManagementGrpc.class) {
+        if ((getRevokeCertificateMethod = PublicEndpointManagementGrpc.getRevokeCertificateMethod) == null) {
+          PublicEndpointManagementGrpc.getRevokeCertificateMethod = getRevokeCertificateMethod =
+              io.grpc.MethodDescriptor.<com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest, com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse>newBuilder()
+              .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName(generateFullMethodName(SERVICE_NAME, "RevokeCertificate"))
+              .setSampledToLocalTracing(true)
+              .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.getDefaultInstance()))
+              .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
+                  com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse.getDefaultInstance()))
+              .setSchemaDescriptor(new PublicEndpointManagementMethodDescriptorSupplier("RevokeCertificate"))
+              .build();
+        }
+      }
+    }
+    return getRevokeCertificateMethod;
+  }
+
   /**
    * Creates a new async stub that supports all call types for the service
    */
@@ -410,6 +441,16 @@ public final class PublicEndpointManagementGrpc {
       io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getPollCertificateSigningMethod(), responseObserver);
     }
 
+    /**
+     * <pre>
+     *Revoke a TLS certificate
+     * </pre>
+     */
+    public void revokeCertificate(com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse> responseObserver) {
+      io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall(getRevokeCertificateMethod(), responseObserver);
+    }
+
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
@@ -468,6 +509,13 @@ public final class PublicEndpointManagementGrpc {
                 com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.PollCertificateSigningRequest,
                 com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.PollCertificateSigningResponse>(
                   this, METHODID_POLL_CERTIFICATE_SIGNING)))
+          .addMethod(
+            getRevokeCertificateMethod(),
+            io.grpc.stub.ServerCalls.asyncUnaryCall(
+              new MethodHandlers<
+                com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest,
+                com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse>(
+                  this, METHODID_REVOKE_CERTIFICATE)))
           .build();
     }
   }
@@ -588,6 +636,17 @@ public final class PublicEndpointManagementGrpc {
       io.grpc.stub.ClientCalls.asyncUnaryCall(
           getChannel().newCall(getPollCertificateSigningMethod(), getCallOptions()), request, responseObserver);
     }
+
+    /**
+     * <pre>
+     *Revoke a TLS certificate
+     * </pre>
+     */
+    public void revokeCertificate(com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest request,
+        io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse> responseObserver) {
+      io.grpc.stub.ClientCalls.asyncUnaryCall(
+          getChannel().newCall(getRevokeCertificateMethod(), getCallOptions()), request, responseObserver);
+    }
   }
 
   /**
@@ -697,6 +756,16 @@ public final class PublicEndpointManagementGrpc {
     public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.PollCertificateSigningResponse pollCertificateSigning(com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.PollCertificateSigningRequest request) {
       return io.grpc.stub.ClientCalls.blockingUnaryCall(
           getChannel(), getPollCertificateSigningMethod(), getCallOptions(), request);
+    }
+
+    /**
+     * <pre>
+     *Revoke a TLS certificate
+     * </pre>
+     */
+    public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse revokeCertificate(com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest request) {
+      return io.grpc.stub.ClientCalls.blockingUnaryCall(
+          getChannel(), getRevokeCertificateMethod(), getCallOptions(), request);
     }
   }
 
@@ -816,6 +885,17 @@ public final class PublicEndpointManagementGrpc {
       return io.grpc.stub.ClientCalls.futureUnaryCall(
           getChannel().newCall(getPollCertificateSigningMethod(), getCallOptions()), request);
     }
+
+    /**
+     * <pre>
+     *Revoke a TLS certificate
+     * </pre>
+     */
+    public com.google.common.util.concurrent.ListenableFuture<com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse> revokeCertificate(
+        com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest request) {
+      return io.grpc.stub.ClientCalls.futureUnaryCall(
+          getChannel().newCall(getRevokeCertificateMethod(), getCallOptions()), request);
+    }
   }
 
   private static final int METHODID_GET_VERSION = 0;
@@ -826,6 +906,7 @@ public final class PublicEndpointManagementGrpc {
   private static final int METHODID_GENERATE_MANAGED_DOMAIN_NAMES = 5;
   private static final int METHODID_SIGN_CERTIFICATE = 6;
   private static final int METHODID_POLL_CERTIFICATE_SIGNING = 7;
+  private static final int METHODID_REVOKE_CERTIFICATE = 8;
 
   private static final class MethodHandlers<Req, Resp> implements
       io.grpc.stub.ServerCalls.UnaryMethod<Req, Resp>,
@@ -875,6 +956,10 @@ public final class PublicEndpointManagementGrpc {
         case METHODID_POLL_CERTIFICATE_SIGNING:
           serviceImpl.pollCertificateSigning((com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.PollCertificateSigningRequest) request,
               (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.PollCertificateSigningResponse>) responseObserver);
+          break;
+        case METHODID_REVOKE_CERTIFICATE:
+          serviceImpl.revokeCertificate((com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest) request,
+              (io.grpc.stub.StreamObserver<com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse>) responseObserver);
           break;
         default:
           throw new AssertionError();
@@ -945,6 +1030,7 @@ public final class PublicEndpointManagementGrpc {
               .addMethod(getGenerateManagedDomainNamesMethod())
               .addMethod(getSignCertificateMethod())
               .addMethod(getPollCertificateSigningMethod())
+              .addMethod(getRevokeCertificateMethod())
               .build();
         }
       }

--- a/cluster-dns-connector/src/generated/main/java/com/cloudera/thunderhead/service/common/options/Options.java
+++ b/cluster-dns-connector/src/generated/main/java/com/cloudera/thunderhead/service/common/options/Options.java
@@ -7,6 +7,14 @@ public final class Options {
   private Options() {}
   public static void registerAllExtensions(
       com.google.protobuf.ExtensionRegistryLite registry) {
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.rateLimitGroupDefinition);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.apiServiceName);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.release);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.admin);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.formFactor);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.version);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FileExtension.audit);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FileExtension.auditEntitlement);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.sensitive);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.skipLogging);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.pagingPageSize);
@@ -23,6 +31,7 @@ public final class Options {
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.minimumLength);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.maximumLength);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.deprecated);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.noParamfile);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.right);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.entitlement);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.paginates);
@@ -31,10 +40,18 @@ public final class Options {
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.hiddenReason);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.hiddenRetention);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.deprecated);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.rateLimitGroup);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.mutating);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.skipAuditing);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.formFactor);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.MethodExtension.extension);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.hidden);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.hiddenReason);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.hiddenRetention);
     registry.add(com.cloudera.thunderhead.service.common.options.Options.MessageExtension.deprecated);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.hidden);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.hiddenReason);
+    registry.add(com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.hiddenRetention);
   }
 
   public static void registerAllExtensions(
@@ -42,6 +59,2685 @@ public final class Options {
     registerAllExtensions(
         (com.google.protobuf.ExtensionRegistryLite) registry);
   }
+  public interface ServiceExtensionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.ServiceExtension)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code options.ServiceExtension}
+   */
+  public static final class ServiceExtension extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.ServiceExtension)
+      ServiceExtensionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use ServiceExtension.newBuilder() to construct.
+    private ServiceExtension(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private ServiceExtension() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new ServiceExtension();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ServiceExtension(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ServiceExtension_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ServiceExtension_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.class, com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.ServiceExtension)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.ServiceExtension other = (com.cloudera.thunderhead.service.common.options.Options.ServiceExtension) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code options.ServiceExtension}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.ServiceExtension)
+        com.cloudera.thunderhead.service.common.options.Options.ServiceExtensionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ServiceExtension_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ServiceExtension_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.class, com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ServiceExtension_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ServiceExtension getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ServiceExtension build() {
+        com.cloudera.thunderhead.service.common.options.Options.ServiceExtension result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ServiceExtension buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.ServiceExtension result = new com.cloudera.thunderhead.service.common.options.Options.ServiceExtension(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.ServiceExtension) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.ServiceExtension)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.ServiceExtension other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.ServiceExtension parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.ServiceExtension) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.ServiceExtension)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.ServiceExtension)
+    private static final com.cloudera.thunderhead.service.common.options.Options.ServiceExtension DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.ServiceExtension();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.ServiceExtension getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ServiceExtension>
+        PARSER = new com.google.protobuf.AbstractParser<ServiceExtension>() {
+      @java.lang.Override
+      public ServiceExtension parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ServiceExtension(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<ServiceExtension> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ServiceExtension> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.ServiceExtension getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+    public static final int RATELIMITGROUPDEFINITION_FIELD_NUMBER = 40000;
+    /**
+     * <pre>
+     * At least one method in this service is rate limited by the specified
+     * rate limit group. Use of this option causes the generated API controller
+     * to include rate limiting for methods that have the rateLimitGroup option.
+     * (Currently, only one group may be defined.) Most services do not require
+     * rate limiting; contact the CDPCP core infra team for guidance.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition> rateLimitGroupDefinition = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          0,
+          com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.class,
+          com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.getDefaultInstance());
+    public static final int APISERVICENAME_FIELD_NUMBER = 40001;
+    /**
+     * <pre>
+     * The API service name, in various casings.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        com.cloudera.thunderhead.service.common.options.Options.ApiServiceName> apiServiceName = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          1,
+          com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.class,
+          com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.getDefaultInstance());
+    public static final int RELEASE_FIELD_NUMBER = 40002;
+    /**
+     * <pre>
+     * The releases that the service belongs in, i.e., PUBLIC.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        java.util.List<java.lang.String>> release = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          2,
+          java.lang.String.class,
+          null);
+    public static final int ADMIN_FIELD_NUMBER = 40003;
+    /**
+     * <pre>
+     * Whether this service is an administrative service. These services are put
+     * on a special, internal only ingress and may only be called by members of
+     * the CDP administration account.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        java.lang.Boolean> admin = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          3,
+          java.lang.Boolean.class,
+          null);
+    public static final int FORMFACTOR_FIELD_NUMBER = 40004;
+    /**
+     * <pre>
+     * The form factor(s) that the service is part of, e.g., public, private.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        java.util.List<java.lang.String>> formFactor = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          4,
+          java.lang.String.class,
+          null);
+    public static final int VERSION_FIELD_NUMBER = 40005;
+    /**
+     * <pre>
+     * The version of the service definition.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.ServiceOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.ServiceOptions,
+        java.lang.String> version = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.ServiceExtension.getDefaultInstance(),
+          5,
+          java.lang.String.class,
+          null);
+  }
+
+  public interface RateLimitGroupDefinitionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.RateLimitGroupDefinition)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * The name of the group. This must be one of the values of the
+     * ApiRateLimitGroup enum.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The name.
+     */
+    java.lang.String getName();
+    /**
+     * <pre>
+     * The name of the group. This must be one of the values of the
+     * ApiRateLimitGroup enum.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The bytes for name.
+     */
+    com.google.protobuf.ByteString
+        getNameBytes();
+
+    /**
+     * <pre>
+     * The limit (calls per second) by remote address for calls controlled by
+     * this group.
+     * </pre>
+     *
+     * <code>int32 byRemoteAddress = 2;</code>
+     * @return The byRemoteAddress.
+     */
+    int getByRemoteAddress();
+
+    /**
+     * <pre>
+     * The limit (calls per second) by access key ID for calls controlled by this
+     * group. (Not yet supported.)
+     * </pre>
+     *
+     * <code>int32 byAccessKeyId = 3;</code>
+     * @return The byAccessKeyId.
+     */
+    int getByAccessKeyId();
+
+    /**
+     * <pre>
+     * The limit (calls per second) by account for calls controlled by this group.
+     * </pre>
+     *
+     * <code>int32 byAccount = 4;</code>
+     * @return The byAccount.
+     */
+    int getByAccount();
+  }
+  /**
+   * <pre>
+   * The definition of an API rate limit group. See the Java classes
+   * ApiRateLimiter and ApiRateLimiterProvider for context.
+   * </pre>
+   *
+   * Protobuf type {@code options.RateLimitGroupDefinition}
+   */
+  public static final class RateLimitGroupDefinition extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.RateLimitGroupDefinition)
+      RateLimitGroupDefinitionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use RateLimitGroupDefinition.newBuilder() to construct.
+    private RateLimitGroupDefinition(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private RateLimitGroupDefinition() {
+      name_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new RateLimitGroupDefinition();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private RateLimitGroupDefinition(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              name_ = s;
+              break;
+            }
+            case 16: {
+
+              byRemoteAddress_ = input.readInt32();
+              break;
+            }
+            case 24: {
+
+              byAccessKeyId_ = input.readInt32();
+              break;
+            }
+            case 32: {
+
+              byAccount_ = input.readInt32();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_RateLimitGroupDefinition_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_RateLimitGroupDefinition_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.class, com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.Builder.class);
+    }
+
+    public static final int NAME_FIELD_NUMBER = 1;
+    private volatile java.lang.Object name_;
+    /**
+     * <pre>
+     * The name of the group. This must be one of the values of the
+     * ApiRateLimitGroup enum.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The name.
+     */
+    @java.lang.Override
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        name_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The name of the group. This must be one of the values of the
+     * ApiRateLimitGroup enum.
+     * </pre>
+     *
+     * <code>string name = 1;</code>
+     * @return The bytes for name.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNameBytes() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        name_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int BYREMOTEADDRESS_FIELD_NUMBER = 2;
+    private int byRemoteAddress_;
+    /**
+     * <pre>
+     * The limit (calls per second) by remote address for calls controlled by
+     * this group.
+     * </pre>
+     *
+     * <code>int32 byRemoteAddress = 2;</code>
+     * @return The byRemoteAddress.
+     */
+    @java.lang.Override
+    public int getByRemoteAddress() {
+      return byRemoteAddress_;
+    }
+
+    public static final int BYACCESSKEYID_FIELD_NUMBER = 3;
+    private int byAccessKeyId_;
+    /**
+     * <pre>
+     * The limit (calls per second) by access key ID for calls controlled by this
+     * group. (Not yet supported.)
+     * </pre>
+     *
+     * <code>int32 byAccessKeyId = 3;</code>
+     * @return The byAccessKeyId.
+     */
+    @java.lang.Override
+    public int getByAccessKeyId() {
+      return byAccessKeyId_;
+    }
+
+    public static final int BYACCOUNT_FIELD_NUMBER = 4;
+    private int byAccount_;
+    /**
+     * <pre>
+     * The limit (calls per second) by account for calls controlled by this group.
+     * </pre>
+     *
+     * <code>int32 byAccount = 4;</code>
+     * @return The byAccount.
+     */
+    @java.lang.Override
+    public int getByAccount() {
+      return byAccount_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
+      }
+      if (byRemoteAddress_ != 0) {
+        output.writeInt32(2, byRemoteAddress_);
+      }
+      if (byAccessKeyId_ != 0) {
+        output.writeInt32(3, byAccessKeyId_);
+      }
+      if (byAccount_ != 0) {
+        output.writeInt32(4, byAccount_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
+      }
+      if (byRemoteAddress_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(2, byRemoteAddress_);
+      }
+      if (byAccessKeyId_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(3, byAccessKeyId_);
+      }
+      if (byAccount_ != 0) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt32Size(4, byAccount_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition other = (com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition) obj;
+
+      if (!getName()
+          .equals(other.getName())) return false;
+      if (getByRemoteAddress()
+          != other.getByRemoteAddress()) return false;
+      if (getByAccessKeyId()
+          != other.getByAccessKeyId()) return false;
+      if (getByAccount()
+          != other.getByAccount()) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + NAME_FIELD_NUMBER;
+      hash = (53 * hash) + getName().hashCode();
+      hash = (37 * hash) + BYREMOTEADDRESS_FIELD_NUMBER;
+      hash = (53 * hash) + getByRemoteAddress();
+      hash = (37 * hash) + BYACCESSKEYID_FIELD_NUMBER;
+      hash = (53 * hash) + getByAccessKeyId();
+      hash = (37 * hash) + BYACCOUNT_FIELD_NUMBER;
+      hash = (53 * hash) + getByAccount();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * The definition of an API rate limit group. See the Java classes
+     * ApiRateLimiter and ApiRateLimiterProvider for context.
+     * </pre>
+     *
+     * Protobuf type {@code options.RateLimitGroupDefinition}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.RateLimitGroupDefinition)
+        com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinitionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_RateLimitGroupDefinition_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_RateLimitGroupDefinition_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.class, com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        name_ = "";
+
+        byRemoteAddress_ = 0;
+
+        byAccessKeyId_ = 0;
+
+        byAccount_ = 0;
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_RateLimitGroupDefinition_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition build() {
+        com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition result = new com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition(this);
+        result.name_ = name_;
+        result.byRemoteAddress_ = byRemoteAddress_;
+        result.byAccessKeyId_ = byAccessKeyId_;
+        result.byAccount_ = byAccount_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition.getDefaultInstance()) return this;
+        if (!other.getName().isEmpty()) {
+          name_ = other.name_;
+          onChanged();
+        }
+        if (other.getByRemoteAddress() != 0) {
+          setByRemoteAddress(other.getByRemoteAddress());
+        }
+        if (other.getByAccessKeyId() != 0) {
+          setByAccessKeyId(other.getByAccessKeyId());
+        }
+        if (other.getByAccount() != 0) {
+          setByAccount(other.getByAccount());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object name_ = "";
+      /**
+       * <pre>
+       * The name of the group. This must be one of the values of the
+       * ApiRateLimitGroup enum.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @return The name.
+       */
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          name_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The name of the group. This must be one of the values of the
+       * ApiRateLimitGroup enum.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @return The bytes for name.
+       */
+      public com.google.protobuf.ByteString
+          getNameBytes() {
+        java.lang.Object ref = name_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          name_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The name of the group. This must be one of the values of the
+       * ApiRateLimitGroup enum.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @param value The name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        name_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The name of the group. This must be one of the values of the
+       * ApiRateLimitGroup enum.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearName() {
+        
+        name_ = getDefaultInstance().getName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The name of the group. This must be one of the values of the
+       * ApiRateLimitGroup enum.
+       * </pre>
+       *
+       * <code>string name = 1;</code>
+       * @param value The bytes for name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        name_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int byRemoteAddress_ ;
+      /**
+       * <pre>
+       * The limit (calls per second) by remote address for calls controlled by
+       * this group.
+       * </pre>
+       *
+       * <code>int32 byRemoteAddress = 2;</code>
+       * @return The byRemoteAddress.
+       */
+      @java.lang.Override
+      public int getByRemoteAddress() {
+        return byRemoteAddress_;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by remote address for calls controlled by
+       * this group.
+       * </pre>
+       *
+       * <code>int32 byRemoteAddress = 2;</code>
+       * @param value The byRemoteAddress to set.
+       * @return This builder for chaining.
+       */
+      public Builder setByRemoteAddress(int value) {
+        
+        byRemoteAddress_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by remote address for calls controlled by
+       * this group.
+       * </pre>
+       *
+       * <code>int32 byRemoteAddress = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearByRemoteAddress() {
+        
+        byRemoteAddress_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int byAccessKeyId_ ;
+      /**
+       * <pre>
+       * The limit (calls per second) by access key ID for calls controlled by this
+       * group. (Not yet supported.)
+       * </pre>
+       *
+       * <code>int32 byAccessKeyId = 3;</code>
+       * @return The byAccessKeyId.
+       */
+      @java.lang.Override
+      public int getByAccessKeyId() {
+        return byAccessKeyId_;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by access key ID for calls controlled by this
+       * group. (Not yet supported.)
+       * </pre>
+       *
+       * <code>int32 byAccessKeyId = 3;</code>
+       * @param value The byAccessKeyId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setByAccessKeyId(int value) {
+        
+        byAccessKeyId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by access key ID for calls controlled by this
+       * group. (Not yet supported.)
+       * </pre>
+       *
+       * <code>int32 byAccessKeyId = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearByAccessKeyId() {
+        
+        byAccessKeyId_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private int byAccount_ ;
+      /**
+       * <pre>
+       * The limit (calls per second) by account for calls controlled by this group.
+       * </pre>
+       *
+       * <code>int32 byAccount = 4;</code>
+       * @return The byAccount.
+       */
+      @java.lang.Override
+      public int getByAccount() {
+        return byAccount_;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by account for calls controlled by this group.
+       * </pre>
+       *
+       * <code>int32 byAccount = 4;</code>
+       * @param value The byAccount to set.
+       * @return This builder for chaining.
+       */
+      public Builder setByAccount(int value) {
+        
+        byAccount_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The limit (calls per second) by account for calls controlled by this group.
+       * </pre>
+       *
+       * <code>int32 byAccount = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearByAccount() {
+        
+        byAccount_ = 0;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.RateLimitGroupDefinition)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.RateLimitGroupDefinition)
+    private static final com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<RateLimitGroupDefinition>
+        PARSER = new com.google.protobuf.AbstractParser<RateLimitGroupDefinition>() {
+      @java.lang.Override
+      public RateLimitGroupDefinition parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new RateLimitGroupDefinition(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<RateLimitGroupDefinition> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<RateLimitGroupDefinition> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.RateLimitGroupDefinition getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface ApiServiceNameOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.ApiServiceName)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * The lowercased service name.
+     * </pre>
+     *
+     * <code>string lowercase = 1;</code>
+     * @return The lowercase.
+     */
+    java.lang.String getLowercase();
+    /**
+     * <pre>
+     * The lowercased service name.
+     * </pre>
+     *
+     * <code>string lowercase = 1;</code>
+     * @return The bytes for lowercase.
+     */
+    com.google.protobuf.ByteString
+        getLowercaseBytes();
+
+    /**
+     * <pre>
+     * The camel-cased service name.
+     * </pre>
+     *
+     * <code>string camelcase = 2;</code>
+     * @return The camelcase.
+     */
+    java.lang.String getCamelcase();
+    /**
+     * <pre>
+     * The camel-cased service name.
+     * </pre>
+     *
+     * <code>string camelcase = 2;</code>
+     * @return The bytes for camelcase.
+     */
+    com.google.protobuf.ByteString
+        getCamelcaseBytes();
+  }
+  /**
+   * <pre>
+   * The API service name, in various casings.
+   * </pre>
+   *
+   * Protobuf type {@code options.ApiServiceName}
+   */
+  public static final class ApiServiceName extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.ApiServiceName)
+      ApiServiceNameOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use ApiServiceName.newBuilder() to construct.
+    private ApiServiceName(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private ApiServiceName() {
+      lowercase_ = "";
+      camelcase_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new ApiServiceName();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private ApiServiceName(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              lowercase_ = s;
+              break;
+            }
+            case 18: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              camelcase_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ApiServiceName_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ApiServiceName_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.class, com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.Builder.class);
+    }
+
+    public static final int LOWERCASE_FIELD_NUMBER = 1;
+    private volatile java.lang.Object lowercase_;
+    /**
+     * <pre>
+     * The lowercased service name.
+     * </pre>
+     *
+     * <code>string lowercase = 1;</code>
+     * @return The lowercase.
+     */
+    @java.lang.Override
+    public java.lang.String getLowercase() {
+      java.lang.Object ref = lowercase_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        lowercase_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The lowercased service name.
+     * </pre>
+     *
+     * <code>string lowercase = 1;</code>
+     * @return The bytes for lowercase.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getLowercaseBytes() {
+      java.lang.Object ref = lowercase_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        lowercase_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CAMELCASE_FIELD_NUMBER = 2;
+    private volatile java.lang.Object camelcase_;
+    /**
+     * <pre>
+     * The camel-cased service name.
+     * </pre>
+     *
+     * <code>string camelcase = 2;</code>
+     * @return The camelcase.
+     */
+    @java.lang.Override
+    public java.lang.String getCamelcase() {
+      java.lang.Object ref = camelcase_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        camelcase_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The camel-cased service name.
+     * </pre>
+     *
+     * <code>string camelcase = 2;</code>
+     * @return The bytes for camelcase.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getCamelcaseBytes() {
+      java.lang.Object ref = camelcase_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        camelcase_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(lowercase_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, lowercase_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(camelcase_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, camelcase_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(lowercase_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, lowercase_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(camelcase_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, camelcase_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.ApiServiceName)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.ApiServiceName other = (com.cloudera.thunderhead.service.common.options.Options.ApiServiceName) obj;
+
+      if (!getLowercase()
+          .equals(other.getLowercase())) return false;
+      if (!getCamelcase()
+          .equals(other.getCamelcase())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + LOWERCASE_FIELD_NUMBER;
+      hash = (53 * hash) + getLowercase().hashCode();
+      hash = (37 * hash) + CAMELCASE_FIELD_NUMBER;
+      hash = (53 * hash) + getCamelcase().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.ApiServiceName prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     * The API service name, in various casings.
+     * </pre>
+     *
+     * Protobuf type {@code options.ApiServiceName}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.ApiServiceName)
+        com.cloudera.thunderhead.service.common.options.Options.ApiServiceNameOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ApiServiceName_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ApiServiceName_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.class, com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        lowercase_ = "";
+
+        camelcase_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_ApiServiceName_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ApiServiceName getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ApiServiceName build() {
+        com.cloudera.thunderhead.service.common.options.Options.ApiServiceName result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.ApiServiceName buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.ApiServiceName result = new com.cloudera.thunderhead.service.common.options.Options.ApiServiceName(this);
+        result.lowercase_ = lowercase_;
+        result.camelcase_ = camelcase_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.ApiServiceName) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.ApiServiceName)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.ApiServiceName other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.ApiServiceName.getDefaultInstance()) return this;
+        if (!other.getLowercase().isEmpty()) {
+          lowercase_ = other.lowercase_;
+          onChanged();
+        }
+        if (!other.getCamelcase().isEmpty()) {
+          camelcase_ = other.camelcase_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.ApiServiceName parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.ApiServiceName) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object lowercase_ = "";
+      /**
+       * <pre>
+       * The lowercased service name.
+       * </pre>
+       *
+       * <code>string lowercase = 1;</code>
+       * @return The lowercase.
+       */
+      public java.lang.String getLowercase() {
+        java.lang.Object ref = lowercase_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          lowercase_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The lowercased service name.
+       * </pre>
+       *
+       * <code>string lowercase = 1;</code>
+       * @return The bytes for lowercase.
+       */
+      public com.google.protobuf.ByteString
+          getLowercaseBytes() {
+        java.lang.Object ref = lowercase_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          lowercase_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The lowercased service name.
+       * </pre>
+       *
+       * <code>string lowercase = 1;</code>
+       * @param value The lowercase to set.
+       * @return This builder for chaining.
+       */
+      public Builder setLowercase(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        lowercase_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The lowercased service name.
+       * </pre>
+       *
+       * <code>string lowercase = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearLowercase() {
+        
+        lowercase_ = getDefaultInstance().getLowercase();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The lowercased service name.
+       * </pre>
+       *
+       * <code>string lowercase = 1;</code>
+       * @param value The bytes for lowercase to set.
+       * @return This builder for chaining.
+       */
+      public Builder setLowercaseBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        lowercase_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object camelcase_ = "";
+      /**
+       * <pre>
+       * The camel-cased service name.
+       * </pre>
+       *
+       * <code>string camelcase = 2;</code>
+       * @return The camelcase.
+       */
+      public java.lang.String getCamelcase() {
+        java.lang.Object ref = camelcase_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          camelcase_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The camel-cased service name.
+       * </pre>
+       *
+       * <code>string camelcase = 2;</code>
+       * @return The bytes for camelcase.
+       */
+      public com.google.protobuf.ByteString
+          getCamelcaseBytes() {
+        java.lang.Object ref = camelcase_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          camelcase_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The camel-cased service name.
+       * </pre>
+       *
+       * <code>string camelcase = 2;</code>
+       * @param value The camelcase to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCamelcase(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        camelcase_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The camel-cased service name.
+       * </pre>
+       *
+       * <code>string camelcase = 2;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearCamelcase() {
+        
+        camelcase_ = getDefaultInstance().getCamelcase();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The camel-cased service name.
+       * </pre>
+       *
+       * <code>string camelcase = 2;</code>
+       * @param value The bytes for camelcase to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCamelcaseBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        camelcase_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.ApiServiceName)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.ApiServiceName)
+    private static final com.cloudera.thunderhead.service.common.options.Options.ApiServiceName DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.ApiServiceName();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.ApiServiceName getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ApiServiceName>
+        PARSER = new com.google.protobuf.AbstractParser<ApiServiceName>() {
+      @java.lang.Override
+      public ApiServiceName parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new ApiServiceName(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<ApiServiceName> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ApiServiceName> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.ApiServiceName getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface FileExtensionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.FileExtension)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code options.FileExtension}
+   */
+  public static final class FileExtension extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.FileExtension)
+      FileExtensionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use FileExtension.newBuilder() to construct.
+    private FileExtension(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private FileExtension() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new FileExtension();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private FileExtension(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FileExtension_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FileExtension_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.FileExtension.class, com.cloudera.thunderhead.service.common.options.Options.FileExtension.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.FileExtension)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.FileExtension other = (com.cloudera.thunderhead.service.common.options.Options.FileExtension) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.FileExtension prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code options.FileExtension}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.FileExtension)
+        com.cloudera.thunderhead.service.common.options.Options.FileExtensionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FileExtension_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FileExtension_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.FileExtension.class, com.cloudera.thunderhead.service.common.options.Options.FileExtension.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.FileExtension.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_FileExtension_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.FileExtension getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.FileExtension.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.FileExtension build() {
+        com.cloudera.thunderhead.service.common.options.Options.FileExtension result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.FileExtension buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.FileExtension result = new com.cloudera.thunderhead.service.common.options.Options.FileExtension(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.FileExtension) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.FileExtension)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.FileExtension other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.FileExtension.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.FileExtension parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.FileExtension) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.FileExtension)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.FileExtension)
+    private static final com.cloudera.thunderhead.service.common.options.Options.FileExtension DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.FileExtension();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.FileExtension getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<FileExtension>
+        PARSER = new com.google.protobuf.AbstractParser<FileExtension>() {
+      @java.lang.Override
+      public FileExtension parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new FileExtension(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<FileExtension> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<FileExtension> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.FileExtension getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+    public static final int AUDIT_FIELD_NUMBER = 80000;
+    /**
+     * <pre>
+     * This field is used to enable auditing for the service.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FileOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FileOptions,
+        java.lang.Boolean> audit = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FileExtension.getDefaultInstance(),
+          0,
+          java.lang.Boolean.class,
+          null);
+    public static final int AUDITENTITLEMENT_FIELD_NUMBER = 80001;
+    /**
+     * <pre>
+     * The name of the entitlement to use to enable submitting auditing records.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FileOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FileOptions,
+        java.lang.String> auditEntitlement = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FileExtension.getDefaultInstance(),
+          1,
+          java.lang.String.class,
+          null);
+  }
+
   public interface FieldExtensionOrBuilder extends
       // @@protoc_insertion_point(interface_extends:options.FieldExtension)
       com.google.protobuf.MessageOrBuilder {
@@ -732,6 +3428,23 @@ public final class Options {
           15,
           java.lang.Boolean.class,
           null);
+    public static final int NOPARAMFILE_FIELD_NUMBER = 50016;
+    /**
+     * <pre>
+     * This field doesn't reference a parameter file.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.FieldOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.FieldOptions,
+        java.lang.Boolean> noParamfile = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.FieldExtension.getDefaultInstance(),
+          16,
+          java.lang.Boolean.class,
+          null);
   }
 
   public interface MethodExtensionOrBuilder extends
@@ -1187,7 +3900,7 @@ public final class Options {
     public static final int PAGINATES_FIELD_NUMBER = 60002;
     /**
      * <pre>
-     * This method returnes paginated results.
+     * This method returns paginated results.
      * </pre>
      *
      * <code>extend .google.protobuf.MethodOptions { ... }</code>
@@ -1285,6 +3998,93 @@ public final class Options {
           com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
           7,
           java.lang.Boolean.class,
+          null);
+    public static final int RATELIMITGROUP_FIELD_NUMBER = 60008;
+    /**
+     * <pre>
+     * This method is rate limited with the specified group. This name must
+     * match the name of a rate limit group declared for the service itself.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.String> rateLimitGroup = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          8,
+          java.lang.String.class,
+          null);
+    public static final int MUTATING_FIELD_NUMBER = 60009;
+    /**
+     * <pre>
+     * This method is a mutating call.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.Boolean> mutating = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          9,
+          java.lang.Boolean.class,
+          null);
+    public static final int SKIPAUDITING_FIELD_NUMBER = 60010;
+    /**
+     * <pre>
+     * This method should not be audited.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.lang.Boolean> skipAuditing = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          10,
+          java.lang.Boolean.class,
+          null);
+    public static final int FORMFACTOR_FIELD_NUMBER = 60011;
+    /**
+     * <pre>
+     * The form factor(s) that the operation is part of, e.g., public, private.
+     * By default, an operation is part of every form factor of its service.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.util.List<java.lang.String>> formFactor = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          11,
+          java.lang.String.class,
+          null);
+    public static final int EXTENSION_FIELD_NUMBER = 60012;
+    /**
+     * <pre>
+     * This method has extensions
+     * </pre>
+     *
+     * <code>extend .google.protobuf.MethodOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.MethodOptions,
+        java.util.List<java.lang.String>> extension = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.MethodExtension.getDefaultInstance(),
+          12,
+          java.lang.String.class,
           null);
   }
 
@@ -1774,6 +4574,495 @@ public final class Options {
           null);
   }
 
+  public interface EnumValueExtensionOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:options.EnumValueExtension)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code options.EnumValueExtension}
+   */
+  public static final class EnumValueExtension extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:options.EnumValueExtension)
+      EnumValueExtensionOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use EnumValueExtension.newBuilder() to construct.
+    private EnumValueExtension(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private EnumValueExtension() {
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new EnumValueExtension();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private EnumValueExtension(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_EnumValueExtension_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_EnumValueExtension_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.class, com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension other = (com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension) obj;
+
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code options.EnumValueExtension}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:options.EnumValueExtension)
+        com.cloudera.thunderhead.service.common.options.Options.EnumValueExtensionOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_EnumValueExtension_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_EnumValueExtension_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.class, com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.internal_static_options_EnumValueExtension_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension build() {
+        com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension buildPartial() {
+        com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension result = new com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension) {
+          return mergeFrom((com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension other) {
+        if (other == com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:options.EnumValueExtension)
+    }
+
+    // @@protoc_insertion_point(class_scope:options.EnumValueExtension)
+    private static final com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension();
+    }
+
+    public static com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<EnumValueExtension>
+        PARSER = new com.google.protobuf.AbstractParser<EnumValueExtension>() {
+      @java.lang.Override
+      public EnumValueExtension parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new EnumValueExtension(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<EnumValueExtension> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<EnumValueExtension> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+    public static final int HIDDEN_FIELD_NUMBER = 90000;
+    /**
+     * <pre>
+     * This value is hidden.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.EnumValueOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.EnumValueOptions,
+        java.lang.Boolean> hidden = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.getDefaultInstance(),
+          0,
+          java.lang.Boolean.class,
+          null);
+    public static final int HIDDENREASON_FIELD_NUMBER = 90001;
+    /**
+     * <pre>
+     * The reason this value is hidden.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.EnumValueOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.EnumValueOptions,
+        java.lang.String> hiddenReason = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.getDefaultInstance(),
+          1,
+          java.lang.String.class,
+          null);
+    public static final int HIDDENRETENTION_FIELD_NUMBER = 90002;
+    /**
+     * <pre>
+     * This conditions under this hidden value is made visible.
+     * </pre>
+     *
+     * <code>extend .google.protobuf.EnumValueOptions { ... }</code>
+     */
+    public static final
+      com.google.protobuf.GeneratedMessage.GeneratedExtension<
+        com.google.protobuf.DescriptorProtos.EnumValueOptions,
+        java.lang.String> hiddenRetention = com.google.protobuf.GeneratedMessage
+            .newMessageScopedGeneratedExtension(
+          com.cloudera.thunderhead.service.common.options.Options.EnumValueExtension.getDefaultInstance(),
+          2,
+          java.lang.String.class,
+          null);
+  }
+
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_ServiceExtension_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_ServiceExtension_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_RateLimitGroupDefinition_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_RateLimitGroupDefinition_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_ApiServiceName_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_ApiServiceName_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_FileExtension_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_FileExtension_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_options_FieldExtension_descriptor;
   private static final 
@@ -1789,6 +5078,11 @@ public final class Options {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_options_MessageExtension_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_options_EnumValueExtension_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_options_EnumValueExtension_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -1799,47 +5093,78 @@ public final class Options {
   static {
     java.lang.String[] descriptorData = {
       "\n\roptions.proto\022\007options\032 google/protobu" +
-      "f/descriptor.proto\"\362\006\n\016FieldExtension22\n" +
-      "\tsensitive\022\035.google.protobuf.FieldOption" +
-      "s\030\320\206\003 \001(\01024\n\013skipLogging\022\035.google.protob" +
-      "uf.FieldOptions\030\321\206\003 \001(\01027\n\016pagingPageSiz" +
-      "e\022\035.google.protobuf.FieldOptions\030\322\206\003 \001(\010" +
-      "29\n\020pagingInputToken\022\035.google.protobuf.F" +
-      "ieldOptions\030\323\206\003 \001(\01025\n\014pagingResult\022\035.go" +
-      "ogle.protobuf.FieldOptions\030\324\206\003 \001(\0102:\n\021pa" +
-      "gingOutputToken\022\035.google.protobuf.FieldO" +
-      "ptions\030\325\206\003 \001(\01021\n\010datetime\022\035.google.prot" +
-      "obuf.FieldOptions\030\326\206\003 \001(\0102/\n\006hidden\022\035.go" +
-      "ogle.protobuf.FieldOptions\030\327\206\003 \001(\01025\n\014hi" +
-      "ddenReason\022\035.google.protobuf.FieldOption" +
-      "s\030\330\206\003 \001(\t28\n\017hiddenRetention\022\035.google.pr" +
-      "otobuf.FieldOptions\030\331\206\003 \001(\t21\n\010required\022" +
-      "\035.google.protobuf.FieldOptions\030\332\206\003 \001(\01020" +
-      "\n\007minimum\022\035.google.protobuf.FieldOptions" +
-      "\030\333\206\003 \001(\00520\n\007maximum\022\035.google.protobuf.Fi" +
-      "eldOptions\030\334\206\003 \001(\00526\n\rminimumLength\022\035.go" +
-      "ogle.protobuf.FieldOptions\030\335\206\003 \001(\00526\n\rma" +
-      "ximumLength\022\035.google.protobuf.FieldOptio" +
-      "ns\030\336\206\003 \001(\00523\n\ndeprecated\022\035.google.protob" +
-      "uf.FieldOptions\030\337\206\003 \001(\010\"\312\003\n\017MethodExtens" +
-      "ion2/\n\005right\022\036.google.protobuf.MethodOpt" +
-      "ions\030\340\324\003 \001(\t25\n\013entitlement\022\036.google.pro" +
-      "tobuf.MethodOptions\030\341\324\003 \001(\t23\n\tpaginates" +
-      "\022\036.google.protobuf.MethodOptions\030\342\324\003 \001(\010" +
-      "2?\n\025pagingDefaultMaxItems\022\036.google.proto" +
-      "buf.MethodOptions\030\343\324\003 \001(\00520\n\006hidden\022\036.go" +
-      "ogle.protobuf.MethodOptions\030\344\324\003 \001(\01026\n\014h" +
-      "iddenReason\022\036.google.protobuf.MethodOpti" +
-      "ons\030\345\324\003 \001(\t29\n\017hiddenRetention\022\036.google." +
-      "protobuf.MethodOptions\030\346\324\003 \001(\t24\n\ndeprec" +
-      "ated\022\036.google.protobuf.MethodOptions\030\347\324\003" +
-      " \001(\010\"\361\001\n\020MessageExtension21\n\006hidden\022\037.go" +
-      "ogle.protobuf.MessageOptions\030\360\242\004 \001(\01027\n\014" +
-      "hiddenReason\022\037.google.protobuf.MessageOp" +
-      "tions\030\361\242\004 \001(\t2:\n\017hiddenRetention\022\037.googl" +
-      "e.protobuf.MessageOptions\030\362\242\004 \001(\t25\n\ndep" +
-      "recated\022\037.google.protobuf.MessageOptions" +
-      "\030\363\242\004 \001(\010BU\n/com.cloudera.thunderhead.ser" +
+      "f/descriptor.proto\"\237\003\n\020ServiceExtension2" +
+      "f\n\030rateLimitGroupDefinition\022\037.google.pro" +
+      "tobuf.ServiceOptions\030\300\270\002 \001(\0132!.options.R" +
+      "ateLimitGroupDefinition2R\n\016apiServiceNam" +
+      "e\022\037.google.protobuf.ServiceOptions\030\301\270\002 \001" +
+      "(\0132\027.options.ApiServiceName22\n\007release\022\037" +
+      ".google.protobuf.ServiceOptions\030\302\270\002 \003(\t2" +
+      "0\n\005admin\022\037.google.protobuf.ServiceOption" +
+      "s\030\303\270\002 \001(\01025\n\nformFactor\022\037.google.protobu" +
+      "f.ServiceOptions\030\304\270\002 \003(\t22\n\007version\022\037.go" +
+      "ogle.protobuf.ServiceOptions\030\305\270\002 \001(\t\"k\n\030" +
+      "RateLimitGroupDefinition\022\014\n\004name\030\001 \001(\t\022\027" +
+      "\n\017byRemoteAddress\030\002 \001(\005\022\025\n\rbyAccessKeyId" +
+      "\030\003 \001(\005\022\021\n\tbyAccount\030\004 \001(\005\"6\n\016ApiServiceN" +
+      "ame\022\021\n\tlowercase\030\001 \001(\t\022\021\n\tcamelcase\030\002 \001(" +
+      "\t\"\202\001\n\rFileExtension2-\n\005audit\022\034.google.pr" +
+      "otobuf.FileOptions\030\200\361\004 \001(\01028\n\020auditEntit" +
+      "lement\022\034.google.protobuf.FileOptions\030\201\361\004" +
+      " \001(\tJ\010\010\202\361\004\020\203\361\004\"\250\007\n\016FieldExtension22\n\tsen" +
+      "sitive\022\035.google.protobuf.FieldOptions\030\320\206" +
+      "\003 \001(\01024\n\013skipLogging\022\035.google.protobuf.F" +
+      "ieldOptions\030\321\206\003 \001(\01027\n\016pagingPageSize\022\035." +
+      "google.protobuf.FieldOptions\030\322\206\003 \001(\01029\n\020" +
+      "pagingInputToken\022\035.google.protobuf.Field" +
+      "Options\030\323\206\003 \001(\01025\n\014pagingResult\022\035.google" +
+      ".protobuf.FieldOptions\030\324\206\003 \001(\0102:\n\021paging" +
+      "OutputToken\022\035.google.protobuf.FieldOptio" +
+      "ns\030\325\206\003 \001(\01021\n\010datetime\022\035.google.protobuf" +
+      ".FieldOptions\030\326\206\003 \001(\0102/\n\006hidden\022\035.google" +
+      ".protobuf.FieldOptions\030\327\206\003 \001(\01025\n\014hidden" +
+      "Reason\022\035.google.protobuf.FieldOptions\030\330\206" +
+      "\003 \001(\t28\n\017hiddenRetention\022\035.google.protob" +
+      "uf.FieldOptions\030\331\206\003 \001(\t21\n\010required\022\035.go" +
+      "ogle.protobuf.FieldOptions\030\332\206\003 \001(\01020\n\007mi" +
+      "nimum\022\035.google.protobuf.FieldOptions\030\333\206\003" +
+      " \001(\00520\n\007maximum\022\035.google.protobuf.FieldO" +
+      "ptions\030\334\206\003 \001(\00526\n\rminimumLength\022\035.google" +
+      ".protobuf.FieldOptions\030\335\206\003 \001(\00526\n\rmaximu" +
+      "mLength\022\035.google.protobuf.FieldOptions\030\336" +
+      "\206\003 \001(\00523\n\ndeprecated\022\035.google.protobuf.F" +
+      "ieldOptions\030\337\206\003 \001(\01024\n\013noParamfile\022\035.goo" +
+      "gle.protobuf.FieldOptions\030\340\206\003 \001(\010\"\333\005\n\017Me" +
+      "thodExtension2/\n\005right\022\036.google.protobuf" +
+      ".MethodOptions\030\340\324\003 \001(\t25\n\013entitlement\022\036." +
+      "google.protobuf.MethodOptions\030\341\324\003 \001(\t23\n" +
+      "\tpaginates\022\036.google.protobuf.MethodOptio" +
+      "ns\030\342\324\003 \001(\0102?\n\025pagingDefaultMaxItems\022\036.go" +
+      "ogle.protobuf.MethodOptions\030\343\324\003 \001(\00520\n\006h" +
+      "idden\022\036.google.protobuf.MethodOptions\030\344\324" +
+      "\003 \001(\01026\n\014hiddenReason\022\036.google.protobuf." +
+      "MethodOptions\030\345\324\003 \001(\t29\n\017hiddenRetention" +
+      "\022\036.google.protobuf.MethodOptions\030\346\324\003 \001(\t" +
+      "24\n\ndeprecated\022\036.google.protobuf.MethodO" +
+      "ptions\030\347\324\003 \001(\01028\n\016rateLimitGroup\022\036.googl" +
+      "e.protobuf.MethodOptions\030\350\324\003 \001(\t22\n\010muta" +
+      "ting\022\036.google.protobuf.MethodOptions\030\351\324\003" +
+      " \001(\01026\n\014skipAuditing\022\036.google.protobuf.M" +
+      "ethodOptions\030\352\324\003 \001(\01024\n\nformFactor\022\036.goo" +
+      "gle.protobuf.MethodOptions\030\353\324\003 \003(\t23\n\tex" +
+      "tension\022\036.google.protobuf.MethodOptions\030" +
+      "\354\324\003 \003(\t\"\361\001\n\020MessageExtension21\n\006hidden\022\037" +
+      ".google.protobuf.MessageOptions\030\360\242\004 \001(\0102" +
+      "7\n\014hiddenReason\022\037.google.protobuf.Messag" +
+      "eOptions\030\361\242\004 \001(\t2:\n\017hiddenRetention\022\037.go" +
+      "ogle.protobuf.MessageOptions\030\362\242\004 \001(\t25\n\n" +
+      "deprecated\022\037.google.protobuf.MessageOpti" +
+      "ons\030\363\242\004 \001(\010\"\302\001\n\022EnumValueExtension23\n\006hi" +
+      "dden\022!.google.protobuf.EnumValueOptions\030" +
+      "\220\277\005 \001(\01029\n\014hiddenReason\022!.google.protobu" +
+      "f.EnumValueOptions\030\221\277\005 \001(\t2<\n\017hiddenRete" +
+      "ntion\022!.google.protobuf.EnumValueOptions" +
+      "\030\222\277\005 \001(\tBU\n/com.cloudera.thunderhead.ser" +
       "vice.common.optionsB\007OptionsZ\031com/cloude" +
       "ra/cdp/protobufb\006proto3"
     };
@@ -1848,23 +5173,53 @@ public final class Options {
         new com.google.protobuf.Descriptors.FileDescriptor[] {
           com.google.protobuf.DescriptorProtos.getDescriptor(),
         });
-    internal_static_options_FieldExtension_descriptor =
+    internal_static_options_ServiceExtension_descriptor =
       getDescriptor().getMessageTypes().get(0);
+    internal_static_options_ServiceExtension_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_ServiceExtension_descriptor,
+        new java.lang.String[] { });
+    internal_static_options_RateLimitGroupDefinition_descriptor =
+      getDescriptor().getMessageTypes().get(1);
+    internal_static_options_RateLimitGroupDefinition_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_RateLimitGroupDefinition_descriptor,
+        new java.lang.String[] { "Name", "ByRemoteAddress", "ByAccessKeyId", "ByAccount", });
+    internal_static_options_ApiServiceName_descriptor =
+      getDescriptor().getMessageTypes().get(2);
+    internal_static_options_ApiServiceName_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_ApiServiceName_descriptor,
+        new java.lang.String[] { "Lowercase", "Camelcase", });
+    internal_static_options_FileExtension_descriptor =
+      getDescriptor().getMessageTypes().get(3);
+    internal_static_options_FileExtension_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_FileExtension_descriptor,
+        new java.lang.String[] { });
+    internal_static_options_FieldExtension_descriptor =
+      getDescriptor().getMessageTypes().get(4);
     internal_static_options_FieldExtension_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_options_FieldExtension_descriptor,
         new java.lang.String[] { });
     internal_static_options_MethodExtension_descriptor =
-      getDescriptor().getMessageTypes().get(1);
+      getDescriptor().getMessageTypes().get(5);
     internal_static_options_MethodExtension_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_options_MethodExtension_descriptor,
         new java.lang.String[] { });
     internal_static_options_MessageExtension_descriptor =
-      getDescriptor().getMessageTypes().get(2);
+      getDescriptor().getMessageTypes().get(6);
     internal_static_options_MessageExtension_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_options_MessageExtension_descriptor,
+        new java.lang.String[] { });
+    internal_static_options_EnumValueExtension_descriptor =
+      getDescriptor().getMessageTypes().get(7);
+    internal_static_options_EnumValueExtension_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_options_EnumValueExtension_descriptor,
         new java.lang.String[] { });
     com.google.protobuf.DescriptorProtos.getDescriptor();
   }

--- a/cluster-dns-connector/src/generated/main/java/com/cloudera/thunderhead/service/publicendpointmanagement/PublicEndpointManagementProto.java
+++ b/cluster-dns-connector/src/generated/main/java/com/cloudera/thunderhead/service/publicendpointmanagement/PublicEndpointManagementProto.java
@@ -6273,6 +6273,50 @@ public final class PublicEndpointManagementProto {
      * @return The csr.
      */
     com.google.protobuf.ByteString getCsr();
+
+    /**
+     * <pre>
+     * The crn of the cluster. You can leave this empty when testing for random endpoints.
+     * </pre>
+     *
+     * <code>string clusterCrn = 6;</code>
+     * @return The clusterCrn.
+     */
+    java.lang.String getClusterCrn();
+    /**
+     * <pre>
+     * The crn of the cluster. You can leave this empty when testing for random endpoints.
+     * </pre>
+     *
+     * <code>string clusterCrn = 6;</code>
+     * @return The bytes for clusterCrn.
+     */
+    com.google.protobuf.ByteString
+        getClusterCrnBytes();
+
+    /**
+     * <pre>
+     * The service requesting the certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample' or leave it empty
+     * </pre>
+     *
+     * <code>string clientName = 7;</code>
+     * @return The clientName.
+     */
+    java.lang.String getClientName();
+    /**
+     * <pre>
+     * The service requesting the certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample' or leave it empty
+     * </pre>
+     *
+     * <code>string clientName = 7;</code>
+     * @return The bytes for clientName.
+     */
+    com.google.protobuf.ByteString
+        getClientNameBytes();
   }
   /**
    * <pre>
@@ -6295,6 +6339,8 @@ public final class PublicEndpointManagementProto {
       environment_ = "";
       endpoint_ = "";
       csr_ = com.google.protobuf.ByteString.EMPTY;
+      clusterCrn_ = "";
+      clientName_ = "";
     }
 
     @java.lang.Override
@@ -6353,6 +6399,18 @@ public final class PublicEndpointManagementProto {
             case 42: {
 
               csr_ = input.readBytes();
+              break;
+            }
+            case 50: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              clusterCrn_ = s;
+              break;
+            }
+            case 58: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              clientName_ = s;
               break;
             }
             default: {
@@ -6556,6 +6614,102 @@ public final class PublicEndpointManagementProto {
       return csr_;
     }
 
+    public static final int CLUSTERCRN_FIELD_NUMBER = 6;
+    private volatile java.lang.Object clusterCrn_;
+    /**
+     * <pre>
+     * The crn of the cluster. You can leave this empty when testing for random endpoints.
+     * </pre>
+     *
+     * <code>string clusterCrn = 6;</code>
+     * @return The clusterCrn.
+     */
+    @java.lang.Override
+    public java.lang.String getClusterCrn() {
+      java.lang.Object ref = clusterCrn_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        clusterCrn_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The crn of the cluster. You can leave this empty when testing for random endpoints.
+     * </pre>
+     *
+     * <code>string clusterCrn = 6;</code>
+     * @return The bytes for clusterCrn.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getClusterCrnBytes() {
+      java.lang.Object ref = clusterCrn_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        clusterCrn_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CLIENTNAME_FIELD_NUMBER = 7;
+    private volatile java.lang.Object clientName_;
+    /**
+     * <pre>
+     * The service requesting the certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample' or leave it empty
+     * </pre>
+     *
+     * <code>string clientName = 7;</code>
+     * @return The clientName.
+     */
+    @java.lang.Override
+    public java.lang.String getClientName() {
+      java.lang.Object ref = clientName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        clientName_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The service requesting the certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample' or leave it empty
+     * </pre>
+     *
+     * <code>string clientName = 7;</code>
+     * @return The bytes for clientName.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getClientNameBytes() {
+      java.lang.Object ref = clientName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        clientName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -6585,6 +6739,12 @@ public final class PublicEndpointManagementProto {
       if (!csr_.isEmpty()) {
         output.writeBytes(5, csr_);
       }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(clusterCrn_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, clusterCrn_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(clientName_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 7, clientName_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -6611,6 +6771,12 @@ public final class PublicEndpointManagementProto {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(5, csr_);
       }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(clusterCrn_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, clusterCrn_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(clientName_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(7, clientName_);
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -6636,6 +6802,10 @@ public final class PublicEndpointManagementProto {
           != other.getAddWildcard()) return false;
       if (!getCsr()
           .equals(other.getCsr())) return false;
+      if (!getClusterCrn()
+          .equals(other.getClusterCrn())) return false;
+      if (!getClientName()
+          .equals(other.getClientName())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -6658,6 +6828,10 @@ public final class PublicEndpointManagementProto {
           getAddWildcard());
       hash = (37 * hash) + CSR_FIELD_NUMBER;
       hash = (53 * hash) + getCsr().hashCode();
+      hash = (37 * hash) + CLUSTERCRN_FIELD_NUMBER;
+      hash = (53 * hash) + getClusterCrn().hashCode();
+      hash = (37 * hash) + CLIENTNAME_FIELD_NUMBER;
+      hash = (53 * hash) + getClientName().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -6805,6 +6979,10 @@ public final class PublicEndpointManagementProto {
 
         csr_ = com.google.protobuf.ByteString.EMPTY;
 
+        clusterCrn_ = "";
+
+        clientName_ = "";
+
         return this;
       }
 
@@ -6836,6 +7014,8 @@ public final class PublicEndpointManagementProto {
         result.endpoint_ = endpoint_;
         result.addWildcard_ = addWildcard_;
         result.csr_ = csr_;
+        result.clusterCrn_ = clusterCrn_;
+        result.clientName_ = clientName_;
         onBuilt();
         return result;
       }
@@ -6901,6 +7081,14 @@ public final class PublicEndpointManagementProto {
         }
         if (other.getCsr() != com.google.protobuf.ByteString.EMPTY) {
           setCsr(other.getCsr());
+        }
+        if (!other.getClusterCrn().isEmpty()) {
+          clusterCrn_ = other.clusterCrn_;
+          onChanged();
+        }
+        if (!other.getClientName().isEmpty()) {
+          clientName_ = other.clientName_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -7307,6 +7495,208 @@ public final class PublicEndpointManagementProto {
       public Builder clearCsr() {
         
         csr_ = getDefaultInstance().getCsr();
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object clusterCrn_ = "";
+      /**
+       * <pre>
+       * The crn of the cluster. You can leave this empty when testing for random endpoints.
+       * </pre>
+       *
+       * <code>string clusterCrn = 6;</code>
+       * @return The clusterCrn.
+       */
+      public java.lang.String getClusterCrn() {
+        java.lang.Object ref = clusterCrn_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          clusterCrn_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The crn of the cluster. You can leave this empty when testing for random endpoints.
+       * </pre>
+       *
+       * <code>string clusterCrn = 6;</code>
+       * @return The bytes for clusterCrn.
+       */
+      public com.google.protobuf.ByteString
+          getClusterCrnBytes() {
+        java.lang.Object ref = clusterCrn_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          clusterCrn_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The crn of the cluster. You can leave this empty when testing for random endpoints.
+       * </pre>
+       *
+       * <code>string clusterCrn = 6;</code>
+       * @param value The clusterCrn to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClusterCrn(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        clusterCrn_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The crn of the cluster. You can leave this empty when testing for random endpoints.
+       * </pre>
+       *
+       * <code>string clusterCrn = 6;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearClusterCrn() {
+        
+        clusterCrn_ = getDefaultInstance().getClusterCrn();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The crn of the cluster. You can leave this empty when testing for random endpoints.
+       * </pre>
+       *
+       * <code>string clusterCrn = 6;</code>
+       * @param value The bytes for clusterCrn to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClusterCrnBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        clusterCrn_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object clientName_ = "";
+      /**
+       * <pre>
+       * The service requesting the certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample' or leave it empty
+       * </pre>
+       *
+       * <code>string clientName = 7;</code>
+       * @return The clientName.
+       */
+      public java.lang.String getClientName() {
+        java.lang.Object ref = clientName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          clientName_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The service requesting the certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample' or leave it empty
+       * </pre>
+       *
+       * <code>string clientName = 7;</code>
+       * @return The bytes for clientName.
+       */
+      public com.google.protobuf.ByteString
+          getClientNameBytes() {
+        java.lang.Object ref = clientName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          clientName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The service requesting the certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample' or leave it empty
+       * </pre>
+       *
+       * <code>string clientName = 7;</code>
+       * @param value The clientName to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClientName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        clientName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The service requesting the certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample' or leave it empty
+       * </pre>
+       *
+       * <code>string clientName = 7;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearClientName() {
+        
+        clientName_ = getDefaultInstance().getClientName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The service requesting the certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample' or leave it empty
+       * </pre>
+       *
+       * <code>string clientName = 7;</code>
+       * @param value The bytes for clientName to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClientNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        clientName_ = value;
         onChanged();
         return this;
       }
@@ -11508,6 +11898,50 @@ public final class PublicEndpointManagementProto {
      * @return The csr.
      */
     com.google.protobuf.ByteString getCsr();
+
+    /**
+     * <pre>
+     * The crn of the cluster. You can leave this empty when testing for random endpoints.
+     * </pre>
+     *
+     * <code>string clusterCrn = 4;</code>
+     * @return The clusterCrn.
+     */
+    java.lang.String getClusterCrn();
+    /**
+     * <pre>
+     * The crn of the cluster. You can leave this empty when testing for random endpoints.
+     * </pre>
+     *
+     * <code>string clusterCrn = 4;</code>
+     * @return The bytes for clusterCrn.
+     */
+    com.google.protobuf.ByteString
+        getClusterCrnBytes();
+
+    /**
+     * <pre>
+     * The service requesting the certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample' or leave it empty
+     * </pre>
+     *
+     * <code>string clientName = 5;</code>
+     * @return The clientName.
+     */
+    java.lang.String getClientName();
+    /**
+     * <pre>
+     * The service requesting the certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample' or leave it empty
+     * </pre>
+     *
+     * <code>string clientName = 5;</code>
+     * @return The bytes for clientName.
+     */
+    com.google.protobuf.ByteString
+        getClientNameBytes();
   }
   /**
    * <pre>
@@ -11529,6 +11963,8 @@ public final class PublicEndpointManagementProto {
       accountId_ = "";
       environmentName_ = "";
       csr_ = com.google.protobuf.ByteString.EMPTY;
+      clusterCrn_ = "";
+      clientName_ = "";
     }
 
     @java.lang.Override
@@ -11576,6 +12012,18 @@ public final class PublicEndpointManagementProto {
             case 26: {
 
               csr_ = input.readBytes();
+              break;
+            }
+            case 34: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              clusterCrn_ = s;
+              break;
+            }
+            case 42: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              clientName_ = s;
               break;
             }
             default: {
@@ -11724,6 +12172,102 @@ public final class PublicEndpointManagementProto {
       return csr_;
     }
 
+    public static final int CLUSTERCRN_FIELD_NUMBER = 4;
+    private volatile java.lang.Object clusterCrn_;
+    /**
+     * <pre>
+     * The crn of the cluster. You can leave this empty when testing for random endpoints.
+     * </pre>
+     *
+     * <code>string clusterCrn = 4;</code>
+     * @return The clusterCrn.
+     */
+    @java.lang.Override
+    public java.lang.String getClusterCrn() {
+      java.lang.Object ref = clusterCrn_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        clusterCrn_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The crn of the cluster. You can leave this empty when testing for random endpoints.
+     * </pre>
+     *
+     * <code>string clusterCrn = 4;</code>
+     * @return The bytes for clusterCrn.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getClusterCrnBytes() {
+      java.lang.Object ref = clusterCrn_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        clusterCrn_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CLIENTNAME_FIELD_NUMBER = 5;
+    private volatile java.lang.Object clientName_;
+    /**
+     * <pre>
+     * The service requesting the certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample' or leave it empty
+     * </pre>
+     *
+     * <code>string clientName = 5;</code>
+     * @return The clientName.
+     */
+    @java.lang.Override
+    public java.lang.String getClientName() {
+      java.lang.Object ref = clientName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        clientName_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The service requesting the certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample' or leave it empty
+     * </pre>
+     *
+     * <code>string clientName = 5;</code>
+     * @return The bytes for clientName.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getClientNameBytes() {
+      java.lang.Object ref = clientName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        clientName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -11747,6 +12291,12 @@ public final class PublicEndpointManagementProto {
       if (!csr_.isEmpty()) {
         output.writeBytes(3, csr_);
       }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(clusterCrn_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, clusterCrn_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(clientName_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, clientName_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -11765,6 +12315,12 @@ public final class PublicEndpointManagementProto {
       if (!csr_.isEmpty()) {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, csr_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(clusterCrn_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, clusterCrn_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(clientName_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, clientName_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -11787,6 +12343,10 @@ public final class PublicEndpointManagementProto {
           .equals(other.getEnvironmentName())) return false;
       if (!getCsr()
           .equals(other.getCsr())) return false;
+      if (!getClusterCrn()
+          .equals(other.getClusterCrn())) return false;
+      if (!getClientName()
+          .equals(other.getClientName())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -11804,6 +12364,10 @@ public final class PublicEndpointManagementProto {
       hash = (53 * hash) + getEnvironmentName().hashCode();
       hash = (37 * hash) + CSR_FIELD_NUMBER;
       hash = (53 * hash) + getCsr().hashCode();
+      hash = (37 * hash) + CLUSTERCRN_FIELD_NUMBER;
+      hash = (53 * hash) + getClusterCrn().hashCode();
+      hash = (37 * hash) + CLIENTNAME_FIELD_NUMBER;
+      hash = (53 * hash) + getClientName().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -11947,6 +12511,10 @@ public final class PublicEndpointManagementProto {
 
         csr_ = com.google.protobuf.ByteString.EMPTY;
 
+        clusterCrn_ = "";
+
+        clientName_ = "";
+
         return this;
       }
 
@@ -11976,6 +12544,8 @@ public final class PublicEndpointManagementProto {
         result.accountId_ = accountId_;
         result.environmentName_ = environmentName_;
         result.csr_ = csr_;
+        result.clusterCrn_ = clusterCrn_;
+        result.clientName_ = clientName_;
         onBuilt();
         return result;
       }
@@ -12034,6 +12604,14 @@ public final class PublicEndpointManagementProto {
         }
         if (other.getCsr() != com.google.protobuf.ByteString.EMPTY) {
           setCsr(other.getCsr());
+        }
+        if (!other.getClusterCrn().isEmpty()) {
+          clusterCrn_ = other.clusterCrn_;
+          onChanged();
+        }
+        if (!other.getClientName().isEmpty()) {
+          clientName_ = other.clientName_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -12317,6 +12895,208 @@ public final class PublicEndpointManagementProto {
       public Builder clearCsr() {
         
         csr_ = getDefaultInstance().getCsr();
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object clusterCrn_ = "";
+      /**
+       * <pre>
+       * The crn of the cluster. You can leave this empty when testing for random endpoints.
+       * </pre>
+       *
+       * <code>string clusterCrn = 4;</code>
+       * @return The clusterCrn.
+       */
+      public java.lang.String getClusterCrn() {
+        java.lang.Object ref = clusterCrn_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          clusterCrn_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The crn of the cluster. You can leave this empty when testing for random endpoints.
+       * </pre>
+       *
+       * <code>string clusterCrn = 4;</code>
+       * @return The bytes for clusterCrn.
+       */
+      public com.google.protobuf.ByteString
+          getClusterCrnBytes() {
+        java.lang.Object ref = clusterCrn_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          clusterCrn_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The crn of the cluster. You can leave this empty when testing for random endpoints.
+       * </pre>
+       *
+       * <code>string clusterCrn = 4;</code>
+       * @param value The clusterCrn to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClusterCrn(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        clusterCrn_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The crn of the cluster. You can leave this empty when testing for random endpoints.
+       * </pre>
+       *
+       * <code>string clusterCrn = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearClusterCrn() {
+        
+        clusterCrn_ = getDefaultInstance().getClusterCrn();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The crn of the cluster. You can leave this empty when testing for random endpoints.
+       * </pre>
+       *
+       * <code>string clusterCrn = 4;</code>
+       * @param value The bytes for clusterCrn to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClusterCrnBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        clusterCrn_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object clientName_ = "";
+      /**
+       * <pre>
+       * The service requesting the certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample' or leave it empty
+       * </pre>
+       *
+       * <code>string clientName = 5;</code>
+       * @return The clientName.
+       */
+      public java.lang.String getClientName() {
+        java.lang.Object ref = clientName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          clientName_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The service requesting the certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample' or leave it empty
+       * </pre>
+       *
+       * <code>string clientName = 5;</code>
+       * @return The bytes for clientName.
+       */
+      public com.google.protobuf.ByteString
+          getClientNameBytes() {
+        java.lang.Object ref = clientName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          clientName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The service requesting the certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample' or leave it empty
+       * </pre>
+       *
+       * <code>string clientName = 5;</code>
+       * @param value The clientName to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClientName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        clientName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The service requesting the certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample' or leave it empty
+       * </pre>
+       *
+       * <code>string clientName = 5;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearClientName() {
+        
+        clientName_ = getDefaultInstance().getClientName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The service requesting the certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample' or leave it empty
+       * </pre>
+       *
+       * <code>string clientName = 5;</code>
+       * @param value The bytes for clientName to set.
+       * @return This builder for chaining.
+       */
+      public Builder setClientNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        clientName_ = value;
         onChanged();
         return this;
       }
@@ -13685,6 +14465,28 @@ public final class PublicEndpointManagementProto {
      */
     com.google.protobuf.ByteString
         getCertificatesBytes(int index);
+
+    /**
+     * <pre>
+     * User friendly message explaining why a signing request failed
+     * This is not sent if the request was successful
+     * </pre>
+     *
+     * <code>string causeOfFailure = 3;</code>
+     * @return The causeOfFailure.
+     */
+    java.lang.String getCauseOfFailure();
+    /**
+     * <pre>
+     * User friendly message explaining why a signing request failed
+     * This is not sent if the request was successful
+     * </pre>
+     *
+     * <code>string causeOfFailure = 3;</code>
+     * @return The bytes for causeOfFailure.
+     */
+    com.google.protobuf.ByteString
+        getCauseOfFailureBytes();
   }
   /**
    * <pre>
@@ -13705,6 +14507,7 @@ public final class PublicEndpointManagementProto {
     private PollCertificateSigningResponse() {
       status_ = 0;
       certificates_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      causeOfFailure_ = "";
     }
 
     @java.lang.Override
@@ -13751,6 +14554,12 @@ public final class PublicEndpointManagementProto {
                 mutable_bitField0_ |= 0x00000001;
               }
               certificates_.add(s);
+              break;
+            }
+            case 26: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              causeOfFailure_ = s;
               break;
             }
             default: {
@@ -14013,6 +14822,54 @@ public final class PublicEndpointManagementProto {
       return certificates_.getByteString(index);
     }
 
+    public static final int CAUSEOFFAILURE_FIELD_NUMBER = 3;
+    private volatile java.lang.Object causeOfFailure_;
+    /**
+     * <pre>
+     * User friendly message explaining why a signing request failed
+     * This is not sent if the request was successful
+     * </pre>
+     *
+     * <code>string causeOfFailure = 3;</code>
+     * @return The causeOfFailure.
+     */
+    @java.lang.Override
+    public java.lang.String getCauseOfFailure() {
+      java.lang.Object ref = causeOfFailure_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        causeOfFailure_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * User friendly message explaining why a signing request failed
+     * This is not sent if the request was successful
+     * </pre>
+     *
+     * <code>string causeOfFailure = 3;</code>
+     * @return The bytes for causeOfFailure.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getCauseOfFailureBytes() {
+      java.lang.Object ref = causeOfFailure_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        causeOfFailure_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -14032,6 +14889,9 @@ public final class PublicEndpointManagementProto {
       }
       for (int i = 0; i < certificates_.size(); i++) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, certificates_.getRaw(i));
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(causeOfFailure_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, causeOfFailure_);
       }
       unknownFields.writeTo(output);
     }
@@ -14054,6 +14914,9 @@ public final class PublicEndpointManagementProto {
         size += dataSize;
         size += 1 * getCertificatesList().size();
       }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(causeOfFailure_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, causeOfFailure_);
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -14072,6 +14935,8 @@ public final class PublicEndpointManagementProto {
       if (status_ != other.status_) return false;
       if (!getCertificatesList()
           .equals(other.getCertificatesList())) return false;
+      if (!getCauseOfFailure()
+          .equals(other.getCauseOfFailure())) return false;
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -14089,6 +14954,8 @@ public final class PublicEndpointManagementProto {
         hash = (37 * hash) + CERTIFICATES_FIELD_NUMBER;
         hash = (53 * hash) + getCertificatesList().hashCode();
       }
+      hash = (37 * hash) + CAUSEOFFAILURE_FIELD_NUMBER;
+      hash = (53 * hash) + getCauseOfFailure().hashCode();
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
       return hash;
@@ -14230,6 +15097,8 @@ public final class PublicEndpointManagementProto {
 
         certificates_ = com.google.protobuf.LazyStringArrayList.EMPTY;
         bitField0_ = (bitField0_ & ~0x00000001);
+        causeOfFailure_ = "";
+
         return this;
       }
 
@@ -14263,6 +15132,7 @@ public final class PublicEndpointManagementProto {
           bitField0_ = (bitField0_ & ~0x00000001);
         }
         result.certificates_ = certificates_;
+        result.causeOfFailure_ = causeOfFailure_;
         onBuilt();
         return result;
       }
@@ -14322,6 +15192,10 @@ public final class PublicEndpointManagementProto {
             ensureCertificatesIsMutable();
             certificates_.addAll(other.certificates_);
           }
+          onChanged();
+        }
+        if (!other.getCauseOfFailure().isEmpty()) {
+          causeOfFailure_ = other.causeOfFailure_;
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -14609,6 +15483,107 @@ public final class PublicEndpointManagementProto {
         onChanged();
         return this;
       }
+
+      private java.lang.Object causeOfFailure_ = "";
+      /**
+       * <pre>
+       * User friendly message explaining why a signing request failed
+       * This is not sent if the request was successful
+       * </pre>
+       *
+       * <code>string causeOfFailure = 3;</code>
+       * @return The causeOfFailure.
+       */
+      public java.lang.String getCauseOfFailure() {
+        java.lang.Object ref = causeOfFailure_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          causeOfFailure_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * User friendly message explaining why a signing request failed
+       * This is not sent if the request was successful
+       * </pre>
+       *
+       * <code>string causeOfFailure = 3;</code>
+       * @return The bytes for causeOfFailure.
+       */
+      public com.google.protobuf.ByteString
+          getCauseOfFailureBytes() {
+        java.lang.Object ref = causeOfFailure_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          causeOfFailure_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * User friendly message explaining why a signing request failed
+       * This is not sent if the request was successful
+       * </pre>
+       *
+       * <code>string causeOfFailure = 3;</code>
+       * @param value The causeOfFailure to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCauseOfFailure(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        causeOfFailure_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * User friendly message explaining why a signing request failed
+       * This is not sent if the request was successful
+       * </pre>
+       *
+       * <code>string causeOfFailure = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearCauseOfFailure() {
+        
+        causeOfFailure_ = getDefaultInstance().getCauseOfFailure();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * User friendly message explaining why a signing request failed
+       * This is not sent if the request was successful
+       * </pre>
+       *
+       * <code>string causeOfFailure = 3;</code>
+       * @param value The bytes for causeOfFailure to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCauseOfFailureBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        causeOfFailure_ = value;
+        onChanged();
+        return this;
+      }
       @java.lang.Override
       public final Builder setUnknownFields(
           final com.google.protobuf.UnknownFieldSet unknownFields) {
@@ -14657,6 +15632,1947 @@ public final class PublicEndpointManagementProto {
 
     @java.lang.Override
     public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.PollCertificateSigningResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface RevokeCertificateRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:publicendpointmanagement.RevokeCertificateRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     *The account id of the CDP tenant
+     * </pre>
+     *
+     * <code>string accountId = 1;</code>
+     * @return The accountId.
+     */
+    java.lang.String getAccountId();
+    /**
+     * <pre>
+     *The account id of the CDP tenant
+     * </pre>
+     *
+     * <code>string accountId = 1;</code>
+     * @return The bytes for accountId.
+     */
+    com.google.protobuf.ByteString
+        getAccountIdBytes();
+
+    /**
+     * <pre>
+     *Leaf certificate in PEM encoded representation of X.509 certificate which needs to be revoked
+     * </pre>
+     *
+     * <code>string certificates = 2 [(.options.FieldExtension.skipLogging) = true];</code>
+     * @return The certificates.
+     */
+    java.lang.String getCertificates();
+    /**
+     * <pre>
+     *Leaf certificate in PEM encoded representation of X.509 certificate which needs to be revoked
+     * </pre>
+     *
+     * <code>string certificates = 2 [(.options.FieldExtension.skipLogging) = true];</code>
+     * @return The bytes for certificates.
+     */
+    com.google.protobuf.ByteString
+        getCertificatesBytes();
+
+    /**
+     * <pre>
+     * As default 'UNSPECIFIED' will be set if not sent in the request
+     * </pre>
+     *
+     * <code>.publicendpointmanagement.RevokeCertificateRequest.RevocationReason reason = 3;</code>
+     * @return The enum numeric value on the wire for reason.
+     */
+    int getReasonValue();
+    /**
+     * <pre>
+     * As default 'UNSPECIFIED' will be set if not sent in the request
+     * </pre>
+     *
+     * <code>.publicendpointmanagement.RevokeCertificateRequest.RevocationReason reason = 3;</code>
+     * @return The reason.
+     */
+    com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason getReason();
+
+    /**
+     * <pre>
+     * The service requesting the revoke certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample'
+     * </pre>
+     *
+     * <code>string requestingService = 4;</code>
+     * @return The requestingService.
+     */
+    java.lang.String getRequestingService();
+    /**
+     * <pre>
+     * The service requesting the revoke certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample'
+     * </pre>
+     *
+     * <code>string requestingService = 4;</code>
+     * @return The bytes for requestingService.
+     */
+    com.google.protobuf.ByteString
+        getRequestingServiceBytes();
+  }
+  /**
+   * <pre>
+   *Request object for RevokeCertificate method
+   * </pre>
+   *
+   * Protobuf type {@code publicendpointmanagement.RevokeCertificateRequest}
+   */
+  public static final class RevokeCertificateRequest extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:publicendpointmanagement.RevokeCertificateRequest)
+      RevokeCertificateRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use RevokeCertificateRequest.newBuilder() to construct.
+    private RevokeCertificateRequest(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private RevokeCertificateRequest() {
+      accountId_ = "";
+      certificates_ = "";
+      reason_ = 0;
+      requestingService_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new RevokeCertificateRequest();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private RevokeCertificateRequest(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              accountId_ = s;
+              break;
+            }
+            case 18: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              certificates_ = s;
+              break;
+            }
+            case 24: {
+              int rawValue = input.readEnum();
+
+              reason_ = rawValue;
+              break;
+            }
+            case 34: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              requestingService_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.internal_static_publicendpointmanagement_RevokeCertificateRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.internal_static_publicendpointmanagement_RevokeCertificateRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.class, com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.Builder.class);
+    }
+
+    /**
+     * <pre>
+     * Enumeration indicating the reason for revocation
+     * </pre>
+     *
+     * Protobuf enum {@code publicendpointmanagement.RevokeCertificateRequest.RevocationReason}
+     */
+    public enum RevocationReason
+        implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>UNSPECIFIED = 0;</code>
+       */
+      UNSPECIFIED(0),
+      /**
+       * <code>KEY_COMPROMISE = 1;</code>
+       */
+      KEY_COMPROMISE(1),
+      /**
+       * <code>CA_COMPROMISE = 2;</code>
+       */
+      CA_COMPROMISE(2),
+      /**
+       * <code>AFFILIATION_CHANGED = 3;</code>
+       */
+      AFFILIATION_CHANGED(3),
+      /**
+       * <code>SUPERSEDED = 4;</code>
+       */
+      SUPERSEDED(4),
+      /**
+       * <code>CESSATION_OF_OPERATION = 5;</code>
+       */
+      CESSATION_OF_OPERATION(5),
+      /**
+       * <code>CERTIFICATE_HOLD = 6;</code>
+       */
+      CERTIFICATE_HOLD(6),
+      /**
+       * <code>REMOVE_FROM_CRL = 8;</code>
+       */
+      REMOVE_FROM_CRL(8),
+      /**
+       * <code>PRIVILEGE_WITHDRAWN = 9;</code>
+       */
+      PRIVILEGE_WITHDRAWN(9),
+      /**
+       * <code>AA_COMPROMISE = 10;</code>
+       */
+      AA_COMPROMISE(10),
+      UNRECOGNIZED(-1),
+      ;
+
+      /**
+       * <code>UNSPECIFIED = 0;</code>
+       */
+      public static final int UNSPECIFIED_VALUE = 0;
+      /**
+       * <code>KEY_COMPROMISE = 1;</code>
+       */
+      public static final int KEY_COMPROMISE_VALUE = 1;
+      /**
+       * <code>CA_COMPROMISE = 2;</code>
+       */
+      public static final int CA_COMPROMISE_VALUE = 2;
+      /**
+       * <code>AFFILIATION_CHANGED = 3;</code>
+       */
+      public static final int AFFILIATION_CHANGED_VALUE = 3;
+      /**
+       * <code>SUPERSEDED = 4;</code>
+       */
+      public static final int SUPERSEDED_VALUE = 4;
+      /**
+       * <code>CESSATION_OF_OPERATION = 5;</code>
+       */
+      public static final int CESSATION_OF_OPERATION_VALUE = 5;
+      /**
+       * <code>CERTIFICATE_HOLD = 6;</code>
+       */
+      public static final int CERTIFICATE_HOLD_VALUE = 6;
+      /**
+       * <code>REMOVE_FROM_CRL = 8;</code>
+       */
+      public static final int REMOVE_FROM_CRL_VALUE = 8;
+      /**
+       * <code>PRIVILEGE_WITHDRAWN = 9;</code>
+       */
+      public static final int PRIVILEGE_WITHDRAWN_VALUE = 9;
+      /**
+       * <code>AA_COMPROMISE = 10;</code>
+       */
+      public static final int AA_COMPROMISE_VALUE = 10;
+
+
+      public final int getNumber() {
+        if (this == UNRECOGNIZED) {
+          throw new java.lang.IllegalArgumentException(
+              "Can't get the number of an unknown enum value.");
+        }
+        return value;
+      }
+
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
+      public static RevocationReason valueOf(int value) {
+        return forNumber(value);
+      }
+
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       */
+      public static RevocationReason forNumber(int value) {
+        switch (value) {
+          case 0: return UNSPECIFIED;
+          case 1: return KEY_COMPROMISE;
+          case 2: return CA_COMPROMISE;
+          case 3: return AFFILIATION_CHANGED;
+          case 4: return SUPERSEDED;
+          case 5: return CESSATION_OF_OPERATION;
+          case 6: return CERTIFICATE_HOLD;
+          case 8: return REMOVE_FROM_CRL;
+          case 9: return PRIVILEGE_WITHDRAWN;
+          case 10: return AA_COMPROMISE;
+          default: return null;
+        }
+      }
+
+      public static com.google.protobuf.Internal.EnumLiteMap<RevocationReason>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          RevocationReason> internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<RevocationReason>() {
+              public RevocationReason findValueByNumber(int number) {
+                return RevocationReason.forNumber(number);
+              }
+            };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor
+          getValueDescriptor() {
+        if (this == UNRECOGNIZED) {
+          throw new java.lang.IllegalStateException(
+              "Can't get the descriptor of an unrecognized enum value.");
+        }
+        return getDescriptor().getValues().get(ordinal());
+      }
+      public final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptorForType() {
+        return getDescriptor();
+      }
+      public static final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.getDescriptor().getEnumTypes().get(0);
+      }
+
+      private static final RevocationReason[] VALUES = values();
+
+      public static RevocationReason valueOf(
+          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+        if (desc.getType() != getDescriptor()) {
+          throw new java.lang.IllegalArgumentException(
+            "EnumValueDescriptor is not for this type.");
+        }
+        if (desc.getIndex() == -1) {
+          return UNRECOGNIZED;
+        }
+        return VALUES[desc.getIndex()];
+      }
+
+      private final int value;
+
+      private RevocationReason(int value) {
+        this.value = value;
+      }
+
+      // @@protoc_insertion_point(enum_scope:publicendpointmanagement.RevokeCertificateRequest.RevocationReason)
+    }
+
+    public static final int ACCOUNTID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object accountId_;
+    /**
+     * <pre>
+     *The account id of the CDP tenant
+     * </pre>
+     *
+     * <code>string accountId = 1;</code>
+     * @return The accountId.
+     */
+    @java.lang.Override
+    public java.lang.String getAccountId() {
+      java.lang.Object ref = accountId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        accountId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *The account id of the CDP tenant
+     * </pre>
+     *
+     * <code>string accountId = 1;</code>
+     * @return The bytes for accountId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getAccountIdBytes() {
+      java.lang.Object ref = accountId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        accountId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int CERTIFICATES_FIELD_NUMBER = 2;
+    private volatile java.lang.Object certificates_;
+    /**
+     * <pre>
+     *Leaf certificate in PEM encoded representation of X.509 certificate which needs to be revoked
+     * </pre>
+     *
+     * <code>string certificates = 2 [(.options.FieldExtension.skipLogging) = true];</code>
+     * @return The certificates.
+     */
+    @java.lang.Override
+    public java.lang.String getCertificates() {
+      java.lang.Object ref = certificates_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        certificates_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *Leaf certificate in PEM encoded representation of X.509 certificate which needs to be revoked
+     * </pre>
+     *
+     * <code>string certificates = 2 [(.options.FieldExtension.skipLogging) = true];</code>
+     * @return The bytes for certificates.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getCertificatesBytes() {
+      java.lang.Object ref = certificates_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        certificates_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int REASON_FIELD_NUMBER = 3;
+    private int reason_;
+    /**
+     * <pre>
+     * As default 'UNSPECIFIED' will be set if not sent in the request
+     * </pre>
+     *
+     * <code>.publicendpointmanagement.RevokeCertificateRequest.RevocationReason reason = 3;</code>
+     * @return The enum numeric value on the wire for reason.
+     */
+    @java.lang.Override public int getReasonValue() {
+      return reason_;
+    }
+    /**
+     * <pre>
+     * As default 'UNSPECIFIED' will be set if not sent in the request
+     * </pre>
+     *
+     * <code>.publicendpointmanagement.RevokeCertificateRequest.RevocationReason reason = 3;</code>
+     * @return The reason.
+     */
+    @java.lang.Override public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason getReason() {
+      @SuppressWarnings("deprecation")
+      com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason result = com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason.valueOf(reason_);
+      return result == null ? com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason.UNRECOGNIZED : result;
+    }
+
+    public static final int REQUESTINGSERVICE_FIELD_NUMBER = 4;
+    private volatile java.lang.Object requestingService_;
+    /**
+     * <pre>
+     * The service requesting the revoke certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample'
+     * </pre>
+     *
+     * <code>string requestingService = 4;</code>
+     * @return The requestingService.
+     */
+    @java.lang.Override
+    public java.lang.String getRequestingService() {
+      java.lang.Object ref = requestingService_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        requestingService_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * The service requesting the revoke certificate.
+     * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+     * For testing purpose you can put the requestingService as 'sample'
+     * </pre>
+     *
+     * <code>string requestingService = 4;</code>
+     * @return The bytes for requestingService.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getRequestingServiceBytes() {
+      java.lang.Object ref = requestingService_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        requestingService_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(accountId_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, accountId_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(certificates_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, certificates_);
+      }
+      if (reason_ != com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason.UNSPECIFIED.getNumber()) {
+        output.writeEnum(3, reason_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(requestingService_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, requestingService_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(accountId_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, accountId_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(certificates_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, certificates_);
+      }
+      if (reason_ != com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason.UNSPECIFIED.getNumber()) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeEnumSize(3, reason_);
+      }
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(requestingService_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, requestingService_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest other = (com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest) obj;
+
+      if (!getAccountId()
+          .equals(other.getAccountId())) return false;
+      if (!getCertificates()
+          .equals(other.getCertificates())) return false;
+      if (reason_ != other.reason_) return false;
+      if (!getRequestingService()
+          .equals(other.getRequestingService())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + ACCOUNTID_FIELD_NUMBER;
+      hash = (53 * hash) + getAccountId().hashCode();
+      hash = (37 * hash) + CERTIFICATES_FIELD_NUMBER;
+      hash = (53 * hash) + getCertificates().hashCode();
+      hash = (37 * hash) + REASON_FIELD_NUMBER;
+      hash = (53 * hash) + reason_;
+      hash = (37 * hash) + REQUESTINGSERVICE_FIELD_NUMBER;
+      hash = (53 * hash) + getRequestingService().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     *Request object for RevokeCertificate method
+     * </pre>
+     *
+     * Protobuf type {@code publicendpointmanagement.RevokeCertificateRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:publicendpointmanagement.RevokeCertificateRequest)
+        com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.internal_static_publicendpointmanagement_RevokeCertificateRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.internal_static_publicendpointmanagement_RevokeCertificateRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.class, com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        accountId_ = "";
+
+        certificates_ = "";
+
+        reason_ = 0;
+
+        requestingService_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.internal_static_publicendpointmanagement_RevokeCertificateRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest build() {
+        com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest buildPartial() {
+        com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest result = new com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest(this);
+        result.accountId_ = accountId_;
+        result.certificates_ = certificates_;
+        result.reason_ = reason_;
+        result.requestingService_ = requestingService_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest) {
+          return mergeFrom((com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest other) {
+        if (other == com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.getDefaultInstance()) return this;
+        if (!other.getAccountId().isEmpty()) {
+          accountId_ = other.accountId_;
+          onChanged();
+        }
+        if (!other.getCertificates().isEmpty()) {
+          certificates_ = other.certificates_;
+          onChanged();
+        }
+        if (other.reason_ != 0) {
+          setReasonValue(other.getReasonValue());
+        }
+        if (!other.getRequestingService().isEmpty()) {
+          requestingService_ = other.requestingService_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object accountId_ = "";
+      /**
+       * <pre>
+       *The account id of the CDP tenant
+       * </pre>
+       *
+       * <code>string accountId = 1;</code>
+       * @return The accountId.
+       */
+      public java.lang.String getAccountId() {
+        java.lang.Object ref = accountId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          accountId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *The account id of the CDP tenant
+       * </pre>
+       *
+       * <code>string accountId = 1;</code>
+       * @return The bytes for accountId.
+       */
+      public com.google.protobuf.ByteString
+          getAccountIdBytes() {
+        java.lang.Object ref = accountId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          accountId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *The account id of the CDP tenant
+       * </pre>
+       *
+       * <code>string accountId = 1;</code>
+       * @param value The accountId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAccountId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        accountId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *The account id of the CDP tenant
+       * </pre>
+       *
+       * <code>string accountId = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearAccountId() {
+        
+        accountId_ = getDefaultInstance().getAccountId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *The account id of the CDP tenant
+       * </pre>
+       *
+       * <code>string accountId = 1;</code>
+       * @param value The bytes for accountId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setAccountIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        accountId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object certificates_ = "";
+      /**
+       * <pre>
+       *Leaf certificate in PEM encoded representation of X.509 certificate which needs to be revoked
+       * </pre>
+       *
+       * <code>string certificates = 2 [(.options.FieldExtension.skipLogging) = true];</code>
+       * @return The certificates.
+       */
+      public java.lang.String getCertificates() {
+        java.lang.Object ref = certificates_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          certificates_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *Leaf certificate in PEM encoded representation of X.509 certificate which needs to be revoked
+       * </pre>
+       *
+       * <code>string certificates = 2 [(.options.FieldExtension.skipLogging) = true];</code>
+       * @return The bytes for certificates.
+       */
+      public com.google.protobuf.ByteString
+          getCertificatesBytes() {
+        java.lang.Object ref = certificates_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          certificates_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *Leaf certificate in PEM encoded representation of X.509 certificate which needs to be revoked
+       * </pre>
+       *
+       * <code>string certificates = 2 [(.options.FieldExtension.skipLogging) = true];</code>
+       * @param value The certificates to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCertificates(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        certificates_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *Leaf certificate in PEM encoded representation of X.509 certificate which needs to be revoked
+       * </pre>
+       *
+       * <code>string certificates = 2 [(.options.FieldExtension.skipLogging) = true];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearCertificates() {
+        
+        certificates_ = getDefaultInstance().getCertificates();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *Leaf certificate in PEM encoded representation of X.509 certificate which needs to be revoked
+       * </pre>
+       *
+       * <code>string certificates = 2 [(.options.FieldExtension.skipLogging) = true];</code>
+       * @param value The bytes for certificates to set.
+       * @return This builder for chaining.
+       */
+      public Builder setCertificatesBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        certificates_ = value;
+        onChanged();
+        return this;
+      }
+
+      private int reason_ = 0;
+      /**
+       * <pre>
+       * As default 'UNSPECIFIED' will be set if not sent in the request
+       * </pre>
+       *
+       * <code>.publicendpointmanagement.RevokeCertificateRequest.RevocationReason reason = 3;</code>
+       * @return The enum numeric value on the wire for reason.
+       */
+      @java.lang.Override public int getReasonValue() {
+        return reason_;
+      }
+      /**
+       * <pre>
+       * As default 'UNSPECIFIED' will be set if not sent in the request
+       * </pre>
+       *
+       * <code>.publicendpointmanagement.RevokeCertificateRequest.RevocationReason reason = 3;</code>
+       * @param value The enum numeric value on the wire for reason to set.
+       * @return This builder for chaining.
+       */
+      public Builder setReasonValue(int value) {
+        
+        reason_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * As default 'UNSPECIFIED' will be set if not sent in the request
+       * </pre>
+       *
+       * <code>.publicendpointmanagement.RevokeCertificateRequest.RevocationReason reason = 3;</code>
+       * @return The reason.
+       */
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason getReason() {
+        @SuppressWarnings("deprecation")
+        com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason result = com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason.valueOf(reason_);
+        return result == null ? com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason.UNRECOGNIZED : result;
+      }
+      /**
+       * <pre>
+       * As default 'UNSPECIFIED' will be set if not sent in the request
+       * </pre>
+       *
+       * <code>.publicendpointmanagement.RevokeCertificateRequest.RevocationReason reason = 3;</code>
+       * @param value The reason to set.
+       * @return This builder for chaining.
+       */
+      public Builder setReason(com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest.RevocationReason value) {
+        if (value == null) {
+          throw new NullPointerException();
+        }
+        
+        reason_ = value.getNumber();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * As default 'UNSPECIFIED' will be set if not sent in the request
+       * </pre>
+       *
+       * <code>.publicendpointmanagement.RevokeCertificateRequest.RevocationReason reason = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearReason() {
+        
+        reason_ = 0;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object requestingService_ = "";
+      /**
+       * <pre>
+       * The service requesting the revoke certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample'
+       * </pre>
+       *
+       * <code>string requestingService = 4;</code>
+       * @return The requestingService.
+       */
+      public java.lang.String getRequestingService() {
+        java.lang.Object ref = requestingService_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          requestingService_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The service requesting the revoke certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample'
+       * </pre>
+       *
+       * <code>string requestingService = 4;</code>
+       * @return The bytes for requestingService.
+       */
+      public com.google.protobuf.ByteString
+          getRequestingServiceBytes() {
+        java.lang.Object ref = requestingService_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          requestingService_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * The service requesting the revoke certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample'
+       * </pre>
+       *
+       * <code>string requestingService = 4;</code>
+       * @param value The requestingService to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRequestingService(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        requestingService_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The service requesting the revoke certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample'
+       * </pre>
+       *
+       * <code>string requestingService = 4;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearRequestingService() {
+        
+        requestingService_ = getDefaultInstance().getRequestingService();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * The service requesting the revoke certificate.
+       * It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+       * For testing purpose you can put the requestingService as 'sample'
+       * </pre>
+       *
+       * <code>string requestingService = 4;</code>
+       * @param value The bytes for requestingService to set.
+       * @return This builder for chaining.
+       */
+      public Builder setRequestingServiceBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        requestingService_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:publicendpointmanagement.RevokeCertificateRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:publicendpointmanagement.RevokeCertificateRequest)
+    private static final com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest();
+    }
+
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<RevokeCertificateRequest>
+        PARSER = new com.google.protobuf.AbstractParser<RevokeCertificateRequest>() {
+      @java.lang.Override
+      public RevokeCertificateRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new RevokeCertificateRequest(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<RevokeCertificateRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<RevokeCertificateRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface RevokeCertificateResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:publicendpointmanagement.RevokeCertificateResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     *Status showing if the requested revoke was successful
+     * </pre>
+     *
+     * <code>string status = 1;</code>
+     * @return The status.
+     */
+    java.lang.String getStatus();
+    /**
+     * <pre>
+     *Status showing if the requested revoke was successful
+     * </pre>
+     *
+     * <code>string status = 1;</code>
+     * @return The bytes for status.
+     */
+    com.google.protobuf.ByteString
+        getStatusBytes();
+  }
+  /**
+   * <pre>
+   *Response object for RevokeCertificate method
+   * </pre>
+   *
+   * Protobuf type {@code publicendpointmanagement.RevokeCertificateResponse}
+   */
+  public static final class RevokeCertificateResponse extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:publicendpointmanagement.RevokeCertificateResponse)
+      RevokeCertificateResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use RevokeCertificateResponse.newBuilder() to construct.
+    private RevokeCertificateResponse(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private RevokeCertificateResponse() {
+      status_ = "";
+    }
+
+    @java.lang.Override
+    @SuppressWarnings({"unused"})
+    protected java.lang.Object newInstance(
+        UnusedPrivateParameter unused) {
+      return new RevokeCertificateResponse();
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private RevokeCertificateResponse(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              java.lang.String s = input.readStringRequireUtf8();
+
+              status_ = s;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.internal_static_publicendpointmanagement_RevokeCertificateResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.internal_static_publicendpointmanagement_RevokeCertificateResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse.class, com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse.Builder.class);
+    }
+
+    public static final int STATUS_FIELD_NUMBER = 1;
+    private volatile java.lang.Object status_;
+    /**
+     * <pre>
+     *Status showing if the requested revoke was successful
+     * </pre>
+     *
+     * <code>string status = 1;</code>
+     * @return The status.
+     */
+    @java.lang.Override
+    public java.lang.String getStatus() {
+      java.lang.Object ref = status_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        status_ = s;
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     *Status showing if the requested revoke was successful
+     * </pre>
+     *
+     * <code>string status = 1;</code>
+     * @return The bytes for status.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getStatusBytes() {
+      java.lang.Object ref = status_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        status_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(status_)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, status_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(status_)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, status_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse)) {
+        return super.equals(obj);
+      }
+      com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse other = (com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse) obj;
+
+      if (!getStatus()
+          .equals(other.getStatus())) return false;
+      if (!unknownFields.equals(other.unknownFields)) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + STATUS_FIELD_NUMBER;
+      hash = (53 * hash) + getStatus().hashCode();
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * <pre>
+     *Response object for RevokeCertificate method
+     * </pre>
+     *
+     * Protobuf type {@code publicendpointmanagement.RevokeCertificateResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:publicendpointmanagement.RevokeCertificateResponse)
+        com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.internal_static_publicendpointmanagement_RevokeCertificateResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.internal_static_publicendpointmanagement_RevokeCertificateResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse.class, com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse.Builder.class);
+      }
+
+      // Construct using com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        status_ = "";
+
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.internal_static_publicendpointmanagement_RevokeCertificateResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse getDefaultInstanceForType() {
+        return com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse build() {
+        com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse buildPartial() {
+        com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse result = new com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse(this);
+        result.status_ = status_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse) {
+          return mergeFrom((com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse other) {
+        if (other == com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse.getDefaultInstance()) return this;
+        if (!other.getStatus().isEmpty()) {
+          status_ = other.status_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+
+      private java.lang.Object status_ = "";
+      /**
+       * <pre>
+       *Status showing if the requested revoke was successful
+       * </pre>
+       *
+       * <code>string status = 1;</code>
+       * @return The status.
+       */
+      public java.lang.String getStatus() {
+        java.lang.Object ref = status_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          status_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       *Status showing if the requested revoke was successful
+       * </pre>
+       *
+       * <code>string status = 1;</code>
+       * @return The bytes for status.
+       */
+      public com.google.protobuf.ByteString
+          getStatusBytes() {
+        java.lang.Object ref = status_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          status_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       *Status showing if the requested revoke was successful
+       * </pre>
+       *
+       * <code>string status = 1;</code>
+       * @param value The status to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStatus(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  
+        status_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *Status showing if the requested revoke was successful
+       * </pre>
+       *
+       * <code>string status = 1;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearStatus() {
+        
+        status_ = getDefaultInstance().getStatus();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       *Status showing if the requested revoke was successful
+       * </pre>
+       *
+       * <code>string status = 1;</code>
+       * @param value The bytes for status to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStatusBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  checkByteStringIsUtf8(value);
+        
+        status_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:publicendpointmanagement.RevokeCertificateResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:publicendpointmanagement.RevokeCertificateResponse)
+    private static final com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse();
+    }
+
+    public static com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<RevokeCertificateResponse>
+        PARSER = new com.google.protobuf.AbstractParser<RevokeCertificateResponse>() {
+      @java.lang.Override
+      public RevokeCertificateResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new RevokeCertificateResponse(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<RevokeCertificateResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<RevokeCertificateResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.RevokeCertificateResponse getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -14752,6 +17668,16 @@ public final class PublicEndpointManagementProto {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_publicendpointmanagement_PollCertificateSigningResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_publicendpointmanagement_RevokeCertificateRequest_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_publicendpointmanagement_RevokeCertificateRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_publicendpointmanagement_RevokeCertificateResponse_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_publicendpointmanagement_RevokeCertificateResponse_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -14778,62 +17704,79 @@ public final class PublicEndpointManagementProto {
       "\030\001 \001(\t\022\023\n\013environment\030\002 \001(\t\022\020\n\010endpoint\030" +
       "\003 \001(\t\022\026\n\016removeWildcard\030\004 \001(\010\0226\n\tdnsTarg" +
       "et\030\005 \001(\0132#.publicendpointmanagement.DnsT" +
-      "arget\"\030\n\026DeleteDnsEntryResponse\"|\n\030Creat" +
-      "eCertificateRequest\022\021\n\taccountId\030\001 \001(\t\022\023" +
-      "\n\013environment\030\002 \001(\t\022\020\n\010endpoint\030\003 \001(\t\022\023\n" +
-      "\013addWildcard\030\004 \001(\010\022\021\n\003csr\030\005 \001(\014B\004\210\265\030\001\".\n" +
-      "\031CreateCertificateResponse\022\021\n\trequestId\030" +
-      "\001 \001(\t\"3\n\036PollCertificateCreationRequest\022" +
-      "\021\n\trequestId\030\001 \001(\t\"\\\n\037PollCertificateCre" +
-      "ationResponse\022\016\n\006status\030\001 \001(\t\022\r\n\005error\030\002" +
-      " \001(\t\022\032\n\014certificates\030\003 \003(\tB\004\210\265\030\001\"c\n!Gene" +
-      "rateManagedDomainNamesRequest\022\021\n\taccount" +
-      "Id\030\001 \001(\t\022\027\n\017environmentName\030\002 \001(\t\022\022\n\nsub" +
-      "domains\030\003 \003(\t\"\260\001\n\"GenerateManagedDomainN" +
-      "amesResponse\022Z\n\007domains\030\001 \003(\0132I.publicen" +
-      "dpointmanagement.GenerateManagedDomainNa" +
-      "mesResponse.DomainsEntry\032.\n\014DomainsEntry" +
-      "\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"Z\n\031Cert" +
-      "ificateSigningRequest\022\021\n\taccountId\030\001 \001(\t" +
-      "\022\027\n\017environmentName\030\002 \001(\t\022\021\n\003csr\030\003 \001(\014B\004" +
-      "\210\265\030\001\"0\n\032CertificateSigningResponse\022\022\n\nwo" +
-      "rkflowId\030\001 \001(\t\"3\n\035PollCertificateSigning" +
-      "Request\022\022\n\nworkflowId\030\001 \001(\t\"\334\001\n\036PollCert" +
-      "ificateSigningResponse\022V\n\006status\030\001 \001(\0162F" +
-      ".publicendpointmanagement.PollCertificat" +
-      "eSigningResponse.SigningStatus\022\032\n\014certif" +
-      "icates\030\002 \003(\tB\004\210\265\030\001\"F\n\rSigningStatus\022\t\n\005U" +
-      "NSET\020\000\022\017\n\013IN_PROGRESS\020\001\022\r\n\tSUCCEEDED\020\002\022\n" +
-      "\n\006FAILED\020\0032\212\010\n\030PublicEndpointManagement\022" +
-      "A\n\nGetVersion\022\027.version.VersionRequest\032\030" +
-      ".version.VersionResponse\"\000\022u\n\016CreateDnsE" +
-      "ntry\022/.publicendpointmanagement.CreateDn" +
-      "sEntryRequest\0320.publicendpointmanagement" +
-      ".CreateDnsEntryResponse\"\000\022u\n\016DeleteDnsEn" +
-      "try\022/.publicendpointmanagement.DeleteDns" +
-      "EntryRequest\0320.publicendpointmanagement." +
-      "DeleteDnsEntryResponse\"\000\022~\n\021CreateCertif" +
-      "icate\0222.publicendpointmanagement.CreateC" +
-      "ertificateRequest\0323.publicendpointmanage" +
-      "ment.CreateCertificateResponse\"\000\022\220\001\n\027Pol" +
-      "lCertificateCreation\0228.publicendpointman" +
-      "agement.PollCertificateCreationRequest\0329" +
-      ".publicendpointmanagement.PollCertificat" +
-      "eCreationResponse\"\000\022\231\001\n\032GenerateManagedD" +
-      "omainNames\022;.publicendpointmanagement.Ge" +
-      "nerateManagedDomainNamesRequest\032<.public" +
-      "endpointmanagement.GenerateManagedDomain" +
-      "NamesResponse\"\000\022~\n\017SignCertificate\0223.pub" +
-      "licendpointmanagement.CertificateSigning" +
-      "Request\0324.publicendpointmanagement.Certi" +
-      "ficateSigningResponse\"\000\022\215\001\n\026PollCertific" +
-      "ateSigning\0227.publicendpointmanagement.Po" +
-      "llCertificateSigningRequest\0328.publicendp" +
-      "ointmanagement.PollCertificateSigningRes" +
-      "ponse\"\000Bu\n9com.cloudera.thunderhead.serv" +
-      "ice.publicendpointmanagementB\035PublicEndp" +
-      "ointManagementProtoZ\031com/cloudera/cdp/pr" +
-      "otobufb\006proto3"
+      "arget\"\030\n\026DeleteDnsEntryResponse\"\244\001\n\030Crea" +
+      "teCertificateRequest\022\021\n\taccountId\030\001 \001(\t\022" +
+      "\023\n\013environment\030\002 \001(\t\022\020\n\010endpoint\030\003 \001(\t\022\023" +
+      "\n\013addWildcard\030\004 \001(\010\022\021\n\003csr\030\005 \001(\014B\004\210\265\030\001\022\022" +
+      "\n\nclusterCrn\030\006 \001(\t\022\022\n\nclientName\030\007 \001(\t\"." +
+      "\n\031CreateCertificateResponse\022\021\n\trequestId" +
+      "\030\001 \001(\t\"3\n\036PollCertificateCreationRequest" +
+      "\022\021\n\trequestId\030\001 \001(\t\"\\\n\037PollCertificateCr" +
+      "eationResponse\022\016\n\006status\030\001 \001(\t\022\r\n\005error\030" +
+      "\002 \001(\t\022\032\n\014certificates\030\003 \003(\tB\004\210\265\030\001\"c\n!Gen" +
+      "erateManagedDomainNamesRequest\022\021\n\taccoun" +
+      "tId\030\001 \001(\t\022\027\n\017environmentName\030\002 \001(\t\022\022\n\nsu" +
+      "bdomains\030\003 \003(\t\"\260\001\n\"GenerateManagedDomain" +
+      "NamesResponse\022Z\n\007domains\030\001 \003(\0132I.publice" +
+      "ndpointmanagement.GenerateManagedDomainN" +
+      "amesResponse.DomainsEntry\032.\n\014DomainsEntr" +
+      "y\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001\"\202\001\n\031Ce" +
+      "rtificateSigningRequest\022\021\n\taccountId\030\001 \001" +
+      "(\t\022\027\n\017environmentName\030\002 \001(\t\022\021\n\003csr\030\003 \001(\014" +
+      "B\004\210\265\030\001\022\022\n\nclusterCrn\030\004 \001(\t\022\022\n\nclientName" +
+      "\030\005 \001(\t\"0\n\032CertificateSigningResponse\022\022\n\n" +
+      "workflowId\030\001 \001(\t\"3\n\035PollCertificateSigni" +
+      "ngRequest\022\022\n\nworkflowId\030\001 \001(\t\"\364\001\n\036PollCe" +
+      "rtificateSigningResponse\022V\n\006status\030\001 \001(\016" +
+      "2F.publicendpointmanagement.PollCertific" +
+      "ateSigningResponse.SigningStatus\022\032\n\014cert" +
+      "ificates\030\002 \003(\tB\004\210\265\030\001\022\026\n\016causeOfFailure\030\003" +
+      " \001(\t\"F\n\rSigningStatus\022\t\n\005UNSET\020\000\022\017\n\013IN_P" +
+      "ROGRESS\020\001\022\r\n\tSUCCEEDED\020\002\022\n\n\006FAILED\020\003\"\242\003\n" +
+      "\030RevokeCertificateRequest\022\021\n\taccountId\030\001" +
+      " \001(\t\022\032\n\014certificates\030\002 \001(\tB\004\210\265\030\001\022S\n\006reas" +
+      "on\030\003 \001(\0162C.publicendpointmanagement.Revo" +
+      "keCertificateRequest.RevocationReason\022\031\n" +
+      "\021requestingService\030\004 \001(\t\"\346\001\n\020RevocationR" +
+      "eason\022\017\n\013UNSPECIFIED\020\000\022\022\n\016KEY_COMPROMISE" +
+      "\020\001\022\021\n\rCA_COMPROMISE\020\002\022\027\n\023AFFILIATION_CHA" +
+      "NGED\020\003\022\016\n\nSUPERSEDED\020\004\022\032\n\026CESSATION_OF_O" +
+      "PERATION\020\005\022\024\n\020CERTIFICATE_HOLD\020\006\022\023\n\017REMO" +
+      "VE_FROM_CRL\020\010\022\027\n\023PRIVILEGE_WITHDRAWN\020\t\022\021" +
+      "\n\rAA_COMPROMISE\020\n\"+\n\031RevokeCertificateRe" +
+      "sponse\022\016\n\006status\030\001 \001(\t2\212\t\n\030PublicEndpoin" +
+      "tManagement\022A\n\nGetVersion\022\027.version.Vers" +
+      "ionRequest\032\030.version.VersionResponse\"\000\022u" +
+      "\n\016CreateDnsEntry\022/.publicendpointmanagem" +
+      "ent.CreateDnsEntryRequest\0320.publicendpoi" +
+      "ntmanagement.CreateDnsEntryResponse\"\000\022u\n" +
+      "\016DeleteDnsEntry\022/.publicendpointmanageme" +
+      "nt.DeleteDnsEntryRequest\0320.publicendpoin" +
+      "tmanagement.DeleteDnsEntryResponse\"\000\022~\n\021" +
+      "CreateCertificate\0222.publicendpointmanage" +
+      "ment.CreateCertificateRequest\0323.publicen" +
+      "dpointmanagement.CreateCertificateRespon" +
+      "se\"\000\022\220\001\n\027PollCertificateCreation\0228.publi" +
+      "cendpointmanagement.PollCertificateCreat" +
+      "ionRequest\0329.publicendpointmanagement.Po" +
+      "llCertificateCreationResponse\"\000\022\231\001\n\032Gene" +
+      "rateManagedDomainNames\022;.publicendpointm" +
+      "anagement.GenerateManagedDomainNamesRequ" +
+      "est\032<.publicendpointmanagement.GenerateM" +
+      "anagedDomainNamesResponse\"\000\022~\n\017SignCerti" +
+      "ficate\0223.publicendpointmanagement.Certif" +
+      "icateSigningRequest\0324.publicendpointmana" +
+      "gement.CertificateSigningResponse\"\000\022\215\001\n\026" +
+      "PollCertificateSigning\0227.publicendpointm" +
+      "anagement.PollCertificateSigningRequest\032" +
+      "8.publicendpointmanagement.PollCertifica" +
+      "teSigningResponse\"\000\022~\n\021RevokeCertificate" +
+      "\0222.publicendpointmanagement.RevokeCertif" +
+      "icateRequest\0323.publicendpointmanagement." +
+      "RevokeCertificateResponse\"\000Bu\n9com.cloud" +
+      "era.thunderhead.service.publicendpointma" +
+      "nagementB\035PublicEndpointManagementProtoZ" +
+      "\031com/cloudera/cdp/protobufb\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -14888,7 +17831,7 @@ public final class PublicEndpointManagementProto {
     internal_static_publicendpointmanagement_CreateCertificateRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_publicendpointmanagement_CreateCertificateRequest_descriptor,
-        new java.lang.String[] { "AccountId", "Environment", "Endpoint", "AddWildcard", "Csr", });
+        new java.lang.String[] { "AccountId", "Environment", "Endpoint", "AddWildcard", "Csr", "ClusterCrn", "ClientName", });
     internal_static_publicendpointmanagement_CreateCertificateResponse_descriptor =
       getDescriptor().getMessageTypes().get(8);
     internal_static_publicendpointmanagement_CreateCertificateResponse_fieldAccessorTable = new
@@ -14930,7 +17873,7 @@ public final class PublicEndpointManagementProto {
     internal_static_publicendpointmanagement_CertificateSigningRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_publicendpointmanagement_CertificateSigningRequest_descriptor,
-        new java.lang.String[] { "AccountId", "EnvironmentName", "Csr", });
+        new java.lang.String[] { "AccountId", "EnvironmentName", "Csr", "ClusterCrn", "ClientName", });
     internal_static_publicendpointmanagement_CertificateSigningResponse_descriptor =
       getDescriptor().getMessageTypes().get(14);
     internal_static_publicendpointmanagement_CertificateSigningResponse_fieldAccessorTable = new
@@ -14948,7 +17891,19 @@ public final class PublicEndpointManagementProto {
     internal_static_publicendpointmanagement_PollCertificateSigningResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_publicendpointmanagement_PollCertificateSigningResponse_descriptor,
-        new java.lang.String[] { "Status", "Certificates", });
+        new java.lang.String[] { "Status", "Certificates", "CauseOfFailure", });
+    internal_static_publicendpointmanagement_RevokeCertificateRequest_descriptor =
+      getDescriptor().getMessageTypes().get(17);
+    internal_static_publicendpointmanagement_RevokeCertificateRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_publicendpointmanagement_RevokeCertificateRequest_descriptor,
+        new java.lang.String[] { "AccountId", "Certificates", "Reason", "RequestingService", });
+    internal_static_publicendpointmanagement_RevokeCertificateResponse_descriptor =
+      getDescriptor().getMessageTypes().get(18);
+    internal_static_publicendpointmanagement_RevokeCertificateResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_publicendpointmanagement_RevokeCertificateResponse_descriptor,
+        new java.lang.String[] { "Status", });
     com.google.protobuf.ExtensionRegistry registry =
         com.google.protobuf.ExtensionRegistry.newInstance();
     registry.add(com.cloudera.thunderhead.service.common.options.Options.FieldExtension.skipLogging);

--- a/cluster-dns-connector/src/main/java/com/sequenceiq/cloudbreak/certificate/service/DnsManagementService.java
+++ b/cluster-dns-connector/src/main/java/com/sequenceiq/cloudbreak/certificate/service/DnsManagementService.java
@@ -1,14 +1,18 @@
 package com.sequenceiq.cloudbreak.certificate.service;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.GenerateManagedDomainNamesResponse;
 import com.sequenceiq.cloudbreak.client.GrpcClusterDnsClient;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 
@@ -16,6 +20,8 @@ import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 public class DnsManagementService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DnsManagementService.class);
+
+    private static final String DOMAIN_NAME_PART_DELIMITER = ".";
 
     @Inject
     private GrpcClusterDnsClient grpcClusterDnsClient;
@@ -73,5 +79,22 @@ public class DnsManagementService {
             LOGGER.warn("Failed to delete DNS entry with endpoint name: '{}', environment name: '{}' and cloud DNS: '{}'", endpoint, environment, cloudDns, e);
         }
         return false;
+    }
+
+    public String generateManagedDomain(String accountId, String environmentName) {
+        String wildCardSubDomain = "*";
+        List<String> subDomains = List.of(wildCardSubDomain);
+        LOGGER.debug("Generating managed domain names for environment: '{}', subdomain: '{}'", environmentName, String.join(",", subDomains));
+        Optional<String> requestIdOptional = Optional.ofNullable(MDCBuilder.getOrGenerateRequestId());
+        GenerateManagedDomainNamesResponse response = grpcClusterDnsClient.generateManagedDomain(environmentName, subDomains, accountId, requestIdOptional);
+        Map<String, String> domainsMap = Optional.ofNullable(response)
+                .map(GenerateManagedDomainNamesResponse::getDomainsMap)
+                .orElse(new HashMap<>());
+        LOGGER.info("Domain names has been generated: '{}'", domainsMap);
+        String environmentDomain = domainsMap.getOrDefault(wildCardSubDomain, null);
+        if (StringUtils.isNotEmpty(environmentDomain) && environmentDomain.startsWith(wildCardSubDomain)) {
+            environmentDomain = environmentDomain.replace(wildCardSubDomain + DOMAIN_NAME_PART_DELIMITER, "");
+        }
+        return environmentDomain;
     }
 }

--- a/cluster-dns-connector/src/main/java/com/sequenceiq/cloudbreak/client/ClusterDnsClient.java
+++ b/cluster-dns-connector/src/main/java/com/sequenceiq/cloudbreak/client/ClusterDnsClient.java
@@ -14,6 +14,8 @@ import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointM
 import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.CreateDnsEntryRequest;
 import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.DeleteDnsEntryRequest;
 import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.DeleteDnsEntryResponse;
+import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.GenerateManagedDomainNamesRequest;
+import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.GenerateManagedDomainNamesResponse;
 import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.PollCertificateSigningRequest;
 import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.PollCertificateSigningResponse;
 import com.google.protobuf.ByteString;
@@ -132,6 +134,21 @@ public class ClusterDnsClient {
             .setEnvironment(environment);
 
         return newStub(requestId).deleteDnsEntry(requestBuilder.build());
+    }
+
+    public GenerateManagedDomainNamesResponse generateManagedDomainNames(String requestId, String environmentName, List<String> subDomains, String accountId) {
+        checkNotNull(requestId, "requestId should not be null.");
+        checkNotNull(environmentName, "environmentName should not be null.");
+        checkNotNull(subDomains, "subDomain should not be null.");
+        checkNotNull(accountId, "accountId should not be null.");
+
+        GenerateManagedDomainNamesRequest.Builder requestBuilder = GenerateManagedDomainNamesRequest.newBuilder();
+        requestBuilder.setEnvironmentName(environmentName);
+        requestBuilder.setAccountId(accountId);
+        requestBuilder.addAllSubdomains(subDomains);
+
+        GenerateManagedDomainNamesRequest request = requestBuilder.build();
+        return newStub(requestId).generateManagedDomainNames(request);
     }
 
     /**

--- a/cluster-dns-connector/src/main/proto/options.proto
+++ b/cluster-dns-connector/src/main/proto/options.proto
@@ -8,6 +8,63 @@ option java_package = "com.cloudera.thunderhead.service.common.options";
 option java_outer_classname = "Options";
 option go_package = "com/cloudera/cdp/protobuf";
 
+message ServiceExtension {
+  extend google.protobuf.ServiceOptions {
+    // At least one method in this service is rate limited by the specified
+    // rate limit group. Use of this option causes the generated API controller
+    // to include rate limiting for methods that have the rateLimitGroup option.
+    // (Currently, only one group may be defined.) Most services do not require
+    // rate limiting; contact the CDPCP core infra team for guidance.
+    RateLimitGroupDefinition rateLimitGroupDefinition = 40000;
+    // The API service name, in various casings.
+    ApiServiceName apiServiceName = 40001;
+    // The releases that the service belongs in, i.e., PUBLIC.
+    repeated string release = 40002;
+    // Whether this service is an administrative service. These services are put
+    // on a special, internal only ingress and may only be called by members of
+    // the CDP administration account.
+    bool admin = 40003;
+    // The form factor(s) that the service is part of, e.g., public, private.
+    repeated string formFactor = 40004;
+    // The version of the service definition.
+    string version = 40005;
+  }
+}
+
+// The definition of an API rate limit group. See the Java classes
+// ApiRateLimiter and ApiRateLimiterProvider for context.
+message RateLimitGroupDefinition {
+  // The name of the group. This must be one of the values of the
+  // ApiRateLimitGroup enum.
+  string name = 1;
+  // The limit (calls per second) by remote address for calls controlled by
+  // this group.
+  int32 byRemoteAddress = 2;
+  // The limit (calls per second) by access key ID for calls controlled by this
+  // group. (Not yet supported.)
+  int32 byAccessKeyId = 3;
+  // The limit (calls per second) by account for calls controlled by this group.
+  int32 byAccount = 4;
+}
+
+// The API service name, in various casings.
+message ApiServiceName {
+  // The lowercased service name.
+  string lowercase = 1;
+  // The camel-cased service name.
+  string camelcase = 2;
+}
+
+message FileExtension {
+  reserved 80002;
+  extend google.protobuf.FileOptions {
+    // This field is used to enable auditing for the service.
+    bool audit = 80000;
+    // The name of the entitlement to use to enable submitting auditing records.
+    string auditEntitlement = 80001;
+  }
+}
+
 message FieldExtension {
   extend google.protobuf.FieldOptions {
     // The field is sensitive. It will not be logged and may receive other special
@@ -44,6 +101,8 @@ message FieldExtension {
     int32 maximumLength = 50014;
     // This field has been deprecated.
     bool deprecated = 50015;
+    // This field doesn't reference a parameter file.
+    bool noParamfile = 50016;
   }
 }
 
@@ -53,7 +112,7 @@ message MethodExtension {
     string right = 60000;
     // This method requires the specified entitlement.
     string entitlement = 60001;
-    // This method returnes paginated results.
+    // This method returns paginated results.
     bool paginates = 60002;
     // This default number of max items for auto-pagination to fetch.
     int32 pagingDefaultMaxItems = 60003;
@@ -65,6 +124,18 @@ message MethodExtension {
     string hiddenRetention = 60006;
     // This method has been deprecated.
     bool deprecated = 60007;
+    // This method is rate limited with the specified group. This name must
+    // match the name of a rate limit group declared for the service itself.
+    string rateLimitGroup = 60008;
+    // This method is a mutating call.
+    bool mutating = 60009;
+    // This method should not be audited.
+    bool skipAuditing = 60010;
+    // The form factor(s) that the operation is part of, e.g., public, private.
+    // By default, an operation is part of every form factor of its service.
+    repeated string formFactor = 60011;
+    // This method has extensions
+    repeated string extension = 60012;
   }
 }
 
@@ -78,5 +149,18 @@ message MessageExtension {
     string hiddenRetention = 70002;
     // This message has been deprecated.
     bool deprecated = 70003;
+  }
+}
+
+// reserving 8xxxx for EnumExtension
+
+message EnumValueExtension {
+  extend google.protobuf.EnumValueOptions {
+    // This value is hidden.
+    bool hidden = 90000;
+    // The reason this value is hidden.
+    string hiddenReason = 90001;
+    // This conditions under this hidden value is made visible.
+    string hiddenRetention = 90002;
   }
 }

--- a/cluster-dns-connector/src/main/proto/publicendpointmanagement.proto
+++ b/cluster-dns-connector/src/main/proto/publicendpointmanagement.proto
@@ -57,6 +57,10 @@ service PublicEndpointManagement {
   // If the workflow is not yet complete, it returns the status as SigningStatus.IN_PROGRESS
   rpc PollCertificateSigning(PollCertificateSigningRequest)
     returns (PollCertificateSigningResponse) {}
+
+  //Revoke a TLS certificate
+  rpc RevokeCertificate(RevokeCertificateRequest)
+    returns (RevokeCertificateResponse) {}
 }
 
 message AWSElbDnsTarget {
@@ -129,6 +133,12 @@ message CreateCertificateRequest {
   // The encoded csr request. We pass the csr instead of domains to allow clients
   // to hold on to the private keys.
   bytes csr = 5 [(options.FieldExtension.skipLogging) = true];
+  // The crn of the cluster. You can leave this empty when testing for random endpoints.
+  string clusterCrn = 6;
+  // The service requesting the certificate.
+  // It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+  // For testing purpose you can put the requestingService as 'sample' or leave it empty
+  string clientName = 7;
 
 }
 
@@ -187,6 +197,15 @@ message CertificateSigningRequest {
   // This byte array should be derived from binary form of the CSR, i.e. DER
   bytes csr = 3 [(options.FieldExtension.skipLogging) = true];
 
+  // The crn of the cluster. You can leave this empty when testing for random endpoints.
+  string clusterCrn = 4;
+
+  // The service requesting the certificate.
+  // It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+  // For testing purpose you can put the requestingService as 'sample' or leave it empty
+  string clientName = 5;
+
+
 }
 
 // Response object for the SignCertificate method.
@@ -223,4 +242,45 @@ message PollCertificateSigningResponse {
   // Each item in the list following this certificate belongs to the authority
   // which signed the preceding certificate.
   repeated string certificates = 2 [(options.FieldExtension.skipLogging) = true];
+
+  // User friendly message explaining why a signing request failed
+  // This is not sent if the request was successful
+  string causeOfFailure = 3;
+}
+
+//Request object for RevokeCertificate method
+message RevokeCertificateRequest {
+  //The account id of the CDP tenant
+  string accountId = 1;
+
+  //Leaf certificate in PEM encoded representation of X.509 certificate which needs to be revoked
+  string certificates = 2 [(options.FieldExtension.skipLogging) = true];
+
+  // Enumeration indicating the reason for revocation
+  enum RevocationReason {
+      UNSPECIFIED = 0;
+      KEY_COMPROMISE = 1;
+      CA_COMPROMISE = 2;
+      AFFILIATION_CHANGED = 3;
+      SUPERSEDED = 4;
+      CESSATION_OF_OPERATION = 5;
+      CERTIFICATE_HOLD = 6;
+      REMOVE_FROM_CRL = 8;
+      PRIVILEGE_WITHDRAWN = 9;
+      AA_COMPROMISE = 10;
+  }
+
+  // As default 'UNSPECIFIED' will be set if not sent in the request
+  RevocationReason reason = 3;
+
+  // The service requesting the revoke certificate.
+  // It must be a service listed in Service enum of Crn class - https://github.infra.cloudera.com/thunderhead/thunderhead/blob/04fe5f2483d553fecf324f0ee21fb8691e5a34c2/services/libs/protocols/src/main/java/com/cloudera/thunderhead/service/common/crn/Crn.java#L123
+  // For testing purpose you can put the requestingService as 'sample'
+  string requestingService = 4;
+}
+
+//Response object for RevokeCertificate method
+message RevokeCertificateResponse {
+  //Status showing if the requested revoke was successful
+  string status = 1;
 }

--- a/common/src/test/java/com/sequenceiq/cloudbreak/dns/LegacyEnvironmentNameBasedDomainNameProviderTest.java
+++ b/common/src/test/java/com/sequenceiq/cloudbreak/dns/LegacyEnvironmentNameBasedDomainNameProviderTest.java
@@ -8,19 +8,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
-class EnvironmentBasedDomainNameProviderTest {
+class LegacyEnvironmentNameBasedDomainNameProviderTest {
 
-    private EnvironmentBasedDomainNameProvider underTest;
+    private LegacyEnvironmentNameBasedDomainNameProvider underTest;
 
     @BeforeEach
     void setUp() {
-        underTest = new EnvironmentBasedDomainNameProvider();
+        underTest = new LegacyEnvironmentNameBasedDomainNameProvider();
     }
 
     @Test
     void testGetDomainWhenEnvironmentNameIsNull() {
         IllegalStateException iSE = assertThrows(IllegalStateException.class, () -> underTest.getDomainName(null, "anAccountName"));
-        assertEquals(EnvironmentBasedDomainNameProvider.ENV_NAME_SHOULD_BE_SPECIFIED_MSG, iSE.getMessage());
+        assertEquals(LegacyEnvironmentNameBasedDomainNameProvider.ENV_NAME_SHOULD_BE_SPECIFIED_MSG, iSE.getMessage());
     }
 
     @Test
@@ -29,13 +29,13 @@ class EnvironmentBasedDomainNameProviderTest {
         IllegalStateException iSE = assertThrows(IllegalStateException.class, () -> {
             underTest.getDomainName(anEnvName, null);
         });
-        assertEquals(String.format(EnvironmentBasedDomainNameProvider.ACCOUNT_NAME_IS_EMTPY_FORMAT, anEnvName), iSE.getMessage());
+        assertEquals(String.format(LegacyEnvironmentNameBasedDomainNameProvider.ACCOUNT_NAME_IS_EMTPY_FORMAT, anEnvName), iSE.getMessage());
     }
 
     @Test
     void testGetDomainWhenEnvironmentNameIsEmpty() {
         IllegalStateException iSE = assertThrows(IllegalStateException.class, () -> underTest.getDomainName("", "anAccountName"));
-        assertEquals(EnvironmentBasedDomainNameProvider.ENV_NAME_SHOULD_BE_SPECIFIED_MSG, iSE.getMessage());
+        assertEquals(LegacyEnvironmentNameBasedDomainNameProvider.ENV_NAME_SHOULD_BE_SPECIFIED_MSG, iSE.getMessage());
     }
 
     @Test
@@ -44,7 +44,7 @@ class EnvironmentBasedDomainNameProviderTest {
         IllegalStateException iSE = assertThrows(IllegalStateException.class, () -> {
             underTest.getDomainName(anEnvName, "");
         });
-        assertEquals(String.format(EnvironmentBasedDomainNameProvider.ACCOUNT_NAME_IS_EMTPY_FORMAT, anEnvName), iSE.getMessage());
+        assertEquals(String.format(LegacyEnvironmentNameBasedDomainNameProvider.ACCOUNT_NAME_IS_EMTPY_FORMAT, anEnvName), iSE.getMessage());
     }
 
     @Test
@@ -122,31 +122,4 @@ class EnvironmentBasedDomainNameProviderTest {
                 && actualMessage.contains("is longer than the allowed 62 characters"));
     }
 
-    @Test
-    void testGetCommonNameWhenTheEndpointNameIsLessThan17AndEnvNameLessThan8Chars() {
-        String endpointName = "test-cl-master0";
-        String envName = "shrt-nv";
-        String accountName = "xcu2-8y8x";
-        String rootDomain = "wl.cloudera.site";
-        ReflectionTestUtils.setField(underTest, "rootDomain", rootDomain);
-
-        String commonName = underTest.getCommonName(endpointName, envName, accountName);
-
-        String expected = String.format("bbd9025ff9fd7c4d.%s.%s.%s", envName, accountName, rootDomain);
-        assertEquals(expected, commonName);
-    }
-
-    @Test
-    void testGetCommonNameWhenTheEndpointNameIsLongerThan17AndEnvNameLongerThan8Chars() {
-        String endpointName = "test-cl-longyloooooooooooong-name-master0";
-        String envName = "notashort-env-name-as28chars";
-        String accountName = "xcu2-8y8x";
-        String rootDomain = "wl.cloudera.site";
-        ReflectionTestUtils.setField(underTest, "rootDomain", rootDomain);
-
-        String commonName = underTest.getCommonName(endpointName, envName, accountName);
-
-        String expected = String.format("a7c2a45fc8f917fe.%s.%s.%s", envName.substring(0, 8), accountName, rootDomain);
-        assertEquals(expected, commonName);
-    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/BasePublicEndpointManagementService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/BasePublicEndpointManagementService.java
@@ -1,17 +1,11 @@
 package com.sequenceiq.cloudbreak.service.publicendpoint;
 
-import java.util.Optional;
-
 import javax.inject.Inject;
 
 import org.springframework.beans.factory.annotation.Value;
 
-import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
-import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.certificate.service.CertificateCreationService;
 import com.sequenceiq.cloudbreak.certificate.service.DnsManagementService;
-import com.sequenceiq.cloudbreak.dns.EnvironmentBasedDomainNameProvider;
-import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 
 public abstract class BasePublicEndpointManagementService {
 
@@ -23,9 +17,6 @@ public abstract class BasePublicEndpointManagementService {
 
     @Inject
     private EnvironmentBasedDomainNameProvider domainNameProvider;
-
-    @Inject
-    private GrpcUmsClient grpcUmsClient;
 
     @Inject
     private CertificateCreationService certificateCreationService;
@@ -44,12 +35,6 @@ public abstract class BasePublicEndpointManagementService {
 
     public CertificateCreationService getCertificateCreationService() {
         return certificateCreationService;
-    }
-
-    String getWorkloadSubdomain(String accountId) {
-        Optional<String> requestIdOptional = Optional.ofNullable(MDCBuilder.getOrGenerateRequestId());
-        UserManagementProto.Account account = grpcUmsClient.getAccountDetails(accountId, requestIdOptional);
-        return account.getWorkloadSubdomain();
     }
 
     protected void setCertGenerationEnabled(boolean enabled) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/EnvironmentBasedDomainNameProvider.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/publicendpoint/EnvironmentBasedDomainNameProvider.java
@@ -1,0 +1,87 @@
+package com.sequenceiq.cloudbreak.service.publicendpoint;
+
+import static com.google.common.hash.Hashing.sipHash24;
+
+import java.util.Optional;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.auth.crn.Crn;
+import com.sequenceiq.cloudbreak.dns.LegacyEnvironmentNameBasedDomainNameProvider;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.validation.HueWorkaroundValidatorService;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+
+@Component
+public class EnvironmentBasedDomainNameProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnvironmentBasedDomainNameProvider.class);
+
+    private static final String DOMAIN_PART_DELIMITER = ".";
+
+    private static final String FREEIPA_DEFAULT_ACCOUNT_DOMAIN = "internal";
+
+    @Inject
+    private HueWorkaroundValidatorService hueWorkaroundValidatorService;
+
+    @Inject
+    private LegacyEnvironmentNameBasedDomainNameProvider legacyEnvironmentNameBasedDomainNameProvider;
+
+    @Inject
+    private GrpcUmsClient grpcUmsClient;
+
+    public String getFullyQualifiedEndpointName(Set<String> hueHostGroups, String endpointName, DetailedEnvironmentResponse environment) {
+        if (StringUtils.isEmpty(endpointName)) {
+            throw new IllegalStateException("Endpoint name must be specified!");
+        }
+        String environmentDomainName = getDomain(environment);
+        String fullyQualifiedEndpointName = endpointName + DOMAIN_PART_DELIMITER + environmentDomainName;
+        LOGGER.info("The generated FQDN: {}, for environment domain: {}", fullyQualifiedEndpointName, environmentDomainName);
+        try {
+            hueWorkaroundValidatorService.validateForEnvironmentDomainName(hueHostGroups, fullyQualifiedEndpointName);
+        } catch (Exception e) {
+            throw new IllegalStateException(e.getMessage());
+        }
+        return fullyQualifiedEndpointName;
+    }
+
+    //It is responsible for creating a CN for the generated CSR, so the result could not exceed 64 chars.
+    public String getCommonName(String endpointName, DetailedEnvironmentResponse environment) {
+        String environmentDomainName = getDomain(environment);
+        //Hashing the concatenation of endpoint and environment names with SipHash24 as they are unique within a base-domain and account
+        String uniqueNameToBeHashed = endpointName + environmentDomainName;
+        String clusterHash = sipHash24().hashUnencodedChars(uniqueNameToBeHashed).toString();
+        String commonName = clusterHash + DOMAIN_PART_DELIMITER + environmentDomainName;
+        LOGGER.info("The generated Common Name: {}, for environment: {}", commonName, environmentDomainName);
+        return commonName;
+    }
+
+    private String getDomain(DetailedEnvironmentResponse environment) {
+        String environmentDomain = environment.getEnvironmentDomain();
+        if (StringUtils.isEmpty(environmentDomain)) {
+            String accountWorkloadSubdomain = getAccountWorkloadSubdomain(environment.getCrn());
+            environmentDomain = legacyEnvironmentNameBasedDomainNameProvider.getDomainName(environment.getName(), accountWorkloadSubdomain);
+        }
+        return environmentDomain;
+    }
+
+    private String getAccountWorkloadSubdomain(String environmentCrn) {
+        //starting to use the CRN of the environment as the certificate renewal will be automatic and be triggered by PEM with internal user
+        String accountId = Crn.safeFromString(environmentCrn).getAccountId();
+        Optional<String> requestIdOptional = Optional.ofNullable(MDCBuilder.getOrGenerateRequestId());
+        UserManagementProto.Account account = grpcUmsClient.getAccountDetails(accountId, requestIdOptional);
+        String accountSubdomain = account.getWorkloadSubdomain();
+        if (accountSubdomain == null || accountSubdomain.isEmpty()) {
+            accountSubdomain = FREEIPA_DEFAULT_ACCOUNT_DOMAIN;
+            LOGGER.info("getWorkloadSubdomain was null, or empty, setting default subdomain: {}", accountSubdomain);
+        }
+        return accountSubdomain;
+    }
+}

--- a/core/src/main/resources/application.yml
+++ b/core/src/main/resources/application.yml
@@ -845,3 +845,7 @@ crn:
 existingstackpatcher:
   intervalhours: 1
   enabled: true
+
+clusterdns:
+  host: localhost
+  port: 8982

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/EnvironmentBasedDomainNameProviderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/EnvironmentBasedDomainNameProviderTest.java
@@ -1,0 +1,80 @@
+package com.sequenceiq.cloudbreak.service.publicendpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
+import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
+import com.sequenceiq.cloudbreak.dns.LegacyEnvironmentNameBasedDomainNameProvider;
+import com.sequenceiq.environment.api.v1.environment.model.response.DetailedEnvironmentResponse;
+
+@ExtendWith(MockitoExtension.class)
+class EnvironmentBasedDomainNameProviderTest {
+
+    private static final String ENV_CRN = "crn:cdp:environments:us-west-1:accountId:environment:ac5ba74b-c35e-45e9-9f47-123456789876";
+
+    @Mock
+    private LegacyEnvironmentNameBasedDomainNameProvider legacyEnvironmentNameBasedDomainNameProvider;
+
+    @Mock
+    private GrpcUmsClient grpcUmsClient;
+
+    @InjectMocks
+    private EnvironmentBasedDomainNameProvider underTest;
+
+    @Test
+    void testGetCommonNameWhenTheEndpointNameIsLessThan17AndEnvNameLessThan8Chars() {
+        String endpointName = "test-cl-master0";
+        String envName = "shrt-nv";
+        String accountName = "xcu2-8y8x";
+        String rootDomain = "wl.cloudera.site";
+        String environmentDomain = envName + "." + accountName + "." + rootDomain;
+        DetailedEnvironmentResponse environment = DetailedEnvironmentResponse.builder()
+                .withName(envName)
+                .withEnvironmentDomain(environmentDomain)
+                .build();
+
+        String commonName = underTest.getCommonName(endpointName, environment);
+
+        String expected = String.format("9fd767c45167db77.%s", environmentDomain);
+        assertEquals(expected, commonName);
+        verifyNoInteractions(grpcUmsClient);
+        verifyNoInteractions(legacyEnvironmentNameBasedDomainNameProvider);
+    }
+
+    @Test
+    void testGetCommonNameWhenTheEndpointNameIsLongerThan17AndEnvNameLongerThan8CharsAndEnvironmentDomainIsNotPresentShouldUseLegacyDomainProvider() {
+        String endpointName = "test-cl-longyloooooooooooong-name-master0";
+        String envName = "notashort-env-name-as28chars";
+        String rootDomain = "wl.cloudera.site";
+        String environmentDomain = envName + "." + rootDomain;
+        DetailedEnvironmentResponse environment = DetailedEnvironmentResponse.builder()
+                .withName(envName)
+                .withCrn(ENV_CRN)
+                .build();
+        String accountWorkloadSubdomain = "aWorkloadSubdomain";
+        UserManagementProto.Account umsAccount = UserManagementProto.Account.newBuilder()
+                .setWorkloadSubdomain(accountWorkloadSubdomain)
+                .build();
+        when(grpcUmsClient.getAccountDetails(anyString(), any())).thenReturn(umsAccount);
+        when(legacyEnvironmentNameBasedDomainNameProvider.getDomainName(anyString(), anyString())).thenReturn(environmentDomain);
+
+        String commonName = underTest.getCommonName(endpointName, environment);
+
+        String expected = String.format("5e8a4beefa5d7f90.%s", environmentDomain);
+        assertEquals(expected, commonName);
+        verify(grpcUmsClient, times(1)).getAccountDetails(anyString(), any());
+        verify(legacyEnvironmentNameBasedDomainNameProvider, times(1)).getDomainName(anyString(), anyString());
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/FreeIPAEndpointManagementServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/FreeIPAEndpointManagementServiceTest.java
@@ -22,7 +22,6 @@ import org.mockito.MockitoAnnotations;
 import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
 import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
-import com.sequenceiq.cloudbreak.dns.EnvironmentBasedDomainNameProvider;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.loadbalancer.LoadBalancer;
 import com.sequenceiq.cloudbreak.service.LoadBalancerConfigService;
@@ -76,7 +75,6 @@ public class FreeIPAEndpointManagementServiceTest {
         stack = mock(Stack.class);
         when(stack.getEnvironmentCrn()).thenReturn(ENVIRONMENT_CRN);
         when(stack.getId()).thenReturn(1L);
-        when(domainNameProvider.getDomainName(any(), any())).thenReturn("cloudera.domain");
         doNothing().when(dnsV1Endpoint).addDnsCnameRecordInternal(any(), any());
         doNothing().when(dnsV1Endpoint).addDnsARecordInternal(any(), any());
         doNothing().when(dnsV1Endpoint).deleteDnsCnameRecord(any(), any(), any());

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/BaseDnsEntryServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/publicendpoint/dns/BaseDnsEntryServiceTest.java
@@ -26,7 +26,7 @@ import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
 import com.sequenceiq.cloudbreak.certificate.service.CertificateCreationService;
 import com.sequenceiq.cloudbreak.certificate.service.DnsManagementService;
 import com.sequenceiq.cloudbreak.cmtemplate.configproviders.nifi.NifiConfigProvider;
-import com.sequenceiq.cloudbreak.dns.EnvironmentBasedDomainNameProvider;
+import com.sequenceiq.cloudbreak.service.publicendpoint.EnvironmentBasedDomainNameProvider;
 import com.sequenceiq.cloudbreak.domain.stack.Stack;
 import com.sequenceiq.cloudbreak.domain.stack.cluster.Cluster;
 import com.sequenceiq.cloudbreak.domain.stack.instance.InstanceGroup;

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/doc/environment/EnvironmentModelDescription.java
@@ -139,6 +139,7 @@ public class EnvironmentModelDescription {
 
     public static final String ENVIRONMENT_SERVICE_VERSION = "The version of the Cloudbreak build used to create the environment.";
     public static final String ENVIRONMENT_DELETION_TYPE = "Deletion type of environment.";
+    public static final String ENVIRONMENT_DOMAIN_NAME = "The domain name that's has been generated for the environment.";
 
     public static final String AWS_DISK_ENCRYPTION_PARAMETERS = "AWS Disk encryption parameters";
     private EnvironmentModelDescription() {

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/DetailedEnvironmentResponse.java
@@ -128,6 +128,8 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
 
         private EnvironmentDeletionType deletionType;
 
+        private String environmentDomain;
+
         private Builder() {
         }
 
@@ -301,6 +303,11 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
             return this;
         }
 
+        public Builder withEnvironmentDomain(String environmentDomainName) {
+            this.environmentDomain = environmentDomainName;
+            return this;
+        }
+
         public DetailedEnvironmentResponse build() {
             DetailedEnvironmentResponse detailedEnvironmentResponse = new DetailedEnvironmentResponse();
             detailedEnvironmentResponse.setCrn(crn);
@@ -337,6 +344,7 @@ public class DetailedEnvironmentResponse extends EnvironmentBaseResponse {
             detailedEnvironmentResponse.setEnvironmentServiceVersion(environmentServiceVersion);
             detailedEnvironmentResponse.setCcmV2TlsType(ccmV2TlsType);
             detailedEnvironmentResponse.setDeletionType(deletionType);
+            detailedEnvironmentResponse.setEnvironmentDomain(environmentDomain);
             return detailedEnvironmentResponse;
         }
     }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/EnvironmentBaseResponse.java
@@ -119,6 +119,9 @@ public abstract class EnvironmentBaseResponse implements TaggedResponse {
     @ApiModelProperty(EnvironmentModelDescription.ENVIRONMENT_DELETION_TYPE)
     private EnvironmentDeletionType deletionType;
 
+    @ApiModelProperty(EnvironmentModelDescription.ENVIRONMENT_DOMAIN_NAME)
+    private String environmentDomain;
+
     @JsonIgnore
     public boolean isCloudStorageLoggingEnabled() {
         return telemetry != null && telemetry.getFeatures() != null && telemetry.getFeatures().getCloudStorageLogging() != null
@@ -388,6 +391,14 @@ public abstract class EnvironmentBaseResponse implements TaggedResponse {
         this.deletionType = deletionType;
     }
 
+    public String getEnvironmentDomain() {
+        return environmentDomain;
+    }
+
+    public void setEnvironmentDomain(String environmentDomain) {
+        this.environmentDomain = environmentDomain;
+    }
+
     @Override
     public String toString() {
         return "EnvironmentBaseResponse{" +
@@ -423,6 +434,7 @@ public abstract class EnvironmentBaseResponse implements TaggedResponse {
                 ", environmentServiceVersion='" + environmentServiceVersion + '\'' +
                 ", ccmV2TlsType='" + ccmV2TlsType + '\'' +
                 ", deletionType='" + deletionType + '\'' +
+                ", environmentDomain='" + environmentDomain + '\'' +
                 '}';
     }
 }

--- a/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/SimpleEnvironmentResponse.java
+++ b/environment-api/src/main/java/com/sequenceiq/environment/api/v1/environment/model/response/SimpleEnvironmentResponse.java
@@ -107,6 +107,8 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
 
         private EnvironmentDeletionType deletionType;
 
+        private String environmentDomain;
+
         private Builder() {
         }
 
@@ -250,6 +252,11 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
             return this;
         }
 
+        public Builder withEnvironmentDomain(String environmentDomain) {
+            this.environmentDomain = environmentDomain;
+            return this;
+        }
+
         public SimpleEnvironmentResponse build() {
             SimpleEnvironmentResponse simpleEnvironmentResponse = new SimpleEnvironmentResponse();
             simpleEnvironmentResponse.setCrn(crn);
@@ -280,6 +287,7 @@ public class SimpleEnvironmentResponse extends EnvironmentBaseResponse {
             simpleEnvironmentResponse.setEnvironmentServiceVersion(environmentServiceVersion);
             simpleEnvironmentResponse.setCcmV2TlsType(ccmV2TlsType);
             simpleEnvironmentResponse.setDeletionType(deletionType);
+            simpleEnvironmentResponse.setEnvironmentDomain(environmentDomain);
             return simpleEnvironmentResponse;
         }
     }

--- a/environment/build.gradle
+++ b/environment/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     implementation     project(":structuredevent-service-cdp")
     implementation     project(":status-checker")
     implementation     project(":template-manager-tag")
+    implementation     project(':cluster-dns-connector')
 
     implementation     group: "org.yaml",                  name: "snakeyaml",                                version: snakeYamlVersion
     implementation     group: "io.springfox",              name: "springfox-swagger2",                       version: swagger2Version

--- a/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/domain/Environment.java
@@ -156,6 +156,9 @@ public class Environment implements AuthResource, AccountAwareResource {
     @Column(name = "environment_service_version")
     private String environmentServiceVersion;
 
+    @Column(name = "environment_domain")
+    private String domain;
+
     public Environment() {
         regions = new Json(new HashSet<Region>());
         tags = new Json(new EnvironmentTags(new HashMap<>(), new HashMap<>()));
@@ -522,6 +525,14 @@ public class Environment implements AuthResource, AccountAwareResource {
         this.deletionType = deletionType;
     }
 
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
     @Override
     public String toString() {
         return "Environment{" +
@@ -533,6 +544,7 @@ public class Environment implements AuthResource, AccountAwareResource {
                 ", statusReason='" + statusReason + '\'' +
                 ", freeIpaEnableMultiAz='" + freeIpaEnableMultiAz + '\'' +
                 ", deletionType='" + deletionType + '\'' +
+                ", domain='" + domain + '\'' +
                 '}';
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDto.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDto.java
@@ -93,6 +93,8 @@ public class EnvironmentDto implements Payload, AccountAwareResource, Environmen
 
     private EnvironmentDeletionType deletionType;
 
+    private String domain;
+
     @Override
     public Long getResourceId() {
         return id;
@@ -410,6 +412,14 @@ public class EnvironmentDto implements Payload, AccountAwareResource, Environmen
         this.deletionType = deletionType;
     }
 
+    public String getDomain() {
+        return domain;
+    }
+
+    public void setDomain(String domain) {
+        this.domain = domain;
+    }
+
     public Map<String, String> mergeTags(CostTagging costTagging) {
         CDPTagMergeRequest mergeRequest = CDPTagMergeRequest.Builder
                 .builder()
@@ -426,7 +436,8 @@ public class EnvironmentDto implements Payload, AccountAwareResource, Environmen
                 + "name='" + name + '\''
                 + ", cloudPlatform='" + cloudPlatform + '\''
                 + ", resourceCrn='" + resourceCrn + '\''
-                + ", status=" + status
+                + ", status='" + status + '\''
+                + ", domain='" + domain + '\''
                 + '}';
     }
 
@@ -498,6 +509,8 @@ public class EnvironmentDto implements Payload, AccountAwareResource, Environmen
         private String environmentServiceVersion;
 
         private EnvironmentDeletionType deletionType;
+
+        private String domain;
 
         private Builder() {
         }
@@ -662,6 +675,11 @@ public class EnvironmentDto implements Payload, AccountAwareResource, Environmen
             return this;
         }
 
+        public Builder withEnvironmentDomain(String domain) {
+            this.domain = domain;
+            return this;
+        }
+
         public EnvironmentDto build() {
             EnvironmentDto environmentDto = new EnvironmentDto();
             environmentDto.setId(id);
@@ -696,6 +714,7 @@ public class EnvironmentDto implements Payload, AccountAwareResource, Environmen
             environmentDto.setProxyConfig(proxyConfig);
             environmentDto.setEnvironmentServiceVersion(environmentServiceVersion);
             environmentDto.setDeletionType(deletionType);
+            environmentDto.setDomain(domain);
             return environmentDto;
         }
     }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/dto/EnvironmentDtoConverter.java
@@ -113,7 +113,8 @@ public class EnvironmentDtoConverter {
                 .withAdminGroupName(environment.getAdminGroupName())
                 .withProxyConfig(environment.getProxyConfig())
                 .withEnvironmentDeletionType(environment.getDeletionType())
-                .withEnvironmentServiceVersion(environment.getEnvironmentServiceVersion());
+                .withEnvironmentServiceVersion(environment.getEnvironmentServiceVersion())
+                .withEnvironmentDomain(environment.getDomain());
 
         CloudPlatform cloudPlatform = CloudPlatform.valueOf(environment.getCloudPlatform());
         doIfNotNull(environment.getParameters(), parameters -> builder.withParameters(

--- a/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaServerRequestProvider.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaServerRequestProvider.java
@@ -1,19 +1,9 @@
 package com.sequenceiq.environment.environment.flow.creation.handler.freeipa;
 
-import java.util.Optional;
-
-import javax.inject.Inject;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
-import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
-import com.sequenceiq.cloudbreak.auth.crn.Crn;
-import com.sequenceiq.cloudbreak.dns.EnvironmentBasedDomainNameProvider;
-import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.util.FreeIpaPasswordUtil;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerRequest;
@@ -23,21 +13,11 @@ class FreeIpaServerRequestProvider {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FreeIpaCreationHandler.class);
 
-    private static final String FREEIPA_DEFAULT_ACCOUNT_DOMAIN = "internal";
-
     private static final String FREEIPA_HOSTNAME = "ipaserver";
 
-    @Inject
-    private GrpcUmsClient grpcUmsClient;
-
-    @Inject
-    private EnvironmentBasedDomainNameProvider environmentBasedDomainNameProvider;
-
     FreeIpaServerRequest create(EnvironmentDto environment) {
-        String environmentName = environment.getName();
-        String accountSubDomain = getAccountSubdomain();
-        String domain = environmentBasedDomainNameProvider.getDomainName(environmentName, accountSubDomain);
-        LOGGER.info("Generate domain: environmentName: {}, accountSubdomain {}, domain: {}", environment.getName(), accountSubDomain, domain);
+        String domain = environment.getDomain();
+        LOGGER.info("Creating FreeIPA request for environment: '{}' with domain: '{}'", environment.getName(), domain);
 
         String adminGroupName = environment.getAdminGroupName();
         FreeIpaServerRequest freeIpaServerRequest = new FreeIpaServerRequest();
@@ -47,18 +27,5 @@ class FreeIpaServerRequestProvider {
         freeIpaServerRequest.setAdminGroupName(adminGroupName);
         LOGGER.info("FreeIpaServerRequest created for environment: {}, request {}", environment.getName(), freeIpaServerRequest);
         return freeIpaServerRequest;
-    }
-
-    private String getAccountSubdomain() {
-        String userCrn = ThreadBasedUserCrnProvider.getUserCrn();
-        Optional<String> requestIdOptional = Optional.ofNullable(MDCBuilder.getOrGenerateRequestId());
-        // I think this should be better/safer if we could use the account id of environment,
-        UserManagementProto.Account account = grpcUmsClient.getAccountDetails(Crn.safeFromString(userCrn).getAccountId(), requestIdOptional);
-        String accountSubdomain = account.getWorkloadSubdomain();
-        if (accountSubdomain == null || accountSubdomain.isEmpty()) {
-            accountSubdomain = FREEIPA_DEFAULT_ACCOUNT_DOMAIN;
-            LOGGER.info("getWorkloadSubdomain was null, or empty, setting default subdomain: {}", accountSubdomain);
-        }
-        return accountSubdomain;
     }
 }

--- a/environment/src/main/java/com/sequenceiq/environment/environment/service/domain/PemBasedEnvironmentDomainProvider.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/service/domain/PemBasedEnvironmentDomainProvider.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.environment.environment.service.domain;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.certificate.service.DnsManagementService;
+import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.exception.EnvironmentServiceException;
+
+@Component
+public class PemBasedEnvironmentDomainProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PemBasedEnvironmentDomainProvider.class);
+
+    @Inject
+    private DnsManagementService dnsManagementService;
+
+    public String generate(Environment environment) {
+        String managedDomain = null;
+        String environmentName = environment.getName();
+        String accountId = ThreadBasedUserCrnProvider.getAccountId();
+        LOGGER.debug("Generate managed domain name via PEM for environment ame: '{}' and account: '{}'", environmentName, accountId);
+        try {
+            managedDomain = dnsManagementService.generateManagedDomain(accountId, environmentName);
+            LOGGER.info("Generated managed domain name via PEM: '{}' for environment name: '{}' and account: '{}'", managedDomain, environmentName, accountId);
+        } catch (Exception ex) {
+            LOGGER.warn("Failed to generate managed domain name for the environment '{}' via PEM", environmentName, ex);
+            throw new EnvironmentServiceException("Failed to generate managed domain name for the environment", ex);
+        }
+        if (StringUtils.isEmpty(managedDomain)) {
+            throw new EnvironmentServiceException("Failed to generate managed domain name for the environment, initialization failed.");
+        }
+        return managedDomain;
+    }
+}

--- a/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
+++ b/environment/src/main/java/com/sequenceiq/environment/environment/v1/converter/EnvironmentResponseConverter.java
@@ -117,7 +117,8 @@ public class EnvironmentResponseConverter {
                 .withParentEnvironmentCloudPlatform(environmentDto.getParentEnvironmentCloudPlatform())
                 .withEnvironmentServiceVersion(environmentDto.getEnvironmentServiceVersion())
                 .withDeletionType(deletionType(environmentDto.getDeletionType()))
-                .withCcmV2TlsType(environmentDto.getExperimentalFeatures().getCcmV2TlsType());
+                .withCcmV2TlsType(environmentDto.getExperimentalFeatures().getCcmV2TlsType())
+                .withEnvironmentDomain(environmentDto.getDomain());
 
         NullUtil.doIfNotNull(environmentDto.getProxyConfig(),
                 proxyConfig -> builder.withProxyConfig(proxyConfigToProxyResponseConverter.convert(environmentDto.getProxyConfig())));
@@ -157,7 +158,8 @@ public class EnvironmentResponseConverter {
                 .withGcp(getIfNotNull(environmentDto.getParameters(), this::gcpEnvParamsToGcpEnvironmentParams))
                 .withDeletionType(deletionType(environmentDto.getDeletionType()))
                 .withParentEnvironmentName(environmentDto.getParentEnvironmentName())
-                .withCcmV2TlsType(environmentDto.getExperimentalFeatures().getCcmV2TlsType());
+                .withCcmV2TlsType(environmentDto.getExperimentalFeatures().getCcmV2TlsType())
+                .withEnvironmentDomain(environmentDto.getDomain());
 
         NullUtil.doIfNotNull(environmentDto.getProxyConfig(),
                 proxyConfig -> builder.withProxyConfig(proxyConfigToProxyResponseConverter.convertToView(environmentDto.getProxyConfig())));

--- a/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/CredentialPlatformResourceController.java
+++ b/environment/src/main/java/com/sequenceiq/environment/platformresource/v1/CredentialPlatformResourceController.java
@@ -339,7 +339,7 @@ public class CredentialPlatformResourceController implements CredentialPlatformR
         LOGGER.info("Get /platform_resources/ssh_keys, request: {}", request);
         CloudSshKeys sshKeys = platformParameterService.getCloudSshKeys(request);
         PlatformSshKeysResponse response = cloudSshKeysToPlatformSshKeysV1ResponseConverter.convert(sshKeys);
-        LOGGER.info("Resp /platform_resources/ssh_keys, request: {}, sshKeys: {}, response: {}", request, sshKeys, response);
+        LOGGER.info("Resp /platform_resources/ssh_keys, request: {}, sshKeys: {}", request, sshKeys);
         return response;
     }
 

--- a/environment/src/main/resources/application.yml
+++ b/environment/src/main/resources/application.yml
@@ -215,4 +215,8 @@ crn:
   partition: cdp
   region: us-west-1
 
+clusterdns:
+  host: localhost
+  port: 8982
+
 

--- a/environment/src/main/resources/schema/app/20211201174115_CB-14678_add_domain_field_to_environment_table.sql
+++ b/environment/src/main/resources/schema/app/20211201174115_CB-14678_add_domain_field_to_environment_table.sql
@@ -1,0 +1,8 @@
+-- // CB-14678 add domain field to environment table
+-- Migration SQL that makes the change goes here.
+ALTER TABLE environment ADD COLUMN IF NOT EXISTS environment_domain varchar(255);
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE environment DROP COLUMN IF EXISTS environment_domain;

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/EnvironmentInitHandlerTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/EnvironmentInitHandlerTest.java
@@ -32,6 +32,7 @@ import com.sequenceiq.environment.environment.domain.Environment;
 import com.sequenceiq.environment.environment.domain.Region;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.environment.environment.service.EnvironmentService;
+import com.sequenceiq.environment.environment.service.domain.PemBasedEnvironmentDomainProvider;
 import com.sequenceiq.environment.network.EnvironmentNetworkService;
 import com.sequenceiq.environment.network.dao.domain.AwsNetwork;
 import com.sequenceiq.environment.network.dao.domain.BaseNetwork;
@@ -74,9 +75,11 @@ class EnvironmentInitHandlerTest {
 
     private final Map<CloudPlatform, EnvironmentNetworkConverter> environmentNetworkConverterMap = Mockito.mock(HashMap.class);
 
+    private final PemBasedEnvironmentDomainProvider domainProvider = Mockito.mock(PemBasedEnvironmentDomainProvider.class);
+
     private final EnvironmentInitHandler environmentInitHandler
             = new EnvironmentInitHandler(eventSender, environmentService, environmentNetworkService,
-            eventBus, virtualGroupService, environmentNetworkConverterMap);
+            eventBus, virtualGroupService, environmentNetworkConverterMap, domainProvider);
 
     @Test
     void testInitFailure() {

--- a/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaServerRequestProviderTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/flow/creation/handler/freeipa/FreeIpaServerRequestProviderTest.java
@@ -2,23 +2,15 @@ package com.sequenceiq.environment.environment.flow.creation.handler.freeipa;
 
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Answers;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.cloudera.thunderhead.service.usermanagement.UserManagementProto;
 import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
-import com.sequenceiq.cloudbreak.auth.altus.GrpcUmsClient;
-import com.sequenceiq.cloudbreak.dns.EnvironmentBasedDomainNameProvider;
 import com.sequenceiq.environment.environment.dto.EnvironmentDto;
 import com.sequenceiq.freeipa.api.v1.freeipa.stack.model.FreeIpaServerRequest;
 
@@ -31,38 +23,23 @@ class FreeIpaServerRequestProviderTest {
 
     private static final String USER_CRN = "crn:altus:iam:us-west-1:" + ACCOUNT_ID + ":user:" + UUID.randomUUID().toString();
 
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private GrpcUmsClient grpcUmsClient;
-
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private EnvironmentBasedDomainNameProvider environmentBasedDomainNameProvider;
+    private static final String ENV_DOMAIN = "mydomain";
 
     @InjectMocks
     private FreeIpaServerRequestProvider underTest;
 
     @Test
-    void testCreateWithLegacyDomain() {
-        UserManagementProto.Account account = UserManagementProto.Account.newBuilder().build();
-        when(grpcUmsClient.getAccountDetails(eq(ACCOUNT_ID), any())).thenReturn(account);
-        when(environmentBasedDomainNameProvider.getDomainName(ENV_NAME, "internal")).thenReturn("mydomain");
-
-        EnvironmentDto environmentDto = new EnvironmentDto();
-        environmentDto.setName(ENV_NAME);
+    void testCreateWithEnvironmentDomain() {
+        EnvironmentDto environmentDto = getEnvironmentDto();
         FreeIpaServerRequest freeIpaServerRequest = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.create(environmentDto));
 
-        assertEquals("mydomain", freeIpaServerRequest.getDomain());
+        assertEquals(ENV_DOMAIN, freeIpaServerRequest.getDomain());
     }
 
-    @Test
-    void testCreateWithDomainReturnedFromUms() {
-        UserManagementProto.Account account = UserManagementProto.Account.newBuilder().setWorkloadSubdomain("checkme").build();
-        when(grpcUmsClient.getAccountDetails(eq(ACCOUNT_ID), any())).thenReturn(account);
-        when(environmentBasedDomainNameProvider.getDomainName(ENV_NAME, "checkme")).thenReturn("checkme.mydomain");
-
+    private EnvironmentDto getEnvironmentDto() {
         EnvironmentDto environmentDto = new EnvironmentDto();
         environmentDto.setName(ENV_NAME);
-        FreeIpaServerRequest freeIpaServerRequest = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.create(environmentDto));
-
-        assertEquals("checkme.mydomain", freeIpaServerRequest.getDomain());
+        environmentDto.setDomain(ENV_DOMAIN);
+        return environmentDto;
     }
 }

--- a/environment/src/test/java/com/sequenceiq/environment/environment/service/domain/PemBasedEnvironmentDomainProviderTest.java
+++ b/environment/src/test/java/com/sequenceiq/environment/environment/service/domain/PemBasedEnvironmentDomainProviderTest.java
@@ -1,0 +1,85 @@
+package com.sequenceiq.environment.environment.service.domain;
+
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.sequenceiq.cloudbreak.auth.ThreadBasedUserCrnProvider;
+import com.sequenceiq.cloudbreak.certificate.service.DnsManagementService;
+import com.sequenceiq.environment.environment.domain.Environment;
+import com.sequenceiq.environment.exception.EnvironmentServiceException;
+
+@ExtendWith(MockitoExtension.class)
+class PemBasedEnvironmentDomainProviderTest {
+    private static final String USER_CRN = "crn:cdp:iam:us-west-1:123:user:123";
+
+    @Mock
+    private DnsManagementService dnsManagementService;
+
+    @InjectMocks
+    private PemBasedEnvironmentDomainProvider underTest;
+
+    @Test
+    void testGenerateShouldThrowServiceExceptionWhenPemReturnsWithNullAsManagedDomainName() {
+        Environment environment = new Environment();
+        String anEnvName = "anEnvName";
+        environment.setName(anEnvName);
+        when(dnsManagementService.generateManagedDomain(anyString(), eq(anEnvName))).thenReturn(null);
+
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                Assertions.assertThrows(EnvironmentServiceException.class, () -> underTest.generate(environment)));
+
+        verify(dnsManagementService, times(1)).generateManagedDomain(anyString(), eq(anEnvName));
+    }
+
+    @Test
+    void testGenerateShouldThrowServiceExceptionWhenPemReturnsWithEmptyStringAsManagedDomainName() {
+        Environment environment = new Environment();
+        String anEnvName = "anEnvName";
+        environment.setName(anEnvName);
+        when(dnsManagementService.generateManagedDomain(anyString(), eq(anEnvName))).thenReturn("");
+
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                Assertions.assertThrows(EnvironmentServiceException.class, () -> underTest.generate(environment)));
+
+        verify(dnsManagementService, times(1)).generateManagedDomain(anyString(), eq(anEnvName));
+    }
+
+    @Test
+    void testGenerateShouldThrowServiceExceptionWhenPemReturnsWithThrowExceptionDuringGenerationOfManagedDomainName() {
+        Environment environment = new Environment();
+        String anEnvName = "anEnvName";
+        environment.setName(anEnvName);
+        when(dnsManagementService.generateManagedDomain(anyString(), eq(anEnvName)))
+                .thenThrow(new RuntimeException("ooo something went wrong, no domain generation from our side."));
+
+        ThreadBasedUserCrnProvider.doAs(USER_CRN, () ->
+                Assertions.assertThrows(EnvironmentServiceException.class, () -> underTest.generate(environment)));
+
+        verify(dnsManagementService, times(1)).generateManagedDomain(anyString(), eq(anEnvName));
+    }
+
+    @Test
+    void testGenerateReturnManagedDomainWhenPemReturnsTheGeneratedManagedDomainName() {
+        Environment environment = new Environment();
+        String anEnvName = "anEnvName";
+        environment.setName(anEnvName);
+        String expectedDomain = anEnvName + ".mydomain.cldr";
+        when(dnsManagementService.generateManagedDomain(anyString(), eq(anEnvName))).thenReturn(expectedDomain);
+
+        String result = ThreadBasedUserCrnProvider.doAs(USER_CRN, () -> underTest.generate(environment));
+
+        Assertions.assertEquals(expectedDomain, result);
+        verify(dnsManagementService, times(1)).generateManagedDomain(anyString(), eq(anEnvName));
+    }
+}

--- a/integration-test/integcb/Profile_template
+++ b/integration-test/integcb/Profile_template
@@ -21,6 +21,7 @@ export ENVIRONMENT_FREEIPA_SYNCHRONIZEONSTART=false
 export ENVIRONMENT_EXPERIENCE_SCAN_ENABLED=true
 
 export ALTUS_AUDIT_ENDPOINT=thunderhead-mock
+export CLUSTERDNS_HOST=thunderhead-mock
 export MOCK_INFRASTRUCTURE_HOST=mock-infrastructure
 
 export CPUS_FOR_CLOUDBREAK=8.0

--- a/mock-thunderhead/build.gradle
+++ b/mock-thunderhead/build.gradle
@@ -81,4 +81,5 @@ dependencies {
   }
   implementation project(':datalake-dr-connector')
   implementation project (':cloud-api')
+  implementation project(':cluster-dns-connector')
 }

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/MockThunderheadApplication.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/MockThunderheadApplication.java
@@ -3,7 +3,7 @@ package com.sequenceiq.thunderhead;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(scanBasePackages = { "com.sequenceiq.cloudbreak.auth.crn", "com.sequenceiq.thunderhead" })
+@SpringBootApplication(scanBasePackages = { "com.sequenceiq.cloudbreak.auth.crn", "com.sequenceiq.thunderhead", "com.sequenceiq.cloudbreak.dns" })
 public class MockThunderheadApplication {
     public static void main(String[] args) {
         if (args.length == 0) {

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/config/GrpcServerConfig.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/config/GrpcServerConfig.java
@@ -12,6 +12,7 @@ import com.sequenceiq.thunderhead.grpc.service.auth.MockAuthorizationService;
 import com.sequenceiq.thunderhead.grpc.service.auth.MockPersonalResourceViewService;
 import com.sequenceiq.thunderhead.grpc.service.auth.MockUserManagementService;
 import com.sequenceiq.thunderhead.grpc.service.datalakedr.MockDatalakeDrService;
+import com.sequenceiq.thunderhead.grpc.service.pem.MockPublicEndpointManagementService;
 
 @Configuration
 public class GrpcServerConfig {
@@ -31,6 +32,9 @@ public class GrpcServerConfig {
     @Inject
     private MockDatalakeDrService datalakeDrService;
 
+    @Inject
+    private MockPublicEndpointManagementService mockPublicEndpointManagementService;
+
     @Value("${grpc.server.port:8982}")
     private int grpcServerPort;
 
@@ -44,7 +48,8 @@ public class GrpcServerConfig {
                 mockUserManagementService.bindService(),
                 mockAuthorizationService.bindService(),
                 mockPersonalResourceViewService.bindService(),
-                mockAuditLogService.bindService());
+                mockAuditLogService.bindService(),
+                mockPublicEndpointManagementService.bindService());
     }
 
     @Bean

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/auth/MockUserManagementService.java
@@ -218,6 +218,8 @@ import io.grpc.stub.StreamObserver;
 @Service
 public class MockUserManagementService extends UserManagementImplBase {
 
+    public static final String ACCOUNT_SUBDOMAIN = "xcu2-8y8x";
+
     @VisibleForTesting
     static final long PASSWORD_LIFETIME = 31449600000L;
 
@@ -234,8 +236,6 @@ public class MockUserManagementService extends UserManagementImplBase {
     private static final String CDP_PRIVATE_KEY = "cdp_private_key";
 
     private static final int MOCK_USER_COUNT = 100;
-
-    private static final String ACCOUNT_SUBDOMAIN = "xcu2-8y8x";
 
     private static final String ACCOUNT_ID_ALTUS = "altus";
 

--- a/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/pem/MockPublicEndpointManagementService.java
+++ b/mock-thunderhead/src/main/java/com/sequenceiq/thunderhead/grpc/service/pem/MockPublicEndpointManagementService.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.thunderhead.grpc.service.pem;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementGrpc;
+import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto;
+import com.cloudera.thunderhead.service.publicendpointmanagement.PublicEndpointManagementProto.GenerateManagedDomainNamesResponse;
+import com.google.common.base.Strings;
+import com.google.protobuf.ProtocolStringList;
+import com.sequenceiq.cloudbreak.dns.LegacyEnvironmentNameBasedDomainNameProvider;
+import com.sequenceiq.thunderhead.grpc.service.auth.MockUserManagementService;
+
+import io.grpc.stub.StreamObserver;
+
+@Component
+public class MockPublicEndpointManagementService extends PublicEndpointManagementGrpc.PublicEndpointManagementImplBase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MockPublicEndpointManagementService.class);
+
+    @Inject
+    private LegacyEnvironmentNameBasedDomainNameProvider environmentNameBasedDomainNameProvider;
+
+    @Override
+    public void generateManagedDomainNames(PublicEndpointManagementProto.GenerateManagedDomainNamesRequest request,
+            StreamObserver<GenerateManagedDomainNamesResponse> responseObserver) {
+        ProtocolStringList subDomains = request.getSubdomainsList();
+        String environmentName = request.getEnvironmentName();
+        String accountId = request.getAccountId();
+        checkArgument(!Strings.isNullOrEmpty(environmentName));
+        checkArgument(!Strings.isNullOrEmpty(accountId));
+        checkArgument(!subDomains.isEmpty());
+        LOGGER.info("Generating mock managed domain for environment: '{}', accountid: '{}' with provided domains: '{}', ", environmentName, accountId,
+                String.join(",", subDomains));
+
+        String generatedManagedDomain = environmentNameBasedDomainNameProvider.getDomainName(environmentName, MockUserManagementService.ACCOUNT_SUBDOMAIN);
+
+        GenerateManagedDomainNamesResponse response = GenerateManagedDomainNamesResponse.newBuilder()
+                .putDomains("*", generatedManagedDomain)
+                .build();
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+}


### PR DESCRIPTION
The legacy logic has been moved to mock-thunderhead module, this way the PEM endpoint integration is tested partially too. The logic is still needed to keep backward compatibility, but using domain from env level where it is applicable.

**Changes:**
 - Update PEM related gRPC proto files and their generated java representatives to the latest version from thunderhead repo
 - Deprecate the legacy domain generation logic, but keeps it for backward compatibility
 - Create a "generateManagedDomainNames" endpoint in our mock-thunderhead service and integrate the legacy logic there to test the integration and use the same calls to obtain domain for the environment in local-dev environments
 - Store the domain name in the environment entity and added to the related DTOs and Response objects too
 - Initiate the domain via PEM endpoint at environment creation init phase

This PR depends on:
 - https://github.com/hortonworks/cloudbreak-deployer/pull/754 - needed for integration test to be able run with this change
 - https://github.infra.cloudera.com/thunderhead/dps-k8s/pull/242 - **for QA and CLOUD-X environments**
 - https://github.infra.cloudera.com/thunderhead/cloud-services-infra/pull/3777 - **for Manowar related environments**